### PR TITLE
[HIPIFY][perl] Added redo if to the generated PERL

### DIFF
--- a/src/CUDA2HIP_Perl.cpp
+++ b/src/CUDA2HIP_Perl.cpp
@@ -459,7 +459,7 @@ namespace perl {
     *streamPtr.get() << tab_5 << "$line_num++;" << endl;
     *streamPtr.get() << tab_5 << "# Remove any whitelisted words" << endl;
     *streamPtr.get() << tab_5 << foreach << "$w (@whitelist) {" << endl;
-    *streamPtr.get() << tab_6 << "s/\\b$w\\b/ZAP/" << endl_tab_5 << "}" << endl;
+    *streamPtr.get() << tab_6 << "redo if s/\\b$w\\b/ZAP/" << endl_tab_5 << "}" << endl;
     *streamPtr.get() << tab_5 << my << "$tag;" << endl;
     *streamPtr.get() << tab_5 << "if ((/(\\bcuda[A-Z]\\w+)/) or (/<<<.*>>>/)) {" << endl;
     *streamPtr.get() << tab_6 << "# Flag any remaining code that look like cuda API calls: may want to add these to hipify" << endl;


### PR DESCRIPTION
Hi All, this is a quick pull to fix a bug with the whitelist behaviour of hipify-perl.  The bug is as follows: The regular expression which replaces the whitelisted 'cudaXXXX' function call with 'ZAP' acts on the first occurrence of the whitelisted 'cudaXXX' and then goes on to the next line. As such it doesn't appropriately ignore lines such as:

``` void cloverDerivative(
      cudaGaugeField &force, cudaGaugeField &gauge, cudaGaugeField &oprod, double coeff, QudaParity parity)```

where the line 

``` cudaGaugeField &force, cudaGaugeField &gauge, cudaGaugeField &oprod, double coeff, QudaParity parity)```

is only zapped to 

```ZAP &force, cudaGaugeField &gauge, cudaGaugeField &oprod, double coeff, QudaParity parity)```

By inserting `redo if` in front of the regex  doing the zapping, as is done in this PR, the regex will keep being applied until there are no more instances of the whitelisted word left. 

This PR has been discussed with Evgeniy Mankov & Nick Curtis at AMD, and I have verified its correctness by rebuilding hipify-clang.