### PR TITLE
[HIPIFY] Add initial support of CUDA deprecated and removed APIs' versioning

### DIFF
--- a/src/CUDA2HIP.cpp
+++ b/src/CUDA2HIP.cpp
@@ -107,3 +107,28 @@ const std::map<llvm::StringRef, hipCounter> &CUDA_RENAMES_MAP() {
   ret.insert(CUDA_CAFFE2_FUNCTION_MAP.begin(), CUDA_CAFFE2_FUNCTION_MAP.end());
   return ret;
 };
+
+const std::map<llvm::StringRef, cudaAPIversions>& CUDA_VERSIONS_MAP() {
+  static std::map<llvm::StringRef, cudaAPIversions> ret;
+  if (!ret.empty())
+    return ret;
+  // First run, so compute the union map.
+  ret.insert(CUDA_DRIVER_TYPE_NAME_VER_MAP.begin(), CUDA_DRIVER_TYPE_NAME_VER_MAP.end());
+  ret.insert(CUDA_DRIVER_FUNCTION_VER_MAP.begin(), CUDA_DRIVER_FUNCTION_VER_MAP.end());
+  ret.insert(CUDA_RUNTIME_TYPE_NAME_VER_MAP.begin(), CUDA_RUNTIME_TYPE_NAME_VER_MAP.end());
+  ret.insert(CUDA_RUNTIME_FUNCTION_VER_MAP.begin(), CUDA_RUNTIME_FUNCTION_VER_MAP.end());
+  ret.insert(CUDA_COMPLEX_TYPE_NAME_VER_MAP.begin(), CUDA_COMPLEX_TYPE_NAME_VER_MAP.end());
+  ret.insert(CUDA_COMPLEX_FUNCTION_VER_MAP.begin(), CUDA_COMPLEX_FUNCTION_VER_MAP.end());
+  ret.insert(CUDA_BLAS_TYPE_NAME_VER_MAP.begin(), CUDA_BLAS_TYPE_NAME_VER_MAP.end());
+  ret.insert(CUDA_BLAS_FUNCTION_VER_MAP.begin(), CUDA_BLAS_FUNCTION_VER_MAP.end());
+  ret.insert(CUDA_RAND_TYPE_NAME_VER_MAP.begin(), CUDA_RAND_TYPE_NAME_VER_MAP.end());
+  ret.insert(CUDA_RAND_FUNCTION_VER_MAP.begin(), CUDA_RAND_FUNCTION_VER_MAP.end());
+  ret.insert(CUDA_DNN_TYPE_NAME_VER_MAP.begin(), CUDA_DNN_TYPE_NAME_VER_MAP.end());
+  ret.insert(CUDA_DNN_FUNCTION_VER_MAP.begin(), CUDA_DNN_FUNCTION_VER_MAP.end());
+  ret.insert(CUDA_FFT_TYPE_NAME_VER_MAP.begin(), CUDA_FFT_TYPE_NAME_VER_MAP.end());
+  ret.insert(CUDA_FFT_FUNCTION_VER_MAP.begin(), CUDA_FFT_FUNCTION_VER_MAP.end());
+  ret.insert(CUDA_SPARSE_TYPE_NAME_VER_MAP.begin(), CUDA_SPARSE_TYPE_NAME_VER_MAP.end());
+  ret.insert(CUDA_SPARSE_FUNCTION_VER_MAP.begin(), CUDA_SPARSE_FUNCTION_VER_MAP.end());
+  ret.insert(CUDA_CAFFE2_TYPE_NAME_VER_MAP.begin(), CUDA_CAFFE2_TYPE_NAME_VER_MAP.end());
+  ret.insert(CUDA_CAFFE2_FUNCTION_VER_MAP.begin(), CUDA_CAFFE2_FUNCTION_VER_MAP.end());
+};

--- a/src/CUDA2HIP.h
+++ b/src/CUDA2HIP.h
@@ -79,3 +79,31 @@ extern const std::map<llvm::StringRef, hipCounter> CUDA_CUB_TYPE_NAME_MAP;
   * a great deal of time.
   */
 const std::map<llvm::StringRef, hipCounter> &CUDA_RENAMES_MAP();
