### PR TITLE
[HIPIFY][fix] Change `__funnelshift` functions HIP `added` version from 4.3 to 4.4

### DIFF
--- a/doc/markdown/CUDA_Device_API_supported_by_HIP.md
+++ b/doc/markdown/CUDA_Device_API_supported_by_HIP.md
@@ -103,10 +103,10 @@
 |`__fsub_rn`| | | |`__fsub_rn`|1.6.0| | |
 |`__fsub_ru`| | | |`__fsub_ru`|1.6.0| | |
 |`__fsub_rz`| | | |`__fsub_rz`|1.6.0| | |
-|`__funnelshift_l`| | | |`__funnelshift_l`|4.3.0| | |
-|`__funnelshift_lc`| | | |`__funnelshift_lc`|4.3.0| | |
-|`__funnelshift_r`| | | |`__funnelshift_r`|4.3.0| | |
-|`__funnelshift_rc`| | | |`__funnelshift_rc`|4.3.0| | |
+|`__funnelshift_l`| | | |`__funnelshift_l`|4.4.0| | |
+|`__funnelshift_lc`| | | |`__funnelshift_lc`|4.4.0| | |
+|`__funnelshift_r`| | | |`__funnelshift_r`|4.4.0| | |
+|`__funnelshift_rc`| | | |`__funnelshift_rc`|4.4.0| | |
 |`__h2div`| | | |`__h2div`|1.9.0| | |
 |`__habs`| | | |`__habs`|3.5.0| | |
 |`__habs2`| | | |`__habs2`|3.5.0| | |

--- a/src/CUDA2HIP_Device_functions.cpp
+++ b/src/CUDA2HIP_Device_functions.cpp
@@ -1200,10 +1200,10 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_DEVICE_FUNCTION_VER_MAP {
   {"atomicAnd_system",    {HIP_4030, HIP_0,    HIP_0   }},
   {"atomicOr_system",     {HIP_4030, HIP_0,    HIP_0   }},
   {"atomicXor_system",    {HIP_4030, HIP_0,    HIP_0   }},
-  {"__funnelshift_l",     {HIP_4030, HIP_0,    HIP_0   }},
-  {"__funnelshift_lc",    {HIP_4030, HIP_0,    HIP_0   }},
-  {"__funnelshift_r",     {HIP_4030, HIP_0,    HIP_0   }},
-  {"__funnelshift_rc",    {HIP_4030, HIP_0,    HIP_0   }},
+  {"__funnelshift_l",     {HIP_4040, HIP_0,    HIP_0   }},
+  {"__funnelshift_lc",    {HIP_4040, HIP_0,    HIP_0   }},
+  {"__funnelshift_r",     {HIP_4040, HIP_0,    HIP_0   }},
+  {"__funnelshift_rc",    {HIP_4040, HIP_0,    HIP_0   }},
 };
 
 const std::map<llvm::StringRef, hipCounter> CUDA_DEVICE_TYPE_NAME_MAP {


### PR DESCRIPTION
+ Update `CUDA_Device_API_supported_by_HIP.md` accordingly
