### PR TITLE
[HIPIFY] Set configurable install path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,11 @@ if (MSVC AND MSVC_VERSION VERSION_LESS "1900")
     return()
 endif()
 
+#Set configurable install path
+if (UNIX)
+    set(CPACK_PACKAGING_INSTALL_PREFIX "/opt/rocm/hip" CACHE PATH "Package Installation path for HIP")
+endif (UNIX)
+
 find_package(LLVM REQUIRED)
 message(STATUS "Found LLVM ${LLVM_PACKAGE_VERSION}:")
 message(STATUS "   - CMake module path: ${LLVM_CMAKE_DIR}")

--- a/packaging/hipify-clang.txt
+++ b/packaging/hipify-clang.txt
@@ -8,7 +8,7 @@ install(DIRECTORY @HIPIFY_INSTALL_PATH@/include DESTINATION bin)
 # Packaging steps
 #############################
 set(CPACK_SET_DESTDIR TRUE)
-set(CPACK_INSTALL_PREFIX "/opt/rocm/hip")
+set(CPACK_INSTALL_PREFIX @CPACK_PACKAGING_INSTALL_PREFIX@)
 set(CPACK_PACKAGE_NAME "hipify-clang")
 set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "hipify-clang: a clang-based tool to translate CUDA source code into portable HIP C++ automatically")
 set(CPACK_PACKAGE_VENDOR "Advanced Micro Devices, Inc.")


### PR DESCRIPTION
Add capability to build package as per user choice.
If the parameter CPACK_PACKAGING_INSTALL_PREFIXX is not provided, 
default to /opt/rocm/hip