### PR TITLE
[HIPIFY][fix][Linux] Add explicit include to <cmath>

### DIFF
--- a/src/Statistics.cpp
+++ b/src/Statistics.cpp
@@ -24,6 +24,7 @@ THE SOFTWARE.
 #include <assert.h>
 #include <sstream>
 #include <iomanip>
+#include <cmath>
 #include "ArgParse.h"
 
 const char *counterNames[NUM_CONV_TYPES] = {


### PR DESCRIPTION
Fix the following compilation error that appeared with the latest LLVM trunk:
error: no member named 'lround' in namespace 'std'