### PR TITLE
[HIPIFY] Sync with HIP-rocm-4.2.0

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -855,6 +855,7 @@ sub simpleSubstitutions {
     $ft{'memory'} += s/\bcuArray3DCreate_v2\b/hipArray3DCreate/g;
     $ft{'memory'} += s/\bcuArrayCreate\b/hipArrayCreate/g;
     $ft{'memory'} += s/\bcuArrayCreate_v2\b/hipArrayCreate/g;
+    $ft{'memory'} += s/\bcuArrayDestroy\b/hipArrayDestroy/g;
     $ft{'memory'} += s/\bcuDeviceGetByPCIBusId\b/hipDeviceGetByPCIBusId/g;
     $ft{'memory'} += s/\bcuDeviceGetPCIBusId\b/hipDeviceGetPCIBusId/g;
     $ft{'memory'} += s/\bcuIpcCloseMemHandle\b/hipIpcCloseMemHandle/g;
@@ -886,6 +887,8 @@ sub simpleSubstitutions {
     $ft{'memory'} += s/\bcuMemcpy2D\b/hipMemcpyParam2D/g;
     $ft{'memory'} += s/\bcuMemcpy2DAsync\b/hipMemcpyParam2DAsync/g;
     $ft{'memory'} += s/\bcuMemcpy2DAsync_v2\b/hipMemcpyParam2DAsync/g;
+    $ft{'memory'} += s/\bcuMemcpy2DUnaligned\b/hipDrvMemcpy2DUnaligned/g;
+    $ft{'memory'} += s/\bcuMemcpy2DUnaligned_v2\b/hipDrvMemcpy2DUnaligned/g;
     $ft{'memory'} += s/\bcuMemcpy2D_v2\b/hipMemcpyParam2D/g;
     $ft{'memory'} += s/\bcuMemcpy3D\b/hipDrvMemcpy3D/g;
     $ft{'memory'} += s/\bcuMemcpy3DAsync\b/hipDrvMemcpy3DAsync/g;
@@ -3003,6 +3006,7 @@ sub simpleSubstitutions {
     $ft{'numeric_literal'} += s/\bcudaErrorInvalidGraphicsContext\b/hipErrorInvalidGraphicsContext/g;
     $ft{'numeric_literal'} += s/\bcudaErrorInvalidKernelImage\b/hipErrorInvalidImage/g;
     $ft{'numeric_literal'} += s/\bcudaErrorInvalidMemcpyDirection\b/hipErrorInvalidMemcpyDirection/g;
+    $ft{'numeric_literal'} += s/\bcudaErrorInvalidPitchValue\b/hipErrorInvalidPitchValue/g;
     $ft{'numeric_literal'} += s/\bcudaErrorInvalidPtx\b/hipErrorInvalidKernelFile/g;
     $ft{'numeric_literal'} += s/\bcudaErrorInvalidResourceHandle\b/hipErrorInvalidHandle/g;
     $ft{'numeric_literal'} += s/\bcudaErrorInvalidSource\b/hipErrorInvalidSource/g;
@@ -4875,7 +4879,6 @@ sub warnUnsupportedFunctions {
         "cudaErrorInvalidTextureBinding",
         "cudaErrorInvalidTexture",
         "cudaErrorInvalidSurface",
-        "cudaErrorInvalidPitchValue",
         "cudaErrorInvalidPc",
         "cudaErrorInvalidNormSetting",
         "cudaErrorInvalidHostPointer",
@@ -5274,8 +5277,6 @@ sub warnUnsupportedFunctions {
         "cuMemcpyAsync",
         "cuMemcpy3DPeerAsync",
         "cuMemcpy3DPeer",
-        "cuMemcpy2DUnaligned_v2",
-        "cuMemcpy2DUnaligned",
         "cuMemcpy",
         "cuMemUnmap",
         "cuMemSetAccess",
@@ -5487,7 +5488,6 @@ sub warnUnsupportedFunctions {
         "cuArrayGetPlane",
         "cuArrayGetDescriptor_v2",
         "cuArrayGetDescriptor",
-        "cuArrayDestroy",
         "cuArray3DGetDescriptor_v2",
         "cuArray3DGetDescriptor",
         "csrsv2Info",

--- a/doc/markdown/CUDA_Driver_API_functions_supported_by_HIP.md
+++ b/doc/markdown/CUDA_Driver_API_functions_supported_by_HIP.md
@@ -733,7 +733,7 @@
 |`CU_STREAM_WAIT_VALUE_EQ`|8.0| | |`hipStreamWaitValueEq`|4.2.0| | |
 |`CU_STREAM_WAIT_VALUE_FLUSH`|8.0| | | | | | |
 |`CU_STREAM_WAIT_VALUE_GEQ`|8.0| | |`hipStreamWaitValueGte`|4.2.0| | |
-|`CU_STREAM_WAIT_VALUE_NOR`| | | |`hipStreamWaitValueNor`|4.2.0| | |
+|`CU_STREAM_WAIT_VALUE_NOR`|9.0| | |`hipStreamWaitValueNor`|4.2.0| | |
 |`CU_STREAM_WRITE_VALUE_DEFAULT`|8.0| | | | | | |
 |`CU_STREAM_WRITE_VALUE_NO_MEMORY_BARRIER`|8.0| | | | | | |
 |`CU_SYNC_POLICY_AUTO`|11.0| | | | | | |
@@ -1138,7 +1138,7 @@
 |`cuArray3DGetDescriptor_v2`| | | | | | | |
 |`cuArrayCreate`| | | |`hipArrayCreate`|1.9.0| | |
 |`cuArrayCreate_v2`| | | |`hipArrayCreate`|1.9.0| | |
-|`cuArrayDestroy`| | | | | | | |
+|`cuArrayDestroy`| | | |`hipArrayDestroy`|4.2.0| | |
 |`cuArrayGetDescriptor`| | | | | | | |
 |`cuArrayGetDescriptor_v2`| | | | | | | |
 |`cuArrayGetPlane`|11.2| | | | | | |
@@ -1175,8 +1175,8 @@
 |`cuMemcpy2D`| | | |`hipMemcpyParam2D`|1.7.0| | |
 |`cuMemcpy2DAsync`| | | |`hipMemcpyParam2DAsync`|2.8.0| | |
 |`cuMemcpy2DAsync_v2`| | | |`hipMemcpyParam2DAsync`|2.8.0| | |
-|`cuMemcpy2DUnaligned`| | | | | | | |
-|`cuMemcpy2DUnaligned_v2`| | | | | | | |
+|`cuMemcpy2DUnaligned`| | | |`hipDrvMemcpy2DUnaligned`|4.2.0| | |
+|`cuMemcpy2DUnaligned_v2`| | | |`hipDrvMemcpy2DUnaligned`|4.2.0| | |
 |`cuMemcpy2D_v2`| | | |`hipMemcpyParam2D`|1.7.0| | |
 |`cuMemcpy3D`| | | |`hipDrvMemcpy3D`|3.5.0| | |
 |`cuMemcpy3DAsync`| | | |`hipDrvMemcpy3DAsync`|3.5.0| | |

--- a/doc/markdown/CUDA_Runtime_API_functions_supported_by_HIP.md
+++ b/doc/markdown/CUDA_Runtime_API_functions_supported_by_HIP.md
@@ -868,7 +868,7 @@ Unsupported
 |`cudaErrorInvalidMemcpyDirection`| | | |`hipErrorInvalidMemcpyDirection`|1.6.0| | |
 |`cudaErrorInvalidNormSetting`| | | | | | | |
 |`cudaErrorInvalidPc`| | | | | | | |
-|`cudaErrorInvalidPitchValue`| | | | | | | |
+|`cudaErrorInvalidPitchValue`| | | |`hipErrorInvalidPitchValue`|4.2.0| | |
 |`cudaErrorInvalidPtx`| | | |`hipErrorInvalidKernelFile`|1.6.0| | |
 |`cudaErrorInvalidResourceHandle`| | | |`hipErrorInvalidHandle`|1.6.0| | |
 |`cudaErrorInvalidSource`|10.1| | |`hipErrorInvalidSource`|1.6.0| | |

--- a/src/CUDA2HIP_Driver_API_functions.cpp
+++ b/src/CUDA2HIP_Driver_API_functions.cpp
@@ -156,7 +156,7 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_FUNCTION_MAP {
   {"cuArray3DGetDescriptor_v2",                            {"hipArray3DGetDescriptor",                                 "", CONV_MEMORY, API_DRIVER, 11, HIP_UNSUPPORTED}},
   {"cuArrayCreate",                                        {"hipArrayCreate",                                          "", CONV_MEMORY, API_DRIVER, 11}},
   {"cuArrayCreate_v2",                                     {"hipArrayCreate",                                          "", CONV_MEMORY, API_DRIVER, 11}},
-  {"cuArrayDestroy",                                       {"hipArrayDestroy",                                         "", CONV_MEMORY, API_DRIVER, 11, HIP_UNSUPPORTED}},
+  {"cuArrayDestroy",                                       {"hipArrayDestroy",                                         "", CONV_MEMORY, API_DRIVER, 11}},
   {"cuArrayGetDescriptor",                                 {"hipArrayGetDescriptor",                                   "", CONV_MEMORY, API_DRIVER, 11, HIP_UNSUPPORTED}},
   {"cuArrayGetDescriptor_v2",                              {"hipArrayGetDescriptor",                                   "", CONV_MEMORY, API_DRIVER, 11, HIP_UNSUPPORTED}},
   // cudaDeviceGetByPCIBusId
@@ -197,8 +197,8 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_FUNCTION_MAP {
   {"cuMemcpy2DAsync",                                      {"hipMemcpyParam2DAsync",                                   "", CONV_MEMORY, API_DRIVER, 11}},
   {"cuMemcpy2DAsync_v2",                                   {"hipMemcpyParam2DAsync",                                   "", CONV_MEMORY, API_DRIVER, 11}},
   // no analogue
-  {"cuMemcpy2DUnaligned",                                  {"hipMemcpy2DUnaligned",                                    "", CONV_MEMORY, API_DRIVER, 11, HIP_UNSUPPORTED}},
-  {"cuMemcpy2DUnaligned_v2",                               {"hipMemcpy2DUnaligned",                                    "", CONV_MEMORY, API_DRIVER, 11, HIP_UNSUPPORTED}},
+  {"cuMemcpy2DUnaligned",                                  {"hipDrvMemcpy2DUnaligned",                                 "", CONV_MEMORY, API_DRIVER, 11}},
+  {"cuMemcpy2DUnaligned_v2",                               {"hipDrvMemcpy2DUnaligned",                                 "", CONV_MEMORY, API_DRIVER, 11}},
   // no analogue
   // NOTE: Not equal to cudaMemcpy3D due to different signatures
   {"cuMemcpy3D",                                           {"hipDrvMemcpy3D",                                          "", CONV_MEMORY, API_DRIVER, 11}},
@@ -1291,6 +1291,8 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_DRIVER_FUNCTION_VER_MAP {
   {"hipStreamWaitValue64",                                 {HIP_4020, HIP_0,    HIP_0   }},
   {"hipStreamWriteValue32",                                {HIP_4020, HIP_0,    HIP_0   }},
   {"hipStreamWriteValue64",                                {HIP_4020, HIP_0,    HIP_0   }},
+  {"hipArrayDestroy",                                      {HIP_4020, HIP_0,    HIP_0   }},
+  {"hipDrvMemcpy2DUnaligned",                              {HIP_4020, HIP_0,    HIP_0   }},
 };
 
 const std::map<unsigned int, llvm::StringRef> CUDA_DRIVER_API_SECTION_MAP {

--- a/src/CUDA2HIP_Runtime_API_types.cpp
+++ b/src/CUDA2HIP_Runtime_API_types.cpp
@@ -681,7 +681,7 @@ const std::map<llvm::StringRef, hipCounter> CUDA_RUNTIME_TYPE_NAME_MAP {
   // no analogue
   {"cudaErrorInvalidConfiguration",                                    {"hipErrorInvalidConfiguration",                             "", CONV_NUMERIC_LITERAL, API_RUNTIME, 36}}, // 9
   // no analogue
-  {"cudaErrorInvalidPitchValue",                                       {"hipErrorInvalidPitchValue",                                "", CONV_NUMERIC_LITERAL, API_RUNTIME, 36, HIP_UNSUPPORTED}}, // 12
+  {"cudaErrorInvalidPitchValue",                                       {"hipErrorInvalidPitchValue",                                "", CONV_NUMERIC_LITERAL, API_RUNTIME, 36}}, // 12
   // no analogue
   {"cudaErrorInvalidSymbol",                                           {"hipErrorInvalidSymbol",                                    "", CONV_NUMERIC_LITERAL, API_RUNTIME, 36}}, // 13
   // Deprecated since CUDA 10.1
@@ -2203,4 +2203,5 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_RUNTIME_TYPE_NAME_VER_MAP {
   {"hipErrorMissingConfiguration",                                     {HIP_1060, HIP_0,    HIP_0   }},
   {"hipErrorPriorLaunchFailure",                                       {HIP_1060, HIP_0,    HIP_0   }},
   {"hipErrorInvalidDeviceFunction",                                    {HIP_1060, HIP_0,    HIP_0   }},
+  {"hipErrorInvalidPitchValue",                                        {HIP_4020, HIP_0,    HIP_0   }},
 };


### PR DESCRIPTION
+ Mark a few data types and functions as supported
+ Update hipify-perl accordingly
+ Update CUDA_Runtime_API_functions_supported_by_HIP.md and CUDA_Driver_API_functions_supported_by_HIP.md accordingly