### PR TITLE
[HIPIFY][tests][fix] Exclude reinterpret_cast.cu if CUDA < 9

### DIFF
--- a/src/CUDA2HIP_Driver_API_types.cpp
+++ b/src/CUDA2HIP_Driver_API_types.cpp
@@ -2527,6 +2527,7 @@ const std::map<llvm::StringRef, cudaAPIversions> CUDA_DRIVER_TYPE_NAME_VER_MAP {
   {"CUuserObjectRetain_flags",                                         {CUDA_113, CUDA_0,   CUDA_0  }},
   {"CUuserObjectRetain_flags_enum",                                    {CUDA_113, CUDA_0,   CUDA_0  }},
   {"CU_GRAPH_USER_OBJECT_MOVE",                                        {CUDA_113, CUDA_0,   CUDA_0  }},
+  {"CU_STREAM_WAIT_VALUE_NOR",                                         {CUDA_90,  CUDA_0,   CUDA_0  }},
 };
 
 const std::map<llvm::StringRef, hipAPIversions> HIP_DRIVER_TYPE_NAME_VER_MAP {

--- a/tests/lit.cfg
+++ b/tests/lit.cfg
@@ -54,6 +54,7 @@ if config.cuda_version_major < 9:
     config.excludes.append('cuSPARSE_06.cu')
     config.excludes.append('cuSPARSE_07.cu')
     config.excludes.append('benchmark_curand_kernel.cpp')
+    config.excludes.append('reinterpret_cast.cu')
 if config.cuda_version_major < 10:
     config.excludes.append('cuSPARSE_08.cu')
     config.excludes.append('cuSPARSE_09.cu')


### PR DESCRIPTION
+ Add missing CUDA version for CUDA 9 data type