+
+extern const std::map<llvm::StringRef, cudaAPIversions> CUDA_DRIVER_TYPE_NAME_VER_MAP;
+extern const std::map<llvm::StringRef, cudaAPIversions> CUDA_DRIVER_FUNCTION_VER_MAP;
+extern const std::map<llvm::StringRef, cudaAPIversions> CUDA_RUNTIME_TYPE_NAME_VER_MAP;
+extern const std::map<llvm::StringRef, cudaAPIversions> CUDA_COMPLEX_TYPE_NAME_VER_MAP;
+extern const std::map<llvm::StringRef, cudaAPIversions> CUDA_COMPLEX_FUNCTION_VER_MAP;
+extern const std::map<llvm::StringRef, cudaAPIversions> CUDA_RUNTIME_FUNCTION_VER_MAP;
+extern const std::map<llvm::StringRef, cudaAPIversions> CUDA_BLAS_TYPE_NAME_VER_MAP;
+extern const std::map<llvm::StringRef, cudaAPIversions> CUDA_BLAS_FUNCTION_VER_MAP;
+extern const std::map<llvm::StringRef, cudaAPIversions> CUDA_RAND_TYPE_NAME_VER_MAP;
+extern const std::map<llvm::StringRef, cudaAPIversions> CUDA_RAND_FUNCTION_VER_MAP;
+extern const std::map<llvm::StringRef, cudaAPIversions> CUDA_DNN_TYPE_NAME_VER_MAP;
+extern const std::map<llvm::StringRef, cudaAPIversions> CUDA_DNN_FUNCTION_VER_MAP;
+extern const std::map<llvm::StringRef, cudaAPIversions> CUDA_FFT_TYPE_NAME_VER_MAP;
+extern const std::map<llvm::StringRef, cudaAPIversions> CUDA_FFT_FUNCTION_VER_MAP;
+extern const std::map<llvm::StringRef, cudaAPIversions> CUDA_SPARSE_TYPE_NAME_VER_MAP;
+extern const std::map<llvm::StringRef, cudaAPIversions> CUDA_SPARSE_FUNCTION_VER_MAP;
+extern const std::map<llvm::StringRef, cudaAPIversions> CUDA_CAFFE2_TYPE_NAME_VER_MAP;
+extern const std::map<llvm::StringRef, cudaAPIversions> CUDA_CAFFE2_FUNCTION_VER_MAP;
+extern const std::map<llvm::StringRef, cudaAPIversions> CUDA_DEVICE_FUNC_VER_MAP;
+extern const std::map<llvm::StringRef, cudaAPIversions> CUDA_CUB_TYPE_NAME_VER_MAP;
+
+/**
+  * The union of all the above versions maps.
+  *
+  * This should be used for documentation generation.
+  */
+const std::map<llvm::StringRef, cudaAPIversions>& CUDA_VERSIONS_MAP();

--- a/src/CUDA2HIP_BLAS_API_functions.cpp
+++ b/src/CUDA2HIP_BLAS_API_functions.cpp
@@ -670,3 +670,6 @@ const std::map<llvm::StringRef, hipCounter> CUDA_BLAS_FUNCTION_MAP {
   {"cublasSrotmg_v2",                {"hipblasSrotmg",                   "rocblas_srotmg",                           CONV_LIB_FUNC, API_BLAS}},
   {"cublasDrotmg_v2",                {"hipblasDrotmg",                   "rocblas_drotmg",                           CONV_LIB_FUNC, API_BLAS}},
 };
+
+const std::map<llvm::StringRef, cudaAPIversions> CUDA_BLAS_FUNCTION_VER_MAP {
+};

