### PR TITLE
[HIPIFY] Support of CUDA2HIP docs generation in 'strict' format

### DIFF
--- a/src/ArgParse.cpp
+++ b/src/ArgParse.cpp
@@ -155,4 +155,9 @@ cl::opt<bool> GenerateCSV("csv",
   cl::value_desc("csv"),
   cl::cat(ToolTemplateCategory));
 
+cl::opt<std::string> DocFormat("doc-format",
+  cl::desc("Documentation format: 'full' (default) or 'strict';\n'--md' or '--csv' option should be specified"),
+  cl::value_desc("value"),
+  cl::cat(ToolTemplateCategory));
+
 cl::extrahelp CommonHelp(ct::CommonOptionsParser::HelpMessage);

--- a/src/ArgParse.h
+++ b/src/ArgParse.h
@@ -55,3 +55,4 @@ extern cl::opt<bool> SkipExcludedPPConditionalBlocks;
 extern cl::opt<std::string> CudaGpuArch;
 extern cl::opt<bool> GenerateMarkdown;
 extern cl::opt<bool> GenerateCSV;
+extern cl::opt<std::string> DocFormat;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -239,6 +239,10 @@ int main(int argc, const char **argv) {
     llvm::errs() << "\n" << sHipify << sError << "Must specify at least 1 positional argument for source file" << "\n";
     return 1;
   }
+  if (!GenerateMarkdown && !GenerateCSV && !DocFormat.empty()) {
+    llvm::errs() << "\n" << sHipify << sError << "Must specify a document type to generate: \"md\" and | or \"csv\"" << "\n";
+    return 1;
+  }
   if (!perl::generate(GeneratePerl)) {
     llvm::errs() << "\n" << sHipify << sError << "hipify-perl generating failed" << "\n";
     return 1;


### PR DESCRIPTION
+ Add option --doc-format={full | strict}, which might be used only with --md or --csv options;
+ Default doc format is 'full'
+ Strict format differences:
  Do not generate rows with unsupported API,
  Do not generate 'A' and 'R' columns,
  Set '+' instead of version in 'D' column