### PR TITLE
[HIPIFY][fix][#372] Mark CUDA_VERSION as unsupported

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -3451,7 +3451,6 @@ sub simpleSubstitutions {
     $ft{'define'} += s/\bCUDA_COOPERATIVE_LAUNCH_MULTI_DEVICE_NO_POST_LAUNCH_SYNC\b/hipCooperativeLaunchMultiDeviceNoPostSync/g;
     $ft{'define'} += s/\bCUDA_COOPERATIVE_LAUNCH_MULTI_DEVICE_NO_PRE_LAUNCH_SYNC\b/hipCooperativeLaunchMultiDeviceNoPreSync/g;
     $ft{'define'} += s/\bCUDA_IPC_HANDLE_SIZE\b/HIP_IPC_HANDLE_SIZE/g;
-    $ft{'define'} += s/\bCUDA_VERSION\b/HIP_VERSION/g;
     $ft{'define'} += s/\bCURAND_VERSION\b/HIPRAND_VERSION/g;
     $ft{'define'} += s/\bCU_DEVICE_CPU\b/hipCpuDeviceId/g;
     $ft{'define'} += s/\bCU_DEVICE_INVALID\b/hipInvalidDeviceId/g;
@@ -6692,6 +6691,7 @@ sub warnUnsupportedFunctions {
         "CUDNN_ADV_INFER_PATCH",
         "CUDNN_ADV_INFER_MINOR",
         "CUDNN_ADV_INFER_MAJOR",
+        "CUDA_VERSION",
         "CUDA_POINTER_ATTRIBUTE_P2P_TOKENS_v1",
         "CUDA_POINTER_ATTRIBUTE_P2P_TOKENS_st",
         "CUDA_POINTER_ATTRIBUTE_P2P_TOKENS",

--- a/doc/markdown/CUDA_Driver_API_functions_supported_by_HIP.md
+++ b/doc/markdown/CUDA_Driver_API_functions_supported_by_HIP.md
@@ -183,7 +183,7 @@
 |`CUDA_TEXTURE_DESC`| | | |`HIP_TEXTURE_DESC`|3.5.0| | |
 |`CUDA_TEXTURE_DESC_st`| | | |`HIP_TEXTURE_DESC_st`|3.5.0| | |
 |`CUDA_TEXTURE_DESC_v1`|11.3| | |`HIP_TEXTURE_DESC`|3.5.0| | |
-|`CUDA_VERSION`| | | |`HIP_VERSION`|1.5.0| | |
+|`CUDA_VERSION`| | | | | | | |
 |`CUGLDeviceList`| | | | | | | |
 |`CUGLDeviceList_enum`| | | | | | | |
 |`CUGLmap_flags`| | | | | | | |

--- a/src/CUDA2HIP_Driver_API_types.cpp
+++ b/src/CUDA2HIP_Driver_API_types.cpp
@@ -2099,7 +2099,7 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_TYPE_NAME_MAP {
   {"CUDA_NVSCISYNC_ATTR_SIGNAL",                                       {"hipNvSciSyncAttrSignal",                                   "", CONV_DEFINE, API_DRIVER, 1, HIP_UNSUPPORTED}}, // 0x1
   // cudaNvSciSyncAttrWait
   {"CUDA_NVSCISYNC_ATTR_WAIT",                                         {"hipNvSciSyncAttrWait",                                     "", CONV_DEFINE, API_DRIVER, 1, HIP_UNSUPPORTED}}, // 0x1
-  {"CUDA_VERSION",                                                     {"HIP_VERSION",                                              "", CONV_DEFINE, API_DRIVER, 1}}, // 10000
+  {"CUDA_VERSION",                                                     {"HIP_VERSION",                                              "", CONV_DEFINE, API_DRIVER, 1, HIP_UNSUPPORTED}}, // 10000
   {"CU_TRSF_DISABLE_TRILINEAR_OPTIMIZATION",                           {"HIP_TRSF_DISABLE_TRILINEAR_OPTIMIZATION",                  "", CONV_DEFINE, API_DRIVER, 1, HIP_UNSUPPORTED}}, // 0x20
   // cudaArraySparsePropertiesSingleMipTail
   {"CU_ARRAY_SPARSE_PROPERTIES_SINGLE_MIPTAIL",                        {"HIP_ARRAY_SPARSE_PROPERTIES_SINGLE_MIPTAIL",               "", CONV_DEFINE, API_DRIVER, 1, HIP_UNSUPPORTED}}, // 0x1
@@ -3053,7 +3053,6 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_DRIVER_TYPE_NAME_VER_MAP {
   {"hipErrorStreamCaptureWrongThread",                                 {HIP_4030, HIP_0,    HIP_0   }},
   {"hipHostFn_t",                                                      {HIP_4030, HIP_0,    HIP_0   }},
   {"hipSurfaceObject_t",                                               {HIP_1090, HIP_0,    HIP_0   }},
-  {"HIP_VERSION",                                                      {HIP_1050, HIP_0,    HIP_0   }},
   {"hipExternalSemaphoreWaitParams_st",                                {HIP_4030, HIP_0,    HIP_0   }},
   {"hipExternalSemaphoreWaitParams",                                   {HIP_4030, HIP_0,    HIP_0   }},
   {"hipLimitPrintfFifoSize",                                           {HIP_4030, HIP_0,    HIP_0   }},


### PR DESCRIPTION
[Reason]
CUDA_VERSION has no 1 to 1 mapping to HIP_VERSION.
Some HIP APIs from the same HIP_VERSION may map to a particular CUDA_VERSION; some may not; thus, there is no actually mapping between CUDA_VERSION and HIP_VERSION.