--- a/src/CUDA2HIP_BLAS_API_types.cpp
+++ b/src/CUDA2HIP_BLAS_API_types.cpp
@@ -172,3 +172,6 @@ const std::map<llvm::StringRef, hipCounter> CUDA_BLAS_TYPE_NAME_MAP {
   {"CUBLAS_COMPUTE_32I",             {"HIPBLAS_COMPUTE_32I",             "",  CONV_NUMERIC_LITERAL, API_BLAS, UNSUPPORTED}}, // 72
   {"CUBLAS_COMPUTE_32I_PEDANTIC",    {"HIPBLAS_COMPUTE_32I_PEDANTIC",    "",  CONV_NUMERIC_LITERAL, API_BLAS, UNSUPPORTED}}, // 73
 };
+
+const std::map<llvm::StringRef, cudaAPIversions> CUDA_BLAS_TYPE_NAME_VER_MAP {
+};

--- a/src/CUDA2HIP_CAFFE2_API_functions.cpp
+++ b/src/CUDA2HIP_CAFFE2_API_functions.cpp
@@ -26,3 +26,6 @@ THE SOFTWARE.
 const std::map<llvm::StringRef, hipCounter> CUDA_CAFFE2_FUNCTION_MAP {
   {"cuda_stream",                                   {"hip_stream",                               "", CONV_LIB_FUNC, API_CAFFE2}},
 };
+
+const std::map<llvm::StringRef, cudaAPIversions> CUDA_CAFFE2_FUNCTION_VER_MAP {
+};

--- a/src/CUDA2HIP_CAFFE2_API_types.cpp
+++ b/src/CUDA2HIP_CAFFE2_API_types.cpp
@@ -32,3 +32,6 @@ const std::map<llvm::StringRef, hipCounter> CUDA_CAFFE2_TYPE_NAME_MAP {
   // 6. Classes
   {"CUDAContext",                                             {"HIPContext",                                                   "", CONV_TYPE, API_CAFFE2}},
 };
+
+const std::map<llvm::StringRef, cudaAPIversions> CUDA_CAFFE2_TYPE_NAME_VER_MAP {
+};

--- a/src/CUDA2HIP_CUB_API_types.cpp
+++ b/src/CUDA2HIP_CUB_API_types.cpp
@@ -26,3 +26,6 @@ THE SOFTWARE.
 const std::map<llvm::StringRef, hipCounter> CUDA_CUB_TYPE_NAME_MAP {
   {"cub",  {"hipcub",  "", CONV_TYPE, API_CUB}},
 };
+
+const std::map<llvm::StringRef, cudaAPIversions> CUDA_CUB_TYPE_NAME_VER_MAP {
+};

--- a/src/CUDA2HIP_Complex_API_functions.cpp
+++ b/src/CUDA2HIP_Complex_API_functions.cpp
@@ -48,3 +48,6 @@ const std::map<llvm::StringRef, hipCounter> CUDA_COMPLEX_FUNCTION_MAP {
   {"cuCfmaf",                {"hipCfmaf",                "", CONV_COMPLEX, API_COMPLEX}},
   {"cuCfma",                 {"hipCfma",                 "", CONV_COMPLEX, API_COMPLEX}},
 };
+
+const std::map<llvm::StringRef, cudaAPIversions> CUDA_COMPLEX_FUNCTION_VER_MAP {
+};

--- a/src/CUDA2HIP_Complex_API_types.cpp
+++ b/src/CUDA2HIP_Complex_API_types.cpp
@@ -28,3 +28,6 @@ const std::map<llvm::StringRef, hipCounter> CUDA_COMPLEX_TYPE_NAME_MAP {
   {"cuDoubleComplex", {"hipDoubleComplex", "", CONV_TYPE, API_COMPLEX}},
   {"cuComplex",       {"hipComplex",       "", CONV_TYPE, API_COMPLEX}},
 };
+
+const std::map<llvm::StringRef, cudaAPIversions> CUDA_COMPLEX_TYPE_NAME_VER_MAP {
+};

--- a/src/CUDA2HIP_DNN_API_functions.cpp
+++ b/src/CUDA2HIP_DNN_API_functions.cpp
@@ -297,3 +297,6 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DNN_FUNCTION_MAP {
   {"cudnnMakeFusedOpsPlan",                               {"hipdnnMakeFusedOpsPlan",                               "", CONV_LIB_FUNC, API_DNN, HIP_UNSUPPORTED}},
   {"cudnnFusedOpsExecute",                                {"hipdnnFusedOpsExecute",                                "", CONV_LIB_FUNC, API_DNN, HIP_UNSUPPORTED}},
 };
