### PR TITLE
[HIPIFY][tests] Add ability to specify more than one hipify-clang specific option in the test itself

### DIFF
--- a/tests/run_test.bat
+++ b/tests/run_test.bat
@@ -8,11 +8,24 @@ set HIPIFY=%1
 set IN_FILE=%2
 set TMP_FILE=%3
 set CUDA_ROOT=%4
-set ROC=%5
-
+set NUM=%5
 set all_args=%*
-call set clang_args=%%all_args:*%6=%%
-set clang_args=%6%clang_args%
+
+if %NUM% EQU 1 (
+  set HIPIFY_OPTS=%6
+  set NUM=%7
+)
+if %NUM% EQU 2 (
+  set HIPIFY_OPTS=%6 %7
+  set NUM=%8
+)
+if %NUM% EQU 3 (
+  set HIPIFY_OPTS=%6 %7 %8
+  set NUM=%9
+)
+
+call set clang_args=%%all_args:*%NUM%=%%
+set clang_args=%NUM%%clang_args%
 
 set test_dir=%~dp2
 set "test_dir=%test_dir:\=/%"
@@ -25,7 +38,7 @@ if exist %json_in% (
   powershell -Command "(gc %json_in%) -replace '<test dir>', '%test_dir%' -replace '<CUDA dir>', '%CUDA_ROOT%' | Out-File -encoding ASCII %json_out%"
   %HIPIFY% -o=%TMP_FILE% %IN_FILE% %CUDA_ROOT% -p=%test_dir% -D_ALLOW_COMPILER_AND_STL_VERSION_MISMATCH=1
 ) else (
-  %HIPIFY% -o=%TMP_FILE% %IN_FILE% %CUDA_ROOT% %ROC% -D_ALLOW_COMPILER_AND_STL_VERSION_MISMATCH=1 -- %clang_args%
+  %HIPIFY% -o=%TMP_FILE% %IN_FILE% %CUDA_ROOT% %HIPIFY_OPTS% -D_ALLOW_COMPILER_AND_STL_VERSION_MISMATCH=1 -- %clang_args%
 )
 
 if errorlevel 1 (echo      Error: hipify-clang.exe failed with exit code: %errorlevel% && exit /b %errorlevel%)

--- a/tests/run_test.sh
+++ b/tests/run_test.sh
@@ -10,8 +10,22 @@ HIPIFY=$1
 IN_FILE=$2
 TMP_FILE=$3
 CUDA_ROOT=$4
