### PR TITLE
[HIPIFY] Fixed Subdirectory Exclusion

### DIFF
--- a/src/CUDA2HIP_Perl.cpp
+++ b/src/CUDA2HIP_Perl.cpp
@@ -454,13 +454,18 @@ namespace perl {
     *streamPtr.get() << my << "$fileCount = @ARGV;" << endl_2;
     *streamPtr.get() << while_ << "(@ARGV) {" << endl;
     *streamPtr.get() << tab << "$fileName=shift (@ARGV);" << endl;
+    *streamPtr.get() << tab << "my $direxclude = 0;" << endl;
     *streamPtr.get() << tab << "$fileDir=dirname( $fileName );" << endl;
-    *streamPtr.get() << tab << "if ( $exclude_dirhash{ $fileDir } ) { " << endl;
-    *streamPtr.get() << tab_2 <<  print << "\" Skipping file: $fileName in excluded directory $fileDir \\n\";" << endl_tab << "}" << endl;
+    *streamPtr.get() << tab <<  while_ << "(( $direxclude == 0) and ( $fileDir ne \".\" and $fileDir ne \"/\"))  { " << endl;
+    *streamPtr.get() << tab_2 << "if ( $exclude_dirhash{ $fileDir } ) {" << endl;
+    *streamPtr.get() << tab_3 << "print STDERR \"Skipping file: $fileName in excluded directory $fileDir \\n\";" << endl;
+    *streamPtr.get() << tab_3 << "$direxclude += 1;" <<  endl_tab_2 << "}" << endl;
+    *streamPtr.get() << tab_2 << "else {" << endl;
+    *streamPtr.get() << tab_3 << "$fileDir = dirname( $fileDir );" << endl_tab_2 << "}" << endl_tab << "}" << endl;
     *streamPtr.get() << tab << "if ( $exclude_filehash{ $fileName } ) { " << endl;
-    *streamPtr.get() << tab_2 <<  print << "\" Skipping  excluded file: $fileName \\n\";" << endl_tab << "}" << endl;
+    *streamPtr.get() << tab_2 <<  print << "\"Skipping  excluded file: $fileName \\n\";" << endl_tab << "}" << endl;
     
-    *streamPtr.get() << tab << "unless( $exclude_dirhash{$fileDir} or $exclude_filehash{$fileName} ) {" << endl;
+    *streamPtr.get() << tab << "unless( $direxclude or $exclude_filehash{$fileName} ) {" << endl;
     *streamPtr.get() << tab_2 << "if ($inplace) {" << endl;
     *streamPtr.get() << tab_3 << my << "$file_prehip = \"$fileName\" . \".prehip\";" << endl;
     *streamPtr.get() << tab_3 << my << "$infile;" << endl;

--- a/src/CUDA2HIP_Perl.cpp
+++ b/src/CUDA2HIP_Perl.cpp
@@ -459,8 +459,8 @@ namespace perl {
     *streamPtr.get() << tab <<  while_ << "(( $direxclude == 0) and ( $fileDir ne \".\" and $fileDir ne \"/\"))  { " << endl;
     *streamPtr.get() << tab_2 << "if ( $exclude_dirhash{ $fileDir } ) {" << endl;
     *streamPtr.get() << tab_3 << "print STDERR \"Skipping file: $fileName in excluded directory $fileDir \\n\";" << endl;
-    *streamPtr.get() << tab_3 << "$direxclude += 1;" <<  endl_tab_2 << "}" << endl;
-    *streamPtr.get() << tab_2 << "else {" << endl;
+    *streamPtr.get() << tab_3 << "$direxclude += 1;" <<  endl ;
+    *streamPtr.get() << tab_2 << "} else {" << endl;
     *streamPtr.get() << tab_3 << "$fileDir = dirname( $fileDir );" << endl_tab_2 << "}" << endl_tab << "}" << endl;
     *streamPtr.get() << tab << "if ( $exclude_filehash{ $fileName } ) { " << endl;
     *streamPtr.get() << tab_2 <<  print << "\"Skipping  excluded file: $fileName \\n\";" << endl_tab << "}" << endl;


### PR DESCRIPTION
previously only files immediately in an excluded directory would be excluded
i.e. for excluded directory /foo/bar the file /foo/bar/fred would be excluded
     but /foo/bar/fred/george would not since /foo/bar/fred was not in the exlcude
     hashmap.
The fix now will keep finding parent direectories of the file until the current
directory is either "." or "/" or the direcory is found in the exclude map

      /foo/bar/fred/george will look in the map for /foo/bar/fred (not find)
then  /foo/bar (find and exit)