+
+const std::map<llvm::StringRef, cudaAPIversions> CUDA_DNN_FUNCTION_VER_MAP {
+};

--- a/src/CUDA2HIP_DNN_API_types.cpp
+++ b/src/CUDA2HIP_DNN_API_types.cpp
@@ -389,3 +389,6 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DNN_TYPE_NAME_MAP {
   {"cudnnFusedOpsPlanStruct",                             {"hipdnnFusedOpsPlanStruct",                             "", CONV_TYPE, API_DNN, HIP_UNSUPPORTED}},
   {"cudnnFusedOpsPlan_t",                                 {"hipdnnFusedOpsPlan_t",                                 "", CONV_TYPE, API_DNN, HIP_UNSUPPORTED}},
 };
+
+const std::map<llvm::StringRef, cudaAPIversions> CUDA_DNN_TYPE_NAME_VER_MAP {
+};

--- a/src/CUDA2HIP_Device_functions.cpp
+++ b/src/CUDA2HIP_Device_functions.cpp
@@ -614,3 +614,6 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DEVICE_FUNC_MAP {
   {"atomicXor",         {"", "", CONV_DEVICE_FUNC, API_RUNTIME}},
   {"atomicCAS",         {"", "", CONV_DEVICE_FUNC, API_RUNTIME}},
 };
+
+const std::map<llvm::StringRef, cudaAPIversions> CUDA_DEVICE_FUNC_VER_MAP {
+};

--- a/src/CUDA2HIP_Driver_API_functions.cpp
+++ b/src/CUDA2HIP_Driver_API_functions.cpp
@@ -836,3 +836,6 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_FUNCTION_MAP {
   // cudaEventCreateFromEGLSync
   {"cuEventCreateFromEGLSync",                             {"hipEventCreateFromEGLSync",                               "", CONV_EGL, API_DRIVER, HIP_UNSUPPORTED}},
 };
+
+const std::map<llvm::StringRef, cudaAPIversions> CUDA_DRIVER_FUNCTION_VER_MAP {
+};

--- a/src/CUDA2HIP_Driver_API_types.cpp
+++ b/src/CUDA2HIP_Driver_API_types.cpp
@@ -1684,3 +1684,6 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_TYPE_NAME_MAP {
   {"CUDA_VERSION",                                                     {"HIP_VERSION",                                              "", CONV_DEFINE, API_DRIVER, HIP_UNSUPPORTED}}, // 10000
   {"CU_TRSF_DISABLE_TRILINEAR_OPTIMIZATION",                           {"HIP_TRSF_DISABLE_TRILINEAR_OPTIMIZATION",                  "", CONV_DEFINE, API_DRIVER, HIP_UNSUPPORTED}}, // 0x20
 };
+
+const std::map<llvm::StringRef, cudaAPIversions> CUDA_DRIVER_TYPE_NAME_VER_MAP {
+};

--- a/src/CUDA2HIP_FFT_API_functions.cpp
+++ b/src/CUDA2HIP_FFT_API_functions.cpp
@@ -57,3 +57,6 @@ const std::map<llvm::StringRef, hipCounter> CUDA_FFT_FUNCTION_MAP {
   {"cufftGetVersion",                                     {"hipfftGetVersion",                                     "", CONV_LIB_FUNC, API_FFT}},
   {"cufftGetProperty",                                    {"hipfftGetProperty",                                    "", CONV_LIB_FUNC, API_FFT}},
 };
+
+const std::map<llvm::StringRef, cudaAPIversions> CUDA_FFT_FUNCTION_VER_MAP {
+};

--- a/src/CUDA2HIP_FFT_API_types.cpp
+++ b/src/CUDA2HIP_FFT_API_types.cpp
@@ -69,3 +69,6 @@ const std::map<llvm::StringRef, hipCounter> CUDA_FFT_TYPE_NAME_MAP {
   {"cufftDoubleComplex",                                  {"hipfftDoubleComplex",                                  "", CONV_TYPE, API_FFT}},
   {"cufftHandle",                                         {"hipfftHandle",                                         "", CONV_TYPE, API_FFT}},
 };
