### PR TITLE
[HIPIFY][#434] Introduce '--experimental' option

### DIFF
--- a/src/ArgParse.cpp
+++ b/src/ArgParse.cpp
@@ -160,4 +160,9 @@ cl::opt<std::string> DocFormat("doc-format",
   cl::value_desc("value"),
   cl::cat(ToolTemplateCategory));
 
+cl::opt<bool> Experimental("experimental",
+  cl::desc("HIPIFY experimentally supported APIs"),
+  cl::value_desc("experimental"),
+  cl::cat(ToolTemplateCategory));
+
 cl::extrahelp CommonHelp(ct::CommonOptionsParser::HelpMessage);

--- a/src/ArgParse.h
+++ b/src/ArgParse.h
@@ -56,3 +56,4 @@ extern cl::opt<std::string> CudaGpuArch;
 extern cl::opt<bool> GenerateMarkdown;
 extern cl::opt<bool> GenerateCSV;
 extern cl::opt<std::string> DocFormat;
+extern cl::opt<bool> Experimental;

--- a/src/HipifyAction.cpp
+++ b/src/HipifyAction.cpp
@@ -169,6 +169,16 @@ void HipifyAction::FindAndReplace(StringRef name,
   if (Statistics::isDeprecated(found->second)) {
     DE.Report(sl, DE.getCustomDiagID(clang::DiagnosticsEngine::Warning, "CUDA identifier is deprecated."));
   }
+  // Warn the user about unsupported experimental identifier.
+  if (Statistics::isHipExperimental(found->second) &&!Experimental) {
+    std::string sWarn;
+    Statistics::isToRoc(found->second) ? sWarn = sROC : sWarn = sHIP;
+    sWarn = "" + sWarn;
+    const auto ID = DE.getCustomDiagID(clang::DiagnosticsEngine::Warning, "CUDA identifier is experimental in %0. To hipify it, use the '--experimental' option.");
+    DE.Report(sl, ID) << sWarn;
+    return;
+  }
+
   // Warn the user about unsupported identifier.
   if (Statistics::isUnsupported(found->second)) {
     std::string sWarn;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -55,7 +55,7 @@ void cleanupHipifyOptions(std::vector<const char*> &args) {
                                             "-no-backup", "-no-output", "-print-stats",
                                             "-print-stats-csv", "-examine", "-save-temps",
                                             "-skip-excluded-preprocessor-conditional-blocks",
-                                            "-md", "-csv", "-doc-format"};
+                                            "-md", "-csv", "-doc-format", "-experimental"};
   for (const auto &a : hipifyOptions) {
     args.erase(std::remove(args.begin(), args.end(), a), args.end());
     args.erase(std::remove(args.begin(), args.end(), "-" + a), args.end());

--- a/tests/unit_tests/graph/simple_mechs.cu
+++ b/tests/unit_tests/graph/simple_mechs.cu
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %hipify_args %clang_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args 1 --experimental %clang_args
 
 // CHECK: #include <hip/hip_runtime.h>
 #include <stdio.h>

--- a/tests/unit_tests/synthetic/driver_enums.cu
+++ b/tests/unit_tests/synthetic/driver_enums.cu
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %hipify_args 1 --skip-excluded-preprocessor-conditional-blocks %clang_args -D__CUDA_API_VERSION_INTERNAL
+// RUN: %run_test hipify "%s" "%t" %hipify_args 2 --skip-excluded-preprocessor-conditional-blocks --experimental %clang_args -D__CUDA_API_VERSION_INTERNAL
 
 // CHECK: #include <hip/hip_runtime.h>
 #include <cuda.h>

--- a/tests/unit_tests/synthetic/driver_structs.cu
+++ b/tests/unit_tests/synthetic/driver_structs.cu
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %hipify_args 1 --skip-excluded-preprocessor-conditional-blocks %clang_args -D__CUDA_API_VERSION_INTERNAL
+// RUN: %run_test hipify "%s" "%t" %hipify_args 2 --skip-excluded-preprocessor-conditional-blocks --experimental %clang_args -D__CUDA_API_VERSION_INTERNAL
 
 // CHECK: #include <hip/hip_runtime.h>
 #include <cuda.h>

--- a/tests/unit_tests/synthetic/runtime_enums.cu
+++ b/tests/unit_tests/synthetic/runtime_enums.cu
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %hipify_args 1 --skip-excluded-preprocessor-conditional-blocks %clang_args -D__CUDA_API_VERSION_INTERNAL
+// RUN: %run_test hipify "%s" "%t" %hipify_args 2 --skip-excluded-preprocessor-conditional-blocks --experimental %clang_args -D__CUDA_API_VERSION_INTERNAL
 
 // CHECK: #include <hip/hip_runtime.h>
 #include <cuda_runtime_api.h>

--- a/tests/unit_tests/synthetic/runtime_structs.cu
+++ b/tests/unit_tests/synthetic/runtime_structs.cu
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %hipify_args 1 --skip-excluded-preprocessor-conditional-blocks %clang_args -D__CUDA_API_VERSION_INTERNAL
+// RUN: %run_test hipify "%s" "%t" %hipify_args 2 --skip-excluded-preprocessor-conditional-blocks --experimental %clang_args -D__CUDA_API_VERSION_INTERNAL
 
 // CHECK: #include <hip/hip_runtime.h>
 #include <cuda_runtime_api.h>


### PR DESCRIPTION
+ Populate some tests with the `--experimental` option

[BEHAVIOR]
+ If not set (by default) API marked as `HIP_EXPERIMENTAL` are not hipified, a warning `CUDA identifier is experimental in HIP. To hipify it, use the '--experimental' option.` is reported.
+ If set silent hipification of all APIs marked as `HIP_EXPERIMENTAL` takes place.
