### PR TITLE
[HIPIFY] Add dependency on rocm-core

### DIFF
--- a/packaging/hipify-clang.txt
+++ b/packaging/hipify-clang.txt
@@ -4,6 +4,10 @@ project(hipify-clang)
 install(PROGRAMS @HIPIFY_INSTALL_PATH@/hipify-clang DESTINATION bin)
 install(DIRECTORY @HIPIFY_INSTALL_PATH@/include DESTINATION bin)
 
+# hipify-clang.txt is processed to produce CMakeList.txt,
+# pass down value from parent
+set (ROCM_DEP_ROCMCORE "@ROCM_DEP_ROCMCORE@")
+
 #############################
 # Packaging steps
 #############################
@@ -28,6 +32,9 @@ endif()
 
 #Debian package specific variables
 set(CPACK_DEBIAN_PACKAGE_HOMEPAGE ${CPACK_DEBIAN_PACKAGE_HOMEPAGE} CACHE STRING "https://github.com/RadeonOpenCompute/ROCm")
+if(ROCM_DEP_ROCMCORE)
+  set(CPACK_DEBIAN_PACKAGE_DEPENDS "rocm-core")
+endif()
 if (DEFINED ENV{CPACK_DEBIAN_PACKAGE_RELEASE})
    set(CPACK_DEBIAN_PACKAGE_RELEASE $ENV{CPACK_DEBIAN_PACKAGE_RELEASE})
 else()
@@ -38,6 +45,9 @@ endif()
 set(CPACK_RPM_PACKAGE_AUTOREQPROV "NO")
 string(REPLACE "/hip" "" ROCM_PATH @CPACK_PACKAGING_INSTALL_PREFIX@)
 set(CPACK_RPM_EXCLUDE_FROM_AUTO_FILELIST_ADDITION "/opt" "${ROCM_PATH}" "@CPACK_PACKAGING_INSTALL_PREFIX@" "@CPACK_PACKAGING_INSTALL_PREFIX@/bin")
+if(ROCM_DEP_ROCMCORE)
+  set(CPACK_RPM_PACKAGE_REQUIRES "rocm-core")
+endif()
 if(DEFINED ENV{CPACK_RPM_PACKAGE_RELEASE})
   set(CPACK_RPM_PACKAGE_RELEASE $ENV{CPACK_RPM_PACKAGE_RELEASE})
 else()


### PR DESCRIPTION
The intention is to make all the rocm packages depend on rocm-core to
enable eveerything to be removed cleanly by just removing the
rocm-core package.

Signed-off-by: Icarus Sparry <icarus.sparry@amd.com>