### PR TITLE
[HIPIFY][tests][win] Workaround for VS 16.10

### DIFF
--- a/tests/run_test.bat
+++ b/tests/run_test.bat
@@ -23,9 +23,9 @@ set json_out=%test_dir%%compile_commands%
 
 if exist %json_in% (
   powershell -Command "(gc %json_in%) -replace '<test dir>', '%test_dir%' -replace '<CUDA dir>', '%CUDA_ROOT%' | Out-File -encoding ASCII %json_out%"
-  %HIPIFY% -o=%TMP_FILE% %IN_FILE% %CUDA_ROOT% -p=%test_dir%
+  %HIPIFY% -o=%TMP_FILE% %IN_FILE% %CUDA_ROOT% -p=%test_dir% -D_ALLOW_COMPILER_AND_STL_VERSION_MISMATCH=1
 ) else (
-  %HIPIFY% -o=%TMP_FILE% %IN_FILE% %CUDA_ROOT% %ROC% -- %clang_args%
+  %HIPIFY% -o=%TMP_FILE% %IN_FILE% %CUDA_ROOT% %ROC% -D_ALLOW_COMPILER_AND_STL_VERSION_MISMATCH=1 -- %clang_args%
 )
 
 if errorlevel 1 (echo      Error: hipify-clang.exe failed with exit code: %errorlevel% && exit /b %errorlevel%)


### PR DESCRIPTION
Workaround for the new error appeared with VS 16.10 release:

`..\VC\Tools\MSVC\14.29.30037\include\yvals_core.h(531,2): error GFDCF76F8: STL1002: Unexpected compiler version, expected CUDA 10.1 Update 2 or newer.`

ToDo: It might be better to do it in hipify-clang itself for Windows target only.
