### PR TITLE
[HIPIFY][tests][SPARSE] Update cuSPARSE_12.cu test

### DIFF
--- a/tests/unit_tests/libraries/cuSPARSE/cuSPARSE_12.cu
+++ b/tests/unit_tests/libraries/cuSPARSE/cuSPARSE_12.cu
@@ -385,7 +385,7 @@ double compute_BSR(BCRSArrays& bcsr, double *x , double *y){
     cudaEventCreate(&startTime);
     cudaEventCreate(&stopTime);
     cudaEventRecord(startTime, bcsr.streamId);
-    // CHECK: cusparseDbsrmv(bcsr.cusparseHandle, HIPSPARSE_DIRECTION_COLUMN, HIPSPARSE_OPERATION_NON_TRANSPOSE,
+    // CHECK: hipsparseDbsrmv(bcsr.cusparseHandle, HIPSPARSE_DIRECTION_COLUMN, HIPSPARSE_OPERATION_NON_TRANSPOSE,
     cusparseDbsrmv(bcsr.cusparseHandle, CUSPARSE_DIRECTION_COLUMN, CUSPARSE_OPERATION_NON_TRANSPOSE,
                    bcsr.nbBlockRow, bcsr.m, bcsr.nbBlocks, &alpha, descr,
                    bcsr.cu_bsrValC, bcsr.cu_bsrRowPtrC, bcsr.cu_bsrColIndC, bcsr.blockSize,


### PR DESCRIPTION
[Reason] cusparseDbsrmv is supported now:
         https://github.com/ROCmSoftwarePlatform/hipSPARSE/pull/102
         https://github.com/ROCm-Developer-Tools/HIPIFY/pull/96