### PR TITLE
[HIPIFY][perl][#294] Fix incorrect transformation of function call as the CUDA launch parameter

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -2987,113 +2987,32 @@ sub transformKernelLaunch {
     no warnings qw/uninitialized/;
     my $k = 0;
 
-    # kern<...><<<dim3(Dg), dim3(Db), Ns, S>>>() syntax
-    $k += s/([:|\w]+)\s*<(.+)>\s*<<<\s*dim3\((.+)\)\s*,\s*dim3\((.+)\)\s*,\s*(.+)\s*,\s*(.+)\s*>>>\s*\(\s*\)/hipLaunchKernelGGL(HIP_KERNEL_NAME($1<$2>), dim3($3), dim3($4), $5, $6)/g;
-    # kern<...><<<dim3(Dg), Db, Ns, S>>>() syntax
-    $k += s/([:|\w]+)\s*<(.+)>\s*<<<\s*dim3\((.+)\)\s*,\s*((?:(?!dim3).)*)\s*,\s*(.+)\s*,\s*(.+)\s*>>>\s*\(\s*\)/hipLaunchKernelGGL(HIP_KERNEL_NAME($1<$2>), dim3($3), dim3($4), $5, $6)/g;
-    # kern<...><<<Dg, dim3(Db), Ns, S>>>() syntax
-    $k += s/([:|\w]+)\s*<(.+)>\s*<<<\s*((?:(?!dim3).)*)\s*,\s*dim3\((.+)\)\s*,\s*(.+)\s*,\s*(.+)\s*>>>\s*\(\s*\)/hipLaunchKernelGGL(HIP_KERNEL_NAME($1<$2>), dim3($3), dim3($4), $5, $6)/g;
-    # kern<...><<<Dg, Db, Ns, S>>>() syntax
-    $k += s/([:|\w]+)\s*<(.+)>\s*<<<\s*((?:(?!dim3).)*)\s*,\s*((?:(?!dim3).)*)\s*,\s*(.+)\s*,\s*(.+)\s*>>>\s*\(\s*\)/hipLaunchKernelGGL(HIP_KERNEL_NAME($1<$2>), dim3($3), dim3($4), $5, $6)/g;
-
-    # kern<<<dim3(Dg), dim3(Db), Ns, S>>>() syntax
-    $k += s/([:|\w]+)\s*<<<\s*dim3\((.+)\)\s*,\s*dim3\((.+)\)\s*,\s*(.+)\s*,\s*(.+)\s*>>>\s*\(\s*\)/hipLaunchKernelGGL($1, dim3($2), dim3($3), $4, $5)/g;
-    # kern<<<dim3(Dg), Db, Ns, S>>>() syntax
-    $k += s/([:|\w]+)\s*<<<\s*dim3\((.+)\)\s*,\s*((?:(?!dim3).)*)\s*,\s*(.+)\s*,\s*(.+)\s*>>>\s*\(\s*\)/hipLaunchKernelGGL($1, dim3($2), dim3($3), $4, $5)/g;
-    # kern<<<Dg, dim3(Db), Ns, S>>>() syntax
-    $k += s/([:|\w]+)\s*<<<\s*((?:(?!dim3).)*)\s*,\s*dim3\((.+)\)\s*,\s*(.+)\s*,\s*(.+)\s*>>>\s*\(\s*\)/hipLaunchKernelGGL($1, dim3($2), dim3($3), $4, $5)/g;
-    # kern<<<Dg, Db, Ns, S>>>() syntax
-    $k += s/([:|\w]+)\s*<<<\s*((?:(?!dim3).)*)\s*,\s*((?:(?!dim3).)*)\s*,\s*(.+)\s*,\s*(.+)\s*>>>\s*\(\s*\)/hipLaunchKernelGGL($1, dim3($2), dim3($3), $4, $5)/g;
-
-    # kern<...><<<dim3(Dg), dim3(Db), Ns, S>>>(...) syntax
-    $k += s/([:|\w]+)\s*<(.+)>\s*<<<\s*dim3\((.+)\)\s*,\s*dim3\((.+)\)\s*,\s*(.+)\s*,\s*(.+)\s*>>>\s*\(/hipLaunchKernelGGL(HIP_KERNEL_NAME($1<$2>), dim3($3), dim3($4), $5, $6, /g;
-    # kern<...><<<dim3(Dg), Db, Ns, S>>>(...) syntax
-    $k += s/([:|\w]+)\s*<(.+)>\s*<<<\s*dim3\((.+)\)\s*,\s*((?:(?!dim3).)*)\s*,\s*(.+)\s*,\s*(.+)\s*>>>\s*\(/hipLaunchKernelGGL(HIP_KERNEL_NAME($1<$2>), dim3($3), dim3($4), $5, $6, /g;
-    # kern<...><<<Dg, dim3(Db), Ns, S>>>(...) syntax
-    $k += s/([:|\w]+)\s*<(.+)>\s*<<<\s*((?:(?!dim3).)*)\s*,\s*dim3\((.+)\)\s*,\s*(.+)\s*,\s*(.+)\s*>>>\s*\(/hipLaunchKernelGGL(HIP_KERNEL_NAME($1<$2>), dim3($3), dim3($4), $5, $6, /g;
-    # kern<...><<<Dg, Db, Ns, S>>>(...) syntax
-    $k += s/([:|\w]+)\s*<(.+)>\s*<<<\s*((?:(?!dim3).)*)\s*,\s*((?:(?!dim3).)*)\s*,\s*(.+)\s*,\s*(.+)\s*>>>\s*\(/hipLaunchKernelGGL(HIP_KERNEL_NAME($1<$2>), dim3($3), dim3($4), $5, $6, /g;
-
-    # kern<<<dim3(Dg), dim3(Db), Ns, S>>>(...) syntax
-    $k += s/([:|\w]+)\s*<<<\s*dim3\((.+)\)\s*,\s*dim3\((.+)\)\s*,\s*(.+)\s*,\s*(.+)\s*>>>\s*\(/hipLaunchKernelGGL($1, dim3($2), dim3($3), $4, $5, /g;
-    # kern<<<dim3(Dg), Db, Ns, S>>>(...) syntax
-    $k += s/([:|\w]+)\s*<<<\s*dim3\((.+)\)\s*,\s*((?:(?!dim3).)*)\s*,\s*(.+)\s*,\s*(.+)\s*>>>\s*\(/hipLaunchKernelGGL($1, dim3($2), dim3($3), $4, $5, /g;
-    # kern<<<Dg, dim3(Db), Ns, S>>>(...) syntax
-    $k += s/([:|\w]+)\s*<<<\s*((?:(?!dim3).)*)\s*,\s*dim3\((.+)\)\s*,\s*(.+)\s*,\s*(.+)\s*>>>\s*\(/hipLaunchKernelGGL($1, dim3($2), dim3($3), $4, $5, /g;
-    # kern<<<Dg, Db, Ns, S>>>(...) syntax
-    $k += s/([:|\w]+)\s*<<<\s*((?:(?!dim3).)*)\s*,\s*((?:(?!dim3).)*)\s*,\s*(.+)\s*,\s*(.+)\s*>>>\s*\(/hipLaunchKernelGGL($1, dim3($2), dim3($3), $4, $5, /g;
-
-    # kern<...><<<dim3(Dg), dim3(Db), Ns>>>() syntax
-    $k += s/([:|\w]+)\s*<(.+)>\s*<<<\s*dim3\((.+)\)\s*,\s*dim3\((.+)\)\s*,\s*(.+)\s*>>>\s*\(\s*\)/hipLaunchKernelGGL(HIP_KERNEL_NAME($1<$2>), dim3($3), dim3($4), $5, 0)/g;
-    # kern<...><<<dim3(Dg), Db, Ns>>>() syntax
-    $k += s/([:|\w]+)\s*<(.+)>\s*<<<\s*dim3\((.+)\)\s*,\s*((?:(?!dim3).)*)\s*,\s*(.+)\s*>>>\s*\(\s*\)/hipLaunchKernelGGL(HIP_KERNEL_NAME($1<$2>), dim3($3), dim3($4), $5, 0)/g;
-    # kern<...><<<Dg, dim3(Db), Ns>>>() syntax
-    $k += s/([:|\w]+)\s*<(.+)>\s*<<<\s*((?:(?!dim3).)*)\s*,\s*dim3\((.+)\)\s*,\s*(.+)\s*>>>\s*\(\s*\)/hipLaunchKernelGGL(HIP_KERNEL_NAME($1<$2>), dim3($3), dim3($4), $5, 0)/g;
-    # kern<...><<<Dg, Db, Ns>>>() syntax
-    $k += s/([:|\w]+)\s*<(.+)>\s*<<<\s*((?:(?!dim3).)*)\s*,\s*((?:(?!dim3).)*)\s*,\s*(.+)\s*>>>\s*\(\s*\)/hipLaunchKernelGGL(HIP_KERNEL_NAME($1<$2>), dim3($3), dim3($4), $5, 0)/g;
-
-    # kern<<<dim3(Dg), dim3(Db), Ns>>>() syntax
-    $k += s/([:|\w]+)\s*<<<\s*dim3\((.+)\)\s*,\s*dim3\((.+)\)\s*,\s*(.+)\s*>>>\s*\(\s*\)/hipLaunchKernelGGL($1, dim3($2), dim3($3), $4, 0)/g;
-    # kern<<<dim3(Dg), Db, Ns>>>() syntax
-    $k += s/([:|\w]+)\s*<<<\s*dim3\((.+)\)\s*,\s*((?:(?!dim3).)*)\s*,\s*(.+)\s*>>>\s*\(\s*\)/hipLaunchKernelGGL($1, dim3($2), dim3($3), $4, 0)/g;
-    # kern<<<Dg, dim3(Db), Ns>>>() syntax
-    $k += s/([:|\w]+)\s*<<<\s*((?:(?!dim3).)*)\s*,\s*dim3\((.+)\)\s*,\s*(.+)\s*>>>\s*\(\s*\)/hipLaunchKernelGGL($1, dim3($2), dim3($3), $4, 0)/g;
-    # kern<<<Dg, Db, Ns>>>() syntax
-    $k += s/([:|\w]+)\s*<<<\s*((?:(?!dim3).)*)\s*,\s*((?:(?!dim3).)*)\s*,\s*(.+)\s*>>>\s*\(\s*\)/hipLaunchKernelGGL($1, dim3($2), dim3($3), $4, 0)/g;
-
-    # kern<...><<<dim3(Dg), dim3(Db), Ns>>>(...) syntax
-    $k += s/([:|\w]+)\s*<(.+)>\s*<<<\s*dim3\((.+)\)\s*,\s*dim3\((.+)\)\s*,\s*(.+)\s*>>>\s*\(/hipLaunchKernelGGL(HIP_KERNEL_NAME($1<$2>), dim3($3), dim3($4), $5, 0, /g;
-    # kern<...><<<dim3(Dg), Db, Ns>>>(...) syntax
-    $k += s/([:|\w]+)\s*<(.+)>\s*<<<\s*dim3\((.+)\)\s*,\s*((?:(?!dim3).)*)\s*,\s*(.+)\s*>>>\s*\(/hipLaunchKernelGGL(HIP_KERNEL_NAME($1<$2>), dim3($3), dim3($4), $5, 0, /g;
-    # kern<...><<<Dg, dim3(Db), Ns>>>(...) syntax
-    $k += s/([:|\w]+)\s*<(.+)>\s*<<<\s*((?:(?!dim3).)*)\s*,\s*dim3\((.+)\)\s*,\s*(.+)\s*>>>\s*\(/hipLaunchKernelGGL(HIP_KERNEL_NAME($1<$2>), dim3($3), dim3($4), $5, 0, /g;
-    # kern<...><<<Dg, Db, Ns>>>(...) syntax
-    $k += s/([:|\w]+)\s*<(.+)>\s*<<<\s*((?:(?!dim3).)*)\s*,\s*((?:(?!dim3).)*)\s*,\s*(.+)\s*>>>\s*\(/hipLaunchKernelGGL(HIP_KERNEL_NAME($1<$2>), dim3($3), dim3($4), $5, 0, /g;
-
-    # kern<<<dim3(Dg), dim3(Db), Ns>>>(...) syntax
-    $k += s/([:|\w]+)\s*<<<\s*dim3\((.+)\)\s*,\s*dim3\((.+)\)\s*,\s*(.+)\s*>>>\s*\(/hipLaunchKernelGGL($1, dim3($2), dim3($3), $4, 0, /g;
-    # kern<<<dim3(Dg), Db, Ns>>>(...) syntax
-    $k += s/([:|\w]+)\s*<<<\s*dim3\((.+)\)\s*,\s*((?:(?!dim3).)*)\s*,\s*(.+)\s*>>>\s*\(/hipLaunchKernelGGL($1, dim3($2), dim3($3), $4, 0, /g;
-    # kern<<<Dg, dim3(Db), Ns>>>(...) syntax
-    $k += s/([:|\w]+)\s*<<<\s*((?:(?!dim3).)*)\s*,\s*dim3\((.+)\)\s*,\s*(.+)\s*>>>\s*\(/hipLaunchKernelGGL($1, dim3($2), dim3($3), $4, 0, /g;
-    # kern<<<Dg, Db, Ns>>>(...) syntax
-    $k += s/([:|\w]+)\s*<<<\s*((?:(?!dim3).)*)\s*,\s*((?:(?!dim3).)*)\s*,\s*(.+)\s*>>>\s*\(/hipLaunchKernelGGL($1, dim3($2), dim3($3), $4, 0, /g;
-
-    # kern<...><<<dim3(Dg), dim3(Db)>>>() syntax
-    $k += s/([:|\w]+)\s*<(.+)>\s*<<<\s*dim3\((.+)\)\s*,\s*dim3\((.+)\)\s*>>>\s*\(\s*\)/hipLaunchKernelGGL(HIP_KERNEL_NAME($1<$2>), dim3($3), dim3($4), 0, 0)/g;
-    # kern<...><<<dim3(Dg), Db>>>() syntax
-    $k += s/([:|\w]+)\s*<(.+)>\s*<<<\s*dim3\((.+)\)\s*,\s*((?:(?!dim3).)*)\s*>>>\s*\(\s*\)/hipLaunchKernelGGL(HIP_KERNEL_NAME($1<$2>), dim3($3), dim3($4), 0, 0)/g;
-    # kern<...><<<Dg, dim3(Db)>>>() syntax
-    $k += s/([:|\w]+)\s*<(.+)>\s*<<<\s*((?:(?!dim3).)*)\s*,\s*dim3\((.+)\)\s*>>>\s*\(\s*\)/hipLaunchKernelGGL(HIP_KERNEL_NAME($1<$2>), dim3($3), dim3($4), 0, 0)/g;
     # kern<...><<<Dg, Db>>>() syntax
-    $k += s/([:|\w]+)\s*<(.+)>\s*<<<\s*((?:(?!dim3).)*)\s*,\s*((?:(?!dim3).)*)\s*>>>\s*\(\s*\)/hipLaunchKernelGGL(HIP_KERNEL_NAME($1<$2>), dim3($3), dim3($4), 0, 0)/g;
-
-    # kern<<<dim3(Dg), dim3(Db)>>>() syntax
-    $k += s/([:|\w]+)\s*<<<\s*dim3\((.+)\)\s*,\s*dim3\((.+)\)\s*>>>\s*\(\s*\)/hipLaunchKernelGGL($1, dim3($2), dim3($3), 0, 0)/g;
-    # kern<<<dim3(Dg), Db>>>() syntax
-    $k += s/([:|\w]+)\s*<<<\s*dim3\((.+)\)\s*,\s*((?:(?!dim3).)*)\s*>>>\s*\(\s*\)/hipLaunchKernelGGL($1, dim3($2), dim3($3), 0, 0)/g;
-    # kern<<<Dg, dim3(Db)>>>() syntax
-    $k += s/([:|\w]+)\s*<<<\s*((?:(?!dim3).)*)\s*,\s*dim3\((.+)\)\s*>>>\s*\(\s*\)/hipLaunchKernelGGL($1, dim3($2), dim3($3), 0, 0)/g;
-    # kern<<<Dg, Db>>>() syntax
-    $k += s/([:|\w]+)\s*<<<\s*((?:(?!dim3).)*)\s*,\s*((?:(?!dim3).)*)\s*>>>\s*\(\s*\)/hipLaunchKernelGGL($1, dim3($2), dim3($3), 0, 0)/g;
-
-    # kern<...><<<dim3(Dg), dim3(Db)>>>(...) syntax
-    $k += s/([:|\w]+)\s*<(.+)>\s*<<<\s*dim3\((.+)\)\s*,\s*dim3\((.+)\)\s*>>>\s*\(/hipLaunchKernelGGL(HIP_KERNEL_NAME($1<$2>), dim3($3), dim3($4), 0, 0, /g;
-    # kern<...><<<dim3(Dg), Db>>>(...) syntax
-    $k += s/([:|\w]+)\s*<(.+)>\s*<<<\s*dim3\((.+)\)\s*,\s*((?:(?!dim3).)*)\s*>>>\s*\(/hipLaunchKernelGGL(HIP_KERNEL_NAME($1<$2>), dim3($3), dim3($4), 0, 0, /g;
-    # kern<...><<<Dg, dim3(Db)>>>(...) syntax
-    $k += s/([:|\w]+)\s*<(.+)>\s*<<<\s*((?:(?!dim3).)*)\s*,\s*dim3\((.+)\)\s*>>>\s*\(/hipLaunchKernelGGL(HIP_KERNEL_NAME($1<$2>), dim3($3), dim3($4), 0, 0, /g;
+    $k += s/([:|\w]+)\s*<(.+)>\s*<<<\s*([^,]+|[\w:]*\([\w|,|:]+\))\s*,\s*([^,]+|[\w:]*\([\w|,|:]+\))\s*>>>\s*\(\s*\)/hipLaunchKernelGGL(HIP_KERNEL_NAME($1<$2>), $3, $4, 0, 0)/g;
     # kern<...><<<Dg, Db>>>(...) syntax
-    $k += s/([:|\w]+)\s*<(.+)>\s*<<<\s*((?:(?!dim3).)*)\s*,\s*((?:(?!dim3).)*)\s*>>>\s*\(/hipLaunchKernelGGL(HIP_KERNEL_NAME($1<$2>), dim3($3), dim3($4), 0, 0, /g;
-
-    # kern<<<dim3(Dg), dim3(Db)>>>(...) syntax
-    $k += s/([:|\w]+)\s*<<<\s*dim3\((.+)\)\s*,\s*dim3\((.+)\)\s*>>>\s*\(/hipLaunchKernelGGL($1, dim3($2), dim3($3), 0, 0, /g;
-    # kern<<<dim3(Dg), Db>>>(...) syntax
-    $k += s/([:|\w]+)\s*<<<\s*dim3\((.+)\)\s*,\s*((?:(?!dim3).)*)\s*>>>\s*\(/hipLaunchKernelGGL($1, dim3($2), dim3($3), 0, 0, /g;
-    # kern<<<Dg, dim3(Db)>>>(...) syntax
-    $k += s/([:|\w]+)\s*<<<\s*((?:(?!dim3).)*)\s*,\s*dim3\((.+)\)\s*>>>\s*\(/hipLaunchKernelGGL($1, dim3($2), dim3($3), 0, 0, /g;
+    $k += s/([:|\w]+)\s*<(.+)>\s*<<<\s*([^,]+|[\w:]*\([\w|,|:]+\))\s*,\s*([^,]+|[\w:]*\([\w|,|:]+\))\s*>>>\s*\(/hipLaunchKernelGGL(HIP_KERNEL_NAME($1<$2>), $3, $4, 0, 0, /g;
+    # kern<<<Dg, Db>>>() syntax
+    $k += s/([:|\w]+)\s*<<<\s*([^,]+|[\w:]*\([\w|,|:]+\))\s*,\s*([^,]+|[\w:]*\([\w|,|:]+\))\s*>>>\s*\(\s*\)/hipLaunchKernelGGL($1, $2, $3, 0, 0)/g;
     # kern<<<Dg, Db>>>(...) syntax
-    $k += s/([:|\w]+)\s*<<<\s*((?:(?!dim3).)*)\s*,\s*((?:(?!dim3).)*)\s*>>>\s*\(/hipLaunchKernelGGL($1, dim3($2), dim3($3), 0, 0, /g;
+    $k += s/([:|\w]+)\s*<<<\s*([^,]+|[\w:]*\([\w|,|:]+\))\s*,\s*([^,]+|[\w:]*\([\w|,|:]+\))\s*>>>\s*\(/hipLaunchKernelGGL($1, $2, $3, 0, 0, /g;
+
+    # kern<...><<<Dg, Db, Ns>>>() syntax
+    $k += s/([:|\w]+)\s*<(.+)>\s*<<<\s*([^,]+|[\w:]*\([\w|,|:]+\))\s*,\s*([^,]+|[\w:]*\([\w|,|:]+\))\s*,\s*([^,]+|[\w:]*\([\w|,|:]+\))\s*>>>\s*\(\s*\)/hipLaunchKernelGGL(HIP_KERNEL_NAME($1<$2>), $3, $4, $5, 0)/g;
+    # kern<...><<<Dg, Db, Ns>>>(...) syntax
+    $k += s/([:|\w]+)\s*<(.+)>\s*<<<\s*([^,]+|[\w:]*\([\w|,|:]+\))\s*,\s*([^,]+|[\w:]*\([\w|,|:]+\))\s*,\s*([^,]+|[\w:]*\([\w|,|:]+\))\s*>>>\s*\(/hipLaunchKernelGGL(HIP_KERNEL_NAME($1<$2>), $3, $4, $5, 0, /g;
+    # kern<<<Dg, Db, Ns>>>() syntax
+    $k += s/([:|\w]+)\s*<<<\s*([^,]+|[\w:]*\([\w|,|:]+\))\s*,\s*([^,]+|[\w:]*\([\w|,|:]+\))\s*,\s*([^,]+|[\w:]*\([\w|,|:]+\))\s*>>>\s*\(\s*\)/hipLaunchKernelGGL($1, $2, $3, $4, 0)/g;
+    # kern<<<Dg, Db, Ns>>>(...) syntax
+    $k += s/([:|\w]+)\s*<<<\s*([^,]+|[\w:]*\([\w|,|:]+\))\s*,\s*([^,]+|[\w:]*\([\w|,|:]+\))\s*,\s*([^,]+|[\w:]*\([\w|,|:]+\))\s*>>>\s*\(/hipLaunchKernelGGL($1, $2, $3, $4, 0, /g;
+
+    # kern<...><<<Dg, Db, Ns, S>>>() syntax
+    $k += s/([:|\w]+)\s*<(.+)>\s*<<<\s*([^,]+|[\w:]*\([\w|,|:]+\))\s*,\s*([^,]+|[\w:]*\([\w|,|:]+\))\s*,\s*([^,]+|[\w:]*\([\w|,|:]+\))\s*,\s*([^,]+|[\w:]*\([\w|,|:]+\))\s*>>>\s*\(\s*\)/hipLaunchKernelGGL(HIP_KERNEL_NAME($1<$2>), $3, $4, $5, $6)/g;
+    # kern<...><<<Dg, Db, Ns, S>>>(...) syntax
+    $k += s/([:|\w]+)\s*<(.+)>\s*<<<\s*([^,]+|[\w:]*\([\w|,|:]+\))\s*,\s*([^,]+|[\w:]*\([\w|,|:]+\))\s*,\s*([^,]+|[\w:]*\([\w|,|:]+\))\s*,\s*([^,]+|[\w:]*\([\w|,|:]+\))\s*>>>\s*\(/hipLaunchKernelGGL(HIP_KERNEL_NAME($1<$2>), $3, $4, $5, $6, /g;
+    # kern<<<Dg, Db, Ns, S>>>() syntax
+    $k += s/([:|\w]+)\s*<<<\s*([^,]+|[\w:]*\([\w|,|:]+\))\s*,\s*([^,]+|[\w:]*\([\w|,|:]+\))\s*,\s*([^,]+|[\w:]*\([\w|,|:]+\))\s*,\s*([^,]+|[\w:]*\([\w|,|:]+\))\s*>>>\s*\(\s*\)/hipLaunchKernelGGL($1, $2, $3, $4, $5)/g;
+    # kern<<<Dg, Db, Ns, S>>>(...) syntax
+    $k += s/([:|\w]+)\s*<<<\s*([^,]+|[\w:]*\([\w|,|:]+\))\s*,\s*([^,]+|[\w:]*\([\w|,|:]+\))\s*,\s*([^,]+|[\w:]*\([\w|,|:]+\))\s*,\s*([^,]+|[\w:]*\([\w|,|:]+\))\s*>>>\s*\(/hipLaunchKernelGGL($1, $2, $3, $4, $5, /g;
 
     if ($k) {
         $ft{'kernel_launch'} += $k;

--- a/src/CUDA2HIP_Perl.cpp
+++ b/src/CUDA2HIP_Perl.cpp
@@ -307,113 +307,32 @@ namespace perl {
 
     string s_k = "$k += s/([:|\\w]+)\\s*";
 
-    *streamPtr.get() << tab << "# kern<...><<<dim3(Dg), dim3(Db), Ns, S>>>() syntax" << endl;
-    *streamPtr.get() << tab << s_k << "<(.+)>\\s*<<<\\s*dim3\\((.+)\\)\\s*,\\s*dim3\\((.+)\\)\\s*,\\s*(.+)\\s*,\\s*(.+)\\s*>>>\\s*\\(\\s*\\)/hipLaunchKernelGGL(HIP_KERNEL_NAME($1<$2>), dim3($3), dim3($4), $5, $6)/g;" << endl;
-    *streamPtr.get() << tab << "# kern<...><<<dim3(Dg), Db, Ns, S>>>() syntax" << endl;
-    *streamPtr.get() << tab << s_k << "<(.+)>\\s*<<<\\s*dim3\\((.+)\\)\\s*,\\s*((?:(?!dim3).)*)\\s*,\\s*(.+)\\s*,\\s*(.+)\\s*>>>\\s*\\(\\s*\\)/hipLaunchKernelGGL(HIP_KERNEL_NAME($1<$2>), dim3($3), dim3($4), $5, $6)/g;" << endl;
-    *streamPtr.get() << tab << "# kern<...><<<Dg, dim3(Db), Ns, S>>>() syntax" << endl;
-    *streamPtr.get() << tab << s_k << "<(.+)>\\s*<<<\\s*((?:(?!dim3).)*)\\s*,\\s*dim3\\((.+)\\)\\s*,\\s*(.+)\\s*,\\s*(.+)\\s*>>>\\s*\\(\\s*\\)/hipLaunchKernelGGL(HIP_KERNEL_NAME($1<$2>), dim3($3), dim3($4), $5, $6)/g;" << endl;
-    *streamPtr.get() << tab << "# kern<...><<<Dg, Db, Ns, S>>>() syntax" << endl;
-    *streamPtr.get() << tab << s_k << "<(.+)>\\s*<<<\\s*((?:(?!dim3).)*)\\s*,\\s*((?:(?!dim3).)*)\\s*,\\s*(.+)\\s*,\\s*(.+)\\s*>>>\\s*\\(\\s*\\)/hipLaunchKernelGGL(HIP_KERNEL_NAME($1<$2>), dim3($3), dim3($4), $5, $6)/g;" << endl_2;
-
-    *streamPtr.get() << tab << "# kern<<<dim3(Dg), dim3(Db), Ns, S>>>() syntax" << endl;
-    *streamPtr.get() << tab << s_k << "<<<\\s*dim3\\((.+)\\)\\s*,\\s*dim3\\((.+)\\)\\s*,\\s*(.+)\\s*,\\s*(.+)\\s*>>>\\s*\\(\\s*\\)/hipLaunchKernelGGL($1, dim3($2), dim3($3), $4, $5)/g;" << endl;
-    *streamPtr.get() << tab << "# kern<<<dim3(Dg), Db, Ns, S>>>() syntax" << endl;
-    *streamPtr.get() << tab << s_k << "<<<\\s*dim3\\((.+)\\)\\s*,\\s*((?:(?!dim3).)*)\\s*,\\s*(.+)\\s*,\\s*(.+)\\s*>>>\\s*\\(\\s*\\)/hipLaunchKernelGGL($1, dim3($2), dim3($3), $4, $5)/g;" << endl;
-    *streamPtr.get() << tab << "# kern<<<Dg, dim3(Db), Ns, S>>>() syntax" << endl;
-    *streamPtr.get() << tab << s_k << "<<<\\s*((?:(?!dim3).)*)\\s*,\\s*dim3\\((.+)\\)\\s*,\\s*(.+)\\s*,\\s*(.+)\\s*>>>\\s*\\(\\s*\\)/hipLaunchKernelGGL($1, dim3($2), dim3($3), $4, $5)/g;" << endl;
-    *streamPtr.get() << tab << "# kern<<<Dg, Db, Ns, S>>>() syntax" << endl;
-    *streamPtr.get() << tab << s_k << "<<<\\s*((?:(?!dim3).)*)\\s*,\\s*((?:(?!dim3).)*)\\s*,\\s*(.+)\\s*,\\s*(.+)\\s*>>>\\s*\\(\\s*\\)/hipLaunchKernelGGL($1, dim3($2), dim3($3), $4, $5)/g;" << endl_2;
-
-    *streamPtr.get() << tab << "# kern<...><<<dim3(Dg), dim3(Db), Ns, S>>>(...) syntax" << endl;
-    *streamPtr.get() << tab << s_k << "<(.+)>\\s*<<<\\s*dim3\\((.+)\\)\\s*,\\s*dim3\\((.+)\\)\\s*,\\s*(.+)\\s*,\\s*(.+)\\s*>>>\\s*\\(/hipLaunchKernelGGL(HIP_KERNEL_NAME($1<$2>), dim3($3), dim3($4), $5, $6, /g;" << endl;
-    *streamPtr.get() << tab << "# kern<...><<<dim3(Dg), Db, Ns, S>>>(...) syntax" << endl;
-    *streamPtr.get() << tab << s_k << "<(.+)>\\s*<<<\\s*dim3\\((.+)\\)\\s*,\\s*((?:(?!dim3).)*)\\s*,\\s*(.+)\\s*,\\s*(.+)\\s*>>>\\s*\\(/hipLaunchKernelGGL(HIP_KERNEL_NAME($1<$2>), dim3($3), dim3($4), $5, $6, /g;" << endl;
-    *streamPtr.get() << tab << "# kern<...><<<Dg, dim3(Db), Ns, S>>>(...) syntax" << endl;
-    *streamPtr.get() << tab << s_k << "<(.+)>\\s*<<<\\s*((?:(?!dim3).)*)\\s*,\\s*dim3\\((.+)\\)\\s*,\\s*(.+)\\s*,\\s*(.+)\\s*>>>\\s*\\(/hipLaunchKernelGGL(HIP_KERNEL_NAME($1<$2>), dim3($3), dim3($4), $5, $6, /g;" << endl;
-    *streamPtr.get() << tab << "# kern<...><<<Dg, Db, Ns, S>>>(...) syntax" << endl;
-    *streamPtr.get() << tab << s_k << "<(.+)>\\s*<<<\\s*((?:(?!dim3).)*)\\s*,\\s*((?:(?!dim3).)*)\\s*,\\s*(.+)\\s*,\\s*(.+)\\s*>>>\\s*\\(/hipLaunchKernelGGL(HIP_KERNEL_NAME($1<$2>), dim3($3), dim3($4), $5, $6, /g;" << endl_2;
-
-    *streamPtr.get() << tab << "# kern<<<dim3(Dg), dim3(Db), Ns, S>>>(...) syntax" << endl;
-    *streamPtr.get() << tab << s_k << "<<<\\s*dim3\\((.+)\\)\\s*,\\s*dim3\\((.+)\\)\\s*,\\s*(.+)\\s*,\\s*(.+)\\s*>>>\\s*\\(/hipLaunchKernelGGL($1, dim3($2), dim3($3), $4, $5, /g;" << endl;
-    *streamPtr.get() << tab << "# kern<<<dim3(Dg), Db, Ns, S>>>(...) syntax" << endl;
-    *streamPtr.get() << tab << s_k << "<<<\\s*dim3\\((.+)\\)\\s*,\\s*((?:(?!dim3).)*)\\s*,\\s*(.+)\\s*,\\s*(.+)\\s*>>>\\s*\\(/hipLaunchKernelGGL($1, dim3($2), dim3($3), $4, $5, /g;" << endl;
-    *streamPtr.get() << tab << "# kern<<<Dg, dim3(Db), Ns, S>>>(...) syntax" << endl;
-    *streamPtr.get() << tab << s_k << "<<<\\s*((?:(?!dim3).)*)\\s*,\\s*dim3\\((.+)\\)\\s*,\\s*(.+)\\s*,\\s*(.+)\\s*>>>\\s*\\(/hipLaunchKernelGGL($1, dim3($2), dim3($3), $4, $5, /g;" << endl;
-    *streamPtr.get() << tab << "# kern<<<Dg, Db, Ns, S>>>(...) syntax" << endl;
-    *streamPtr.get() << tab << s_k << "<<<\\s*((?:(?!dim3).)*)\\s*,\\s*((?:(?!dim3).)*)\\s*,\\s*(.+)\\s*,\\s*(.+)\\s*>>>\\s*\\(/hipLaunchKernelGGL($1, dim3($2), dim3($3), $4, $5, /g;" << endl_2;
-
-    *streamPtr.get() << tab << "# kern<...><<<dim3(Dg), dim3(Db), Ns>>>() syntax" << endl;
-    *streamPtr.get() << tab << s_k << "<(.+)>\\s*<<<\\s*dim3\\((.+)\\)\\s*,\\s*dim3\\((.+)\\)\\s*,\\s*(.+)\\s*>>>\\s*\\(\\s*\\)/hipLaunchKernelGGL(HIP_KERNEL_NAME($1<$2>), dim3($3), dim3($4), $5, 0)/g;" << endl;
-    *streamPtr.get() << tab << "# kern<...><<<dim3(Dg), Db, Ns>>>() syntax" << endl;
-    *streamPtr.get() << tab << s_k << "<(.+)>\\s*<<<\\s*dim3\\((.+)\\)\\s*,\\s*((?:(?!dim3).)*)\\s*,\\s*(.+)\\s*>>>\\s*\\(\\s*\\)/hipLaunchKernelGGL(HIP_KERNEL_NAME($1<$2>), dim3($3), dim3($4), $5, 0)/g;" << endl;
-    *streamPtr.get() << tab << "# kern<...><<<Dg, dim3(Db), Ns>>>() syntax" << endl;
-    *streamPtr.get() << tab << s_k << "<(.+)>\\s*<<<\\s*((?:(?!dim3).)*)\\s*,\\s*dim3\\((.+)\\)\\s*,\\s*(.+)\\s*>>>\\s*\\(\\s*\\)/hipLaunchKernelGGL(HIP_KERNEL_NAME($1<$2>), dim3($3), dim3($4), $5, 0)/g;" << endl;
-    *streamPtr.get() << tab << "# kern<...><<<Dg, Db, Ns>>>() syntax" << endl;
-    *streamPtr.get() << tab << s_k << "<(.+)>\\s*<<<\\s*((?:(?!dim3).)*)\\s*,\\s*((?:(?!dim3).)*)\\s*,\\s*(.+)\\s*>>>\\s*\\(\\s*\\)/hipLaunchKernelGGL(HIP_KERNEL_NAME($1<$2>), dim3($3), dim3($4), $5, 0)/g;" << endl_2;
-
-    *streamPtr.get() << tab << "# kern<<<dim3(Dg), dim3(Db), Ns>>>() syntax" << endl;
-    *streamPtr.get() << tab << s_k << "<<<\\s*dim3\\((.+)\\)\\s*,\\s*dim3\\((.+)\\)\\s*,\\s*(.+)\\s*>>>\\s*\\(\\s*\\)/hipLaunchKernelGGL($1, dim3($2), dim3($3), $4, 0)/g;" << endl;
-    *streamPtr.get() << tab << "# kern<<<dim3(Dg), Db, Ns>>>() syntax" << endl;
-    *streamPtr.get() << tab << s_k << "<<<\\s*dim3\\((.+)\\)\\s*,\\s*((?:(?!dim3).)*)\\s*,\\s*(.+)\\s*>>>\\s*\\(\\s*\\)/hipLaunchKernelGGL($1, dim3($2), dim3($3), $4, 0)/g;" << endl;
-    *streamPtr.get() << tab << "# kern<<<Dg, dim3(Db), Ns>>>() syntax" << endl;
-    *streamPtr.get() << tab << s_k << "<<<\\s*((?:(?!dim3).)*)\\s*,\\s*dim3\\((.+)\\)\\s*,\\s*(.+)\\s*>>>\\s*\\(\\s*\\)/hipLaunchKernelGGL($1, dim3($2), dim3($3), $4, 0)/g;" << endl;
-    *streamPtr.get() << tab << "# kern<<<Dg, Db, Ns>>>() syntax" << endl;
-    *streamPtr.get() << tab << s_k << "<<<\\s*((?:(?!dim3).)*)\\s*,\\s*((?:(?!dim3).)*)\\s*,\\s*(.+)\\s*>>>\\s*\\(\\s*\\)/hipLaunchKernelGGL($1, dim3($2), dim3($3), $4, 0)/g;" << endl_2;
-
-    *streamPtr.get() << tab << "# kern<...><<<dim3(Dg), dim3(Db), Ns>>>(...) syntax" << endl;
-    *streamPtr.get() << tab << s_k << "<(.+)>\\s*<<<\\s*dim3\\((.+)\\)\\s*,\\s*dim3\\((.+)\\)\\s*,\\s*(.+)\\s*>>>\\s*\\(/hipLaunchKernelGGL(HIP_KERNEL_NAME($1<$2>), dim3($3), dim3($4), $5, 0, /g;" << endl;
-    *streamPtr.get() << tab << "# kern<...><<<dim3(Dg), Db, Ns>>>(...) syntax" << endl;
-    *streamPtr.get() << tab << s_k << "<(.+)>\\s*<<<\\s*dim3\\((.+)\\)\\s*,\\s*((?:(?!dim3).)*)\\s*,\\s*(.+)\\s*>>>\\s*\\(/hipLaunchKernelGGL(HIP_KERNEL_NAME($1<$2>), dim3($3), dim3($4), $5, 0, /g;" << endl;
-    *streamPtr.get() << tab << "# kern<...><<<Dg, dim3(Db), Ns>>>(...) syntax" << endl;
-    *streamPtr.get() << tab << s_k << "<(.+)>\\s*<<<\\s*((?:(?!dim3).)*)\\s*,\\s*dim3\\((.+)\\)\\s*,\\s*(.+)\\s*>>>\\s*\\(/hipLaunchKernelGGL(HIP_KERNEL_NAME($1<$2>), dim3($3), dim3($4), $5, 0, /g;" << endl;
-    *streamPtr.get() << tab << "# kern<...><<<Dg, Db, Ns>>>(...) syntax" << endl;
-    *streamPtr.get() << tab << s_k << "<(.+)>\\s*<<<\\s*((?:(?!dim3).)*)\\s*,\\s*((?:(?!dim3).)*)\\s*,\\s*(.+)\\s*>>>\\s*\\(/hipLaunchKernelGGL(HIP_KERNEL_NAME($1<$2>), dim3($3), dim3($4), $5, 0, /g;" << endl_2;
-
-    *streamPtr.get() << tab << "# kern<<<dim3(Dg), dim3(Db), Ns>>>(...) syntax" << endl;
-    *streamPtr.get() << tab << s_k << "<<<\\s*dim3\\((.+)\\)\\s*,\\s*dim3\\((.+)\\)\\s*,\\s*(.+)\\s*>>>\\s*\\(/hipLaunchKernelGGL($1, dim3($2), dim3($3), $4, 0, /g;" << endl;
-    *streamPtr.get() << tab << "# kern<<<dim3(Dg), Db, Ns>>>(...) syntax" << endl;
-    *streamPtr.get() << tab << s_k << "<<<\\s*dim3\\((.+)\\)\\s*,\\s*((?:(?!dim3).)*)\\s*,\\s*(.+)\\s*>>>\\s*\\(/hipLaunchKernelGGL($1, dim3($2), dim3($3), $4, 0, /g;" << endl;
-    *streamPtr.get() << tab << "# kern<<<Dg, dim3(Db), Ns>>>(...) syntax" << endl;
-    *streamPtr.get() << tab << s_k << "<<<\\s*((?:(?!dim3).)*)\\s*,\\s*dim3\\((.+)\\)\\s*,\\s*(.+)\\s*>>>\\s*\\(/hipLaunchKernelGGL($1, dim3($2), dim3($3), $4, 0, /g;" << endl;
-    *streamPtr.get() << tab << "# kern<<<Dg, Db, Ns>>>(...) syntax" << endl;
-    *streamPtr.get() << tab << s_k << "<<<\\s*((?:(?!dim3).)*)\\s*,\\s*((?:(?!dim3).)*)\\s*,\\s*(.+)\\s*>>>\\s*\\(/hipLaunchKernelGGL($1, dim3($2), dim3($3), $4, 0, /g;" << endl_2;
-
-    *streamPtr.get() << tab << "# kern<...><<<dim3(Dg), dim3(Db)>>>() syntax" << endl;
-    *streamPtr.get() << tab << s_k << "<(.+)>\\s*<<<\\s*dim3\\((.+)\\)\\s*,\\s*dim3\\((.+)\\)\\s*>>>\\s*\\(\\s*\\)/hipLaunchKernelGGL(HIP_KERNEL_NAME($1<$2>), dim3($3), dim3($4), 0, 0)/g;" << endl;
-    *streamPtr.get() << tab << "# kern<...><<<dim3(Dg), Db>>>() syntax" << endl;
-    *streamPtr.get() << tab << s_k << "<(.+)>\\s*<<<\\s*dim3\\((.+)\\)\\s*,\\s*((?:(?!dim3).)*)\\s*>>>\\s*\\(\\s*\\)/hipLaunchKernelGGL(HIP_KERNEL_NAME($1<$2>), dim3($3), dim3($4), 0, 0)/g;" << endl;
-    *streamPtr.get() << tab << "# kern<...><<<Dg, dim3(Db)>>>() syntax" << endl;
-    *streamPtr.get() << tab << s_k << "<(.+)>\\s*<<<\\s*((?:(?!dim3).)*)\\s*,\\s*dim3\\((.+)\\)\\s*>>>\\s*\\(\\s*\\)/hipLaunchKernelGGL(HIP_KERNEL_NAME($1<$2>), dim3($3), dim3($4), 0, 0)/g;" << endl;
     *streamPtr.get() << tab << "# kern<...><<<Dg, Db>>>() syntax" << endl;
-    *streamPtr.get() << tab << s_k << "<(.+)>\\s*<<<\\s*((?:(?!dim3).)*)\\s*,\\s*((?:(?!dim3).)*)\\s*>>>\\s*\\(\\s*\\)/hipLaunchKernelGGL(HIP_KERNEL_NAME($1<$2>), dim3($3), dim3($4), 0, 0)/g;" << endl_2;
-
-    *streamPtr.get() << tab << "# kern<<<dim3(Dg), dim3(Db)>>>() syntax" << endl;
-    *streamPtr.get() << tab << s_k << "<<<\\s*dim3\\((.+)\\)\\s*,\\s*dim3\\((.+)\\)\\s*>>>\\s*\\(\\s*\\)/hipLaunchKernelGGL($1, dim3($2), dim3($3), 0, 0)/g;" << endl;
-    *streamPtr.get() << tab << "# kern<<<dim3(Dg), Db>>>() syntax" << endl;
-    *streamPtr.get() << tab << s_k << "<<<\\s*dim3\\((.+)\\)\\s*,\\s*((?:(?!dim3).)*)\\s*>>>\\s*\\(\\s*\\)/hipLaunchKernelGGL($1, dim3($2), dim3($3), 0, 0)/g;" << endl;
-    *streamPtr.get() << tab << "# kern<<<Dg, dim3(Db)>>>() syntax" << endl;
-    *streamPtr.get() << tab << s_k << "<<<\\s*((?:(?!dim3).)*)\\s*,\\s*dim3\\((.+)\\)\\s*>>>\\s*\\(\\s*\\)/hipLaunchKernelGGL($1, dim3($2), dim3($3), 0, 0)/g;" << endl;
-    *streamPtr.get() << tab << "# kern<<<Dg, Db>>>() syntax" << endl;
-    *streamPtr.get() << tab << s_k << "<<<\\s*((?:(?!dim3).)*)\\s*,\\s*((?:(?!dim3).)*)\\s*>>>\\s*\\(\\s*\\)/hipLaunchKernelGGL($1, dim3($2), dim3($3), 0, 0)/g;" << endl_2;
-
-    *streamPtr.get() << tab << "# kern<...><<<dim3(Dg), dim3(Db)>>>(...) syntax" << endl;
-    *streamPtr.get() << tab << s_k << "<(.+)>\\s*<<<\\s*dim3\\((.+)\\)\\s*,\\s*dim3\\((.+)\\)\\s*>>>\\s*\\(/hipLaunchKernelGGL(HIP_KERNEL_NAME($1<$2>), dim3($3), dim3($4), 0, 0, /g;" << endl;
-    *streamPtr.get() << tab << "# kern<...><<<dim3(Dg), Db>>>(...) syntax" << endl;
-    *streamPtr.get() << tab << s_k << "<(.+)>\\s*<<<\\s*dim3\\((.+)\\)\\s*,\\s*((?:(?!dim3).)*)\\s*>>>\\s*\\(/hipLaunchKernelGGL(HIP_KERNEL_NAME($1<$2>), dim3($3), dim3($4), 0, 0, /g;" << endl;
-    *streamPtr.get() << tab << "# kern<...><<<Dg, dim3(Db)>>>(...) syntax" << endl;
-    *streamPtr.get() << tab << s_k << "<(.+)>\\s*<<<\\s*((?:(?!dim3).)*)\\s*,\\s*dim3\\((.+)\\)\\s*>>>\\s*\\(/hipLaunchKernelGGL(HIP_KERNEL_NAME($1<$2>), dim3($3), dim3($4), 0, 0, /g;" << endl;
+    *streamPtr.get() << tab << s_k << "<(.+)>\\s*<<<\\s*([^,]+|[\\w:]*\\([\\w|,|:]+\\))\\s*,\\s*([^,]+|[\\w:]*\\([\\w|,|:]+\\))\\s*>>>\\s*\\(\\s*\\)/hipLaunchKernelGGL(HIP_KERNEL_NAME($1<$2>), $3, $4, 0, 0)/g;" << endl;
     *streamPtr.get() << tab << "# kern<...><<<Dg, Db>>>(...) syntax" << endl;
-    *streamPtr.get() << tab << s_k << "<(.+)>\\s*<<<\\s*((?:(?!dim3).)*)\\s*,\\s*((?:(?!dim3).)*)\\s*>>>\\s*\\(/hipLaunchKernelGGL(HIP_KERNEL_NAME($1<$2>), dim3($3), dim3($4), 0, 0, /g;" << endl_2;
-
-    *streamPtr.get() << tab << "# kern<<<dim3(Dg), dim3(Db)>>>(...) syntax" << endl;
-    *streamPtr.get() << tab << s_k << "<<<\\s*dim3\\((.+)\\)\\s*,\\s*dim3\\((.+)\\)\\s*>>>\\s*\\(/hipLaunchKernelGGL($1, dim3($2), dim3($3), 0, 0, /g;" << endl;
-    *streamPtr.get() << tab << "# kern<<<dim3(Dg), Db>>>(...) syntax" << endl;
-    *streamPtr.get() << tab << s_k << "<<<\\s*dim3\\((.+)\\)\\s*,\\s*((?:(?!dim3).)*)\\s*>>>\\s*\\(/hipLaunchKernelGGL($1, dim3($2), dim3($3), 0, 0, /g;" << endl;
-    *streamPtr.get() << tab << "# kern<<<Dg, dim3(Db)>>>(...) syntax" << endl;
-    *streamPtr.get() << tab << s_k << "<<<\\s*((?:(?!dim3).)*)\\s*,\\s*dim3\\((.+)\\)\\s*>>>\\s*\\(/hipLaunchKernelGGL($1, dim3($2), dim3($3), 0, 0, /g;" << endl;
+    *streamPtr.get() << tab << s_k << "<(.+)>\\s*<<<\\s*([^,]+|[\\w:]*\\([\\w|,|:]+\\))\\s*,\\s*([^,]+|[\\w:]*\\([\\w|,|:]+\\))\\s*>>>\\s*\\(/hipLaunchKernelGGL(HIP_KERNEL_NAME($1<$2>), $3, $4, 0, 0, /g;" << endl;
+    *streamPtr.get() << tab << "# kern<<<Dg, Db>>>() syntax" << endl;
+    *streamPtr.get() << tab << s_k << "<<<\\s*([^,]+|[\\w:]*\\([\\w|,|:]+\\))\\s*,\\s*([^,]+|[\\w:]*\\([\\w|,|:]+\\))\\s*>>>\\s*\\(\\s*\\)/hipLaunchKernelGGL($1, $2, $3, 0, 0)/g;" << endl;
     *streamPtr.get() << tab << "# kern<<<Dg, Db>>>(...) syntax" << endl;
-    *streamPtr.get() << tab << s_k << "<<<\\s*((?:(?!dim3).)*)\\s*,\\s*((?:(?!dim3).)*)\\s*>>>\\s*\\(/hipLaunchKernelGGL($1, dim3($2), dim3($3), 0, 0, /g;" << endl_2;
+    *streamPtr.get() << tab << s_k << "<<<\\s*([^,]+|[\\w:]*\\([\\w|,|:]+\\))\\s*,\\s*([^,]+|[\\w:]*\\([\\w|,|:]+\\))\\s*>>>\\s*\\(/hipLaunchKernelGGL($1, $2, $3, 0, 0, /g;" << endl_2;
+
+    *streamPtr.get() << tab << "# kern<...><<<Dg, Db, Ns>>>() syntax" << endl;
+    *streamPtr.get() << tab << s_k << "<(.+)>\\s*<<<\\s*([^,]+|[\\w:]*\\([\\w|,|:]+\\))\\s*,\\s*([^,]+|[\\w:]*\\([\\w|,|:]+\\))\\s*,\\s*([^,]+|[\\w:]*\\([\\w|,|:]+\\))\\s*>>>\\s*\\(\\s*\\)/hipLaunchKernelGGL(HIP_KERNEL_NAME($1<$2>), $3, $4, $5, 0)/g;" << endl;
+    *streamPtr.get() << tab << "# kern<...><<<Dg, Db, Ns>>>(...) syntax" << endl;
+    *streamPtr.get() << tab << s_k << "<(.+)>\\s*<<<\\s*([^,]+|[\\w:]*\\([\\w|,|:]+\\))\\s*,\\s*([^,]+|[\\w:]*\\([\\w|,|:]+\\))\\s*,\\s*([^,]+|[\\w:]*\\([\\w|,|:]+\\))\\s*>>>\\s*\\(/hipLaunchKernelGGL(HIP_KERNEL_NAME($1<$2>), $3, $4, $5, 0, /g;" << endl;
+    *streamPtr.get() << tab << "# kern<<<Dg, Db, Ns>>>() syntax" << endl;
+    *streamPtr.get() << tab << s_k << "<<<\\s*([^,]+|[\\w:]*\\([\\w|,|:]+\\))\\s*,\\s*([^,]+|[\\w:]*\\([\\w|,|:]+\\))\\s*,\\s*([^,]+|[\\w:]*\\([\\w|,|:]+\\))\\s*>>>\\s*\\(\\s*\\)/hipLaunchKernelGGL($1, $2, $3, $4, 0)/g;" << endl;
+    *streamPtr.get() << tab << "# kern<<<Dg, Db, Ns>>>(...) syntax" << endl;
+    *streamPtr.get() << tab << s_k << "<<<\\s*([^,]+|[\\w:]*\\([\\w|,|:]+\\))\\s*,\\s*([^,]+|[\\w:]*\\([\\w|,|:]+\\))\\s*,\\s*([^,]+|[\\w:]*\\([\\w|,|:]+\\))\\s*>>>\\s*\\(/hipLaunchKernelGGL($1, $2, $3, $4, 0, /g;" << endl_2;
+
+    *streamPtr.get() << tab << "# kern<...><<<Dg, Db, Ns, S>>>() syntax" << endl;
+    *streamPtr.get() << tab << s_k << "<(.+)>\\s*<<<\\s*([^,]+|[\\w:]*\\([\\w|,|:]+\\))\\s*,\\s*([^,]+|[\\w:]*\\([\\w|,|:]+\\))\\s*,\\s*([^,]+|[\\w:]*\\([\\w|,|:]+\\))\\s*,\\s*([^,]+|[\\w:]*\\([\\w|,|:]+\\))\\s*>>>\\s*\\(\\s*\\)/hipLaunchKernelGGL(HIP_KERNEL_NAME($1<$2>), $3, $4, $5, $6)/g;" << endl;
+    *streamPtr.get() << tab << "# kern<...><<<Dg, Db, Ns, S>>>(...) syntax" << endl;
+    *streamPtr.get() << tab << s_k << "<(.+)>\\s*<<<\\s*([^,]+|[\\w:]*\\([\\w|,|:]+\\))\\s*,\\s*([^,]+|[\\w:]*\\([\\w|,|:]+\\))\\s*,\\s*([^,]+|[\\w:]*\\([\\w|,|:]+\\))\\s*,\\s*([^,]+|[\\w:]*\\([\\w|,|:]+\\))\\s*>>>\\s*\\(/hipLaunchKernelGGL(HIP_KERNEL_NAME($1<$2>), $3, $4, $5, $6, /g;" << endl;
+    *streamPtr.get() << tab << "# kern<<<Dg, Db, Ns, S>>>() syntax" << endl;
+    *streamPtr.get() << tab << s_k << "<<<\\s*([^,]+|[\\w:]*\\([\\w|,|:]+\\))\\s*,\\s*([^,]+|[\\w:]*\\([\\w|,|:]+\\))\\s*,\\s*([^,]+|[\\w:]*\\([\\w|,|:]+\\))\\s*,\\s*([^,]+|[\\w:]*\\([\\w|,|:]+\\))\\s*>>>\\s*\\(\\s*\\)/hipLaunchKernelGGL($1, $2, $3, $4, $5)/g;" << endl;
+    *streamPtr.get() << tab << "# kern<<<Dg, Db, Ns, S>>>(...) syntax" << endl;
+    *streamPtr.get() << tab << s_k << "<<<\\s*([^,]+|[\\w:]*\\([\\w|,|:]+\\))\\s*,\\s*([^,]+|[\\w:]*\\([\\w|,|:]+\\))\\s*,\\s*([^,]+|[\\w:]*\\([\\w|,|:]+\\))\\s*,\\s*([^,]+|[\\w:]*\\([\\w|,|:]+\\))\\s*>>>\\s*\\(/hipLaunchKernelGGL($1, $2, $3, $4, $5, /g;" << endl_2;
 
     *streamPtr.get() << tab << "if ($k) {" << endl;
     *streamPtr.get() << tab_2 << "$ft{'kernel_launch'} += $k;" << endl;


### PR DESCRIPTION
+ Add support of function calls and typecasting as the CUDA launch parameters
+ Get rid of dim3() typecasting of CUDA launch Dg and Db arguments
+ Update kernel_launch_syntax.cu test with the supported cases
+ Update hipify-perl script accordingly

ToDo:
+ Implement transformations with nested function calls and typecasting as the CUDA launch parameters