### PR TITLE
[HIPIFY] Fix Linux build

### DIFF
--- a/src/CUDA2HIP_Doc.cpp
+++ b/src/CUDA2HIP_Doc.cpp
@@ -134,7 +134,7 @@ namespace doc {
           return false;
         }
         files.insert({ format, file });
-        tmpFiles.insert({ format, string(tmpFile) });
+        tmpFiles.insert({ format, tmpFile.str().str() });
         streams.insert(make_pair(format, unique_ptr<ostream>(new ofstream(tmpFile.c_str(), ios_base::trunc))));
         return true;
       }


### PR DESCRIPTION
Fix the error:
```c++
no matching conversion for functional-style cast from 'SmallString<128>' to 'std::__cxx11::string' (aka 'basic_string<char>')
```