### PR TITLE
[HIPIFY][fix] Fix building by old C++ compilers

### DIFF
--- a/src/Statistics.h
+++ b/src/Statistics.h
@@ -273,15 +273,15 @@ enum hipVersions {
 };
 
 struct cudaAPIversions {
-  cudaVersions appeared = cudaVersions::CUDA_0;
-  cudaVersions deprecated = cudaVersions::CUDA_0;
-  cudaVersions removed = cudaVersions::CUDA_0;
+  cudaVersions appeared;
+  cudaVersions deprecated;
+  cudaVersions removed;
 };
 
 struct hipAPIversions {
-  hipVersions appeared = hipVersions::HIP_0;
-  hipVersions deprecated = hipVersions::HIP_0;
-  hipVersions removed = hipVersions::HIP_0;
+  hipVersions appeared;
+  hipVersions deprecated;
+  hipVersions removed;
 };
 
 // The names of various fields in in the statistics reports.


### PR DESCRIPTION
For instance, compiling hipify-clang by Visual Studio 2015 leads to the following error:
`error C2440: 'initializing': cannot convert from 'initializer list' to 'std::map<llvm::StringRef,cudaAPIversions,std::less<_Kty>,std::allocator<std::pair<const _Kty,_Ty>>>'`