### PR TITLE
[HIPIFY] CUDA 11.0 Driver API support

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -1214,10 +1214,16 @@ sub simpleSubstitutions {
     $ft{'type'} += s/\bCUDA_ARRAY3D_DESCRIPTOR_st\b/HIP_ARRAY3D_DESCRIPTOR/g;
     $ft{'type'} += s/\bCUDA_ARRAY_DESCRIPTOR\b/HIP_ARRAY_DESCRIPTOR/g;
     $ft{'type'} += s/\bCUDA_ARRAY_DESCRIPTOR_st\b/HIP_ARRAY_DESCRIPTOR/g;
+    $ft{'type'} += s/\bCUDA_ARRAY_DESCRIPTOR_v1\b/HIP_ARRAY_DESCRIPTOR/g;
+    $ft{'type'} += s/\bCUDA_ARRAY_DESCRIPTOR_v1_st\b/HIP_ARRAY_DESCRIPTOR/g;
     $ft{'type'} += s/\bCUDA_MEMCPY2D\b/hip_Memcpy2D/g;
     $ft{'type'} += s/\bCUDA_MEMCPY2D_st\b/hip_Memcpy2D/g;
+    $ft{'type'} += s/\bCUDA_MEMCPY2D_v1\b/hip_Memcpy2D/g;
+    $ft{'type'} += s/\bCUDA_MEMCPY2D_v1_st\b/hip_Memcpy2D/g;
     $ft{'type'} += s/\bCUDA_MEMCPY3D\b/HIP_MEMCPY3D/g;
     $ft{'type'} += s/\bCUDA_MEMCPY3D_st\b/HIP_MEMCPY3D/g;
+    $ft{'type'} += s/\bCUDA_MEMCPY3D_v1\b/HIP_MEMCPY3D/g;
+    $ft{'type'} += s/\bCUDA_MEMCPY3D_v1_st\b/HIP_MEMCPY3D/g;
     $ft{'type'} += s/\bCUaddress_mode\b/hipTextureAddressMode/g;
     $ft{'type'} += s/\bCUaddress_mode_enum\b/hipTextureAddressMode/g;
     $ft{'type'} += s/\bCUarray\b/hipArray */g;
@@ -1232,6 +1238,7 @@ sub simpleSubstitutions {
     $ft{'type'} += s/\bCUdevice_attribute\b/hipDeviceAttribute_t/g;
     $ft{'type'} += s/\bCUdevice_attribute_enum\b/hipDeviceAttribute_t/g;
     $ft{'type'} += s/\bCUdeviceptr\b/hipDeviceptr_t/g;
+    $ft{'type'} += s/\bCUdeviceptr_v1\b/hipDeviceptr_t/g;
     $ft{'type'} += s/\bCUevent\b/hipEvent_t/g;
     $ft{'type'} += s/\bCUevent_st\b/ihipEvent_t/g;
     $ft{'type'} += s/\bCUfilter_mode\b/hipTextureFilterMode/g;
@@ -3739,6 +3746,7 @@ sub warnUnsupportedFunctions {
         "CUmemAllocationProp_st",
         "CUmemAttach_flags",
         "CUmemAttach_flags_enum",
+        "CUmemGenericAllocationHandle",
         "CUmemLocation",
         "CUmemLocationType",
         "CUmemLocationType_enum",
@@ -3802,6 +3810,7 @@ sub warnUnsupportedFunctions {
         "cuArrayGetDescriptor_v2",
         "cuCtxAttach",
         "cuCtxDetach",
+        "cuCtxResetPersistingL2Cache",
         "cuD3D10CtxCreate",
         "cuD3D10CtxCreateOnDevice",
         "cuD3D10GetDevice",
@@ -3856,6 +3865,7 @@ sub warnUnsupportedFunctions {
         "cuEventCreateFromEGLSync",
         "cuExternalMemoryGetMappedBuffer",
         "cuExternalMemoryGetMappedMipmappedArray",
+        "cuFuncGetModule",
         "cuFuncSetAttribute",
         "cuFuncSetBlockShape",
         "cuFuncSetCacheConfig",
@@ -3898,7 +3908,10 @@ sub warnUnsupportedFunctions {
         "cuGraphHostNodeSetParams",
         "cuGraphInstantiate",
         "cuGraphInstantiate_v2",
+        "cuGraphKernelNodeCopyAttributes",
+        "cuGraphKernelNodeGetAttribute",
         "cuGraphKernelNodeGetParams",
+        "cuGraphKernelNodeSetAttribute",
         "cuGraphKernelNodeSetParams",
         "cuGraphLaunch",
         "cuGraphMemcpyNodeGetParams",
@@ -3960,6 +3973,7 @@ sub warnUnsupportedFunctions {
         "cuMemRangeGetAttribute",
         "cuMemRangeGetAttributes",
         "cuMemRelease",
+        "cuMemRetainAllocationHandle",
         "cuMemSetAccess",
         "cuMemUnmap",
         "cuMemcpy",
@@ -3994,6 +4008,7 @@ sub warnUnsupportedFunctions {
         "cuMipmappedArrayGetLevel",
         "cuModuleGetSurfRef",
         "cuModuleLoadFatBinary",
+        "cuOccupancyAvailableDynamicSMemPerBlock",
         "cuOccupancyMaxPotentialBlockSizeWithFlags",
         "cuParamSetSize",
         "cuParamSetTexRef",
@@ -4010,10 +4025,13 @@ sub warnUnsupportedFunctions {
         "cuStreamBeginCapture",
         "cuStreamBeginCapture_ptsz",
         "cuStreamBeginCapture_v2",
+        "cuStreamCopyAttributes",
         "cuStreamEndCapture",
+        "cuStreamGetAttribute",
         "cuStreamGetCaptureInfo",
         "cuStreamGetCtx",
         "cuStreamIsCapturing",
+        "cuStreamSetAttribute",
         "cuStreamWaitValue32",
         "cuStreamWaitValue64",
         "cuStreamWriteValue32",

--- a/src/CUDA2HIP_Driver_API_functions.cpp
+++ b/src/CUDA2HIP_Driver_API_functions.cpp
@@ -102,6 +102,7 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_FUNCTION_MAP{
   {"cuCtxPushCurrent",                                     {"hipCtxPushCurrent",                                       "", CONV_CONTEXT, API_DRIVER}},
   {"cuCtxPushCurrent_v2",                                  {"hipCtxPushCurrent",                                       "", CONV_CONTEXT, API_DRIVER}},
   {"cuCtxSetCacheConfig",                                  {"hipCtxSetCacheConfig",                                    "", CONV_CONTEXT, API_DRIVER}},
+  {"cuCtxResetPersistingL2Cache",                          {"hipCtxResetPersistingL2Cache",                            "", CONV_CONTEXT, API_DRIVER, HIP_UNSUPPORTED}},
   {"cuCtxSetCurrent",                                      {"hipCtxSetCurrent",                                        "", CONV_CONTEXT, API_DRIVER}},
   // cudaDeviceSetLimit
   {"cuCtxSetLimit",                                        {"hipDeviceSetLimit",                                       "", CONV_CONTEXT, API_DRIVER}},
@@ -327,6 +328,7 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_FUNCTION_MAP{
   {"cuMemImportFromShareableHandle",                       {"hipMemImportFromShareableHandle",                         "", CONV_VIRTUAL_MEMORY, API_DRIVER, HIP_UNSUPPORTED}},
   {"cuMemMap",                                             {"hipMemMap",                                               "", CONV_VIRTUAL_MEMORY, API_DRIVER, HIP_UNSUPPORTED}},
   {"cuMemRelease",                                         {"hipMemRelease",                                           "", CONV_VIRTUAL_MEMORY, API_DRIVER, HIP_UNSUPPORTED}},
+  {"cuMemRetainAllocationHandle",                          {"hipMemRetainAllocationHandle",                            "", CONV_VIRTUAL_MEMORY, API_DRIVER, HIP_UNSUPPORTED}},
   {"cuMemSetAccess",                                       {"hipMemSetAccess",                                         "", CONV_VIRTUAL_MEMORY, API_DRIVER, HIP_UNSUPPORTED}},
   {"cuMemUnmap",                                           {"hipMemUnmap",                                             "", CONV_VIRTUAL_MEMORY, API_DRIVER, HIP_UNSUPPORTED}},
 
@@ -356,6 +358,7 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_FUNCTION_MAP{
   {"cuStreamBeginCapture",                                 {"hipStreamBeginCapture",                                   "", CONV_STREAM, API_DRIVER, HIP_UNSUPPORTED}},
   {"cuStreamBeginCapture_v2",                              {"hipStreamBeginCapture",                                   "", CONV_STREAM, API_DRIVER, HIP_UNSUPPORTED}},
   {"cuStreamBeginCapture_ptsz",                            {"hipStreamBeginCapture",                                   "", CONV_STREAM, API_DRIVER, HIP_UNSUPPORTED}},
+  {"cuStreamCopyAttributes",                               {"hipStreamCopyAttributes",                                 "", CONV_STREAM, API_DRIVER, HIP_UNSUPPORTED}},
   // cudaStreamCreateWithFlags
   {"cuStreamCreate",                                       {"hipStreamCreateWithFlags",                                "", CONV_STREAM, API_DRIVER}},
   // cudaStreamCreateWithPriority
@@ -365,6 +368,8 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_FUNCTION_MAP{
   {"cuStreamDestroy_v2",                                   {"hipStreamDestroy",                                        "", CONV_STREAM, API_DRIVER}},
   // cudaStreamEndCapture
   {"cuStreamEndCapture",                                   {"hipStreamEndCapture",                                     "", CONV_STREAM, API_DRIVER, HIP_UNSUPPORTED}},
+  //
+  {"cuStreamGetAttribute",                                 {"hipStreamGetAttribute",                                   "", CONV_STREAM, API_DRIVER, HIP_UNSUPPORTED}},
   // cudaStreamGetCaptureInfo
   {"cuStreamGetCaptureInfo",                               {"hipStreamGetCaptureInfo",                                 "", CONV_STREAM, API_DRIVER, HIP_UNSUPPORTED}},
   // no analogue
@@ -377,6 +382,8 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_FUNCTION_MAP{
   {"cuStreamIsCapturing",                                  {"hipStreamIsCapturing",                                    "", CONV_STREAM, API_DRIVER, HIP_UNSUPPORTED}},
   // cudaStreamQuery
   {"cuStreamQuery",                                        {"hipStreamQuery",                                          "", CONV_STREAM, API_DRIVER}},
+  //
+  {"cuStreamSetAttribute",                                 {"hipStreamSetAttribute",                                   "", CONV_STREAM, API_DRIVER, HIP_UNSUPPORTED}},
   // cudaStreamSynchronize
   {"cuStreamSynchronize",                                  {"hipStreamSynchronize",                                    "", CONV_STREAM, API_DRIVER}},
   // cudaStreamWaitEvent
@@ -428,6 +435,8 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_FUNCTION_MAP{
   // 5.18.Execution Control
   // no analogue
   {"cuFuncGetAttribute",                                   {"hipFuncGetAttribute",                                     "", CONV_EXECUTION, API_DRIVER}},
+  //
+  {"cuFuncGetModule",                                      {"hipFuncGetModule",                                        "", CONV_EXECUTION, API_DRIVER, HIP_UNSUPPORTED}},
   // no analogue
   // NOTE: Not equal to cudaFuncSetAttribute due to different signatures
   {"cuFuncSetAttribute",                                   {"hipFuncSetAttribute",                                     "", CONV_EXECUTION, API_DRIVER, HIP_UNSUPPORTED}},
@@ -512,10 +521,16 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_FUNCTION_MAP{
   // cudaGraphInstantiate
   {"cuGraphInstantiate",                                   {"hipGraphInstantiate",                                     "", CONV_GRAPH, API_DRIVER, HIP_UNSUPPORTED}},
   {"cuGraphInstantiate_v2",                                {"hipGraphInstantiate",                                     "", CONV_GRAPH, API_DRIVER, HIP_UNSUPPORTED}},
+  //
+  {"cuGraphKernelNodeCopyAttributes",                      {"hipGraphKernelNodeCopyAttributes",                        "", CONV_GRAPH, API_DRIVER, HIP_UNSUPPORTED}},
+  //
+  {"cuGraphKernelNodeGetAttribute",                        {"hipGraphKernelNodeGetAttribute",                          "", CONV_GRAPH, API_DRIVER, HIP_UNSUPPORTED}},
   // cudaGraphExecKernelNodeSetParams
   {"cuGraphExecKernelNodeSetParams",                       {"hipGraphExecKernelNodeSetParams",                         "", CONV_GRAPH, API_DRIVER, HIP_UNSUPPORTED}},
   // cudaGraphKernelNodeGetParams
   {"cuGraphKernelNodeGetParams",                           {"hipGraphKernelNodeGetParams",                             "", CONV_GRAPH, API_DRIVER, HIP_UNSUPPORTED}},
+  //
+  {"cuGraphKernelNodeSetAttribute",                        {"hipGraphKernelNodeSetAttribute",                          "", CONV_GRAPH, API_DRIVER, HIP_UNSUPPORTED}},
   // cudaGraphKernelNodeSetParams
   {"cuGraphKernelNodeSetParams",                           {"hipGraphKernelNodeSetParams",                             "", CONV_GRAPH, API_DRIVER, HIP_UNSUPPORTED}},
   // cudaGraphLaunch
@@ -548,6 +563,8 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_FUNCTION_MAP{
   {"cuGraphExecUpdate",                                    {"hipGraphExecUpdate",                                      "", CONV_GRAPH, API_DRIVER, HIP_UNSUPPORTED}},
 
   // 5.21. Occupancy
+  //
+  {"cuOccupancyAvailableDynamicSMemPerBlock",              {"hipOccupancyAvailableDynamicSMemPerBlock",                "", CONV_OCCUPANCY, API_DRIVER, HIP_UNSUPPORTED}},
   // cudaOccupancyMaxActiveBlocksPerMultiprocessor
   {"cuOccupancyMaxActiveBlocksPerMultiprocessor",          {"hipDrvOccupancyMaxActiveBlocksPerMultiprocessor",         "", CONV_OCCUPANCY, API_DRIVER}},
   // cudaOccupancyMaxActiveBlocksPerMultiprocessorWithFlags

--- a/src/CUDA2HIP_Driver_API_types.cpp
+++ b/src/CUDA2HIP_Driver_API_types.cpp
@@ -31,7 +31,9 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_TYPE_NAME_MAP{
   {"CUDA_ARRAY3D_DESCRIPTOR",                                          {"HIP_ARRAY3D_DESCRIPTOR",                                   "", CONV_TYPE, API_DRIVER}},
 
   {"CUDA_ARRAY_DESCRIPTOR_st",                                         {"HIP_ARRAY_DESCRIPTOR",                                     "", CONV_TYPE, API_DRIVER}},
+  {"CUDA_ARRAY_DESCRIPTOR_v1_st",                                      {"HIP_ARRAY_DESCRIPTOR",                                     "", CONV_TYPE, API_DRIVER}},
   {"CUDA_ARRAY_DESCRIPTOR",                                            {"HIP_ARRAY_DESCRIPTOR",                                     "", CONV_TYPE, API_DRIVER}},
+  {"CUDA_ARRAY_DESCRIPTOR_v1",                                         {"HIP_ARRAY_DESCRIPTOR",                                     "", CONV_TYPE, API_DRIVER}},
 
   // cudaExternalMemoryBufferDesc
   {"CUDA_EXTERNAL_MEMORY_BUFFER_DESC_st",                              {"HIP_EXTERNAL_MEMORY_BUFFER_DESC",                          "", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED}},
@@ -71,11 +73,15 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_TYPE_NAME_MAP{
   {"CUDA_LAUNCH_PARAMS",                                               {"hipLaunchParams",                                          "", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED}},
 
   {"CUDA_MEMCPY2D_st",                                                 {"hip_Memcpy2D",                                             "", CONV_TYPE, API_DRIVER}},
+  {"CUDA_MEMCPY2D_v1_st",                                              {"hip_Memcpy2D",                                             "", CONV_TYPE, API_DRIVER}},
   {"CUDA_MEMCPY2D",                                                    {"hip_Memcpy2D",                                             "", CONV_TYPE, API_DRIVER}},
+  {"CUDA_MEMCPY2D_v1",                                                 {"hip_Memcpy2D",                                             "", CONV_TYPE, API_DRIVER}},
 
   // no analogue
   {"CUDA_MEMCPY3D_st",                                                 {"HIP_MEMCPY3D",                                             "", CONV_TYPE, API_DRIVER}},
+  {"CUDA_MEMCPY3D_v1_st",                                              {"HIP_MEMCPY3D",                                             "", CONV_TYPE, API_DRIVER}},
   {"CUDA_MEMCPY3D",                                                    {"HIP_MEMCPY3D",                                             "", CONV_TYPE, API_DRIVER}},
+  {"CUDA_MEMCPY3D_v1",                                                 {"HIP_MEMCPY3D",                                             "", CONV_TYPE, API_DRIVER}},
 
   {"CUDA_MEMCPY3D_PEER_st",                                            {"hip_Memcpy3D_Peer",                                        "", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED}},
   {"CUDA_MEMCPY3D_PEER",                                               {"hip_Memcpy3D_Peer",                                        "", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED}},
@@ -1591,6 +1597,7 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_TYPE_NAME_MAP{
   // no analogue
   {"CUdevice",                                                         {"hipDevice_t",                                              "", CONV_TYPE, API_DRIVER}},
   {"CUdeviceptr",                                                      {"hipDeviceptr_t",                                           "", CONV_TYPE, API_DRIVER}},
+  {"CUdeviceptr_v1",                                                   {"hipDeviceptr_t",                                           "", CONV_TYPE, API_DRIVER}},
 
   // cudaHostFn_t
   {"CUhostFn",                                                         {"hipHostFn",                                                "", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED}},
@@ -1606,6 +1613,9 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_TYPE_NAME_MAP{
 
   // cudaTextureObject_t
   {"CUtexObject",                                                      {"hipTextureObject_t",                                       "", CONV_TYPE, API_DRIVER}},
+
+  //
+  {"CUmemGenericAllocationHandle",                                     {"hipMemGenericAllocationHandle",                            "", CONV_DEFINE, API_DRIVER, HIP_UNSUPPORTED}},
 
   // 5. Defines
 


### PR DESCRIPTION
+ Functions and data types from cuda.h only
+ Update hipify-perl accordingly

[ToDo] Update HIP's CUDA_Driver_API_functions_supported_by_HIP.md and hipify-perl accordingly