### PR TITLE
[HIPIFY][fix][perl] Undo args typecasting for 4 Driver API functions - Part 2

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -3886,20 +3886,6 @@ sub transformHostFunctions {
     {
         $k += s/(?<!\/\/ CHECK: )($func)\s*\(\s*([^,]+)\s*,\s*([^,\)]+)\s*(,\s*|\))\s*/$func\($2, reinterpret_cast<const void*>\($3\)$4/g;
     }
-    foreach $func (
-        "hipStreamWaitValue32",
-        "hipStreamWriteValue32"
-    )
-    {
-        $k += s/(?<!\/\/ CHECK: )($func)\s*\((\s*[^,]+\s*,\s*[^,]+\s*),\s*([^,]+)\s*(,\s*|\))\s*/$func\($2, int32_t\($3\)$4/g;
-    }
-    foreach $func (
-        "hipStreamWaitValue64",
-        "hipStreamWriteValue64"
-    )
-    {
-        $k += s/(?<!\/\/ CHECK: )($func)\s*\((\s*[^,]+\s*,\s*[^,]+\s*),\s*([^,]+)\s*(,\s*|\))\s*/$func\($2, int64_t\($3\)$4/g;
-    }
     return $k;
 }
 
@@ -7131,25 +7117,6 @@ sub warnUnsupportedFunctions {
     return $k;
 }
 
-sub warnDataLossFunctions {
-    my $line_num = shift;
-    my $k = 0;
-    foreach $func (
-        "cuStreamWaitValue32",
-        "cuStreamWaitValue64",
-        "cuStreamWriteValue32",
-        "cuStreamWriteValue64"
-    )
-    {
-        my $mt = m/($func)/g;
-        if ($mt) {
-            $k += $mt;
-            print STDERR "  warning: $fileName:$line_num: possible data loss in 3 argument of \"$func\": $_\n";
-        }
-    }
-    return $k;
-}
-
 # Count of transforms in all files
 my %tt;
 clearStats(\%tt, \@statNames);
@@ -7231,8 +7198,6 @@ while (@ARGV) {
                     $s = warnUnsupportedFunctions($line_num);
                     $warnings += $s;
                     $s = warnUnsupportedDeviceFunctions($line_num);
-                    $warnings += $s;
-                    $s = warnDataLossFunctions($line_num);
                     $warnings += $s;
                 }
                 $_ = $tmp;


### PR DESCRIPTION
Affected functions: `hipStreamWaitValue32`, `hipStreamWaitValue64`, `hipStreamWriteValue32`, `hipStreamWriteValue64`.
Their 3rd args was `int` become `uint` as in CUDA analogues; thus remove casting to `int` while hipifying.

+ Update hipify-perl generation and the generated hipify-perl script
