### PR TITLE
[HIPIFY][SPARSE][fix] Add missing APis appeared with CUDA 11.3.x

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -4436,6 +4436,8 @@ sub warnUnsupportedFunctions {
         "cusparseSpSV_createDescr",
         "cusparseSpSV_bufferSize",
         "cusparseSpSV_analysis",
+        "cusparseSpSVDescr_t",
+        "cusparseSpSVDescr",
         "cusparseSpSVAlg_t",
         "cusparseSpSM_solve",
         "cusparseSpSM_destroyDescr",

--- a/doc/markdown/CUSPARSE_API_supported_by_HIP.md
+++ b/doc/markdown/CUSPARSE_API_supported_by_HIP.md
@@ -157,6 +157,8 @@
 |`cusparseSpSMDescr`|11.3| | | | | | |
 |`cusparseSpSMDescr_t`|11.3| | | | | | |
 |`cusparseSpSVAlg_t`|11.3| | | | | | |
+|`cusparseSpSVDescr`|11.3| | | | | | |
+|`cusparseSpSVDescr_t`|11.3| | | | | | |
 |`cusparseSpVecDescr`|10.2| | | | | | |
 |`cusparseSpVecDescr_t`|10.2| | |`hipsparseSpVecDescr_t`|4.1.0| | |
 |`cusparseSparseToDenseAlg_t`|11.1| | |`hipsparseSparseToDenseAlg_t`|4.2.0| | |

--- a/src/CUDA2HIP_SPARSE_API_types.cpp
+++ b/src/CUDA2HIP_SPARSE_API_types.cpp
@@ -89,6 +89,9 @@ const std::map<llvm::StringRef, hipCounter> CUDA_SPARSE_TYPE_NAME_MAP {
   {"cusparseSpSMDescr",                         {"hipsparseSpSMDescr",                         "", CONV_TYPE, API_SPARSE, 4, HIP_UNSUPPORTED}},
   {"cusparseSpSMDescr_t",                       {"hipsparseSpSMDescr_t",                       "", CONV_TYPE, API_SPARSE, 4, HIP_UNSUPPORTED}},
 
+  {"cusparseSpSVDescr",                         {"hipsparseSpSVDescr",                         "", CONV_TYPE, API_SPARSE, 4, HIP_UNSUPPORTED}},
+  {"cusparseSpSVDescr_t",                       {"hipsparseSpSVDescr_t",                       "", CONV_TYPE, API_SPARSE, 4, HIP_UNSUPPORTED}},
+
   // 2. Enums
   {"cusparseAction_t",                          {"hipsparseAction_t",                          "", CONV_TYPE, API_SPARSE, 4}},
   {"CUSPARSE_ACTION_SYMBOLIC",                  {"HIPSPARSE_ACTION_SYMBOLIC",                  "", CONV_NUMERIC_LITERAL, API_SPARSE, 4}},
@@ -331,6 +334,8 @@ const std::map<llvm::StringRef, cudaAPIversions> CUDA_SPARSE_TYPE_NAME_VER_MAP {
   {"cusparseSDDMMAlg_t",                        {CUDA_112, CUDA_0,   CUDA_0  }},
   {"CUSPARSE_SDDMM_ALG_DEFAULT",                {CUDA_112, CUDA_0,   CUDA_0  }},
   {"CUSPARSE_FORMAT_BLOCKED_ELL",               {CUDA_112, CUDA_0,   CUDA_0  }},
+  {"cusparseSpSVDescr",                         {CUDA_113, CUDA_0,   CUDA_0  }},
+  {"cusparseSpSVDescr_t",                       {CUDA_113, CUDA_0,   CUDA_0  }},
 };
 
 const std::map<llvm::StringRef, hipAPIversions> HIP_SPARSE_TYPE_NAME_VER_MAP {


### PR DESCRIPTION
+ Update hipify-perl and SPARSE documentation accordingly