### PR TITLE
[HIPIFY][#92][#126] Fix clang internal includes

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -127,10 +127,14 @@ void appendArgumentsAdjusters(ct::RefactoringTool &Tool, const std::string &sSou
   std::string clang_inc_path = std::string(llvm::sys::path::parent_path(hipify));
   clang_inc_path.append("/include");
   Tool.appendArgumentsAdjuster(ct::getInsertArgumentAdjuster(clang_inc_path.c_str(), ct::ArgumentInsertPosition::BEGIN));
-  Tool.appendArgumentsAdjuster(ct::getInsertArgumentAdjuster("-isystem", ct::ArgumentInsertPosition::BEGIN));
+  Tool.appendArgumentsAdjuster(ct::getInsertArgumentAdjuster("-Xclang", ct::ArgumentInsertPosition::BEGIN));
+  Tool.appendArgumentsAdjuster(ct::getInsertArgumentAdjuster("-internal-isystem", ct::ArgumentInsertPosition::BEGIN));
+  Tool.appendArgumentsAdjuster(ct::getInsertArgumentAdjuster("-Xclang", ct::ArgumentInsertPosition::BEGIN));
   clang_inc_path.append("/cuda_wrappers");
   Tool.appendArgumentsAdjuster(ct::getInsertArgumentAdjuster(clang_inc_path.c_str(), ct::ArgumentInsertPosition::BEGIN));
-  Tool.appendArgumentsAdjuster(ct::getInsertArgumentAdjuster("-isystem", ct::ArgumentInsertPosition::BEGIN));
+  Tool.appendArgumentsAdjuster(ct::getInsertArgumentAdjuster("-Xclang", ct::ArgumentInsertPosition::BEGIN));
+  Tool.appendArgumentsAdjuster(ct::getInsertArgumentAdjuster("-internal-isystem", ct::ArgumentInsertPosition::BEGIN));
+  Tool.appendArgumentsAdjuster(ct::getInsertArgumentAdjuster("-Xclang", ct::ArgumentInsertPosition::BEGIN));
   // Ensure at least c++11 is used.
   std::string stdCpp = "-std=c++11";
 #if defined(_MSC_VER)


### PR DESCRIPTION
Instead of proposed in #126 removing of the corresponding clang source include paths, the analogous include paths to hipify-clang dist was changed:

`-isystem <dist>/include` => `-Xclang -internal-isystem -Xclang <dist>/include`
`-isystem <dist>/include/cuda_wrapper` => `-Xclang -internal-isystem -Xclang <dist>/include/cuda_wrapper`

It allows coexisting both source clang includes and hipify-clang dist includes. If source LLVM/clang is deleted/renamed or moved installed hipify-clang continue works properly using its header files from dist/include subfolder.

This PR fixes #92 as well.