### PR TITLE
[HIPIFY][#304] Support of Stream Memory Operations (ROCm 4.2)

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -985,6 +985,10 @@ sub simpleSubstitutions {
     $ft{'event'} += s/\bcudaEventQuery\b/hipEventQuery/g;
     $ft{'event'} += s/\bcudaEventRecord\b/hipEventRecord/g;
     $ft{'event'} += s/\bcudaEventSynchronize\b/hipEventSynchronize/g;
+    $ft{'stream_memory'} += s/\bcuStreamWaitValue32\b/hipStreamWaitValue32/g;
+    $ft{'stream_memory'} += s/\bcuStreamWaitValue64\b/hipStreamWaitValue64/g;
+    $ft{'stream_memory'} += s/\bcuStreamWriteValue32\b/hipStreamWriteValue32/g;
+    $ft{'stream_memory'} += s/\bcuStreamWriteValue64\b/hipStreamWriteValue64/g;
     $ft{'execution'} += s/\bcuFuncGetAttribute\b/hipFuncGetAttribute/g;
     $ft{'execution'} += s/\bcuLaunchKernel\b/hipModuleLaunchKernel/g;
     $ft{'execution'} += s/\bcudaConfigureCall\b/hipConfigureCall/g;
@@ -2806,6 +2810,10 @@ sub simpleSubstitutions {
     $ft{'numeric_literal'} += s/\bCU_SHARED_MEM_CONFIG_FOUR_BYTE_BANK_SIZE\b/hipSharedMemBankSizeFourByte/g;
     $ft{'numeric_literal'} += s/\bCU_STREAM_DEFAULT\b/hipStreamDefault/g;
     $ft{'numeric_literal'} += s/\bCU_STREAM_NON_BLOCKING\b/hipStreamNonBlocking/g;
+    $ft{'numeric_literal'} += s/\bCU_STREAM_WAIT_VALUE_AND\b/hipStreamWaitValueAnd/g;
+    $ft{'numeric_literal'} += s/\bCU_STREAM_WAIT_VALUE_EQ\b/hipStreamWaitValueEq/g;
+    $ft{'numeric_literal'} += s/\bCU_STREAM_WAIT_VALUE_GEQ\b/hipStreamWaitValueGte/g;
+    $ft{'numeric_literal'} += s/\bCU_STREAM_WAIT_VALUE_NOR\b/hipStreamWaitValueNor/g;
     $ft{'numeric_literal'} += s/\bCU_TR_ADDRESS_MODE_BORDER\b/HIP_TR_ADDRESS_MODE_BORDER/g;
     $ft{'numeric_literal'} += s/\bCU_TR_ADDRESS_MODE_CLAMP\b/HIP_TR_ADDRESS_MODE_CLAMP/g;
     $ft{'numeric_literal'} += s/\bCU_TR_ADDRESS_MODE_MIRROR\b/HIP_TR_ADDRESS_MODE_MIRROR/g;
@@ -5065,10 +5073,6 @@ sub warnUnsupportedFunctions {
         "cuSurfObjectGetResourceDesc",
         "cuSurfObjectDestroy",
         "cuSurfObjectCreate",
-        "cuStreamWriteValue64",
-        "cuStreamWriteValue32",
-        "cuStreamWaitValue64",
-        "cuStreamWaitValue32",
         "cuStreamSetAttribute",
         "cuStreamIsCapturing",
         "cuStreamGetCtx",
@@ -5519,10 +5523,7 @@ sub warnUnsupportedFunctions {
         "CU_SYNC_POLICY_AUTO",
         "CU_STREAM_WRITE_VALUE_NO_MEMORY_BARRIER",
         "CU_STREAM_WRITE_VALUE_DEFAULT",
-        "CU_STREAM_WAIT_VALUE_GEQ",
         "CU_STREAM_WAIT_VALUE_FLUSH",
-        "CU_STREAM_WAIT_VALUE_EQ",
-        "CU_STREAM_WAIT_VALUE_AND",
         "CU_STREAM_PER_THREAD",
         "CU_STREAM_MEM_OP_WRITE_VALUE_64",
         "CU_STREAM_MEM_OP_WRITE_VALUE_32",

--- a/doc/markdown/CUDA_Driver_API_functions_supported_by_HIP.md
+++ b/doc/markdown/CUDA_Driver_API_functions_supported_by_HIP.md
@@ -671,10 +671,11 @@
 |`CU_STREAM_MEM_OP_WRITE_VALUE_64`|9.0| | | | | | |
 |`CU_STREAM_NON_BLOCKING`| | | |`hipStreamNonBlocking`|1.6.0| | |
 |`CU_STREAM_PER_THREAD`| | | | | | | |
-|`CU_STREAM_WAIT_VALUE_AND`|8.0| | | | | | |
-|`CU_STREAM_WAIT_VALUE_EQ`|8.0| | | | | | |
+|`CU_STREAM_WAIT_VALUE_AND`|8.0| | |`hipStreamWaitValueAnd`|4.2.0| | |
+|`CU_STREAM_WAIT_VALUE_EQ`|8.0| | |`hipStreamWaitValueEq`|4.2.0| | |
 |`CU_STREAM_WAIT_VALUE_FLUSH`|8.0| | | | | | |
-|`CU_STREAM_WAIT_VALUE_GEQ`|8.0| | | | | | |
+|`CU_STREAM_WAIT_VALUE_GEQ`|8.0| | |`hipStreamWaitValueGte`|4.2.0| | |
+|`CU_STREAM_WAIT_VALUE_NOR`| | | |`hipStreamWaitValueNor`|4.2.0| | |
 |`CU_STREAM_WRITE_VALUE_DEFAULT`|8.0| | | | | | |
 |`CU_STREAM_WRITE_VALUE_NO_MEMORY_BARRIER`|8.0| | | | | | |
 |`CU_SYNC_POLICY_AUTO`|11.0| | | | | | |
@@ -1248,10 +1249,10 @@
 |**CUDA**|**A**|**D**|**R**|**HIP**|**A**|**D**|**R**|
 |:--|:-:|:-:|:-:|:--|:-:|:-:|:-:|
 |`cuStreamBatchMemOp`|8.0| | | | | | |
-|`cuStreamWaitValue32`|8.0| | | | | | |
-|`cuStreamWaitValue64`|9.0| | | | | | |
-|`cuStreamWriteValue32`|8.0| | | | | | |
-|`cuStreamWriteValue64`|9.0| | | | | | |
+|`cuStreamWaitValue32`|8.0| | |`hipStreamWaitValue32`|4.2.0| | |
+|`cuStreamWaitValue64`|9.0| | |`hipStreamWaitValue64`|4.2.0| | |
+|`cuStreamWriteValue32`|8.0| | |`hipStreamWriteValue32`|4.2.0| | |
+|`cuStreamWriteValue64`|9.0| | |`hipStreamWriteValue64`|4.2.0| | |
 
 ## **19. Execution Control**
 

--- a/src/CUDA2HIP_Driver_API_functions.cpp
+++ b/src/CUDA2HIP_Driver_API_functions.cpp
@@ -474,10 +474,19 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_FUNCTION_MAP {
   // 18. Stream Memory Operations
   // no analogues
   {"cuStreamBatchMemOp",                                   {"hipStreamBatchMemOp",                                     "", CONV_STREAM_MEMORY, API_DRIVER, 18, HIP_UNSUPPORTED}},
-  {"cuStreamWaitValue32",                                  {"hipStreamWaitValue32",                                    "", CONV_STREAM_MEMORY, API_DRIVER, 18, HIP_UNSUPPORTED}},
-  {"cuStreamWaitValue64",                                  {"hipStreamWaitValue64",                                    "", CONV_STREAM_MEMORY, API_DRIVER, 18, HIP_UNSUPPORTED}},
-  {"cuStreamWriteValue32",                                 {"hipStreamWriteValue32",                                   "", CONV_STREAM_MEMORY, API_DRIVER, 18, HIP_UNSUPPORTED}},
-  {"cuStreamWriteValue64",                                 {"hipStreamWriteValue64",                                   "", CONV_STREAM_MEMORY, API_DRIVER, 18, HIP_UNSUPPORTED}},
+
+  // CUresult CUDAAPI cuStreamWriteValue32(CUstream stream, CUdeviceptr addr, cuuint32_t value, unsigned int flags);
+  // hipError_t hipStreamWaitValue32(hipStream_t stream, void* ptr, int32_t value, unsigned int flags, uint32_t mask __dparm(0xFFFFFFFF));
+  {"cuStreamWaitValue32",                                  {"hipStreamWaitValue32",                                    "", CONV_STREAM_MEMORY, API_DRIVER, 18}},
+  // CUresult CUDAAPI cuStreamWaitValue64(CUstream stream, CUdeviceptr addr, cuuint64_t value, unsigned int flags);
+  // hipError_t hipStreamWaitValue64(hipStream_t stream, void* ptr, int64_t value, unsigned int flags, uint64_t mask __dparm(0xFFFFFFFFFFFFFFFF));
+  {"cuStreamWaitValue64",                                  {"hipStreamWaitValue64",                                    "", CONV_STREAM_MEMORY, API_DRIVER, 18}},
+  // CUresult CUDAAPI cuStreamWriteValue32(CUstream stream, CUdeviceptr addr, cuuint32_t value, unsigned int flags);
+  // hipError_t hipStreamWriteValue32(hipStream_t stream, void* ptr, int32_t value, unsigned int flags);
+  {"cuStreamWriteValue32",                                 {"hipStreamWriteValue32",                                   "", CONV_STREAM_MEMORY, API_DRIVER, 18}},
+  // CUresult CUDAAPI cuStreamWriteValue64(CUstream stream, CUdeviceptr addr, cuuint64_t value, unsigned int flags);
+  // hipError_t hipStreamWriteValue64(hipStream_t stream, void* ptr, int64_t value, unsigned int flags);
+  {"cuStreamWriteValue64",                                 {"hipStreamWriteValue64",                                   "", CONV_STREAM_MEMORY, API_DRIVER, 18}},
 
   // 19. Execution Control
   // no analogue
@@ -1246,6 +1255,10 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_DRIVER_FUNCTION_VER_MAP {
   {"hipTexObjectGetTextureDesc",                           {HIP_3050, HIP_0,    HIP_0   }},
   {"hipCtxEnablePeerAccess",                               {HIP_1060, HIP_1090, HIP_0   }},
   {"hipCtxDisablePeerAccess",                              {HIP_1060, HIP_1090, HIP_0   }},
+  {"hipStreamWaitValue32",                                 {HIP_4020, HIP_0,    HIP_0   }},
+  {"hipStreamWaitValue64",                                 {HIP_4020, HIP_0,    HIP_0   }},
+  {"hipStreamWriteValue32",                                {HIP_4020, HIP_0,    HIP_0   }},
+  {"hipStreamWriteValue64",                                {HIP_4020, HIP_0,    HIP_0   }},
 };
 
 const std::map<unsigned int, llvm::StringRef> CUDA_DRIVER_API_SECTION_MAP {

--- a/src/CUDA2HIP_Driver_API_types.cpp
+++ b/src/CUDA2HIP_Driver_API_types.cpp
@@ -1491,9 +1491,10 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_TYPE_NAME_MAP {
   {"CUstreamWaitValue_flags",                                          {"hipStreamWaitValueFlags",                                  "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
   {"CUstreamWaitValue_flags_enum",                                     {"hipStreamWaitValueFlags",                                  "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
   // CUstreamWaitValue_flags enum values
-  {"CU_STREAM_WAIT_VALUE_GEQ",                                         {"hipStreamWaitValueGeq",                                    "", CONV_NUMERIC_LITERAL, API_DRIVER, 1, HIP_UNSUPPORTED}}, // 0x0
-  {"CU_STREAM_WAIT_VALUE_EQ",                                          {"hipStreamWaitValueEq",                                     "", CONV_NUMERIC_LITERAL, API_DRIVER, 1, HIP_UNSUPPORTED}}, // 0x1
-  {"CU_STREAM_WAIT_VALUE_AND",                                         {"hipStreamWaitValueAnd",                                    "", CONV_NUMERIC_LITERAL, API_DRIVER, 1, HIP_UNSUPPORTED}}, // 0x2
+  {"CU_STREAM_WAIT_VALUE_GEQ",                                         {"hipStreamWaitValueGte",                                    "", CONV_NUMERIC_LITERAL, API_DRIVER, 1}}, // 0x0
+  {"CU_STREAM_WAIT_VALUE_EQ",                                          {"hipStreamWaitValueEq",                                     "", CONV_NUMERIC_LITERAL, API_DRIVER, 1}}, // 0x1
+  {"CU_STREAM_WAIT_VALUE_AND",                                         {"hipStreamWaitValueAnd",                                    "", CONV_NUMERIC_LITERAL, API_DRIVER, 1}}, // 0x2
+  {"CU_STREAM_WAIT_VALUE_NOR",                                         {"hipStreamWaitValueNor",                                    "", CONV_NUMERIC_LITERAL, API_DRIVER, 1}}, // 0x3
   {"CU_STREAM_WAIT_VALUE_FLUSH",                                       {"hipStreamWaitValueFlush",                                  "", CONV_NUMERIC_LITERAL, API_DRIVER, 1, HIP_UNSUPPORTED}}, // 1<<30
 
   // no analogue
@@ -2584,4 +2585,8 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_DRIVER_TYPE_NAME_VER_MAP {
   {"hipDeviceAttributeConcurrentManagedAccess",                        {HIP_3100, HIP_0,    HIP_0   }},
   {"hipDeviceAttributePageableMemoryAccess",                           {HIP_3100, HIP_0,    HIP_0   }},
   {"hipDeviceAttributePageableMemoryAccessUsesHostPageTables",         {HIP_3100, HIP_0,    HIP_0   }},
+  {"hipStreamWaitValueGte",                                            {HIP_4020, HIP_0,    HIP_0   }},
+  {"hipStreamWaitValueEq",                                             {HIP_4020, HIP_0,    HIP_0   }},
+  {"hipStreamWaitValueAnd",                                            {HIP_4020, HIP_0,    HIP_0   }},
+  {"hipStreamWaitValueNor",                                            {HIP_4020, HIP_0,    HIP_0   }},
 };

--- a/src/Statistics.cpp
+++ b/src/Statistics.cpp
@@ -498,6 +498,7 @@ std::string Statistics::getHipVersion(const hipVersions& ver) {
     case HIP_3100: return "3.10.0";
     case HIP_4000: return "4.0.0";
     case HIP_4100: return "4.1.0";
+    case HIP_4020: return "4.2.0";
   }
   return "";
 }

--- a/src/Statistics.h
+++ b/src/Statistics.h
@@ -265,6 +265,7 @@ enum hipVersions {
   HIP_3100 = 3100,
   HIP_4000 = 4000,
   HIP_4100 = 4100,
+  HIP_4020 = 4020,
 };
 
 struct cudaAPIversions {

--- a/tests/unit_tests/casts/reinterpret_cast.cu
+++ b/tests/unit_tests/casts/reinterpret_cast.cu
@@ -24,6 +24,12 @@ THE SOFTWARE.
 
 // CHECK: #include <hip/hip_runtime.h>
 #include <cuda_runtime.h>
+#include <stdint.h>
+
+// Random predefiend 32 and 64 bit values
+constexpr int32_t value32 = 0x70F0F0FF;
+constexpr int64_t value64 = 0x7FFF0000FFFF0000;
+constexpr unsigned int writeFlag = 0;
 
 __global__
 void fn(float* px, float* py) {
@@ -32,6 +38,329 @@ void fn(float* px, float* py) {
   for (auto&& x : b) x = *py++;
   for (auto&& x : a) x = *px++ > 0.0;
   for (auto&& x : a) if (x) *--py = *--px;
+}
+
+void testWrite() {
+  int64_t* signalPtr;
+  // CHECK: hipStream_t stream;
+  cudaStream_t stream;
+  // CHECK: hipStreamCreate(&stream);
+  cudaStreamCreate(&stream);
+  int64_t* host_ptr64 = (int64_t*)malloc(sizeof(int64_t));
+  int32_t* host_ptr32 = (int32_t*)malloc(sizeof(int32_t));
+  //  hipExtMallocWithFlags((void**)&signalPtr, 8, hipMallocSignalMemory);
+  void* device_ptr64;
+  void* device_ptr32;
+  *host_ptr64 = 0x0;
+  *host_ptr32 = 0x0;
+  *signalPtr = 0x0;
+  // CHECK: hipHostRegister(host_ptr64, sizeof(int64_t), 0);
+  cudaHostRegister(host_ptr64, sizeof(int64_t), 0);
+  // CHECK: hipHostRegister(host_ptr32, sizeof(int32_t), 0);
+  cudaHostRegister(host_ptr32, sizeof(int32_t), 0);
+  // CHECK: hipStreamWriteValue64(stream, hipDeviceptr_t(host_ptr64), int64_t(value64), writeFlag);
+  cuStreamWriteValue64(stream, CUdeviceptr(host_ptr64), value64, writeFlag);
+  // CHECK: hipStreamWriteValue32(stream, hipDeviceptr_t(host_ptr32), int32_t(value32), writeFlag);
+  cuStreamWriteValue32(stream, CUdeviceptr(host_ptr32), value32, writeFlag);
+  // CHECK: hipStreamSynchronize(stream);
+  cudaStreamSynchronize(stream);
+  // CHECK: hipHostGetDevicePointer((void**)&device_ptr64, host_ptr64, 0);
+  cudaHostGetDevicePointer((void**)&device_ptr64, host_ptr64, 0);
+  // CHECK: hipHostGetDevicePointer((void**)&device_ptr32, host_ptr32, 0);
+  cudaHostGetDevicePointer((void**)&device_ptr32, host_ptr32, 0);
+  // Reset values
+  *host_ptr64 = 0x0;
+  *host_ptr32 = 0x0;
+  // CHECK: hipStreamWriteValue64(stream, hipDeviceptr_t(device_ptr64), int64_t(value64), writeFlag);
+  cuStreamWriteValue64(stream, CUdeviceptr(device_ptr64), value64, writeFlag);
+  // CHECK: hipStreamWriteValue32(stream, hipDeviceptr_t(device_ptr32), int32_t(value32), writeFlag);
+  cuStreamWriteValue32(stream, CUdeviceptr(device_ptr32), value32, writeFlag);
+  // CHECK: hipStreamSynchronize(stream);
+  cudaStreamSynchronize(stream);
+  // Test Writing to Signal Memory
+  // CHECK: hipStreamWriteValue64(stream, hipDeviceptr_t(signalPtr), int64_t(value64), writeFlag);
+  cuStreamWriteValue64(stream, CUdeviceptr(signalPtr), value64, writeFlag);
+  // CHECK: hipStreamSynchronize(stream);
+  cudaStreamSynchronize(stream);
+  // Cleanup
+  // CHECK: hipStreamDestroy(stream);
+  cudaStreamDestroy(stream);
+  // CHECK: hipHostUnregister(host_ptr64);
+  cudaHostUnregister(host_ptr64);
+  // CHECK: hipHostUnregister(host_ptr32);
+  cudaHostUnregister(host_ptr32);
+  // CHECK: hipFree(signalPtr);
+  cudaFree(signalPtr);
+  free(host_ptr32);
+  free(host_ptr64);
+}
+
+void testWait() {
+  int64_t* signalPtr;
+  // random data values
+  int32_t DATA_INIT = 0x1234;
+  int32_t DATA_UPDATE = 0X4321;
+
+  struct TEST_WAIT {
+    int compareOp;
+    uint64_t mask;
+    int64_t waitValue;
+    int64_t signalValueFail;
+    int64_t signalValuePass;
+  };
+
+  TEST_WAIT testCases[] = {
+    {
+      // mask will ignore few MSB bits
+      // CHECK: hipStreamWaitValueGte,
+      CU_STREAM_WAIT_VALUE_GEQ,
+      0x0000FFFFFFFFFFFF,
+      0x000000007FFF0001,
+      0x7FFF00007FFF0000,
+      0x000000007FFF0001
+    },
+    {
+      // CHECK: hipStreamWaitValueGte,
+      CU_STREAM_WAIT_VALUE_GEQ,
+      0xF,
+      0x4,
+      0x3,
+      0x6
+    },
+    {
+      // mask will ignore few MSB bits
+      // CHECK: hipStreamWaitValueEq,
+      CU_STREAM_WAIT_VALUE_EQ,
+      0x0000FFFFFFFFFFFF,
+      0x000000000FFF0001,
+      0x7FFF00000FFF0000,
+      0x7F0000000FFF0001
+    },
+    {
+      // CHECK: hipStreamWaitValueEq,
+      CU_STREAM_WAIT_VALUE_EQ,
+      0xFF,
+      0x11,
+      0x25,
+      0x11
+    },
+    {
+      // mask will discard bits 8 to 11
+      // CHECK: hipStreamWaitValueAnd,
+      CU_STREAM_WAIT_VALUE_AND,
+      0xFF,
+      0xF4A,
+      0xF35,
+      0X02
+    },
+    {
+      // mask is set to ignore the sign bit.
+      // CHECK: hipStreamWaitValueNor,
+      CU_STREAM_WAIT_VALUE_NOR,
+      0x7FFFFFFFFFFFFFFF,
+      0x7FFFFFFFFFFFF247,
+      0x7FFFFFFFFFFFFdbd,
+      0x7FFFFFFFFFFFFdb5
+    },
+    {
+      // mask is set to apply NOR for bits 0 to 3.
+      // CHECK: hipStreamWaitValueNor,
+      CU_STREAM_WAIT_VALUE_NOR,
+      0xF,
+      0x7E,
+      0x7D,
+      0x76
+    }
+  };
+
+  struct TEST_WAIT32_NO_MASK {
+    int compareOp;
+    int32_t waitValue;
+    int32_t signalValueFail;
+    int32_t signalValuePass;
+  };
+
+  // default mask 0xFFFFFFFF will be used.
+  TEST_WAIT32_NO_MASK testCasesNoMask32[] = {
+    {
+      // CHECK: hipStreamWaitValueGte,
+      CU_STREAM_WAIT_VALUE_GEQ,
+      0x7FFF0001,
+      0x7FFF0000,
+      0x7FFF0010
+    },
+    {
+      // CHECK: hipStreamWaitValueEq,
+      CU_STREAM_WAIT_VALUE_EQ,
+      0x7FFFFFFF,
+      0x7FFF0000,
+      0x7FFFFFFF
+    },
+    {
+      // CHECK: hipStreamWaitValueAnd,
+      CU_STREAM_WAIT_VALUE_AND,
+      0x70F0F0F0,
+      0x0F0F0F0F,
+      0X1F0F0F0F
+    },
+    {
+      // CHECK: hipStreamWaitValueNor,
+      CU_STREAM_WAIT_VALUE_NOR,
+      0x7AAAAAAA,
+      static_cast<int32_t>(0x85555555),
+      static_cast<int32_t>(0x9AAAAAAA)
+    }
+  };
+
+  struct TEST_WAIT64_NO_MASK {
+    int compareOp;
+    int64_t waitValue;
+    int64_t signalValueFail;
+    int64_t signalValuePass;
+  };
+
+  // default mask 0xFFFFFFFFFFFFFFFF will be used.
+  TEST_WAIT64_NO_MASK testCasesNoMask64[] = {
+    {
+      // CHECK: hipStreamWaitValueGte,
+      CU_STREAM_WAIT_VALUE_GEQ,
+      0x7FFFFFFFFFFF0001,
+      0x7FFFFFFFFFFF0000,
+      0x7FFFFFFFFFFF0001
+    },
+    {
+      // CHECK: hipStreamWaitValueEq,
+      CU_STREAM_WAIT_VALUE_EQ,
+      0x7FFFFFFFFFFFFFFF,
+      0x7FFFFFFF0FFF0000,
+      0x7FFFFFFFFFFFFFFF
+    },
+    {
+      // CHECK: hipStreamWaitValueAnd,
+      CU_STREAM_WAIT_VALUE_AND,
+      0x70F0F0F0F0F0F0F0,
+      0x0F0F0F0F0F0F0F0F,
+      0X1F0F0F0F0F0F0F0F
+    },
+    {
+      // CHECK: hipStreamWaitValueNor,
+      CU_STREAM_WAIT_VALUE_NOR,
+      0x4724724747247247,
+      static_cast<int64_t>(0xbddbddbdbddbddbd),
+      static_cast<int64_t>(0xbddbddbdbddbddb3)
+    }
+  };
+
+  // CHECK: hipStream_t stream;
+  cudaStream_t stream;
+  // CHECK: hipStreamCreate(&stream);
+  cudaStreamCreate(&stream);
+  // hipExtMallocWithFlags((void**)&signalPtr, 8, hipMallocSignalMemory);
+  int64_t* dataPtr64 = (int64_t*)malloc(sizeof(int64_t));
+  int32_t* dataPtr32 = (int32_t*)malloc(sizeof(int32_t));
+  // hipHostRegister(dataPtr64, sizeof(int64_t), 0);
+  cudaHostRegister(dataPtr64, sizeof(int64_t), 0);
+  // CHECK: hipHostRegister(dataPtr32, sizeof(int32_t), 0);
+  cudaHostRegister(dataPtr32, sizeof(int32_t), 0);
+  // Run-1: streamWait is blocking (wait conditions is false)
+  // Run-2: streamWait is non-blocking (wait condition is true)
+  for (int run = 0; run < 2; run++) {
+    bool isBlocking = run == 0;
+    for (const auto & tc : testCases) {
+      *signalPtr = isBlocking ? tc.signalValueFail : tc.signalValuePass;
+      *dataPtr64 = DATA_INIT;
+      // CHECK: hipStreamWaitValue64(stream, hipDeviceptr_t(signalPtr), int64_t(tc.waitValue), tc.compareOp);
+      cuStreamWaitValue64(stream, CUdeviceptr(signalPtr), tc.waitValue, tc.compareOp);
+      // CHECK: hipStreamWriteValue64(stream, hipDeviceptr_t(dataPtr64), int64_t(DATA_UPDATE), writeFlag);
+      cuStreamWriteValue64(stream, CUdeviceptr(dataPtr64), DATA_UPDATE, writeFlag);
+      if (isBlocking) {
+        // Trigger an implict flush and verify stream has pending work.
+        // CHECK: if (hipStreamQuery(stream) != hipErrorNotReady) {}
+        if (cudaStreamQuery(stream) != cudaErrorNotReady) {}
+        // update signal to unblock the wait.
+        *signalPtr = tc.signalValuePass;
+      }
+      // CHECK: if (hipStreamQuery(stream) != hipSuccess) {}
+      if (cudaStreamQuery(stream) != cudaSuccess) {}
+      // CHECK: hipStreamSynchronize(stream);
+      cudaStreamSynchronize(stream);
+      if (*dataPtr64 != DATA_UPDATE) {}
+      // 32-bit API
+      *signalPtr = isBlocking ? tc.signalValueFail : tc.signalValuePass;
+      *dataPtr32 = DATA_INIT;
+      // CHECK: hipStreamWaitValue32(stream, hipDeviceptr_t(signalPtr), int32_t(tc.waitValue), tc.compareOp);
+      cuStreamWaitValue32(stream, CUdeviceptr(signalPtr), tc.waitValue, tc.compareOp);
+      // CHECK: hipStreamWriteValue32(stream, hipDeviceptr_t(dataPtr32), int32_t(DATA_UPDATE), writeFlag);
+      cuStreamWriteValue32(stream, CUdeviceptr(dataPtr32), DATA_UPDATE, writeFlag);
+      if (isBlocking) {
+        // Trigger an implict flush and verify stream has pending work.
+        // CHECK: if (hipStreamQuery(stream) != hipErrorNotReady) {}
+        if (cudaStreamQuery(stream) != cudaErrorNotReady) {}
+        // update signal to unblock the wait.
+        *signalPtr = static_cast<int32_t>(tc.signalValuePass);
+      }
+      // CHECK: hipStreamSynchronize(stream);
+      cudaStreamSynchronize(stream);
+      if (*dataPtr32 != DATA_UPDATE) {}
+    }
+  }
+  // Run-1: streamWait is blocking (wait conditions is false)
+  // Run-2: streamWait is non-blocking (wait condition is true)
+  for (int run = 0; run < 2; run++) {
+    bool isBlocking = run == 0;
+    for (const auto& tc : testCasesNoMask32) {
+      *signalPtr = isBlocking ? tc.signalValueFail : tc.signalValuePass;
+      *dataPtr32 = DATA_INIT;
+      // CHECK: hipStreamWaitValue32(stream, hipDeviceptr_t(signalPtr), int32_t(tc.waitValue), tc.compareOp);
+      cuStreamWaitValue32(stream, CUdeviceptr(signalPtr), tc.waitValue, tc.compareOp);
+      // CHECK: hipStreamWriteValue32(stream, hipDeviceptr_t(dataPtr32), int32_t(DATA_UPDATE), writeFlag);
+      cuStreamWriteValue32(stream, CUdeviceptr(dataPtr32), DATA_UPDATE, writeFlag);
+      if (isBlocking) {
+        // Trigger an implict flush and verify stream has pending work.
+        // CHECK: if (hipStreamQuery(stream) != hipErrorNotReady) {}
+        if (cudaStreamQuery(stream) != cudaErrorNotReady) {}
+        // update signal to unblock the wait.
+        *signalPtr = tc.signalValuePass;
+      }
+      // CHECK: hipStreamSynchronize(stream);
+      cudaStreamSynchronize(stream);
+      if (*dataPtr32 != DATA_UPDATE) {}
+    }
+  }
+  // Run-1: streamWait is blocking (wait conditions is false)
+  // Run-2: streamWait is non-blocking (wait condition is true)
+  for (int run = 0; run < 2; run++) {
+    bool isBlocking = run == 0;
+    for (const auto& tc : testCasesNoMask64) {
+      *signalPtr = isBlocking ? tc.signalValueFail : tc.signalValuePass;
+      *dataPtr64 = DATA_INIT;
+      // CHECK: hipStreamWaitValue64(stream, hipDeviceptr_t(signalPtr), int64_t(tc.waitValue), tc.compareOp);
+      cuStreamWaitValue64(stream, CUdeviceptr(signalPtr), tc.waitValue, tc.compareOp);
+      // CHECK: hipStreamWriteValue64(stream, hipDeviceptr_t(dataPtr64), int64_t(DATA_UPDATE), writeFlag);
+      cuStreamWriteValue64(stream, CUdeviceptr(dataPtr64), DATA_UPDATE, writeFlag);
+      if (isBlocking) {
+        // Trigger an implict flush and verify stream has pending work.
+        // CHECK: if (hipStreamQuery(stream) != hipErrorNotReady) {}
+        if (cudaStreamQuery(stream) != cudaErrorNotReady) {}
+        // update signal to unblock the wait.
+        *signalPtr = tc.signalValuePass;
+      }
+      // CHECK: hipStreamSynchronize(stream);
+      cudaStreamSynchronize(stream);
+      if (*dataPtr64 != DATA_UPDATE) {}
+    }
+  }
+  // Cleanup
+  // CHECK: hipFree(signalPtr);
+  cudaFree(signalPtr);
+  // CHECK: hipHostUnregister(dataPtr64);
+  cudaHostUnregister(dataPtr64);
+  // CHECK: hipHostUnregister(dataPtr32);
+  cudaHostUnregister(dataPtr32);
+  free(dataPtr64);
+  free(dataPtr32);
+  // CHECK: hipStreamDestroy(stream);
+  cudaStreamDestroy(stream);
 }
 
 int main() {
@@ -48,5 +377,7 @@ int main() {
   if (r != cudaSuccess || attr.maxThreadsPerBlock == 0) {
     return 1;
   }
+  testWrite();
+  testWait();
   return 0;
 }


### PR DESCRIPTION
+ Add typecasting to the third functions' arg
+ Rewrite casting procedure in `HipifyActions`
+ Update the `reinterpret_cast.cu` test
+ Update `hipify-perl` and `CUDA_Driver_API_functions_supported_by_HIP.md` accordingly
+ Bump internal HIP version to 4.2.0