### PR TITLE
[HIPIFY] Support CUDA 11.3 Driver API types

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -2088,26 +2088,34 @@ sub simpleSubstitutions {
     $ft{'type'} += s/\bCUDAContext\b/HIPContext/g;
     $ft{'type'} += s/\bCUDA_ARRAY3D_DESCRIPTOR\b/HIP_ARRAY3D_DESCRIPTOR/g;
     $ft{'type'} += s/\bCUDA_ARRAY3D_DESCRIPTOR_st\b/HIP_ARRAY3D_DESCRIPTOR/g;
+    $ft{'type'} += s/\bCUDA_ARRAY3D_DESCRIPTOR_v2\b/HIP_ARRAY3D_DESCRIPTOR/g;
     $ft{'type'} += s/\bCUDA_ARRAY_DESCRIPTOR\b/HIP_ARRAY_DESCRIPTOR/g;
     $ft{'type'} += s/\bCUDA_ARRAY_DESCRIPTOR_st\b/HIP_ARRAY_DESCRIPTOR/g;
     $ft{'type'} += s/\bCUDA_ARRAY_DESCRIPTOR_v1\b/HIP_ARRAY_DESCRIPTOR/g;
     $ft{'type'} += s/\bCUDA_ARRAY_DESCRIPTOR_v1_st\b/HIP_ARRAY_DESCRIPTOR/g;
+    $ft{'type'} += s/\bCUDA_ARRAY_DESCRIPTOR_v2\b/HIP_ARRAY_DESCRIPTOR/g;
     $ft{'type'} += s/\bCUDA_LAUNCH_PARAMS\b/hipLaunchParams/g;
     $ft{'type'} += s/\bCUDA_LAUNCH_PARAMS_st\b/hipLaunchParams/g;
+    $ft{'type'} += s/\bCUDA_LAUNCH_PARAMS_v1\b/hipLaunchParams/g;
     $ft{'type'} += s/\bCUDA_MEMCPY2D\b/hip_Memcpy2D/g;
     $ft{'type'} += s/\bCUDA_MEMCPY2D_st\b/hip_Memcpy2D/g;
     $ft{'type'} += s/\bCUDA_MEMCPY2D_v1\b/hip_Memcpy2D/g;
     $ft{'type'} += s/\bCUDA_MEMCPY2D_v1_st\b/hip_Memcpy2D/g;
+    $ft{'type'} += s/\bCUDA_MEMCPY2D_v2\b/hip_Memcpy2D/g;
     $ft{'type'} += s/\bCUDA_MEMCPY3D\b/HIP_MEMCPY3D/g;
     $ft{'type'} += s/\bCUDA_MEMCPY3D_st\b/HIP_MEMCPY3D/g;
     $ft{'type'} += s/\bCUDA_MEMCPY3D_v1\b/HIP_MEMCPY3D/g;
     $ft{'type'} += s/\bCUDA_MEMCPY3D_v1_st\b/HIP_MEMCPY3D/g;
+    $ft{'type'} += s/\bCUDA_MEMCPY3D_v2\b/HIP_MEMCPY3D/g;
     $ft{'type'} += s/\bCUDA_RESOURCE_DESC\b/HIP_RESOURCE_DESC/g;
     $ft{'type'} += s/\bCUDA_RESOURCE_DESC_st\b/HIP_RESOURCE_DESC_st/g;
+    $ft{'type'} += s/\bCUDA_RESOURCE_DESC_v1\b/HIP_RESOURCE_DESC/g;
     $ft{'type'} += s/\bCUDA_RESOURCE_VIEW_DESC\b/HIP_RESOURCE_VIEW_DESC/g;
     $ft{'type'} += s/\bCUDA_RESOURCE_VIEW_DESC_st\b/HIP_RESOURCE_VIEW_DESC_st/g;
+    $ft{'type'} += s/\bCUDA_RESOURCE_VIEW_DESC_v1\b/HIP_RESOURCE_VIEW_DESC/g;
     $ft{'type'} += s/\bCUDA_TEXTURE_DESC\b/HIP_TEXTURE_DESC/g;
     $ft{'type'} += s/\bCUDA_TEXTURE_DESC_st\b/HIP_TEXTURE_DESC_st/g;
+    $ft{'type'} += s/\bCUDA_TEXTURE_DESC_v1\b/HIP_TEXTURE_DESC/g;
     $ft{'type'} += s/\bCUaddress_mode\b/HIPaddress_mode/g;
     $ft{'type'} += s/\bCUaddress_mode_enum\b/HIPaddress_mode_enum/g;
     $ft{'type'} += s/\bCUarray\b/hipArray */g;
@@ -2123,8 +2131,10 @@ sub simpleSubstitutions {
     $ft{'type'} += s/\bCUdevice_P2PAttribute_enum\b/hipDeviceP2PAttr/g;
     $ft{'type'} += s/\bCUdevice_attribute\b/hipDeviceAttribute_t/g;
     $ft{'type'} += s/\bCUdevice_attribute_enum\b/hipDeviceAttribute_t/g;
+    $ft{'type'} += s/\bCUdevice_v1\b/hipDevice_t/g;
     $ft{'type'} += s/\bCUdeviceptr\b/hipDeviceptr_t/g;
     $ft{'type'} += s/\bCUdeviceptr_v1\b/hipDeviceptr_t/g;
+    $ft{'type'} += s/\bCUdeviceptr_v2\b/hipDeviceptr_t/g;
     $ft{'type'} += s/\bCUevent\b/hipEvent_t/g;
     $ft{'type'} += s/\bCUevent_st\b/ihipEvent_t/g;
     $ft{'type'} += s/\bCUfilter_mode\b/HIPfilter_mode/g;
@@ -2137,8 +2147,10 @@ sub simpleSubstitutions {
     $ft{'type'} += s/\bCUfunction_attribute_enum\b/hipFunction_attribute/g;
     $ft{'type'} += s/\bCUipcEventHandle\b/hipIpcEventHandle_t/g;
     $ft{'type'} += s/\bCUipcEventHandle_st\b/hipIpcEventHandle_st/g;
+    $ft{'type'} += s/\bCUipcEventHandle_v1\b/hipIpcEventHandle_t/g;
     $ft{'type'} += s/\bCUipcMemHandle\b/hipIpcMemHandle_t/g;
     $ft{'type'} += s/\bCUipcMemHandle_st\b/hipIpcMemHandle_st/g;
+    $ft{'type'} += s/\bCUipcMemHandle_v1\b/hipIpcMemHandle_t/g;
     $ft{'type'} += s/\bCUjit_option\b/hipJitOption/g;
     $ft{'type'} += s/\bCUjit_option_enum\b/hipJitOption/g;
     $ft{'type'} += s/\bCUlimit\b/hipLimit_t/g;
@@ -2164,6 +2176,7 @@ sub simpleSubstitutions {
     $ft{'type'} += s/\bCUstreamCallback\b/hipStreamCallback_t/g;
     $ft{'type'} += s/\bCUstream_st\b/ihipStream_t/g;
     $ft{'type'} += s/\bCUtexObject\b/hipTextureObject_t/g;
+    $ft{'type'} += s/\bCUtexObject_v1\b/hipTextureObject_t/g;
     $ft{'type'} += s/\bCUtexref_st\b/textureReference/g;
     $ft{'type'} += s/\bbsric02Info_t\b/bsric02Info_t/g;
     $ft{'type'} += s/\bbsrilu02Info_t\b/bsrilu02Info_t/g;
@@ -5363,11 +5376,18 @@ sub warnUnsupportedFunctions {
         "MAJOR_VERSION",
         "CUuuid_st",
         "CUuuid",
+        "CUuserObject_st",
+        "CUuserObject_flags_enum",
+        "CUuserObject_flags",
+        "CUuserObjectRetain_flags_enum",
+        "CUuserObjectRetain_flags",
+        "CUuserObject",
         "CUtexref",
         "CUsynchronizationPolicy_enum",
         "CUsynchronizationPolicy",
         "CUsurfref_st",
         "CUsurfref",
+        "CUsurfObject_v1",
         "CUsurfObject",
         "CUstream_flags_enum",
         "CUstream_flags",
@@ -5375,14 +5395,18 @@ sub warnUnsupportedFunctions {
         "CUstreamWriteValue_flags",
         "CUstreamWaitValue_flags_enum",
         "CUstreamWaitValue_flags",
+        "CUstreamUpdateCaptureDependencies_flags_enum",
+        "CUstreamUpdateCaptureDependencies_flags",
         "CUstreamCaptureStatus_enum",
         "CUstreamCaptureStatus",
         "CUstreamCaptureMode_enum",
         "CUstreamCaptureMode",
         "CUstreamBatchMemOpType_enum",
         "CUstreamBatchMemOpType",
+        "CUstreamBatchMemOpParams_v1",
         "CUstreamBatchMemOpParams_union",
         "CUstreamBatchMemOpParams",
+        "CUstreamAttrValue_v1",
         "CUstreamAttrValue_union",
         "CUstreamAttrValue",
         "CUstreamAttrID_enum",
@@ -5397,24 +5421,29 @@ sub warnUnsupportedFunctions {
         "CUmemoryPool",
         "CUmemPool_attribute_enum",
         "CUmemPool_attribute",
+        "CUmemPoolPtrExportData_v1",
         "CUmemPoolPtrExportData_st",
         "CUmemPoolPtrExportData",
+        "CUmemPoolProps_v1",
         "CUmemPoolProps_st",
         "CUmemPoolProps",
         "CUmemPoolHandle_st",
         "CUmemOperationType_enum",
         "CUmemOperationType",
+        "CUmemLocation_v1",
         "CUmemLocation_st",
         "CUmemLocationType_enum",
         "CUmemLocationType",
         "CUmemLocation",
         "CUmemHandleType_enum",
         "CUmemHandleType",
+        "CUmemGenericAllocationHandle_v1",
         "CUmemGenericAllocationHandle",
         "CUmemAttach_flags_enum",
         "CUmemAttach_flags",
         "CUmemAllocationType_enum",
         "CUmemAllocationType",
+        "CUmemAllocationProp_v1",
         "CUmemAllocationProp_st",
         "CUmemAllocationProp",
         "CUmemAllocationHandleType_enum",
@@ -5423,8 +5452,10 @@ sub warnUnsupportedFunctions {
         "CUmemAllocationGranularity_flags",
         "CUmemAccess_flags_enum",
         "CUmemAccess_flags",
+        "CUmemAccessDesc_v1",
         "CUmemAccessDesc_st",
         "CUmemAccessDesc",
+        "CUkernelNodeAttrValue_v1",
         "CUkernelNodeAttrValue_union",
         "CUkernelNodeAttrValue",
         "CUkernelNodeAttrID_enum",
@@ -5455,7 +5486,15 @@ sub warnUnsupportedFunctions {
         "CUgraphExecUpdateResult_enum",
         "CUgraphExecUpdateResult",
         "CUgraphExec",
+        "CUgraphDebugDot_flags_enum",
+        "CUgraphDebugDot_flags",
         "CUgraph",
+        "CUflushGPUDirectRDMAWritesTarget_enum",
+        "CUflushGPUDirectRDMAWritesTarget",
+        "CUflushGPUDirectRDMAWritesScope_enum",
+        "CUflushGPUDirectRDMAWritesScope",
+        "CUflushGPUDirectRDMAWritesOptions_enum",
+        "CUflushGPUDirectRDMAWritesOptions",
         "CUexternalSemaphore_st",
         "CUexternalSemaphoreHandleType_enum",
         "CUexternalSemaphoreHandleType",
@@ -5480,6 +5519,9 @@ sub warnUnsupportedFunctions {
         "CUeglFrameType",
         "CUeglColorFormate_enum",
         "CUeglColorFormat",
+        "CUdriverProcAddress_flags_enum",
+        "CUdriverProcAddress_flags",
+        "CUdevprop_v1",
         "CUdevprop_st",
         "CUdevprop",
         "CUd3d9register_flags_enum",
@@ -5502,12 +5544,14 @@ sub warnUnsupportedFunctions {
         "CUarray_cubemap_face",
         "CUarraySparseSubresourceType_enum",
         "CUarraySparseSubresourceType",
+        "CUarrayMapInfo_v1",
         "CUarrayMapInfo_st",
         "CUarrayMapInfo",
         "CUaccessProperty_enum",
         "CUaccessProperty",
         "CUaccessPolicyWindow_st",
         "CUaccessPolicyWindow",
+        "CU_USER_OBJECT_NO_DESTRUCTOR_SYNC",
         "CU_TRSF_DISABLE_TRILINEAR_OPTIMIZATION",
         "CU_TARGET_COMPUTE_86",
         "CU_TARGET_COMPUTE_80",
@@ -5538,6 +5582,7 @@ sub warnUnsupportedFunctions {
         "CU_STREAM_WRITE_VALUE_NO_MEMORY_BARRIER",
         "CU_STREAM_WRITE_VALUE_DEFAULT",
         "CU_STREAM_WAIT_VALUE_FLUSH",
+        "CU_STREAM_SET_CAPTURE_DEPENDENCIES",
         "CU_STREAM_PER_THREAD",
         "CU_STREAM_MEM_OP_WRITE_VALUE_64",
         "CU_STREAM_MEM_OP_WRITE_VALUE_32",
@@ -5553,6 +5598,7 @@ sub warnUnsupportedFunctions {
         "CU_STREAM_CAPTURE_MODE_GLOBAL",
         "CU_STREAM_ATTRIBUTE_SYNCHRONIZATION_POLICY",
         "CU_STREAM_ATTRIBUTE_ACCESS_POLICY_WINDOW",
+        "CU_STREAM_ADD_CAPTURE_DEPENDENCIES",
         "CU_SHAREDMEM_CARVEOUT_MAX_SHARED",
         "CU_SHAREDMEM_CARVEOUT_MAX_L1",
         "CU_SHAREDMEM_CARVEOUT_DEFAULT",
@@ -5562,6 +5608,7 @@ sub warnUnsupportedFunctions {
         "CU_POINTER_ATTRIBUTE_RANGE_START_ADDR",
         "CU_POINTER_ATTRIBUTE_RANGE_SIZE",
         "CU_POINTER_ATTRIBUTE_P2P_TOKENS",
+        "CU_POINTER_ATTRIBUTE_MEMPOOL_HANDLE",
         "CU_POINTER_ATTRIBUTE_MEMORY_TYPE",
         "CU_POINTER_ATTRIBUTE_MAPPED",
         "CU_POINTER_ATTRIBUTE_IS_MANAGED",
@@ -5600,9 +5647,13 @@ sub warnUnsupportedFunctions {
         "CU_MEM_ACCESS_FLAGS_PROT_READ",
         "CU_MEM_ACCESS_FLAGS_PROT_NONE",
         "CU_MEM_ACCESS_FLAGS_PROT_MAX",
+        "CU_MEMPOOL_ATTR_USED_MEM_HIGH",
+        "CU_MEMPOOL_ATTR_USED_MEM_CURRENT",
         "CU_MEMPOOL_ATTR_REUSE_FOLLOW_EVENT_DEPENDENCIES",
         "CU_MEMPOOL_ATTR_REUSE_ALLOW_OPPORTUNISTIC",
         "CU_MEMPOOL_ATTR_REUSE_ALLOW_INTERNAL_DEPENDENCIES",
+        "CU_MEMPOOL_ATTR_RESERVED_MEM_HIGH",
+        "CU_MEMPOOL_ATTR_RESERVED_MEM_CURRENT",
         "CU_MEMPOOL_ATTR_RELEASE_THRESHOLD",
         "CU_MEMHOSTREGISTER_READ_ONLY",
         "CU_LIMIT_STACK_SIZE",
@@ -5626,6 +5677,7 @@ sub warnUnsupportedFunctions {
         "CU_JIT_CACHE_OPTION_NONE",
         "CU_JIT_CACHE_OPTION_CG",
         "CU_JIT_CACHE_OPTION_CA",
+        "CU_GRAPH_USER_OBJECT_MOVE",
         "CU_GRAPH_NODE_TYPE_WAIT_EVENT",
         "CU_GRAPH_NODE_TYPE_MEMSET",
         "CU_GRAPH_NODE_TYPE_MEMCPY",
@@ -5645,6 +5697,17 @@ sub warnUnsupportedFunctions {
         "CU_GRAPH_EXEC_UPDATE_ERROR_NODE_TYPE_CHANGED",
         "CU_GRAPH_EXEC_UPDATE_ERROR_FUNCTION_CHANGED",
         "CU_GRAPH_EXEC_UPDATE_ERROR",
+        "CU_GRAPH_DEBUG_DOT_FLAGS_VERBOSE",
+        "CU_GRAPH_DEBUG_DOT_FLAGS_RUNTIME_TYPES",
+        "CU_GRAPH_DEBUG_DOT_FLAGS_MEMSET_NODE_PARAMS",
+        "CU_GRAPH_DEBUG_DOT_FLAGS_MEMCPY_NODE_PARAMS",
+        "CU_GRAPH_DEBUG_DOT_FLAGS_KERNEL_NODE_PARAMS",
+        "CU_GRAPH_DEBUG_DOT_FLAGS_KERNEL_NODE_ATTRIBUTES",
+        "CU_GRAPH_DEBUG_DOT_FLAGS_HOST_NODE_PARAMS",
+        "CU_GRAPH_DEBUG_DOT_FLAGS_HANDLES",
+        "CU_GRAPH_DEBUG_DOT_FLAGS_EXT_SEMAS_WAIT_NODE_PARAMS",
+        "CU_GRAPH_DEBUG_DOT_FLAGS_EXT_SEMAS_SIGNAL_NODE_PARAMS",
+        "CU_GRAPH_DEBUG_DOT_FLAGS_EVENT_NODE_PARAMS",
         "CU_GRAPHICS_REGISTER_FLAGS_WRITE_DISCARD",
         "CU_GRAPHICS_REGISTER_FLAGS_TEXTURE_GATHER",
         "CU_GRAPHICS_REGISTER_FLAGS_SURFACE_LDST",
@@ -5653,12 +5716,23 @@ sub warnUnsupportedFunctions {
         "CU_GRAPHICS_MAP_RESOURCE_FLAGS_WRITE_DISCARD",
         "CU_GRAPHICS_MAP_RESOURCE_FLAGS_READ_ONLY",
         "CU_GRAPHICS_MAP_RESOURCE_FLAGS_NONE",
+        "CU_GPU_DIRECT_RDMA_WRITES_ORDERING_OWNER",
+        "CU_GPU_DIRECT_RDMA_WRITES_ORDERING_NONE",
+        "CU_GPU_DIRECT_RDMA_WRITES_ORDERING_ALL_DEVICES",
         "CU_GL_MAP_RESOURCE_FLAGS_WRITE_DISCARD",
         "CU_GL_MAP_RESOURCE_FLAGS_READ_ONLY",
         "CU_GL_MAP_RESOURCE_FLAGS_NONE",
         "CU_GL_DEVICE_LIST_NEXT_FRAME",
         "CU_GL_DEVICE_LIST_CURRENT_FRAME",
         "CU_GL_DEVICE_LIST_ALL",
+        "CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM",
+        "CU_GET_PROC_ADDRESS_LEGACY_STREAM",
+        "CU_GET_PROC_ADDRESS_DEFAULT",
+        "CU_FLUSH_GPU_DIRECT_RDMA_WRITES_TO_OWNER",
+        "CU_FLUSH_GPU_DIRECT_RDMA_WRITES_TO_ALL_DEVICES",
+        "CU_FLUSH_GPU_DIRECT_RDMA_WRITES_TARGET_CURRENT_CTX",
+        "CU_FLUSH_GPU_DIRECT_RDMA_WRITES_OPTION_MEMOPS",
+        "CU_FLUSH_GPU_DIRECT_RDMA_WRITES_OPTION_HOST",
         "CU_EXTERNAL_SEMAPHORE_HANDLE_TYPE_TIMELINE_SEMAPHORE_WIN32",
         "CU_EXTERNAL_SEMAPHORE_HANDLE_TYPE_TIMELINE_SEMAPHORE_FD",
         "CU_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_WIN32_KMT",
@@ -5772,6 +5846,7 @@ sub warnUnsupportedFunctions {
         "CU_DEVICE_ATTRIBUTE_READ_ONLY_HOST_REGISTER_SUPPORTED",
         "CU_DEVICE_ATTRIBUTE_PCI_DOMAIN_ID",
         "CU_DEVICE_ATTRIBUTE_MULTI_GPU_BOARD_GROUP_ID",
+        "CU_DEVICE_ATTRIBUTE_MEMPOOL_SUPPORTED_HANDLE_TYPES",
         "CU_DEVICE_ATTRIBUTE_MEMORY_POOLS_SUPPORTED",
         "CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_BLOCK_OPTIN",
         "CU_DEVICE_ATTRIBUTE_MAX_REGISTERS_PER_MULTIPROCESSOR",
@@ -5823,7 +5898,10 @@ sub warnUnsupportedFunctions {
         "CU_DEVICE_ATTRIBUTE_HANDLE_TYPE_WIN32_HANDLE_SUPPORTED",
         "CU_DEVICE_ATTRIBUTE_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR_SUPPORTED",
         "CU_DEVICE_ATTRIBUTE_GPU_OVERLAP",
+        "CU_DEVICE_ATTRIBUTE_GPU_DIRECT_RDMA_WRITES_ORDERING",
         "CU_DEVICE_ATTRIBUTE_GPU_DIRECT_RDMA_WITH_CUDA_VMM_SUPPORTED",
+        "CU_DEVICE_ATTRIBUTE_GPU_DIRECT_RDMA_SUPPORTED",
+        "CU_DEVICE_ATTRIBUTE_GPU_DIRECT_RDMA_FLUSH_WRITES_OPTIONS",
         "CU_DEVICE_ATTRIBUTE_GLOBAL_L1_CACHE_SUPPORTED",
         "CU_DEVICE_ATTRIBUTE_GENERIC_COMPRESSION_SUPPORTED",
         "CU_DEVICE_ATTRIBUTE_COMPUTE_PREEMPTION_SUPPORTED",
@@ -5926,6 +6004,8 @@ sub warnUnsupportedFunctions {
         "CURAND_CHOOSE_BEST",
         "CURAND_BINARY_SEARCH",
         "CURAND_3RD",
+        "CUGPUDirectRDMAWritesOrdering_enum",
+        "CUGPUDirectRDMAWritesOrdering",
         "CUGLmap_flags_enum",
         "CUGLmap_flags",
         "CUGLDeviceList_enum",
@@ -6339,37 +6419,50 @@ sub warnUnsupportedFunctions {
         "CUDNN_ADV_INFER_MINOR",
         "CUDNN_ADV_INFER_MAJOR",
         "CUDA_VERSION",
+        "CUDA_POINTER_ATTRIBUTE_P2P_TOKENS_v1",
         "CUDA_POINTER_ATTRIBUTE_P2P_TOKENS_st",
         "CUDA_POINTER_ATTRIBUTE_P2P_TOKENS",
         "CUDA_POINTER_ATTRIBUTE_ACCESS_FLAGS_enum",
         "CUDA_POINTER_ATTRIBUTE_ACCESS_FLAGS",
         "CUDA_NVSCISYNC_ATTR_WAIT",
         "CUDA_NVSCISYNC_ATTR_SIGNAL",
+        "CUDA_MEMSET_NODE_PARAMS_v1",
         "CUDA_MEMSET_NODE_PARAMS_st",
         "CUDA_MEMSET_NODE_PARAMS",
+        "CUDA_MEMCPY3D_PEER_v1",
         "CUDA_MEMCPY3D_PEER_st",
         "CUDA_MEMCPY3D_PEER",
+        "CUDA_KERNEL_NODE_PARAMS_v1",
         "CUDA_KERNEL_NODE_PARAMS_st",
         "CUDA_KERNEL_NODE_PARAMS",
+        "CUDA_HOST_NODE_PARAMS_v1",
         "CUDA_HOST_NODE_PARAMS_st",
         "CUDA_HOST_NODE_PARAMS",
+        "CUDA_EXT_SEM_WAIT_NODE_PARAMS_v1",
         "CUDA_EXT_SEM_WAIT_NODE_PARAMS_st",
         "CUDA_EXT_SEM_WAIT_NODE_PARAMS",
+        "CUDA_EXT_SEM_SIGNAL_NODE_PARAMS_v1",
         "CUDA_EXT_SEM_SIGNAL_NODE_PARAMS_st",
         "CUDA_EXT_SEM_SIGNAL_NODE_PARAMS",
         "CUDA_EXTERNAL_SEMAPHORE_WAIT_SKIP_NVSCIBUF_MEMSYNC",
+        "CUDA_EXTERNAL_SEMAPHORE_WAIT_PARAMS_v1",
         "CUDA_EXTERNAL_SEMAPHORE_WAIT_PARAMS_st",
         "CUDA_EXTERNAL_SEMAPHORE_WAIT_PARAMS",
         "CUDA_EXTERNAL_SEMAPHORE_SIGNAL_SKIP_NVSCIBUF_MEMSYNC",
+        "CUDA_EXTERNAL_SEMAPHORE_SIGNAL_PARAMS_v1",
         "CUDA_EXTERNAL_SEMAPHORE_SIGNAL_PARAMS_st",
         "CUDA_EXTERNAL_SEMAPHORE_SIGNAL_PARAMS",
+        "CUDA_EXTERNAL_SEMAPHORE_HANDLE_DESC_v1",
         "CUDA_EXTERNAL_SEMAPHORE_HANDLE_DESC_st",
         "CUDA_EXTERNAL_SEMAPHORE_HANDLE_DESC",
+        "CUDA_EXTERNAL_MEMORY_MIPMAPPED_ARRAY_DESC_v1",
         "CUDA_EXTERNAL_MEMORY_MIPMAPPED_ARRAY_DESC_st",
         "CUDA_EXTERNAL_MEMORY_MIPMAPPED_ARRAY_DESC",
+        "CUDA_EXTERNAL_MEMORY_HANDLE_DESC_v1",
         "CUDA_EXTERNAL_MEMORY_HANDLE_DESC_st",
         "CUDA_EXTERNAL_MEMORY_HANDLE_DESC",
         "CUDA_EXTERNAL_MEMORY_DEDICATED",
+        "CUDA_EXTERNAL_MEMORY_BUFFER_DESC_v1",
         "CUDA_EXTERNAL_MEMORY_BUFFER_DESC_st",
         "CUDA_EXTERNAL_MEMORY_BUFFER_DESC",
         "CUDA_ERROR_UNSUPPORTED_PTX_VERSION",
@@ -6404,6 +6497,7 @@ sub warnUnsupportedFunctions {
         "CUDA_ERROR_CAPTURED_EVENT",
         "CUDA_EGL_MAX_PLANES",
         "CUDA_CB",
+        "CUDA_ARRAY_SPARSE_PROPERTIES_v1",
         "CUDA_ARRAY_SPARSE_PROPERTIES_st",
         "CUDA_ARRAY_SPARSE_PROPERTIES",
         "CUDA_ARRAY3D_SPARSE",

--- a/doc/markdown/CUDA_Driver_API_functions_supported_by_HIP.md
+++ b/doc/markdown/CUDA_Driver_API_functions_supported_by_HIP.md
@@ -10,6 +10,7 @@
 |`CUDA_ARRAY3D_DEPTH_TEXTURE`| | | | | | | |
 |`CUDA_ARRAY3D_DESCRIPTOR`| | | |`HIP_ARRAY3D_DESCRIPTOR`|2.7.0| | |
 |`CUDA_ARRAY3D_DESCRIPTOR_st`| | | |`HIP_ARRAY3D_DESCRIPTOR`|2.7.0| | |
+|`CUDA_ARRAY3D_DESCRIPTOR_v2`|11.3| | |`HIP_ARRAY3D_DESCRIPTOR`|2.7.0| | |
 |`CUDA_ARRAY3D_LAYERED`| | | |`hipArrayLayered`|1.7.0| | |
 |`CUDA_ARRAY3D_SPARSE`|11.1| | | | | | |
 |`CUDA_ARRAY3D_SURFACE_LDST`| | | |`hipArraySurfaceLoadStore`|1.7.0| | |
@@ -18,8 +19,10 @@
 |`CUDA_ARRAY_DESCRIPTOR_st`| | | |`HIP_ARRAY_DESCRIPTOR`|1.7.0| | |
 |`CUDA_ARRAY_DESCRIPTOR_v1`| | | |`HIP_ARRAY_DESCRIPTOR`|1.7.0| | |
 |`CUDA_ARRAY_DESCRIPTOR_v1_st`| | | |`HIP_ARRAY_DESCRIPTOR`|1.7.0| | |
+|`CUDA_ARRAY_DESCRIPTOR_v2`|11.3| | |`HIP_ARRAY_DESCRIPTOR`|1.7.0| | |
 |`CUDA_ARRAY_SPARSE_PROPERTIES`|11.1| | | | | | |
 |`CUDA_ARRAY_SPARSE_PROPERTIES_st`|11.1| | | | | | |
+|`CUDA_ARRAY_SPARSE_PROPERTIES_v1`|11.3| | | | | | |
 |`CUDA_CB`| | | | | | | |
 |`CUDA_COOPERATIVE_LAUNCH_MULTI_DEVICE_NO_POST_LAUNCH_SYNC`|9.0| | |`hipCooperativeLaunchMultiDeviceNoPostSync`|3.2.0| | |
 |`CUDA_COOPERATIVE_LAUNCH_MULTI_DEVICE_NO_PRE_LAUNCH_SYNC`|9.0| | |`hipCooperativeLaunchMultiDeviceNoPreSync`|3.2.0| | |
@@ -104,59 +107,80 @@
 |`CUDA_ERROR_UNSUPPORTED_PTX_VERSION`|11.1| | | | | | |
 |`CUDA_EXTERNAL_MEMORY_BUFFER_DESC`|10.0| | | | | | |
 |`CUDA_EXTERNAL_MEMORY_BUFFER_DESC_st`|10.0| | | | | | |
+|`CUDA_EXTERNAL_MEMORY_BUFFER_DESC_v1`|11.3| | | | | | |
 |`CUDA_EXTERNAL_MEMORY_DEDICATED`|10.0| | | | | | |
 |`CUDA_EXTERNAL_MEMORY_HANDLE_DESC`|10.0| | | | | | |
 |`CUDA_EXTERNAL_MEMORY_HANDLE_DESC_st`|10.0| | | | | | |
+|`CUDA_EXTERNAL_MEMORY_HANDLE_DESC_v1`|11.3| | | | | | |
 |`CUDA_EXTERNAL_MEMORY_MIPMAPPED_ARRAY_DESC`|10.0| | | | | | |
 |`CUDA_EXTERNAL_MEMORY_MIPMAPPED_ARRAY_DESC_st`|10.0| | | | | | |
+|`CUDA_EXTERNAL_MEMORY_MIPMAPPED_ARRAY_DESC_v1`|11.3| | | | | | |
 |`CUDA_EXTERNAL_SEMAPHORE_HANDLE_DESC`|10.0| | | | | | |
 |`CUDA_EXTERNAL_SEMAPHORE_HANDLE_DESC_st`|10.0| | | | | | |
+|`CUDA_EXTERNAL_SEMAPHORE_HANDLE_DESC_v1`|11.3| | | | | | |
 |`CUDA_EXTERNAL_SEMAPHORE_SIGNAL_PARAMS`|10.0| | | | | | |
 |`CUDA_EXTERNAL_SEMAPHORE_SIGNAL_PARAMS_st`|10.0| | | | | | |
+|`CUDA_EXTERNAL_SEMAPHORE_SIGNAL_PARAMS_v1`|11.3| | | | | | |
 |`CUDA_EXTERNAL_SEMAPHORE_SIGNAL_SKIP_NVSCIBUF_MEMSYNC`|10.2| | | | | | |
 |`CUDA_EXTERNAL_SEMAPHORE_WAIT_PARAMS`|10.0| | | | | | |
 |`CUDA_EXTERNAL_SEMAPHORE_WAIT_PARAMS_st`|10.0| | | | | | |
+|`CUDA_EXTERNAL_SEMAPHORE_WAIT_PARAMS_v1`|11.3| | | | | | |
 |`CUDA_EXTERNAL_SEMAPHORE_WAIT_SKIP_NVSCIBUF_MEMSYNC`|10.2| | | | | | |
 |`CUDA_EXT_SEM_SIGNAL_NODE_PARAMS`|11.2| | | | | | |
 |`CUDA_EXT_SEM_SIGNAL_NODE_PARAMS_st`|11.2| | | | | | |
+|`CUDA_EXT_SEM_SIGNAL_NODE_PARAMS_v1`|11.3| | | | | | |
 |`CUDA_EXT_SEM_WAIT_NODE_PARAMS`|11.2| | | | | | |
 |`CUDA_EXT_SEM_WAIT_NODE_PARAMS_st`|11.2| | | | | | |
+|`CUDA_EXT_SEM_WAIT_NODE_PARAMS_v1`|11.3| | | | | | |
 |`CUDA_HOST_NODE_PARAMS`|10.0| | | | | | |
 |`CUDA_HOST_NODE_PARAMS_st`|10.0| | | | | | |
+|`CUDA_HOST_NODE_PARAMS_v1`|11.3| | | | | | |
 |`CUDA_KERNEL_NODE_PARAMS`|10.0| | | | | | |
 |`CUDA_KERNEL_NODE_PARAMS_st`|10.0| | | | | | |
+|`CUDA_KERNEL_NODE_PARAMS_v1`|11.3| | | | | | |
 |`CUDA_LAUNCH_PARAMS`|9.0| | |`hipLaunchParams`|2.6.0| | |
 |`CUDA_LAUNCH_PARAMS_st`|9.0| | |`hipLaunchParams`|2.6.0| | |
+|`CUDA_LAUNCH_PARAMS_v1`|11.3| | |`hipLaunchParams`|2.6.0| | |
 |`CUDA_MEMCPY2D`| | | |`hip_Memcpy2D`|1.7.0| | |
 |`CUDA_MEMCPY2D_st`| | | |`hip_Memcpy2D`|1.7.0| | |
 |`CUDA_MEMCPY2D_v1`| | | |`hip_Memcpy2D`|1.7.0| | |
 |`CUDA_MEMCPY2D_v1_st`| | | |`hip_Memcpy2D`|1.7.0| | |
+|`CUDA_MEMCPY2D_v2`|11.3| | |`hip_Memcpy2D`|1.7.0| | |
 |`CUDA_MEMCPY3D`| | | |`HIP_MEMCPY3D`|3.2.0| | |
 |`CUDA_MEMCPY3D_PEER`| | | | | | | |
 |`CUDA_MEMCPY3D_PEER_st`| | | | | | | |
+|`CUDA_MEMCPY3D_PEER_v1`|11.3| | | | | | |
 |`CUDA_MEMCPY3D_st`| | | |`HIP_MEMCPY3D`|3.2.0| | |
 |`CUDA_MEMCPY3D_v1`| | | |`HIP_MEMCPY3D`|3.2.0| | |
 |`CUDA_MEMCPY3D_v1_st`| | | |`HIP_MEMCPY3D`|3.2.0| | |
+|`CUDA_MEMCPY3D_v2`|11.3| | |`HIP_MEMCPY3D`|3.2.0| | |
 |`CUDA_MEMSET_NODE_PARAMS`|10.0| | | | | | |
 |`CUDA_MEMSET_NODE_PARAMS_st`|10.0| | | | | | |
+|`CUDA_MEMSET_NODE_PARAMS_v1`|11.3| | | | | | |
 |`CUDA_NVSCISYNC_ATTR_SIGNAL`|10.2| | | | | | |
 |`CUDA_NVSCISYNC_ATTR_WAIT`|10.2| | | | | | |
 |`CUDA_POINTER_ATTRIBUTE_ACCESS_FLAGS`|11.1| | | | | | |
 |`CUDA_POINTER_ATTRIBUTE_ACCESS_FLAGS_enum`|11.1| | | | | | |
 |`CUDA_POINTER_ATTRIBUTE_P2P_TOKENS`| | | | | | | |
 |`CUDA_POINTER_ATTRIBUTE_P2P_TOKENS_st`| | | | | | | |
+|`CUDA_POINTER_ATTRIBUTE_P2P_TOKENS_v1`|11.3| | | | | | |
 |`CUDA_RESOURCE_DESC`| | | |`HIP_RESOURCE_DESC`|3.5.0| | |
 |`CUDA_RESOURCE_DESC_st`| | | |`HIP_RESOURCE_DESC_st`|3.5.0| | |
+|`CUDA_RESOURCE_DESC_v1`|11.3| | |`HIP_RESOURCE_DESC`|3.5.0| | |
 |`CUDA_RESOURCE_VIEW_DESC`| | | |`HIP_RESOURCE_VIEW_DESC`|3.5.0| | |
 |`CUDA_RESOURCE_VIEW_DESC_st`| | | |`HIP_RESOURCE_VIEW_DESC_st`|3.5.0| | |
+|`CUDA_RESOURCE_VIEW_DESC_v1`|11.3| | |`HIP_RESOURCE_VIEW_DESC`|3.5.0| | |
 |`CUDA_SUCCESS`| | | |`hipSuccess`|1.5.0| | |
 |`CUDA_TEXTURE_DESC`| | | |`HIP_TEXTURE_DESC`|3.5.0| | |
 |`CUDA_TEXTURE_DESC_st`| | | |`HIP_TEXTURE_DESC_st`|3.5.0| | |
+|`CUDA_TEXTURE_DESC_v1`|11.3| | |`HIP_TEXTURE_DESC`|3.5.0| | |
 |`CUDA_VERSION`| | | | | | | |
 |`CUGLDeviceList`| | | | | | | |
 |`CUGLDeviceList_enum`| | | | | | | |
 |`CUGLmap_flags`| | | | | | | |
 |`CUGLmap_flags_enum`| | | | | | | |
+|`CUGPUDirectRDMAWritesOrdering`|11.3| | | | | | |
+|`CUGPUDirectRDMAWritesOrdering_enum`|11.3| | | | | | |
 |`CU_ACCESS_PROPERTY_NORMAL`|11.0| | | | | | |
 |`CU_ACCESS_PROPERTY_PERSISTING`|11.0| | | | | | |
 |`CU_ACCESS_PROPERTY_STREAMING`|11.0| | | | | | |
@@ -232,7 +256,10 @@
 |`CU_DEVICE_ATTRIBUTE_GENERIC_COMPRESSION_SUPPORTED`|11.0| | | | | | |
 |`CU_DEVICE_ATTRIBUTE_GLOBAL_L1_CACHE_SUPPORTED`| | | | | | | |
 |`CU_DEVICE_ATTRIBUTE_GLOBAL_MEMORY_BUS_WIDTH`| | | |`hipDeviceAttributeMemoryBusWidth`|1.6.0| | |
+|`CU_DEVICE_ATTRIBUTE_GPU_DIRECT_RDMA_FLUSH_WRITES_OPTIONS`|11.3| | | | | | |
+|`CU_DEVICE_ATTRIBUTE_GPU_DIRECT_RDMA_SUPPORTED`|11.3| | | | | | |
 |`CU_DEVICE_ATTRIBUTE_GPU_DIRECT_RDMA_WITH_CUDA_VMM_SUPPORTED`|11.0| | | | | | |
+|`CU_DEVICE_ATTRIBUTE_GPU_DIRECT_RDMA_WRITES_ORDERING`|11.3| | | | | | |
 |`CU_DEVICE_ATTRIBUTE_GPU_OVERLAP`| |5.0| | | | | |
 |`CU_DEVICE_ATTRIBUTE_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR_SUPPORTED`|10.2| | | | | | |
 |`CU_DEVICE_ATTRIBUTE_HANDLE_TYPE_WIN32_HANDLE_SUPPORTED`|10.2| | | | | | |
@@ -307,6 +334,7 @@
 |`CU_DEVICE_ATTRIBUTE_MAX_THREADS_PER_MULTIPROCESSOR`| | | |`hipDeviceAttributeMaxThreadsPerMultiProcessor`|1.6.0| | |
 |`CU_DEVICE_ATTRIBUTE_MEMORY_CLOCK_RATE`| | | |`hipDeviceAttributeMemoryClockRate`|1.6.0| | |
 |`CU_DEVICE_ATTRIBUTE_MEMORY_POOLS_SUPPORTED`|11.2| | | | | | |
+|`CU_DEVICE_ATTRIBUTE_MEMPOOL_SUPPORTED_HANDLE_TYPES`|11.3| | | | | | |
 |`CU_DEVICE_ATTRIBUTE_MULTIPROCESSOR_COUNT`| | | |`hipDeviceAttributeMultiprocessorCount`|1.6.0| | |
 |`CU_DEVICE_ATTRIBUTE_MULTI_GPU_BOARD`| | | |`hipDeviceAttributeIsMultiGpuBoard`|1.6.0| | |
 |`CU_DEVICE_ATTRIBUTE_MULTI_GPU_BOARD_GROUP_ID`| | | | | | | |
@@ -443,6 +471,11 @@
 |`CU_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_WIN32_KMT`|10.0| | | | | | |
 |`CU_EXTERNAL_SEMAPHORE_HANDLE_TYPE_TIMELINE_SEMAPHORE_FD`|11.2| | | | | | |
 |`CU_EXTERNAL_SEMAPHORE_HANDLE_TYPE_TIMELINE_SEMAPHORE_WIN32`|11.2| | | | | | |
+|`CU_FLUSH_GPU_DIRECT_RDMA_WRITES_OPTION_HOST`|11.3| | | | | | |
+|`CU_FLUSH_GPU_DIRECT_RDMA_WRITES_OPTION_MEMOPS`|11.3| | | | | | |
+|`CU_FLUSH_GPU_DIRECT_RDMA_WRITES_TARGET_CURRENT_CTX`|11.3| | | | | | |
+|`CU_FLUSH_GPU_DIRECT_RDMA_WRITES_TO_ALL_DEVICES`|11.3| | | | | | |
+|`CU_FLUSH_GPU_DIRECT_RDMA_WRITES_TO_OWNER`|11.3| | | | | | |
 |`CU_FUNC_ATTRIBUTE_BINARY_VERSION`| | | |`HIP_FUNC_ATTRIBUTE_BINARY_VERSION`|2.8.0| | |
 |`CU_FUNC_ATTRIBUTE_CACHE_MODE_CA`| | | |`HIP_FUNC_ATTRIBUTE_CACHE_MODE_CA`|2.8.0| | |
 |`CU_FUNC_ATTRIBUTE_CONST_SIZE_BYTES`| | | |`HIP_FUNC_ATTRIBUTE_CONST_SIZE_BYTES`|2.8.0| | |
@@ -458,12 +491,18 @@
 |`CU_FUNC_CACHE_PREFER_L1`| | | |`hipFuncCachePreferL1`|1.6.0| | |
 |`CU_FUNC_CACHE_PREFER_NONE`| | | |`hipFuncCachePreferNone`|1.6.0| | |
 |`CU_FUNC_CACHE_PREFER_SHARED`| | | |`hipFuncCachePreferShared`|1.6.0| | |
+|`CU_GET_PROC_ADDRESS_DEFAULT`|11.3| | | | | | |
+|`CU_GET_PROC_ADDRESS_LEGACY_STREAM`|11.3| | | | | | |
+|`CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM`|11.3| | | | | | |
 |`CU_GL_DEVICE_LIST_ALL`| | | | | | | |
 |`CU_GL_DEVICE_LIST_CURRENT_FRAME`| | | | | | | |
 |`CU_GL_DEVICE_LIST_NEXT_FRAME`| | | | | | | |
 |`CU_GL_MAP_RESOURCE_FLAGS_NONE`| | | | | | | |
 |`CU_GL_MAP_RESOURCE_FLAGS_READ_ONLY`| | | | | | | |
 |`CU_GL_MAP_RESOURCE_FLAGS_WRITE_DISCARD`| | | | | | | |
+|`CU_GPU_DIRECT_RDMA_WRITES_ORDERING_ALL_DEVICES`|11.3| | | | | | |
+|`CU_GPU_DIRECT_RDMA_WRITES_ORDERING_NONE`|11.3| | | | | | |
+|`CU_GPU_DIRECT_RDMA_WRITES_ORDERING_OWNER`|11.3| | | | | | |
 |`CU_GRAPHICS_MAP_RESOURCE_FLAGS_NONE`| | | | | | | |
 |`CU_GRAPHICS_MAP_RESOURCE_FLAGS_READ_ONLY`| | | | | | | |
 |`CU_GRAPHICS_MAP_RESOURCE_FLAGS_WRITE_DISCARD`| | | | | | | |
@@ -472,6 +511,17 @@
 |`CU_GRAPHICS_REGISTER_FLAGS_SURFACE_LDST`| | | | | | | |
 |`CU_GRAPHICS_REGISTER_FLAGS_TEXTURE_GATHER`| | | | | | | |
 |`CU_GRAPHICS_REGISTER_FLAGS_WRITE_DISCARD`| | | | | | | |
+|`CU_GRAPH_DEBUG_DOT_FLAGS_EVENT_NODE_PARAMS`|11.3| | | | | | |
+|`CU_GRAPH_DEBUG_DOT_FLAGS_EXT_SEMAS_SIGNAL_NODE_PARAMS`|11.3| | | | | | |
+|`CU_GRAPH_DEBUG_DOT_FLAGS_EXT_SEMAS_WAIT_NODE_PARAMS`|11.3| | | | | | |
+|`CU_GRAPH_DEBUG_DOT_FLAGS_HANDLES`|11.3| | | | | | |
+|`CU_GRAPH_DEBUG_DOT_FLAGS_HOST_NODE_PARAMS`|11.3| | | | | | |
+|`CU_GRAPH_DEBUG_DOT_FLAGS_KERNEL_NODE_ATTRIBUTES`|11.3| | | | | | |
+|`CU_GRAPH_DEBUG_DOT_FLAGS_KERNEL_NODE_PARAMS`|11.3| | | | | | |
+|`CU_GRAPH_DEBUG_DOT_FLAGS_MEMCPY_NODE_PARAMS`|11.3| | | | | | |
+|`CU_GRAPH_DEBUG_DOT_FLAGS_MEMSET_NODE_PARAMS`|11.3| | | | | | |
+|`CU_GRAPH_DEBUG_DOT_FLAGS_RUNTIME_TYPES`|11.3| | | | | | |
+|`CU_GRAPH_DEBUG_DOT_FLAGS_VERBOSE`|11.3| | | | | | |
 |`CU_GRAPH_EXEC_UPDATE_ERROR`|10.2| | | | | | |
 |`CU_GRAPH_EXEC_UPDATE_ERROR_FUNCTION_CHANGED`|10.2| | | | | | |
 |`CU_GRAPH_EXEC_UPDATE_ERROR_NODE_TYPE_CHANGED`|10.2| | | | | | |
@@ -491,6 +541,7 @@
 |`CU_GRAPH_NODE_TYPE_MEMCPY`|10.0| | | | | | |
 |`CU_GRAPH_NODE_TYPE_MEMSET`|10.0| | | | | | |
 |`CU_GRAPH_NODE_TYPE_WAIT_EVENT`|11.1| | | | | | |
+|`CU_GRAPH_USER_OBJECT_MOVE`|11.3| | | | | | |
 |`CU_IPC_HANDLE_SIZE`| | | |`HIP_IPC_HANDLE_SIZE`|1.6.0| | |
 |`CU_IPC_MEM_LAZY_ENABLE_PEER_ACCESS`| | | |`hipIpcMemLazyEnablePeerAccess`|1.6.0| | |
 |`CU_JIT_CACHE_MODE`| | | |`hipJitOptionCacheMode`|1.6.0| | |
@@ -548,9 +599,13 @@
 |`CU_MEMORYTYPE_HOST`| | | |`hipMemoryTypeHost`|1.6.0| | |
 |`CU_MEMORYTYPE_UNIFIED`| | | |`hipMemoryTypeUnified`|1.6.0| | |
 |`CU_MEMPOOL_ATTR_RELEASE_THRESHOLD`|11.2| | | | | | |
+|`CU_MEMPOOL_ATTR_RESERVED_MEM_CURRENT`|11.3| | | | | | |
+|`CU_MEMPOOL_ATTR_RESERVED_MEM_HIGH`|11.3| | | | | | |
 |`CU_MEMPOOL_ATTR_REUSE_ALLOW_INTERNAL_DEPENDENCIES`|11.2| | | | | | |
 |`CU_MEMPOOL_ATTR_REUSE_ALLOW_OPPORTUNISTIC`|11.2| | | | | | |
 |`CU_MEMPOOL_ATTR_REUSE_FOLLOW_EVENT_DEPENDENCIES`|11.2| | | | | | |
+|`CU_MEMPOOL_ATTR_USED_MEM_CURRENT`|11.3| | | | | | |
+|`CU_MEMPOOL_ATTR_USED_MEM_HIGH`|11.3| | | | | | |
 |`CU_MEM_ACCESS_FLAGS_PROT_MAX`|10.2| | | | | | |
 |`CU_MEM_ACCESS_FLAGS_PROT_NONE`|10.2| | | | | | |
 |`CU_MEM_ACCESS_FLAGS_PROT_READ`|10.2| | | | | | |
@@ -603,6 +658,7 @@
 |`CU_POINTER_ATTRIBUTE_IS_MANAGED`| | | | | | | |
 |`CU_POINTER_ATTRIBUTE_MAPPED`|10.2| | | | | | |
 |`CU_POINTER_ATTRIBUTE_MEMORY_TYPE`| | | | | | | |
+|`CU_POINTER_ATTRIBUTE_MEMPOOL_HANDLE`|11.3| | | | | | |
 |`CU_POINTER_ATTRIBUTE_P2P_TOKENS`| | | | | | | |
 |`CU_POINTER_ATTRIBUTE_RANGE_SIZE`|10.2| | | | | | |
 |`CU_POINTER_ATTRIBUTE_RANGE_START_ADDR`|10.2| | | | | | |
@@ -654,6 +710,7 @@
 |`CU_SHARED_MEM_CONFIG_DEFAULT_BANK_SIZE`| | | |`hipSharedMemBankSizeDefault`|1.6.0| | |
 |`CU_SHARED_MEM_CONFIG_EIGHT_BYTE_BANK_SIZE`| | | |`hipSharedMemBankSizeEightByte`|1.6.0| | |
 |`CU_SHARED_MEM_CONFIG_FOUR_BYTE_BANK_SIZE`| | | |`hipSharedMemBankSizeFourByte`|1.6.0| | |
+|`CU_STREAM_ADD_CAPTURE_DEPENDENCIES`|11.3| | | | | | |
 |`CU_STREAM_ATTRIBUTE_ACCESS_POLICY_WINDOW`|11.0| | | | | | |
 |`CU_STREAM_ATTRIBUTE_SYNCHRONIZATION_POLICY`|11.0| | | | | | |
 |`CU_STREAM_CAPTURE_MODE_GLOBAL`|10.1| | | | | | |
@@ -671,6 +728,7 @@
 |`CU_STREAM_MEM_OP_WRITE_VALUE_64`|9.0| | | | | | |
 |`CU_STREAM_NON_BLOCKING`| | | |`hipStreamNonBlocking`|1.6.0| | |
 |`CU_STREAM_PER_THREAD`| | | | | | | |
+|`CU_STREAM_SET_CAPTURE_DEPENDENCIES`|11.3| | | | | | |
 |`CU_STREAM_WAIT_VALUE_AND`|8.0| | |`hipStreamWaitValueAnd`|4.2.0| | |
 |`CU_STREAM_WAIT_VALUE_EQ`|8.0| | |`hipStreamWaitValueEq`|4.2.0| | |
 |`CU_STREAM_WAIT_VALUE_FLUSH`|8.0| | | | | | |
@@ -715,6 +773,7 @@
 |`CU_TR_ADDRESS_MODE_WRAP`| | | |`HIP_TR_ADDRESS_MODE_WRAP`|3.5.0| | |
 |`CU_TR_FILTER_MODE_LINEAR`| | | |`HIP_TR_FILTER_MODE_LINEAR`|3.5.0| | |
 |`CU_TR_FILTER_MODE_POINT`| | | |`HIP_TR_FILTER_MODE_POINT`|3.5.0| | |
+|`CU_USER_OBJECT_NO_DESTRUCTOR_SYNC`|11.3| | | | | | |
 |`CUaccessPolicyWindow`|11.0| | | | | | |
 |`CUaccessPolicyWindow_st`|11.0| | | | | | |
 |`CUaccessProperty`|11.0| | | | | | |
@@ -724,6 +783,7 @@
 |`CUarray`| | | |`hipArray *`| | | |
 |`CUarrayMapInfo`|11.1| | | | | | |
 |`CUarrayMapInfo_st`|11.1| | | | | | |
+|`CUarrayMapInfo_v1`|11.3| | | | | | |
 |`CUarraySparseSubresourceType`|11.1| | | | | | |
 |`CUarraySparseSubresourceType_enum`|11.1| | | | | | |
 |`CUarray_cubemap_face`| | | | | | | |
@@ -756,10 +816,15 @@
 |`CUdevice_P2PAttribute_enum`|8.0| | |`hipDeviceP2PAttr`|3.8.0| | |
 |`CUdevice_attribute`| | | |`hipDeviceAttribute_t`|1.6.0| | |
 |`CUdevice_attribute_enum`| | | |`hipDeviceAttribute_t`|1.6.0| | |
+|`CUdevice_v1`|11.3| | |`hipDevice_t`|1.6.0| | |
 |`CUdeviceptr`| | | |`hipDeviceptr_t`|1.7.0| | |
 |`CUdeviceptr_v1`| | | |`hipDeviceptr_t`|1.7.0| | |
+|`CUdeviceptr_v2`|11.3| | |`hipDeviceptr_t`|1.7.0| | |
 |`CUdevprop`| | | | | | | |
 |`CUdevprop_st`| | | | | | | |
+|`CUdevprop_v1`|11.3| | | | | | |
+|`CUdriverProcAddress_flags`|11.3| | | | | | |
+|`CUdriverProcAddress_flags_enum`|11.3| | | | | | |
 |`CUeglColorFormat`|9.0| | | | | | |
 |`CUeglColorFormate_enum`|9.0| | | | | | |
 |`CUeglFrameType`|9.0| | | | | | |
@@ -786,6 +851,12 @@
 |`CUexternalSemaphoreHandleType_enum`|10.0| | | | | | |
 |`CUfilter_mode`| | | |`HIPfilter_mode`|3.5.0| | |
 |`CUfilter_mode_enum`| | | |`HIPfilter_mode_enum`|3.5.0| | |
+|`CUflushGPUDirectRDMAWritesOptions`|11.3| | | | | | |
+|`CUflushGPUDirectRDMAWritesOptions_enum`|11.3| | | | | | |
+|`CUflushGPUDirectRDMAWritesScope`|11.3| | | | | | |
+|`CUflushGPUDirectRDMAWritesScope_enum`|11.3| | | | | | |
+|`CUflushGPUDirectRDMAWritesTarget`|11.3| | | | | | |
+|`CUflushGPUDirectRDMAWritesTarget_enum`|11.3| | | | | | |
 |`CUfunc_cache`| | | |`hipFuncCache_t`|1.6.0| | |
 |`CUfunc_cache_enum`| | | |`hipFuncCache_t`|1.6.0| | |
 |`CUfunc_st`| | | |`ihipModuleSymbol_t`|1.6.0| | |
@@ -793,6 +864,8 @@
 |`CUfunction_attribute`| | | |`hipFunction_attribute`|2.8.0| | |
 |`CUfunction_attribute_enum`| | | |`hipFunction_attribute`|2.8.0| | |
 |`CUgraph`|10.0| | | | | | |
+|`CUgraphDebugDot_flags`|11.3| | | | | | |
+|`CUgraphDebugDot_flags_enum`|11.3| | | | | | |
 |`CUgraphExec`|10.0| | | | | | |
 |`CUgraphExecUpdateResult`|10.2| | | | | | |
 |`CUgraphExecUpdateResult_enum`|10.2| | | | | | |
@@ -811,8 +884,10 @@
 |`CUhostFn`|10.0| | | | | | |
 |`CUipcEventHandle`| | | |`hipIpcEventHandle_t`|1.6.0| | |
 |`CUipcEventHandle_st`| | | |`hipIpcEventHandle_st`|3.5.0| | |
+|`CUipcEventHandle_v1`|11.3| | |`hipIpcEventHandle_t`|1.6.0| | |
 |`CUipcMemHandle`| | | |`hipIpcMemHandle_t`|1.6.0| | |
 |`CUipcMemHandle_st`| | | |`hipIpcMemHandle_st`|1.6.0| | |
+|`CUipcMemHandle_v1`|11.3| | |`hipIpcMemHandle_t`|1.6.0| | |
 |`CUipcMem_flags`| | | | | | | |
 |`CUipcMem_flags_enum`| | | | | | | |
 |`CUjitInputType`| | | | | | | |
@@ -829,10 +904,12 @@
 |`CUkernelNodeAttrID_enum`|11.0| | | | | | |
 |`CUkernelNodeAttrValue`|11.0| | | | | | |
 |`CUkernelNodeAttrValue_union`|11.0| | | | | | |
+|`CUkernelNodeAttrValue_v1`|11.3| | | | | | |
 |`CUlimit`| | | |`hipLimit_t`|1.6.0| | |
 |`CUlimit_enum`| | | |`hipLimit_t`|1.6.0| | |
 |`CUmemAccessDesc`|10.2| | | | | | |
 |`CUmemAccessDesc_st`|10.2| | | | | | |
+|`CUmemAccessDesc_v1`|11.3| | | | | | |
 |`CUmemAccess_flags`|10.2| | | | | | |
 |`CUmemAccess_flags_enum`|10.2| | | | | | |
 |`CUmemAllocationGranularity_flags`|10.2| | | | | | |
@@ -841,24 +918,29 @@
 |`CUmemAllocationHandleType_enum`|10.2| | | | | | |
 |`CUmemAllocationProp`|10.2| | | | | | |
 |`CUmemAllocationProp_st`|10.2| | | | | | |
+|`CUmemAllocationProp_v1`|11.3| | | | | | |
 |`CUmemAllocationType`|10.2| | | | | | |
 |`CUmemAllocationType_enum`|10.2| | | | | | |
 |`CUmemAttach_flags`| | | | | | | |
 |`CUmemAttach_flags_enum`| | | | | | | |
 |`CUmemGenericAllocationHandle`|10.2| | | | | | |
+|`CUmemGenericAllocationHandle_v1`|11.3| | | | | | |
 |`CUmemHandleType`|11.1| | | | | | |
 |`CUmemHandleType_enum`|11.1| | | | | | |
 |`CUmemLocation`|10.2| | | | | | |
 |`CUmemLocationType`|10.2| | | | | | |
 |`CUmemLocationType_enum`|10.2| | | | | | |
 |`CUmemLocation_st`|10.2| | | | | | |
+|`CUmemLocation_v1`|11.3| | | | | | |
 |`CUmemOperationType`|11.1| | | | | | |
 |`CUmemOperationType_enum`|11.1| | | | | | |
 |`CUmemPoolHandle_st`|11.2| | | | | | |
 |`CUmemPoolProps`|11.2| | | | | | |
 |`CUmemPoolProps_st`|11.2| | | | | | |
+|`CUmemPoolProps_v1`|11.3| | | | | | |
 |`CUmemPoolPtrExportData`|11.2| | | | | | |
 |`CUmemPoolPtrExportData_st`|11.2| | | | | | |
+|`CUmemPoolPtrExportData_v1`|11.3| | | | | | |
 |`CUmemPool_attribute`|11.2| | | | | | |
 |`CUmemPool_attribute_enum`|11.2| | | | | | |
 |`CUmem_advise`|8.0| | |`hipMemoryAdvise`|3.7.0| | |
@@ -891,8 +973,10 @@
 |`CUstreamAttrID_enum`|11.0| | | | | | |
 |`CUstreamAttrValue`|11.0| | | | | | |
 |`CUstreamAttrValue_union`|11.0| | | | | | |
+|`CUstreamAttrValue_v1`|11.3| | | | | | |
 |`CUstreamBatchMemOpParams`|8.0| | | | | | |
 |`CUstreamBatchMemOpParams_union`|8.0| | | | | | |
+|`CUstreamBatchMemOpParams_v1`|11.3| | | | | | |
 |`CUstreamBatchMemOpType`|8.0| | | | | | |
 |`CUstreamBatchMemOpType_enum`|8.0| | | | | | |
 |`CUstreamCallback`| | | |`hipStreamCallback_t`|1.6.0| | |
@@ -900,6 +984,8 @@
 |`CUstreamCaptureMode_enum`|10.1| | | | | | |
 |`CUstreamCaptureStatus`|10.0| | | | | | |
 |`CUstreamCaptureStatus_enum`|10.0| | | | | | |
+|`CUstreamUpdateCaptureDependencies_flags`|11.3| | | | | | |
+|`CUstreamUpdateCaptureDependencies_flags_enum`|11.3| | | | | | |
 |`CUstreamWaitValue_flags`|8.0| | | | | | |
 |`CUstreamWaitValue_flags_enum`|8.0| | | | | | |
 |`CUstreamWriteValue_flags`|8.0| | | | | | |
@@ -908,13 +994,21 @@
 |`CUstream_flags_enum`| | | | | | | |
 |`CUstream_st`| | | |`ihipStream_t`|1.5.0| | |
 |`CUsurfObject`| | | | | | | |
+|`CUsurfObject_v1`|11.3| | | | | | |
 |`CUsurfref`| | | | | | | |
 |`CUsurfref_st`| | | | | | | |
 |`CUsynchronizationPolicy`|11.0| | | | | | |
 |`CUsynchronizationPolicy_enum`|11.0| | | | | | |
 |`CUtexObject`| | | |`hipTextureObject_t`|1.7.0| | |
+|`CUtexObject_v1`|11.3| | |`hipTextureObject_t`|1.7.0| | |
 |`CUtexref`| | | | | | | |
 |`CUtexref_st`| | | |`textureReference`|1.6.0| | |
+|`CUuserObject`|11.3| | | | | | |
+|`CUuserObjectRetain_flags`|11.3| | | | | | |
+|`CUuserObjectRetain_flags_enum`|11.3| | | | | | |
+|`CUuserObject_flags`|11.3| | | | | | |
+|`CUuserObject_flags_enum`|11.3| | | | | | |
+|`CUuserObject_st`|11.3| | | | | | |
 |`CUuuid`| | | | | | | |
 |`CUuuid_st`| | | | | | | |
 |`__CUDACC__`| | | |`__HIPCC__`|1.6.0| | |

--- a/src/CUDA2HIP_Driver_API_types.cpp
+++ b/src/CUDA2HIP_Driver_API_types.cpp
@@ -29,99 +29,121 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_TYPE_NAME_MAP {
 
   {"CUDA_ARRAY3D_DESCRIPTOR_st",                                       {"HIP_ARRAY3D_DESCRIPTOR",                                   "", CONV_TYPE, API_DRIVER, 1}},
   {"CUDA_ARRAY3D_DESCRIPTOR",                                          {"HIP_ARRAY3D_DESCRIPTOR",                                   "", CONV_TYPE, API_DRIVER, 1}},
+  {"CUDA_ARRAY3D_DESCRIPTOR_v2",                                       {"HIP_ARRAY3D_DESCRIPTOR",                                   "", CONV_TYPE, API_DRIVER, 1}},
 
   {"CUDA_ARRAY_DESCRIPTOR_st",                                         {"HIP_ARRAY_DESCRIPTOR",                                     "", CONV_TYPE, API_DRIVER, 1}},
   {"CUDA_ARRAY_DESCRIPTOR_v1_st",                                      {"HIP_ARRAY_DESCRIPTOR",                                     "", CONV_TYPE, API_DRIVER, 1}},
   {"CUDA_ARRAY_DESCRIPTOR",                                            {"HIP_ARRAY_DESCRIPTOR",                                     "", CONV_TYPE, API_DRIVER, 1}},
   {"CUDA_ARRAY_DESCRIPTOR_v1",                                         {"HIP_ARRAY_DESCRIPTOR",                                     "", CONV_TYPE, API_DRIVER, 1}},
+  {"CUDA_ARRAY_DESCRIPTOR_v2",                                         {"HIP_ARRAY_DESCRIPTOR",                                     "", CONV_TYPE, API_DRIVER, 1}},
 
   // cudaExternalMemoryBufferDesc
   {"CUDA_EXTERNAL_MEMORY_BUFFER_DESC_st",                              {"HIP_EXTERNAL_MEMORY_BUFFER_DESC",                          "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
   {"CUDA_EXTERNAL_MEMORY_BUFFER_DESC",                                 {"HIP_EXTERNAL_MEMORY_BUFFER_DESC",                          "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
+  {"CUDA_EXTERNAL_MEMORY_BUFFER_DESC_v1",                              {"HIP_EXTERNAL_MEMORY_BUFFER_DESC",                          "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
 
   // cudaExternalMemoryHandleDesc
   {"CUDA_EXTERNAL_MEMORY_HANDLE_DESC_st",                              {"HIP_EXTERNAL_MEMORY_HANDLE_DESC",                          "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
   {"CUDA_EXTERNAL_MEMORY_HANDLE_DESC",                                 {"HIP_EXTERNAL_MEMORY_HANDLE_DESC",                          "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
+  {"CUDA_EXTERNAL_MEMORY_HANDLE_DESC_v1",                              {"HIP_EXTERNAL_MEMORY_HANDLE_DESC",                          "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
 
   // cudaExternalMemoryMipmappedArrayDesc
   {"CUDA_EXTERNAL_MEMORY_MIPMAPPED_ARRAY_DESC_st",                     {"HIP_EXTERNAL_MEMORY_MIPMAPPED_ARRAY_DESC",                 "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
   {"CUDA_EXTERNAL_MEMORY_MIPMAPPED_ARRAY_DESC",                        {"HIP_EXTERNAL_MEMORY_MIPMAPPED_ARRAY_DESC",                 "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
+  {"CUDA_EXTERNAL_MEMORY_MIPMAPPED_ARRAY_DESC_v1",                     {"HIP_EXTERNAL_MEMORY_MIPMAPPED_ARRAY_DESC",                 "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
 
   // cudaExternalSemaphoreHandleDesc
   {"CUDA_EXTERNAL_SEMAPHORE_HANDLE_DESC_st",                           {"HIP_EXTERNAL_SEMAPHORE_HANDLE_DESC",                       "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
   {"CUDA_EXTERNAL_SEMAPHORE_HANDLE_DESC",                              {"HIP_EXTERNAL_SEMAPHORE_HANDLE_DESC",                       "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
+  {"CUDA_EXTERNAL_SEMAPHORE_HANDLE_DESC_v1",                           {"HIP_EXTERNAL_SEMAPHORE_HANDLE_DESC",                       "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
 
   // cudaExternalSemaphoreSignalParams
   {"CUDA_EXTERNAL_SEMAPHORE_SIGNAL_PARAMS_st",                         {"HIP_EXTERNAL_SEMAPHORE_SIGNAL_PARAMS",                     "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
   {"CUDA_EXTERNAL_SEMAPHORE_SIGNAL_PARAMS",                            {"HIP_EXTERNAL_SEMAPHORE_SIGNAL_PARAMS",                     "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
+  {"CUDA_EXTERNAL_SEMAPHORE_SIGNAL_PARAMS_v1",                         {"HIP_EXTERNAL_SEMAPHORE_SIGNAL_PARAMS",                     "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
 
   // cudaExternalSemaphoreWaitParams
   {"CUDA_EXTERNAL_SEMAPHORE_WAIT_PARAMS_st",                           {"HIP_EXTERNAL_SEMAPHORE_WAIT_PARAMS",                       "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
   {"CUDA_EXTERNAL_SEMAPHORE_WAIT_PARAMS",                              {"HIP_EXTERNAL_SEMAPHORE_WAIT_PARAMS",                       "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
+  {"CUDA_EXTERNAL_SEMAPHORE_WAIT_PARAMS_v1",                           {"HIP_EXTERNAL_SEMAPHORE_WAIT_PARAMS",                       "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
 
   // cudaHostNodeParams
   {"CUDA_HOST_NODE_PARAMS_st",                                         {"hipHostNodeParams",                                        "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
   {"CUDA_HOST_NODE_PARAMS",                                            {"hipHostNodeParams",                                        "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
+  {"CUDA_HOST_NODE_PARAMS_v1",                                         {"hipHostNodeParams",                                        "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
 
   // cudaKernelNodeParams
   {"CUDA_KERNEL_NODE_PARAMS_st",                                       {"hipKernelNodeParams",                                      "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
   {"CUDA_KERNEL_NODE_PARAMS",                                          {"hipKernelNodeParams",                                      "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
+  {"CUDA_KERNEL_NODE_PARAMS_v1",                                       {"hipKernelNodeParams",                                      "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
 
   // no analogue
   // NOTE: cudaLaunchParams struct differs
   {"CUDA_LAUNCH_PARAMS_st",                                            {"hipLaunchParams",                                          "", CONV_TYPE, API_DRIVER, 1}},
   {"CUDA_LAUNCH_PARAMS",                                               {"hipLaunchParams",                                          "", CONV_TYPE, API_DRIVER, 1}},
+  {"CUDA_LAUNCH_PARAMS_v1",                                            {"hipLaunchParams",                                          "", CONV_TYPE, API_DRIVER, 1}},
 
   {"CUDA_MEMCPY2D_st",                                                 {"hip_Memcpy2D",                                             "", CONV_TYPE, API_DRIVER, 1}},
   {"CUDA_MEMCPY2D_v1_st",                                              {"hip_Memcpy2D",                                             "", CONV_TYPE, API_DRIVER, 1}},
   {"CUDA_MEMCPY2D",                                                    {"hip_Memcpy2D",                                             "", CONV_TYPE, API_DRIVER, 1}},
   {"CUDA_MEMCPY2D_v1",                                                 {"hip_Memcpy2D",                                             "", CONV_TYPE, API_DRIVER, 1}},
+  {"CUDA_MEMCPY2D_v2",                                                 {"hip_Memcpy2D",                                             "", CONV_TYPE, API_DRIVER, 1}},
 
   // no analogue
   {"CUDA_MEMCPY3D_st",                                                 {"HIP_MEMCPY3D",                                             "", CONV_TYPE, API_DRIVER, 1}},
   {"CUDA_MEMCPY3D_v1_st",                                              {"HIP_MEMCPY3D",                                             "", CONV_TYPE, API_DRIVER, 1}},
   {"CUDA_MEMCPY3D",                                                    {"HIP_MEMCPY3D",                                             "", CONV_TYPE, API_DRIVER, 1}},
   {"CUDA_MEMCPY3D_v1",                                                 {"HIP_MEMCPY3D",                                             "", CONV_TYPE, API_DRIVER, 1}},
+  {"CUDA_MEMCPY3D_v2",                                                 {"HIP_MEMCPY3D",                                             "", CONV_TYPE, API_DRIVER, 1}},
 
   {"CUDA_MEMCPY3D_PEER_st",                                            {"hip_Memcpy3D_Peer",                                        "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
   {"CUDA_MEMCPY3D_PEER",                                               {"hip_Memcpy3D_Peer",                                        "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
+  {"CUDA_MEMCPY3D_PEER_v1",                                            {"hip_Memcpy3D_Peer",                                        "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
 
   // cudaMemsetParams
   {"CUDA_MEMSET_NODE_PARAMS_st",                                       {"hipMemsetParams",                                          "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
   {"CUDA_MEMSET_NODE_PARAMS",                                          {"hipMemsetParams",                                          "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
+  {"CUDA_MEMSET_NODE_PARAMS_v1",                                       {"hipMemsetParams",                                          "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
 
   {"CUDA_POINTER_ATTRIBUTE_P2P_TOKENS_st",                             {"HIP_POINTER_ATTRIBUTE_P2P_TOKENS",                         "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
   {"CUDA_POINTER_ATTRIBUTE_P2P_TOKENS",                                {"HIP_POINTER_ATTRIBUTE_P2P_TOKENS",                         "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
+  {"CUDA_POINTER_ATTRIBUTE_P2P_TOKENS_v1",                             {"HIP_POINTER_ATTRIBUTE_P2P_TOKENS",                         "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
 
   // no analogue
   // NOTE: cudaResourceDesc struct differs
   {"CUDA_RESOURCE_DESC_st",                                            {"HIP_RESOURCE_DESC_st",                                     "", CONV_TYPE, API_DRIVER, 1}},
   {"CUDA_RESOURCE_DESC",                                               {"HIP_RESOURCE_DESC",                                        "", CONV_TYPE, API_DRIVER, 1}},
+  {"CUDA_RESOURCE_DESC_v1",                                            {"HIP_RESOURCE_DESC",                                        "", CONV_TYPE, API_DRIVER, 1}},
 
   // cudaResourceViewDesc
   // NOTE: cudaResourceViewDesc hasn't reserved bytes in the end
   {"CUDA_RESOURCE_VIEW_DESC_st",                                       {"HIP_RESOURCE_VIEW_DESC_st",                                "", CONV_TYPE, API_DRIVER, 1}},
   {"CUDA_RESOURCE_VIEW_DESC",                                          {"HIP_RESOURCE_VIEW_DESC",                                   "", CONV_TYPE, API_DRIVER, 1}},
+  {"CUDA_RESOURCE_VIEW_DESC_v1",                                       {"HIP_RESOURCE_VIEW_DESC",                                   "", CONV_TYPE, API_DRIVER, 1}},
 
   // no analogue
   // NOTE: cudaTextureDesc differs
   {"CUDA_TEXTURE_DESC_st",                                             {"HIP_TEXTURE_DESC_st",                                      "", CONV_TYPE, API_DRIVER, 1}},
   {"CUDA_TEXTURE_DESC",                                                {"HIP_TEXTURE_DESC",                                         "", CONV_TYPE, API_DRIVER, 1}},
+  {"CUDA_TEXTURE_DESC_v1",                                             {"HIP_TEXTURE_DESC",                                         "", CONV_TYPE, API_DRIVER, 1}},
 
   // no analogue
   // NOTE: cudaDeviceProp differs
-  {"CUdevprop_st",                                                     {"hipDevprop_st",                                            "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
-  {"CUdevprop",                                                        {"hipDevprop_t",                                             "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
+  {"CUdevprop_st",                                                     {"hipDevprop",                                               "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
+  {"CUdevprop",                                                        {"hipDevprop",                                               "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
+  {"CUdevprop_v1",                                                     {"hipDevprop",                                               "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
 
   // cudaIpcEventHandle_st
   {"CUipcEventHandle_st",                                              {"hipIpcEventHandle_st",                                     "", CONV_TYPE, API_DRIVER, 1}},
   // cudaIpcEventHandle_t
   {"CUipcEventHandle",                                                 {"hipIpcEventHandle_t",                                      "", CONV_TYPE, API_DRIVER, 1}},
+  {"CUipcEventHandle_v1",                                              {"hipIpcEventHandle_t",                                      "", CONV_TYPE, API_DRIVER, 1}},
 
   // cudaIpcMemHandle_st
   {"CUipcMemHandle_st",                                                {"hipIpcMemHandle_st",                                       "", CONV_TYPE, API_DRIVER, 1}},
   // cudaIpcMemHandle_t
   {"CUipcMemHandle",                                                   {"hipIpcMemHandle_t",                                        "", CONV_TYPE, API_DRIVER, 1}},
+  {"CUipcMemHandle_v1",                                                {"hipIpcMemHandle_t",                                        "", CONV_TYPE, API_DRIVER, 1}},
 
   // CUDA: "The types CUarray and cudaArray * represent the same data type and may be used interchangeably by casting the two types between each other."
   // cudaArray
@@ -208,14 +230,17 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_TYPE_NAME_MAP {
   // cudaMemLocation
   {"CUmemLocation_st",                                                 {"hipMemoryLocation",                                        "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
   {"CUmemLocation",                                                    {"hipMemoryLocation",                                        "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
+  {"CUmemLocation_v1",                                                 {"hipMemoryLocation",                                        "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
 
   // no analogue
   {"CUmemAllocationProp_st",                                           {"hipMemoryAllocationProperties",                            "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
   {"CUmemAllocationProp",                                              {"hipMemoryAllocationProperties",                            "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
+  {"CUmemAllocationProp_v1",                                           {"hipMemoryAllocationProperties",                            "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
 
   // cudaMemAccessDesc
   {"CUmemAccessDesc_st",                                               {"hipMemoryAccessDescription",                               "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
   {"CUmemAccessDesc",                                                  {"hipMemoryAccessDescription",                               "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
+  {"CUmemAccessDesc_v1",                                               {"hipMemoryAccessDescription",                               "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
 
   // cudaAccessPolicyWindow
   {"CUaccessPolicyWindow_st",                                          {"hipAccessPolicyWindow",                                    "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
@@ -224,9 +249,11 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_TYPE_NAME_MAP {
   // cudaArraySparseProperties
   {"CUDA_ARRAY_SPARSE_PROPERTIES_st",                                  {"hipArraySparseProperties",                                 "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
   {"CUDA_ARRAY_SPARSE_PROPERTIES",                                     {"hipArraySparseProperties",                                 "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
+  {"CUDA_ARRAY_SPARSE_PROPERTIES_v1",                                  {"hipArraySparseProperties",                                 "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
 
   {"CUarrayMapInfo_st",                                                {"hipArrayMapInfo",                                          "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
   {"CUarrayMapInfo",                                                   {"hipArrayMapInfo",                                          "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
+  {"CUarrayMapInfo_v1",                                                {"hipArrayMapInfo",                                          "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
 
   //
   {"CUmemPoolHandle_st",                                               {"hipMemPoolHandle_st",                                      "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
@@ -236,28 +263,39 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_TYPE_NAME_MAP {
   // cudaExternalSemaphoreSignalNodeParams
   {"CUDA_EXT_SEM_SIGNAL_NODE_PARAMS_st",                               {"hipExternalSemaphoreSignalNodeParams",                     "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
   {"CUDA_EXT_SEM_SIGNAL_NODE_PARAMS",                                  {"hipExternalSemaphoreSignalNodeParams",                     "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
+  {"CUDA_EXT_SEM_SIGNAL_NODE_PARAMS_v1",                               {"hipExternalSemaphoreSignalNodeParams",                     "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
 
   // cudaExternalSemaphoreWaitNodeParams
   {"CUDA_EXT_SEM_WAIT_NODE_PARAMS_st",                                 {"hipExternalSemaphoreWaitNodeParams",                       "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
   {"CUDA_EXT_SEM_WAIT_NODE_PARAMS",                                    {"hipExternalSemaphoreWaitNodeParams",                       "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
+  {"CUDA_EXT_SEM_WAIT_NODE_PARAMS_v1",                                 {"hipExternalSemaphoreWaitNodeParams",                       "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
 
   // cudaMemPoolProps
   {"CUmemPoolProps_st",                                                {"hipMemPoolProps",                                          "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
   {"CUmemPoolProps",                                                   {"hipMemPoolProps",                                          "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
+  {"CUmemPoolProps_v1",                                                {"hipMemPoolProps",                                          "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
 
   // cudaMemPoolPtrExportData
-  {"CUmemPoolPtrExportData_st",                                        {"hipMemPoolPtrExportData",                               "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
+  {"CUmemPoolPtrExportData_st",                                        {"hipMemPoolPtrExportData",                                  "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
   {"CUmemPoolPtrExportData",                                           {"hipMemPoolPtrExportData",                                  "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
+  {"CUmemPoolPtrExportData_v1",                                        {"hipMemPoolPtrExportData",                                  "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
+
+  //
+  {"CUuserObject_st",                                                  {"hipUserObject",                                            "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
+  {"CUuserObject",                                                     {"hipUserObject_t",                                          "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
 
   // 2. Unions
 
   {"CUstreamBatchMemOpParams",                                         {"hipStreamBatchMemOpParams",                                "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
+  {"CUstreamBatchMemOpParams_v1",                                      {"hipStreamBatchMemOpParams",                                "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
   {"CUstreamBatchMemOpParams_union",                                   {"hipStreamBatchMemOpParams",                                "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
 
   {"CUkernelNodeAttrValue",                                            {"hipKernelNodeAttrValue",                                   "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
+  {"CUkernelNodeAttrValue_v1",                                         {"hipKernelNodeAttrValue",                                   "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
   {"CUkernelNodeAttrValue_union",                                      {"hipKernelNodeAttrValue",                                   "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
 
   {"CUstreamAttrValue",                                                {"hipStreamAttrValue",                                       "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
+  {"CUstreamAttrValue_v1",                                             {"hipStreamAttrValue",                                       "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
   {"CUstreamAttrValue_union",                                          {"hipStreamAttrValue",                                       "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
 
   // 3. Enums
@@ -592,8 +630,16 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_TYPE_NAME_MAP {
   {"CU_DEVICE_ATTRIBUTE_TIMELINE_SEMAPHORE_INTEROP_SUPPORTED",         {"hipDeviceAttributeMaxTimelineSemaphoreInteropSupported",   "", CONV_NUMERIC_LITERAL, API_DRIVER, 1, HIP_UNSUPPORTED}}, // 114
   // cudaDevAttrMemoryPoolsSupported
   {"CU_DEVICE_ATTRIBUTE_MEMORY_POOLS_SUPPORTED",                       {"hipDeviceAttributeMemoryPoolsSupported",                   "", CONV_NUMERIC_LITERAL, API_DRIVER, 1, HIP_UNSUPPORTED}}, // 115
+  //
+  {"CU_DEVICE_ATTRIBUTE_GPU_DIRECT_RDMA_SUPPORTED",                    {"hipDeviceAttributeGpuDirectRdmaSupported",                 "", CONV_NUMERIC_LITERAL, API_DRIVER, 1, HIP_UNSUPPORTED}}, // 116
+  //
+  {"CU_DEVICE_ATTRIBUTE_GPU_DIRECT_RDMA_FLUSH_WRITES_OPTIONS",         {"hipDeviceAttributeGpuDirectRdmaFlushWritesOptions",        "", CONV_NUMERIC_LITERAL, API_DRIVER, 1, HIP_UNSUPPORTED}}, // 117
+  //
+  {"CU_DEVICE_ATTRIBUTE_GPU_DIRECT_RDMA_WRITES_ORDERING",              {"hipDeviceAttributeGpuDirectRdmaWritesOrdering",            "", CONV_NUMERIC_LITERAL, API_DRIVER, 1, HIP_UNSUPPORTED}}, // 118
+  //
+  {"CU_DEVICE_ATTRIBUTE_MEMPOOL_SUPPORTED_HANDLE_TYPES",               {"hipDeviceAttributeMempoolSupportedHandleTypes",            "", CONV_NUMERIC_LITERAL, API_DRIVER, 1, HIP_UNSUPPORTED}}, // 119
   // no analogue
-  {"CU_DEVICE_ATTRIBUTE_MAX",                                          {"hipDeviceAttributeMax",                                    "", CONV_NUMERIC_LITERAL, API_DRIVER, 1, HIP_UNSUPPORTED}}, // 116
+  {"CU_DEVICE_ATTRIBUTE_MAX",                                          {"hipDeviceAttributeMax",                                    "", CONV_NUMERIC_LITERAL, API_DRIVER, 1, HIP_UNSUPPORTED}}, // 120
 
   // cudaDeviceP2PAttr
   {"CUdevice_P2PAttribute",                                            {"hipDeviceP2PAttr",                                         "", CONV_TYPE, API_DRIVER, 1}},
@@ -1164,6 +1210,7 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_TYPE_NAME_MAP {
   {"CU_POINTER_ATTRIBUTE_ALLOWED_HANDLE_TYPES",                        {"hipPointerAttributeAllowedHandleTypes",                    "", CONV_NUMERIC_LITERAL, API_DRIVER, 1, HIP_UNSUPPORTED}}, // 14
   {"CU_POINTER_ATTRIBUTE_IS_GPU_DIRECT_RDMA_CAPABLE",                  {"hipPointerAttributeIsGpuDirectRdmaCapable",                "", CONV_NUMERIC_LITERAL, API_DRIVER, 1, HIP_UNSUPPORTED}}, // 15
   {"CU_POINTER_ATTRIBUTE_ACCESS_FLAGS",                                {"hipPointerAttributeAccessFlags",                           "", CONV_NUMERIC_LITERAL, API_DRIVER, 1, HIP_UNSUPPORTED}}, // 16
+  {"CU_POINTER_ATTRIBUTE_MEMPOOL_HANDLE",                              {"hipPointerAttributeMempoolHandle",                         "", CONV_NUMERIC_LITERAL, API_DRIVER, 1, HIP_UNSUPPORTED}}, // 17
 
   // TODO: HIPresourcetype_enum and all its values should be hipResourceType as long as they are equal
   // cudaResourceType
@@ -1613,7 +1660,7 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_TYPE_NAME_MAP {
   // cudaMemHandleTypeWin32Kmt
   {"CU_MEM_HANDLE_TYPE_WIN32_KMT",                                     {"hipMemoryHandleTypeWin32Kmt",                              "", CONV_NUMERIC_LITERAL, API_DRIVER, 1, HIP_UNSUPPORTED}}, // 0x4
   // no analogue
-  {"CU_MEM_HANDLE_TYPE_MAX",                                           {"hipMemoryHandleTypeMax",                                   "", CONV_NUMERIC_LITERAL, API_DRIVER, 1, HIP_UNSUPPORTED}}, // 0xFFFFFFFF
+  {"CU_MEM_HANDLE_TYPE_MAX",                                           {"hipMemoryHandleTypeMax",                                   "", CONV_NUMERIC_LITERAL, API_DRIVER, 1, HIP_UNSUPPORTED}}, // 0x7FFFFFFF
 
   // cudaMemAccessFlags
   {"CUmemAccess_flags",                                                {"hipMemoryAccessFlags",                                     "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
@@ -1626,7 +1673,7 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_TYPE_NAME_MAP {
   // cudaMemAccessFlagsProtReadWrite
   {"CU_MEM_ACCESS_FLAGS_PROT_READWRITE",                               {"hipMemoryAccessFlagsProtReadWrite",                        "", CONV_NUMERIC_LITERAL, API_DRIVER, 1, HIP_UNSUPPORTED}}, // 0x3
   // no analogue
-  {"CU_MEM_ACCESS_FLAGS_PROT_MAX",                                     {"hipMemoryAccessFlagsProtMax",                              "", CONV_NUMERIC_LITERAL, API_DRIVER, 1, HIP_UNSUPPORTED}}, // 0xFFFFFFFF
+  {"CU_MEM_ACCESS_FLAGS_PROT_MAX",                                     {"hipMemoryAccessFlagsProtMax",                              "", CONV_NUMERIC_LITERAL, API_DRIVER, 1, HIP_UNSUPPORTED}}, // 0x7FFFFFFF
 
   // cudaMemLocationType
   {"CUmemLocationType",                                                {"hipMemoryLocationType",                                    "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
@@ -1637,7 +1684,7 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_TYPE_NAME_MAP {
   // cudaMemLocationTypeDevice
   {"CU_MEM_LOCATION_TYPE_DEVICE",                                      {"hipMemoryLocationTypeDevice",                              "", CONV_NUMERIC_LITERAL, API_DRIVER, 1, HIP_UNSUPPORTED}}, // 0x1
   // no analogue
-  {"CU_MEM_LOCATION_TYPE_MAX",                                         {"hipMemoryLocationTypeMax",                                 "", CONV_NUMERIC_LITERAL, API_DRIVER, 1, HIP_UNSUPPORTED}}, // 0xFFFFFFFF
+  {"CU_MEM_LOCATION_TYPE_MAX",                                         {"hipMemoryLocationTypeMax",                                 "", CONV_NUMERIC_LITERAL, API_DRIVER, 1, HIP_UNSUPPORTED}}, // 0x7FFFFFFF
 
   // cudaMemAllocationType
   {"CUmemAllocationType",                                              {"hipMemoryAllocationType",                                  "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
@@ -1648,7 +1695,7 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_TYPE_NAME_MAP {
   // cudaMemAllocationTypePinned
   {"CU_MEM_ALLOCATION_TYPE_PINNED",                                    {"hipMemoryAllocationTypePinned",                            "", CONV_NUMERIC_LITERAL, API_DRIVER, 1, HIP_UNSUPPORTED}}, // 0x1
   // cudaMemAllocationTypeMax
-  {"CU_MEM_ALLOCATION_TYPE_MAX",                                       {"hipMemoryAllocationTypeMax",                               "", CONV_NUMERIC_LITERAL, API_DRIVER, 1, HIP_UNSUPPORTED}}, // 0xFFFFFFFF
+  {"CU_MEM_ALLOCATION_TYPE_MAX",                                       {"hipMemoryAllocationTypeMax",                               "", CONV_NUMERIC_LITERAL, API_DRIVER, 1, HIP_UNSUPPORTED}}, // 0x7FFFFFFF
 
   // no analogue
   {"CUmemAllocationGranularity_flags",                                 {"hipMemoryAllocationGranularityFlags",                      "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
@@ -1743,13 +1790,120 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_TYPE_NAME_MAP {
   {"CU_MEMPOOL_ATTR_REUSE_ALLOW_INTERNAL_DEPENDENCIES",                {"hipMemPoolReuseAllowInternalDependencies",                 "", CONV_NUMERIC_LITERAL, API_DRIVER, 1, HIP_UNSUPPORTED}},
   // cudaMemPoolAttrReleaseThreshold
   {"CU_MEMPOOL_ATTR_RELEASE_THRESHOLD",                                {"hipMemPoolAttrReleaseThreshold",                           "", CONV_NUMERIC_LITERAL, API_DRIVER, 1, HIP_UNSUPPORTED}},
+  //
+  {"CU_MEMPOOL_ATTR_RESERVED_MEM_CURRENT",                             {"hipMemPoolAttrReservedMemCurrent",                         "", CONV_NUMERIC_LITERAL, API_DRIVER, 1, HIP_UNSUPPORTED}},
+  //
+  {"CU_MEMPOOL_ATTR_RESERVED_MEM_HIGH",                                {"hipMemPoolAttrReservedMemHigh",                            "", CONV_NUMERIC_LITERAL, API_DRIVER, 1, HIP_UNSUPPORTED}},
+  //
+  {"CU_MEMPOOL_ATTR_USED_MEM_CURRENT",                                 {"hipMemPoolAttrUsedMemCurrent",                             "", CONV_NUMERIC_LITERAL, API_DRIVER, 1, HIP_UNSUPPORTED}},
+  //
+  {"CU_MEMPOOL_ATTR_USED_MEM_HIGH",                                    {"hipMemPoolAttrUsedMemHigh",                                "", CONV_NUMERIC_LITERAL, API_DRIVER, 1, HIP_UNSUPPORTED}},
+
+  //
+  {"CUstreamUpdateCaptureDependencies_flags",                          {"hipStreamUpdateCaptureDependencies",                       "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
+  {"CUstreamUpdateCaptureDependencies_flags_enum",                     {"hipStreamUpdateCaptureDependencies",                       "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
+  // CUstreamUpdateCaptureDependencies_flags enum values
+  //
+  {"CU_STREAM_ADD_CAPTURE_DEPENDENCIES",                               {"HIP_STREAM_SET_CAPTURE_DEPENDENCIES",                      "", CONV_NUMERIC_LITERAL, API_DRIVER, 1, HIP_UNSUPPORTED}}, // 0x0
+  //
+  {"CU_STREAM_SET_CAPTURE_DEPENDENCIES",                               {"HIP_STREAM_SET_CAPTURE_DEPENDENCIES",                      "", CONV_NUMERIC_LITERAL, API_DRIVER, 1, HIP_UNSUPPORTED}}, // 0x1
+
+  //
+  {"CUdriverProcAddress_flags",                                        {"hipDriverProcAddress",                                     "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
+  {"CUdriverProcAddress_flags_enum",                                   {"hipDriverProcAddress",                                     "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
+  // CUdriverProcAddress_flags enum values
+  //
+  {"CU_GET_PROC_ADDRESS_DEFAULT",                                      {"HIP_GET_PROC_ADDRESS_DEFAULT",                             "", CONV_NUMERIC_LITERAL, API_DRIVER, 1, HIP_UNSUPPORTED}}, // 0
+  //
+  {"CU_GET_PROC_ADDRESS_LEGACY_STREAM",                                {"HIP_GET_PROC_ADDRESS_LEGACY_STREAM",                       "", CONV_NUMERIC_LITERAL, API_DRIVER, 1, HIP_UNSUPPORTED}}, // 1 << 0
+  //
+  {"CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM",                    {"HIP_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM",           "", CONV_NUMERIC_LITERAL, API_DRIVER, 1, HIP_UNSUPPORTED}}, // 1 << 1
+
+  //
+  {"CUflushGPUDirectRDMAWritesOptions",                                {"hipFlushGPUDirectRDMAWritesOptions",                       "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
+  {"CUflushGPUDirectRDMAWritesOptions_enum",                           {"hipFlushGPUDirectRDMAWritesOptions",                       "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
+  // CUflushGPUDirectRDMAWritesOptions enum values
+  //
+  {"CU_FLUSH_GPU_DIRECT_RDMA_WRITES_OPTION_HOST",                      {"HIP_FLUSH_GPU_DIRECT_RDMA_WRITES_OPTION_HOST",             "", CONV_NUMERIC_LITERAL, API_DRIVER, 1, HIP_UNSUPPORTED}}, // 1<<0
+  //
+  {"CU_FLUSH_GPU_DIRECT_RDMA_WRITES_OPTION_MEMOPS",                    {"HIP_FLUSH_GPU_DIRECT_RDMA_WRITES_OPTION_MEMOPS",           "", CONV_NUMERIC_LITERAL, API_DRIVER, 1, HIP_UNSUPPORTED}}, // 1<<1
+
+  //
+  {"CUGPUDirectRDMAWritesOrdering",                                    {"hipGPUDirectRDMAWritesOrdering",                           "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
+  {"CUGPUDirectRDMAWritesOrdering_enum",                               {"hipGPUDirectRDMAWritesOrdering",                           "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
+  // CUGPUDirectRDMAWritesOrdering enum values
+  //
+  {"CU_GPU_DIRECT_RDMA_WRITES_ORDERING_NONE",                          {"HIP_GPU_DIRECT_RDMA_WRITES_ORDERING_NONE",                 "", CONV_NUMERIC_LITERAL, API_DRIVER, 1, HIP_UNSUPPORTED}}, // 0
+  //
+  {"CU_GPU_DIRECT_RDMA_WRITES_ORDERING_OWNER",                         {"HIP_GPU_DIRECT_RDMA_WRITES_ORDERING_OWNER",                "", CONV_NUMERIC_LITERAL, API_DRIVER, 1, HIP_UNSUPPORTED}}, // 100
+  //
+  {"CU_GPU_DIRECT_RDMA_WRITES_ORDERING_ALL_DEVICES",                   {"HIP_GPU_DIRECT_RDMA_WRITES_ORDERING_ALL_DEVICES",          "", CONV_NUMERIC_LITERAL, API_DRIVER, 1, HIP_UNSUPPORTED}}, // 200
+
+  //
+  {"CUflushGPUDirectRDMAWritesScope",                                  {"hipFlushGPUDirectRDMAWritesScope",                         "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
+  {"CUflushGPUDirectRDMAWritesScope_enum",                             {"hipFlushGPUDirectRDMAWritesScope",                         "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
+  // CUflushGPUDirectRDMAWritesScope enum values
+  //
+  {"CU_FLUSH_GPU_DIRECT_RDMA_WRITES_TO_OWNER",                         {"HIP_FLUSH_GPU_DIRECT_RDMA_WRITES_TO_OWNER",                "", CONV_NUMERIC_LITERAL, API_DRIVER, 1, HIP_UNSUPPORTED}}, // 100
+  //
+  {"CU_FLUSH_GPU_DIRECT_RDMA_WRITES_TO_ALL_DEVICES",                   {"HIP_FLUSH_GPU_DIRECT_RDMA_WRITES_TO_ALL_DEVICES",          "", CONV_NUMERIC_LITERAL, API_DRIVER, 1, HIP_UNSUPPORTED}}, // 200
+
+  //
+  {"CUflushGPUDirectRDMAWritesTarget",                                 {"hipFlushGPUDirectRDMAWritesTarget",                        "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
+  {"CUflushGPUDirectRDMAWritesTarget_enum",                            {"hipFlushGPUDirectRDMAWritesTarget",                        "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
+  // CUflushGPUDirectRDMAWritesTarget enum values
+  //
+  {"CU_FLUSH_GPU_DIRECT_RDMA_WRITES_TARGET_CURRENT_CTX",               {"HIP_FLUSH_GPU_DIRECT_RDMA_WRITES_TARGET_CURRENT_CTX",      "", CONV_NUMERIC_LITERAL, API_DRIVER, 1, HIP_UNSUPPORTED}}, // 0
+
+  //
+  {"CUgraphDebugDot_flags",                                            {"hipGraphDebugDotFlags",                                    "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
+  {"CUgraphDebugDot_flags_enum",                                       {"hipGraphDebugDotFlags",                                    "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
+  // CUgraphDebugDot_flags enum values
+  //
+  {"CU_GRAPH_DEBUG_DOT_FLAGS_VERBOSE",                                 {"HIP_GRAPH_DEBUG_DOT_FLAGS_VERBOSE",                        "", CONV_NUMERIC_LITERAL, API_DRIVER, 1, HIP_UNSUPPORTED}}, // 1<<0
+  //
+  {"CU_GRAPH_DEBUG_DOT_FLAGS_RUNTIME_TYPES",                           {"HIP_GRAPH_DEBUG_DOT_FLAGS_RUNTIME_TYPES",                  "", CONV_NUMERIC_LITERAL, API_DRIVER, 1, HIP_UNSUPPORTED}}, // 1<<1
+  //
+  {"CU_GRAPH_DEBUG_DOT_FLAGS_KERNEL_NODE_PARAMS",                      {"HIP_GRAPH_DEBUG_DOT_FLAGS_KERNEL_NODE_PARAMS",             "", CONV_NUMERIC_LITERAL, API_DRIVER, 1, HIP_UNSUPPORTED}}, // 1<<2
+  //
+  {"CU_GRAPH_DEBUG_DOT_FLAGS_MEMCPY_NODE_PARAMS",                      {"HIP_GRAPH_DEBUG_DOT_FLAGS_MEMCPY_NODE_PARAMS",             "", CONV_NUMERIC_LITERAL, API_DRIVER, 1, HIP_UNSUPPORTED}}, // 1<<3
+  //
+  {"CU_GRAPH_DEBUG_DOT_FLAGS_MEMSET_NODE_PARAMS",                      {"HIP_GRAPH_DEBUG_DOT_FLAGS_MEMSET_NODE_PARAMS",             "", CONV_NUMERIC_LITERAL, API_DRIVER, 1, HIP_UNSUPPORTED}}, // 1<<4
+  //
+  {"CU_GRAPH_DEBUG_DOT_FLAGS_HOST_NODE_PARAMS",                        {"HIP_GRAPH_DEBUG_DOT_FLAGS_HOST_NODE_PARAMS",               "", CONV_NUMERIC_LITERAL, API_DRIVER, 1, HIP_UNSUPPORTED}}, // 1<<5
+  //
+  {"CU_GRAPH_DEBUG_DOT_FLAGS_EVENT_NODE_PARAMS",                       {"HIP_GRAPH_DEBUG_DOT_FLAGS_EVENT_NODE_PARAMS",              "", CONV_NUMERIC_LITERAL, API_DRIVER, 1, HIP_UNSUPPORTED}}, // 1<<6
+  //
+  {"CU_GRAPH_DEBUG_DOT_FLAGS_EXT_SEMAS_SIGNAL_NODE_PARAMS",            {"HIP_GRAPH_DEBUG_DOT_FLAGS_EXT_SEMAS_SIGNAL_NODE_PARAMS",   "", CONV_NUMERIC_LITERAL, API_DRIVER, 1, HIP_UNSUPPORTED}}, // 1<<7
+  //
+  {"CU_GRAPH_DEBUG_DOT_FLAGS_EXT_SEMAS_WAIT_NODE_PARAMS",              {"HIP_GRAPH_DEBUG_DOT_FLAGS_EXT_SEMAS_WAIT_NODE_PARAMS",     "", CONV_NUMERIC_LITERAL, API_DRIVER, 1, HIP_UNSUPPORTED}}, // 1<<8
+  //
+  {"CU_GRAPH_DEBUG_DOT_FLAGS_KERNEL_NODE_ATTRIBUTES",                  {"HIP_GRAPH_DEBUG_DOT_FLAGS_KERNEL_NODE_ATTRIBUTES",         "", CONV_NUMERIC_LITERAL, API_DRIVER, 1, HIP_UNSUPPORTED}}, // 1<<9
+  //
+  {"CU_GRAPH_DEBUG_DOT_FLAGS_HANDLES",                                 {"HIP_GRAPH_DEBUG_DOT_FLAGS_HANDLES",                        "", CONV_NUMERIC_LITERAL, API_DRIVER, 1, HIP_UNSUPPORTED}}, // 1<<10
+
+  //
+  {"CUuserObject_flags",                                               {"hipUserObjectFlags",                                       "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
+  {"CUuserObject_flags_enum",                                          {"hipUserObjectFlags",                                       "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
+  // CUuserObject_flags enum values
+  //
+  {"CU_USER_OBJECT_NO_DESTRUCTOR_SYNC",                                {"HIP_USER_OBJECT_NO_DESTRUCTOR_SYNC",                       "", CONV_NUMERIC_LITERAL, API_DRIVER, 1, HIP_UNSUPPORTED}}, // 1
+
+  //
+  {"CUuserObjectRetain_flags",                                         {"hipUserObjectRetainFlags",                                 "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
+  {"CUuserObjectRetain_flags_enum",                                    {"hipUserObjectRetainFlags",                                 "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
+  // CUuserObjectRetain_flags enum values
+  //
+  {"CU_GRAPH_USER_OBJECT_MOVE",                                        {"HIP_GRAPH_USER_OBJECT_MOVE",                               "", CONV_NUMERIC_LITERAL, API_DRIVER, 1, HIP_UNSUPPORTED}}, // 1
 
   // 4. Typedefs
 
   // no analogue
   {"CUdevice",                                                         {"hipDevice_t",                                              "", CONV_TYPE, API_DRIVER, 1}},
+  {"CUdevice_v1",                                                      {"hipDevice_t",                                              "", CONV_TYPE, API_DRIVER, 1}},
   {"CUdeviceptr",                                                      {"hipDeviceptr_t",                                           "", CONV_TYPE, API_DRIVER, 1}},
   {"CUdeviceptr_v1",                                                   {"hipDeviceptr_t",                                           "", CONV_TYPE, API_DRIVER, 1}},
+  {"CUdeviceptr_v2",                                                   {"hipDeviceptr_t",                                           "", CONV_TYPE, API_DRIVER, 1}},
 
   // cudaHostFn_t
   {"CUhostFn",                                                         {"hipHostFn",                                                "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
@@ -1762,12 +1916,15 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_TYPE_NAME_MAP {
 
   // cudaSurfaceObject_t
   {"CUsurfObject",                                                     {"hipSurfaceObject",                                         "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
+  {"CUsurfObject_v1",                                                  {"hipSurfaceObject",                                         "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
 
   // cudaTextureObject_t
   {"CUtexObject",                                                      {"hipTextureObject_t",                                       "", CONV_TYPE, API_DRIVER, 1}},
+  {"CUtexObject_v1",                                                   {"hipTextureObject_t",                                       "", CONV_TYPE, API_DRIVER, 1}},
 
   //
   {"CUmemGenericAllocationHandle",                                     {"hipMemGenericAllocationHandle",                            "", CONV_DEFINE, API_DRIVER, 1, HIP_UNSUPPORTED}},
+  {"CUmemGenericAllocationHandle_v1",                                  {"hipMemGenericAllocationHandle",                            "", CONV_DEFINE, API_DRIVER, 1, HIP_UNSUPPORTED}},
 
   // 5. Defines
 
@@ -2275,6 +2432,100 @@ const std::map<llvm::StringRef, cudaAPIversions> CUDA_DRIVER_TYPE_NAME_VER_MAP {
   {"CU_MEM_ALLOCATION_TYPE_INVALID",                                   {CUDA_102, CUDA_0,   CUDA_0  }},
   {"CU_MEM_ALLOCATION_TYPE_PINNED",                                    {CUDA_102, CUDA_0,   CUDA_0  }},
   {"CU_MEM_ALLOCATION_TYPE_MAX",                                       {CUDA_102, CUDA_0,   CUDA_0  }},
+  {"CUdeviceptr_v2",                                                   {CUDA_113, CUDA_0,   CUDA_0  }},
+  {"CUdevice_v1",                                                      {CUDA_113, CUDA_0,   CUDA_0  }},
+  {"CUtexObject_v1",                                                   {CUDA_113, CUDA_0,   CUDA_0  }},
+  {"CUsurfObject_v1",                                                  {CUDA_113, CUDA_0,   CUDA_0  }},
+  {"CUuserObject_st",                                                  {CUDA_113, CUDA_0,   CUDA_0  }},
+  {"CUuserObject",                                                     {CUDA_113, CUDA_0,   CUDA_0  }},
+  {"CUipcEventHandle_v1",                                              {CUDA_113, CUDA_0,   CUDA_0  }},
+  {"CUipcMemHandle_v1",                                                {CUDA_113, CUDA_0,   CUDA_0  }},
+  {"CUstreamBatchMemOpParams_v1",                                      {CUDA_113, CUDA_0,   CUDA_0  }},
+  {"CUstreamUpdateCaptureDependencies_flags",                          {CUDA_113, CUDA_0,   CUDA_0  }},
+  {"CUstreamUpdateCaptureDependencies_flags_enum",                     {CUDA_113, CUDA_0,   CUDA_0  }},
+  {"CU_STREAM_ADD_CAPTURE_DEPENDENCIES",                               {CUDA_113, CUDA_0,   CUDA_0  }},
+  {"CU_STREAM_SET_CAPTURE_DEPENDENCIES",                               {CUDA_113, CUDA_0,   CUDA_0  }},
+  {"CU_DEVICE_ATTRIBUTE_GPU_DIRECT_RDMA_SUPPORTED",                    {CUDA_113, CUDA_0,   CUDA_0  }},
+  {"CU_DEVICE_ATTRIBUTE_GPU_DIRECT_RDMA_FLUSH_WRITES_OPTIONS",         {CUDA_113, CUDA_0,   CUDA_0  }},
+  {"CU_DEVICE_ATTRIBUTE_GPU_DIRECT_RDMA_WRITES_ORDERING",              {CUDA_113, CUDA_0,   CUDA_0  }},
+  {"CU_DEVICE_ATTRIBUTE_MEMPOOL_SUPPORTED_HANDLE_TYPES",               {CUDA_113, CUDA_0,   CUDA_0  }},
+  {"CUdevprop_v1",                                                     {CUDA_113, CUDA_0,   CUDA_0  }},
+  {"CU_POINTER_ATTRIBUTE_MEMPOOL_HANDLE",                              {CUDA_113, CUDA_0,   CUDA_0  }},
+  {"CUDA_KERNEL_NODE_PARAMS_v1",                                       {CUDA_113, CUDA_0,   CUDA_0  }},
+  {"CUDA_MEMSET_NODE_PARAMS_v1",                                       {CUDA_113, CUDA_0,   CUDA_0  }},
+  {"CUDA_HOST_NODE_PARAMS_v1",                                         {CUDA_113, CUDA_0,   CUDA_0  }},
+  {"CUkernelNodeAttrValue_v1",                                         {CUDA_113, CUDA_0,   CUDA_0  }},
+  {"CUstreamAttrValue_v1",                                             {CUDA_113, CUDA_0,   CUDA_0  }},
+  {"CUdriverProcAddress_flags",                                        {CUDA_113, CUDA_0,   CUDA_0  }},
+  {"CUdriverProcAddress_flags_enum",                                   {CUDA_113, CUDA_0,   CUDA_0  }},
+  {"CU_GET_PROC_ADDRESS_DEFAULT",                                      {CUDA_113, CUDA_0,   CUDA_0  }},
+  {"CU_GET_PROC_ADDRESS_LEGACY_STREAM",                                {CUDA_113, CUDA_0,   CUDA_0  }},
+  {"CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM",                    {CUDA_113, CUDA_0,   CUDA_0  }},
+  {"CUDA_MEMCPY2D_v2",                                                 {CUDA_113, CUDA_0,   CUDA_0  }},
+  {"CUDA_MEMCPY3D_v2",                                                 {CUDA_113, CUDA_0,   CUDA_0  }},
+  {"CUDA_MEMCPY3D_PEER_v1",                                            {CUDA_113, CUDA_0,   CUDA_0  }},
+  {"CUDA_ARRAY_DESCRIPTOR_v2",                                         {CUDA_113, CUDA_0,   CUDA_0  }},
+  {"CUDA_ARRAY3D_DESCRIPTOR_v2",                                       {CUDA_113, CUDA_0,   CUDA_0  }},
+  {"CUDA_ARRAY_SPARSE_PROPERTIES_v1",                                  {CUDA_113, CUDA_0,   CUDA_0  }},
+  {"CUDA_RESOURCE_DESC_v1",                                            {CUDA_113, CUDA_0,   CUDA_0  }},
+  {"CUDA_TEXTURE_DESC_v1",                                             {CUDA_113, CUDA_0,   CUDA_0  }},
+  {"CUDA_RESOURCE_VIEW_DESC_v1",                                       {CUDA_113, CUDA_0,   CUDA_0  }},
+  {"CUDA_POINTER_ATTRIBUTE_P2P_TOKENS_v1",                             {CUDA_113, CUDA_0,   CUDA_0  }},
+  {"CUDA_LAUNCH_PARAMS_v1",                                            {CUDA_113, CUDA_0,   CUDA_0  }},
+  {"CUDA_EXTERNAL_MEMORY_HANDLE_DESC_v1",                              {CUDA_113, CUDA_0,   CUDA_0  }},
+  {"CUDA_EXTERNAL_MEMORY_BUFFER_DESC_v1",                              {CUDA_113, CUDA_0,   CUDA_0  }},
+  {"CUDA_EXTERNAL_MEMORY_MIPMAPPED_ARRAY_DESC_v1",                     {CUDA_113, CUDA_0,   CUDA_0  }},
+  {"CUDA_EXTERNAL_SEMAPHORE_HANDLE_DESC_v1",                           {CUDA_113, CUDA_0,   CUDA_0  }},
+  {"CUDA_EXTERNAL_SEMAPHORE_SIGNAL_PARAMS_v1",                         {CUDA_113, CUDA_0,   CUDA_0  }},
+  {"CUDA_EXTERNAL_SEMAPHORE_WAIT_PARAMS_v1",                           {CUDA_113, CUDA_0,   CUDA_0  }},
+  {"CUDA_EXT_SEM_SIGNAL_NODE_PARAMS_v1",                               {CUDA_113, CUDA_0,   CUDA_0  }},
+  {"CUDA_EXT_SEM_WAIT_NODE_PARAMS_v1",                                 {CUDA_113, CUDA_0,   CUDA_0  }},
+  {"CUmemGenericAllocationHandle_v1",                                  {CUDA_113, CUDA_0,   CUDA_0  }},
+  {"CUarrayMapInfo_v1",                                                {CUDA_113, CUDA_0,   CUDA_0  }},
+  {"CUmemLocation_v1",                                                 {CUDA_113, CUDA_0,   CUDA_0  }},
+  {"CUmemAllocationProp_v1",                                           {CUDA_113, CUDA_0,   CUDA_0  }},
+  {"CUmemAccessDesc_v1",                                               {CUDA_113, CUDA_0,   CUDA_0  }},
+  {"CU_MEMPOOL_ATTR_RESERVED_MEM_CURRENT",                             {CUDA_113, CUDA_0,   CUDA_0  }},
+  {"CU_MEMPOOL_ATTR_RESERVED_MEM_HIGH",                                {CUDA_113, CUDA_0,   CUDA_0  }},
+  {"CU_MEMPOOL_ATTR_USED_MEM_CURRENT",                                 {CUDA_113, CUDA_0,   CUDA_0  }},
+  {"CU_MEMPOOL_ATTR_USED_MEM_HIGH",                                    {CUDA_113, CUDA_0,   CUDA_0  }},
+  {"CUmemPoolProps_v1",                                                {CUDA_113, CUDA_0,   CUDA_0  }},
+  {"CUmemPoolPtrExportData_v1",                                        {CUDA_113, CUDA_0,   CUDA_0  }},
+  {"CUflushGPUDirectRDMAWritesOptions",                                {CUDA_113, CUDA_0,   CUDA_0  }},
+  {"CUflushGPUDirectRDMAWritesOptions_enum",                           {CUDA_113, CUDA_0,   CUDA_0  }},
+  {"CU_FLUSH_GPU_DIRECT_RDMA_WRITES_OPTION_HOST",                      {CUDA_113, CUDA_0,   CUDA_0  }},
+  {"CU_FLUSH_GPU_DIRECT_RDMA_WRITES_OPTION_MEMOPS",                    {CUDA_113, CUDA_0,   CUDA_0  }},
+  {"CUGPUDirectRDMAWritesOrdering",                                    {CUDA_113, CUDA_0,   CUDA_0  }},
+  {"CUGPUDirectRDMAWritesOrdering_enum",                               {CUDA_113, CUDA_0,   CUDA_0  }},
+  {"CU_GPU_DIRECT_RDMA_WRITES_ORDERING_NONE",                          {CUDA_113, CUDA_0,   CUDA_0  }},
+  {"CU_GPU_DIRECT_RDMA_WRITES_ORDERING_OWNER",                         {CUDA_113, CUDA_0,   CUDA_0  }},
+  {"CU_GPU_DIRECT_RDMA_WRITES_ORDERING_ALL_DEVICES",                   {CUDA_113, CUDA_0,   CUDA_0  }},
+  {"CUflushGPUDirectRDMAWritesScope",                                  {CUDA_113, CUDA_0,   CUDA_0  }},
+  {"CUflushGPUDirectRDMAWritesScope_enum",                             {CUDA_113, CUDA_0,   CUDA_0  }},
+  {"CU_FLUSH_GPU_DIRECT_RDMA_WRITES_TO_OWNER",                         {CUDA_113, CUDA_0,   CUDA_0  }},
+  {"CU_FLUSH_GPU_DIRECT_RDMA_WRITES_TO_ALL_DEVICES",                   {CUDA_113, CUDA_0,   CUDA_0  }},
+  {"CUflushGPUDirectRDMAWritesTarget",                                 {CUDA_113, CUDA_0,   CUDA_0  }},
+  {"CUflushGPUDirectRDMAWritesTarget_enum",                            {CUDA_113, CUDA_0,   CUDA_0  }},
+  {"CU_FLUSH_GPU_DIRECT_RDMA_WRITES_TARGET_CURRENT_CTX",               {CUDA_113, CUDA_0,   CUDA_0  }},
+  {"CUgraphDebugDot_flags",                                            {CUDA_113, CUDA_0,   CUDA_0  }},
+  {"CUgraphDebugDot_flags_enum",                                       {CUDA_113, CUDA_0,   CUDA_0  }},
+  {"CU_GRAPH_DEBUG_DOT_FLAGS_VERBOSE",                                 {CUDA_113, CUDA_0,   CUDA_0  }},
+  {"CU_GRAPH_DEBUG_DOT_FLAGS_RUNTIME_TYPES",                           {CUDA_113, CUDA_0,   CUDA_0  }},
+  {"CU_GRAPH_DEBUG_DOT_FLAGS_KERNEL_NODE_PARAMS",                      {CUDA_113, CUDA_0,   CUDA_0  }},
+  {"CU_GRAPH_DEBUG_DOT_FLAGS_MEMCPY_NODE_PARAMS",                      {CUDA_113, CUDA_0,   CUDA_0  }},
+  {"CU_GRAPH_DEBUG_DOT_FLAGS_MEMSET_NODE_PARAMS",                      {CUDA_113, CUDA_0,   CUDA_0  }},
+  {"CU_GRAPH_DEBUG_DOT_FLAGS_HOST_NODE_PARAMS",                        {CUDA_113, CUDA_0,   CUDA_0  }},
+  {"CU_GRAPH_DEBUG_DOT_FLAGS_EVENT_NODE_PARAMS",                       {CUDA_113, CUDA_0,   CUDA_0  }},
+  {"CU_GRAPH_DEBUG_DOT_FLAGS_EXT_SEMAS_SIGNAL_NODE_PARAMS",            {CUDA_113, CUDA_0,   CUDA_0  }},
+  {"CU_GRAPH_DEBUG_DOT_FLAGS_EXT_SEMAS_WAIT_NODE_PARAMS",              {CUDA_113, CUDA_0,   CUDA_0  }},
+  {"CU_GRAPH_DEBUG_DOT_FLAGS_KERNEL_NODE_ATTRIBUTES",                  {CUDA_113, CUDA_0,   CUDA_0  }},
+  {"CU_GRAPH_DEBUG_DOT_FLAGS_HANDLES",                                 {CUDA_113, CUDA_0,   CUDA_0  }},
+  {"CUuserObject_flags",                                               {CUDA_113, CUDA_0,   CUDA_0  }},
+  {"CUuserObject_flags_enum",                                          {CUDA_113, CUDA_0,   CUDA_0  }},
+  {"CU_USER_OBJECT_NO_DESTRUCTOR_SYNC",                                {CUDA_113, CUDA_0,   CUDA_0  }},
+  {"CUuserObjectRetain_flags",                                         {CUDA_113, CUDA_0,   CUDA_0  }},
+  {"CUuserObjectRetain_flags_enum",                                    {CUDA_113, CUDA_0,   CUDA_0  }},
+  {"CU_GRAPH_USER_OBJECT_MOVE",                                        {CUDA_113, CUDA_0,   CUDA_0  }},
 };
 
 const std::map<llvm::StringRef, hipAPIversions> HIP_DRIVER_TYPE_NAME_VER_MAP {

--- a/src/Statistics.cpp
+++ b/src/Statistics.cpp
@@ -418,6 +418,7 @@ std::string Statistics::getCudaVersion(const cudaVersions& ver) {
     case CUDA_110: return "11.0";
     case CUDA_111: return "11.1";
     case CUDA_112: return "11.2";
+    case CUDA_113: return "11.3";
     case CUDNN_10: return "1.0.0";
     case CUDNN_20: return "2.0.0";
     case CUDNN_30: return "3.0.0";

--- a/src/Statistics.h
+++ b/src/Statistics.h
@@ -189,6 +189,7 @@ enum cudaVersions {
   CUDA_110 = 11000,
   CUDA_111 = 11010,
   CUDA_112 = 11020,
+  CUDA_113 = 11030,
   CUDNN_10 = 100,
   CUDNN_20 = 200,
   CUDNN_30 = 300,


### PR DESCRIPTION
+ Add CUDA 11.3 to enums
+ Update hipify-perl accordingly
+ Update CUDA_Driver_API_functions_supported_by_HIP.md accordingly