### PR TITLE
[HIPIFY][tests][fix] Fix CUB tests failed on THRUST_NS_QUALIFIER

### DIFF
--- a/tests/unit_tests/libraries/CUB/cub_01.cu
+++ b/tests/unit_tests/libraries/CUB/cub_01.cu
@@ -3,6 +3,7 @@
 #include <iostream>
 // CHECK: #include <hiprand.h>
 #include <curand.h>
+#define THRUST_NS_QUALIFIER ::thrust
 // CHECK: #include <hipcub/hipcub.hpp>
 #include <cub/cub.cuh>
 

--- a/tests/unit_tests/libraries/CUB/cub_02.cu
+++ b/tests/unit_tests/libraries/CUB/cub_02.cu
@@ -3,6 +3,7 @@
 #include <iostream>
 // CHECK: #include <hiprand.h>
 #include <curand.h>
+#define THRUST_NS_QUALIFIER ::thrust
 // CHECK: #include <hipcub/hipcub.hpp>
 #include <cub/cub.cuh>
 

--- a/tests/unit_tests/libraries/CUB/cub_03.cu
+++ b/tests/unit_tests/libraries/CUB/cub_03.cu
@@ -1,6 +1,7 @@
 // RUN: %run_test hipify "%s" "%t" %hipify_args %clang_args
 // CHECK: #include <hip/hip_runtime.h>
 #include <iostream>
+#define THRUST_NS_QUALIFIER ::thrust
 // CHECK: #include <hipcub/hipcub.hpp>
 #include <cub/cub.cuh>
 


### PR DESCRIPTION
+ An issue observed on CUB starting 1.12:
  `/root/cub/cub/device/dispatch/../../agent/agent_merge_sort.cuh:80:32: error: use of undeclared identifier 'THRUST_NS_QUALIFIER'`