### PR TITLE
[HIPIFY][fix] Undo args typecasting for 4 Driver API functions

### DIFF
--- a/src/HipifyAction.cpp
+++ b/src/HipifyAction.cpp
@@ -58,11 +58,6 @@ const std::string sCudaMemcpyFromSymbol = "cudaMemcpyFromSymbol";
 const std::string sCudaMemcpyFromSymbolAsync = "cudaMemcpyFromSymbolAsync";
 const std::string sCudaFuncSetCacheConfig = "cudaFuncSetCacheConfig";
 const std::string sCudaFuncGetAttributes = "cudaFuncGetAttributes";
-// CUDA functions, which need typecasting of its arguments
-const std::string sCuStreamWaitValue32 = "cuStreamWaitValue32";
-const std::string sCuStreamWaitValue64 = "cuStreamWaitValue64";
-const std::string sCuStreamWriteValue32 = "cuStreamWriteValue32";
-const std::string sCuStreamWriteValue64 = "cuStreamWriteValue64";
 // Matchers' names
 const StringRef sCudaLaunchKernel = "cudaLaunchKernel";
 const StringRef sCudaHostFuncCall = "cudaHostFuncCall";
@@ -90,10 +85,6 @@ std::map<std::string, ArgCastMap> FuncArgCasts {
   {sCudaMemcpyFromSymbolAsync, {{1, {e_HIP_SYMBOL, cw_None}}}},
   {sCudaFuncSetCacheConfig, {{0, {e_reinterpret_cast, cw_None}}}},
   {sCudaFuncGetAttributes, {{1, {e_reinterpret_cast, cw_None}}}},
-  {sCuStreamWaitValue32, {{2, {e_int32_t, cw_DataLoss}}}},
-  {sCuStreamWaitValue64, {{2, {e_int64_t, cw_DataLoss}}}},
-  {sCuStreamWriteValue32, {{2, {e_int32_t, cw_DataLoss}}}},
-  {sCuStreamWriteValue64, {{2, {e_int64_t, cw_DataLoss}}}},
 };
 
 void HipifyAction::RewriteString(StringRef s, clang::SourceLocation start) {
@@ -561,11 +552,7 @@ std::unique_ptr<clang::ASTConsumer> HipifyAction::CreateASTConsumer(clang::Compi
             sCudaMemcpyToSymbol,
             sCudaMemcpyToSymbolAsync,
             sCudaFuncSetCacheConfig,
-            sCudaFuncGetAttributes,
-            sCuStreamWaitValue32,
-            sCuStreamWaitValue64,
-            sCuStreamWriteValue32,
-            sCuStreamWriteValue64
+            sCudaFuncGetAttributes
           )
         )
       )

--- a/tests/unit_tests/casts/reinterpret_cast.cu
+++ b/tests/unit_tests/casts/reinterpret_cast.cu
@@ -27,8 +27,8 @@ THE SOFTWARE.
 #include <stdint.h>
 
 // Random predefiend 32 and 64 bit values
-constexpr int32_t value32 = 0x70F0F0FF;
-constexpr int64_t value64 = 0x7FFF0000FFFF0000;
+constexpr uint32_t value32 = 0x70F0F0FF;
+constexpr uint64_t value64 = 0x7FFF0000FFFF0000;
 constexpr unsigned int writeFlag = 0;
 
 __global__
