### PR TITLE
[HIPIFY][#430] Introducing HIP_EXPERIMENTAL attribute

### DIFF
--- a/src/CUDA2HIP_Doc.cpp
+++ b/src/CUDA2HIP_Doc.cpp
@@ -97,6 +97,7 @@ namespace doc {
   const string sA = "A";
   const string sD = "D";
   const string sR = "R";
+  const string sE = "E";
 
   enum docType {
     none = 0,
@@ -193,7 +194,7 @@ namespace doc {
             string sS = (doc == md) ? "|" : ",";
             stringstream rows;
             for (auto &f : fMap) {
-              string a, d, r, ha, hd, hr;
+              string a, d, r, ha, hd, hr, he;
               for (auto &v : vMap) {
                 if (v.first == f.first) {
                   a = Statistics::getCudaVersion(v.second.appeared);
@@ -207,6 +208,7 @@ namespace doc {
                 ha = Statistics::getHipVersion(hv->second.appeared);
                 hd = Statistics::getHipVersion(hv->second.deprecated);
                 hr = Statistics::getHipVersion(hv->second.removed);
+                he = Statistics::getHipVersion(hv->second.experimental);
               }
               string sHip = Statistics::isUnsupported(f.second) ? "" : string(f.second.hipName);
               if (doc == md) {
@@ -218,11 +220,11 @@ namespace doc {
                   switch (format) {
                     case strict:
                     case compact:
-                      rows << (d.empty() ? "" : "+") << sS << sHip << sS << (hd.empty() ? "" : "+") << endl;
+                      rows << (d.empty() ? "" : "+") << sS << sHip << sS << (hd.empty() ? "" : "+") << sS << (he.empty() ? "" : "+") << endl;
                       break;
                     case full:
                     default:
-                      rows << a << sS << d << sS << r << sS << sHip << sS << ha << sS << hd << sS << hr << endl;
+                      rows << a << sS << d << sS << r << sS << sHip << sS << ha << sS << hd << sS << hr << sS << he << endl;
                       break;
                   }
                   break;
@@ -231,12 +233,12 @@ namespace doc {
                   switch (format) {
                     case strict:
                     case compact:
-                      rows << (d.empty() ? " " : "+") << sS << sHip << sS << (hd.empty() ? " " : "+") << sS << endl;
+                      rows << (d.empty() ? " " : "+") << sS << sHip << sS << (hd.empty() ? " " : "+") << sS << (he.empty() ? " " : "+") << sS << endl;
                       break;
                     case full:
                     default:
                       rows << (a.empty() ? " " : a) << sS << (d.empty() ? " " : d) << sS << (r.empty() ? " " : r) << sS << sHip << sS <<
-                        (ha.empty() ? " " : ha) << sS << (hd.empty() ? " " : hd) << sS << (hr.empty() ? " " : hr) << sS << endl;
+                        (ha.empty() ? " " : ha) << sS << (hd.empty() ? " " : hd) << sS << (hr.empty() ? " " : hr) << sS << (he.empty() ? " " : he) << sS << endl;
                       break;
                   }
                   break;
@@ -247,10 +249,10 @@ namespace doc {
             section_header << (doc == md ? "## **" : "") << (format != compact ? s.first : compact_only_cur_sec_num) << ". " << string(s.second) << (doc == md ? "**" : "") << endl << endl;
             section << (doc == md ? "|**" : "") << sCUDA << sS << (format == full ? sA : "") << (format == full ? sS : "") <<
               sD << sS << (format == full ? sR : "") << (format == full ? sS : "") << sHIP << sS << (format == full ? sA : "") << (format == full ? sS : "") <<
-              sD << (format == full ? sS : "") << (format == full ? sR : "") << (doc == md ? "**|" : "") << endl;
+              sD << (format == full ? sS : "") << (format == full ? sR : "") << sS << sE << (doc == md ? "**|" : "") << endl;
             if (doc == md) {
               section << "|:--|" << (format == full ? ":-:|" : "") << ":-:|" << (format == full ? ":-:|" : "") <<
-                ":--|" << (format == full ? ":-:|" : "") << ":-:|" << (format == full ? ":-:|" : "") << endl;
+                ":--|" << (format == full ? ":-:|" : "") << ":-:|" << (format == full ? ":-:|" : "") << ":-:|" << endl;
             }
             switch (format) {
               case full:
@@ -270,7 +272,7 @@ namespace doc {
               *streams[doc].get() << rows.str() << endl;
             }
           }
-          *streams[doc].get() << endl << (doc == md ? "\\" : "") << (format == full ? "*A - Added; D - Deprecated; R - Removed" : "*D - Deprecated");
+          *streams[doc].get() << endl << (doc == md ? "\\" : "") << (format == full ? "*A - Added; D - Deprecated; R - Removed; E - Experimental" : "*D - Deprecated; E - Experimental");
         }
         return true;
       }

--- a/src/Statistics.cpp
+++ b/src/Statistics.cpp
@@ -343,6 +343,10 @@ bool Statistics::isToRoc(const hipCounter &counter) {
   return TranslateToRoc && counter.apiType == API_BLAS;
 }
 
+bool Statistics::isHipExperimental(const hipCounter& counter) {
+  return HIP_EXPERIMENTAL == (counter.supportDegree & HIP_EXPERIMENTAL);
+}
+
 bool Statistics::isHipUnsupported(const hipCounter &counter) {
   return HIP_UNSUPPORTED == (counter.supportDegree & HIP_UNSUPPORTED);
 }

--- a/src/Statistics.h
+++ b/src/Statistics.h
@@ -158,6 +158,7 @@ enum SupportDegree {
   CUDA_REMOVED = 0x40,
   HIP_REMOVED = 0x80,
   REMOVED = 0x100,
+  HIP_EXPERIMENTAL = 0x200
 };
 
 enum cudaVersions {
@@ -275,6 +276,7 @@ enum hipVersions {
   HIP_4030 = 4030,
   HIP_4040 = 4040,
   HIP_4050 = 4050,
+  HIP_LATEST = HIP_4050,
 };
 
 struct cudaAPIversions {
@@ -287,6 +289,7 @@ struct hipAPIversions {
   hipVersions appeared;
   hipVersions deprecated;
   hipVersions removed;
+  hipVersions experimental = HIP_0;
 };
 
 // The names of various fields in in the statistics reports.
@@ -377,6 +380,8 @@ public:
   static void setActive(const std::string &name);
   // Check the counter and option TranslateToRoc whether it should be translated to Roc or not.
   static bool isToRoc(const hipCounter &counter);
+  // Check whether the counter is HIP_EXPERIMENTAL or not.
+  static bool isHipExperimental(const hipCounter &counter);
   // Check whether the counter is HIP_UNSUPPORTED or not.
   static bool isHipUnsupported(const hipCounter &counter);
   // Check whether the counter is ROC_UNSUPPORTED or not.


### PR DESCRIPTION
+ Add `hipVersions experimental = HIP_0` to the `struct hipAPIversions`
+ Add `HIP_LATEST = HIP_4050` to `enum hipVersions`
+ Add "Experimental" (E) column for HIP API only in the generated CUDA2HIP documents' tables
