### PR TITLE
[HIPIFY][#405] Implement `compact` doc-format

### DIFF
--- a/src/ArgParse.cpp
+++ b/src/ArgParse.cpp
@@ -156,7 +156,7 @@ cl::opt<bool> GenerateCSV("csv",
   cl::cat(ToolTemplateCategory));
 
 cl::opt<std::string> DocFormat("doc-format",
-  cl::desc("Documentation format: 'full' (default) or 'strict';\n'--md' or '--csv' option should be specified"),
+  cl::desc("Documentation format: 'full' (default), 'strict', or 'compact';\n'--md' or '--csv' option should be specified"),
   cl::value_desc("value"),
   cl::cat(ToolTemplateCategory));
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -55,7 +55,7 @@ void cleanupHipifyOptions(std::vector<const char*> &args) {
                                             "-no-backup", "-no-output", "-print-stats",
                                             "-print-stats-csv", "-examine", "-save-temps",
                                             "-skip-excluded-preprocessor-conditional-blocks",
-                                            "-md", "-csv"};
+                                            "-md", "-csv", "-doc-format"};
   for (const auto &a : hipifyOptions) {
     args.erase(std::remove(args.begin(), args.end(), a), args.end());
     args.erase(std::remove(args.begin(), args.end(), "-" + a), args.end());


### PR DESCRIPTION
+ Additionally, apply sequential numbering for docs' sections (compact format only)
+ [fix] Add `-doc-format`option to hipifyOptions vector