-ROC=$5
-shift 5
+NUM=$5
+HIPIFY_OPTS=""
+
+if [ $NUM -eq 1 ]
+then
+HIPIFY_OPTS=$6
+shift 6
+elif [ $NUM -eq 2 ]
+then
+HIPIFY_OPTS="$6 $7"
+shift 7
+elif [ $NUM -eq 3 ]
+then
+HIPIFY_OPTS="$6 $7 $8"
+shift 8
+fi
 
 test_dir=${IN_FILE%/*}
 
@@ -27,5 +41,5 @@ cp $json_in $json_out
 sed -i -e "s|<test dir>|${test_dir}|g; s|<CUDA dir>|${CUDA_ROOT}|g" $json_out
 $HIPIFY -o=$TMP_FILE $IN_FILE $CUDA_ROOT -p=$test_dir && cat $TMP_FILE | sed -Ee 's|//.+|// |g' | FileCheck $IN_FILE
 else
-$HIPIFY -o=$TMP_FILE $IN_FILE $CUDA_ROOT $ROC -- $@ && cat $TMP_FILE | sed -Ee 's|//.+|// |g' | FileCheck $IN_FILE
+$HIPIFY -o=$TMP_FILE $IN_FILE $CUDA_ROOT $HIPIFY_OPTS -- $@ && cat $TMP_FILE | sed -Ee 's|//.+|// |g' | FileCheck $IN_FILE
 fi

--- a/tests/unit_tests/device/atomics.cu
+++ b/tests/unit_tests/device/atomics.cu
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" --skip-excluded-preprocessor-conditional-blocks %hipify_args %clang_args "-Xclang" "-fcuda-allow-variadic-functions"
+// RUN: %run_test hipify "%s" "%t" %hipify_args 1 --skip-excluded-preprocessor-conditional-blocks %clang_args "-Xclang" "-fcuda-allow-variadic-functions"
 
 /*
 Copyright (c) 2015-present Advanced Micro Devices, Inc. All rights reserved.

--- a/tests/unit_tests/libraries/cuBLAS/rocBLAS/cublas_0_based_indexing_rocblas.cu
+++ b/tests/unit_tests/libraries/cuBLAS/rocBLAS/cublas_0_based_indexing_rocblas.cu
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %hipify_args "-roc" %clang_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args 1 -roc %clang_args
 
 // CHECK: #include <hip/hip_runtime.h>
 #include <stdio.h>

--- a/tests/unit_tests/libraries/cuBLAS/rocBLAS/cublas_1_based_indexing_rocblas.cu
+++ b/tests/unit_tests/libraries/cuBLAS/rocBLAS/cublas_1_based_indexing_rocblas.cu
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %hipify_args "-roc" %clang_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args 1 -roc %clang_args
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/tests/unit_tests/libraries/cuBLAS/rocBLAS/cublas_sgemm_matrix_multiplication_rocblas.cu
+++ b/tests/unit_tests/libraries/cuBLAS/rocBLAS/cublas_sgemm_matrix_multiplication_rocblas.cu
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %hipify_args "-roc" %clang_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args 1 -roc %clang_args
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/tests/unit_tests/libraries/cuComplex/cuComplex_Julia.cu
+++ b/tests/unit_tests/libraries/cuComplex/cuComplex_Julia.cu
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %hipify_args "--skip-excluded-preprocessor-conditional-blocks" %clang_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args 1 --skip-excluded-preprocessor-conditional-blocks %clang_args
 
 // CHECK: #include <hip/hip_runtime.h>
 // CHECK: #include "hip/hip_complex.h"

--- a/tests/unit_tests/libraries/cuSPARSE/cuSPARSE_03.cu
+++ b/tests/unit_tests/libraries/cuSPARSE/cuSPARSE_03.cu
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %hipify_args "--skip-excluded-preprocessor-conditional-blocks" %clang_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args 1 --skip-excluded-preprocessor-conditional-blocks %clang_args
 #include <stdio.h>
 #include <stdlib.h>
 #include <assert.h>

--- a/tests/unit_tests/pp/pp_if_else_conditionals.cu
+++ b/tests/unit_tests/pp/pp_if_else_conditionals.cu
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %hipify_args "--skip-excluded-preprocessor-conditional-blocks" %clang_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args 1 --skip-excluded-preprocessor-conditional-blocks %clang_args
 // CHECK: #include <hip/hip_runtime.h>
 
 #include <cuda.h>

--- a/tests/unit_tests/pp/pp_if_else_conditionals_01.cu
+++ b/tests/unit_tests/pp/pp_if_else_conditionals_01.cu
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %hipify_args "--skip-excluded-preprocessor-conditional-blocks" %clang_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args 1 --skip-excluded-preprocessor-conditional-blocks %clang_args
 // CHECK: #include <hip/hip_runtime.h>
 
 __global__ void axpy_kernel(float a, float* x, float* y) {

--- a/tests/unit_tests/synthetic/driver_defines.cu
+++ b/tests/unit_tests/synthetic/driver_defines.cu
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" --skip-excluded-preprocessor-conditional-blocks %hipify_args -D__CUDA_API_VERSION_INTERNAL %clang_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args 1 --skip-excluded-preprocessor-conditional-blocks %clang_args -D__CUDA_API_VERSION_INTERNAL
 
 // CHECK: #include <hip/hip_runtime.h>
 #include <cuda.h>

--- a/tests/unit_tests/synthetic/driver_enums.cu
+++ b/tests/unit_tests/synthetic/driver_enums.cu
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" --skip-excluded-preprocessor-conditional-blocks %hipify_args -D__CUDA_API_VERSION_INTERNAL %clang_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args 1 --skip-excluded-preprocessor-conditional-blocks %clang_args -D__CUDA_API_VERSION_INTERNAL
 
 // CHECK: #include <hip/hip_runtime.h>
 #include <cuda.h>

--- a/tests/unit_tests/synthetic/driver_functions.cu
+++ b/tests/unit_tests/synthetic/driver_functions.cu
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" --skip-excluded-preprocessor-conditional-blocks %hipify_args %clang_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args 1 --skip-excluded-preprocessor-conditional-blocks %clang_args
 
 // CHECK: #include <hip/hip_runtime.h>
 #include <cuda.h>

--- a/tests/unit_tests/synthetic/driver_structs.cu
+++ b/tests/unit_tests/synthetic/driver_structs.cu
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" --skip-excluded-preprocessor-conditional-blocks %hipify_args -D__CUDA_API_VERSION_INTERNAL %clang_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args 1 --skip-excluded-preprocessor-conditional-blocks %clang_args -D__CUDA_API_VERSION_INTERNAL
 
 // CHECK: #include <hip/hip_runtime.h>
 #include <cuda.h>

--- a/tests/unit_tests/synthetic/driver_typedefs.cu
+++ b/tests/unit_tests/synthetic/driver_typedefs.cu
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" --skip-excluded-preprocessor-conditional-blocks %hipify_args -D__CUDA_API_VERSION_INTERNAL %clang_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args 1 --skip-excluded-preprocessor-conditional-blocks %clang_args -D__CUDA_API_VERSION_INTERNAL
 
 // CHECK: #include <hip/hip_runtime.h>
 #include <cuda.h>

--- a/tests/unit_tests/synthetic/runtime_defines.cu
+++ b/tests/unit_tests/synthetic/runtime_defines.cu
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" --skip-excluded-preprocessor-conditional-blocks %hipify_args -D__CUDA_API_VERSION_INTERNAL %clang_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args 1 --skip-excluded-preprocessor-conditional-blocks %clang_args -D__CUDA_API_VERSION_INTERNAL
 
 // CHECK: #include <hip/hip_runtime.h>
 #include <cuda_runtime_api.h>

--- a/tests/unit_tests/synthetic/runtime_enums.cu
+++ b/tests/unit_tests/synthetic/runtime_enums.cu
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" --skip-excluded-preprocessor-conditional-blocks %hipify_args -D__CUDA_API_VERSION_INTERNAL %clang_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args 1 --skip-excluded-preprocessor-conditional-blocks %clang_args -D__CUDA_API_VERSION_INTERNAL
 
 // CHECK: #include <hip/hip_runtime.h>
 #include <cuda_runtime_api.h>

--- a/tests/unit_tests/synthetic/runtime_structs.cu
+++ b/tests/unit_tests/synthetic/runtime_structs.cu
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" --skip-excluded-preprocessor-conditional-blocks %hipify_args -D__CUDA_API_VERSION_INTERNAL %clang_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args 1 --skip-excluded-preprocessor-conditional-blocks %clang_args -D__CUDA_API_VERSION_INTERNAL
 
 // CHECK: #include <hip/hip_runtime.h>
 #include <cuda_runtime_api.h>

--- a/tests/unit_tests/synthetic/runtime_typedefs.cu
+++ b/tests/unit_tests/synthetic/runtime_typedefs.cu
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" --skip-excluded-preprocessor-conditional-blocks %hipify_args -D__CUDA_API_VERSION_INTERNAL %clang_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args 1 --skip-excluded-preprocessor-conditional-blocks %clang_args -D__CUDA_API_VERSION_INTERNAL
 
 // CHECK: #include <hip/hip_runtime.h>
 #include <cuda_runtime_api.h>


### PR DESCRIPTION
+ Update Linux and Windows test scripts (tested)
+ Update tests accordingly
+ The feature will be needed with the `--experimental` option introduction

[How to use]
+ If no additional hipify-clang options are specified, then nothing to do;
+ If there is only one additional option, then ` 1 --option1 ` should be specified in test's `// RUN:` header line after `%hipify_args`;
+ If there are two additional options, then ` 2 --option1 --option2 ` should be specified;
+ etc.