### PR TITLE
[HIPIFY][fix] Explicit #include <system_error> for std::error_code

### DIFF
--- a/src/StringUtils.h
+++ b/src/StringUtils.h
@@ -23,6 +23,7 @@ THE SOFTWARE.
 #pragma once
 
 #include <string>
+#include <system_error>
 #include "llvm/ADT/StringRef.h"
 
 /**


### PR DESCRIPTION
The issue appeared with VS 2019 16.6.0, where std is redesigned to support some C++20 features.