### PR TITLE
[HIPIFY][tests][#131] Exclude cuSparse 01, 02, and 12 tests if CUDA 11.0 and higher

### DIFF
--- a/tests/lit.cfg
+++ b/tests/lit.cfg
@@ -66,6 +66,9 @@ if config.llvm_version_major < 10:
 if config.cuda_version_major > 10:
     clang_arguments += " -DTHRUST_IGNORE_CUB_VERSION_CHECK"
     config.excludes.append('cudnn_convolution_forward.cu')
+    config.excludes.append('cuSPARSE_01.cu')
+    config.excludes.append('cuSPARSE_02.cu')
+    config.excludes.append('cuSPARSE_12.cu')
 
 # name: The name of this test suite.
 config.name = 'hipify'


### PR DESCRIPTION
[Reason] cuSPARSE for CUDA 11 is changed a lot: many deprecated APIs were removed
[ToDo] Implement alternate cuSparse tests for CUDA 11
