### PR TITLE
[HIPIFY][SPARSE] sync with hipSPARSE's #102 and #103

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -738,6 +738,7 @@ sub simpleSubstitutions {
     $ft{'library'} += s/\bcurandSetQuasiRandomGeneratorDimensions\b/hiprandSetQuasiRandomGeneratorDimensions/g;
     $ft{'library'} += s/\bcurandSetStream\b/hiprandSetStream/g;
     $ft{'library'} += s/\bcusparseCaxpyi\b/hipsparseCaxpyi/g;
+    $ft{'library'} += s/\bcusparseCbsrmv\b/hipsparseCbsrmv/g;
     $ft{'library'} += s/\bcusparseCcsr2csc\b/hipsparseCcsr2csc/g;
     $ft{'library'} += s/\bcusparseCcsr2hyb\b/hipsparseCcsr2hyb/g;
     $ft{'library'} += s/\bcusparseCcsrgeam\b/hipsparseCcsrgeam/g;
@@ -766,6 +767,7 @@ sub simpleSubstitutions {
     $ft{'library'} += s/\bcusparseCgthrz\b/hipsparseCgthrz/g;
     $ft{'library'} += s/\bcusparseChybmv\b/hipsparseChybmv/g;
     $ft{'library'} += s/\bcusparseCnnz\b/hipsparseCnnz/g;
+    $ft{'library'} += s/\bcusparseCnnz_compress\b/hipsparseCnnz_compress/g;
     $ft{'library'} += s/\bcusparseCreate\b/hipsparseCreate/g;
     $ft{'library'} += s/\bcusparseCreateCsrgemm2Info\b/hipsparseCreateCsrgemm2Info/g;
     $ft{'library'} += s/\bcusparseCreateCsrilu02Info\b/hipsparseCreateCsrilu02Info/g;
@@ -776,6 +778,7 @@ sub simpleSubstitutions {
     $ft{'library'} += s/\bcusparseCreateMatDescr\b/hipsparseCreateMatDescr/g;
     $ft{'library'} += s/\bcusparseCsctr\b/hipsparseCsctr/g;
     $ft{'library'} += s/\bcusparseDaxpyi\b/hipsparseDaxpyi/g;
+    $ft{'library'} += s/\bcusparseDbsrmv\b/hipsparseDbsrmv/g;
     $ft{'library'} += s/\bcusparseDcsr2csc\b/hipsparseDcsr2csc/g;
     $ft{'library'} += s/\bcusparseDcsr2hyb\b/hipsparseDcsr2hyb/g;
     $ft{'library'} += s/\bcusparseDcsrgeam\b/hipsparseDcsrgeam/g;
@@ -810,6 +813,7 @@ sub simpleSubstitutions {
     $ft{'library'} += s/\bcusparseDgthrz\b/hipsparseDgthrz/g;
     $ft{'library'} += s/\bcusparseDhybmv\b/hipsparseDhybmv/g;
     $ft{'library'} += s/\bcusparseDnnz\b/hipsparseDnnz/g;
+    $ft{'library'} += s/\bcusparseDnnz_compress\b/hipsparseDnnz_compress/g;
     $ft{'library'} += s/\bcusparseDroti\b/hipsparseDroti/g;
     $ft{'library'} += s/\bcusparseDsctr\b/hipsparseDsctr/g;
     $ft{'library'} += s/\bcusparseGetMatDiagType\b/hipsparseGetMatDiagType/g;
@@ -820,6 +824,7 @@ sub simpleSubstitutions {
     $ft{'library'} += s/\bcusparseGetStream\b/hipsparseGetStream/g;
     $ft{'library'} += s/\bcusparseGetVersion\b/hipsparseGetVersion/g;
     $ft{'library'} += s/\bcusparseSaxpyi\b/hipsparseSaxpyi/g;
+    $ft{'library'} += s/\bcusparseSbsrmv\b/hipsparseSbsrmv/g;
     $ft{'library'} += s/\bcusparseScsr2csc\b/hipsparseScsr2csc/g;
     $ft{'library'} += s/\bcusparseScsr2hyb\b/hipsparseScsr2hyb/g;
     $ft{'library'} += s/\bcusparseScsrgeam\b/hipsparseScsrgeam/g;
@@ -853,6 +858,7 @@ sub simpleSubstitutions {
     $ft{'library'} += s/\bcusparseSgthrz\b/hipsparseSgthrz/g;
     $ft{'library'} += s/\bcusparseShybmv\b/hipsparseShybmv/g;
     $ft{'library'} += s/\bcusparseSnnz\b/hipsparseSnnz/g;
+    $ft{'library'} += s/\bcusparseSnnz_compress\b/hipsparseSnnz_compress/g;
     $ft{'library'} += s/\bcusparseSroti\b/hipsparseSroti/g;
     $ft{'library'} += s/\bcusparseSsctr\b/hipsparseSsctr/g;
     $ft{'library'} += s/\bcusparseXbsrilu02_zeroPivot\b/hipsparseXbsrilu02_zeroPivot/g;
@@ -873,6 +879,7 @@ sub simpleSubstitutions {
     $ft{'library'} += s/\bcusparseXcsrsort_bufferSizeExt\b/hipsparseXcsrsort_bufferSizeExt/g;
     $ft{'library'} += s/\bcusparseXcsrsv2_zeroPivot\b/hipsparseXcsrsv2_zeroPivot/g;
     $ft{'library'} += s/\bcusparseZaxpyi\b/hipsparseZaxpyi/g;
+    $ft{'library'} += s/\bcusparseZbsrmv\b/hipsparseZbsrmv/g;
     $ft{'library'} += s/\bcusparseZcsr2csc\b/hipsparseZcsr2csc/g;
     $ft{'library'} += s/\bcusparseZcsr2hyb\b/hipsparseZcsr2hyb/g;
     $ft{'library'} += s/\bcusparseZcsrgeam\b/hipsparseZcsrgeam/g;
@@ -901,6 +908,7 @@ sub simpleSubstitutions {
     $ft{'library'} += s/\bcusparseZgthrz\b/hipsparseZgthrz/g;
     $ft{'library'} += s/\bcusparseZhybmv\b/hipsparseZhybmv/g;
     $ft{'library'} += s/\bcusparseZnnz\b/hipsparseZnnz/g;
+    $ft{'library'} += s/\bcusparseZnnz_compress\b/hipsparseZnnz_compress/g;
     $ft{'library'} += s/\bcusparseZsctr\b/hipsparseZsctr/g;
     $ft{'device_library'} += s/\bcurand\b/hiprand/g;
     $ft{'device_library'} += s/\bcurand_discrete\b/hiprand_discrete/g;

--- a/src/CUDA2HIP_SPARSE_API_functions.cpp
+++ b/src/CUDA2HIP_SPARSE_API_functions.cpp
@@ -101,10 +101,10 @@ const std::map<llvm::StringRef, hipCounter> CUDA_SPARSE_FUNCTION_MAP{
   {"cusparseZsctr",                               {"hipsparseZsctr",                               "", CONV_LIB_FUNC, API_SPARSE}},
 
   // 7. cuSPARSE Level 2 Function Reference
-  {"cusparseSbsrmv",                              {"hipsparseSbsrmv",                              "", CONV_LIB_FUNC, API_SPARSE, HIP_UNSUPPORTED}},
-  {"cusparseDbsrmv",                              {"hipsparseDbsrmv",                              "", CONV_LIB_FUNC, API_SPARSE, HIP_UNSUPPORTED}},
-  {"cusparseCbsrmv",                              {"hipsparseCbsrmv",                              "", CONV_LIB_FUNC, API_SPARSE, HIP_UNSUPPORTED}},
-  {"cusparseZbsrmv",                              {"hipsparseZbsrmv",                              "", CONV_LIB_FUNC, API_SPARSE, HIP_UNSUPPORTED}},
+  {"cusparseSbsrmv",                              {"hipsparseSbsrmv",                              "", CONV_LIB_FUNC, API_SPARSE}},
+  {"cusparseDbsrmv",                              {"hipsparseDbsrmv",                              "", CONV_LIB_FUNC, API_SPARSE}},
+  {"cusparseCbsrmv",                              {"hipsparseCbsrmv",                              "", CONV_LIB_FUNC, API_SPARSE}},
+  {"cusparseZbsrmv",                              {"hipsparseZbsrmv",                              "", CONV_LIB_FUNC, API_SPARSE}},
 
   {"cusparseSbsrxmv",                             {"hipsparseSbsrxmv",                             "", CONV_LIB_FUNC, API_SPARSE, HIP_UNSUPPORTED}},
   {"cusparseDbsrxmv",                             {"hipsparseDbsrxmv",                             "", CONV_LIB_FUNC, API_SPARSE, HIP_UNSUPPORTED}},
@@ -697,10 +697,10 @@ const std::map<llvm::StringRef, hipCounter> CUDA_SPARSE_FUNCTION_MAP{
   {"cusparseSpruneCsr2csrNnzByPercentage",        {"hipsparseSpruneCsr2csrNnzByPercentage",        "", CONV_LIB_FUNC, API_SPARSE, HIP_UNSUPPORTED}},
   {"cusparseDpruneCsr2csrNnzByPercentage",        {"hipsparseDpruneCsr2csrNnzByPercentage",        "", CONV_LIB_FUNC, API_SPARSE, HIP_UNSUPPORTED}},
 
-  {"cusparseSnnz_compress",                       {"hipsparseSnnz_compress",                       "", CONV_LIB_FUNC, API_SPARSE, HIP_UNSUPPORTED}},
-  {"cusparseDnnz_compress",                       {"hipsparseDnnz_compress",                       "", CONV_LIB_FUNC, API_SPARSE, HIP_UNSUPPORTED}},
-  {"cusparseCnnz_compress",                       {"hipsparseCnnz_compress",                       "", CONV_LIB_FUNC, API_SPARSE, HIP_UNSUPPORTED}},
-  {"cusparseZnnz_compress",                       {"hipsparseZnnz_compress",                       "", CONV_LIB_FUNC, API_SPARSE, HIP_UNSUPPORTED}},
+  {"cusparseSnnz_compress",                       {"hipsparseSnnz_compress",                       "", CONV_LIB_FUNC, API_SPARSE}},
+  {"cusparseDnnz_compress",                       {"hipsparseDnnz_compress",                       "", CONV_LIB_FUNC, API_SPARSE}},
+  {"cusparseCnnz_compress",                       {"hipsparseCnnz_compress",                       "", CONV_LIB_FUNC, API_SPARSE}},
+  {"cusparseZnnz_compress",                       {"hipsparseZnnz_compress",                       "", CONV_LIB_FUNC, API_SPARSE}},
 
   // 13. cuSPARSE Generic API Reference
   // Generic Sparse API helper functions


### PR DESCRIPTION
+ Based on:
  https://github.com/ROCmSoftwarePlatform/hipSPARSE/pull/102
  https://github.com/ROCmSoftwarePlatform/hipSPARSE/pull/103
+ bsrmv and csr2csr_compress functions support
+ Update hipify-perl accordingly