+
+const std::map<llvm::StringRef, cudaAPIversions> CUDA_FFT_TYPE_NAME_VER_MAP {
+};

--- a/src/CUDA2HIP_RAND_API_functions.cpp
+++ b/src/CUDA2HIP_RAND_API_functions.cpp
@@ -84,3 +84,6 @@ const std::map<llvm::StringRef, hipCounter> CUDA_RAND_FUNCTION_MAP {
   {"curand_Philox4x32_10",                          {"hiprand_Philox4x32_10",                          "", CONV_LIB_DEVICE_FUNC, API_RAND, HIP_UNSUPPORTED}},
   // unchanged function names: skipahead, skipahead_sequence, skipahead_subsequence
 };
+
+const std::map<llvm::StringRef, cudaAPIversions> CUDA_RAND_FUNCTION_VER_MAP {
+};

--- a/src/CUDA2HIP_RAND_API_types.cpp
+++ b/src/CUDA2HIP_RAND_API_types.cpp
@@ -139,3 +139,6 @@ const std::map<llvm::StringRef, hipCounter> CUDA_RAND_TYPE_NAME_MAP {
   {"CURAND_DEFINITION",                             {"HIPRAND_DEFINITION",                             "", CONV_NUMERIC_LITERAL, API_RAND, HIP_UNSUPPORTED}},
   {"CURAND_POISSON",                                {"HIPRAND_POISSON",                                "", CONV_NUMERIC_LITERAL, API_RAND, HIP_UNSUPPORTED}},
 };
+
+const std::map<llvm::StringRef, cudaAPIversions> CUDA_RAND_TYPE_NAME_VER_MAP {
+};

--- a/src/CUDA2HIP_Runtime_API_functions.cpp
+++ b/src/CUDA2HIP_Runtime_API_functions.cpp
@@ -707,3 +707,6 @@ const std::map<llvm::StringRef, hipCounter> CUDA_RUNTIME_FUNCTION_MAP {
   // cuProfilerStop
   {"cudaProfilerStop",                                        {"hipProfilerStop",                                        "", CONV_PROFILER, API_RUNTIME}},
 };
+
+const std::map<llvm::StringRef, cudaAPIversions> CUDA_RUNTIME_FUNCTION_VER_MAP {
+};

--- a/src/CUDA2HIP_Runtime_API_types.cpp
+++ b/src/CUDA2HIP_Runtime_API_types.cpp
@@ -1479,3 +1479,6 @@ const std::map<llvm::StringRef, hipCounter> CUDA_RUNTIME_TYPE_NAME_MAP {
   // CU_STREAM_PER_THREAD ((CUstream)0x2)
   {"cudaStreamPerThread",                                              {"hipStreamPerThread",                                       "", CONV_DEFINE, API_RUNTIME, HIP_UNSUPPORTED}}, // ((cudaStream_t)0x2)
 };
+
+const std::map<llvm::StringRef, cudaAPIversions> CUDA_RUNTIME_TYPE_NAME_VER_MAP {
+};

--- a/src/CUDA2HIP_SPARSE_API_functions.cpp
+++ b/src/CUDA2HIP_SPARSE_API_functions.cpp
@@ -756,3 +756,7 @@ const std::map<llvm::StringRef, hipCounter> CUDA_SPARSE_FUNCTION_MAP {
   {"cusparseSpMV",                                {"hipsparseSpMV",                                "", CONV_LIB_FUNC, API_SPARSE, HIP_UNSUPPORTED}},
   {"cusparseSpMV_bufferSize",                     {"hipsparseSpMV_bufferSize",                     "", CONV_LIB_FUNC, API_SPARSE, HIP_UNSUPPORTED}},
 };
