### PR TITLE
[HIPIFY][#425][tests] Add support of running tests against hipify-clang, the path to which is specified by `CMAKE_INSTALL_PREFIX`

### DIFF
--- a/tests/lit.cfg
+++ b/tests/lit.cfg
@@ -108,11 +108,15 @@ if obj_root is not None:
     path = os.path.pathsep.join((llvm_tools_dir, config.environment['PATH']))
     config.environment['PATH'] = path
 
-hipify_path = obj_root
+if config.hipify_clang_tests_only == "1" or config.hipify_clang_tests_only == "ON":
+    hipify_path = config.hipify_install_path
+else:
+    hipify_path = obj_root
 
 if sys.platform in ['win32']:
     run_test_ext = ".bat"
-    hipify_path += "/" + config.build_type
+    if config.hipify_clang_tests_only != "1" and config.hipify_clang_tests_only != "ON":
+        hipify_path += "/" + config.build_type
     # CUDA SDK ROOT
     clang_arguments += " -isystem'%s'/common/inc"
 else:

--- a/tests/lit.site.cfg.in
+++ b/tests/lit.site.cfg.in
@@ -1,6 +1,8 @@
 import sys
 import os
 
+config.hipify_install_path = "@CMAKE_INSTALL_PREFIX@"
+config.hipify_clang_tests_only = "@HIPIFY_CLANG_TESTS_ONLY@"
 config.pointer_size = @CMAKE_SIZEOF_VOID_P@
 config.llvm_version = "@LLVM_PACKAGE_VERSION@"
 config.llvm_version_major = int("@LLVM_VERSION_MAJOR@")


### PR DESCRIPTION
+ Works only if `HIPIFY_CLANG_TESTS_ONLY` is set to `ON`
