### PR TITLE
[HIPIFY][HIP] Sync with the latest ROCclr 3.9.0

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -162,7 +162,7 @@ sub simpleSubstitutions {
     $ft{'version'} += s/\bcudaDriverGetVersion\b/hipDriverGetVersion/g;
     $ft{'version'} += s/\bcudaRuntimeGetVersion\b/hipRuntimeGetVersion/g;
     $ft{'device'} += s/\bcuDeviceComputeCapability\b/hipDeviceComputeCapability/g;
-    $ft{'device'} += s/\bcuDeviceGet\b/hipGetDevice/g;
+    $ft{'device'} += s/\bcuDeviceGet\b/hipDeviceGet/g;
     $ft{'device'} += s/\bcuDeviceGetAttribute\b/hipDeviceGetAttribute/g;
     $ft{'device'} += s/\bcuDeviceGetCount\b/hipGetDeviceCount/g;
     $ft{'device'} += s/\bcuDeviceGetName\b/hipDeviceGetName/g;
@@ -173,6 +173,7 @@ sub simpleSubstitutions {
     $ft{'device'} += s/\bcudaDeviceGetByPCIBusId\b/hipDeviceGetByPCIBusId/g;
     $ft{'device'} += s/\bcudaDeviceGetCacheConfig\b/hipDeviceGetCacheConfig/g;
     $ft{'device'} += s/\bcudaDeviceGetLimit\b/hipDeviceGetLimit/g;
+    $ft{'device'} += s/\bcudaDeviceGetP2PAttribute\b/hipDeviceGetP2PAttribute/g;
     $ft{'device'} += s/\bcudaDeviceGetPCIBusId\b/hipDeviceGetPCIBusId/g;
     $ft{'device'} += s/\bcudaDeviceGetSharedMemConfig\b/hipDeviceGetSharedMemConfig/g;
     $ft{'device'} += s/\bcudaDeviceGetStreamPriorityRange\b/hipDeviceGetStreamPriorityRange/g;
@@ -184,7 +185,7 @@ sub simpleSubstitutions {
     $ft{'device'} += s/\bcudaFuncSetCacheConfig\b/hipFuncSetCacheConfig/g;
     $ft{'device'} += s/\bcudaGetDevice\b/hipGetDevice/g;
     $ft{'device'} += s/\bcudaGetDeviceCount\b/hipGetDeviceCount/g;
-    $ft{'device'} += s/\bcudaGetDeviceFlags\b/hipCtxGetFlags/g;
+    $ft{'device'} += s/\bcudaGetDeviceFlags\b/hipGetDeviceFlags/g;
     $ft{'device'} += s/\bcudaGetDeviceProperties\b/hipGetDeviceProperties/g;
     $ft{'device'} += s/\bcudaIpcCloseMemHandle\b/hipIpcCloseMemHandle/g;
     $ft{'device'} += s/\bcudaIpcGetEventHandle\b/hipIpcGetEventHandle/g;
@@ -237,7 +238,9 @@ sub simpleSubstitutions {
     $ft{'memory'} += s/\bcuDeviceGetByPCIBusId\b/hipDeviceGetByPCIBusId/g;
     $ft{'memory'} += s/\bcuDeviceGetPCIBusId\b/hipDeviceGetPCIBusId/g;
     $ft{'memory'} += s/\bcuIpcCloseMemHandle\b/hipIpcCloseMemHandle/g;
+    $ft{'memory'} += s/\bcuIpcGetEventHandle\b/hipIpcGetEventHandle/g;
     $ft{'memory'} += s/\bcuIpcGetMemHandle\b/hipIpcGetMemHandle/g;
+    $ft{'memory'} += s/\bcuIpcOpenEventHandle\b/hipIpcOpenEventHandle/g;
     $ft{'memory'} += s/\bcuIpcOpenMemHandle\b/hipIpcOpenMemHandle/g;
     $ft{'memory'} += s/\bcuMemAlloc\b/hipMalloc/g;
     $ft{'memory'} += s/\bcuMemAllocHost\b/hipHostMalloc/g;
@@ -293,9 +296,14 @@ sub simpleSubstitutions {
     $ft{'memory'} += s/\bcuMemsetD8\b/hipMemsetD8/g;
     $ft{'memory'} += s/\bcuMemsetD8Async\b/hipMemsetD8Async/g;
     $ft{'memory'} += s/\bcuMemsetD8_v2\b/hipMemsetD8/g;
+    $ft{'memory'} += s/\bcuMipmappedArrayCreate\b/hipMipmappedArrayCreate/g;
+    $ft{'memory'} += s/\bcuMipmappedArrayDestroy\b/hipMipmappedArrayDestroy/g;
+    $ft{'memory'} += s/\bcuMipmappedArrayGetLevel\b/hipMipmappedArrayGetLevel/g;
     $ft{'memory'} += s/\bcudaFree\b/hipFree/g;
     $ft{'memory'} += s/\bcudaFreeArray\b/hipFreeArray/g;
     $ft{'memory'} += s/\bcudaFreeHost\b/hipHostFree/g;
+    $ft{'memory'} += s/\bcudaFreeMipmappedArray\b/hipFreeMipmappedArray/g;
+    $ft{'memory'} += s/\bcudaGetMipmappedArrayLevel\b/hipGetMipmappedArrayLevel/g;
     $ft{'memory'} += s/\bcudaGetSymbolAddress\b/hipGetSymbolAddress/g;
     $ft{'memory'} += s/\bcudaGetSymbolSize\b/hipGetSymbolSize/g;
     $ft{'memory'} += s/\bcudaHostAlloc\b/hipHostMalloc/g;
@@ -309,8 +317,13 @@ sub simpleSubstitutions {
     $ft{'memory'} += s/\bcudaMallocArray\b/hipMallocArray/g;
     $ft{'memory'} += s/\bcudaMallocHost\b/hipHostMalloc/g;
     $ft{'memory'} += s/\bcudaMallocManaged\b/hipMallocManaged/g;
+    $ft{'memory'} += s/\bcudaMallocMipmappedArray\b/hipMallocMipmappedArray/g;
     $ft{'memory'} += s/\bcudaMallocPitch\b/hipMallocPitch/g;
+    $ft{'memory'} += s/\bcudaMemAdvise\b/hipMemAdvise/g;
     $ft{'memory'} += s/\bcudaMemGetInfo\b/hipMemGetInfo/g;
+    $ft{'memory'} += s/\bcudaMemPrefetchAsync\b/hipMemPrefetchAsync/g;
+    $ft{'memory'} += s/\bcudaMemRangeGetAttribute\b/hipMemRangeGetAttribute/g;
+    $ft{'memory'} += s/\bcudaMemRangeGetAttributes\b/hipMemRangeGetAttributes/g;
     $ft{'memory'} += s/\bcudaMemcpy\b/hipMemcpy/g;
     $ft{'memory'} += s/\bcudaMemcpy2D\b/hipMemcpy2D/g;
     $ft{'memory'} += s/\bcudaMemcpy2DAsync\b/hipMemcpy2DAsync/g;
@@ -338,8 +351,12 @@ sub simpleSubstitutions {
     $ft{'memory'} += s/\bmake_cudaExtent\b/make_hipExtent/g;
     $ft{'memory'} += s/\bmake_cudaPitchedPtr\b/make_hipPitchedPtr/g;
     $ft{'memory'} += s/\bmake_cudaPos\b/make_hipPos/g;
+    $ft{'addressing'} += s/\bcuMemAdvise\b/hipMemAdvise/g;
+    $ft{'addressing'} += s/\bcuMemRangeGetAttribute\b/hipMemRangeGetAttribute/g;
+    $ft{'addressing'} += s/\bcuMemRangeGetAttributes\b/hipMemRangeGetAttributes/g;
     $ft{'addressing'} += s/\bcudaPointerGetAttributes\b/hipPointerGetAttributes/g;
     $ft{'stream'} += s/\bcuStreamAddCallback\b/hipStreamAddCallback/g;
+    $ft{'stream'} += s/\bcuStreamAttachMemAsync\b/hipStreamAttachMemAsync/g;
     $ft{'stream'} += s/\bcuStreamCreate\b/hipStreamCreateWithFlags/g;
     $ft{'stream'} += s/\bcuStreamCreateWithPriority\b/hipStreamCreateWithPriority/g;
     $ft{'stream'} += s/\bcuStreamDestroy\b/hipStreamDestroy/g;
@@ -350,6 +367,7 @@ sub simpleSubstitutions {
     $ft{'stream'} += s/\bcuStreamSynchronize\b/hipStreamSynchronize/g;
     $ft{'stream'} += s/\bcuStreamWaitEvent\b/hipStreamWaitEvent/g;
     $ft{'stream'} += s/\bcudaStreamAddCallback\b/hipStreamAddCallback/g;
+    $ft{'stream'} += s/\bcudaStreamAttachMemAsync\b/hipStreamAttachMemAsync/g;
     $ft{'stream'} += s/\bcudaStreamCreate\b/hipStreamCreate/g;
     $ft{'stream'} += s/\bcudaStreamCreateWithFlags\b/hipStreamCreateWithFlags/g;
     $ft{'stream'} += s/\bcudaStreamCreateWithPriority\b/hipStreamCreateWithPriority/g;
@@ -377,21 +395,38 @@ sub simpleSubstitutions {
     $ft{'execution'} += s/\bcuLaunchKernel\b/hipModuleLaunchKernel/g;
     $ft{'execution'} += s/\bcudaConfigureCall\b/hipConfigureCall/g;
     $ft{'execution'} += s/\bcudaFuncGetAttributes\b/hipFuncGetAttributes/g;
+    $ft{'execution'} += s/\bcudaFuncSetAttribute\b/hipFuncSetAttribute/g;
+    $ft{'execution'} += s/\bcudaFuncSetSharedMemConfig\b/hipFuncSetSharedMemConfig/g;
     $ft{'execution'} += s/\bcudaLaunch\b/hipLaunchByPtr/g;
     $ft{'execution'} += s/\bcudaLaunchCooperativeKernel\b/hipLaunchCooperativeKernel/g;
     $ft{'execution'} += s/\bcudaLaunchCooperativeKernelMultiDevice\b/hipLaunchCooperativeKernelMultiDevice/g;
     $ft{'execution'} += s/\bcudaLaunchKernel\b/hipLaunchKernel/g;
     $ft{'execution'} += s/\bcudaSetupArgument\b/hipSetupArgument/g;
-    $ft{'occupancy'} += s/\bcuOccupancyMaxActiveBlocksPerMultiprocessor\b/hipDrvOccupancyMaxActiveBlocksPerMultiprocessor/g;
-    $ft{'occupancy'} += s/\bcuOccupancyMaxActiveBlocksPerMultiprocessorWithFlags\b/hipDrvOccupancyMaxActiveBlocksPerMultiprocessorWithFlags/g;
-    $ft{'occupancy'} += s/\bcuOccupancyMaxPotentialBlockSize\b/hipOccupancyMaxPotentialBlockSize/g;
+    $ft{'occupancy'} += s/\bcuOccupancyMaxActiveBlocksPerMultiprocessor\b/hipModuleOccupancyMaxActiveBlocksPerMultiprocessor/g;
+    $ft{'occupancy'} += s/\bcuOccupancyMaxActiveBlocksPerMultiprocessorWithFlags\b/hipModuleOccupancyMaxActiveBlocksPerMultiprocessorWithFlags/g;
+    $ft{'occupancy'} += s/\bcuOccupancyMaxPotentialBlockSize\b/hipModuleOccupancyMaxPotentialBlockSize/g;
+    $ft{'occupancy'} += s/\bcuOccupancyMaxPotentialBlockSizeWithFlags\b/hipModuleOccupancyMaxPotentialBlockSizeWithFlags/g;
     $ft{'occupancy'} += s/\bcudaOccupancyMaxActiveBlocksPerMultiprocessor\b/hipOccupancyMaxActiveBlocksPerMultiprocessor/g;
     $ft{'occupancy'} += s/\bcudaOccupancyMaxActiveBlocksPerMultiprocessorWithFlags\b/hipOccupancyMaxActiveBlocksPerMultiprocessorWithFlags/g;
     $ft{'occupancy'} += s/\bcudaOccupancyMaxPotentialBlockSize\b/hipOccupancyMaxPotentialBlockSize/g;
+    $ft{'occupancy'} += s/\bcudaOccupancyMaxPotentialBlockSizeWithFlags\b/hipOccupancyMaxPotentialBlockSizeWithFlags/g;
+    $ft{'texture'} += s/\bcuTexObjectCreate\b/hipTexObjectCreate/g;
+    $ft{'texture'} += s/\bcuTexObjectDestroy\b/hipTexObjectDestroy/g;
+    $ft{'texture'} += s/\bcuTexObjectGetResourceDesc\b/hipTexObjectGetResourceDesc/g;
+    $ft{'texture'} += s/\bcuTexObjectGetResourceViewDesc\b/hipTexObjectGetResourceViewDesc/g;
+    $ft{'texture'} += s/\bcuTexObjectGetTextureDesc\b/hipTexObjectGetTextureDesc/g;
     $ft{'texture'} += s/\bcuTexRefGetAddress\b/hipTexRefGetAddress/g;
     $ft{'texture'} += s/\bcuTexRefGetAddressMode\b/hipTexRefGetAddressMode/g;
     $ft{'texture'} += s/\bcuTexRefGetAddress_v2\b/hipTexRefGetAddress/g;
     $ft{'texture'} += s/\bcuTexRefGetArray\b/hipTexRefGetArray/g;
+    $ft{'texture'} += s/\bcuTexRefGetFilterMode\b/hipTexRefGetFilterMode/g;
+    $ft{'texture'} += s/\bcuTexRefGetFlags\b/hipTexRefGetFlags/g;
+    $ft{'texture'} += s/\bcuTexRefGetFormat\b/hipTexRefGetFormat/g;
+    $ft{'texture'} += s/\bcuTexRefGetMaxAnisotropy\b/hipTexRefGetMaxAnisotropy/g;
+    $ft{'texture'} += s/\bcuTexRefGetMipmapFilterMode\b/hipTexRefGetMipmapFilterMode/g;
+    $ft{'texture'} += s/\bcuTexRefGetMipmapLevelBias\b/hipTexRefGetMipmapLevelBias/g;
+    $ft{'texture'} += s/\bcuTexRefGetMipmapLevelClamp\b/hipTexRefGetMipmapLevelClamp/g;
+    $ft{'texture'} += s/\bcuTexRefGetMipmappedArray\b/hipTexRefGetMipMappedArray/g;
     $ft{'texture'} += s/\bcuTexRefSetAddress\b/hipTexRefSetAddress/g;
     $ft{'texture'} += s/\bcuTexRefSetAddress2D\b/hipTexRefSetAddress2D/g;
     $ft{'texture'} += s/\bcuTexRefSetAddress2D_v2\b/hipTexRefSetAddress2D/g;
@@ -399,9 +434,15 @@ sub simpleSubstitutions {
     $ft{'texture'} += s/\bcuTexRefSetAddressMode\b/hipTexRefSetAddressMode/g;
     $ft{'texture'} += s/\bcuTexRefSetAddress_v2\b/hipTexRefSetAddress/g;
     $ft{'texture'} += s/\bcuTexRefSetArray\b/hipTexRefSetArray/g;
+    $ft{'texture'} += s/\bcuTexRefSetBorderColor\b/hipTexRefSetBorderColor/g;
     $ft{'texture'} += s/\bcuTexRefSetFilterMode\b/hipTexRefSetFilterMode/g;
     $ft{'texture'} += s/\bcuTexRefSetFlags\b/hipTexRefSetFlags/g;
     $ft{'texture'} += s/\bcuTexRefSetFormat\b/hipTexRefSetFormat/g;
+    $ft{'texture'} += s/\bcuTexRefSetMaxAnisotropy\b/hipTexRefSetMaxAnisotropy/g;
+    $ft{'texture'} += s/\bcuTexRefSetMipmapFilterMode\b/hipTexRefSetMipmapFilterMode/g;
+    $ft{'texture'} += s/\bcuTexRefSetMipmapLevelBias\b/hipTexRefSetMipmapLevelBias/g;
+    $ft{'texture'} += s/\bcuTexRefSetMipmapLevelClamp\b/hipTexRefSetMipmapLevelClamp/g;
+    $ft{'texture'} += s/\bcuTexRefSetMipmappedArray\b/hipTexRefSetMipmappedArray/g;
     $ft{'texture'} += s/\bcudaBindTexture\b/hipBindTexture/g;
     $ft{'texture'} += s/\bcudaBindTexture2D\b/hipBindTexture2D/g;
     $ft{'texture'} += s/\bcudaBindTextureToArray\b/hipBindTextureToArray/g;
@@ -420,6 +461,7 @@ sub simpleSubstitutions {
     $ft{'peer'} += s/\bcuCtxDisablePeerAccess\b/hipCtxDisablePeerAccess/g;
     $ft{'peer'} += s/\bcuCtxEnablePeerAccess\b/hipCtxEnablePeerAccess/g;
     $ft{'peer'} += s/\bcuDeviceCanAccessPeer\b/hipDeviceCanAccessPeer/g;
+    $ft{'peer'} += s/\bcuDeviceGetP2PAttribute\b/hipDeviceGetP2PAttribute/g;
     $ft{'peer'} += s/\bcudaDeviceCanAccessPeer\b/hipDeviceCanAccessPeer/g;
     $ft{'peer'} += s/\bcudaDeviceDisablePeerAccess\b/hipDeviceDisablePeerAccess/g;
     $ft{'peer'} += s/\bcudaDeviceEnablePeerAccess\b/hipDeviceEnablePeerAccess/g;
@@ -1430,6 +1472,8 @@ sub simpleSubstitutions {
     $ft{'type'} += s/\bCUcontext\b/hipCtx_t/g;
     $ft{'type'} += s/\bCUctx_st\b/ihipCtx_t/g;
     $ft{'type'} += s/\bCUdevice\b/hipDevice_t/g;
+    $ft{'type'} += s/\bCUdevice_P2PAttribute\b/hipDeviceP2PAttr/g;
+    $ft{'type'} += s/\bCUdevice_P2PAttribute_enum\b/hipDeviceP2PAttr/g;
     $ft{'type'} += s/\bCUdevice_attribute\b/hipDeviceAttribute_t/g;
     $ft{'type'} += s/\bCUdevice_attribute_enum\b/hipDeviceAttribute_t/g;
     $ft{'type'} += s/\bCUdeviceptr\b/hipDeviceptr_t/g;
@@ -1444,14 +1488,18 @@ sub simpleSubstitutions {
     $ft{'type'} += s/\bCUfunction\b/hipFunction_t/g;
     $ft{'type'} += s/\bCUfunction_attribute\b/hipFunction_attribute/g;
     $ft{'type'} += s/\bCUfunction_attribute_enum\b/hipFunction_attribute/g;
-    $ft{'type'} += s/\bCUipcEventHandle\b/ihipIpcEventHandle_t/g;
-    $ft{'type'} += s/\bCUipcEventHandle_st\b/ihipIpcEventHandle_t/g;
+    $ft{'type'} += s/\bCUipcEventHandle\b/hipIpcEventHandle_t/g;
+    $ft{'type'} += s/\bCUipcEventHandle_st\b/hipIpcEventHandle_st/g;
     $ft{'type'} += s/\bCUipcMemHandle\b/hipIpcMemHandle_t/g;
     $ft{'type'} += s/\bCUipcMemHandle_st\b/hipIpcMemHandle_st/g;
     $ft{'type'} += s/\bCUjit_option\b/hipJitOption/g;
     $ft{'type'} += s/\bCUjit_option_enum\b/hipJitOption/g;
     $ft{'type'} += s/\bCUlimit\b/hipLimit_t/g;
     $ft{'type'} += s/\bCUlimit_enum\b/hipLimit_t/g;
+    $ft{'type'} += s/\bCUmem_advise\b/hipMemoryAdvise/g;
+    $ft{'type'} += s/\bCUmem_advise_enum\b/hipMemoryAdvise/g;
+    $ft{'type'} += s/\bCUmem_range_attribute\b/hipMemRangeAttribute/g;
+    $ft{'type'} += s/\bCUmem_range_attribute_enum\b/hipMemRangeAttribute/g;
     $ft{'type'} += s/\bCUmemorytype\b/hipMemoryType/g;
     $ft{'type'} += s/\bCUmemorytype_enum\b/hipMemoryType/g;
     $ft{'type'} += s/\bCUmipmappedArray\b/hipMipmappedArray_t/g;
@@ -1501,23 +1549,27 @@ sub simpleSubstitutions {
     $ft{'type'} += s/\bcudaDataType\b/hipblasDatatype_t/g;
     $ft{'type'} += s/\bcudaDataType_t\b/hipblasDatatype_t/g;
     $ft{'type'} += s/\bcudaDeviceAttr\b/hipDeviceAttribute_t/g;
+    $ft{'type'} += s/\bcudaDeviceP2PAttr\b/hipDeviceP2PAttr/g;
     $ft{'type'} += s/\bcudaDeviceProp\b/hipDeviceProp_t/g;
     $ft{'type'} += s/\bcudaError\b/hipError_t/g;
     $ft{'type'} += s/\bcudaError_enum\b/hipError_t/g;
     $ft{'type'} += s/\bcudaError_t\b/hipError_t/g;
     $ft{'type'} += s/\bcudaEvent_t\b/hipEvent_t/g;
     $ft{'type'} += s/\bcudaExtent\b/hipExtent/g;
+    $ft{'type'} += s/\bcudaFuncAttribute\b/hipFuncAttribute/g;
     $ft{'type'} += s/\bcudaFuncAttributes\b/hipFuncAttributes/g;
     $ft{'type'} += s/\bcudaFuncCache\b/hipFuncCache_t/g;
     $ft{'type'} += s/\bcudaFunction_t\b/hipFunction_t/g;
-    $ft{'type'} += s/\bcudaIpcEventHandle_st\b/ihipIpcEventHandle_t/g;
-    $ft{'type'} += s/\bcudaIpcEventHandle_t\b/ihipIpcEventHandle_t/g;
+    $ft{'type'} += s/\bcudaIpcEventHandle_st\b/hipIpcEventHandle_st/g;
+    $ft{'type'} += s/\bcudaIpcEventHandle_t\b/hipIpcEventHandle_t/g;
     $ft{'type'} += s/\bcudaIpcMemHandle_st\b/hipIpcMemHandle_st/g;
     $ft{'type'} += s/\bcudaIpcMemHandle_t\b/hipIpcMemHandle_t/g;
     $ft{'type'} += s/\bcudaLaunchParams\b/hipLaunchParams/g;
     $ft{'type'} += s/\bcudaLimit\b/hipLimit_t/g;
+    $ft{'type'} += s/\bcudaMemRangeAttribute\b/hipMemRangeAttribute/g;
     $ft{'type'} += s/\bcudaMemcpy3DParms\b/hipMemcpy3DParms/g;
     $ft{'type'} += s/\bcudaMemcpyKind\b/hipMemcpyKind/g;
+    $ft{'type'} += s/\bcudaMemoryAdvise\b/hipMemoryAdvise/g;
     $ft{'type'} += s/\bcudaMipmappedArray\b/hipMipmappedArray/g;
     $ft{'type'} += s/\bcudaMipmappedArray_const_t\b/hipMipmappedArray_const_t/g;
     $ft{'type'} += s/\bcudaMipmappedArray_t\b/hipMipmappedArray_t/g;
@@ -1941,13 +1993,16 @@ sub simpleSubstitutions {
     $ft{'numeric_literal'} += s/\bCU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MINOR\b/hipDeviceAttributeComputeCapabilityMinor/g;
     $ft{'numeric_literal'} += s/\bCU_DEVICE_ATTRIBUTE_COMPUTE_MODE\b/hipDeviceAttributeComputeMode/g;
     $ft{'numeric_literal'} += s/\bCU_DEVICE_ATTRIBUTE_CONCURRENT_KERNELS\b/hipDeviceAttributeConcurrentKernels/g;
+    $ft{'numeric_literal'} += s/\bCU_DEVICE_ATTRIBUTE_CONCURRENT_MANAGED_ACCESS\b/hipDeviceAttributeConcurrentManagedAccess/g;
     $ft{'numeric_literal'} += s/\bCU_DEVICE_ATTRIBUTE_COOPERATIVE_LAUNCH\b/hipDeviceAttributeCooperativeLaunch/g;
     $ft{'numeric_literal'} += s/\bCU_DEVICE_ATTRIBUTE_COOPERATIVE_MULTI_DEVICE_LAUNCH\b/hipDeviceAttributeCooperativeMultiDeviceLaunch/g;
+    $ft{'numeric_literal'} += s/\bCU_DEVICE_ATTRIBUTE_DIRECT_MANAGED_MEM_ACCESS_FROM_HOST\b/hipDeviceAttributeDirectManagedMemAccessFromHost/g;
     $ft{'numeric_literal'} += s/\bCU_DEVICE_ATTRIBUTE_ECC_ENABLED\b/hipDeviceAttributeEccEnabled/g;
     $ft{'numeric_literal'} += s/\bCU_DEVICE_ATTRIBUTE_GLOBAL_MEMORY_BUS_WIDTH\b/hipDeviceAttributeMemoryBusWidth/g;
     $ft{'numeric_literal'} += s/\bCU_DEVICE_ATTRIBUTE_INTEGRATED\b/hipDeviceAttributeIntegrated/g;
     $ft{'numeric_literal'} += s/\bCU_DEVICE_ATTRIBUTE_KERNEL_EXEC_TIMEOUT\b/hipDeviceAttributeKernelExecTimeout/g;
     $ft{'numeric_literal'} += s/\bCU_DEVICE_ATTRIBUTE_L2_CACHE_SIZE\b/hipDeviceAttributeL2CacheSize/g;
+    $ft{'numeric_literal'} += s/\bCU_DEVICE_ATTRIBUTE_MANAGED_MEMORY\b/hipDeviceAttributeManagedMemory/g;
     $ft{'numeric_literal'} += s/\bCU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE1D_WIDTH\b/hipDeviceAttributeMaxTexture1DWidth/g;
     $ft{'numeric_literal'} += s/\bCU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_HEIGHT\b/hipDeviceAttributeMaxTexture2DHeight/g;
     $ft{'numeric_literal'} += s/\bCU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_WIDTH\b/hipDeviceAttributeMaxTexture2DWidth/g;
@@ -1969,6 +2024,8 @@ sub simpleSubstitutions {
     $ft{'numeric_literal'} += s/\bCU_DEVICE_ATTRIBUTE_MEMORY_CLOCK_RATE\b/hipDeviceAttributeMemoryClockRate/g;
     $ft{'numeric_literal'} += s/\bCU_DEVICE_ATTRIBUTE_MULTIPROCESSOR_COUNT\b/hipDeviceAttributeMultiprocessorCount/g;
     $ft{'numeric_literal'} += s/\bCU_DEVICE_ATTRIBUTE_MULTI_GPU_BOARD\b/hipDeviceAttributeIsMultiGpuBoard/g;
+    $ft{'numeric_literal'} += s/\bCU_DEVICE_ATTRIBUTE_PAGEABLE_MEMORY_ACCESS\b/hipDeviceAttributePageableMemoryAccess/g;
+    $ft{'numeric_literal'} += s/\bCU_DEVICE_ATTRIBUTE_PAGEABLE_MEMORY_ACCESS_USES_HOST_PAGE_TABLES\b/hipDeviceAttributePageableMemoryAccessUsesHostPageTables/g;
     $ft{'numeric_literal'} += s/\bCU_DEVICE_ATTRIBUTE_PCI_BUS_ID\b/hipDeviceAttributePciBusId/g;
     $ft{'numeric_literal'} += s/\bCU_DEVICE_ATTRIBUTE_PCI_DEVICE_ID\b/hipDeviceAttributePciDeviceId/g;
     $ft{'numeric_literal'} += s/\bCU_DEVICE_ATTRIBUTE_REGISTERS_PER_BLOCK\b/hipDeviceAttributeMaxRegistersPerBlock/g;
@@ -1976,6 +2033,12 @@ sub simpleSubstitutions {
     $ft{'numeric_literal'} += s/\bCU_DEVICE_ATTRIBUTE_TEXTURE_ALIGNMENT\b/hipDeviceAttributeTextureAlignment/g;
     $ft{'numeric_literal'} += s/\bCU_DEVICE_ATTRIBUTE_TOTAL_CONSTANT_MEMORY\b/hipDeviceAttributeTotalConstantMemory/g;
     $ft{'numeric_literal'} += s/\bCU_DEVICE_ATTRIBUTE_WARP_SIZE\b/hipDeviceAttributeWarpSize/g;
+    $ft{'numeric_literal'} += s/\bCU_DEVICE_P2P_ATTRIBUTE_ACCESS_ACCESS_SUPPORTED\b/hipDevP2PAttrHipArrayAccessSupported/g;
+    $ft{'numeric_literal'} += s/\bCU_DEVICE_P2P_ATTRIBUTE_ACCESS_SUPPORTED\b/hipDevP2PAttrAccessSupported/g;
+    $ft{'numeric_literal'} += s/\bCU_DEVICE_P2P_ATTRIBUTE_ARRAY_ACCESS_ACCESS_SUPPORTED\b/hipDevP2PAttrHipArrayAccessSupported/g;
+    $ft{'numeric_literal'} += s/\bCU_DEVICE_P2P_ATTRIBUTE_CUDA_ARRAY_ACCESS_SUPPORTED\b/hipDevP2PAttrHipArrayAccessSupported/g;
+    $ft{'numeric_literal'} += s/\bCU_DEVICE_P2P_ATTRIBUTE_NATIVE_ATOMIC_SUPPORTED\b/hipDevP2PAttrNativeAtomicSupported/g;
+    $ft{'numeric_literal'} += s/\bCU_DEVICE_P2P_ATTRIBUTE_PERFORMANCE_RANK\b/hipDevP2PAttrPerformanceRank/g;
     $ft{'numeric_literal'} += s/\bCU_EVENT_BLOCKING_SYNC\b/hipEventBlockingSync/g;
     $ft{'numeric_literal'} += s/\bCU_EVENT_DEFAULT\b/hipEventDefault/g;
     $ft{'numeric_literal'} += s/\bCU_EVENT_DISABLE_TIMING\b/hipEventDisableTiming/g;
@@ -2003,9 +2066,6 @@ sub simpleSubstitutions {
     $ft{'numeric_literal'} += s/\bCU_JIT_FAST_COMPILE\b/hipJitOptionFastCompile/g;
     $ft{'numeric_literal'} += s/\bCU_JIT_GENERATE_DEBUG_INFO\b/hipJitOptionGenerateDebugInfo/g;
     $ft{'numeric_literal'} += s/\bCU_JIT_GENERATE_LINE_INFO\b/hipJitOptionGenerateLineInfo/g;
-    $ft{'numeric_literal'} += s/\bCU_JIT_GLOBAL_SYMBOL_ADDRESSES\b/hipJitGlobalSymbolAddresses/g;
-    $ft{'numeric_literal'} += s/\bCU_JIT_GLOBAL_SYMBOL_COUNT\b/hipJitGlobalSymbolCount/g;
-    $ft{'numeric_literal'} += s/\bCU_JIT_GLOBAL_SYMBOL_NAMES\b/hipJitGlobalSymbolNames/g;
     $ft{'numeric_literal'} += s/\bCU_JIT_INFO_LOG_BUFFER\b/hipJitOptionInfoLogBuffer/g;
     $ft{'numeric_literal'} += s/\bCU_JIT_INFO_LOG_BUFFER_SIZE_BYTES\b/hipJitOptionInfoLogBufferSizeBytes/g;
     $ft{'numeric_literal'} += s/\bCU_JIT_LOG_VERBOSE\b/hipJitOptionLogVerbose/g;
@@ -2022,8 +2082,19 @@ sub simpleSubstitutions {
     $ft{'numeric_literal'} += s/\bCU_MEMORYTYPE_DEVICE\b/hipMemoryTypeDevice/g;
     $ft{'numeric_literal'} += s/\bCU_MEMORYTYPE_HOST\b/hipMemoryTypeHost/g;
     $ft{'numeric_literal'} += s/\bCU_MEMORYTYPE_UNIFIED\b/hipMemoryTypeUnified/g;
+    $ft{'numeric_literal'} += s/\bCU_MEM_ADVISE_SET_ACCESSED_BY\b/hipMemAdviseSetAccessedBy/g;
+    $ft{'numeric_literal'} += s/\bCU_MEM_ADVISE_SET_PREFERRED_LOCATION\b/hipMemAdviseSetPreferredLocation/g;
+    $ft{'numeric_literal'} += s/\bCU_MEM_ADVISE_SET_READ_MOSTLY\b/hipMemAdviseSetReadMostly/g;
+    $ft{'numeric_literal'} += s/\bCU_MEM_ADVISE_UNSET_ACCESSED_BY\b/hipMemAdviseUnsetAccessedBy/g;
+    $ft{'numeric_literal'} += s/\bCU_MEM_ADVISE_UNSET_PREFERRED_LOCATION\b/hipMemAdviseUnsetPreferredLocation/g;
+    $ft{'numeric_literal'} += s/\bCU_MEM_ADVISE_UNSET_READ_MOSTLY\b/hipMemAdviseUnsetReadMostly/g;
     $ft{'numeric_literal'} += s/\bCU_MEM_ATTACH_GLOBAL\b/hipMemAttachGlobal/g;
     $ft{'numeric_literal'} += s/\bCU_MEM_ATTACH_HOST\b/hipMemAttachHost/g;
+    $ft{'numeric_literal'} += s/\bCU_MEM_ATTACH_SINGLE\b/hipMemAttachSingle/g;
+    $ft{'numeric_literal'} += s/\bCU_MEM_RANGE_ATTRIBUTE_ACCESSED_BY\b/hipMemRangeAttributeAccessedBy/g;
+    $ft{'numeric_literal'} += s/\bCU_MEM_RANGE_ATTRIBUTE_LAST_PREFETCH_LOCATION\b/hipMemRangeAttributeLastPrefetchLocation/g;
+    $ft{'numeric_literal'} += s/\bCU_MEM_RANGE_ATTRIBUTE_PREFERRED_LOCATION\b/hipMemRangeAttributePreferredLocation/g;
+    $ft{'numeric_literal'} += s/\bCU_MEM_RANGE_ATTRIBUTE_READ_MOSTLY\b/hipMemRangeAttributeReadMostly/g;
     $ft{'numeric_literal'} += s/\bCU_OCCUPANCY_DEFAULT\b/hipOccupancyDefault/g;
     $ft{'numeric_literal'} += s/\bCU_RESOURCE_TYPE_ARRAY\b/hipResourceTypeArray/g;
     $ft{'numeric_literal'} += s/\bCU_RESOURCE_TYPE_LINEAR\b/hipResourceTypeLinear/g;
@@ -2096,14 +2167,17 @@ sub simpleSubstitutions {
     $ft{'numeric_literal'} += s/\bcudaDevAttrComputeCapabilityMinor\b/hipDeviceAttributeComputeCapabilityMinor/g;
     $ft{'numeric_literal'} += s/\bcudaDevAttrComputeMode\b/hipDeviceAttributeComputeMode/g;
     $ft{'numeric_literal'} += s/\bcudaDevAttrConcurrentKernels\b/hipDeviceAttributeConcurrentKernels/g;
+    $ft{'numeric_literal'} += s/\bcudaDevAttrConcurrentManagedAccess\b/hipDeviceAttributeConcurrentManagedAccess/g;
     $ft{'numeric_literal'} += s/\bcudaDevAttrCooperativeLaunch\b/hipDeviceAttributeCooperativeLaunch/g;
     $ft{'numeric_literal'} += s/\bcudaDevAttrCooperativeMultiDeviceLaunch\b/hipDeviceAttributeCooperativeMultiDeviceLaunch/g;
+    $ft{'numeric_literal'} += s/\bcudaDevAttrDirectManagedMemAccessFromHost\b/hipDeviceAttributeDirectManagedMemAccessFromHost/g;
     $ft{'numeric_literal'} += s/\bcudaDevAttrEccEnabled\b/hipDeviceAttributeEccEnabled/g;
     $ft{'numeric_literal'} += s/\bcudaDevAttrGlobalMemoryBusWidth\b/hipDeviceAttributeMemoryBusWidth/g;
     $ft{'numeric_literal'} += s/\bcudaDevAttrIntegrated\b/hipDeviceAttributeIntegrated/g;
     $ft{'numeric_literal'} += s/\bcudaDevAttrIsMultiGpuBoard\b/hipDeviceAttributeIsMultiGpuBoard/g;
     $ft{'numeric_literal'} += s/\bcudaDevAttrKernelExecTimeout\b/hipDeviceAttributeKernelExecTimeout/g;
     $ft{'numeric_literal'} += s/\bcudaDevAttrL2CacheSize\b/hipDeviceAttributeL2CacheSize/g;
+    $ft{'numeric_literal'} += s/\bcudaDevAttrManagedMemory\b/hipDeviceAttributeManagedMemory/g;
     $ft{'numeric_literal'} += s/\bcudaDevAttrMaxBlockDimX\b/hipDeviceAttributeMaxBlockDimX/g;
     $ft{'numeric_literal'} += s/\bcudaDevAttrMaxBlockDimY\b/hipDeviceAttributeMaxBlockDimY/g;
     $ft{'numeric_literal'} += s/\bcudaDevAttrMaxBlockDimZ\b/hipDeviceAttributeMaxBlockDimZ/g;
@@ -2124,11 +2198,17 @@ sub simpleSubstitutions {
     $ft{'numeric_literal'} += s/\bcudaDevAttrMaxThreadsPerMultiProcessor\b/hipDeviceAttributeMaxThreadsPerMultiProcessor/g;
     $ft{'numeric_literal'} += s/\bcudaDevAttrMemoryClockRate\b/hipDeviceAttributeMemoryClockRate/g;
     $ft{'numeric_literal'} += s/\bcudaDevAttrMultiProcessorCount\b/hipDeviceAttributeMultiprocessorCount/g;
+    $ft{'numeric_literal'} += s/\bcudaDevAttrPageableMemoryAccess\b/hipDeviceAttributePageableMemoryAccess/g;
+    $ft{'numeric_literal'} += s/\bcudaDevAttrPageableMemoryAccessUsesHostPageTables\b/hipDeviceAttributePageableMemoryAccessUsesHostPageTables/g;
     $ft{'numeric_literal'} += s/\bcudaDevAttrPciBusId\b/hipDeviceAttributePciBusId/g;
     $ft{'numeric_literal'} += s/\bcudaDevAttrPciDeviceId\b/hipDeviceAttributePciDeviceId/g;
     $ft{'numeric_literal'} += s/\bcudaDevAttrTextureAlignment\b/hipDeviceAttributeTextureAlignment/g;
     $ft{'numeric_literal'} += s/\bcudaDevAttrTotalConstantMemory\b/hipDeviceAttributeTotalConstantMemory/g;
     $ft{'numeric_literal'} += s/\bcudaDevAttrWarpSize\b/hipDeviceAttributeWarpSize/g;
+    $ft{'numeric_literal'} += s/\bcudaDevP2PAttrAccessSupported\b/hipDevP2PAttrAccessSupported/g;
+    $ft{'numeric_literal'} += s/\bcudaDevP2PAttrCudaArrayAccessSupported\b/hipDevP2PAttrHipArrayAccessSupported/g;
+    $ft{'numeric_literal'} += s/\bcudaDevP2PAttrNativeAtomicSupported\b/hipDevP2PAttrNativeAtomicSupported/g;
+    $ft{'numeric_literal'} += s/\bcudaDevP2PAttrPerformanceRank\b/hipDevP2PAttrPerformanceRank/g;
     $ft{'numeric_literal'} += s/\bcudaErrorAlreadyAcquired\b/hipErrorAlreadyAcquired/g;
     $ft{'numeric_literal'} += s/\bcudaErrorAlreadyMapped\b/hipErrorAlreadyMapped/g;
     $ft{'numeric_literal'} += s/\bcudaErrorArrayIsMapped\b/hipErrorArrayIsMapped/g;
@@ -2188,11 +2268,24 @@ sub simpleSubstitutions {
     $ft{'numeric_literal'} += s/\bcudaErrorUnsupportedLimit\b/hipErrorUnsupportedLimit/g;
     $ft{'numeric_literal'} += s/\bcudaFilterModeLinear\b/hipFilterModeLinear/g;
     $ft{'numeric_literal'} += s/\bcudaFilterModePoint\b/hipFilterModePoint/g;
+    $ft{'numeric_literal'} += s/\bcudaFuncAttributeMax\b/hipFuncAttributeMax/g;
+    $ft{'numeric_literal'} += s/\bcudaFuncAttributeMaxDynamicSharedMemorySize\b/hipFuncAttributeMaxDynamicSharedMemorySize/g;
+    $ft{'numeric_literal'} += s/\bcudaFuncAttributePreferredSharedMemoryCarveout\b/hipFuncAttributePreferredSharedMemoryCarveout/g;
     $ft{'numeric_literal'} += s/\bcudaFuncCachePreferEqual\b/hipFuncCachePreferEqual/g;
     $ft{'numeric_literal'} += s/\bcudaFuncCachePreferL1\b/hipFuncCachePreferL1/g;
     $ft{'numeric_literal'} += s/\bcudaFuncCachePreferNone\b/hipFuncCachePreferNone/g;
     $ft{'numeric_literal'} += s/\bcudaFuncCachePreferShared\b/hipFuncCachePreferShared/g;
     $ft{'numeric_literal'} += s/\bcudaLimitMallocHeapSize\b/hipLimitMallocHeapSize/g;
+    $ft{'numeric_literal'} += s/\bcudaMemAdviseSetAccessedBy\b/hipMemAdviseSetAccessedBy/g;
+    $ft{'numeric_literal'} += s/\bcudaMemAdviseSetPreferredLocation\b/hipMemAdviseSetPreferredLocation/g;
+    $ft{'numeric_literal'} += s/\bcudaMemAdviseSetReadMostly\b/hipMemAdviseSetReadMostly/g;
+    $ft{'numeric_literal'} += s/\bcudaMemAdviseUnsetAccessedBy\b/hipMemAdviseUnsetAccessedBy/g;
+    $ft{'numeric_literal'} += s/\bcudaMemAdviseUnsetPreferredLocation\b/hipMemAdviseUnsetPreferredLocation/g;
+    $ft{'numeric_literal'} += s/\bcudaMemAdviseUnsetReadMostly\b/hipMemAdviseUnsetReadMostly/g;
+    $ft{'numeric_literal'} += s/\bcudaMemRangeAttributeAccessedBy\b/hipMemRangeAttributeAccessedBy/g;
+    $ft{'numeric_literal'} += s/\bcudaMemRangeAttributeLastPrefetchLocation\b/hipMemRangeAttributeLastPrefetchLocation/g;
+    $ft{'numeric_literal'} += s/\bcudaMemRangeAttributePreferredLocation\b/hipMemRangeAttributePreferredLocation/g;
+    $ft{'numeric_literal'} += s/\bcudaMemRangeAttributeReadMostly\b/hipMemRangeAttributeReadMostly/g;
     $ft{'numeric_literal'} += s/\bcudaMemcpyDefault\b/hipMemcpyDefault/g;
     $ft{'numeric_literal'} += s/\bcudaMemcpyDeviceToDevice\b/hipMemcpyDeviceToDevice/g;
     $ft{'numeric_literal'} += s/\bcudaMemcpyDeviceToHost\b/hipMemcpyDeviceToHost/g;
@@ -2249,6 +2342,10 @@ sub simpleSubstitutions {
     $ft{'define'} += s/\bCUDA_ARRAY3D_TEXTURE_GATHER\b/hipArrayTextureGather/g;
     $ft{'define'} += s/\bCUDA_COOPERATIVE_LAUNCH_MULTI_DEVICE_NO_POST_LAUNCH_SYNC\b/hipCooperativeLaunchMultiDeviceNoPostSync/g;
     $ft{'define'} += s/\bCUDA_COOPERATIVE_LAUNCH_MULTI_DEVICE_NO_PRE_LAUNCH_SYNC\b/hipCooperativeLaunchMultiDeviceNoPreSync/g;
+    $ft{'define'} += s/\bCUDA_IPC_HANDLE_SIZE\b/HIP_IPC_HANDLE_SIZE/g;
+    $ft{'define'} += s/\bCU_DEVICE_CPU\b/hipCpuDeviceId/g;
+    $ft{'define'} += s/\bCU_DEVICE_INVALID\b/hipInvalidDeviceId/g;
+    $ft{'define'} += s/\bCU_IPC_HANDLE_SIZE\b/HIP_IPC_HANDLE_SIZE/g;
     $ft{'define'} += s/\bCU_LAUNCH_PARAM_BUFFER_POINTER\b/HIP_LAUNCH_PARAM_BUFFER_POINTER/g;
     $ft{'define'} += s/\bCU_LAUNCH_PARAM_BUFFER_SIZE\b/HIP_LAUNCH_PARAM_BUFFER_SIZE/g;
     $ft{'define'} += s/\bCU_LAUNCH_PARAM_END\b/HIP_LAUNCH_PARAM_END/g;
@@ -2271,6 +2368,7 @@ sub simpleSubstitutions {
     $ft{'define'} += s/\bcudaArrayTextureGather\b/hipArrayTextureGather/g;
     $ft{'define'} += s/\bcudaCooperativeLaunchMultiDeviceNoPostSync\b/hipCooperativeLaunchMultiDeviceNoPostSync/g;
     $ft{'define'} += s/\bcudaCooperativeLaunchMultiDeviceNoPreSync\b/hipCooperativeLaunchMultiDeviceNoPreSync/g;
+    $ft{'define'} += s/\bcudaCpuDeviceId\b/hipCpuDeviceId/g;
     $ft{'define'} += s/\bcudaDeviceBlockingSync\b/hipDeviceScheduleBlockingSync/g;
     $ft{'define'} += s/\bcudaDeviceLmemResizeToMax\b/hipDeviceLmemResizeToMax/g;
     $ft{'define'} += s/\bcudaDeviceMapHost\b/hipDeviceMapHost/g;
@@ -2291,9 +2389,11 @@ sub simpleSubstitutions {
     $ft{'define'} += s/\bcudaHostRegisterIoMemory\b/hipHostRegisterIoMemory/g;
     $ft{'define'} += s/\bcudaHostRegisterMapped\b/hipHostRegisterMapped/g;
     $ft{'define'} += s/\bcudaHostRegisterPortable\b/hipHostRegisterPortable/g;
+    $ft{'define'} += s/\bcudaInvalidDeviceId\b/hipInvalidDeviceId/g;
     $ft{'define'} += s/\bcudaIpcMemLazyEnablePeerAccess\b/hipIpcMemLazyEnablePeerAccess/g;
     $ft{'define'} += s/\bcudaMemAttachGlobal\b/hipMemAttachGlobal/g;
     $ft{'define'} += s/\bcudaMemAttachHost\b/hipMemAttachHost/g;
+    $ft{'define'} += s/\bcudaMemAttachSingle\b/hipMemAttachSingle/g;
     $ft{'define'} += s/\bcudaOccupancyDefault\b/hipOccupancyDefault/g;
     $ft{'define'} += s/\bcudaStreamDefault\b/hipStreamDefault/g;
     $ft{'define'} += s/\bcudaStreamNonBlocking\b/hipStreamNonBlocking/g;
@@ -4030,7 +4130,6 @@ sub warnUnsupportedFunctions {
         "cudaStreamAttributeAccessPolicyWindow",
         "cudaStreamAttrValue",
         "cudaStreamAttrID",
-        "cudaStreamAttachMemAsync",
         "cudaSignalExternalSemaphoresAsync",
         "cudaSharedmemCarveoutMaxShared",
         "cudaSharedmemCarveoutMaxL1",
@@ -4042,7 +4141,6 @@ sub warnUnsupportedFunctions {
         "cudaProfilerInitialize",
         "cudaOutputMode_t",
         "cudaOutputMode",
-        "cudaOccupancyMaxPotentialBlockSizeWithFlags",
         "cudaOccupancyMaxPotentialBlockSizeVariableSMemWithFlags",
         "cudaOccupancyMaxPotentialBlockSizeVariableSMem",
         "cudaOccupancyDisableCachingOverride",
@@ -4055,7 +4153,6 @@ sub warnUnsupportedFunctions {
         "cudaMemoryTypeHost",
         "cudaMemoryTypeDevice",
         "cudaMemoryType",
-        "cudaMemoryAdvise",
         "cudaMemcpyFromArrayAsync",
         "cudaMemcpyArrayToArray",
         "cudaMemcpy3DPeerParms",
@@ -4063,23 +4160,6 @@ sub warnUnsupportedFunctions {
         "cudaMemcpy3DPeer",
         "cudaMemcpy2DToArrayAsync",
         "cudaMemcpy2DArrayToArray",
-        "cudaMemRangeGetAttributes",
-        "cudaMemRangeGetAttribute",
-        "cudaMemRangeAttributeReadMostly",
-        "cudaMemRangeAttributePreferredLocation",
-        "cudaMemRangeAttributeLastPrefetchLocation",
-        "cudaMemRangeAttributeAccessedBy",
-        "cudaMemRangeAttribute",
-        "cudaMemPrefetchAsync",
-        "cudaMemAttachSingle",
-        "cudaMemAdviseUnsetReadMostly",
-        "cudaMemAdviseUnsetPreferredLocation",
-        "cudaMemAdviseUnsetAccessedBy",
-        "cudaMemAdviseSetReadMostly",
-        "cudaMemAdviseSetPreferredLocation",
-        "cudaMemAdviseSetAccessedBy",
-        "cudaMemAdvise",
-        "cudaMallocMipmappedArray",
         "cudaLimitStackSize",
         "cudaLimitPrintfFifoSize",
         "cudaLimitPersistingL2CacheSize",
@@ -4093,7 +4173,6 @@ sub warnUnsupportedFunctions {
         "cudaKernelNodeAttributeAccessPolicyWindow",
         "cudaKernelNodeAttrValue",
         "cudaKernelNodeAttrID",
-        "cudaInvalidDeviceId",
         "cudaImportExternalSemaphore",
         "cudaImportExternalMemory",
         "cudaHostRegisterReadOnly",
@@ -4217,7 +4296,6 @@ sub warnUnsupportedFunctions {
         "cudaGetSurfaceObjectResourceDesc",
         "cudaGetParameterBufferV2",
         "cudaGetParameterBuffer",
-        "cudaGetMipmappedArrayLevel",
         "cudaGetFuncBySymbol",
         "cudaGLUnregisterBufferObject",
         "cudaGLUnmapBufferObjectAsync",
@@ -4236,13 +4314,6 @@ sub warnUnsupportedFunctions {
         "cudaGLDeviceListCurrentFrame",
         "cudaGLDeviceListAll",
         "cudaGLDeviceList",
-        "cudaFuncSetSharedMemConfig",
-        "cudaFuncSetAttribute",
-        "cudaFuncAttributePreferredSharedMemoryCarveout",
-        "cudaFuncAttributeMaxDynamicSharedMemorySize",
-        "cudaFuncAttributeMax",
-        "cudaFuncAttribute",
-        "cudaFreeMipmappedArray",
         "cudaFormatModeForced",
         "cudaFormatModeAuto",
         "cudaExternalSemaphore_t",
@@ -4433,15 +4504,9 @@ sub warnUnsupportedFunctions {
         "cudaEGLStreamConsumerConnect",
         "cudaEGLStreamConsumerAcquireFrame",
         "cudaDevicePropDontCare",
-        "cudaDeviceP2PAttr",
         "cudaDeviceMask",
         "cudaDeviceGetTexture1DLinearMaxWidth",
-        "cudaDeviceGetP2PAttribute",
         "cudaDeviceGetNvSciSyncAttributes",
-        "cudaDevP2PAttrPerformanceRank",
-        "cudaDevP2PAttrNativeAtomicSupported",
-        "cudaDevP2PAttrCudaArrayAccessSupported",
-        "cudaDevP2PAttrAccessSupported",
         "cudaDevAttrUnifiedAddressing",
         "cudaDevAttrTexturePitchAlignment",
         "cudaDevAttrTccDriver",
@@ -4454,8 +4519,6 @@ sub warnUnsupportedFunctions {
         "cudaDevAttrReserved93",
         "cudaDevAttrReserved92",
         "cudaDevAttrPciDomainId",
-        "cudaDevAttrPageableMemoryAccessUsesHostPageTables",
-        "cudaDevAttrPageableMemoryAccess",
         "cudaDevAttrMultiGpuBoardGroupID",
         "cudaDevAttrMaxTextureCubemapWidth",
         "cudaDevAttrMaxTextureCubemapLayeredWidth",
@@ -4494,15 +4557,12 @@ sub warnUnsupportedFunctions {
         "cudaDevAttrMaxSharedMemoryPerBlockOptin",
         "cudaDevAttrMaxRegistersPerMultiprocessor",
         "cudaDevAttrMaxBlocksPerMultiprocessor",
-        "cudaDevAttrManagedMemory",
         "cudaDevAttrLocalL1CacheSupported",
         "cudaDevAttrHostRegisterSupported",
         "cudaDevAttrHostRegisterReadOnlySupported",
         "cudaDevAttrHostNativeAtomicSupported",
         "cudaDevAttrGpuOverlap",
         "cudaDevAttrGlobalL1CacheSupported",
-        "cudaDevAttrDirectManagedMemAccessFromHost",
-        "cudaDevAttrConcurrentManagedAccess",
         "cudaDevAttrComputePreemptionSupported",
         "cudaDevAttrCanUseHostPointerForRegisteredMem",
         "cudaDevAttrCanFlushRemoteWrites",
@@ -4568,7 +4628,6 @@ sub warnUnsupportedFunctions {
         "cudaD3D10DeviceListAll",
         "cudaD3D10DeviceList",
         "cudaCtxResetPersistingL2Cache",
-        "cudaCpuDeviceId",
         "cudaCSV",
         "cudaCGScopeMultiGrid",
         "cudaCGScopeInvalid",
@@ -4654,28 +4713,9 @@ sub warnUnsupportedFunctions {
         "cuVDPAUGetDevice",
         "cuVDPAUCtxCreate",
         "cuThreadExchangeStreamCaptureMode",
-        "cuTexRefSetMipmappedArray",
-        "cuTexRefSetMipmapLevelClamp",
-        "cuTexRefSetMipmapLevelBias",
-        "cuTexRefSetMipmapFilterMode",
-        "cuTexRefSetMaxAnisotropy",
-        "cuTexRefSetBorderColor",
-        "cuTexRefGetMipmappedArray",
-        "cuTexRefGetMipmapLevelClamp",
-        "cuTexRefGetMipmapLevelBias",
-        "cuTexRefGetMipmapFilterMode",
-        "cuTexRefGetMaxAnisotropy",
-        "cuTexRefGetFormat",
-        "cuTexRefGetFlags",
-        "cuTexRefGetFilterMode",
         "cuTexRefGetBorderColor",
         "cuTexRefDestroy",
         "cuTexRefCreate",
-        "cuTexObjectGetTextureDesc",
-        "cuTexObjectGetResourceViewDesc",
-        "cuTexObjectGetResourceDesc",
-        "cuTexObjectDestroy",
-        "cuTexObjectCreate",
         "cuSurfRefSetArray",
         "cuSurfRefGetArray",
         "cuSurfObjectGetResourceDesc",
@@ -4696,7 +4736,6 @@ sub warnUnsupportedFunctions {
         "cuStreamBeginCapture_ptsz",
         "cuStreamBeginCapture",
         "cuStreamBatchMemOp",
-        "cuStreamAttachMemAsync",
         "cuSignalExternalSemaphoresAsync",
         "cuProfilerInitialize",
         "cuPointerSetAttribute",
@@ -4707,13 +4746,9 @@ sub warnUnsupportedFunctions {
         "cuParamSetf",
         "cuParamSetTexRef",
         "cuParamSetSize",
-        "cuOccupancyMaxPotentialBlockSizeWithFlags",
         "cuOccupancyAvailableDynamicSMemPerBlock",
         "cuModuleLoadFatBinary",
         "cuModuleGetSurfRef",
-        "cuMipmappedArrayGetLevel",
-        "cuMipmappedArrayDestroy",
-        "cuMipmappedArrayCreate",
         "cuMemsetD2D8_v2",
         "cuMemsetD2D8Async",
         "cuMemsetD2D8",
@@ -4745,8 +4780,6 @@ sub warnUnsupportedFunctions {
         "cuMemSetAccess",
         "cuMemRetainAllocationHandle",
         "cuMemRelease",
-        "cuMemRangeGetAttributes",
-        "cuMemRangeGetAttribute",
         "cuMemPrefetchAsync",
         "cuMemMapArrayAsync",
         "cuMemMap",
@@ -4756,7 +4789,6 @@ sub warnUnsupportedFunctions {
         "cuMemGetAccess",
         "cuMemExportToShareableHandle",
         "cuMemCreate",
-        "cuMemAdvise",
         "cuMemAddressReserve",
         "cuMemAddressFree",
         "cuLinkDestroy",
@@ -4773,8 +4805,6 @@ sub warnUnsupportedFunctions {
         "cuLaunchCooperativeKernelMultiDevice",
         "cuLaunchCooperativeKernel",
         "cuLaunch",
-        "cuIpcOpenEventHandle",
-        "cuIpcGetEventHandle",
         "cuImportExternalSemaphore",
         "cuImportExternalMemory",
         "cuGraphicsVDPAURegisterVideoSurface",
@@ -4879,7 +4909,6 @@ sub warnUnsupportedFunctions {
         "cuDeviceGetUuid",
         "cuDeviceGetTexture1DLinearMaxWidth",
         "cuDeviceGetProperties",
-        "cuDeviceGetP2PAttribute",
         "cuDeviceGetNvSciSyncAttributes",
         "cuDeviceGetLuid",
         "cuDestroyExternalSemaphore",
@@ -4975,10 +5004,6 @@ sub warnUnsupportedFunctions {
         "CUoccupancy_flags_enum",
         "CUoccupancy_flags",
         "CUoccupancyB2DSize",
-        "CUmem_range_attribute_enum",
-        "CUmem_range_attribute",
-        "CUmem_advise_enum",
-        "CUmem_advise",
         "CUmemOperationType_enum",
         "CUmemOperationType",
         "CUmemLocation_st",
@@ -5057,8 +5082,6 @@ sub warnUnsupportedFunctions {
         "CUeglColorFormat",
         "CUdevprop_st",
         "CUdevprop",
-        "CUdevice_P2PAttribute_enum",
-        "CUdevice_P2PAttribute",
         "CUd3d9register_flags_enum",
         "CUd3d9register_flags",
         "CUd3d9map_flags_enum",
@@ -5160,10 +5183,6 @@ sub warnUnsupportedFunctions {
         "CU_POINTER_ATTRIBUTE_ACCESS_FLAGS",
         "CU_PARAM_TR_DEFAULT",
         "CU_OCCUPANCY_DISABLE_CACHING_OVERRIDE",
-        "CU_MEM_RANGE_ATTRIBUTE_READ_MOSTLY",
-        "CU_MEM_RANGE_ATTRIBUTE_PREFERRED_LOCATION",
-        "CU_MEM_RANGE_ATTRIBUTE_LAST_PREFETCH_LOCATION",
-        "CU_MEM_RANGE_ATTRIBUTE_ACCESSED_BY",
         "CU_MEM_OPERATION_TYPE_UNMAP",
         "CU_MEM_OPERATION_TYPE_MAP",
         "CU_MEM_LOCATION_TYPE_MAX",
@@ -5175,15 +5194,8 @@ sub warnUnsupportedFunctions {
         "CU_MEM_HANDLE_TYPE_MAX",
         "CU_MEM_HANDLE_TYPE_GENERIC",
         "CU_MEM_CREATE_USAGE_TILE_POOL",
-        "CU_MEM_ATTACH_SINGLE",
         "CU_MEM_ALLOC_GRANULARITY_RECOMMENDED",
         "CU_MEM_ALLOC_GRANULARITY_MINIMUM",
-        "CU_MEM_ADVISE_UNSET_READ_MOSTLY",
-        "CU_MEM_ADVISE_UNSET_PREFERRED_LOCATION",
-        "CU_MEM_ADVISE_UNSET_ACCESSED_BY",
-        "CU_MEM_ADVISE_SET_READ_MOSTLY",
-        "CU_MEM_ADVISE_SET_PREFERRED_LOCATION",
-        "CU_MEM_ADVISE_SET_ACCESSED_BY",
         "CU_MEM_ACCESS_FLAGS_PROT_READWRITE",
         "CU_MEM_ACCESS_FLAGS_PROT_READ",
         "CU_MEM_ACCESS_FLAGS_PROT_NONE",
@@ -5204,10 +5216,12 @@ sub warnUnsupportedFunctions {
         "CU_JIT_INPUT_LIBRARY",
         "CU_JIT_INPUT_FATBINARY",
         "CU_JIT_INPUT_CUBIN",
+        "CU_JIT_GLOBAL_SYMBOL_NAMES",
+        "CU_JIT_GLOBAL_SYMBOL_COUNT",
+        "CU_JIT_GLOBAL_SYMBOL_ADDRESSES",
         "CU_JIT_CACHE_OPTION_NONE",
         "CU_JIT_CACHE_OPTION_CG",
         "CU_JIT_CACHE_OPTION_CA",
-        "CU_IPC_HANDLE_SIZE",
         "CU_GRAPH_NODE_TYPE_WAIT_EVENT",
         "CU_GRAPH_NODE_TYPE_MEMSET",
         "CU_GRAPH_NODE_TYPE_MEMCPY",
@@ -5335,14 +5349,6 @@ sub warnUnsupportedFunctions {
         "CU_EGL_COLOR_FORMAT_ARGB",
         "CU_EGL_COLOR_FORMAT_ABGR",
         "CU_EGL_COLOR_FORMAT_A",
-        "CU_DEVICE_P2P_ATTRIBUTE_PERFORMANCE_RANK",
-        "CU_DEVICE_P2P_ATTRIBUTE_NATIVE_ATOMIC_SUPPORTED",
-        "CU_DEVICE_P2P_ATTRIBUTE_CUDA_ARRAY_ACCESS_SUPPORTED",
-        "CU_DEVICE_P2P_ATTRIBUTE_ARRAY_ACCESS_ACCESS_SUPPORTED",
-        "CU_DEVICE_P2P_ATTRIBUTE_ACCESS_SUPPORTED",
-        "CU_DEVICE_P2P_ATTRIBUTE_ACCESS_ACCESS_SUPPORTED",
-        "CU_DEVICE_INVALID",
-        "CU_DEVICE_CPU",
         "CU_DEVICE_ATTRIBUTE_VIRTUAL_ADDRESS_MANAGEMENT_SUPPORTED",
         "CU_DEVICE_ATTRIBUTE_UNIFIED_ADDRESSING",
         "CU_DEVICE_ATTRIBUTE_TEXTURE_PITCH_ALIGNMENT",
@@ -5354,8 +5360,6 @@ sub warnUnsupportedFunctions {
         "CU_DEVICE_ATTRIBUTE_RESERVED_SHARED_MEMORY_PER_BLOCK",
         "CU_DEVICE_ATTRIBUTE_READ_ONLY_HOST_REGISTER_SUPPORTED",
         "CU_DEVICE_ATTRIBUTE_PCI_DOMAIN_ID",
-        "CU_DEVICE_ATTRIBUTE_PAGEABLE_MEMORY_ACCESS_USES_HOST_PAGE_TABLES",
-        "CU_DEVICE_ATTRIBUTE_PAGEABLE_MEMORY_ACCESS",
         "CU_DEVICE_ATTRIBUTE_MULTI_GPU_BOARD_GROUP_ID",
         "CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_BLOCK_OPTIN",
         "CU_DEVICE_ATTRIBUTE_MAX_REGISTERS_PER_MULTIPROCESSOR",
@@ -5400,7 +5404,6 @@ sub warnUnsupportedFunctions {
         "CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACE1D_LAYERED_WIDTH",
         "CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACE1D_LAYERED_LAYERS",
         "CU_DEVICE_ATTRIBUTE_MAX",
-        "CU_DEVICE_ATTRIBUTE_MANAGED_MEMORY",
         "CU_DEVICE_ATTRIBUTE_LOCAL_L1_CACHE_SUPPORTED",
         "CU_DEVICE_ATTRIBUTE_HOST_REGISTER_SUPPORTED",
         "CU_DEVICE_ATTRIBUTE_HOST_NATIVE_ATOMIC_SUPPORTED",
@@ -5411,8 +5414,6 @@ sub warnUnsupportedFunctions {
         "CU_DEVICE_ATTRIBUTE_GPU_DIRECT_RDMA_WITH_CUDA_VMM_SUPPORTED",
         "CU_DEVICE_ATTRIBUTE_GLOBAL_L1_CACHE_SUPPORTED",
         "CU_DEVICE_ATTRIBUTE_GENERIC_COMPRESSION_SUPPORTED",
-        "CU_DEVICE_ATTRIBUTE_DIRECT_MANAGED_MEM_ACCESS_FROM_HOST",
-        "CU_DEVICE_ATTRIBUTE_CONCURRENT_MANAGED_ACCESS",
         "CU_DEVICE_ATTRIBUTE_COMPUTE_PREEMPTION_SUPPORTED",
         "CU_DEVICE_ATTRIBUTE_CAN_USE_STREAM_WAIT_VALUE_NOR",
         "CU_DEVICE_ATTRIBUTE_CAN_USE_STREAM_MEM_OPS",
@@ -5902,7 +5903,6 @@ sub warnUnsupportedFunctions {
         "CUDA_LAUNCH_PARAMS",
         "CUDA_KERNEL_NODE_PARAMS_st",
         "CUDA_KERNEL_NODE_PARAMS",
-        "CUDA_IPC_HANDLE_SIZE",
         "CUDA_HOST_NODE_PARAMS_st",
         "CUDA_HOST_NODE_PARAMS",
         "CUDA_EXTERNAL_SEMAPHORE_WAIT_SKIP_NVSCIBUF_MEMSYNC",

--- a/src/CUDA2HIP_Driver_API_functions.cpp
+++ b/src/CUDA2HIP_Driver_API_functions.cpp
@@ -43,7 +43,7 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_FUNCTION_MAP {
   // 5. Device Management
   // cudaGetDevice
   // NOTE: cudaGetDevice has additional attr: int ordinal
-  {"cuDeviceGet",                                          {"hipGetDevice",                                            "", CONV_DEVICE, API_DRIVER, 5}},
+  {"cuDeviceGet",                                          {"hipDeviceGet",                                            "", CONV_DEVICE, API_DRIVER, 5}},
   // cudaDeviceGetAttribute
   {"cuDeviceGetAttribute",                                 {"hipDeviceGetAttribute",                                   "", CONV_DEVICE, API_DRIVER, 5}},
   // cudaGetDeviceCount
@@ -160,11 +160,11 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_FUNCTION_MAP {
   // cudaIpcCloseMemHandle
   {"cuIpcCloseMemHandle",                                  {"hipIpcCloseMemHandle",                                    "", CONV_MEMORY, API_DRIVER, 11}},
   // cudaIpcGetEventHandle
-  {"cuIpcGetEventHandle",                                  {"hipIpcGetEventHandle",                                    "", CONV_MEMORY, API_DRIVER, 11, HIP_UNSUPPORTED}},
+  {"cuIpcGetEventHandle",                                  {"hipIpcGetEventHandle",                                    "", CONV_MEMORY, API_DRIVER, 11}},
   // cudaIpcGetMemHandle
   {"cuIpcGetMemHandle",                                    {"hipIpcGetMemHandle",                                      "", CONV_MEMORY, API_DRIVER, 11}},
   // cudaIpcOpenEventHandle
-  {"cuIpcOpenEventHandle",                                 {"hipIpcOpenEventHandle",                                   "", CONV_MEMORY, API_DRIVER, 11, HIP_UNSUPPORTED}},
+  {"cuIpcOpenEventHandle",                                 {"hipIpcOpenEventHandle",                                   "", CONV_MEMORY, API_DRIVER, 11}},
   // cudaIpcOpenMemHandle
   {"cuIpcOpenMemHandle",                                   {"hipIpcOpenMemHandle",                                     "", CONV_MEMORY, API_DRIVER, 11}},
   // cudaMalloc
@@ -311,13 +311,13 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_FUNCTION_MAP {
   {"cuMemsetD8Async",                                      {"hipMemsetD8Async",                                        "", CONV_MEMORY, API_DRIVER, 11}},
   // no analogue
   // NOTE: Not equal to cudaMallocMipmappedArray due to different signatures
-  {"cuMipmappedArrayCreate",                               {"hipMipmappedArrayCreate",                                 "", CONV_MEMORY, API_DRIVER, 11, HIP_UNSUPPORTED}},
+  {"cuMipmappedArrayCreate",                               {"hipMipmappedArrayCreate",                                 "", CONV_MEMORY, API_DRIVER, 11}},
   // no analogue
   // NOTE: Not equal to cudaFreeMipmappedArray due to different signatures
-  {"cuMipmappedArrayDestroy",                              {"hipMipmappedArrayDestroy",                                "", CONV_MEMORY, API_DRIVER, 11, HIP_UNSUPPORTED}},
+  {"cuMipmappedArrayDestroy",                              {"hipMipmappedArrayDestroy",                                "", CONV_MEMORY, API_DRIVER, 11}},
   // no analogue
   // NOTE: Not equal to cudaGetMipmappedArrayLevel due to different signatures
-  {"cuMipmappedArrayGetLevel",                             {"hipMipmappedArrayGetLevel",                               "", CONV_MEMORY, API_DRIVER, 11, HIP_UNSUPPORTED}},
+  {"cuMipmappedArrayGetLevel",                             {"hipMipmappedArrayGetLevel",                               "", CONV_MEMORY, API_DRIVER, 11}},
   // cudaArrayGetSparseProperties
   {"cuArrayGetSparseProperties",                           {"hipArrayGetSparseProperties",                             "", CONV_MEMORY, API_DRIVER, 11, HIP_UNSUPPORTED}},
 
@@ -340,13 +340,13 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_FUNCTION_MAP {
 
   // 13. Unified Addressing
   // cudaMemAdvise
-  {"cuMemAdvise",                                          {"hipMemAdvise",                                            "", CONV_ADDRESSING, API_DRIVER, 13, HIP_UNSUPPORTED}},
+  {"cuMemAdvise",                                          {"hipMemAdvise",                                            "", CONV_ADDRESSING, API_DRIVER, 13}},
   // TODO: double check cudaMemPrefetchAsync
   {"cuMemPrefetchAsync",                                   {"hipMemPrefetchAsync_",                                    "", CONV_ADDRESSING, API_DRIVER, 13, HIP_UNSUPPORTED}},
   // cudaMemRangeGetAttribute
-  {"cuMemRangeGetAttribute",                               {"hipMemRangeGetAttribute",                                 "", CONV_ADDRESSING, API_DRIVER, 13, HIP_UNSUPPORTED}},
+  {"cuMemRangeGetAttribute",                               {"hipMemRangeGetAttribute",                                 "", CONV_ADDRESSING, API_DRIVER, 13}},
   // cudaMemRangeGetAttributes
-  {"cuMemRangeGetAttributes",                              {"hipMemRangeGetAttributes",                                "", CONV_ADDRESSING, API_DRIVER, 13, HIP_UNSUPPORTED}},
+  {"cuMemRangeGetAttributes",                              {"hipMemRangeGetAttributes",                                "", CONV_ADDRESSING, API_DRIVER, 13}},
   // no analogue
   {"cuPointerGetAttribute",                                {"hipPointerGetAttribute",                                  "", CONV_ADDRESSING, API_DRIVER, 13, HIP_UNSUPPORTED}},
   // no analogue
@@ -359,7 +359,7 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_FUNCTION_MAP {
   // cudaStreamAddCallback
   {"cuStreamAddCallback",                                  {"hipStreamAddCallback",                                    "", CONV_STREAM, API_DRIVER, 14}},
   // cudaStreamAttachMemAsync
-  {"cuStreamAttachMemAsync",                               {"hipStreamAttachMemAsync",                                 "", CONV_STREAM, API_DRIVER, 14, HIP_UNSUPPORTED}},
+  {"cuStreamAttachMemAsync",                               {"hipStreamAttachMemAsync",                                 "", CONV_STREAM, API_DRIVER, 14}},
   // cudaStreamBeginCapture
   {"cuStreamBeginCapture",                                 {"hipStreamBeginCapture",                                   "", CONV_STREAM, API_DRIVER, 14, HIP_UNSUPPORTED}},
   {"cuStreamBeginCapture_v2",                              {"hipStreamBeginCapture",                                   "", CONV_STREAM, API_DRIVER, 14, HIP_UNSUPPORTED}},
@@ -448,7 +448,7 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_FUNCTION_MAP {
   {"cuFuncGetModule",                                      {"hipFuncGetModule",                                        "", CONV_EXECUTION, API_DRIVER, 18, HIP_UNSUPPORTED}},
   // no analogue
   // NOTE: Not equal to cudaFuncSetAttribute due to different signatures
-  {"cuFuncSetAttribute",                                   {"hipFuncSetAttribute",                                     "", CONV_EXECUTION, API_DRIVER, 18, HIP_UNSUPPORTED}},
+  {"cuFuncSetAttribute",                                   {"hipFuncSetAttribute_",                                    "", CONV_EXECUTION, API_DRIVER, 18, HIP_UNSUPPORTED}},
   // no analogue
   // NOTE: Not equal to cudaFuncSetCacheConfig due to different signatures
   {"cuFuncSetCacheConfig",                                 {"hipFuncSetCacheConfig",                                   "", CONV_EXECUTION, API_DRIVER, 18, HIP_UNSUPPORTED}},
@@ -593,15 +593,15 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_FUNCTION_MAP {
 
   // 21. Occupancy
   // cudaOccupancyAvailableDynamicSMemPerBlock
-  {"cuOccupancyAvailableDynamicSMemPerBlock",              {"hipOccupancyAvailableDynamicSMemPerBlock",                "", CONV_OCCUPANCY, API_DRIVER, 21, HIP_UNSUPPORTED}},
+  {"cuOccupancyAvailableDynamicSMemPerBlock",              {"hipModuleOccupancyAvailableDynamicSMemPerBlock",          "", CONV_OCCUPANCY, API_DRIVER, 21, HIP_UNSUPPORTED}},
   // cudaOccupancyMaxActiveBlocksPerMultiprocessor
-  {"cuOccupancyMaxActiveBlocksPerMultiprocessor",          {"hipDrvOccupancyMaxActiveBlocksPerMultiprocessor",         "", CONV_OCCUPANCY, API_DRIVER, 21}},
+  {"cuOccupancyMaxActiveBlocksPerMultiprocessor",          {"hipModuleOccupancyMaxActiveBlocksPerMultiprocessor",      "", CONV_OCCUPANCY, API_DRIVER, 21}},
   // cudaOccupancyMaxActiveBlocksPerMultiprocessorWithFlags
-  {"cuOccupancyMaxActiveBlocksPerMultiprocessorWithFlags", {"hipDrvOccupancyMaxActiveBlocksPerMultiprocessorWithFlags","", CONV_OCCUPANCY, API_DRIVER, 21}},
+  {"cuOccupancyMaxActiveBlocksPerMultiprocessorWithFlags", {"hipModuleOccupancyMaxActiveBlocksPerMultiprocessorWithFlags","", CONV_OCCUPANCY, API_DRIVER, 21}},
   // cudaOccupancyMaxPotentialBlockSize
-  {"cuOccupancyMaxPotentialBlockSize",                     {"hipOccupancyMaxPotentialBlockSize",                       "", CONV_OCCUPANCY, API_DRIVER, 21}},
+  {"cuOccupancyMaxPotentialBlockSize",                     {"hipModuleOccupancyMaxPotentialBlockSize",                 "", CONV_OCCUPANCY, API_DRIVER, 21}},
   // cudaOccupancyMaxPotentialBlockSizeWithFlags
-  {"cuOccupancyMaxPotentialBlockSizeWithFlags",            {"hipOccupancyMaxPotentialBlockSizeWithFlags",              "", CONV_OCCUPANCY, API_DRIVER, 21, HIP_UNSUPPORTED}},
+  {"cuOccupancyMaxPotentialBlockSizeWithFlags",            {"hipModuleOccupancyMaxPotentialBlockSizeWithFlags",        "", CONV_OCCUPANCY, API_DRIVER, 21}},
 
   // 22. Texture Reference Management [DEPRECATED]
   // no analogues
@@ -610,14 +610,15 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_FUNCTION_MAP {
   {"cuTexRefGetAddressMode",                               {"hipTexRefGetAddressMode",                                 "", CONV_TEXTURE, API_DRIVER, 22, DEPRECATED}},
   {"cuTexRefGetArray",                                     {"hipTexRefGetArray",                                       "", CONV_TEXTURE, API_DRIVER, 22, DEPRECATED}},
   {"cuTexRefGetBorderColor",                               {"hipTexRefGetBorderColor",                                 "", CONV_TEXTURE, API_DRIVER, 22, HIP_UNSUPPORTED | DEPRECATED}},
-  {"cuTexRefGetFilterMode",                                {"hipTexRefGetFilterMode",                                  "", CONV_TEXTURE, API_DRIVER, 22, HIP_UNSUPPORTED | DEPRECATED}},
-  {"cuTexRefGetFlags",                                     {"hipTexRefGetFlags",                                       "", CONV_TEXTURE, API_DRIVER, 22, HIP_UNSUPPORTED | DEPRECATED}},
-  {"cuTexRefGetFormat",                                    {"hipTexRefGetFormat",                                      "", CONV_TEXTURE, API_DRIVER, 22, HIP_UNSUPPORTED | DEPRECATED}},
-  {"cuTexRefGetMaxAnisotropy",                             {"hipTexRefGetMaxAnisotropy",                               "", CONV_TEXTURE, API_DRIVER, 22, HIP_UNSUPPORTED | DEPRECATED}},
-  {"cuTexRefGetMipmapFilterMode",                          {"hipTexRefGetMipmapFilterMode",                            "", CONV_TEXTURE, API_DRIVER, 22, HIP_UNSUPPORTED | DEPRECATED}},
-  {"cuTexRefGetMipmapLevelBias",                           {"hipTexRefGetMipmapLevelBias",                             "", CONV_TEXTURE, API_DRIVER, 22, HIP_UNSUPPORTED | DEPRECATED}},
-  {"cuTexRefGetMipmapLevelClamp",                          {"hipTexRefGetMipmapLevelClamp",                            "", CONV_TEXTURE, API_DRIVER, 22, HIP_UNSUPPORTED | DEPRECATED}},
-  {"cuTexRefGetMipmappedArray",                            {"hipTexRefGetMipmappedArray",                              "", CONV_TEXTURE, API_DRIVER, 22, HIP_UNSUPPORTED | DEPRECATED}},
+  {"cuTexRefGetFilterMode",                                {"hipTexRefGetFilterMode",                                  "", CONV_TEXTURE, API_DRIVER, 22, DEPRECATED}},
+  {"cuTexRefGetFlags",                                     {"hipTexRefGetFlags",                                       "", CONV_TEXTURE, API_DRIVER, 22, DEPRECATED}},
+  {"cuTexRefGetFormat",                                    {"hipTexRefGetFormat",                                      "", CONV_TEXTURE, API_DRIVER, 22, DEPRECATED}},
+  {"cuTexRefGetMaxAnisotropy",                             {"hipTexRefGetMaxAnisotropy",                               "", CONV_TEXTURE, API_DRIVER, 22, DEPRECATED}},
+  {"cuTexRefGetMipmapFilterMode",                          {"hipTexRefGetMipmapFilterMode",                            "", CONV_TEXTURE, API_DRIVER, 22, DEPRECATED}},
+  {"cuTexRefGetMipmapLevelBias",                           {"hipTexRefGetMipmapLevelBias",                             "", CONV_TEXTURE, API_DRIVER, 22, DEPRECATED}},
+  {"cuTexRefGetMipmapLevelClamp",                          {"hipTexRefGetMipmapLevelClamp",                            "", CONV_TEXTURE, API_DRIVER, 22, DEPRECATED}},
+  // TODO: [HIP] fix typo hipTexRefGetMipMappedArray -> hipTexRefGetMipmappedArray
+  {"cuTexRefGetMipmappedArray",                            {"hipTexRefGetMipMappedArray",                              "", CONV_TEXTURE, API_DRIVER, 22, DEPRECATED}},
   {"cuTexRefSetAddress",                                   {"hipTexRefSetAddress",                                     "", CONV_TEXTURE, API_DRIVER, 22, DEPRECATED}},
   {"cuTexRefSetAddress_v2",                                {"hipTexRefSetAddress",                                     "", CONV_TEXTURE, API_DRIVER, 22, DEPRECATED}},
   {"cuTexRefSetAddress2D",                                 {"hipTexRefSetAddress2D",                                   "", CONV_TEXTURE, API_DRIVER, 22, DEPRECATED}},
@@ -625,15 +626,15 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_FUNCTION_MAP {
   {"cuTexRefSetAddress2D_v3",                              {"hipTexRefSetAddress2D",                                   "", CONV_TEXTURE, API_DRIVER, 22}},
   {"cuTexRefSetAddressMode",                               {"hipTexRefSetAddressMode",                                 "", CONV_TEXTURE, API_DRIVER, 22, DEPRECATED}},
   {"cuTexRefSetArray",                                     {"hipTexRefSetArray",                                       "", CONV_TEXTURE, API_DRIVER, 22, DEPRECATED}},
-  {"cuTexRefSetBorderColor",                               {"hipTexRefSetBorderColor",                                 "", CONV_TEXTURE, API_DRIVER, 22, HIP_UNSUPPORTED | DEPRECATED}},
+  {"cuTexRefSetBorderColor",                               {"hipTexRefSetBorderColor",                                 "", CONV_TEXTURE, API_DRIVER, 22, DEPRECATED}},
   {"cuTexRefSetFilterMode",                                {"hipTexRefSetFilterMode",                                  "", CONV_TEXTURE, API_DRIVER, 22, DEPRECATED}},
   {"cuTexRefSetFlags",                                     {"hipTexRefSetFlags",                                       "", CONV_TEXTURE, API_DRIVER, 22, DEPRECATED}},
   {"cuTexRefSetFormat",                                    {"hipTexRefSetFormat",                                      "", CONV_TEXTURE, API_DRIVER, 22, DEPRECATED}},
-  {"cuTexRefSetMaxAnisotropy",                             {"hipTexRefSetMaxAnisotropy",                               "", CONV_TEXTURE, API_DRIVER, 22, HIP_UNSUPPORTED | DEPRECATED}},
-  {"cuTexRefSetMipmapFilterMode",                          {"hipTexRefSetMipmapFilterMode",                            "", CONV_TEXTURE, API_DRIVER, 22, HIP_UNSUPPORTED | DEPRECATED}},
-  {"cuTexRefSetMipmapLevelBias",                           {"hipTexRefSetMipmapLevelBias",                             "", CONV_TEXTURE, API_DRIVER, 22, HIP_UNSUPPORTED | DEPRECATED}},
-  {"cuTexRefSetMipmapLevelClamp",                          {"hipTexRefSetMipmapLevelClamp",                            "", CONV_TEXTURE, API_DRIVER, 22, HIP_UNSUPPORTED | DEPRECATED}},
-  {"cuTexRefSetMipmappedArray",                            {"hipTexRefSetMipmappedArray",                              "", CONV_TEXTURE, API_DRIVER, 22, HIP_UNSUPPORTED | DEPRECATED}},
+  {"cuTexRefSetMaxAnisotropy",                             {"hipTexRefSetMaxAnisotropy",                               "", CONV_TEXTURE, API_DRIVER, 22, DEPRECATED}},
+  {"cuTexRefSetMipmapFilterMode",                          {"hipTexRefSetMipmapFilterMode",                            "", CONV_TEXTURE, API_DRIVER, 22, DEPRECATED}},
+  {"cuTexRefSetMipmapLevelBias",                           {"hipTexRefSetMipmapLevelBias",                             "", CONV_TEXTURE, API_DRIVER, 22, DEPRECATED}},
+  {"cuTexRefSetMipmapLevelClamp",                          {"hipTexRefSetMipmapLevelClamp",                            "", CONV_TEXTURE, API_DRIVER, 22, DEPRECATED}},
+  {"cuTexRefSetMipmappedArray",                            {"hipTexRefSetMipmappedArray",                              "", CONV_TEXTURE, API_DRIVER, 22, DEPRECATED}},
   {"cuTexRefCreate",                                       {"hipTexRefCreate",                                         "", CONV_TEXTURE, API_DRIVER, 22, HIP_UNSUPPORTED | DEPRECATED}},
   {"cuTexRefDestroy",                                      {"hipTexRefDestroy",                                        "", CONV_TEXTURE, API_DRIVER, 22, HIP_UNSUPPORTED | DEPRECATED}},
 
@@ -645,17 +646,17 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_FUNCTION_MAP {
   // 24. Texture Object Management
   // no analogue
   // NOTE: Not equal to cudaCreateTextureObject due to different signatures
-  {"cuTexObjectCreate",                                    {"hipTexObjectCreate",                                      "", CONV_TEXTURE, API_DRIVER, 24, HIP_UNSUPPORTED}},
+  {"cuTexObjectCreate",                                    {"hipTexObjectCreate",                                      "", CONV_TEXTURE, API_DRIVER, 24}},
   // cudaDestroyTextureObject
-  {"cuTexObjectDestroy",                                   {"hipTexObjectDestroy",                                     "", CONV_TEXTURE, API_DRIVER, 24, HIP_UNSUPPORTED}},
+  {"cuTexObjectDestroy",                                   {"hipTexObjectDestroy",                                     "", CONV_TEXTURE, API_DRIVER, 24}},
   // no analogue
   // NOTE: Not equal to cudaGetTextureObjectResourceDesc due to different signatures
-  {"cuTexObjectGetResourceDesc",                           {"hipTexObjectGetResourceDesc",                             "", CONV_TEXTURE, API_DRIVER, 24, HIP_UNSUPPORTED}},
+  {"cuTexObjectGetResourceDesc",                           {"hipTexObjectGetResourceDesc",                             "", CONV_TEXTURE, API_DRIVER, 24}},
   // cudaGetTextureObjectResourceViewDesc
-  {"cuTexObjectGetResourceViewDesc",                       {"hipTexObjectGetResourceViewDesc",                         "", CONV_TEXTURE, API_DRIVER, 24, HIP_UNSUPPORTED}},
+  {"cuTexObjectGetResourceViewDesc",                       {"hipTexObjectGetResourceViewDesc",                         "", CONV_TEXTURE, API_DRIVER, 24}},
   // no analogue
   // NOTE: Not equal to cudaGetTextureObjectTextureDesc due to different signatures
-  {"cuTexObjectGetTextureDesc",                            {"hipTexObjectGetTextureDesc",                              "", CONV_TEXTURE, API_DRIVER, 24, HIP_UNSUPPORTED}},
+  {"cuTexObjectGetTextureDesc",                            {"hipTexObjectGetTextureDesc",                              "", CONV_TEXTURE, API_DRIVER, 24}},
 
   // 25. Surface Object Management
   // no analogue
@@ -677,7 +678,7 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_FUNCTION_MAP {
   // cudaDeviceCanAccessPeer
   {"cuDeviceCanAccessPeer",                                {"hipDeviceCanAccessPeer",                                  "", CONV_PEER, API_DRIVER, 26}},
   // cudaDeviceGetP2PAttribute
-  {"cuDeviceGetP2PAttribute",                              {"hipDeviceGetP2PAttribute",                                "", CONV_PEER, API_DRIVER, 26, HIP_UNSUPPORTED}},
+  {"cuDeviceGetP2PAttribute",                              {"hipDeviceGetP2PAttribute",                                "", CONV_PEER, API_DRIVER, 26}},
 
   // 27. Graphics Interoperability
   // cudaGraphicsMapResources

--- a/src/CUDA2HIP_Driver_API_types.cpp
+++ b/src/CUDA2HIP_Driver_API_types.cpp
@@ -114,9 +114,9 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_TYPE_NAME_MAP {
   {"CUdevprop",                                                        {"hipDeviceProp_t",                                          "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
 
   // cudaIpcEventHandle_st
-  {"CUipcEventHandle_st",                                              {"ihipIpcEventHandle_t",                                     "", CONV_TYPE, API_DRIVER, 1}},
+  {"CUipcEventHandle_st",                                              {"hipIpcEventHandle_st",                                     "", CONV_TYPE, API_DRIVER, 1}},
   // cudaIpcEventHandle_t
-  {"CUipcEventHandle",                                                 {"ihipIpcEventHandle_t",                                     "", CONV_TYPE, API_DRIVER, 1}},
+  {"CUipcEventHandle",                                                 {"hipIpcEventHandle_t",                                      "", CONV_TYPE, API_DRIVER, 1}},
 
   // cudaIpcMemHandle_st
   {"CUipcMemHandle_st",                                                {"hipIpcMemHandle_st",                                       "", CONV_TYPE, API_DRIVER, 1}},
@@ -498,7 +498,7 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_TYPE_NAME_MAP {
   // cudaDevAttrMaxRegistersPerMultiprocessor
   {"CU_DEVICE_ATTRIBUTE_MAX_REGISTERS_PER_MULTIPROCESSOR",             {"hipDeviceAttributeMaxRegistersPerMultiprocessor",          "", CONV_NUMERIC_LITERAL, API_DRIVER, 1, HIP_UNSUPPORTED}}, // 82
   // cudaDevAttrManagedMemory
-  {"CU_DEVICE_ATTRIBUTE_MANAGED_MEMORY",                               {"hipDeviceAttributeManagedMemory",                          "", CONV_NUMERIC_LITERAL, API_DRIVER, 1, HIP_UNSUPPORTED}}, // 83
+  {"CU_DEVICE_ATTRIBUTE_MANAGED_MEMORY",                               {"hipDeviceAttributeManagedMemory",                          "", CONV_NUMERIC_LITERAL, API_DRIVER, 1}}, // 83
   // cudaDevAttrIsMultiGpuBoard
   {"CU_DEVICE_ATTRIBUTE_MULTI_GPU_BOARD",                              {"hipDeviceAttributeIsMultiGpuBoard",                        "", CONV_NUMERIC_LITERAL, API_DRIVER, 1}}, // 84
   // cudaDevAttrMultiGpuBoardGroupID
@@ -508,9 +508,9 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_TYPE_NAME_MAP {
   // cudaDevAttrSingleToDoublePrecisionPerfRatio
   {"CU_DEVICE_ATTRIBUTE_SINGLE_TO_DOUBLE_PRECISION_PERF_RATIO",        {"hipDeviceAttributeSingleToDoublePrecisionPerfRatio",       "", CONV_NUMERIC_LITERAL, API_DRIVER, 1, HIP_UNSUPPORTED}}, // 87
   // cudaDevAttrPageableMemoryAccess
-  {"CU_DEVICE_ATTRIBUTE_PAGEABLE_MEMORY_ACCESS",                       {"hipDeviceAttributePageableMemoryAccess",                   "", CONV_NUMERIC_LITERAL, API_DRIVER, 1, HIP_UNSUPPORTED}}, // 88
+  {"CU_DEVICE_ATTRIBUTE_PAGEABLE_MEMORY_ACCESS",                       {"hipDeviceAttributePageableMemoryAccess",                   "", CONV_NUMERIC_LITERAL, API_DRIVER, 1}}, // 88
   // cudaDevAttrConcurrentManagedAccess
-  {"CU_DEVICE_ATTRIBUTE_CONCURRENT_MANAGED_ACCESS",                    {"hipDeviceAttributeConcurrentManagedAccess",                "", CONV_NUMERIC_LITERAL, API_DRIVER, 1, HIP_UNSUPPORTED}}, // 89
+  {"CU_DEVICE_ATTRIBUTE_CONCURRENT_MANAGED_ACCESS",                    {"hipDeviceAttributeConcurrentManagedAccess",                "", CONV_NUMERIC_LITERAL, API_DRIVER, 1}}, // 89
   // cudaDevAttrComputePreemptionSupported
   {"CU_DEVICE_ATTRIBUTE_COMPUTE_PREEMPTION_SUPPORTED",                 {"hipDeviceAttributeComputePreemptionSupported",             "", CONV_NUMERIC_LITERAL, API_DRIVER, 1, HIP_UNSUPPORTED}}, // 90
   // cudaDevAttrCanUseHostPointerForRegisteredMem
@@ -532,9 +532,9 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_TYPE_NAME_MAP {
   // cudaDevAttrHostRegisterSupported
   {"CU_DEVICE_ATTRIBUTE_HOST_REGISTER_SUPPORTED",                      {"hipDeviceAttributeHostRegisterSupported",                  "", CONV_NUMERIC_LITERAL, API_DRIVER, 1, HIP_UNSUPPORTED}}, // 99
   // cudaDevAttrPageableMemoryAccessUsesHostPageTables
-  {"CU_DEVICE_ATTRIBUTE_PAGEABLE_MEMORY_ACCESS_USES_HOST_PAGE_TABLES", {"hipDeviceAttributePageableMemoryAccessUsesHostPageTables", "", CONV_NUMERIC_LITERAL, API_DRIVER, 1, HIP_UNSUPPORTED}}, // 100
+  {"CU_DEVICE_ATTRIBUTE_PAGEABLE_MEMORY_ACCESS_USES_HOST_PAGE_TABLES", {"hipDeviceAttributePageableMemoryAccessUsesHostPageTables", "", CONV_NUMERIC_LITERAL, API_DRIVER, 1}}, // 100
   // cudaDevAttrDirectManagedMemAccessFromHost
-  {"CU_DEVICE_ATTRIBUTE_DIRECT_MANAGED_MEM_ACCESS_FROM_HOST",          {"hipDeviceAttributeDirectManagedMemAccessFromHost",         "", CONV_NUMERIC_LITERAL, API_DRIVER, 1, HIP_UNSUPPORTED}}, // 101
+  {"CU_DEVICE_ATTRIBUTE_DIRECT_MANAGED_MEM_ACCESS_FROM_HOST",          {"hipDeviceAttributeDirectManagedMemAccessFromHost",         "", CONV_NUMERIC_LITERAL, API_DRIVER, 1}}, // 101
   // no analogue
   {"CU_DEVICE_ATTRIBUTE_VIRTUAL_ADDRESS_MANAGEMENT_SUPPORTED",         {"hipDeviceAttributeVirtualAddressManagementSupported",      "", CONV_NUMERIC_LITERAL, API_DRIVER, 1, HIP_UNSUPPORTED}}, // 102
   // no analogue
@@ -563,22 +563,22 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_TYPE_NAME_MAP {
   {"CU_DEVICE_ATTRIBUTE_MAX",                                          {"hipDeviceAttributeMax",                                    "", CONV_NUMERIC_LITERAL, API_DRIVER, 1, HIP_UNSUPPORTED}}, // 114
 
   // cudaDeviceP2PAttr
-  {"CUdevice_P2PAttribute",                                            {"hipDeviceP2PAttribute",                                    "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
-  {"CUdevice_P2PAttribute_enum",                                       {"hipDeviceP2PAttribute",                                    "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
+  {"CUdevice_P2PAttribute",                                            {"hipDeviceP2PAttr",                                         "", CONV_TYPE, API_DRIVER, 1}},
+  {"CUdevice_P2PAttribute_enum",                                       {"hipDeviceP2PAttr",                                         "", CONV_TYPE, API_DRIVER, 1}},
   // CUdevice_P2PAttribute enum values
   // cudaDevP2PAttrPerformanceRank = 1
-  {"CU_DEVICE_P2P_ATTRIBUTE_PERFORMANCE_RANK",                         {"hipDeviceP2PAttributePerformanceRank",                     "", CONV_NUMERIC_LITERAL, API_DRIVER, 1, HIP_UNSUPPORTED}}, // 0x01
+  {"CU_DEVICE_P2P_ATTRIBUTE_PERFORMANCE_RANK",                         {"hipDevP2PAttrPerformanceRank",                             "", CONV_NUMERIC_LITERAL, API_DRIVER, 1}}, // 0x01
   // cudaDevP2PAttrAccessSupported = 2
-  {"CU_DEVICE_P2P_ATTRIBUTE_ACCESS_SUPPORTED",                         {"hipDeviceP2PAttributeAccessSupported",                     "", CONV_NUMERIC_LITERAL, API_DRIVER, 1, HIP_UNSUPPORTED}}, // 0x02
+  {"CU_DEVICE_P2P_ATTRIBUTE_ACCESS_SUPPORTED",                         {"hipDevP2PAttrAccessSupported",                             "", CONV_NUMERIC_LITERAL, API_DRIVER, 1}}, // 0x02
   // cudaDevP2PAttrNativeAtomicSupported = 3
-  {"CU_DEVICE_P2P_ATTRIBUTE_NATIVE_ATOMIC_SUPPORTED",                  {"hipDeviceP2PAttributeNativeAtomicSupported",               "", CONV_NUMERIC_LITERAL, API_DRIVER, 1, HIP_UNSUPPORTED}}, // 0x03
+  {"CU_DEVICE_P2P_ATTRIBUTE_NATIVE_ATOMIC_SUPPORTED",                  {"hipDevP2PAttrNativeAtomicSupported",                       "", CONV_NUMERIC_LITERAL, API_DRIVER, 1}}, // 0x03
   // cudaDevP2PAttrCudaArrayAccessSupported = 4
   // NOTE" deprecated, use CU_DEVICE_P2P_ATTRIBUTE_CUDA_ARRAY_ACCESS_SUPPORTED instead
-  {"CU_DEVICE_P2P_ATTRIBUTE_ACCESS_ACCESS_SUPPORTED",                  {"hipDevP2PAttributeCudaArrayAccessSupported",               "", CONV_NUMERIC_LITERAL, API_DRIVER, 1, HIP_UNSUPPORTED | DEPRECATED}}, // 0x04
+  {"CU_DEVICE_P2P_ATTRIBUTE_ACCESS_ACCESS_SUPPORTED",                  {"hipDevP2PAttrHipArrayAccessSupported",                     "", CONV_NUMERIC_LITERAL, API_DRIVER, 1, DEPRECATED}}, // 0x04
   // NOTE" deprecated, use CU_DEVICE_P2P_ATTRIBUTE_CUDA_ARRAY_ACCESS_SUPPORTED instead
-  {"CU_DEVICE_P2P_ATTRIBUTE_ARRAY_ACCESS_ACCESS_SUPPORTED",            {"hipDevP2PAttributeCudaArrayAccessSupported",               "", CONV_NUMERIC_LITERAL, API_DRIVER, 1, HIP_UNSUPPORTED | DEPRECATED | REMOVED}}, // 0x04
+  {"CU_DEVICE_P2P_ATTRIBUTE_ARRAY_ACCESS_ACCESS_SUPPORTED",            {"hipDevP2PAttrHipArrayAccessSupported",                     "", CONV_NUMERIC_LITERAL, API_DRIVER, 1, DEPRECATED | REMOVED}}, // 0x04
   // cudaDevP2PAttrCudaArrayAccessSupported = 4
-  {"CU_DEVICE_P2P_ATTRIBUTE_CUDA_ARRAY_ACCESS_SUPPORTED",              {"hipDevP2PAttributeCudaArrayAccessSupported",               "", CONV_NUMERIC_LITERAL, API_DRIVER, 1, HIP_UNSUPPORTED}}, // 0x04
+  {"CU_DEVICE_P2P_ATTRIBUTE_CUDA_ARRAY_ACCESS_SUPPORTED",              {"hipDevP2PAttrHipArrayAccessSupported",                     "", CONV_NUMERIC_LITERAL, API_DRIVER, 1}}, // 0x04
 
   // cudaEGL.h - presented only on Linux in nvidia-cuda-dev package
   // cudaEglColorFormat
@@ -969,9 +969,9 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_TYPE_NAME_MAP {
   {"CU_JIT_CACHE_MODE",                                                {"hipJitOptionCacheMode",                                    "", CONV_NUMERIC_LITERAL, API_DRIVER, 1}},
   {"CU_JIT_NEW_SM3X_OPT",                                              {"hipJitOptionSm3xOpt",                                      "", CONV_NUMERIC_LITERAL, API_DRIVER, 1}},
   {"CU_JIT_FAST_COMPILE",                                              {"hipJitOptionFastCompile",                                  "", CONV_NUMERIC_LITERAL, API_DRIVER, 1}},
-  {"CU_JIT_GLOBAL_SYMBOL_NAMES",                                       {"hipJitGlobalSymbolNames",                                  "", CONV_NUMERIC_LITERAL, API_DRIVER, 1}},
-  {"CU_JIT_GLOBAL_SYMBOL_ADDRESSES",                                   {"hipJitGlobalSymbolAddresses",                              "", CONV_NUMERIC_LITERAL, API_DRIVER, 1}},
-  {"CU_JIT_GLOBAL_SYMBOL_COUNT",                                       {"hipJitGlobalSymbolCount",                                  "", CONV_NUMERIC_LITERAL, API_DRIVER, 1}},
+  {"CU_JIT_GLOBAL_SYMBOL_NAMES",                                       {"hipJitGlobalSymbolNames",                                  "", CONV_NUMERIC_LITERAL, API_DRIVER, 1, HIP_UNSUPPORTED}},
+  {"CU_JIT_GLOBAL_SYMBOL_ADDRESSES",                                   {"hipJitGlobalSymbolAddresses",                              "", CONV_NUMERIC_LITERAL, API_DRIVER, 1, HIP_UNSUPPORTED}},
+  {"CU_JIT_GLOBAL_SYMBOL_COUNT",                                       {"hipJitGlobalSymbolCount",                                  "", CONV_NUMERIC_LITERAL, API_DRIVER, 1, HIP_UNSUPPORTED}},
   {"CU_JIT_NUM_OPTIONS",                                               {"hipJitOptionNumOptions",                                   "", CONV_NUMERIC_LITERAL, API_DRIVER, 1}},
 
   // no analogue
@@ -1039,21 +1039,21 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_TYPE_NAME_MAP {
   {"CU_LIMIT_MAX",                                                     {"hipLimitMax",                                              "", CONV_NUMERIC_LITERAL, API_DRIVER, 1, HIP_UNSUPPORTED}},
 
   // cudaMemoryAdvise
-  {"CUmem_advise",                                                     {"hipMemAdvise",                                             "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
-  {"CUmem_advise_enum",                                                {"hipMemAdvise",                                             "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
+  {"CUmem_advise",                                                     {"hipMemoryAdvise",                                          "", CONV_TYPE, API_DRIVER, 1}},
+  {"CUmem_advise_enum",                                                {"hipMemoryAdvise",                                          "", CONV_TYPE, API_DRIVER, 1}},
   // CUmem_advise enum values
   // cudaMemAdviseSetReadMostly
-  {"CU_MEM_ADVISE_SET_READ_MOSTLY",                                    {"hipMemAdviseSetReadMostly",                                "", CONV_NUMERIC_LITERAL, API_DRIVER, 1, HIP_UNSUPPORTED}}, // 1
+  {"CU_MEM_ADVISE_SET_READ_MOSTLY",                                    {"hipMemAdviseSetReadMostly",                                "", CONV_NUMERIC_LITERAL, API_DRIVER, 1}}, // 1
   // cudaMemAdviseUnsetReadMostly
-  {"CU_MEM_ADVISE_UNSET_READ_MOSTLY",                                  {"hipMemAdviseUnsetReadMostly",                              "", CONV_NUMERIC_LITERAL, API_DRIVER, 1, HIP_UNSUPPORTED}}, // 2
+  {"CU_MEM_ADVISE_UNSET_READ_MOSTLY",                                  {"hipMemAdviseUnsetReadMostly",                              "", CONV_NUMERIC_LITERAL, API_DRIVER, 1}}, // 2
   // cudaMemAdviseSetPreferredLocation
-  {"CU_MEM_ADVISE_SET_PREFERRED_LOCATION",                             {"hipMemAdviseSetPreferredLocation",                         "", CONV_NUMERIC_LITERAL, API_DRIVER, 1, HIP_UNSUPPORTED}}, // 3
+  {"CU_MEM_ADVISE_SET_PREFERRED_LOCATION",                             {"hipMemAdviseSetPreferredLocation",                         "", CONV_NUMERIC_LITERAL, API_DRIVER, 1}}, // 3
   // cudaMemAdviseUnsetPreferredLocation
-  {"CU_MEM_ADVISE_UNSET_PREFERRED_LOCATION",                           {"hipMemAdviseUnsetPreferredLocation",                       "", CONV_NUMERIC_LITERAL, API_DRIVER, 1, HIP_UNSUPPORTED}}, // 4
+  {"CU_MEM_ADVISE_UNSET_PREFERRED_LOCATION",                           {"hipMemAdviseUnsetPreferredLocation",                       "", CONV_NUMERIC_LITERAL, API_DRIVER, 1}}, // 4
   // cudaMemAdviseSetAccessedBy
-  {"CU_MEM_ADVISE_SET_ACCESSED_BY",                                    {"hipMemAdviseSetAccessedBy",                                "", CONV_NUMERIC_LITERAL, API_DRIVER, 1, HIP_UNSUPPORTED}}, // 5
+  {"CU_MEM_ADVISE_SET_ACCESSED_BY",                                    {"hipMemAdviseSetAccessedBy",                                "", CONV_NUMERIC_LITERAL, API_DRIVER, 1}}, // 5
   // cudaMemAdviseUnsetAccessedBy
-  {"CU_MEM_ADVISE_UNSET_ACCESSED_BY",                                  {"hipMemAdviseUnsetAccessedBy",                              "", CONV_NUMERIC_LITERAL, API_DRIVER, 1, HIP_UNSUPPORTED}}, // 6
+  {"CU_MEM_ADVISE_UNSET_ACCESSED_BY",                                  {"hipMemAdviseUnsetAccessedBy",                              "", CONV_NUMERIC_LITERAL, API_DRIVER, 1}}, // 6
 
   // no analogue
   {"CUmemAttach_flags",                                                {"hipMemAttachFlags_t",                                      "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
@@ -1064,7 +1064,7 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_TYPE_NAME_MAP {
   // cudaMemAttachHost
   {"CU_MEM_ATTACH_HOST",                                               {"hipMemAttachHost",                                         "", CONV_NUMERIC_LITERAL, API_DRIVER, 1}}, // 0x2
   // cudaMemAttachSingle
-  {"CU_MEM_ATTACH_SINGLE",                                             {"hipMemAttachSingle",                                       "", CONV_NUMERIC_LITERAL, API_DRIVER, 1, HIP_UNSUPPORTED}}, // 0x4
+  {"CU_MEM_ATTACH_SINGLE",                                             {"hipMemAttachSingle",                                       "", CONV_NUMERIC_LITERAL, API_DRIVER, 1}}, // 0x4
 
   // no analogue
   // NOTE: cudaMemoryType is partial analogue
@@ -1077,17 +1077,17 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_TYPE_NAME_MAP {
   {"CU_MEMORYTYPE_UNIFIED",                                            {"hipMemoryTypeUnified",                                     "", CONV_NUMERIC_LITERAL, API_DRIVER, 1}}, // 0x04
 
   // cudaMemRangeAttribute
-  {"CUmem_range_attribute",                                            {"hipMemRangeAttribute",                                     "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
-  {"CUmem_range_attribute_enum",                                       {"hipMemRangeAttribute",                                     "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
+  {"CUmem_range_attribute",                                            {"hipMemRangeAttribute",                                     "", CONV_TYPE, API_DRIVER, 1}},
+  {"CUmem_range_attribute_enum",                                       {"hipMemRangeAttribute",                                     "", CONV_TYPE, API_DRIVER, 1}},
   // CUmem_range_attribute enum values
   // cudaMemRangeAttributeReadMostly
-  {"CU_MEM_RANGE_ATTRIBUTE_READ_MOSTLY",                               {"hipMemRangeAttributeReadMostly",                           "", CONV_NUMERIC_LITERAL, API_DRIVER, 1, HIP_UNSUPPORTED}}, // 1
+  {"CU_MEM_RANGE_ATTRIBUTE_READ_MOSTLY",                               {"hipMemRangeAttributeReadMostly",                           "", CONV_NUMERIC_LITERAL, API_DRIVER, 1}}, // 1
   // cudaMemRangeAttributePreferredLocation
-  {"CU_MEM_RANGE_ATTRIBUTE_PREFERRED_LOCATION",                        {"hipMemRangeAttributePreferredLocation",                    "", CONV_NUMERIC_LITERAL, API_DRIVER, 1, HIP_UNSUPPORTED}}, // 2
+  {"CU_MEM_RANGE_ATTRIBUTE_PREFERRED_LOCATION",                        {"hipMemRangeAttributePreferredLocation",                    "", CONV_NUMERIC_LITERAL, API_DRIVER, 1}}, // 2
   // cudaMemRangeAttributeAccessedBy
-  {"CU_MEM_RANGE_ATTRIBUTE_ACCESSED_BY",                               {"hipMemRangeAttributeAccessedBy",                           "", CONV_NUMERIC_LITERAL, API_DRIVER, 1, HIP_UNSUPPORTED}}, // 3
+  {"CU_MEM_RANGE_ATTRIBUTE_ACCESSED_BY",                               {"hipMemRangeAttributeAccessedBy",                           "", CONV_NUMERIC_LITERAL, API_DRIVER, 1}}, // 3
   // cudaMemRangeAttributeLastPrefetchLocation
-  {"CU_MEM_RANGE_ATTRIBUTE_LAST_PREFETCH_LOCATION",                    {"hipMemRangeAttributeLastPrefetchLocation",                 "", CONV_NUMERIC_LITERAL, API_DRIVER, 1, HIP_UNSUPPORTED}}, // 4
+  {"CU_MEM_RANGE_ATTRIBUTE_LAST_PREFETCH_LOCATION",                    {"hipMemRangeAttributeLastPrefetchLocation",                 "", CONV_NUMERIC_LITERAL, API_DRIVER, 1}}, // 4
 
   // no analogue
   {"CUoccupancy_flags",                                                {"hipOccupancyFlags",                                        "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
@@ -1688,11 +1688,11 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_TYPE_NAME_MAP {
   {"__CUDACC__",                                                       {"__HIPCC__",                                                "", CONV_DEFINE, API_DRIVER, 1}},
   {"CUDA_CB",                                                          {"HIP_CB",                                                   "", CONV_DEFINE, API_DRIVER, 1, HIP_UNSUPPORTED}},
   // cudaCpuDeviceId ((int)-1)
-  {"CU_DEVICE_CPU",                                                    {"hipCpuDeviceId",                                           "", CONV_DEFINE, API_DRIVER, 1, HIP_UNSUPPORTED}}, // ((CUdevice)-1)
+  {"CU_DEVICE_CPU",                                                    {"hipCpuDeviceId",                                           "", CONV_DEFINE, API_DRIVER, 1}}, // ((CUdevice)-1)
   // cudaInvalidDeviceId ((int)-1)
-  {"CU_DEVICE_INVALID",                                                {"hipInvalidDeviceId",                                       "", CONV_DEFINE, API_DRIVER, 1, HIP_UNSUPPORTED}}, // ((CUdevice)-2)
+  {"CU_DEVICE_INVALID",                                                {"hipInvalidDeviceId",                                       "", CONV_DEFINE, API_DRIVER, 1}}, // ((CUdevice)-2)
   // CUDA_IPC_HANDLE_SIZE
-  {"CU_IPC_HANDLE_SIZE",                                               {"HIP_IPC_HANDLE_SIZE",                                      "", CONV_DEFINE, API_DRIVER, 1, HIP_UNSUPPORTED}}, // 64
+  {"CU_IPC_HANDLE_SIZE",                                               {"HIP_IPC_HANDLE_SIZE",                                      "", CONV_DEFINE, API_DRIVER, 1}}, // 64
   {"CU_LAUNCH_PARAM_BUFFER_POINTER",                                   {"HIP_LAUNCH_PARAM_BUFFER_POINTER",                          "", CONV_DEFINE, API_DRIVER, 1}}, // ((void*)0x01)
   {"CU_LAUNCH_PARAM_BUFFER_SIZE",                                      {"HIP_LAUNCH_PARAM_BUFFER_SIZE",                             "", CONV_DEFINE, API_DRIVER, 1}}, // ((void*)0x02)
   {"CU_LAUNCH_PARAM_END",                                              {"HIP_LAUNCH_PARAM_END",                                     "", CONV_DEFINE, API_DRIVER, 1}}, // ((void*)0x00)

--- a/src/CUDA2HIP_Runtime_API_functions.cpp
+++ b/src/CUDA2HIP_Runtime_API_functions.cpp
@@ -38,7 +38,7 @@ const std::map<llvm::StringRef, hipCounter> CUDA_RUNTIME_FUNCTION_MAP {
   // cuDeviceGetNvSciSyncAttributes
   {"cudaDeviceGetNvSciSyncAttributes",                        {"hipDeviceGetNvSciSyncAttributes",                        "", CONV_DEVICE, API_RUNTIME, 1, HIP_UNSUPPORTED}},
   // cuDeviceGetP2PAttribute
-  {"cudaDeviceGetP2PAttribute",                               {"hipDeviceGetP2PAttribute",                               "", CONV_DEVICE, API_RUNTIME, 1, HIP_UNSUPPORTED}},
+  {"cudaDeviceGetP2PAttribute",                               {"hipDeviceGetP2PAttribute",                               "", CONV_DEVICE, API_RUNTIME, 1}},
   // cuDeviceGetPCIBusId
   {"cudaDeviceGetPCIBusId",                                   {"hipDeviceGetPCIBusId",                                   "", CONV_DEVICE, API_RUNTIME, 1}},
   // cuCtxGetSharedMemConfig
@@ -61,8 +61,7 @@ const std::map<llvm::StringRef, hipCounter> CUDA_RUNTIME_FUNCTION_MAP {
   // cuDeviceGetCount
   {"cudaGetDeviceCount",                                      {"hipGetDeviceCount",                                      "", CONV_DEVICE, API_RUNTIME, 1}},
   // cuCtxGetFlags
-  // TODO: rename to hipGetDeviceFlags
-  {"cudaGetDeviceFlags",                                      {"hipCtxGetFlags",                                         "", CONV_DEVICE, API_RUNTIME, 1}},
+  {"cudaGetDeviceFlags",                                      {"hipGetDeviceFlags",                                      "", CONV_DEVICE, API_RUNTIME, 1}},
   // no analogue
   // NOTE: Not equal to cuDeviceGetProperties due to different attributes: CUdevprop and cudaDeviceProp
   {"cudaGetDeviceProperties",                                 {"hipGetDeviceProperties",                                 "", CONV_DEVICE, API_RUNTIME, 1}},
@@ -117,7 +116,7 @@ const std::map<llvm::StringRef, hipCounter> CUDA_RUNTIME_FUNCTION_MAP {
   // cuCtxResetPersistingL2Cache
   {"cudaCtxResetPersistingL2Cache",                           {"hipCtxResetPersistingL2Cache",                           "", CONV_STREAM, API_RUNTIME, 4, HIP_UNSUPPORTED}},
   // cuStreamAttachMemAsync
-  {"cudaStreamAttachMemAsync",                                {"hipStreamAttachMemAsync",                                "", CONV_STREAM, API_RUNTIME, 4, HIP_UNSUPPORTED}},
+  {"cudaStreamAttachMemAsync",                                {"hipStreamAttachMemAsync",                                "", CONV_STREAM, API_RUNTIME, 4}},
   // cuStreamBeginCapture
   {"cudaStreamBeginCapture",                                  {"hipStreamBeginCapture",                                  "", CONV_STREAM, API_RUNTIME, 4, HIP_UNSUPPORTED}},
   // cuStreamCopyAttributes
@@ -195,13 +194,14 @@ const std::map<llvm::StringRef, hipCounter> CUDA_RUNTIME_FUNCTION_MAP {
   // no analogue
   {"cudaFuncGetAttributes",                                   {"hipFuncGetAttributes",                                   "", CONV_EXECUTION, API_RUNTIME, 7}},
   // no analogue
-  {"cudaFuncSetAttribute",                                    {"hipFuncSetAttribute",                                    "", CONV_EXECUTION, API_RUNTIME, 7, HIP_UNSUPPORTED}},
+  // NOTE: Not equal to cuFuncSetAttribute due to different signatures
+  {"cudaFuncSetAttribute",                                    {"hipFuncSetAttribute",                                    "", CONV_EXECUTION, API_RUNTIME, 7}},
   // no analogue
   // NOTE: Not equal to cuFuncSetCacheConfig due to different signatures
   {"cudaFuncSetCacheConfig",                                  {"hipFuncSetCacheConfig",                                  "", CONV_DEVICE, API_RUNTIME, 7}},
   // no analogue
   // NOTE: Not equal to cuFuncSetSharedMemConfig due to different signatures
-  {"cudaFuncSetSharedMemConfig",                              {"hipFuncSetSharedMemConfig",                              "", CONV_EXECUTION, API_RUNTIME, 7, HIP_UNSUPPORTED}},
+  {"cudaFuncSetSharedMemConfig",                              {"hipFuncSetSharedMemConfig",                              "", CONV_EXECUTION, API_RUNTIME, 7}},
   // no analogue
   {"cudaGetParameterBuffer",                                  {"hipGetParameterBuffer",                                  "", CONV_EXECUTION, API_RUNTIME, 7, HIP_UNSUPPORTED}},
   // no analogue
@@ -232,7 +232,7 @@ const std::map<llvm::StringRef, hipCounter> CUDA_RUNTIME_FUNCTION_MAP {
   // cuOccupancyMaxPotentialBlockSize
   {"cudaOccupancyMaxPotentialBlockSize",                      {"hipOccupancyMaxPotentialBlockSize",                      "", CONV_OCCUPANCY, API_RUNTIME, 8}},
   // cuOccupancyMaxPotentialBlockSizeWithFlags
-  {"cudaOccupancyMaxPotentialBlockSizeWithFlags",             {"hipOccupancyMaxPotentialBlockSizeWithFlags",             "", CONV_OCCUPANCY, API_RUNTIME, 8, HIP_UNSUPPORTED}},
+  {"cudaOccupancyMaxPotentialBlockSizeWithFlags",             {"hipOccupancyMaxPotentialBlockSizeWithFlags",             "", CONV_OCCUPANCY, API_RUNTIME, 8}},
   // no analogue
   {"cudaOccupancyMaxPotentialBlockSizeVariableSMem",          {"hipOccupancyMaxPotentialBlockSizeVariableSMem",          "", CONV_OCCUPANCY, API_RUNTIME, 8, HIP_UNSUPPORTED}},
   // no analogue
@@ -249,10 +249,10 @@ const std::map<llvm::StringRef, hipCounter> CUDA_RUNTIME_FUNCTION_MAP {
   {"cudaFreeHost",                                            {"hipHostFree",                                            "", CONV_MEMORY, API_RUNTIME, 9}},
   // no analogue
   // NOTE: Not equal to cuMipmappedArrayDestroy due to different signatures
-  {"cudaFreeMipmappedArray",                                  {"hipFreeMipmappedArray",                                  "", CONV_MEMORY, API_RUNTIME, 9, HIP_UNSUPPORTED}},
+  {"cudaFreeMipmappedArray",                                  {"hipFreeMipmappedArray",                                  "", CONV_MEMORY, API_RUNTIME, 9}},
   // no analogue
   // NOTE: Not equal to cuMipmappedArrayGetLevel due to different signatures
-  {"cudaGetMipmappedArrayLevel",                              {"hipGetMipmappedArrayLevel",                              "", CONV_MEMORY, API_RUNTIME, 9, HIP_UNSUPPORTED}},
+  {"cudaGetMipmappedArrayLevel",                              {"hipGetMipmappedArrayLevel",                              "", CONV_MEMORY, API_RUNTIME, 9}},
   // no analogue
   {"cudaGetSymbolAddress",                                    {"hipGetSymbolAddress",                                    "", CONV_MEMORY, API_RUNTIME, 9}},
   // no analogue
@@ -281,12 +281,12 @@ const std::map<llvm::StringRef, hipCounter> CUDA_RUNTIME_FUNCTION_MAP {
   {"cudaMallocManaged",                                       {"hipMallocManaged",                                       "", CONV_MEMORY, API_RUNTIME, 9}},
   // no analogue
   // NOTE: Not equal to cuMipmappedArrayCreate due to different signatures
-  {"cudaMallocMipmappedArray",                                {"hipMallocMipmappedArray",                                "", CONV_MEMORY, API_RUNTIME, 9, HIP_UNSUPPORTED}},
+  {"cudaMallocMipmappedArray",                                {"hipMallocMipmappedArray",                                "", CONV_MEMORY, API_RUNTIME, 9}},
   // no analogue
   // NOTE: Not equal to cuMemAllocPitch due to different signatures
   {"cudaMallocPitch",                                         {"hipMallocPitch",                                         "", CONV_MEMORY, API_RUNTIME, 9}},
   // cuMemAdvise
-  {"cudaMemAdvise",                                           {"hipMemAdvise",                                           "", CONV_MEMORY, API_RUNTIME, 9, HIP_UNSUPPORTED}},
+  {"cudaMemAdvise",                                           {"hipMemAdvise",                                           "", CONV_MEMORY, API_RUNTIME, 9}},
   // no analogue
   // NOTE: Not equal to cuMemcpy due to different signatures
   {"cudaMemcpy",                                              {"hipMemcpy",                                              "", CONV_MEMORY, API_RUNTIME, 9}},
@@ -338,11 +338,11 @@ const std::map<llvm::StringRef, hipCounter> CUDA_RUNTIME_FUNCTION_MAP {
   // cuMemGetInfo
   {"cudaMemGetInfo",                                          {"hipMemGetInfo",                                          "", CONV_MEMORY, API_RUNTIME, 9}},
   // TODO: double check cuMemPrefetchAsync
-  {"cudaMemPrefetchAsync",                                    {"hipMemPrefetchAsync",                                    "", CONV_MEMORY, API_RUNTIME, 9, HIP_UNSUPPORTED}},
+  {"cudaMemPrefetchAsync",                                    {"hipMemPrefetchAsync",                                    "", CONV_MEMORY, API_RUNTIME, 9}},
   // cuMemRangeGetAttribute
-  {"cudaMemRangeGetAttribute",                                {"hipMemRangeGetAttribute",                                "", CONV_MEMORY, API_RUNTIME, 9, HIP_UNSUPPORTED}},
+  {"cudaMemRangeGetAttribute",                                {"hipMemRangeGetAttribute",                                "", CONV_MEMORY, API_RUNTIME, 9}},
   // cuMemRangeGetAttributes
-  {"cudaMemRangeGetAttributes",                               {"hipMemRangeGetAttributes",                               "", CONV_MEMORY, API_RUNTIME, 9, HIP_UNSUPPORTED}},
+  {"cudaMemRangeGetAttributes",                               {"hipMemRangeGetAttributes",                               "", CONV_MEMORY, API_RUNTIME, 9}},
   // cuMemsetD32 - hipMemsetD32
   {"cudaMemset",                                              {"hipMemset",                                              "", CONV_MEMORY, API_RUNTIME, 9}},
   // no analogue

--- a/src/CUDA2HIP_Runtime_API_types.cpp
+++ b/src/CUDA2HIP_Runtime_API_types.cpp
@@ -68,9 +68,9 @@ const std::map<llvm::StringRef, hipCounter> CUDA_RUNTIME_TYPE_NAME_MAP {
   {"cudaHostNodeParams",                                               {"HIP_HOST_NODE_PARAMS",                                     "", CONV_TYPE, API_RUNTIME, 34, HIP_UNSUPPORTED}},
 
   // CUipcEventHandle
-  {"cudaIpcEventHandle_t",                                             {"ihipIpcEventHandle_t",                                     "", CONV_TYPE, API_RUNTIME, 34}},
+  {"cudaIpcEventHandle_t",                                             {"hipIpcEventHandle_t",                                      "", CONV_TYPE, API_RUNTIME, 34}},
   // CUipcEventHandle_st
-  {"cudaIpcEventHandle_st",                                            {"ihipIpcEventHandle_t",                                     "", CONV_TYPE, API_RUNTIME, 34}},
+  {"cudaIpcEventHandle_st",                                            {"hipIpcEventHandle_st",                                     "", CONV_TYPE, API_RUNTIME, 34}},
 
   // CUipcMemHandle
   {"cudaIpcMemHandle_t",                                               {"hipIpcMemHandle_t",                                        "", CONV_TYPE, API_RUNTIME, 34}},
@@ -393,7 +393,7 @@ const std::map<llvm::StringRef, hipCounter> CUDA_RUNTIME_TYPE_NAME_MAP {
   // CU_DEVICE_ATTRIBUTE_MAX_REGISTERS_PER_MULTIPROCESSOR
   {"cudaDevAttrMaxRegistersPerMultiprocessor",                         {"hipDeviceAttributeMaxRegistersPerMultiprocessor",          "", CONV_NUMERIC_LITERAL, API_RUNTIME, 34, HIP_UNSUPPORTED}}, // 82
   // CU_DEVICE_ATTRIBUTE_MANAGED_MEMORY
-  {"cudaDevAttrManagedMemory",                                         {"hipDeviceAttributeManagedMemory",                          "", CONV_NUMERIC_LITERAL, API_RUNTIME, 34, HIP_UNSUPPORTED}}, // 83
+  {"cudaDevAttrManagedMemory",                                         {"hipDeviceAttributeManagedMemory",                          "", CONV_NUMERIC_LITERAL, API_RUNTIME, 34}}, // 83
   // CU_DEVICE_ATTRIBUTE_MULTI_GPU_BOARD
   {"cudaDevAttrIsMultiGpuBoard",                                       {"hipDeviceAttributeIsMultiGpuBoard",                        "", CONV_NUMERIC_LITERAL, API_RUNTIME, 34}}, // 84
   // CU_DEVICE_ATTRIBUTE_MULTI_GPU_BOARD_GROUP_ID
@@ -403,9 +403,9 @@ const std::map<llvm::StringRef, hipCounter> CUDA_RUNTIME_TYPE_NAME_MAP {
   // CU_DEVICE_ATTRIBUTE_SINGLE_TO_DOUBLE_PRECISION_PERF_RATIO
   {"cudaDevAttrSingleToDoublePrecisionPerfRatio",                      {"hipDeviceAttributeSingleToDoublePrecisionPerfRatio",       "", CONV_NUMERIC_LITERAL, API_RUNTIME, 34, HIP_UNSUPPORTED}}, // 87
   // CU_DEVICE_ATTRIBUTE_PAGEABLE_MEMORY_ACCESS
-  {"cudaDevAttrPageableMemoryAccess",                                  {"hipDeviceAttributePageableMemoryAccess",                   "", CONV_NUMERIC_LITERAL, API_RUNTIME, 34, HIP_UNSUPPORTED}}, // 88
+  {"cudaDevAttrPageableMemoryAccess",                                  {"hipDeviceAttributePageableMemoryAccess",                   "", CONV_NUMERIC_LITERAL, API_RUNTIME, 34}}, // 88
   // CU_DEVICE_ATTRIBUTE_CONCURRENT_MANAGED_ACCESS
-  {"cudaDevAttrConcurrentManagedAccess",                               {"hipDeviceAttributeConcurrentManagedAccess",                "", CONV_NUMERIC_LITERAL, API_RUNTIME, 34, HIP_UNSUPPORTED}}, // 89
+  {"cudaDevAttrConcurrentManagedAccess",                               {"hipDeviceAttributeConcurrentManagedAccess",                "", CONV_NUMERIC_LITERAL, API_RUNTIME, 34}}, // 89
   // CU_DEVICE_ATTRIBUTE_COMPUTE_PREEMPTION_SUPPORTED
   {"cudaDevAttrComputePreemptionSupported",                            {"hipDeviceAttributeComputePreemptionSupported",             "", CONV_NUMERIC_LITERAL, API_RUNTIME, 34, HIP_UNSUPPORTED}}, // 90
   // CU_DEVICE_ATTRIBUTE_CAN_USE_HOST_POINTER_FOR_REGISTERED_MEM
@@ -427,9 +427,9 @@ const std::map<llvm::StringRef, hipCounter> CUDA_RUNTIME_TYPE_NAME_MAP {
   // CU_DEVICE_ATTRIBUTE_HOST_REGISTER_SUPPORTED
   {"cudaDevAttrHostRegisterSupported",                                 {"hipDeviceAttributeHostRegisterSupported",                  "", CONV_NUMERIC_LITERAL, API_RUNTIME, 34, HIP_UNSUPPORTED}}, // 99
   // CU_DEVICE_ATTRIBUTE_PAGEABLE_MEMORY_ACCESS_USES_HOST_PAGE_TABLES
-  {"cudaDevAttrPageableMemoryAccessUsesHostPageTables",                {"hipDeviceAttributePageableMemoryAccessUsesHostPageTables", "", CONV_NUMERIC_LITERAL, API_RUNTIME, 34, HIP_UNSUPPORTED}}, // 100
+  {"cudaDevAttrPageableMemoryAccessUsesHostPageTables",                {"hipDeviceAttributePageableMemoryAccessUsesHostPageTables", "", CONV_NUMERIC_LITERAL, API_RUNTIME, 34}}, // 100
   // CU_DEVICE_ATTRIBUTE_DIRECT_MANAGED_MEM_ACCESS_FROM_HOST
-  {"cudaDevAttrDirectManagedMemAccessFromHost",                        {"hipDeviceAttributeDirectManagedMemAccessFromHost",         "", CONV_NUMERIC_LITERAL, API_RUNTIME, 34, HIP_UNSUPPORTED}}, // 101
+  {"cudaDevAttrDirectManagedMemAccessFromHost",                        {"hipDeviceAttributeDirectManagedMemAccessFromHost",         "", CONV_NUMERIC_LITERAL, API_RUNTIME, 34}}, // 101
   // CU_DEVICE_ATTRIBUTE_MAX_BLOCKS_PER_MULTIPROCESSOR
   {"cudaDevAttrMaxBlocksPerMultiprocessor",                            {"hipDeviceAttributeMaxBlocksPerMultiprocessor",             "", CONV_NUMERIC_LITERAL, API_RUNTIME, 34, HIP_UNSUPPORTED}}, // 106
   // CU_DEVICE_ATTRIBUTE_RESERVED_SHARED_MEMORY_PER_BLOCK
@@ -440,16 +440,16 @@ const std::map<llvm::StringRef, hipCounter> CUDA_RUNTIME_TYPE_NAME_MAP {
   {"cudaDevAttrHostRegisterReadOnlySupported",                         {"hipDeviceAttributeReadOnlyHostRestigerSupported",          "", CONV_NUMERIC_LITERAL, API_RUNTIME, 34, HIP_UNSUPPORTED}}, // 113
 
   // CUdevice_P2PAttribute
-  {"cudaDeviceP2PAttr",                                                {"hipDeviceP2PAttribute",                                    "", CONV_TYPE, API_RUNTIME, 34, HIP_UNSUPPORTED}},
+  {"cudaDeviceP2PAttr",                                                {"hipDeviceP2PAttr",                                         "", CONV_TYPE, API_RUNTIME, 34}},
   // cudaDeviceP2PAttr enum values
   // CU_DEVICE_P2P_ATTRIBUTE_PERFORMANCE_RANK = 0x01
-  {"cudaDevP2PAttrPerformanceRank",                                    {"hipDeviceP2PAttributePerformanceRank",                     "", CONV_NUMERIC_LITERAL, API_RUNTIME, 34, HIP_UNSUPPORTED}}, // 1
+  {"cudaDevP2PAttrPerformanceRank",                                    {"hipDevP2PAttrPerformanceRank",                             "", CONV_NUMERIC_LITERAL, API_RUNTIME, 34}}, // 1
   // CU_DEVICE_P2P_ATTRIBUTE_ACCESS_SUPPORTED = 0x02
-  {"cudaDevP2PAttrAccessSupported",                                    {"hipDeviceP2PAttributeAccessSupported",                     "", CONV_NUMERIC_LITERAL, API_RUNTIME, 34, HIP_UNSUPPORTED}}, // 2
+  {"cudaDevP2PAttrAccessSupported",                                    {"hipDevP2PAttrAccessSupported",                             "", CONV_NUMERIC_LITERAL, API_RUNTIME, 34}}, // 2
   // CU_DEVICE_P2P_ATTRIBUTE_NATIVE_ATOMIC_SUPPORTED = 0x03
-  {"cudaDevP2PAttrNativeAtomicSupported",                              {"hipDeviceP2PAttributeNativeAtomicSupported",               "", CONV_NUMERIC_LITERAL, API_RUNTIME, 34, HIP_UNSUPPORTED}}, // 3
+  {"cudaDevP2PAttrNativeAtomicSupported",                              {"hipDevP2PAttrNativeAtomicSupported",                       "", CONV_NUMERIC_LITERAL, API_RUNTIME, 34}}, // 3
   // CU_DEVICE_P2P_ATTRIBUTE_CUDA_ARRAY_ACCESS_SUPPORTED = 0x04
-  {"cudaDevP2PAttrCudaArrayAccessSupported",                           {"hipDevP2PAttributeCudaArrayAccessSupported",               "", CONV_NUMERIC_LITERAL, API_RUNTIME, 34, HIP_UNSUPPORTED}}, // 4
+  {"cudaDevP2PAttrCudaArrayAccessSupported",                           {"hipDevP2PAttrHipArrayAccessSupported",                     "", CONV_NUMERIC_LITERAL, API_RUNTIME, 34}}, // 4
 
   // cudaEGL.h - presented only on Linux in nvidia-cuda-dev package
   // CUeglColorFormat
@@ -907,14 +907,14 @@ const std::map<llvm::StringRef, hipCounter> CUDA_RUNTIME_TYPE_NAME_MAP {
 
   // CUfunction_attribute
   // NOTE: only last, starting from 8, values are presented and are equal to Driver's ones
-  {"cudaFuncAttribute",                                                {"hipFuncAttribute",                                         "", CONV_TYPE, API_RUNTIME, 34, HIP_UNSUPPORTED}},
+  {"cudaFuncAttribute",                                                {"hipFuncAttribute",                                         "", CONV_TYPE, API_RUNTIME, 34}},
   // cudaFuncAttribute enum values
   // CU_FUNC_ATTRIBUTE_MAX_DYNAMIC_SHARED_SIZE_BYTES
-  {"cudaFuncAttributeMaxDynamicSharedMemorySize",                      {"hipFuncAttributeMaxDynamicSharedMemorySize",               "", CONV_NUMERIC_LITERAL, API_RUNTIME, 34, HIP_UNSUPPORTED}}, //  8
+  {"cudaFuncAttributeMaxDynamicSharedMemorySize",                      {"hipFuncAttributeMaxDynamicSharedMemorySize",               "", CONV_NUMERIC_LITERAL, API_RUNTIME, 34}}, //  8
   // CU_FUNC_ATTRIBUTE_PREFERRED_SHARED_MEMORY_CARVEOUT
-  {"cudaFuncAttributePreferredSharedMemoryCarveout",                   {"hipFuncAttributePreferredSharedMemoryCarveout",            "", CONV_NUMERIC_LITERAL, API_RUNTIME, 34, HIP_UNSUPPORTED}}, //  9
+  {"cudaFuncAttributePreferredSharedMemoryCarveout",                   {"hipFuncAttributePreferredSharedMemoryCarveout",            "", CONV_NUMERIC_LITERAL, API_RUNTIME, 34}}, //  9
   // CU_FUNC_ATTRIBUTE_MAX
-  {"cudaFuncAttributeMax",                                             {"hipFuncAttributeMax",                                      "", CONV_NUMERIC_LITERAL, API_RUNTIME, 34, HIP_UNSUPPORTED}}, // 10
+  {"cudaFuncAttributeMax",                                             {"hipFuncAttributeMax",                                      "", CONV_NUMERIC_LITERAL, API_RUNTIME, 34}}, // 10
 
   // CUfunc_cache
   {"cudaFuncCache",                                                    {"hipFuncCache_t",                                           "", CONV_TYPE, API_RUNTIME, 34}},
@@ -1036,20 +1036,20 @@ const std::map<llvm::StringRef, hipCounter> CUDA_RUNTIME_TYPE_NAME_MAP {
   {"cudaMemcpyDefault",                                                {"hipMemcpyDefault",                                         "", CONV_NUMERIC_LITERAL, API_RUNTIME, 34}}, // 4
 
   // CUmem_advise
-  {"cudaMemoryAdvise",                                                 {"hipMemAdvise",                                             "", CONV_TYPE, API_RUNTIME, 34, HIP_UNSUPPORTED}},
+  {"cudaMemoryAdvise",                                                 {"hipMemoryAdvise",                                          "", CONV_TYPE, API_RUNTIME, 34}},
   // cudaMemoryAdvise enum values
   // CU_MEM_ADVISE_SET_READ_MOSTLY
-  {"cudaMemAdviseSetReadMostly",                                       {"hipMemAdviseSetReadMostly",                                "", CONV_NUMERIC_LITERAL, API_RUNTIME, 34, HIP_UNSUPPORTED}}, // 1
+  {"cudaMemAdviseSetReadMostly",                                       {"hipMemAdviseSetReadMostly",                                "", CONV_NUMERIC_LITERAL, API_RUNTIME, 34}}, // 1
   // CU_MEM_ADVISE_UNSET_READ_MOSTLY
-  {"cudaMemAdviseUnsetReadMostly",                                     {"hipMemAdviseUnsetReadMostly",                              "", CONV_NUMERIC_LITERAL, API_RUNTIME, 34, HIP_UNSUPPORTED}}, // 2
+  {"cudaMemAdviseUnsetReadMostly",                                     {"hipMemAdviseUnsetReadMostly",                              "", CONV_NUMERIC_LITERAL, API_RUNTIME, 34}}, // 2
   // CU_MEM_ADVISE_SET_PREFERRED_LOCATION
-  {"cudaMemAdviseSetPreferredLocation",                                {"hipMemAdviseSetPreferredLocation",                         "", CONV_NUMERIC_LITERAL, API_RUNTIME, 34, HIP_UNSUPPORTED}}, // 3
+  {"cudaMemAdviseSetPreferredLocation",                                {"hipMemAdviseSetPreferredLocation",                         "", CONV_NUMERIC_LITERAL, API_RUNTIME, 34}}, // 3
   // CU_MEM_ADVISE_UNSET_PREFERRED_LOCATION
-  {"cudaMemAdviseUnsetPreferredLocation",                              {"hipMemAdviseUnsetPreferredLocation",                       "", CONV_NUMERIC_LITERAL, API_RUNTIME, 34, HIP_UNSUPPORTED}}, // 4
+  {"cudaMemAdviseUnsetPreferredLocation",                              {"hipMemAdviseUnsetPreferredLocation",                       "", CONV_NUMERIC_LITERAL, API_RUNTIME, 34}}, // 4
   // CU_MEM_ADVISE_SET_ACCESSED_BY
-  {"cudaMemAdviseSetAccessedBy",                                       {"hipMemAdviseSetAccessedBy",                                "", CONV_NUMERIC_LITERAL, API_RUNTIME, 34, HIP_UNSUPPORTED}}, // 5
+  {"cudaMemAdviseSetAccessedBy",                                       {"hipMemAdviseSetAccessedBy",                                "", CONV_NUMERIC_LITERAL, API_RUNTIME, 34}}, // 5
   // CU_MEM_ADVISE_UNSET_ACCESSED_BY
-  {"cudaMemAdviseUnsetAccessedBy",                                     {"hipMemAdviseUnsetAccessedBy",                              "", CONV_NUMERIC_LITERAL, API_RUNTIME, 34, HIP_UNSUPPORTED}}, // 6
+  {"cudaMemAdviseUnsetAccessedBy",                                     {"hipMemAdviseUnsetAccessedBy",                              "", CONV_NUMERIC_LITERAL, API_RUNTIME, 34}}, // 6
 
   // no analogue
   // NOTE: CUmemorytype is partial analogue
@@ -1061,16 +1061,16 @@ const std::map<llvm::StringRef, hipCounter> CUDA_RUNTIME_TYPE_NAME_MAP {
   {"cudaMemoryTypeManaged",                                            {"hipMemoryTypeManaged",                                     "", CONV_NUMERIC_LITERAL, API_RUNTIME, 34, HIP_UNSUPPORTED}}, // 3
 
   // CUmem_range_attribute
-  {"cudaMemRangeAttribute",                                            {"hipMemRangeAttribute",                                     "", CONV_TYPE, API_RUNTIME, 34, HIP_UNSUPPORTED}},
+  {"cudaMemRangeAttribute",                                            {"hipMemRangeAttribute",                                     "", CONV_TYPE, API_RUNTIME, 34}},
   // cudaMemRangeAttribute enum values
   // CU_MEM_RANGE_ATTRIBUTE_READ_MOSTLY
-  {"cudaMemRangeAttributeReadMostly",                                  {"hipMemRangeAttributeReadMostly",                           "", CONV_NUMERIC_LITERAL, API_RUNTIME, 34, HIP_UNSUPPORTED}}, // 1
+  {"cudaMemRangeAttributeReadMostly",                                  {"hipMemRangeAttributeReadMostly",                           "", CONV_NUMERIC_LITERAL, API_RUNTIME, 34}}, // 1
   // CU_MEM_RANGE_ATTRIBUTE_PREFERRED_LOCATION
-  {"cudaMemRangeAttributePreferredLocation",                           {"hipMemRangeAttributePreferredLocation",                    "", CONV_NUMERIC_LITERAL, API_RUNTIME, 34, HIP_UNSUPPORTED}}, // 2
+  {"cudaMemRangeAttributePreferredLocation",                           {"hipMemRangeAttributePreferredLocation",                    "", CONV_NUMERIC_LITERAL, API_RUNTIME, 34}}, // 2
   // CU_MEM_RANGE_ATTRIBUTE_ACCESSED_BY
-  {"cudaMemRangeAttributeAccessedBy",                                  {"hipMemRangeAttributeAccessedBy",                           "", CONV_NUMERIC_LITERAL, API_RUNTIME, 34, HIP_UNSUPPORTED}}, // 3
+  {"cudaMemRangeAttributeAccessedBy",                                  {"hipMemRangeAttributeAccessedBy",                           "", CONV_NUMERIC_LITERAL, API_RUNTIME, 34}}, // 3
   // CU_MEM_RANGE_ATTRIBUTE_LAST_PREFETCH_LOCATION
-  {"cudaMemRangeAttributeLastPrefetchLocation",                        {"hipMemRangeAttributeLastPrefetchLocation",                 "", CONV_NUMERIC_LITERAL, API_RUNTIME, 34, HIP_UNSUPPORTED}}, // 4
+  {"cudaMemRangeAttributeLastPrefetchLocation",                        {"hipMemRangeAttributeLastPrefetchLocation",                 "", CONV_NUMERIC_LITERAL, API_RUNTIME, 34}}, // 4
 
   // no analogue
   {"cudaOutputMode",                                                   {"hipOutputMode",                                            "", CONV_TYPE, API_RUNTIME, 34, HIP_UNSUPPORTED}},
@@ -1393,7 +1393,7 @@ const std::map<llvm::StringRef, hipCounter> CUDA_RUNTIME_TYPE_NAME_MAP {
   // no analogue
   {"CUDA_EGL_MAX_PLANES",                                              {"HIP_EGL_MAX_PLANES",                                       "", CONV_DEFINE, API_RUNTIME, 34, HIP_UNSUPPORTED}}, // 3
   // CU_IPC_HANDLE_SIZE
-  {"CUDA_IPC_HANDLE_SIZE",                                             {"HIP_IPC_HANDLE_SIZE",                                      "", CONV_DEFINE, API_RUNTIME, 34, HIP_UNSUPPORTED}}, // 64
+  {"CUDA_IPC_HANDLE_SIZE",                                             {"HIP_IPC_HANDLE_SIZE",                                      "", CONV_DEFINE, API_RUNTIME, 34}}, // 64
   // no analogue
   {"cudaArrayDefault",                                                 {"hipArrayDefault",                                          "", CONV_DEFINE, API_RUNTIME, 34}}, // 0x00
   // CUDA_ARRAY3D_LAYERED
@@ -1413,9 +1413,9 @@ const std::map<llvm::StringRef, hipCounter> CUDA_RUNTIME_TYPE_NAME_MAP {
   // CUDA_COOPERATIVE_LAUNCH_MULTI_DEVICE_NO_POST_LAUNCH_SYNC
   {"cudaCooperativeLaunchMultiDeviceNoPostSync",                       {"hipCooperativeLaunchMultiDeviceNoPostSync",                "", CONV_DEFINE, API_RUNTIME, 34}}, // 0x02
   // CU_DEVICE_CPU ((CUdevice)-1)
-  {"cudaCpuDeviceId",                                                  {"hipCpuDeviceId",                                           "", CONV_DEFINE, API_RUNTIME, 34, HIP_UNSUPPORTED}}, // ((int)-1)
+  {"cudaCpuDeviceId",                                                  {"hipCpuDeviceId",                                           "", CONV_DEFINE, API_RUNTIME, 34}}, // ((int)-1)
   // CU_DEVICE_INVALID ((CUdevice)-2)
-  {"cudaInvalidDeviceId",                                              {"hipInvalidDeviceId",                                       "", CONV_DEFINE, API_RUNTIME, 34, HIP_UNSUPPORTED}}, // ((int)-2)
+  {"cudaInvalidDeviceId",                                              {"hipInvalidDeviceId",                                       "", CONV_DEFINE, API_RUNTIME, 34}}, // ((int)-2)
   // CU_CTX_BLOCKING_SYNC
   // NOTE: Deprecated since CUDA 4.0 and replaced with cudaDeviceScheduleBlockingSync
   {"cudaDeviceBlockingSync",                                           {"hipDeviceScheduleBlockingSync",                            "", CONV_DEFINE, API_RUNTIME, 34, DEPRECATED}}, // 0x04
@@ -1488,7 +1488,7 @@ const std::map<llvm::StringRef, hipCounter> CUDA_RUNTIME_TYPE_NAME_MAP {
   // CU_MEM_ATTACH_HOST
   {"cudaMemAttachHost",                                                {"hipMemAttachHost",                                         "", CONV_DEFINE, API_RUNTIME, 34}}, // 0x02
   // CU_MEM_ATTACH_SINGLE
-  {"cudaMemAttachSingle",                                              {"hipMemAttachSingle",                                       "", CONV_DEFINE, API_RUNTIME, 34, HIP_UNSUPPORTED}}, // 0x04
+  {"cudaMemAttachSingle",                                              {"hipMemAttachSingle",                                       "", CONV_DEFINE, API_RUNTIME, 34}}, // 0x04
   // no analogue
   {"cudaTextureType1D",                                                {"hipTextureType1D",                                         "", CONV_DEFINE, API_RUNTIME, 34}}, // 0x01
   // no analogue


### PR DESCRIPTION
+ Add missing functions and data types
+ Rename some HIP functions, for instance: `hipDrv...` -> `hipModule...`
+ Mark all lately supported functions and data types
+ Update hipify-perl accordingly