### PR TITLE
[HIPIFY][doc] CUDA 11.3.1 is the latest supported release

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ After applying all the matchers, the output HIP source is produced.
 
 1. [**LLVM+CLANG**](http://releases.llvm.org) of at least version [3.8.0](http://releases.llvm.org/download.html#3.8.0); the latest stable and recommended release: [**12.0.0**](https://github.com/llvm/llvm-project/releases/tag/llvmorg-12.0.0).
 
-2. [**CUDA**](https://developer.nvidia.com/cuda-downloads) of at least version [7.0](https://developer.nvidia.com/cuda-toolkit-70), the latest supported version is [**11.3**](https://developer.nvidia.com/cuda-downloads).
+2. [**CUDA**](https://developer.nvidia.com/cuda-downloads) of at least version [7.0](https://developer.nvidia.com/cuda-toolkit-70), the latest supported version is [**11.3.1**](https://developer.nvidia.com/cuda-downloads).
 
 <table align="center">
   <thead>
@@ -147,7 +147,7 @@ After applying all the matchers, the output HIP source is produced.
     </tr>
     <tr align="center">
       <td bgcolor="eefaeb"><a href="https://github.com/llvm/llvm-project/releases/tag/llvmorg-12.0.0">12.0.0</a>
-      <td bgcolor="eefaeb"><a href="https://developer.nvidia.com/cuda-downloads"><b>11.3</b></a></td>
+      <td bgcolor="eefaeb"><a href="https://developer.nvidia.com/cuda-downloads"><b>11.3.1</b></a></td>
       <td colspan=2 bgcolor="eefaeb"><font color="green"><b>LATEST STABLE CONFIG</b></font></td>
     </tr>
   </tbody>
@@ -346,7 +346,7 @@ Ubuntu 14: LLVM 4.0.0 - 7.1.0, CUDA 7.0 - 9.0, cuDNN 5.0.5 - 7.6.5
 
 Ubuntu 16-18: LLVM 8.0.0 - 12.0.0, CUDA 8.0 - 10.2, cuDNN 5.1.10 - 8.0.5
 
-Ubuntu 20: LLVM 9.0.0 - 12.0.0, CUDA 8.0 - 11.3, cuDNN 5.1.10 - 8.2.0
+Ubuntu 20: LLVM 9.0.0 - 12.0.0, CUDA 8.0 - 11.3.1, cuDNN 5.1.10 - 8.2.0
 
 Minimum build system requirements for the above configurations:
 
@@ -497,17 +497,17 @@ Testing Time: 2.91s
 
 *Tested configurations:*
 
-|      **LLVM**   | **CUDA**     |   **cuDNN**    | **Visual Studio (latest)**|   **cmake**    |  **Python**  |
-|----------------:|-------------:|---------------:|--------------------------:|---------------:|-------------:|
-| 4.0.0 - 5.0.2   | 8.0          | 5.1.10 - 7.1.4 | 2015.14.0, 2017.15.5.2    | 3.5.1, 3.18.0  | 3.6.4, 3.8.5 |
-| 6.0.0 - 6.0.1   | 9.0          | 7.0.5  - 7.6.5 | 2015.14.0, 2017.15.5.5    | 3.6.0, 3.18.0  | 3.7.2, 3.8.5 |
-| 7.0.0 - 7.1.0   | 9.2          | 7.6.5          | 2017.15.9.11              | 3.13.3, 3.18.0 | 3.7.3, 3.8.5 |
-| 8.0.0 - 8.0.1   | 10.0         | 7.6.5          | 2017.15.9.15              | 3.14.2, 3.18.0 | 3.7.4, 3.8.5 |
-| 9.0.0 - 9.0.1   | 10.1         | 7.6.5          | 2017.15.9.20, 2019.16.4.5 | 3.16.4, 3.18.0 | 3.8.0, 3.8.5 |
-| 10.0.0 - 11.0.0 | 8.0 - 11.1   | 7.6.5  - 8.0.5 | 2017.15.9.30, 2019.16.8.3 | 3.19.2         | 3.9.1        |
-| 11.0.1 - 11.1.0 | 8.0 - 11.2.2 | 7.6.5  - 8.0.5 | 2017.15.9.31, 2019.16.8.4 | 3.19.3         | 3.9.2        |
-| 12.0.0          | 8.0 - 11.3   | 7.6.5  - 8.2.0 | 2017.15.9.35, 2019.16.9.4 | 3.20.2         | 3.9.5        |
-| 13.0.0git       | 8.0 - 11.3   | 7.6.5  - 8.2.0 | 2017.15.9.35, 2019.16.9.4 | 3.20.2         | 3.9.5        |
+|      **LLVM**   | **CUDA**     |   **cuDNN**    | **Visual Studio (latest)** |   **cmake**    |  **Python**  |
+|----------------:|-------------:|---------------:|---------------------------:|---------------:|-------------:|
+| 4.0.0 - 5.0.2   | 8.0          | 5.1.10 - 7.1.4 | 2015.14.0, 2017.15.5.2     | 3.5.1, 3.18.0  | 3.6.4, 3.8.5 |
+| 6.0.0 - 6.0.1   | 9.0          | 7.0.5  - 7.6.5 | 2015.14.0, 2017.15.5.5     | 3.6.0, 3.18.0  | 3.7.2, 3.8.5 |
+| 7.0.0 - 7.1.0   | 9.2          | 7.6.5          | 2017.15.9.11               | 3.13.3, 3.18.0 | 3.7.3, 3.8.5 |
+| 8.0.0 - 8.0.1   | 10.0         | 7.6.5          | 2017.15.9.15               | 3.14.2, 3.18.0 | 3.7.4, 3.8.5 |
+| 9.0.0 - 9.0.1   | 10.1         | 7.6.5          | 2017.15.9.20, 2019.16.4.5  | 3.16.4, 3.18.0 | 3.8.0, 3.8.5 |
+| 10.0.0 - 11.0.0 | 8.0 - 11.1   | 7.6.5  - 8.0.5 | 2017.15.9.30, 2019.16.8.3  | 3.19.2         | 3.9.1        |
+| 11.0.1 - 11.1.0 | 8.0 - 11.2.2 | 7.6.5  - 8.0.5 | 2017.15.9.31, 2019.16.8.4  | 3.19.3         | 3.9.2        |
+| 12.0.0          | 8.0 - 11.3.1 | 7.6.5  - 8.2.0 | 2017.15.9.36, 2019.16.10.0 | 3.20.3         | 3.9.5        |
+| 13.0.0git       | 8.0 - 11.3.1 | 7.6.5  - 8.2.0 | 2017.15.9.36, 2019.16.10.0 | 3.20.3         | 3.9.5        |
 
 *Building with testing support by `Visual Studio 16 2019` on `Windows 10`:*
 


### PR DESCRIPTION
+ All new APIs have been taken into account
+ All the tests are passed
+ Update README.md accordingly
