### PR TITLE
[HIPIFY][tests][#132] Exclude cudnn_convolution_forward.cu test if CUDA 11.0 and higher

### DIFF
--- a/tests/lit.cfg
+++ b/tests/lit.cfg
@@ -65,6 +65,7 @@ if config.llvm_version_major < 10:
 
 if config.cuda_version_major > 10:
     clang_arguments += " -DTHRUST_IGNORE_CUB_VERSION_CHECK"
+    config.excludes.append('cudnn_convolution_forward.cu')
 
 # name: The name of this test suite.
 config.name = 'hipify'


### PR DESCRIPTION
[Reason] cuDNN v.8.0 for CUDA 11 is changed a lot: many APIs were removed, for instance, cudnnGetConvolutionForwardAlgorithm().