### PR TITLE
[HIPIFY][fix] Remove unsupported CUDA API from a cuRAND test

### DIFF
--- a/tests/unit_tests/libraries/cuRAND/benchmark_curand_kernel.cpp
+++ b/tests/unit_tests/libraries/cuRAND/benchmark_curand_kernel.cpp
@@ -621,7 +621,6 @@ int main(int argc, char *argv[])
     // cudaRuntimeGetVersion is yet unsupported by HIP
     // CHECK: CUDA_CALL(hipRuntimeGetVersion(&runtime_version));
     CUDA_CALL(cudaRuntimeGetVersion(&runtime_version));
-    CUDA_CALL(cuGLInit());
     int device_id;
     // CHECK: CUDA_CALL(hipGetDevice(&device_id));
     // CHECK: hipDeviceProp_t props;


### PR DESCRIPTION
Unsupported API GL cuGLInit was not only reported as unsupported and deprecated but led to an error due to the missing include to cudaGL.h.
cuGLInit was added to the test for testing warning on deprecated API.

[ToDo] Tests on different types of warnings.