### PR TITLE
[HIPIFY][SPARSE] Sync with hipSPARSE 4.3

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -1817,8 +1817,14 @@ sub simpleSubstitutions {
     $ft{'library'} += s/\bcusparseCgebsr2gebsr\b/hipsparseCgebsr2gebsr/g;
     $ft{'library'} += s/\bcusparseCgebsr2gebsr_bufferSize\b/hipsparseCgebsr2gebsr_bufferSize/g;
     $ft{'library'} += s/\bcusparseCgemmi\b/hipsparseCgemmi/g;
+    $ft{'library'} += s/\bcusparseCgemvi\b/hipsparseCgemvi/g;
+    $ft{'library'} += s/\bcusparseCgemvi_bufferSize\b/hipsparseCgemvi_bufferSize/g;
     $ft{'library'} += s/\bcusparseCgthr\b/hipsparseCgthr/g;
     $ft{'library'} += s/\bcusparseCgthrz\b/hipsparseCgthrz/g;
+    $ft{'library'} += s/\bcusparseCgtsv2\b/hipsparseCgtsv2/g;
+    $ft{'library'} += s/\bcusparseCgtsv2_bufferSizeExt\b/hipsparseCgtsv2_bufferSizeExt/g;
+    $ft{'library'} += s/\bcusparseCgtsv2_nopivot\b/hipsparseCgtsv2_nopivot/g;
+    $ft{'library'} += s/\bcusparseCgtsv2_nopivot_bufferSizeExt\b/hipsparseCgtsv2_nopivot_bufferSizeExt/g;
     $ft{'library'} += s/\bcusparseChyb2csr\b/hipsparseChyb2csr/g;
     $ft{'library'} += s/\bcusparseChybmv\b/hipsparseChybmv/g;
     $ft{'library'} += s/\bcusparseCnnz\b/hipsparseCnnz/g;
@@ -1931,8 +1937,14 @@ sub simpleSubstitutions {
     $ft{'library'} += s/\bcusparseDgebsr2gebsr\b/hipsparseDgebsr2gebsr/g;
     $ft{'library'} += s/\bcusparseDgebsr2gebsr_bufferSize\b/hipsparseDgebsr2gebsr_bufferSize/g;
     $ft{'library'} += s/\bcusparseDgemmi\b/hipsparseDgemmi/g;
+    $ft{'library'} += s/\bcusparseDgemvi\b/hipsparseDgemvi/g;
+    $ft{'library'} += s/\bcusparseDgemvi_bufferSize\b/hipsparseDgemvi_bufferSize/g;
     $ft{'library'} += s/\bcusparseDgthr\b/hipsparseDgthr/g;
     $ft{'library'} += s/\bcusparseDgthrz\b/hipsparseDgthrz/g;
+    $ft{'library'} += s/\bcusparseDgtsv2\b/hipsparseDgtsv2/g;
+    $ft{'library'} += s/\bcusparseDgtsv2_bufferSizeExt\b/hipsparseDgtsv2_bufferSizeExt/g;
+    $ft{'library'} += s/\bcusparseDgtsv2_nopivot\b/hipsparseDgtsv2_nopivot/g;
+    $ft{'library'} += s/\bcusparseDgtsv2_nopivot_bufferSizeExt\b/hipsparseDgtsv2_nopivot_bufferSizeExt/g;
     $ft{'library'} += s/\bcusparseDhyb2csr\b/hipsparseDhyb2csr/g;
     $ft{'library'} += s/\bcusparseDhybmv\b/hipsparseDhybmv/g;
     $ft{'library'} += s/\bcusparseDnMatGet\b/hipsparseDnMatGet/g;
@@ -1966,6 +1978,9 @@ sub simpleSubstitutions {
     $ft{'library'} += s/\bcusparseGetStream\b/hipsparseGetStream/g;
     $ft{'library'} += s/\bcusparseGetVersion\b/hipsparseGetVersion/g;
     $ft{'library'} += s/\bcusparseRot\b/hipsparseRot/g;
+    $ft{'library'} += s/\bcusparseSDDMM\b/hipsparseSDDMM/g;
+    $ft{'library'} += s/\bcusparseSDDMM_bufferSize\b/hipsparseSDDMM_bufferSize/g;
+    $ft{'library'} += s/\bcusparseSDDMM_preprocess\b/hipsparseSDDMM_preprocess/g;
     $ft{'library'} += s/\bcusparseSaxpyi\b/hipsparseSaxpyi/g;
     $ft{'library'} += s/\bcusparseSbsr2csr\b/hipsparseSbsr2csr/g;
     $ft{'library'} += s/\bcusparseSbsric02\b/hipsparseSbsric02/g;
@@ -2033,8 +2048,14 @@ sub simpleSubstitutions {
     $ft{'library'} += s/\bcusparseSgebsr2gebsr\b/hipsparseSgebsr2gebsr/g;
     $ft{'library'} += s/\bcusparseSgebsr2gebsr_bufferSize\b/hipsparseSgebsr2gebsr_bufferSize/g;
     $ft{'library'} += s/\bcusparseSgemmi\b/hipsparseSgemmi/g;
+    $ft{'library'} += s/\bcusparseSgemvi\b/hipsparseSgemvi/g;
+    $ft{'library'} += s/\bcusparseSgemvi_bufferSize\b/hipsparseSgemvi_bufferSize/g;
     $ft{'library'} += s/\bcusparseSgthr\b/hipsparseSgthr/g;
     $ft{'library'} += s/\bcusparseSgthrz\b/hipsparseSgthrz/g;
+    $ft{'library'} += s/\bcusparseSgtsv2\b/hipsparseSgtsv2/g;
+    $ft{'library'} += s/\bcusparseSgtsv2_bufferSizeExt\b/hipsparseSgtsv2_bufferSizeExt/g;
+    $ft{'library'} += s/\bcusparseSgtsv2_nopivot\b/hipsparseSgtsv2_nopivot/g;
+    $ft{'library'} += s/\bcusparseSgtsv2_nopivot_bufferSizeExt\b/hipsparseSgtsv2_nopivot_bufferSizeExt/g;
     $ft{'library'} += s/\bcusparseShyb2csr\b/hipsparseShyb2csr/g;
     $ft{'library'} += s/\bcusparseShybmv\b/hipsparseShybmv/g;
     $ft{'library'} += s/\bcusparseSnnz\b/hipsparseSnnz/g;
@@ -2159,8 +2180,14 @@ sub simpleSubstitutions {
     $ft{'library'} += s/\bcusparseZgebsr2gebsr\b/hipsparseZgebsr2gebsr/g;
     $ft{'library'} += s/\bcusparseZgebsr2gebsr_bufferSize\b/hipsparseZgebsr2gebsr_bufferSize/g;
     $ft{'library'} += s/\bcusparseZgemmi\b/hipsparseZgemmi/g;
+    $ft{'library'} += s/\bcusparseZgemvi\b/hipsparseZgemvi/g;
+    $ft{'library'} += s/\bcusparseZgemvi_bufferSize\b/hipsparseZgemvi_bufferSize/g;
     $ft{'library'} += s/\bcusparseZgthr\b/hipsparseZgthr/g;
     $ft{'library'} += s/\bcusparseZgthrz\b/hipsparseZgthrz/g;
+    $ft{'library'} += s/\bcusparseZgtsv2\b/hipsparseZgtsv2/g;
+    $ft{'library'} += s/\bcusparseZgtsv2_bufferSizeExt\b/hipsparseZgtsv2_bufferSizeExt/g;
+    $ft{'library'} += s/\bcusparseZgtsv2_nopivot\b/hipsparseZgtsv2_nopivot/g;
+    $ft{'library'} += s/\bcusparseZgtsv2_nopivot_bufferSizeExt\b/hipsparseZgtsv2_nopivot_bufferSizeExt/g;
     $ft{'library'} += s/\bcusparseZhyb2csr\b/hipsparseZhyb2csr/g;
     $ft{'library'} += s/\bcusparseZhybmv\b/hipsparseZhybmv/g;
     $ft{'library'} += s/\bcusparseZnnz\b/hipsparseZnnz/g;
@@ -2561,6 +2588,7 @@ sub simpleSubstitutions {
     $ft{'type'} += s/\bcusparseOperation_t\b/hipsparseOperation_t/g;
     $ft{'type'} += s/\bcusparseOrder_t\b/hipsparseOrder_t/g;
     $ft{'type'} += s/\bcusparsePointerMode_t\b/hipsparsePointerMode_t/g;
+    $ft{'type'} += s/\bcusparseSDDMMAlg_t\b/hipsparseSDDMMAlg_t/g;
     $ft{'type'} += s/\bcusparseSolvePolicy_t\b/hipsparseSolvePolicy_t/g;
     $ft{'type'} += s/\bcusparseSpGEMMAlg_t\b/hipsparseSpGEMMAlg_t/g;
     $ft{'type'} += s/\bcusparseSpGEMMDescr\b/hipsparseSpGEMMDescr/g;
@@ -2889,6 +2917,7 @@ sub simpleSubstitutions {
     $ft{'numeric_literal'} += s/\bCUSPARSE_ORDER_ROW\b/HIPSPARSE_ORDER_ROW/g;
     $ft{'numeric_literal'} += s/\bCUSPARSE_POINTER_MODE_DEVICE\b/HIPSPARSE_POINTER_MODE_DEVICE/g;
     $ft{'numeric_literal'} += s/\bCUSPARSE_POINTER_MODE_HOST\b/HIPSPARSE_POINTER_MODE_HOST/g;
+    $ft{'numeric_literal'} += s/\bCUSPARSE_SDDMM_ALG_DEFAULT\b/HIPSPARSE_SDDMM_ALG_DEFAULT/g;
     $ft{'numeric_literal'} += s/\bCUSPARSE_SOLVE_POLICY_NO_LEVEL\b/HIPSPARSE_SOLVE_POLICY_NO_LEVEL/g;
     $ft{'numeric_literal'} += s/\bCUSPARSE_SOLVE_POLICY_USE_LEVEL\b/HIPSPARSE_SOLVE_POLICY_USE_LEVEL/g;
     $ft{'numeric_literal'} += s/\bCUSPARSE_SPARSETODENSE_ALG_DEFAULT\b/HIPSPARSE_SPARSETODENSE_ALG_DEFAULT/g;
@@ -4362,17 +4391,11 @@ sub warnUnsupportedFunctions {
         "cusparseZgtsvStridedBatch",
         "cusparseZgtsvInterleavedBatch_bufferSizeExt",
         "cusparseZgtsvInterleavedBatch",
-        "cusparseZgtsv2_nopivot_bufferSizeExt",
-        "cusparseZgtsv2_nopivot",
-        "cusparseZgtsv2_bufferSizeExt",
         "cusparseZgtsv2StridedBatch_bufferSizeExt",
         "cusparseZgtsv2StridedBatch",
-        "cusparseZgtsv2",
         "cusparseZgtsv",
         "cusparseZgpsvInterleavedBatch_bufferSizeExt",
         "cusparseZgpsvInterleavedBatch",
-        "cusparseZgemvi_bufferSize",
-        "cusparseZgemvi",
         "cusparseZgebsr2gebsr_bufferSizeExt",
         "cusparseZgebsr2gebsc_bufferSizeExt",
         "cusparseZdense2hyb",
@@ -4432,17 +4455,11 @@ sub warnUnsupportedFunctions {
         "cusparseSgtsvStridedBatch",
         "cusparseSgtsvInterleavedBatch_bufferSizeExt",
         "cusparseSgtsvInterleavedBatch",
-        "cusparseSgtsv2_nopivot_bufferSizeExt",
-        "cusparseSgtsv2_nopivot",
-        "cusparseSgtsv2_bufferSizeExt",
         "cusparseSgtsv2StridedBatch_bufferSizeExt",
         "cusparseSgtsv2StridedBatch",
-        "cusparseSgtsv2",
         "cusparseSgtsv",
         "cusparseSgpsvInterleavedBatch_bufferSizeExt",
         "cusparseSgpsvInterleavedBatch",
-        "cusparseSgemvi_bufferSize",
-        "cusparseSgemvi",
         "cusparseSgebsr2gebsr_bufferSizeExt",
         "cusparseSgebsr2gebsc_bufferSizeExt",
         "cusparseSdense2hyb",
@@ -4489,17 +4506,11 @@ sub warnUnsupportedFunctions {
         "cusparseDgtsvStridedBatch",
         "cusparseDgtsvInterleavedBatch_bufferSizeExt",
         "cusparseDgtsvInterleavedBatch",
-        "cusparseDgtsv2_nopivot_bufferSizeExt",
-        "cusparseDgtsv2_nopivot",
-        "cusparseDgtsv2_bufferSizeExt",
         "cusparseDgtsv2StridedBatch_bufferSizeExt",
         "cusparseDgtsv2StridedBatch",
-        "cusparseDgtsv2",
         "cusparseDgtsv",
         "cusparseDgpsvInterleavedBatch_bufferSizeExt",
         "cusparseDgpsvInterleavedBatch",
-        "cusparseDgemvi_bufferSize",
-        "cusparseDgemvi",
         "cusparseDgebsr2gebsr_bufferSizeExt",
         "cusparseDgebsr2gebsc_bufferSizeExt",
         "cusparseDestroySolveAnalysisInfo",
@@ -4549,17 +4560,11 @@ sub warnUnsupportedFunctions {
         "cusparseCgtsvStridedBatch",
         "cusparseCgtsvInterleavedBatch_bufferSizeExt",
         "cusparseCgtsvInterleavedBatch",
-        "cusparseCgtsv2_nopivot_bufferSizeExt",
-        "cusparseCgtsv2_nopivot",
-        "cusparseCgtsv2_bufferSizeExt",
         "cusparseCgtsv2StridedBatch_bufferSizeExt",
         "cusparseCgtsv2StridedBatch",
-        "cusparseCgtsv2",
         "cusparseCgtsv",
         "cusparseCgpsvInterleavedBatch_bufferSizeExt",
         "cusparseCgpsvInterleavedBatch",
-        "cusparseCgemvi_bufferSize",
-        "cusparseCgemvi",
         "cusparseCgebsr2gebsr_bufferSizeExt",
         "cusparseCgebsr2gebsc_bufferSizeExt",
         "cusparseCdense2hyb",

--- a/doc/markdown/CUSPARSE_API_supported_by_HIP.md
+++ b/doc/markdown/CUSPARSE_API_supported_by_HIP.md
@@ -51,6 +51,7 @@
 |`CUSPARSE_ORDER_ROW`|10.1| | |`HIPSPARSE_ORDER_ROW`|4.2.0| | |
 |`CUSPARSE_POINTER_MODE_DEVICE`| | | |`HIPSPARSE_POINTER_MODE_DEVICE`|1.9.2| | |
 |`CUSPARSE_POINTER_MODE_HOST`| | | |`HIPSPARSE_POINTER_MODE_HOST`|1.9.2| | |
+|`CUSPARSE_SDDMM_ALG_DEFAULT`|11.2| | |`HIPSPARSE_SDDMM_ALG_DEFAULT`|4.3.0| | |
 |`CUSPARSE_SOLVE_POLICY_NO_LEVEL`| | | |`HIPSPARSE_SOLVE_POLICY_NO_LEVEL`|1.9.2| | |
 |`CUSPARSE_SOLVE_POLICY_USE_LEVEL`| | | |`HIPSPARSE_SOLVE_POLICY_USE_LEVEL`|1.9.2| | |
 |`CUSPARSE_SPARSETODENSE_ALG_DEFAULT`|11.1| | |`HIPSPARSE_SPARSETODENSE_ALG_DEFAULT`|4.2.0| | |
@@ -139,6 +140,7 @@
 |`cusparseOperation_t`| | | |`hipsparseOperation_t`|1.9.2| | |
 |`cusparseOrder_t`|10.1| | |`hipsparseOrder_t`|4.2.0| | |
 |`cusparsePointerMode_t`| | | |`hipsparsePointerMode_t`|1.9.2| | |
+|`cusparseSDDMMAlg_t`|11.2| | |`hipsparseSDDMMAlg_t`|4.3.0| | |
 |`cusparseSolveAnalysisInfo`| |10.2|11.0| | | | |
 |`cusparseSolveAnalysisInfo_t`| |10.2|11.0| | | | |
 |`cusparseSolvePolicy_t`| | | |`hipsparseSolvePolicy_t`|1.9.2| | |
@@ -260,8 +262,8 @@
 |`cusparseCcsrsv2_solve`| |11.3| |`hipsparseCcsrsv2_solve`|3.1.0| | |
 |`cusparseCcsrsv_analysis`| |10.2|11.0| | | | |
 |`cusparseCcsrsv_solve`| |10.2|11.0| | | | |
-|`cusparseCgemvi`|7.5| | | | | | |
-|`cusparseCgemvi_bufferSize`|7.5| | | | | | |
+|`cusparseCgemvi`|7.5| | |`hipsparseCgemvi`|4.3.0| | |
+|`cusparseCgemvi_bufferSize`|7.5| | |`hipsparseCgemvi_bufferSize`|4.3.0| | |
 |`cusparseChybmv`| |10.2|11.0|`hipsparseChybmv`|3.1.0| | |
 |`cusparseChybsv_analysis`| |10.2|11.0| | | | |
 |`cusparseChybsv_solve`| |10.2|11.0| | | | |
@@ -283,8 +285,8 @@
 |`cusparseDcsrsv2_solve`| |11.3| |`hipsparseDcsrsv2_solve`|1.9.2| | |
 |`cusparseDcsrsv_analysis`| |10.2|11.0| | | | |
 |`cusparseDcsrsv_solve`| |10.2|11.0| | | | |
-|`cusparseDgemvi`|7.5| | | | | | |
-|`cusparseDgemvi_bufferSize`|7.5| | | | | | |
+|`cusparseDgemvi`|7.5| | |`hipsparseDgemvi`|4.3.0| | |
+|`cusparseDgemvi_bufferSize`|7.5| | |`hipsparseDgemvi_bufferSize`|4.3.0| | |
 |`cusparseDhybmv`| |10.2|11.0|`hipsparseDhybmv`|1.9.2| | |
 |`cusparseDhybsv_analysis`| |10.2|11.0| | | | |
 |`cusparseDhybsv_solve`| |10.2|11.0| | | | |
@@ -302,8 +304,8 @@
 |`cusparseScsrsv2_solve`| |11.3| |`hipsparseScsrsv2_solve`|1.9.2| | |
 |`cusparseScsrsv_analysis`| |10.2|11.0| | | | |
 |`cusparseScsrsv_solve`| |10.2|11.0| | | | |
-|`cusparseSgemvi`|7.5| | | | | | |
-|`cusparseSgemvi_bufferSize`|7.5| | | | | | |
+|`cusparseSgemvi`|7.5| | |`hipsparseSgemvi`|4.3.0| | |
+|`cusparseSgemvi_bufferSize`|7.5| | |`hipsparseSgemvi_bufferSize`|4.3.0| | |
 |`cusparseShybmv`| |10.2|11.0|`hipsparseShybmv`|1.9.2| | |
 |`cusparseShybsv_analysis`| |10.2|11.0| | | | |
 |`cusparseShybsv_solve`| |10.2|11.0| | | | |
@@ -323,8 +325,8 @@
 |`cusparseZcsrsv2_solve`| |11.3| |`hipsparseZcsrsv2_solve`|3.1.0| | |
 |`cusparseZcsrsv_analysis`| |10.2|11.0| | | | |
 |`cusparseZcsrsv_solve`| |10.2|11.0| | | | |
-|`cusparseZgemvi`|7.5| | | | | | |
-|`cusparseZgemvi_bufferSize`|7.5| | | | | | |
+|`cusparseZgemvi`|7.5| | |`hipsparseZgemvi`|4.3.0| | |
+|`cusparseZgemvi_bufferSize`|7.5| | |`hipsparseZgemvi_bufferSize`|4.3.0| | |
 |`cusparseZhybmv`| |10.2|11.0|`hipsparseZhybmv`|3.1.0| | |
 |`cusparseZhybsv_analysis`| |10.2|11.0| | | | |
 |`cusparseZhybsv_solve`| |10.2|11.0| | | | |
@@ -448,12 +450,12 @@
 |`cusparseCgpsvInterleavedBatch`|9.2| | | | | | |
 |`cusparseCgpsvInterleavedBatch_bufferSizeExt`|9.2| | | | | | |
 |`cusparseCgtsv`| |10.2|11.0| | | | |
-|`cusparseCgtsv2`|9.0| | | | | | |
+|`cusparseCgtsv2`|9.0| | |`hipsparseCgtsv2`|4.3.0| | |
 |`cusparseCgtsv2StridedBatch`| | | | | | | |
 |`cusparseCgtsv2StridedBatch_bufferSizeExt`| | | | | | | |
-|`cusparseCgtsv2_bufferSizeExt`|9.0| | | | | | |
-|`cusparseCgtsv2_nopivot`|9.0| | | | | | |
-|`cusparseCgtsv2_nopivot_bufferSizeExt`|9.0| | | | | | |
+|`cusparseCgtsv2_bufferSizeExt`|9.0| | |`hipsparseCgtsv2_bufferSizeExt`|4.3.0| | |
+|`cusparseCgtsv2_nopivot`|9.0| | |`hipsparseCgtsv2_nopivot`|4.3.0| | |
+|`cusparseCgtsv2_nopivot_bufferSizeExt`|9.0| | |`hipsparseCgtsv2_nopivot_bufferSizeExt`|4.3.0| | |
 |`cusparseCgtsvInterleavedBatch`|9.2| | | | | | |
 |`cusparseCgtsvInterleavedBatch_bufferSizeExt`|9.2| | | | | | |
 |`cusparseCgtsvStridedBatch`| |10.2|11.0| | | | |
@@ -482,12 +484,12 @@
 |`cusparseDgpsvInterleavedBatch`|9.2| | | | | | |
 |`cusparseDgpsvInterleavedBatch_bufferSizeExt`|9.2| | | | | | |
 |`cusparseDgtsv`| |10.2|11.0| | | | |
-|`cusparseDgtsv2`|9.0| | | | | | |
+|`cusparseDgtsv2`|9.0| | |`hipsparseDgtsv2`|4.3.0| | |
 |`cusparseDgtsv2StridedBatch`| | | | | | | |
 |`cusparseDgtsv2StridedBatch_bufferSizeExt`| | | | | | | |
-|`cusparseDgtsv2_bufferSizeExt`|9.0| | | | | | |
-|`cusparseDgtsv2_nopivot`|9.0| | | | | | |
-|`cusparseDgtsv2_nopivot_bufferSizeExt`|9.0| | | | | | |
+|`cusparseDgtsv2_bufferSizeExt`|9.0| | |`hipsparseDgtsv2_bufferSizeExt`|4.3.0| | |
+|`cusparseDgtsv2_nopivot`|9.0| | |`hipsparseDgtsv2_nopivot`|4.3.0| | |
+|`cusparseDgtsv2_nopivot_bufferSizeExt`|9.0| | |`hipsparseDgtsv2_nopivot_bufferSizeExt`|4.3.0| | |
 |`cusparseDgtsvInterleavedBatch`|9.2| | | | | | |
 |`cusparseDgtsvInterleavedBatch_bufferSizeExt`|9.2| | | | | | |
 |`cusparseDgtsvStridedBatch`| |10.2|11.0| | | | |
@@ -515,12 +517,12 @@
 |`cusparseSgpsvInterleavedBatch`|9.2| | | | | | |
 |`cusparseSgpsvInterleavedBatch_bufferSizeExt`|9.2| | | | | | |
 |`cusparseSgtsv`| |10.2|11.0| | | | |
-|`cusparseSgtsv2`|9.0| | | | | | |
+|`cusparseSgtsv2`|9.0| | |`hipsparseSgtsv2`|4.3.0| | |
 |`cusparseSgtsv2StridedBatch`|9.0| | | | | | |
 |`cusparseSgtsv2StridedBatch_bufferSizeExt`|9.0| | | | | | |
-|`cusparseSgtsv2_bufferSizeExt`|9.0| | | | | | |
-|`cusparseSgtsv2_nopivot`|9.0| | | | | | |
-|`cusparseSgtsv2_nopivot_bufferSizeExt`|9.0| | | | | | |
+|`cusparseSgtsv2_bufferSizeExt`|9.0| | |`hipsparseSgtsv2_bufferSizeExt`|4.3.0| | |
+|`cusparseSgtsv2_nopivot`|9.0| | |`hipsparseSgtsv2_nopivot`|4.3.0| | |
+|`cusparseSgtsv2_nopivot_bufferSizeExt`|9.0| | |`hipsparseSgtsv2_nopivot_bufferSizeExt`|4.3.0| | |
 |`cusparseSgtsvInterleavedBatch`|9.2| | | | | | |
 |`cusparseSgtsvInterleavedBatch_bufferSizeExt`|9.2| | | | | | |
 |`cusparseSgtsvStridedBatch`| |10.2|11.0| | | | |
@@ -552,12 +554,12 @@
 |`cusparseZgpsvInterleavedBatch`|9.2| | | | | | |
 |`cusparseZgpsvInterleavedBatch_bufferSizeExt`|9.2| | | | | | |
 |`cusparseZgtsv`| |10.2|11.0| | | | |
-|`cusparseZgtsv2`|9.0| | | | | | |
+|`cusparseZgtsv2`|9.0| | |`hipsparseZgtsv2`|4.3.0| | |
 |`cusparseZgtsv2StridedBatch`| | | | | | | |
 |`cusparseZgtsv2StridedBatch_bufferSizeExt`| | | | | | | |
-|`cusparseZgtsv2_bufferSizeExt`|9.0| | | | | | |
-|`cusparseZgtsv2_nopivot`|9.0| | | | | | |
-|`cusparseZgtsv2_nopivot_bufferSizeExt`|9.0| | | | | | |
+|`cusparseZgtsv2_bufferSizeExt`|9.0| | |`hipsparseZgtsv2_bufferSizeExt`|4.3.0| | |
+|`cusparseZgtsv2_nopivot`|9.0| | |`hipsparseZgtsv2_nopivot`|4.3.0| | |
+|`cusparseZgtsv2_nopivot_bufferSizeExt`|9.0| | |`hipsparseZgtsv2_nopivot_bufferSizeExt`|4.3.0| | |
 |`cusparseZgtsvInterleavedBatch`|9.2| | | | | | |
 |`cusparseZgtsvInterleavedBatch_bufferSizeExt`|9.2| | | | | | |
 |`cusparseZgtsvStridedBatch`| |10.2|11.0| | | | |
@@ -787,6 +789,9 @@
 |`cusparseDnVecSetValues`|10.2| | |`hipsparseDnVecSetValues`|4.1.0| | |
 |`cusparseGather`|11.0| | |`hipsparseGather`|4.1.0| | |
 |`cusparseRot`|11.0| | |`hipsparseRot`|4.1.0| | |
+|`cusparseSDDMM`|11.2| | |`hipsparseSDDMM`|4.3.0| | |
+|`cusparseSDDMM_bufferSize`|11.2| | |`hipsparseSDDMM_bufferSize`|4.3.0| | |
+|`cusparseSDDMM_preprocess`|11.2| | |`hipsparseSDDMM_preprocess`|4.3.0| | |
 |`cusparseScatter`|11.0| | |`hipsparseScatter`|4.1.0| | |
 |`cusparseSpGEMM_compute`|11.0| | |`hipsparseSpGEMM_compute`|4.1.0| | |
 |`cusparseSpGEMM_copy`|11.0| | |`hipsparseSpGEMM_copy`|4.1.0| | |

--- a/src/CUDA2HIP_SPARSE_API_functions.cpp
+++ b/src/CUDA2HIP_SPARSE_API_functions.cpp
@@ -126,15 +126,15 @@ const std::map<llvm::StringRef, hipCounter> CUDA_SPARSE_FUNCTION_MAP {
   {"cusparseCcsrmv_mp",                                 {"hipsparseCcsrmv_mp",                                 "", CONV_LIB_FUNC, API_SPARSE, 8, HIP_UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED}},
   {"cusparseZcsrmv_mp",                                 {"hipsparseZcsrmv_mp",                                 "", CONV_LIB_FUNC, API_SPARSE, 8, HIP_UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED}},
 
-  {"cusparseSgemvi",                                    {"hipsparseSgemvi",                                    "", CONV_LIB_FUNC, API_SPARSE, 8, HIP_UNSUPPORTED}},
-  {"cusparseDgemvi",                                    {"hipsparseDgemvi",                                    "", CONV_LIB_FUNC, API_SPARSE, 8, HIP_UNSUPPORTED}},
-  {"cusparseCgemvi",                                    {"hipsparseCgemvi",                                    "", CONV_LIB_FUNC, API_SPARSE, 8, HIP_UNSUPPORTED}},
-  {"cusparseZgemvi",                                    {"hipsparseZgemvi",                                    "", CONV_LIB_FUNC, API_SPARSE, 8, HIP_UNSUPPORTED}},
+  {"cusparseSgemvi",                                    {"hipsparseSgemvi",                                    "", CONV_LIB_FUNC, API_SPARSE, 8}},
+  {"cusparseDgemvi",                                    {"hipsparseDgemvi",                                    "", CONV_LIB_FUNC, API_SPARSE, 8}},
+  {"cusparseCgemvi",                                    {"hipsparseCgemvi",                                    "", CONV_LIB_FUNC, API_SPARSE, 8}},
+  {"cusparseZgemvi",                                    {"hipsparseZgemvi",                                    "", CONV_LIB_FUNC, API_SPARSE, 8}},
 
-  {"cusparseSgemvi_bufferSize",                         {"hipsparseSgemvi_bufferSize",                         "", CONV_LIB_FUNC, API_SPARSE, 8, HIP_UNSUPPORTED}},
-  {"cusparseDgemvi_bufferSize",                         {"hipsparseDgemvi_bufferSize",                         "", CONV_LIB_FUNC, API_SPARSE, 8, HIP_UNSUPPORTED}},
-  {"cusparseCgemvi_bufferSize",                         {"hipsparseCgemvi_bufferSize",                         "", CONV_LIB_FUNC, API_SPARSE, 8, HIP_UNSUPPORTED}},
-  {"cusparseZgemvi_bufferSize",                         {"hipsparseZgemvi_bufferSize",                         "", CONV_LIB_FUNC, API_SPARSE, 8, HIP_UNSUPPORTED}},
+  {"cusparseSgemvi_bufferSize",                         {"hipsparseSgemvi_bufferSize",                         "", CONV_LIB_FUNC, API_SPARSE, 8}},
+  {"cusparseDgemvi_bufferSize",                         {"hipsparseDgemvi_bufferSize",                         "", CONV_LIB_FUNC, API_SPARSE, 8}},
+  {"cusparseCgemvi_bufferSize",                         {"hipsparseCgemvi_bufferSize",                         "", CONV_LIB_FUNC, API_SPARSE, 8}},
+  {"cusparseZgemvi_bufferSize",                         {"hipsparseZgemvi_bufferSize",                         "", CONV_LIB_FUNC, API_SPARSE, 8}},
 
   {"cusparseSbsrsv2_bufferSize",                        {"hipsparseSbsrsv2_bufferSize",                        "", CONV_LIB_FUNC, API_SPARSE, 8}},
   {"cusparseSbsrsv2_bufferSizeExt",                     {"hipsparseSbsrsv2_bufferSizeExt",                     "", CONV_LIB_FUNC, API_SPARSE, 8}},
@@ -421,25 +421,25 @@ const std::map<llvm::StringRef, hipCounter> CUDA_SPARSE_FUNCTION_MAP {
   {"cusparseCgtsv_nopivot",                             {"hipsparseCgtsv_nopivot",                             "", CONV_LIB_FUNC, API_SPARSE, 11, HIP_UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED}},
   {"cusparseZgtsv_nopivot",                             {"hipsparseZgtsv_nopivot",                             "", CONV_LIB_FUNC, API_SPARSE, 11, HIP_UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED}},
 
-  {"cusparseSgtsv2_bufferSizeExt",                      {"hipsparseSgtsv2_bufferSizeExt",                      "", CONV_LIB_FUNC, API_SPARSE, 11, HIP_UNSUPPORTED}},
-  {"cusparseDgtsv2_bufferSizeExt",                      {"hipsparseDgtsv2_bufferSizeExt",                      "", CONV_LIB_FUNC, API_SPARSE, 11, HIP_UNSUPPORTED}},
-  {"cusparseCgtsv2_bufferSizeExt",                      {"hipsparseCgtsv2_bufferSizeExt",                      "", CONV_LIB_FUNC, API_SPARSE, 11, HIP_UNSUPPORTED}},
-  {"cusparseZgtsv2_bufferSizeExt",                      {"hipsparseZgtsv2_bufferSizeExt",                      "", CONV_LIB_FUNC, API_SPARSE, 11, HIP_UNSUPPORTED}},
+  {"cusparseSgtsv2_bufferSizeExt",                      {"hipsparseSgtsv2_bufferSizeExt",                      "", CONV_LIB_FUNC, API_SPARSE, 11}},
+  {"cusparseDgtsv2_bufferSizeExt",                      {"hipsparseDgtsv2_bufferSizeExt",                      "", CONV_LIB_FUNC, API_SPARSE, 11}},
+  {"cusparseCgtsv2_bufferSizeExt",                      {"hipsparseCgtsv2_bufferSizeExt",                      "", CONV_LIB_FUNC, API_SPARSE, 11}},
+  {"cusparseZgtsv2_bufferSizeExt",                      {"hipsparseZgtsv2_bufferSizeExt",                      "", CONV_LIB_FUNC, API_SPARSE, 11}},
 
-  {"cusparseSgtsv2",                                    {"hipsparseSgtsv2",                                    "", CONV_LIB_FUNC, API_SPARSE, 11, HIP_UNSUPPORTED}},
-  {"cusparseDgtsv2",                                    {"hipsparseDgtsv2",                                    "", CONV_LIB_FUNC, API_SPARSE, 11, HIP_UNSUPPORTED}},
-  {"cusparseCgtsv2",                                    {"hipsparseCgtsv2",                                    "", CONV_LIB_FUNC, API_SPARSE, 11, HIP_UNSUPPORTED}},
-  {"cusparseZgtsv2",                                    {"hipsparseZgtsv2",                                    "", CONV_LIB_FUNC, API_SPARSE, 11, HIP_UNSUPPORTED}},
+  {"cusparseSgtsv2",                                    {"hipsparseSgtsv2",                                    "", CONV_LIB_FUNC, API_SPARSE, 11}},
+  {"cusparseDgtsv2",                                    {"hipsparseDgtsv2",                                    "", CONV_LIB_FUNC, API_SPARSE, 11}},
+  {"cusparseCgtsv2",                                    {"hipsparseCgtsv2",                                    "", CONV_LIB_FUNC, API_SPARSE, 11}},
+  {"cusparseZgtsv2",                                    {"hipsparseZgtsv2",                                    "", CONV_LIB_FUNC, API_SPARSE, 11}},
 
-  {"cusparseSgtsv2_nopivot_bufferSizeExt",              {"hipsparseSgtsv2_nopivot_bufferSizeExt",              "", CONV_LIB_FUNC, API_SPARSE, 11, HIP_UNSUPPORTED}},
-  {"cusparseDgtsv2_nopivot_bufferSizeExt",              {"hipsparseDgtsv2_nopivot_bufferSizeExt",              "", CONV_LIB_FUNC, API_SPARSE, 11, HIP_UNSUPPORTED}},
-  {"cusparseCgtsv2_nopivot_bufferSizeExt",              {"hipsparseCgtsv2_nopivot_bufferSizeExt",              "", CONV_LIB_FUNC, API_SPARSE, 11, HIP_UNSUPPORTED}},
-  {"cusparseZgtsv2_nopivot_bufferSizeExt",              {"hipsparseZgtsv2_nopivot_bufferSizeExt",              "", CONV_LIB_FUNC, API_SPARSE, 11, HIP_UNSUPPORTED}},
+  {"cusparseSgtsv2_nopivot_bufferSizeExt",              {"hipsparseSgtsv2_nopivot_bufferSizeExt",              "", CONV_LIB_FUNC, API_SPARSE, 11}},
+  {"cusparseDgtsv2_nopivot_bufferSizeExt",              {"hipsparseDgtsv2_nopivot_bufferSizeExt",              "", CONV_LIB_FUNC, API_SPARSE, 11}},
+  {"cusparseCgtsv2_nopivot_bufferSizeExt",              {"hipsparseCgtsv2_nopivot_bufferSizeExt",              "", CONV_LIB_FUNC, API_SPARSE, 11}},
+  {"cusparseZgtsv2_nopivot_bufferSizeExt",              {"hipsparseZgtsv2_nopivot_bufferSizeExt",              "", CONV_LIB_FUNC, API_SPARSE, 11}},
 
-  {"cusparseSgtsv2_nopivot",                            {"hipsparseSgtsv2_nopivot",                            "", CONV_LIB_FUNC, API_SPARSE, 11, HIP_UNSUPPORTED}},
-  {"cusparseDgtsv2_nopivot",                            {"hipsparseDgtsv2_nopivot",                            "", CONV_LIB_FUNC, API_SPARSE, 11, HIP_UNSUPPORTED}},
-  {"cusparseCgtsv2_nopivot",                            {"hipsparseCgtsv2_nopivot",                            "", CONV_LIB_FUNC, API_SPARSE, 11, HIP_UNSUPPORTED}},
-  {"cusparseZgtsv2_nopivot",                            {"hipsparseZgtsv2_nopivot",                            "", CONV_LIB_FUNC, API_SPARSE, 11, HIP_UNSUPPORTED}},
+  {"cusparseSgtsv2_nopivot",                            {"hipsparseSgtsv2_nopivot",                            "", CONV_LIB_FUNC, API_SPARSE, 11}},
+  {"cusparseDgtsv2_nopivot",                            {"hipsparseDgtsv2_nopivot",                            "", CONV_LIB_FUNC, API_SPARSE, 11}},
+  {"cusparseCgtsv2_nopivot",                            {"hipsparseCgtsv2_nopivot",                            "", CONV_LIB_FUNC, API_SPARSE, 11}},
+  {"cusparseZgtsv2_nopivot",                            {"hipsparseZgtsv2_nopivot",                            "", CONV_LIB_FUNC, API_SPARSE, 11}},
 
   // 11.4. Batched Tridiagonal Solve
   {"cusparseSgtsvStridedBatch",                         {"hipsparseSgtsvStridedBatch",                         "", CONV_LIB_FUNC, API_SPARSE, 11, HIP_UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED}},
@@ -806,6 +806,12 @@ const std::map<llvm::StringRef, hipCounter> CUDA_SPARSE_FUNCTION_MAP {
   {"cusparseDenseToSparse_bufferSize",                  {"hipsparseDenseToSparse_bufferSize",                  "", CONV_LIB_FUNC, API_SPARSE, 14}},
   {"cusparseDenseToSparse_analysis",                    {"hipsparseDenseToSparse_analysis",                    "", CONV_LIB_FUNC, API_SPARSE, 14}},
   {"cusparseDenseToSparse_convert",                     {"hipsparseDenseToSparse_convert",                     "", CONV_LIB_FUNC, API_SPARSE, 14}},
+
+  // Sampled Dense-dense Matrix Multiplication
+  {"cusparseSDDMM",                                     {"hipsparseSDDMM",                                     "", CONV_LIB_FUNC, API_SPARSE, 14}},
+  {"cusparseSDDMM_bufferSize",                          {"hipsparseSDDMM_bufferSize",                          "", CONV_LIB_FUNC, API_SPARSE, 14}},
+  {"cusparseSDDMM_preprocess",                          {"hipsparseSDDMM_preprocess",                          "", CONV_LIB_FUNC, API_SPARSE, 14}},
+
 };
 
 const std::map<llvm::StringRef, cudaAPIversions> CUDA_SPARSE_FUNCTION_VER_MAP {
@@ -1193,6 +1199,9 @@ const std::map<llvm::StringRef, cudaAPIversions> CUDA_SPARSE_FUNCTION_VER_MAP {
   {"cusparseSpGEMMreuse_nnz",                           {CUDA_113, CUDA_0,   CUDA_0  }},
   {"cusparseSpGEMMreuse_copy",                          {CUDA_113, CUDA_0,   CUDA_0  }},
   {"cusparseSpGEMMreuse_compute",                       {CUDA_113, CUDA_0,   CUDA_0  }},
+  {"cusparseSDDMM",                                     {CUDA_112, CUDA_0,   CUDA_0  }},
+  {"cusparseSDDMM_bufferSize",                          {CUDA_112, CUDA_0,   CUDA_0  }},
+  {"cusparseSDDMM_preprocess",                          {CUDA_112, CUDA_0,   CUDA_0  }},
 };
 
 const std::map<llvm::StringRef, hipAPIversions> HIP_SPARSE_FUNCTION_VER_MAP {
@@ -1606,6 +1615,33 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_SPARSE_FUNCTION_VER_MAP {
   {"hipsparseDenseToSparse_convert",                     {HIP_4020, HIP_0,    HIP_0   }},
   {"hipsparseSpMM_bufferSize",                           {HIP_4020, HIP_0,    HIP_0   }},
   {"hipsparseSpMM",                                      {HIP_4020, HIP_0,    HIP_0   }},
+  {"hipsparseSgemvi_bufferSize",                         {HIP_4030, HIP_0,    HIP_0   }},
+  {"hipsparseDgemvi_bufferSize",                         {HIP_4030, HIP_0,    HIP_0   }},
+  {"hipsparseCgemvi_bufferSize",                         {HIP_4030, HIP_0,    HIP_0   }},
+  {"hipsparseZgemvi_bufferSize",                         {HIP_4030, HIP_0,    HIP_0   }},
+  {"hipsparseSgemvi",                                    {HIP_4030, HIP_0,    HIP_0   }},
+  {"hipsparseDgemvi",                                    {HIP_4030, HIP_0,    HIP_0   }},
+  {"hipsparseCgemvi",                                    {HIP_4030, HIP_0,    HIP_0   }},
+  {"hipsparseZgemvi",                                    {HIP_4030, HIP_0,    HIP_0   }},
+  {"hipsparseSgtsv2_bufferSizeExt",                      {HIP_4030, HIP_0,    HIP_0   }},
+  {"hipsparseDgtsv2_bufferSizeExt",                      {HIP_4030, HIP_0,    HIP_0   }},
+  {"hipsparseCgtsv2_bufferSizeExt",                      {HIP_4030, HIP_0,    HIP_0   }},
+  {"hipsparseZgtsv2_bufferSizeExt",                      {HIP_4030, HIP_0,    HIP_0   }},
+  {"hipsparseSgtsv2",                                    {HIP_4030, HIP_0,    HIP_0   }},
+  {"hipsparseDgtsv2",                                    {HIP_4030, HIP_0,    HIP_0   }},
+  {"hipsparseCgtsv2",                                    {HIP_4030, HIP_0,    HIP_0   }},
+  {"hipsparseZgtsv2",                                    {HIP_4030, HIP_0,    HIP_0   }},
+  {"hipsparseSgtsv2_nopivot_bufferSizeExt",              {HIP_4030, HIP_0,    HIP_0   }},
+  {"hipsparseDgtsv2_nopivot_bufferSizeExt",              {HIP_4030, HIP_0,    HIP_0   }},
+  {"hipsparseCgtsv2_nopivot_bufferSizeExt",              {HIP_4030, HIP_0,    HIP_0   }},
+  {"hipsparseZgtsv2_nopivot_bufferSizeExt",              {HIP_4030, HIP_0,    HIP_0   }},
+  {"hipsparseSgtsv2_nopivot",                            {HIP_4030, HIP_0,    HIP_0   }},
+  {"hipsparseDgtsv2_nopivot",                            {HIP_4030, HIP_0,    HIP_0   }},
+  {"hipsparseCgtsv2_nopivot",                            {HIP_4030, HIP_0,    HIP_0   }},
+  {"hipsparseZgtsv2_nopivot",                            {HIP_4030, HIP_0,    HIP_0   }},
+  {"hipsparseSDDMM",                                     {HIP_4030, HIP_0,    HIP_0   }},
+  {"hipsparseSDDMM_bufferSize",                          {HIP_4030, HIP_0,    HIP_0   }},
+  {"hipsparseSDDMM_preprocess",                          {HIP_4030, HIP_0,    HIP_0   }},
 };
 
 const std::map<unsigned int, llvm::StringRef> CUDA_SPARSE_API_SECTION_MAP {

--- a/src/CUDA2HIP_SPARSE_API_types.cpp
+++ b/src/CUDA2HIP_SPARSE_API_types.cpp
@@ -223,6 +223,9 @@ const std::map<llvm::StringRef, hipCounter> CUDA_SPARSE_TYPE_NAME_MAP {
   {"cusparseSpSMAlg_t",                         {"hipsparseSpSMAlg_t",                         "", CONV_TYPE, API_SPARSE, 4, HIP_UNSUPPORTED}},
   {"CUSPARSE_SPSM_ALG_DEFAULT",                 {"HIPSPARSE_SPSM_ALG_DEFAULT",                 "", CONV_NUMERIC_LITERAL, API_SPARSE, 4, HIP_UNSUPPORTED}},
 
+  {"cusparseSDDMMAlg_t",                        {"hipsparseSDDMMAlg_t",                        "", CONV_TYPE, API_SPARSE, 4}},
+  {"CUSPARSE_SDDMM_ALG_DEFAULT",                {"HIPSPARSE_SDDMM_ALG_DEFAULT",                 "", CONV_NUMERIC_LITERAL, API_SPARSE, 4}},
+
   // 3. Defines
   {"CUSPARSE_VER_MAJOR",                        {"HIPSPARSE_VER_MAJOR",                        "", CONV_DEFINE, API_SPARSE, 4, HIP_UNSUPPORTED}},
   {"CUSPARSE_VER_MINOR",                        {"HIPSPARSE_VER_MINOR",                        "", CONV_DEFINE, API_SPARSE, 4, HIP_UNSUPPORTED}},
@@ -324,6 +327,8 @@ const std::map<llvm::StringRef, cudaAPIversions> CUDA_SPARSE_TYPE_NAME_VER_MAP {
   {"cusparseSpSMDescr_t",                       {CUDA_113, CUDA_0,   CUDA_0  }},
   {"CUSPARSE_SPGEMM_CSR_ALG_DETERMINITIC",      {CUDA_113, CUDA_0,   CUDA_0  }},
   {"CUSPARSE_SPGEMM_CSR_ALG_NONDETERMINITIC",   {CUDA_113, CUDA_0,   CUDA_0  }},
+  {"cusparseSDDMMAlg_t",                        {CUDA_112, CUDA_0,   CUDA_0  }},
+  {"CUSPARSE_SDDMM_ALG_DEFAULT",                {CUDA_112, CUDA_0,   CUDA_0  }},
 };
 
 const std::map<llvm::StringRef, hipAPIversions> HIP_SPARSE_TYPE_NAME_VER_MAP {
@@ -428,4 +433,6 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_SPARSE_TYPE_NAME_VER_MAP {
   {"HIPSPARSE_SPMM_CSR_ALG2",                    {HIP_4020, HIP_0,    HIP_0   }},
   {"hipsparseSparseToDenseAlg_t",                {HIP_4020, HIP_0,    HIP_0   }},
   {"HIPSPARSE_SPARSETODENSE_ALG_DEFAULT",        {HIP_4020, HIP_0,    HIP_0   }},
+  {"hipsparseSDDMMAlg_t",                        {HIP_4030, HIP_0,    HIP_0   }},
+  {"HIPSPARSE_SDDMM_ALG_DEFAULT",                {HIP_4030, HIP_0,    HIP_0   }},
 };


### PR DESCRIPTION
+ Add missing cuSPARSE types and functions
+ Update hipify-perl and cuSPARSE documentation
+ ToDo: Revise and add the rest of the missing cuSPARSE APIs since CUDA 11.2
