### PR TITLE
[HIPIFY][#304] Add warning for StreamWaitValue32(64) and StreamWriteValue32(64) functions

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -6486,6 +6486,25 @@ sub warnUnsupportedFunctions {
     return $k;
 }
 
+sub warnDataLossFunctions {
+    my $line_num = shift;
+    my $k = 0;
+    foreach $func (
+        "cuStreamWaitValue32",
+        "cuStreamWaitValue64",
+        "cuStreamWriteValue32",
+        "cuStreamWriteValue64"
+    )
+    {
+        my $mt = m/($func)/g;
+        if ($mt) {
+            $k += $mt;
+            print STDERR "  warning: $fileName:$line_num: possible data loss in 3 argument of \"$func\": $_\n";
+        }
+    }
+    return $k;
+}
+
 # Count of transforms in all files
 my %tt;
 clearStats(\%tt, \@statNames);
@@ -6563,6 +6582,8 @@ while (@ARGV) {
                     $s = warnUnsupportedFunctions($line_num);
                     $warnings += $s;
                     $s = warnUnsupportedDeviceFunctions($line_num);
+                    $warnings += $s;
+                    $s = warnDataLossFunctions($line_num);
                     $warnings += $s;
                 }
                 $_ = $tmp;

--- a/src/CUDA2HIP_Scripting.h
+++ b/src/CUDA2HIP_Scripting.h
@@ -29,7 +29,17 @@ enum CastTypes {
   e_int64_t,
 };
 
-typedef std::map<unsigned, CastTypes> ArgCastMap;
+enum CastWarning {
+  cw_None,
+  cw_DataLoss,
+};
+
+struct CastInfo {
+  CastTypes castType;
+  CastWarning castWarn;
+};
+
+typedef std::map<unsigned, CastInfo> ArgCastMap;
 
 extern std::string getCastType(CastTypes c);
 extern std::map<std::string, ArgCastMap> FuncArgCasts;


### PR DESCRIPTION
[Reason] Possible data loss after type-casting of the 3rd argument of the above functions, where CUDA's unsigned int value is explicitly type-casted to signed int
[ToDo] Add the corresponding warning in the documentation on the above functions

+ Update hipify-perl accordingly