### PR TITLE
[HIPIFY][SPARSE] Sync with hipSPARSE 4.2.0 (functions)

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -1686,6 +1686,7 @@ sub simpleSubstitutions {
     $ft{'library'} += s/\bcusparseCcsr2bsr\b/hipsparseCcsr2bsr/g;
     $ft{'library'} += s/\bcusparseCcsr2csc\b/hipsparseCcsr2csc/g;
     $ft{'library'} += s/\bcusparseCcsr2csr_compress\b/hipsparseCcsr2csr_compress/g;
+    $ft{'library'} += s/\bcusparseCcsr2csru\b/hipsparseCcsr2csru/g;
     $ft{'library'} += s/\bcusparseCcsr2dense\b/hipsparseCcsr2dense/g;
     $ft{'library'} += s/\bcusparseCcsr2gebsr\b/hipsparseCcsr2gebsr/g;
     $ft{'library'} += s/\bcusparseCcsr2gebsr_bufferSize\b/hipsparseCcsr2gebsr_bufferSize/g;
@@ -1715,6 +1716,8 @@ sub simpleSubstitutions {
     $ft{'library'} += s/\bcusparseCcsrsv2_bufferSize\b/hipsparseCcsrsv2_bufferSize/g;
     $ft{'library'} += s/\bcusparseCcsrsv2_bufferSizeExt\b/hipsparseCcsrsv2_bufferSizeExt/g;
     $ft{'library'} += s/\bcusparseCcsrsv2_solve\b/hipsparseCcsrsv2_solve/g;
+    $ft{'library'} += s/\bcusparseCcsru2csr\b/hipsparseCcsru2csr/g;
+    $ft{'library'} += s/\bcusparseCcsru2csr_bufferSizeExt\b/hipsparseCcsru2csr_bufferSizeExt/g;
     $ft{'library'} += s/\bcusparseCdense2csc\b/hipsparseCdense2csc/g;
     $ft{'library'} += s/\bcusparseCdense2csr\b/hipsparseCdense2csr/g;
     $ft{'library'} += s/\bcusparseCdotci\b/hipsparseCdotci/g;
@@ -1733,24 +1736,29 @@ sub simpleSubstitutions {
     $ft{'library'} += s/\bcusparseCnnz_compress\b/hipsparseCnnz_compress/g;
     $ft{'library'} += s/\bcusparseCooAoSGet\b/hipsparseCooAoSGet/g;
     $ft{'library'} += s/\bcusparseCooGet\b/hipsparseCooGet/g;
+    $ft{'library'} += s/\bcusparseCooSetPointers\b/hipsparseCooSetPointers/g;
     $ft{'library'} += s/\bcusparseCreate\b/hipsparseCreate/g;
     $ft{'library'} += s/\bcusparseCreateBsric02Info\b/hipsparseCreateBsric02Info/g;
     $ft{'library'} += s/\bcusparseCreateBsrilu02Info\b/hipsparseCreateBsrilu02Info/g;
     $ft{'library'} += s/\bcusparseCreateBsrsv2Info\b/hipsparseCreateBsrsv2Info/g;
     $ft{'library'} += s/\bcusparseCreateCoo\b/hipsparseCreateCoo/g;
     $ft{'library'} += s/\bcusparseCreateCooAoS\b/hipsparseCreateCooAoS/g;
+    $ft{'library'} += s/\bcusparseCreateCsc\b/hipsparseCreateCsc/g;
     $ft{'library'} += s/\bcusparseCreateCsr\b/hipsparseCreateCsr/g;
     $ft{'library'} += s/\bcusparseCreateCsrgemm2Info\b/hipsparseCreateCsrgemm2Info/g;
     $ft{'library'} += s/\bcusparseCreateCsric02Info\b/hipsparseCreateCsric02Info/g;
     $ft{'library'} += s/\bcusparseCreateCsrilu02Info\b/hipsparseCreateCsrilu02Info/g;
     $ft{'library'} += s/\bcusparseCreateCsrsm2Info\b/hipsparseCreateCsrsm2Info/g;
     $ft{'library'} += s/\bcusparseCreateCsrsv2Info\b/hipsparseCreateCsrsv2Info/g;
+    $ft{'library'} += s/\bcusparseCreateCsru2csrInfo\b/hipsparseCreateCsru2csrInfo/g;
+    $ft{'library'} += s/\bcusparseCreateDnMat\b/hipsparseCreateDnMat/g;
     $ft{'library'} += s/\bcusparseCreateDnVec\b/hipsparseCreateDnVec/g;
     $ft{'library'} += s/\bcusparseCreateHybMat\b/hipsparseCreateHybMat/g;
     $ft{'library'} += s/\bcusparseCreateIdentityPermutation\b/hipsparseCreateIdentityPermutation/g;
     $ft{'library'} += s/\bcusparseCreateMatDescr\b/hipsparseCreateMatDescr/g;
     $ft{'library'} += s/\bcusparseCreatePruneInfo\b/hipsparseCreatePruneInfo/g;
     $ft{'library'} += s/\bcusparseCreateSpVec\b/hipsparseCreateSpVec/g;
+    $ft{'library'} += s/\bcusparseCscSetPointers\b/hipsparseCscSetPointers/g;
     $ft{'library'} += s/\bcusparseCsctr\b/hipsparseCsctr/g;
     $ft{'library'} += s/\bcusparseCsrGet\b/hipsparseCsrGet/g;
     $ft{'library'} += s/\bcusparseCsrSetPointers\b/hipsparseCsrSetPointers/g;
@@ -1773,6 +1781,7 @@ sub simpleSubstitutions {
     $ft{'library'} += s/\bcusparseDcsr2bsr\b/hipsparseDcsr2bsr/g;
     $ft{'library'} += s/\bcusparseDcsr2csc\b/hipsparseDcsr2csc/g;
     $ft{'library'} += s/\bcusparseDcsr2csr_compress\b/hipsparseDcsr2csr_compress/g;
+    $ft{'library'} += s/\bcusparseDcsr2csru\b/hipsparseDcsr2csru/g;
     $ft{'library'} += s/\bcusparseDcsr2dense\b/hipsparseDcsr2dense/g;
     $ft{'library'} += s/\bcusparseDcsr2gebsr\b/hipsparseDcsr2gebsr/g;
     $ft{'library'} += s/\bcusparseDcsr2gebsr_bufferSize\b/hipsparseDcsr2gebsr_bufferSize/g;
@@ -1802,9 +1811,14 @@ sub simpleSubstitutions {
     $ft{'library'} += s/\bcusparseDcsrsv2_bufferSize\b/hipsparseDcsrsv2_bufferSize/g;
     $ft{'library'} += s/\bcusparseDcsrsv2_bufferSizeExt\b/hipsparseDcsrsv2_bufferSizeExt/g;
     $ft{'library'} += s/\bcusparseDcsrsv2_solve\b/hipsparseDcsrsv2_solve/g;
+    $ft{'library'} += s/\bcusparseDcsru2csr\b/hipsparseDcsru2csr/g;
+    $ft{'library'} += s/\bcusparseDcsru2csr_bufferSizeExt\b/hipsparseDcsru2csr_bufferSizeExt/g;
     $ft{'library'} += s/\bcusparseDdense2csc\b/hipsparseDdense2csc/g;
     $ft{'library'} += s/\bcusparseDdense2csr\b/hipsparseDdense2csr/g;
     $ft{'library'} += s/\bcusparseDdoti\b/hipsparseDdoti/g;
+    $ft{'library'} += s/\bcusparseDenseToSparse_analysis\b/hipsparseDenseToSparse_analysis/g;
+    $ft{'library'} += s/\bcusparseDenseToSparse_bufferSize\b/hipsparseDenseToSparse_bufferSize/g;
+    $ft{'library'} += s/\bcusparseDenseToSparse_convert\b/hipsparseDenseToSparse_convert/g;
     $ft{'library'} += s/\bcusparseDestroy\b/hipsparseDestroy/g;
     $ft{'library'} += s/\bcusparseDestroyBsric02Info\b/hipsparseDestroyBsric02Info/g;
     $ft{'library'} += s/\bcusparseDestroyBsrilu02Info\b/hipsparseDestroyBsrilu02Info/g;
@@ -1814,6 +1828,8 @@ sub simpleSubstitutions {
     $ft{'library'} += s/\bcusparseDestroyCsrilu02Info\b/hipsparseDestroyCsrilu02Info/g;
     $ft{'library'} += s/\bcusparseDestroyCsrsm2Info\b/hipsparseDestroyCsrsm2Info/g;
     $ft{'library'} += s/\bcusparseDestroyCsrsv2Info\b/hipsparseDestroyCsrsv2Info/g;
+    $ft{'library'} += s/\bcusparseDestroyCsru2csrInfo\b/hipsparseDestroyCsru2csrInfo/g;
+    $ft{'library'} += s/\bcusparseDestroyDnMat\b/hipsparseDestroyDnMat/g;
     $ft{'library'} += s/\bcusparseDestroyDnVec\b/hipsparseDestroyDnVec/g;
     $ft{'library'} += s/\bcusparseDestroyHybMat\b/hipsparseDestroyHybMat/g;
     $ft{'library'} += s/\bcusparseDestroyMatDescr\b/hipsparseDestroyMatDescr/g;
@@ -1830,6 +1846,9 @@ sub simpleSubstitutions {
     $ft{'library'} += s/\bcusparseDgthrz\b/hipsparseDgthrz/g;
     $ft{'library'} += s/\bcusparseDhyb2csr\b/hipsparseDhyb2csr/g;
     $ft{'library'} += s/\bcusparseDhybmv\b/hipsparseDhybmv/g;
+    $ft{'library'} += s/\bcusparseDnMatGet\b/hipsparseDnMatGet/g;
+    $ft{'library'} += s/\bcusparseDnMatGetValues\b/hipsparseDnMatGetValues/g;
+    $ft{'library'} += s/\bcusparseDnMatSetValues\b/hipsparseDnMatSetValues/g;
     $ft{'library'} += s/\bcusparseDnVecGet\b/hipsparseDnVecGet/g;
     $ft{'library'} += s/\bcusparseDnVecGetValues\b/hipsparseDnVecGetValues/g;
     $ft{'library'} += s/\bcusparseDnVecSetValues\b/hipsparseDnVecSetValues/g;
@@ -1878,6 +1897,7 @@ sub simpleSubstitutions {
     $ft{'library'} += s/\bcusparseScsr2bsr\b/hipsparseScsr2bsr/g;
     $ft{'library'} += s/\bcusparseScsr2csc\b/hipsparseScsr2csc/g;
     $ft{'library'} += s/\bcusparseScsr2csr_compress\b/hipsparseScsr2csr_compress/g;
+    $ft{'library'} += s/\bcusparseScsr2csru\b/hipsparseScsr2csru/g;
     $ft{'library'} += s/\bcusparseScsr2dense\b/hipsparseScsr2dense/g;
     $ft{'library'} += s/\bcusparseScsr2gebsr\b/hipsparseScsr2gebsr/g;
     $ft{'library'} += s/\bcusparseScsr2gebsr_bufferSize\b/hipsparseScsr2gebsr_bufferSize/g;
@@ -1907,6 +1927,8 @@ sub simpleSubstitutions {
     $ft{'library'} += s/\bcusparseScsrsv2_bufferSize\b/hipsparseScsrsv2_bufferSize/g;
     $ft{'library'} += s/\bcusparseScsrsv2_bufferSizeExt\b/hipsparseScsrsv2_bufferSizeExt/g;
     $ft{'library'} += s/\bcusparseScsrsv2_solve\b/hipsparseScsrsv2_solve/g;
+    $ft{'library'} += s/\bcusparseScsru2csr\b/hipsparseScsru2csr/g;
+    $ft{'library'} += s/\bcusparseScsru2csr_bufferSizeExt\b/hipsparseScsru2csr_bufferSizeExt/g;
     $ft{'library'} += s/\bcusparseSdense2csc\b/hipsparseSdense2csc/g;
     $ft{'library'} += s/\bcusparseSdense2csr\b/hipsparseSdense2csr/g;
     $ft{'library'} += s/\bcusparseSdoti\b/hipsparseSdoti/g;
@@ -1933,6 +1955,8 @@ sub simpleSubstitutions {
     $ft{'library'} += s/\bcusparseSpGEMM_createDescr\b/hipsparseSpGEMM_createDescr/g;
     $ft{'library'} += s/\bcusparseSpGEMM_destroyDescr\b/hipsparseSpGEMM_destroyDescr/g;
     $ft{'library'} += s/\bcusparseSpGEMM_workEstimation\b/hipsparseSpGEMM_workEstimation/g;
+    $ft{'library'} += s/\bcusparseSpMM\b/hipsparseSpMM/g;
+    $ft{'library'} += s/\bcusparseSpMM_bufferSize\b/hipsparseSpMM_bufferSize/g;
     $ft{'library'} += s/\bcusparseSpMV\b/hipsparseSpMV/g;
     $ft{'library'} += s/\bcusparseSpMV_bufferSize\b/hipsparseSpMV_bufferSize/g;
     $ft{'library'} += s/\bcusparseSpMatGetFormat\b/hipsparseSpMatGetFormat/g;
@@ -1946,6 +1970,8 @@ sub simpleSubstitutions {
     $ft{'library'} += s/\bcusparseSpVecGetIndexBase\b/hipsparseSpVecGetIndexBase/g;
     $ft{'library'} += s/\bcusparseSpVecGetValues\b/hipsparseSpVecGetValues/g;
     $ft{'library'} += s/\bcusparseSpVecSetValues\b/hipsparseSpVecSetValues/g;
+    $ft{'library'} += s/\bcusparseSparseToDense\b/hipsparseSparseToDense/g;
+    $ft{'library'} += s/\bcusparseSparseToDense_bufferSize\b/hipsparseSparseToDense_bufferSize/g;
     $ft{'library'} += s/\bcusparseSpruneCsr2csr\b/hipsparseSpruneCsr2csr/g;
     $ft{'library'} += s/\bcusparseSpruneCsr2csrByPercentage\b/hipsparseSpruneCsr2csrByPercentage/g;
     $ft{'library'} += s/\bcusparseSpruneCsr2csrByPercentage_bufferSizeExt\b/hipsparseSpruneCsr2csrByPercentage_bufferSizeExt/g;
@@ -2002,6 +2028,7 @@ sub simpleSubstitutions {
     $ft{'library'} += s/\bcusparseZcsr2bsr\b/hipsparseZcsr2bsr/g;
     $ft{'library'} += s/\bcusparseZcsr2csc\b/hipsparseZcsr2csc/g;
     $ft{'library'} += s/\bcusparseZcsr2csr_compress\b/hipsparseZcsr2csr_compress/g;
+    $ft{'library'} += s/\bcusparseZcsr2csru\b/hipsparseZcsr2csru/g;
     $ft{'library'} += s/\bcusparseZcsr2dense\b/hipsparseZcsr2dense/g;
     $ft{'library'} += s/\bcusparseZcsr2gebsr\b/hipsparseZcsr2gebsr/g;
     $ft{'library'} += s/\bcusparseZcsr2gebsr_bufferSize\b/hipsparseZcsr2gebsr_bufferSize/g;
@@ -2031,6 +2058,8 @@ sub simpleSubstitutions {
     $ft{'library'} += s/\bcusparseZcsrsv2_bufferSize\b/hipsparseZcsrsv2_bufferSize/g;
     $ft{'library'} += s/\bcusparseZcsrsv2_bufferSizeExt\b/hipsparseZcsrsv2_bufferSizeExt/g;
     $ft{'library'} += s/\bcusparseZcsrsv2_solve\b/hipsparseZcsrsv2_solve/g;
+    $ft{'library'} += s/\bcusparseZcsru2csr\b/hipsparseZcsru2csr/g;
+    $ft{'library'} += s/\bcusparseZcsru2csr_bufferSizeExt\b/hipsparseZcsru2csr_bufferSizeExt/g;
     $ft{'library'} += s/\bcusparseZdense2csc\b/hipsparseZdense2csc/g;
     $ft{'library'} += s/\bcusparseZdense2csr\b/hipsparseZdense2csr/g;
     $ft{'library'} += s/\bcusparseZdotci\b/hipsparseZdotci/g;
@@ -2377,6 +2406,7 @@ sub simpleSubstitutions {
     $ft{'type'} += s/\bcusparseSpMVAlg_t\b/hipsparseSpMVAlg_t/g;
     $ft{'type'} += s/\bcusparseSpMatDescr_t\b/hipsparseSpMatDescr_t/g;
     $ft{'type'} += s/\bcusparseSpVecDescr_t\b/hipsparseSpVecDescr_t/g;
+    $ft{'type'} += s/\bcusparseSparseToDenseAlg_t\b/hipsparseSparseToDenseAlg_t/g;
     $ft{'type'} += s/\bcusparseStatus_t\b/hipsparseStatus_t/g;
     $ft{'type'} += s/\bpruneInfo_t\b/pruneInfo_t/g;
     $ft{'type'} += s/\bsurfaceReference\b/surfaceReference/g;
@@ -2679,6 +2709,7 @@ sub simpleSubstitutions {
     $ft{'numeric_literal'} += s/\bCUSPARSE_POINTER_MODE_HOST\b/HIPSPARSE_POINTER_MODE_HOST/g;
     $ft{'numeric_literal'} += s/\bCUSPARSE_SOLVE_POLICY_NO_LEVEL\b/HIPSPARSE_SOLVE_POLICY_NO_LEVEL/g;
     $ft{'numeric_literal'} += s/\bCUSPARSE_SOLVE_POLICY_USE_LEVEL\b/HIPSPARSE_SOLVE_POLICY_USE_LEVEL/g;
+    $ft{'numeric_literal'} += s/\bCUSPARSE_SPARSETODENSE_ALG_DEFAULT\b/HIPSPARSE_SPARSETODENSE_ALG_DEFAULT/g;
     $ft{'numeric_literal'} += s/\bCUSPARSE_SPGEMM_DEFAULT\b/HIPSPARSE_SPGEMM_DEFAULT/g;
     $ft{'numeric_literal'} += s/\bCUSPARSE_SPMM_ALG_DEFAULT\b/HIPSPARSE_SPMM_ALG_DEFAULT/g;
     $ft{'numeric_literal'} += s/\bCUSPARSE_SPMM_COO_ALG1\b/HIPSPARSE_SPMM_COO_ALG1/g;
@@ -3979,7 +4010,6 @@ sub warnUnsupportedFunctions {
         "cusparseZgebsr2gebsr_bufferSizeExt",
         "cusparseZgebsr2gebsc_bufferSizeExt",
         "cusparseZdense2hyb",
-        "cusparseZcsru2csr_bufferSizeExt",
         "cusparseZcsrsv_solve",
         "cusparseZcsrsv_analysis",
         "cusparseZcsrsm_solve",
@@ -3989,7 +4019,6 @@ sub warnUnsupportedFunctions {
         "cusparseZcsric0",
         "cusparseZcsrcolor",
         "cusparseZcsr2gebsr_bufferSizeExt",
-        "cusparseZcsr2csru",
         "cusparseZcsc2hyb",
         "cusparseZbsrxmv",
         "cusparseZbsrsm2_solve",
@@ -4000,9 +4029,6 @@ sub warnUnsupportedFunctions {
         "cusparseZbsric02_bufferSizeExt",
         "cusparseXgebsr2csr",
         "cusparseXbsrsm2_zeroPivot",
-        "cusparseSparseToDense_bufferSize",
-        "cusparseSparseToDenseAlg_t",
-        "cusparseSparseToDense",
         "cusparseSpVecDescr",
         "cusparseSpSV_solve",
         "cusparseSpSV_destroyDescr",
@@ -4018,8 +4044,6 @@ sub warnUnsupportedFunctions {
         "cusparseSpMatGetAttribute",
         "cusparseSpMatDescr",
         "cusparseSpMatAttribute_t",
-        "cusparseSpMM_bufferSize",
-        "cusparseSpMM",
         "cusparseSolveAnalysisInfo_t",
         "cusparseSolveAnalysisInfo",
         "cusparseShybsv_solve",
@@ -4044,7 +4068,6 @@ sub warnUnsupportedFunctions {
         "cusparseSgebsr2gebsr_bufferSizeExt",
         "cusparseSgebsr2gebsc_bufferSizeExt",
         "cusparseSdense2hyb",
-        "cusparseScsru2csr_bufferSizeExt",
         "cusparseScsrsv_solve",
         "cusparseScsrsv_analysis",
         "cusparseScsrsm_solve",
@@ -4054,7 +4077,6 @@ sub warnUnsupportedFunctions {
         "cusparseScsric0",
         "cusparseScsrcolor",
         "cusparseScsr2gebsr_bufferSizeExt",
-        "cusparseScsr2csru",
         "cusparseScsc2hyb",
         "cusparseSbsrxmv",
         "cusparseSbsrsm2_solve",
@@ -4079,11 +4101,8 @@ sub warnUnsupportedFunctions {
         "cusparseHpruneCsr2csr",
         "cusparseGetLevelInfo",
         "cusparseDnVecDescr",
-        "cusparseDnMatSetValues",
         "cusparseDnMatSetStridedBatch",
-        "cusparseDnMatGetValues",
         "cusparseDnMatGetStridedBatch",
-        "cusparseDnMatGet",
         "cusparseDhybsv_solve",
         "cusparseDhybsv_analysis",
         "cusparseDhyb2dense",
@@ -4106,15 +4125,9 @@ sub warnUnsupportedFunctions {
         "cusparseDgebsr2gebsr_bufferSizeExt",
         "cusparseDgebsr2gebsc_bufferSizeExt",
         "cusparseDestroySolveAnalysisInfo",
-        "cusparseDestroyDnMat",
-        "cusparseDestroyCsru2csrInfo",
         "cusparseDestroyBsrsm2Info",
-        "cusparseDenseToSparse_convert",
-        "cusparseDenseToSparse_bufferSize",
-        "cusparseDenseToSparse_analysis",
         "cusparseDenseToSparseAlg_t",
         "cusparseDdense2hyb",
-        "cusparseDcsru2csr_bufferSizeExt",
         "cusparseDcsrsv_solve",
         "cusparseDcsrsv_analysis",
         "cusparseDcsrsm_solve",
@@ -4124,7 +4137,6 @@ sub warnUnsupportedFunctions {
         "cusparseDcsric0",
         "cusparseDcsrcolor",
         "cusparseDcsr2gebsr_bufferSizeExt",
-        "cusparseDcsr2csru",
         "cusparseDcsc2hyb",
         "cusparseDbsrxmv",
         "cusparseDbsrsm2_solve",
@@ -4143,14 +4155,9 @@ sub warnUnsupportedFunctions {
         "cusparseCsr2cscEx2",
         "cusparseCsr2cscEx",
         "cusparseCsr2CscAlg_t",
-        "cusparseCscSetPointers",
         "cusparseCreateSolveAnalysisInfo",
-        "cusparseCreateDnMat",
-        "cusparseCreateCsru2csrInfo",
-        "cusparseCreateCsc",
         "cusparseCreateBsrsm2Info",
         "cusparseCooSetStridedBatch",
-        "cusparseCooSetPointers",
         "cusparseContext",
         "cusparseConstrainedGeMM_bufferSize",
         "cusparseConstrainedGeMM",
@@ -4178,7 +4185,6 @@ sub warnUnsupportedFunctions {
         "cusparseCgebsr2gebsr_bufferSizeExt",
         "cusparseCgebsr2gebsc_bufferSizeExt",
         "cusparseCdense2hyb",
-        "cusparseCcsru2csr_bufferSizeExt",
         "cusparseCcsrsv_solve",
         "cusparseCcsrsv_analysis",
         "cusparseCcsrsm_solve",
@@ -4188,7 +4194,6 @@ sub warnUnsupportedFunctions {
         "cusparseCcsric0",
         "cusparseCcsrcolor",
         "cusparseCcsr2gebsr_bufferSizeExt",
-        "cusparseCcsr2csru",
         "cusparseCcsc2hyb",
         "cusparseCbsrxmv",
         "cusparseCbsrsm2_solve",
@@ -6082,7 +6087,6 @@ sub warnUnsupportedFunctions {
         "CUSPARSE_SPMMA_ALG1",
         "CUSPARSE_SPMAT_FILL_MODE",
         "CUSPARSE_SPMAT_DIAG_TYPE",
-        "CUSPARSE_SPARSETODENSE_ALG_DEFAULT",
         "CUSPARSE_DENSETOSPARSE_ALG_DEFAULT",
         "CUSPARSE_CSR2CSC_ALG2",
         "CUSPARSE_CSR2CSC_ALG1",

--- a/doc/markdown/CUSPARSE_API_supported_by_HIP.md
+++ b/doc/markdown/CUSPARSE_API_supported_by_HIP.md
@@ -53,7 +53,7 @@
 |`CUSPARSE_POINTER_MODE_HOST`| | | |`HIPSPARSE_POINTER_MODE_HOST`|1.9.2| | |
 |`CUSPARSE_SOLVE_POLICY_NO_LEVEL`| | | |`HIPSPARSE_SOLVE_POLICY_NO_LEVEL`|1.9.2| | |
 |`CUSPARSE_SOLVE_POLICY_USE_LEVEL`| | | |`HIPSPARSE_SOLVE_POLICY_USE_LEVEL`|1.9.2| | |
-|`CUSPARSE_SPARSETODENSE_ALG_DEFAULT`|11.1| | | | | | |
+|`CUSPARSE_SPARSETODENSE_ALG_DEFAULT`|11.1| | |`HIPSPARSE_SPARSETODENSE_ALG_DEFAULT`|4.2.0| | |
 |`CUSPARSE_SPGEMM_DEFAULT`|11.0| | |`HIPSPARSE_SPGEMM_DEFAULT`|4.1.0| | |
 |`CUSPARSE_SPMAT_DIAG_TYPE`|11.3| | | | | | |
 |`CUSPARSE_SPMAT_FILL_MODE`|11.3| | | | | | |
@@ -150,7 +150,7 @@
 |`cusparseSpSVAlg_t`|11.3| | | | | | |
 |`cusparseSpVecDescr`|10.2| | | | | | |
 |`cusparseSpVecDescr_t`|10.2| | |`hipsparseSpVecDescr_t`|4.1.0| | |
-|`cusparseSparseToDenseAlg_t`|11.1| | | | | | |
+|`cusparseSparseToDenseAlg_t`|11.1| | |`hipsparseSparseToDenseAlg_t`|4.2.0| | |
 |`cusparseStatus_t`| | | |`hipsparseStatus_t`|1.9.2| | |
 |`pruneInfo`|9.0| | | | | | |
 |`pruneInfo_t`|9.0| | |`pruneInfo_t`|3.9.0| | |
@@ -576,13 +576,14 @@
 |`cusparseCcsr2bsr`| | | |`hipsparseCcsr2bsr`|3.5.0| | |
 |`cusparseCcsr2csc`| |10.2|11.0|`hipsparseCcsr2csc`|3.1.0| | |
 |`cusparseCcsr2csr_compress`|8.0| | |`hipsparseCcsr2csr_compress`|3.5.0| | |
-|`cusparseCcsr2csru`| | | | | | | |
+|`cusparseCcsr2csru`| | | |`hipsparseCcsr2csru`|4.2.0| | |
 |`cusparseCcsr2dense`| |11.1| |`hipsparseCcsr2dense`|3.5.0| | |
 |`cusparseCcsr2gebsr`| | | |`hipsparseCcsr2gebsr`|4.1.0| | |
 |`cusparseCcsr2gebsr_bufferSize`| | | |`hipsparseCcsr2gebsr_bufferSize`|4.1.0| | |
 |`cusparseCcsr2gebsr_bufferSizeExt`| | | | | | | |
 |`cusparseCcsr2hyb`| |10.2|11.0|`hipsparseCcsr2hyb`|3.1.0| | |
-|`cusparseCcsru2csr_bufferSizeExt`| | | | | | | |
+|`cusparseCcsru2csr`| | | |`hipsparseCcsru2csr`|4.2.0| | |
+|`cusparseCcsru2csr_bufferSizeExt`| | | |`hipsparseCcsru2csr_bufferSizeExt`|4.2.0| | |
 |`cusparseCdense2csc`| |11.1| |`hipsparseCdense2csc`|3.5.0| | |
 |`cusparseCdense2csr`| |11.1| |`hipsparseCdense2csr`|3.5.0| | |
 |`cusparseCdense2hyb`| |10.2|11.0| | | | |
@@ -598,7 +599,7 @@
 |`cusparseChyb2dense`| |10.2|11.0| | | | |
 |`cusparseCnnz`| | | |`hipsparseCnnz`|3.2.0| | |
 |`cusparseCnnz_compress`|8.0| | |`hipsparseCnnz_compress`|3.5.0| | |
-|`cusparseCreateCsru2csrInfo`| | | | | | | |
+|`cusparseCreateCsru2csrInfo`| | | |`hipsparseCreateCsru2csrInfo`|4.2.0| | |
 |`cusparseCreateIdentityPermutation`| | | |`hipsparseCreateIdentityPermutation`|1.9.2| | |
 |`cusparseCsr2cscEx`|8.0|10.2|11.0| | | | |
 |`cusparseCsr2cscEx2`|10.1| | | | | | |
@@ -609,17 +610,18 @@
 |`cusparseDcsr2bsr`| | | |`hipsparseDcsr2bsr`|3.5.0| | |
 |`cusparseDcsr2csc`| |10.2|11.0|`hipsparseDcsr2csc`|1.9.2| | |
 |`cusparseDcsr2csr_compress`|8.0| | |`hipsparseDcsr2csr_compress`|3.5.0| | |
-|`cusparseDcsr2csru`| | | | | | | |
+|`cusparseDcsr2csru`| | | |`hipsparseDcsr2csru`|4.2.0| | |
 |`cusparseDcsr2dense`| |11.1| |`hipsparseDcsr2dense`|3.5.0| | |
 |`cusparseDcsr2gebsr`| | | |`hipsparseDcsr2gebsr`|4.1.0| | |
 |`cusparseDcsr2gebsr_bufferSize`| | | |`hipsparseDcsr2gebsr_bufferSize`|4.1.0| | |
 |`cusparseDcsr2gebsr_bufferSizeExt`| | | | | | | |
 |`cusparseDcsr2hyb`| |10.2|11.0|`hipsparseDcsr2hyb`|1.9.2| | |
-|`cusparseDcsru2csr_bufferSizeExt`| | | | | | | |
+|`cusparseDcsru2csr`| | | |`hipsparseDcsru2csr`|4.2.0| | |
+|`cusparseDcsru2csr_bufferSizeExt`| | | |`hipsparseDcsru2csr_bufferSizeExt`|4.2.0| | |
 |`cusparseDdense2csc`| |11.1| |`hipsparseDdense2csc`|3.5.0| | |
 |`cusparseDdense2csr`| |11.1| |`hipsparseDdense2csr`|3.5.0| | |
 |`cusparseDdense2hyb`| |10.2|11.0| | | | |
-|`cusparseDestroyCsru2csrInfo`| | | | | | | |
+|`cusparseDestroyCsru2csrInfo`| | | |`hipsparseDestroyCsru2csrInfo`|4.2.0| | |
 |`cusparseDgebsr2csr`| | | |`hipsparseDgebsr2csr`|4.1.0| | |
 |`cusparseDgebsr2gebsc`| | | |`hipsparseDgebsr2gebsc`|4.1.0| | |
 |`cusparseDgebsr2gebsc_bufferSize`| | | |`hipsparseDgebsr2gebsc_bufferSize`|4.1.0| | |
@@ -662,13 +664,14 @@
 |`cusparseScsr2bsr`| | | |`hipsparseScsr2bsr`|3.5.0| | |
 |`cusparseScsr2csc`| |10.2|11.0|`hipsparseScsr2csc`|1.9.2| | |
 |`cusparseScsr2csr_compress`|8.0| | |`hipsparseScsr2csr_compress`|3.5.0| | |
-|`cusparseScsr2csru`| | | | | | | |
+|`cusparseScsr2csru`| | | |`hipsparseScsr2csru`|4.2.0| | |
 |`cusparseScsr2dense`| |11.1| |`hipsparseScsr2dense`|3.5.0| | |
 |`cusparseScsr2gebsr`| | | |`hipsparseScsr2gebsr`|4.1.0| | |
 |`cusparseScsr2gebsr_bufferSize`| | | |`hipsparseScsr2gebsr_bufferSize`|4.1.0| | |
 |`cusparseScsr2gebsr_bufferSizeExt`| | | | | | | |
 |`cusparseScsr2hyb`| |10.2|11.0|`hipsparseScsr2hyb`|1.9.2| | |
-|`cusparseScsru2csr_bufferSizeExt`| | | | | | | |
+|`cusparseScsru2csr`| | | |`hipsparseScsru2csr`|4.2.0| | |
+|`cusparseScsru2csr_bufferSizeExt`| | | |`hipsparseScsru2csr_bufferSizeExt`|4.2.0| | |
 |`cusparseSdense2csc`| |11.1| |`hipsparseSdense2csc`|3.5.0| | |
 |`cusparseSdense2csr`| |11.1| |`hipsparseSdense2csr`|3.5.0| | |
 |`cusparseSdense2hyb`| |10.2|11.0| | | | |
@@ -715,13 +718,14 @@
 |`cusparseZcsr2bsr`| | | |`hipsparseZcsr2bsr`|3.5.0| | |
 |`cusparseZcsr2csc`| |10.2|11.0|`hipsparseZcsr2csc`|3.1.0| | |
 |`cusparseZcsr2csr_compress`|8.0| | |`hipsparseZcsr2csr_compress`|3.5.0| | |
-|`cusparseZcsr2csru`| | | | | | | |
+|`cusparseZcsr2csru`| | | |`hipsparseZcsr2csru`|4.2.0| | |
 |`cusparseZcsr2dense`| |11.1| |`hipsparseZcsr2dense`|3.5.0| | |
 |`cusparseZcsr2gebsr`| | | |`hipsparseZcsr2gebsr`|4.1.0| | |
 |`cusparseZcsr2gebsr_bufferSize`| | | |`hipsparseZcsr2gebsr_bufferSize`|4.1.0| | |
 |`cusparseZcsr2gebsr_bufferSizeExt`| | | | | | | |
 |`cusparseZcsr2hyb`| |10.2|11.0|`hipsparseZcsr2hyb`|3.1.0| | |
-|`cusparseZcsru2csr_bufferSizeExt`| | | | | | | |
+|`cusparseZcsru2csr`| | | |`hipsparseZcsru2csr`|4.2.0| | |
+|`cusparseZcsru2csr_bufferSizeExt`| | | |`hipsparseZcsru2csr_bufferSizeExt`|4.2.0| | |
 |`cusparseZdense2csc`| |11.1| |`hipsparseZdense2csc`|3.5.0| | |
 |`cusparseZdense2csr`| |11.1| |`hipsparseZdense2csr`|3.5.0| | |
 |`cusparseZdense2hyb`| |10.2|11.0| | | | |
@@ -747,31 +751,31 @@
 |`cusparseConstrainedGeMM_bufferSize`|10.2| | | | | | |
 |`cusparseCooAoSGet`|10.2| | |`hipsparseCooAoSGet`|4.1.0| | |
 |`cusparseCooGet`|10.1| | |`hipsparseCooGet`|4.1.0| | |
-|`cusparseCooSetPointers`|11.1| | | | | | |
+|`cusparseCooSetPointers`|11.1| | |`hipsparseCooSetPointers`|4.2.0| | |
 |`cusparseCooSetStridedBatch`|11.0| | | | | | |
 |`cusparseCreateCoo`|10.1| | |`hipsparseCreateCoo`|4.1.0| | |
 |`cusparseCreateCooAoS`|10.2| | |`hipsparseCreateCooAoS`|4.1.0| | |
-|`cusparseCreateCsc`|11.1| | | | | | |
+|`cusparseCreateCsc`|11.1| | |`hipsparseCreateCsc`|4.2.0| | |
 |`cusparseCreateCsr`|10.2| | |`hipsparseCreateCsr`|4.1.0| | |
-|`cusparseCreateDnMat`|10.1| | | | | | |
+|`cusparseCreateDnMat`|10.1| | |`hipsparseCreateDnMat`|4.2.0| | |
 |`cusparseCreateDnVec`|10.2| | |`hipsparseCreateDnVec`|4.1.0| | |
 |`cusparseCreateSpVec`|10.2| | |`hipsparseCreateSpVec`|4.1.0| | |
-|`cusparseCscSetPointers`|11.1| | | | | | |
+|`cusparseCscSetPointers`|11.1| | |`hipsparseCscSetPointers`|4.2.0| | |
 |`cusparseCsrGet`|10.2| | |`hipsparseCsrGet`|4.1.0| | |
 |`cusparseCsrSetPointers`|11.0| | |`hipsparseCsrSetPointers`|4.1.0| | |
 |`cusparseCsrSetStridedBatch`|11.0| | | | | | |
-|`cusparseDenseToSparse_analysis`|11.1| | | | | | |
-|`cusparseDenseToSparse_bufferSize`|11.1| | | | | | |
-|`cusparseDenseToSparse_convert`|11.1| | | | | | |
-|`cusparseDestroyDnMat`|10.1| | | | | | |
+|`cusparseDenseToSparse_analysis`|11.1| | |`hipsparseDenseToSparse_analysis`|4.2.0| | |
+|`cusparseDenseToSparse_bufferSize`|11.1| | |`hipsparseDenseToSparse_bufferSize`|4.2.0| | |
+|`cusparseDenseToSparse_convert`|11.1| | |`hipsparseDenseToSparse_convert`|4.2.0| | |
+|`cusparseDestroyDnMat`|10.1| | |`hipsparseDestroyDnMat`|4.2.0| | |
 |`cusparseDestroyDnVec`|10.2| | |`hipsparseDestroyDnVec`|4.1.0| | |
 |`cusparseDestroySpMat`|10.1| | |`hipsparseDestroySpMat`|4.1.0| | |
 |`cusparseDestroySpVec`|10.2| | |`hipsparseDestroySpVec`|4.1.0| | |
-|`cusparseDnMatGet`|10.1| | | | | | |
+|`cusparseDnMatGet`|10.1| | |`hipsparseDnMatGet`|4.2.0| | |
 |`cusparseDnMatGetStridedBatch`|10.1| | | | | | |
-|`cusparseDnMatGetValues`|10.2| | | | | | |
+|`cusparseDnMatGetValues`|10.2| | |`hipsparseDnMatGetValues`|4.2.0| | |
 |`cusparseDnMatSetStridedBatch`|10.1| | | | | | |
-|`cusparseDnMatSetValues`|10.2| | | | | | |
+|`cusparseDnMatSetValues`|10.2| | |`hipsparseDnMatSetValues`|4.2.0| | |
 |`cusparseDnVecGet`|10.2| | |`hipsparseDnVecGet`|4.1.0| | |
 |`cusparseDnVecGetValues`|10.2| | |`hipsparseDnVecGetValues`|4.1.0| | |
 |`cusparseDnVecSetValues`|10.2| | |`hipsparseDnVecSetValues`|4.1.0| | |
@@ -783,8 +787,8 @@
 |`cusparseSpGEMM_createDescr`|11.0| | |`hipsparseSpGEMM_createDescr`|4.1.0| | |
 |`cusparseSpGEMM_destroyDescr`|11.0| | |`hipsparseSpGEMM_destroyDescr`|4.1.0| | |
 |`cusparseSpGEMM_workEstimation`| | | |`hipsparseSpGEMM_workEstimation`|4.1.0| | |
-|`cusparseSpMM`|10.1| | | | | | |
-|`cusparseSpMM_bufferSize`|10.1| | | | | | |
+|`cusparseSpMM`|10.1| | |`hipsparseSpMM`|4.2.0| | |
+|`cusparseSpMM_bufferSize`|10.1| | |`hipsparseSpMM_bufferSize`|4.2.0| | |
 |`cusparseSpMV`|10.2| | |`hipsparseSpMV`|4.1.0| | |
 |`cusparseSpMV_bufferSize`|10.2| | |`hipsparseSpMV_bufferSize`|4.1.0| | |
 |`cusparseSpMatGetAttribute`|11.3| | | | | | |
@@ -809,8 +813,8 @@
 |`cusparseSpVecGetIndexBase`|10.2| | |`hipsparseSpVecGetIndexBase`|4.1.0| | |
 |`cusparseSpVecGetValues`|10.2| | |`hipsparseSpVecGetValues`|4.1.0| | |
 |`cusparseSpVecSetValues`|10.2| | |`hipsparseSpVecSetValues`|4.1.0| | |
-|`cusparseSparseToDense`|11.1| | | | | | |
-|`cusparseSparseToDense_bufferSize`|11.1| | | | | | |
+|`cusparseSparseToDense`|11.1| | |`hipsparseSparseToDense`|4.2.0| | |
+|`cusparseSparseToDense_bufferSize`|11.1| | |`hipsparseSparseToDense_bufferSize`|4.2.0| | |
 
 
 \*A - Added; D - Deprecated; R - Removed

--- a/src/CUDA2HIP_SPARSE_API_functions.cpp
+++ b/src/CUDA2HIP_SPARSE_API_functions.cpp
@@ -631,18 +631,23 @@ const std::map<llvm::StringRef, hipCounter> CUDA_SPARSE_FUNCTION_MAP {
   {"cusparseXcscsort_bufferSizeExt",                    {"hipsparseXcscsort_bufferSizeExt",                    "", CONV_LIB_FUNC, API_SPARSE, 13}},
   {"cusparseXcscsort",                                  {"hipsparseXcscsort",                                  "", CONV_LIB_FUNC, API_SPARSE, 13}},
 
-  {"cusparseCreateCsru2csrInfo",                        {"hipsparseCreateCsru2csrInfo",                        "", CONV_LIB_FUNC, API_SPARSE, 13, HIP_UNSUPPORTED}},
-  {"cusparseDestroyCsru2csrInfo",                       {"hipsparseDestroyCsru2csrInfo",                       "", CONV_LIB_FUNC, API_SPARSE, 13, HIP_UNSUPPORTED}},
+  {"cusparseCreateCsru2csrInfo",                        {"hipsparseCreateCsru2csrInfo",                        "", CONV_LIB_FUNC, API_SPARSE, 13}},
+  {"cusparseDestroyCsru2csrInfo",                       {"hipsparseDestroyCsru2csrInfo",                       "", CONV_LIB_FUNC, API_SPARSE, 13}},
 
-  {"cusparseScsru2csr_bufferSizeExt",                   {"hipsparseScsru2csr_bufferSizeExt",                   "", CONV_LIB_FUNC, API_SPARSE, 13, HIP_UNSUPPORTED}},
-  {"cusparseDcsru2csr_bufferSizeExt",                   {"hipsparseDcsru2csr_bufferSizeExt",                   "", CONV_LIB_FUNC, API_SPARSE, 13, HIP_UNSUPPORTED}},
-  {"cusparseCcsru2csr_bufferSizeExt",                   {"hipsparseCcsru2csr_bufferSizeExt",                   "", CONV_LIB_FUNC, API_SPARSE, 13, HIP_UNSUPPORTED}},
-  {"cusparseZcsru2csr_bufferSizeExt",                   {"hipsparseZcsru2csr_bufferSizeExt",                   "", CONV_LIB_FUNC, API_SPARSE, 13, HIP_UNSUPPORTED}},
+  {"cusparseScsru2csr",                                 {"hipsparseScsru2csr",                                 "", CONV_LIB_FUNC, API_SPARSE, 13}},
+  {"cusparseDcsru2csr",                                 {"hipsparseDcsru2csr",                                 "", CONV_LIB_FUNC, API_SPARSE, 13}},
+  {"cusparseCcsru2csr",                                 {"hipsparseCcsru2csr",                                 "", CONV_LIB_FUNC, API_SPARSE, 13}},
+  {"cusparseZcsru2csr",                                 {"hipsparseZcsru2csr",                                 "", CONV_LIB_FUNC, API_SPARSE, 13}},
 
-  {"cusparseScsr2csru",                                 {"hipsparseScsr2csru",                                 "", CONV_LIB_FUNC, API_SPARSE, 13, HIP_UNSUPPORTED}},
-  {"cusparseDcsr2csru",                                 {"hipsparseDcsr2csru",                                 "", CONV_LIB_FUNC, API_SPARSE, 13, HIP_UNSUPPORTED}},
-  {"cusparseCcsr2csru",                                 {"hipsparseCcsr2csru",                                 "", CONV_LIB_FUNC, API_SPARSE, 13, HIP_UNSUPPORTED}},
-  {"cusparseZcsr2csru",                                 {"hipsparseZcsr2csru",                                 "", CONV_LIB_FUNC, API_SPARSE, 13, HIP_UNSUPPORTED}},
+  {"cusparseScsru2csr_bufferSizeExt",                   {"hipsparseScsru2csr_bufferSizeExt",                   "", CONV_LIB_FUNC, API_SPARSE, 13}},
+  {"cusparseDcsru2csr_bufferSizeExt",                   {"hipsparseDcsru2csr_bufferSizeExt",                   "", CONV_LIB_FUNC, API_SPARSE, 13}},
+  {"cusparseCcsru2csr_bufferSizeExt",                   {"hipsparseCcsru2csr_bufferSizeExt",                   "", CONV_LIB_FUNC, API_SPARSE, 13}},
+  {"cusparseZcsru2csr_bufferSizeExt",                   {"hipsparseZcsru2csr_bufferSizeExt",                   "", CONV_LIB_FUNC, API_SPARSE, 13}},
+
+  {"cusparseScsr2csru",                                 {"hipsparseScsr2csru",                                 "", CONV_LIB_FUNC, API_SPARSE, 13}},
+  {"cusparseDcsr2csru",                                 {"hipsparseDcsr2csru",                                 "", CONV_LIB_FUNC, API_SPARSE, 13}},
+  {"cusparseCcsr2csru",                                 {"hipsparseCcsr2csru",                                 "", CONV_LIB_FUNC, API_SPARSE, 13}},
+  {"cusparseZcsr2csru",                                 {"hipsparseZcsr2csru",                                 "", CONV_LIB_FUNC, API_SPARSE, 13}},
 
   {"cusparseHpruneDense2csr",                           {"hipsparseHpruneDense2csr",                           "", CONV_LIB_FUNC, API_SPARSE, 13, HIP_UNSUPPORTED}},
   {"cusparseSpruneDense2csr",                           {"hipsparseSpruneDense2csr",                           "", CONV_LIB_FUNC, API_SPARSE, 13}},
@@ -703,15 +708,15 @@ const std::map<llvm::StringRef, hipCounter> CUDA_SPARSE_FUNCTION_MAP {
   {"cusparseCreateCoo",                                 {"hipsparseCreateCoo",                                 "", CONV_LIB_FUNC, API_SPARSE, 14}},
   {"cusparseCreateCooAoS",                              {"hipsparseCreateCooAoS",                              "", CONV_LIB_FUNC, API_SPARSE, 14}},
   {"cusparseCreateCsr",                                 {"hipsparseCreateCsr",                                 "", CONV_LIB_FUNC, API_SPARSE, 14}},
-  {"cusparseCreateCsc",                                 {"hipsparseCreateCsc",                                 "", CONV_LIB_FUNC, API_SPARSE, 14, HIP_UNSUPPORTED}},
+  {"cusparseCreateCsc",                                 {"hipsparseCreateCsc",                                 "", CONV_LIB_FUNC, API_SPARSE, 14}},
   {"cusparseDestroySpMat",                              {"hipsparseDestroySpMat",                              "", CONV_LIB_FUNC, API_SPARSE, 14}},
   {"cusparseCooGet",                                    {"hipsparseCooGet",                                    "", CONV_LIB_FUNC, API_SPARSE, 14}},
   {"cusparseCooAoSGet",                                 {"hipsparseCooAoSGet",                                 "", CONV_LIB_FUNC, API_SPARSE, 14}},
   {"cusparseCooSetStridedBatch",                        {"hipsparseCooSetStridedBatch",                        "", CONV_LIB_FUNC, API_SPARSE, 14, HIP_UNSUPPORTED}},
   {"cusparseCsrGet",                                    {"hipsparseCsrGet",                                    "", CONV_LIB_FUNC, API_SPARSE, 14}},
   {"cusparseCsrSetPointers",                            {"hipsparseCsrSetPointers",                            "", CONV_LIB_FUNC, API_SPARSE, 14}},
-  {"cusparseCscSetPointers",                            {"hipsparseCscSetPointers",                            "", CONV_LIB_FUNC, API_SPARSE, 14, HIP_UNSUPPORTED}},
-  {"cusparseCooSetPointers",                            {"hipsparseCooSetPointers",                            "", CONV_LIB_FUNC, API_SPARSE, 14, HIP_UNSUPPORTED}},
+  {"cusparseCscSetPointers",                            {"hipsparseCscSetPointers",                            "", CONV_LIB_FUNC, API_SPARSE, 14}},
+  {"cusparseCooSetPointers",                            {"hipsparseCooSetPointers",                            "", CONV_LIB_FUNC, API_SPARSE, 14}},
   {"cusparseCsrSetStridedBatch",                        {"hipsparseCsrSetStridedBatch",                        "", CONV_LIB_FUNC, API_SPARSE, 14, HIP_UNSUPPORTED}},
   {"cusparseSpMatGetFormat",                            {"hipsparseSpMatGetFormat",                            "", CONV_LIB_FUNC, API_SPARSE, 14}},
   {"cusparseSpMatGetIndexBase",                         {"hipsparseSpMatGetIndexBase",                         "", CONV_LIB_FUNC, API_SPARSE, 14}},
@@ -734,11 +739,11 @@ const std::map<llvm::StringRef, hipCounter> CUDA_SPARSE_FUNCTION_MAP {
 
   // Generic Dense API helper functions
   // Dense Matrix descriptor
-  {"cusparseCreateDnMat",                               {"hipsparseCreateDnMat",                               "", CONV_LIB_FUNC, API_SPARSE, 14, HIP_UNSUPPORTED}},
-  {"cusparseDestroyDnMat",                              {"hipsparseDestroyDnMat",                              "", CONV_LIB_FUNC, API_SPARSE, 14, HIP_UNSUPPORTED}},
-  {"cusparseDnMatGet",                                  {"hipsparseDnMatGet",                                  "", CONV_LIB_FUNC, API_SPARSE, 14, HIP_UNSUPPORTED}},
-  {"cusparseDnMatGetValues",                            {"hipsparseDnMatGetValues",                            "", CONV_LIB_FUNC, API_SPARSE, 14, HIP_UNSUPPORTED}},
-  {"cusparseDnMatSetValues",                            {"hipsparseDnMatSetValues",                            "", CONV_LIB_FUNC, API_SPARSE, 14, HIP_UNSUPPORTED}},
+  {"cusparseCreateDnMat",                               {"hipsparseCreateDnMat",                               "", CONV_LIB_FUNC, API_SPARSE, 14}},
+  {"cusparseDestroyDnMat",                              {"hipsparseDestroyDnMat",                              "", CONV_LIB_FUNC, API_SPARSE, 14}},
+  {"cusparseDnMatGet",                                  {"hipsparseDnMatGet",                                  "", CONV_LIB_FUNC, API_SPARSE, 14}},
+  {"cusparseDnMatGetValues",                            {"hipsparseDnMatGetValues",                            "", CONV_LIB_FUNC, API_SPARSE, 14}},
+  {"cusparseDnMatSetValues",                            {"hipsparseDnMatSetValues",                            "", CONV_LIB_FUNC, API_SPARSE, 14}},
   {"cusparseDnMatSetStridedBatch",                      {"hipsparseDnMatSetStridedBatch",                      "", CONV_LIB_FUNC, API_SPARSE, 14, HIP_UNSUPPORTED}},
   {"cusparseDnMatGetStridedBatch",                      {"hipsparseDnMatGetStridedBatch",                      "", CONV_LIB_FUNC, API_SPARSE, 14, HIP_UNSUPPORTED}},
   // Dense Vector descriptor
@@ -762,8 +767,8 @@ const std::map<llvm::StringRef, hipCounter> CUDA_SPARSE_FUNCTION_MAP {
   {"cusparseSpSV_solve",                                {"hipsparseSpSV_solve",                                "", CONV_LIB_FUNC, API_SPARSE, 14, HIP_UNSUPPORTED}},
 
   // Sparse Matrix * Matrix Multiplication
-  {"cusparseSpMM",                                      {"hipsparseSpMM",                                      "", CONV_LIB_FUNC, API_SPARSE, 14, HIP_UNSUPPORTED}},
-  {"cusparseSpMM_bufferSize",                           {"hipsparseSpMM_bufferSize",                           "", CONV_LIB_FUNC, API_SPARSE, 14, HIP_UNSUPPORTED}},
+  {"cusparseSpMM",                                      {"hipsparseSpMM",                                      "", CONV_LIB_FUNC, API_SPARSE, 14}},
+  {"cusparseSpMM_bufferSize",                           {"hipsparseSpMM_bufferSize",                           "", CONV_LIB_FUNC, API_SPARSE, 14}},
 
   // Sparse Matrix * Matrix Pattern-constrained Multiplication
   {"cusparseConstrainedGeMM",                           {"hipsparseConstrainedGeMM",                           "", CONV_LIB_FUNC, API_SPARSE, 14, HIP_UNSUPPORTED}},
@@ -782,11 +787,11 @@ const std::map<llvm::StringRef, hipCounter> CUDA_SPARSE_FUNCTION_MAP {
   {"cusparseSpMV",                                      {"hipsparseSpMV",                                      "", CONV_LIB_FUNC, API_SPARSE, 14}},
   {"cusparseSpMV_bufferSize",                           {"hipsparseSpMV_bufferSize",                           "", CONV_LIB_FUNC, API_SPARSE, 14}},
 
-  {"cusparseSparseToDense",                             {"hipsparseSparseToDense",                             "", CONV_LIB_FUNC, API_SPARSE, 14, HIP_UNSUPPORTED}},
-  {"cusparseSparseToDense_bufferSize",                  {"hipsparseSparseToDense_bufferSize",                  "", CONV_LIB_FUNC, API_SPARSE, 14, HIP_UNSUPPORTED}},
-  {"cusparseDenseToSparse_bufferSize",                  {"hipsparseDenseToSparse_bufferSize",                  "", CONV_LIB_FUNC, API_SPARSE, 14, HIP_UNSUPPORTED}},
-  {"cusparseDenseToSparse_analysis",                    {"hipsparseDenseToSparse_analysis",                    "", CONV_LIB_FUNC, API_SPARSE, 14, HIP_UNSUPPORTED}},
-  {"cusparseDenseToSparse_convert",                     {"hipsparseDenseToSparse_convert",                     "", CONV_LIB_FUNC, API_SPARSE, 14, HIP_UNSUPPORTED}},
+  {"cusparseSparseToDense",                             {"hipsparseSparseToDense",                             "", CONV_LIB_FUNC, API_SPARSE, 14}},
+  {"cusparseSparseToDense_bufferSize",                  {"hipsparseSparseToDense_bufferSize",                  "", CONV_LIB_FUNC, API_SPARSE, 14}},
+  {"cusparseDenseToSparse_bufferSize",                  {"hipsparseDenseToSparse_bufferSize",                  "", CONV_LIB_FUNC, API_SPARSE, 14}},
+  {"cusparseDenseToSparse_analysis",                    {"hipsparseDenseToSparse_analysis",                    "", CONV_LIB_FUNC, API_SPARSE, 14}},
+  {"cusparseDenseToSparse_convert",                     {"hipsparseDenseToSparse_convert",                     "", CONV_LIB_FUNC, API_SPARSE, 14}},
 };
 
 const std::map<llvm::StringRef, cudaAPIversions> CUDA_SPARSE_FUNCTION_VER_MAP {
@@ -1549,6 +1554,35 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_SPARSE_FUNCTION_VER_MAP {
   {"hipsparseRot",                                       {HIP_4010, HIP_0,    HIP_0   }},
   {"hipsparseSpMV",                                      {HIP_4010, HIP_0,    HIP_0   }},
   {"hipsparseSpMV_bufferSize",                           {HIP_4010, HIP_0,    HIP_0   }},
+  {"hipsparseCreateCsru2csrInfo",                        {HIP_4020, HIP_0,    HIP_0   }},
+  {"hipsparseDestroyCsru2csrInfo",                       {HIP_4020, HIP_0,    HIP_0   }},
+  {"hipsparseScsru2csr_bufferSizeExt",                   {HIP_4020, HIP_0,    HIP_0   }},
+  {"hipsparseDcsru2csr_bufferSizeExt",                   {HIP_4020, HIP_0,    HIP_0   }},
+  {"hipsparseCcsru2csr_bufferSizeExt",                   {HIP_4020, HIP_0,    HIP_0   }},
+  {"hipsparseZcsru2csr_bufferSizeExt",                   {HIP_4020, HIP_0,    HIP_0   }},
+  {"hipsparseScsru2csr",                                 {HIP_4020, HIP_0,    HIP_0   }},
+  {"hipsparseDcsru2csr",                                 {HIP_4020, HIP_0,    HIP_0   }},
+  {"hipsparseCcsru2csr",                                 {HIP_4020, HIP_0,    HIP_0   }},
+  {"hipsparseZcsru2csr",                                 {HIP_4020, HIP_0,    HIP_0   }},
+  {"hipsparseScsr2csru",                                 {HIP_4020, HIP_0,    HIP_0   }},
+  {"hipsparseDcsr2csru",                                 {HIP_4020, HIP_0,    HIP_0   }},
+  {"hipsparseCcsr2csru",                                 {HIP_4020, HIP_0,    HIP_0   }},
+  {"hipsparseZcsr2csru",                                 {HIP_4020, HIP_0,    HIP_0   }},
+  {"hipsparseCreateCsc",                                 {HIP_4020, HIP_0,    HIP_0   }},
+  {"hipsparseCscSetPointers",                            {HIP_4020, HIP_0,    HIP_0   }},
+  {"hipsparseCooSetPointers",                            {HIP_4020, HIP_0,    HIP_0   }},
+  {"hipsparseCreateDnMat",                               {HIP_4020, HIP_0,    HIP_0   }},
+  {"hipsparseDestroyDnMat",                              {HIP_4020, HIP_0,    HIP_0   }},
+  {"hipsparseDnMatGet",                                  {HIP_4020, HIP_0,    HIP_0   }},
+  {"hipsparseDnMatGetValues",                            {HIP_4020, HIP_0,    HIP_0   }},
+  {"hipsparseDnMatSetValues",                            {HIP_4020, HIP_0,    HIP_0   }},
+  {"hipsparseSparseToDense_bufferSize",                  {HIP_4020, HIP_0,    HIP_0   }},
+  {"hipsparseSparseToDense",                             {HIP_4020, HIP_0,    HIP_0   }},
+  {"hipsparseDenseToSparse_bufferSize",                  {HIP_4020, HIP_0,    HIP_0   }},
+  {"hipsparseDenseToSparse_analysis",                    {HIP_4020, HIP_0,    HIP_0   }},
+  {"hipsparseDenseToSparse_convert",                     {HIP_4020, HIP_0,    HIP_0   }},
+  {"hipsparseSpMM_bufferSize",                           {HIP_4020, HIP_0,    HIP_0   }},
+  {"hipsparseSpMM",                                      {HIP_4020, HIP_0,    HIP_0   }},
 };
 
 const std::map<unsigned int, llvm::StringRef> CUDA_SPARSE_API_SECTION_MAP {

--- a/src/CUDA2HIP_SPARSE_API_types.cpp
+++ b/src/CUDA2HIP_SPARSE_API_types.cpp
@@ -205,8 +205,8 @@ const std::map<llvm::StringRef, hipCounter> CUDA_SPARSE_TYPE_NAME_MAP {
   {"cusparseDenseToSparseAlg_t",                {"hipsparseDenseToSparseAlg_t",                "", CONV_TYPE, API_SPARSE, 4, HIP_UNSUPPORTED}},
   {"CUSPARSE_DENSETOSPARSE_ALG_DEFAULT",        {"HIPSPARSE_DENSETOSPARSE_ALG_DEFAULT",        "", CONV_NUMERIC_LITERAL, API_SPARSE, 4, HIP_UNSUPPORTED}},
 
-  {"cusparseSparseToDenseAlg_t",                {"hipsparseSparseToDenseAlg_t",                "", CONV_TYPE, API_SPARSE, 4, HIP_UNSUPPORTED}},
-  {"CUSPARSE_SPARSETODENSE_ALG_DEFAULT",        {"HIPSPARSE_SPARSETODENSE_ALG_DEFAULT",        "", CONV_NUMERIC_LITERAL, API_SPARSE, 4, HIP_UNSUPPORTED}},
+  {"cusparseSparseToDenseAlg_t",                {"hipsparseSparseToDenseAlg_t",                "", CONV_TYPE, API_SPARSE, 4}},
+  {"CUSPARSE_SPARSETODENSE_ALG_DEFAULT",        {"HIPSPARSE_SPARSETODENSE_ALG_DEFAULT",        "", CONV_NUMERIC_LITERAL, API_SPARSE, 4}},
 
   {"cusparseSpMatAttribute_t",                  {"hipsparseSpMatAttribute_t",                  "", CONV_TYPE, API_SPARSE, 4, HIP_UNSUPPORTED}},
   {"CUSPARSE_SPMAT_FILL_MODE",                  {"HIPSPARSE_SPMAT_FILL_MODE",                  "", CONV_NUMERIC_LITERAL, API_SPARSE, 4, HIP_UNSUPPORTED}},
@@ -412,4 +412,6 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_SPARSE_TYPE_NAME_VER_MAP {
   {"HIPSPARSE_SPMM_CSR_ALG1",                    {HIP_4020, HIP_0,    HIP_0   }},
   {"HIPSPARSE_SPMM_COO_ALG4",                    {HIP_4020, HIP_0,    HIP_0   }},
   {"HIPSPARSE_SPMM_CSR_ALG2",                    {HIP_4020, HIP_0,    HIP_0   }},
+  {"hipsparseSparseToDenseAlg_t",                {HIP_4020, HIP_0,    HIP_0   }},
+  {"HIPSPARSE_SPARSETODENSE_ALG_DEFAULT",        {HIP_4020, HIP_0,    HIP_0   }},
 };


### PR DESCRIPTION
+ Add missing cuSPARSE functions
+ Add missing hipSPARSE data types
+ Update hipify-perl accordingly
+ Update CUSPARSE_API_supported_by_HIP.md accordingly