### PR TITLE
[HIPIFY][#460][fix] Stop printing HIP API versions if CUDA API is unsupported

### DIFF
--- a/doc/markdown/CUDA_Driver_API_functions_supported_by_HIP.md
+++ b/doc/markdown/CUDA_Driver_API_functions_supported_by_HIP.md
@@ -1464,8 +1464,8 @@
 |`cuGraphAddKernelNode`|10.0| | |`hipGraphAddKernelNode`|4.3.0| | |4.5.0|
 |`cuGraphAddMemAllocNode`|11.4| | | | | | | |
 |`cuGraphAddMemFreeNode`|11.4| | | | | | | |
-|`cuGraphAddMemcpyNode`|10.0| | | |4.3.0| | |4.5.0|
-|`cuGraphAddMemsetNode`|10.0| | | |4.3.0| | |4.5.0|
+|`cuGraphAddMemcpyNode`|10.0| | | | | | | |
+|`cuGraphAddMemsetNode`|10.0| | | | | | | |
 |`cuGraphChildGraphNodeGetGraph`|10.0| | | | | | | |
 |`cuGraphClone`|10.0| | | | | | | |
 |`cuGraphCreate`|10.0| | |`hipGraphCreate`|4.3.0| | |4.5.0|

--- a/src/CUDA2HIP_Doc.cpp
+++ b/src/CUDA2HIP_Doc.cpp
@@ -209,7 +209,7 @@ namespace doc {
                 }
               }
               auto hv = hMap.find(f.second.hipName);
-              if (hv != hMap.end()) {
+              if (hv != hMap.end() && !Statistics::isUnsupported(f.second)) {
                 ha = Statistics::getHipVersion(hv->second.appeared);
                 hd = Statistics::getHipVersion(hv->second.deprecated);
                 hr = Statistics::getHipVersion(hv->second.removed);


### PR DESCRIPTION
It happens with HIP API common for CUDA RT API and Device API when for one CUDA API (for instance, RT) HIP API is supported and for another is not (due to differences in function signatures, for example). As long as the HIP API name is the same, HIP versions for the unsupported CUDA API shouldn't be printed.

+ Update the affected doc CUDA_Driver_API_functions_supported_by_HIP.md
