### PR TITLE
[HIPIFY][doc][tests] Revise functionality with the former LLVM versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,18 +49,20 @@ After applying all the matchers, the output HIP source is produced.
 
 | **LLVM release version**                                   | **CUDA latest supported version**                                        | **Windows** | **Linux** |
 |:----------------------------------------------------------:|:------------------------------------------------------------------------:|:-----------:|:---------:|
-| [3.8.0](http://releases.llvm.org/download.html#3.8.0) , [3.8.1](http://releases.llvm.org/download.html#3.8.1) , [3.9.0](http://releases.llvm.org/download.html#3.9.0) , [3.9.1](http://releases.llvm.org/download.html#3.9.1)    | [7.5](https://developer.nvidia.com/cuda-75-downloads-archive)            | +           | +         |
+| [3.8.0](http://releases.llvm.org/download.html#3.8.0)\* , [3.8.1](http://releases.llvm.org/download.html#3.8.1)\* , <br>[3.9.0](http://releases.llvm.org/download.html#3.9.0)\* , [3.9.1](http://releases.llvm.org/download.html#3.9.1)\*         | [7.5](https://developer.nvidia.com/cuda-75-downloads-archive)            | +           | +         |
 | [4.0.0](http://releases.llvm.org/download.html#4.0.0) , [4.0.1](http://releases.llvm.org/download.html#4.0.1) | [8.0](https://developer.nvidia.com/cuda-80-ga2-download-archive)         | +           | +         |
 | [5.0.0](http://releases.llvm.org/download.html#5.0.0) , [5.0.1](http://releases.llvm.org/download.html#5.0.1) , [5.0.2](http://releases.llvm.org/download.html#5.0.2) | [8.0](https://developer.nvidia.com/cuda-80-ga2-download-archive)         | +           | +         |
 | [6.0.0](http://releases.llvm.org/download.html#6.0.0) , [6.0.1](http://releases.llvm.org/download.html#6.0.1) | [9.0](https://developer.nvidia.com/cuda-90-download-archive)             | +           | +         |
-| [7.0.0](http://releases.llvm.org/download.html#7.0.0) , [7.0.1](http://releases.llvm.org/download.html#7.0.1) , [7.1.0](http://releases.llvm.org/download.html#7.1.0) | [9.2](https://developer.nvidia.com/cuda-92-download-archive)             | works only with the patch <br> due to the clang's bug [38811](https://bugs.llvm.org/show_bug.cgi?id=38811) <br> [patch for 7.0.0](patches/patch_for_clang_7.0.0_bug_38811.zip)\* <br> [patch for 7.0.1](patches/patch_for_clang_7.0.1_bug_38811.zip)\* <br> [patch for 7.1.0](patches/patch_for_clang_7.1.0_bug_38811.zip)\* | - <br> not working due to <br> the clang's bug [36384](https://bugs.llvm.org/show_bug.cgi?id=36384) |
-| [8.0.0](http://releases.llvm.org/download.html#8.0.0) , [8.0.1](http://releases.llvm.org/download.html#8.0.1) | [10.0](https://developer.nvidia.com/cuda-10.0-download-archive)          | works only with the patch <br> due to the clang's bug [38811](https://bugs.llvm.org/show_bug.cgi?id=38811) <br>[patch for 8.0.0](patches/patch_for_clang_8.0.0_bug_38811.zip)\* <br>[patch for 8.0.1](patches/patch_for_clang_8.0.1_bug_38811.zip)\*<br>| + |
+| [7.0.0](http://releases.llvm.org/download.html#7.0.0) , [7.0.1](http://releases.llvm.org/download.html#7.0.1) , [7.1.0](http://releases.llvm.org/download.html#7.1.0) | [9.2](https://developer.nvidia.com/cuda-92-download-archive)             | works only with the patch <br> due to the clang's bug [38811](https://bugs.llvm.org/show_bug.cgi?id=38811) <br> [patch for 7.0.0](patches/patch_for_clang_7.0.0_bug_38811.zip)\*\* <br> [patch for 7.0.1](patches/patch_for_clang_7.0.1_bug_38811.zip)\*\* <br> [patch for 7.1.0](patches/patch_for_clang_7.1.0_bug_38811.zip)\*\* | - <br> not working due to <br> the clang's bug [36384](https://bugs.llvm.org/show_bug.cgi?id=36384) |
+| [8.0.0](http://releases.llvm.org/download.html#8.0.0) , [8.0.1](http://releases.llvm.org/download.html#8.0.1) | [10.0](https://developer.nvidia.com/cuda-10.0-download-archive)          | works only with the patch <br> due to the clang's bug [38811](https://bugs.llvm.org/show_bug.cgi?id=38811) <br>[patch for 8.0.0](patches/patch_for_clang_8.0.0_bug_38811.zip)\*\* <br>[patch for 8.0.1](patches/patch_for_clang_8.0.1_bug_38811.zip)\*\*<br>| + |
 | [9.0.0](http://releases.llvm.org/download.html#9.0.0) , [9.0.1](http://releases.llvm.org/download.html#9.0.1) | [10.1](https://developer.nvidia.com/cuda-10.1-download-archive-base)     | +           | +         |
 | [10.0.0](http://releases.llvm.org/download.html#10.0.0)    | [11.0](https://developer.nvidia.com/cuda-downloads)                      | +           | +         |
 | [**10.0.1**](https://github.com/llvm/llvm-project/releases/tag/llvmorg-10.0.1) | [**11.0**](https://developer.nvidia.com/cuda-downloads)  | + <br/> **LATEST STABLE RELEASE** | + <br/> **LATEST STABLE RELEASE** |
 | [11.0.0-rc1](https://github.com/llvm/llvm-project/releases/tag/llvmorg-11.0.0-rc1) | [11.0](https://developer.nvidia.com/cuda-downloads)             | +           | +         |
 
-`*` Download the patch and unpack it into your `LLVM` distributive directory: a few header files will be overwritten; rebuilding of `LLVM` is not needed.
+`*`  `LLVM 3.x` is not supported anymore but might still work.
+
+`**` Download the patch and unpack it into your `LLVM` distributive directory: a few header files will be overwritten; rebuilding of `LLVM` is not needed.
 
 In most cases, you can get a suitable version of `LLVM+CLANG` with your package manager.
 
@@ -86,7 +88,7 @@ were compiling the input file. For example:
 
 The [Clang manual for compiling CUDA](https://llvm.org/docs/CompileCudaWithLLVM.html#compiling-cuda-code) may be useful.
 
-For some hipification automation, it is also possible to provide a [Compilation Database in JSON format](https://clang.llvm.org/docs/JSONCompilationDatabase.html) in the `compile_commands.json` file:
+For some hipification automation (starting from clang 8.0.0), it is also possible to provide a [Compilation Database in JSON format](https://clang.llvm.org/docs/JSONCompilationDatabase.html) in the `compile_commands.json` file:
 
 ```bash
 -p <folder containing compile_commands.json> or
@@ -200,9 +202,9 @@ Run `Visual Studio 16 2019`, open the generated `LLVM.sln`, build all, build pro
 
     * Path to cuDNN should be specified by the `CUDA_DNN_ROOT_DIR` option:
 
-        - ***Linux***: `-DCUDA_DNN_ROOT_DIR=/srv/CUDNN/cudnn-11.0-v8.0.1.13`
+        - ***Linux***: `-DCUDA_DNN_ROOT_DIR=/srv/CUDNN/cudnn-11.0-v8.0.2.39`
 
-        - ***Windows***: `-DCUDA_DNN_ROOT_DIR=d:/CUDNN/cudnn-11.0-windows10-x64-v8.0.1.13`
+        - ***Windows***: `-DCUDA_DNN_ROOT_DIR=d:/CUDNN/cudnn-11.0-windows10-x64-v8.0.2.39`
 
 5. Ensure [`CUB`](https://github.com/NVlabs/cub) of the version corresponding to CUDA's version is installed.
 
@@ -244,9 +246,9 @@ Run `Visual Studio 16 2019`, open the generated `LLVM.sln`, build all, build pro
 
 On Linux the following configurations are tested:
 
-Ubuntu 14: LLVM 5.0.0 - 7.1.0, CUDA 7.0 - 9.0, cuDNN 5.0.5 - 7.6.5.32
+Ubuntu 14: LLVM 4.0.0 - 7.1.0, CUDA 7.0 - 9.0, cuDNN 5.0.5 - 7.6.5.32
 
-Ubuntu 16-18: LLVM 8.0.0 - 11.0.0-rc1, CUDA 8.0 - 11.0, cuDNN 5.1.10 - 8.0.1.13
+Ubuntu 16-18: LLVM 8.0.0 - 11.0.0-rc1, CUDA 8.0 - 11.0, cuDNN 5.1.10 - 8.0.2.39
 
 Minimum build system requirements for the above configurations:
 
@@ -261,7 +263,7 @@ cmake
  -DCMAKE_INSTALL_PREFIX=../dist \
  -DCMAKE_PREFIX_PATH=/srv/git/LLVM/10.0.1/dist \
  -DCUDA_TOOLKIT_ROOT_DIR=/usr/local/cuda-11.0 \
- -DCUDA_DNN_ROOT_DIR=/srv/CUDNN/cudnn-11.0-v8.0.1.13 \
+ -DCUDA_DNN_ROOT_DIR=/srv/CUDNN/cudnn-11.0-v8.0.2.39 \
  -DCUDA_CUB_ROOT_DIR=/srv/git/CUB \
  -DLLVM_EXTERNAL_LIT=/srv/git/LLVM/10.0.1/build/bin/llvm-lit \
  ..
@@ -397,15 +399,15 @@ Testing Time: 3.28s
 
 *Tested configurations:*
 
-|      **LLVM**       |  **CUDA**   |      **cuDNN**      | **Visual Studio (latest)**| **cmake** | **Python** |
-|:-------------------:|------------:|--------------------:|--------------------------:|----------:|-----------:|
-| 5.0.0 - 5.0.2       | 8.0         | 5.1.10   - 7.1.4.18 | 2017.15.5.2               | 3.5.1     | 3.6.4      |
-| 6.0.0 - 6.0.1       | 9.0         | 7.0.5.15 - 7.6.5.32 | 2017.15.5.5               | 3.6.0     | 3.7.2      |
-| 7.0.0 - 7.1.0       | 9.2         | 7.6.5.32            | 2017.15.9.11              | 3.13.3    | 3.7.3      |
-| 8.0.0 - 8.0.1       | 10.0        | 7.6.5.32            | 2017.15.9.15              | 3.14.2    | 3.7.4      |
-| 9.0.0 - 9.0.1       | 10.1        | 7.6.5.32            | 2017.15.9.20, 2019.16.4.5 | 3.16.4    | 3.8.0      |
-| 10.0.0 - 11.0.0-rc1 | 10.0 - 11.0 | 7.6.5.32 - 8.0.1.13 | 2017.15.9.25, 2019.16.6.5 | 3.18.0    | 3.8.5      |
-| 12.0.0git           | 10.0 - 11.0 | 7.6.5.32 - 8.0.1.13 | 2017.15.9.25, 2019.16.6.5 | 3.18.0    | 3.8.5      |
+|      **LLVM**       |  **CUDA**  |      **cuDNN**      | **Visual Studio (latest)**|   **cmake**    |  **Python**  |
+|--------------------:|-----------:|--------------------:|--------------------------:|---------------:|-------------:|
+| 4.0.0 - 5.0.2       | 8.0        | 5.1.10   - 7.1.4.18 | 2015.14.0, 2017.15.5.2    | 3.5.1, 3.18.0  | 3.6.4, 3.8.5 |
+| 6.0.0 - 6.0.1       | 9.0        | 7.0.5.15 - 7.6.5.32 | 2015.14.0, 2017.15.5.5    | 3.6.0, 3.18.0  | 3.7.2, 3.8.5 |
+| 7.0.0 - 7.1.0       | 9.2        | 7.6.5.32            | 2017.15.9.11              | 3.13.3, 3.18.0 | 3.7.3, 3.8.5 |
+| 8.0.0 - 8.0.1       | 10.0       | 7.6.5.32            | 2017.15.9.15              | 3.14.2, 3.18.0 | 3.7.4, 3.8.5 |
+| 9.0.0 - 9.0.1       | 10.1       | 7.6.5.32            | 2017.15.9.20, 2019.16.4.5 | 3.16.4, 3.18.0 | 3.8.0, 3.8.5 |
+| 10.0.0 - 11.0.0-rc1 | 8.0 - 11.0 | 7.6.5.32 - 8.0.2.39 | 2017.15.9.25, 2019.16.6.5 | 3.18.0         | 3.8.5        |
+| 12.0.0git           | 8.0 - 11.0 | 7.6.5.32 - 8.0.2.39 | 2017.15.9.25, 2019.16.6.5 | 3.18.0         | 3.8.5        |
 
 *Building with testing support by `Visual Studio 16 2019` on `Windows 10`:*
 
@@ -419,7 +421,7 @@ cmake
  -DCMAKE_PREFIX_PATH=d:/LLVM/10.0.1/dist \
  -DCUDA_TOOLKIT_ROOT_DIR="c:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v11.0" \
  -DCUDA_SDK_ROOT_DIR="c:/ProgramData/NVIDIA Corporation/CUDA Samples/v11.0" \
- -DCUDA_DNN_ROOT_DIR=d:/CUDNN/cudnn-11.0-windows10-x64-v8.0.1.13 \
+ -DCUDA_DNN_ROOT_DIR=d:/CUDNN/cudnn-11.0-windows10-x64-v8.0.2.39 \
  -DCUDA_CUB_ROOT_DIR=d:/GIT/cub \
  -DLLVM_EXTERNAL_LIT=d:/LLVM/10.0.1/build/Release/bin/llvm-lit.py \
  -Thost=x64

--- a/tests/lit.cfg
+++ b/tests/lit.cfg
@@ -60,6 +60,9 @@ if config.cuda_version_major < 10:
     config.excludes.append('cuSPARSE_10.cu')
     config.excludes.append('cuSPARSE_11.cu')
 
+if config.llvm_version_major < 8:
+    config.excludes.append('cd_intro.cu')
+
 if config.llvm_version_major < 10:
     config.excludes.append('pp_if_else_conditionals_LLVM_10.cu')
     config.excludes.append('pp_if_else_conditionals_01_LLVM_10.cu')


### PR DESCRIPTION
+ Confirmation: hipify-clang work smoothly with former LLVM versions from 4.0.x to 10.0.x
+ LLVM 3.x is not supported anymore but might still work
+ Update Readme.md and lit testing accordingly