+
+const std::map<llvm::StringRef, cudaAPIversions> CUDA_SPARSE_FUNCTION_VER_MAP {
+  {"cusparseCreateSolveAnalysisInfo",             {CUDA_70, CUDA_102, CUDA_110}},
+};

--- a/src/CUDA2HIP_SPARSE_API_types.cpp
+++ b/src/CUDA2HIP_SPARSE_API_types.cpp
@@ -185,3 +185,6 @@ const std::map<llvm::StringRef, hipCounter> CUDA_SPARSE_TYPE_NAME_MAP {
   {"CUSPARSE_VER_BUILD",                        {"HIPSPARSE_VER_BUILD",                        "", CONV_DEFINE, API_SPARSE, HIP_UNSUPPORTED}},
   {"CUSPARSE_VERSION",                          {"HIPSPARSE_VERSION",                          "", CONV_DEFINE, API_SPARSE, HIP_UNSUPPORTED}},
 };
+
+const std::map<llvm::StringRef, cudaAPIversions> CUDA_SPARSE_TYPE_NAME_VER_MAP {
+};

--- a/src/Statistics.cpp
+++ b/src/Statistics.cpp
@@ -358,6 +358,34 @@ bool Statistics::isUnsupported(const hipCounter &counter) {
     return Statistics::isHipUnsupported(counter);
   }
 }
+std::string Statistics::getCudaVersion(const cudaVersions& ver) {
+  switch (ver) {
+    case CUDA_0:
+    default:
+      return "";
+    case CUDA_70:
+      return "7.0";
+    case CUDA_75:
+      return "7.5";
+    case CUDA_80:
+      return "8.0";
+    case CUDA_90:
+      return "9.0";
+    case CUDA_91:
+      return "9.1";
+    case CUDA_92:
+      return "9.2";
+    case CUDA_100:
+      return "10.0";
+    case CUDA_101:
+      return "10.1";
+    case CUDA_102:
+      return "10.2";
+    case CUDA_110:
+      return "11.0";
+  }
+  return "";
+}
 
 std::map<std::string, Statistics> Statistics::stats = {};
 Statistics *Statistics::currentStatistics = nullptr;

--- a/src/Statistics.h
+++ b/src/Statistics.h
@@ -147,7 +147,32 @@ enum SupportDegree {
   HIP_UNSUPPORTED = 0x1,
   ROC_UNSUPPORTED = 0x2,
   UNSUPPORTED = 0x4,
-  DEPRECATED = 0x8
+  DEPRECATED = 0x8,
+  HIP_DEPRECATED = 0x10,
+  REMOVED = 0x20,
+  HIP_REMOVED = 0x40,
+};
+constexpr int CUDA_DEPRECATED = (int) SupportDegree::DEPRECATED;
+constexpr int CUDA_REMOVED = (int) SupportDegree::REMOVED;
+
+enum cudaVersions {
+  CUDA_0 = 0, // Unknown version
+  CUDA_70 = 7000,
+  CUDA_75 = 7050,
+  CUDA_80 = 8000,
+  CUDA_90 = 9000,
+  CUDA_91 = 9010,
+  CUDA_92 = 9020,
+  CUDA_100 = 10000,
+  CUDA_101 = 10010,
+  CUDA_102 = 10020,
+  CUDA_110 = 11000,
+};
+
+struct cudaAPIversions {
+  cudaVersions appeared = cudaVersions::CUDA_70;
+  cudaVersions deprecated = cudaVersions::CUDA_0;
+  cudaVersions removed = cudaVersions::CUDA_0;
 };
 
 // The names of various fields in in the statistics reports.
@@ -248,6 +273,8 @@ public:
     * based on counter's API_TYPE and option TranslateToRoc.
     */
   static bool isUnsupported(const hipCounter &counter);
+  //
+  static std::string getCudaVersion(const cudaVersions &ver);
   // Set this flag in case of hipification errors
   bool hasErrors = false;
 };


### PR DESCRIPTION
Preliminary steps for #172 implementation.

[ToDo]
Decide whether to do the same for ROCm/HIP-clang versioning or not.
Implement initial Markdown documentation generation for a single API (Runtime, Driver, or SPARSE).