@@ -58,9 +58,9 @@ void testWrite() {
   cudaHostRegister(host_ptr64, sizeof(int64_t), 0);
   // CHECK: hipHostRegister(host_ptr32, sizeof(int32_t), 0);
   cudaHostRegister(host_ptr32, sizeof(int32_t), 0);
-  // CHECK: hipStreamWriteValue64(stream, hipDeviceptr_t(host_ptr64), int64_t(value64), writeFlag);
+  // CHECK: hipStreamWriteValue64(stream, hipDeviceptr_t(host_ptr64), value64, writeFlag);
   cuStreamWriteValue64(stream, CUdeviceptr(host_ptr64), value64, writeFlag);
-  // CHECK: hipStreamWriteValue32(stream, hipDeviceptr_t(host_ptr32), int32_t(value32), writeFlag);
+  // CHECK: hipStreamWriteValue32(stream, hipDeviceptr_t(host_ptr32), value32, writeFlag);
   cuStreamWriteValue32(stream, CUdeviceptr(host_ptr32), value32, writeFlag);
   // CHECK: hipStreamSynchronize(stream);
   cudaStreamSynchronize(stream);
@@ -71,14 +71,14 @@ void testWrite() {
   // Reset values
   *host_ptr64 = 0x0;
   *host_ptr32 = 0x0;
-  // CHECK: hipStreamWriteValue64(stream, hipDeviceptr_t(device_ptr64), int64_t(value64), writeFlag);
+  // CHECK: hipStreamWriteValue64(stream, hipDeviceptr_t(device_ptr64), value64, writeFlag);
   cuStreamWriteValue64(stream, CUdeviceptr(device_ptr64), value64, writeFlag);
-  // CHECK: hipStreamWriteValue32(stream, hipDeviceptr_t(device_ptr32), int32_t(value32), writeFlag);
+  // CHECK: hipStreamWriteValue32(stream, hipDeviceptr_t(device_ptr32), value32, writeFlag);
   cuStreamWriteValue32(stream, CUdeviceptr(device_ptr32), value32, writeFlag);
   // CHECK: hipStreamSynchronize(stream);
   cudaStreamSynchronize(stream);
   // Test Writing to Signal Memory
-  // CHECK: hipStreamWriteValue64(stream, hipDeviceptr_t(signalPtr), int64_t(value64), writeFlag);
+  // CHECK: hipStreamWriteValue64(stream, hipDeviceptr_t(signalPtr), value64, writeFlag);
   cuStreamWriteValue64(stream, CUdeviceptr(signalPtr), value64, writeFlag);
   // CHECK: hipStreamSynchronize(stream);
   cudaStreamSynchronize(stream);
@@ -269,9 +269,9 @@ void testWait() {
     for (const auto & tc : testCases) {
       *signalPtr = isBlocking ? tc.signalValueFail : tc.signalValuePass;
       *dataPtr64 = DATA_INIT;
-      // CHECK: hipStreamWaitValue64(stream, hipDeviceptr_t(signalPtr), int64_t(tc.waitValue), tc.compareOp);
+      // CHECK: hipStreamWaitValue64(stream, hipDeviceptr_t(signalPtr), tc.waitValue, tc.compareOp);
       cuStreamWaitValue64(stream, CUdeviceptr(signalPtr), tc.waitValue, tc.compareOp);
-      // CHECK: hipStreamWriteValue64(stream, hipDeviceptr_t(dataPtr64), int64_t(DATA_UPDATE), writeFlag);
+      // CHECK: hipStreamWriteValue64(stream, hipDeviceptr_t(dataPtr64), DATA_UPDATE, writeFlag);
       cuStreamWriteValue64(stream, CUdeviceptr(dataPtr64), DATA_UPDATE, writeFlag);
       if (isBlocking) {
         // Trigger an implict flush and verify stream has pending work.
@@ -288,9 +288,9 @@ void testWait() {
       // 32-bit API
       *signalPtr = isBlocking ? tc.signalValueFail : tc.signalValuePass;
       *dataPtr32 = DATA_INIT;
-      // CHECK: hipStreamWaitValue32(stream, hipDeviceptr_t(signalPtr), int32_t(tc.waitValue), tc.compareOp);
+      // CHECK: hipStreamWaitValue32(stream, hipDeviceptr_t(signalPtr), tc.waitValue, tc.compareOp);
       cuStreamWaitValue32(stream, CUdeviceptr(signalPtr), tc.waitValue, tc.compareOp);
-      // CHECK: hipStreamWriteValue32(stream, hipDeviceptr_t(dataPtr32), int32_t(DATA_UPDATE), writeFlag);
+      // CHECK: hipStreamWriteValue32(stream, hipDeviceptr_t(dataPtr32), DATA_UPDATE, writeFlag);
       cuStreamWriteValue32(stream, CUdeviceptr(dataPtr32), DATA_UPDATE, writeFlag);
       if (isBlocking) {
         // Trigger an implict flush and verify stream has pending work.
@@ -311,9 +311,9 @@ void testWait() {
     for (const auto& tc : testCasesNoMask32) {
       *signalPtr = isBlocking ? tc.signalValueFail : tc.signalValuePass;
       *dataPtr32 = DATA_INIT;
-      // CHECK: hipStreamWaitValue32(stream, hipDeviceptr_t(signalPtr), int32_t(tc.waitValue), tc.compareOp);
+      // CHECK: hipStreamWaitValue32(stream, hipDeviceptr_t(signalPtr), tc.waitValue, tc.compareOp);
       cuStreamWaitValue32(stream, CUdeviceptr(signalPtr), tc.waitValue, tc.compareOp);
-      // CHECK: hipStreamWriteValue32(stream, hipDeviceptr_t(dataPtr32), int32_t(DATA_UPDATE), writeFlag);
+      // CHECK: hipStreamWriteValue32(stream, hipDeviceptr_t(dataPtr32), DATA_UPDATE, writeFlag);
       cuStreamWriteValue32(stream, CUdeviceptr(dataPtr32), DATA_UPDATE, writeFlag);
       if (isBlocking) {
         // Trigger an implict flush and verify stream has pending work.
@@ -334,9 +334,9 @@ void testWait() {
     for (const auto& tc : testCasesNoMask64) {
       *signalPtr = isBlocking ? tc.signalValueFail : tc.signalValuePass;
       *dataPtr64 = DATA_INIT;
-      // CHECK: hipStreamWaitValue64(stream, hipDeviceptr_t(signalPtr), int64_t(tc.waitValue), tc.compareOp);
+      // CHECK: hipStreamWaitValue64(stream, hipDeviceptr_t(signalPtr), tc.waitValue, tc.compareOp);
       cuStreamWaitValue64(stream, CUdeviceptr(signalPtr), tc.waitValue, tc.compareOp);
-      // CHECK: hipStreamWriteValue64(stream, hipDeviceptr_t(dataPtr64), int64_t(DATA_UPDATE), writeFlag);
+      // CHECK: hipStreamWriteValue64(stream, hipDeviceptr_t(dataPtr64), DATA_UPDATE, writeFlag);
       cuStreamWriteValue64(stream, CUdeviceptr(dataPtr64), DATA_UPDATE, writeFlag);
       if (isBlocking) {
         // Trigger an implict flush and verify stream has pending work.

--- a/tests/unit_tests/synthetic/driver_functions.cu
+++ b/tests/unit_tests/synthetic/driver_functions.cu
@@ -754,24 +754,24 @@ int main() {
 #if CUDA_VERSION > 7050
   // CUDA: CUresult CUDAAPI cuStreamWaitValue32(CUstream stream, CUdeviceptr addr, cuuint32_t value, unsigned int flags);
   // HIP: hipError_t hipStreamWaitValue32(hipStream_t stream, void* ptr, uint32_t value, unsigned int flags, uint32_t mask __dparm(0xFFFFFFFF));
-  // CHECK: result = hipStreamWaitValue32(stream, deviceptr, int32_t(u_value), flags);
+  // CHECK: result = hipStreamWaitValue32(stream, deviceptr, u_value, flags);
   result = cuStreamWaitValue32(stream, deviceptr, u_value, flags);
 
   // CUDA: CUresult CUDAAPI cuStreamWriteValue32(CUstream stream, CUdeviceptr addr, cuuint32_t value, unsigned int flags);
   // HIP: hipError_t hipStreamWriteValue32(hipStream_t stream, void* ptr, uint32_t value, unsigned int flags, uint32_t mask __dparm(0xFFFFFFFF));
-  // CHECK: result = hipStreamWriteValue32(stream, deviceptr, int32_t(u_value), flags);
+  // CHECK: result = hipStreamWriteValue32(stream, deviceptr, u_value, flags);
   result = cuStreamWriteValue32(stream, deviceptr, u_value, flags);
 #endif
 
 #if CUDA_VERSION > 8000
   // CUDA: CUresult CUDAAPI cuStreamWaitValue64(CUstream stream, CUdeviceptr addr, cuuint64_t value, unsigned int flags);
   // HIP: hipError_t hipStreamWaitValue64(hipStream_t stream, void* ptr, uint64_t value, unsigned int flags, uint64_t mask __dparm(0xFFFFFFFFFFFFFFFF));
-  // CHECK: result = hipStreamWaitValue64(stream, deviceptr, int64_t(u_value), flags);
+  // CHECK: result = hipStreamWaitValue64(stream, deviceptr, u_value, flags);
   result = cuStreamWaitValue64(stream, deviceptr, u_value, flags);
 
   // CUDA: CUresult CUDAAPI cuStreamWriteValue64(CUstream stream, CUdeviceptr addr, cuuint64_t value, unsigned int flags);
   // HIP: hipError_t hipStreamWriteValue64(hipStream_t stream, void* ptr, uint64_t value, unsigned int flags, uint64_t mask __dparm(0xFFFFFFFFFFFFFFFF));
-  // CHECK: result = hipStreamWriteValue64(stream, deviceptr, int64_t(u_value), flags);
+  // CHECK: result = hipStreamWriteValue64(stream, deviceptr, u_value, flags);
   result = cuStreamWriteValue64(stream, deviceptr, u_value, flags);
 #endif
   return 0;


### PR DESCRIPTION
Affected functions: hipStreamWaitValue32, hipStreamWaitValue64, hipStreamWriteValue32, hipStreamWriteValue64.
Their 3rd args was `int` become `uint` as in CUDA analogues; thus remove casting to `int` while hipifying.

+ Update affected tests