### PR TITLE
[HIPIFY][tests][fix] Switch preprocessor's mode to regular for some OS-specific tests

### DIFF
--- a/tests/unit_tests/synthetic/driver_enums.cu
+++ b/tests/unit_tests/synthetic/driver_enums.cu
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %hipify_args -D__CUDA_API_VERSION_INTERNAL %clang_args
+// RUN: %run_test hipify "%s" "%t" --skip-excluded-preprocessor-conditional-blocks %hipify_args -D__CUDA_API_VERSION_INTERNAL %clang_args
 
 // CHECK: #include <hip/hip_runtime.h>
 #include <cuda.h>

--- a/tests/unit_tests/synthetic/runtime_enums.cu
+++ b/tests/unit_tests/synthetic/runtime_enums.cu
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %hipify_args -D__CUDA_API_VERSION_INTERNAL %clang_args
+// RUN: %run_test hipify "%s" "%t" --skip-excluded-preprocessor-conditional-blocks %hipify_args -D__CUDA_API_VERSION_INTERNAL %clang_args
 
 // CHECK: #include <hip/hip_runtime.h>
 #include <cuda_runtime_api.h>


### PR DESCRIPTION
+ Add '--skip-excluded-preprocessor-conditional-blocks' option to the tests which have the following conditional includes:
```c++
  #if defined(_WIN32)
  #include "windows.h"
  #endif
```