### PR TITLE
[HIPIFY] Sync with the upcoming HIP-rocm-5.0.0 - Part 4

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -707,8 +707,39 @@ my %experimental_funcs = (
     "cudaStreamGetCaptureInfo" => "5.0.0",
     "cudaStreamAddCaptureDependencies" => "5.0.0",
     "cudaGraphRemoveDependencies" => "5.0.0",
+    "cudaGraphNodeGetType" => "5.0.0",
+    "cudaGraphNodeGetDependentNodes" => "5.0.0",
     "cudaGraphNodeGetDependencies" => "5.0.0",
+    "cudaGraphNodeFindInClone" => "5.0.0",
+    "cudaGraphMemcpyNodeSetParamsToSymbol" => "5.0.0",
+    "cudaGraphMemcpyNodeSetParamsFromSymbol" => "5.0.0",
+    "cudaGraphMemcpyNodeSetParams1D" => "5.0.0",
+    "cudaGraphInstantiateWithFlags" => "5.0.0",
+    "cudaGraphHostNodeSetParams" => "5.0.0",
+    "cudaGraphHostNodeGetParams" => "5.0.0",
     "cudaGraphGetEdges" => "5.0.0",
+    "cudaGraphExecUpdate" => "5.0.0",
+    "cudaGraphExecMemsetNodeSetParams" => "5.0.0",
+    "cudaGraphExecMemcpyNodeSetParamsToSymbol" => "5.0.0",
+    "cudaGraphExecMemcpyNodeSetParamsFromSymbol" => "5.0.0",
+    "cudaGraphExecMemcpyNodeSetParams1D" => "5.0.0",
+    "cudaGraphExecMemcpyNodeSetParams" => "5.0.0",
+    "cudaGraphExecHostNodeSetParams" => "5.0.0",
+    "cudaGraphExecEventWaitNodeSetEvent" => "5.0.0",
+    "cudaGraphExecEventRecordNodeSetEvent" => "5.0.0",
+    "cudaGraphExecChildGraphNodeSetParams" => "5.0.0",
+    "cudaGraphEventWaitNodeSetEvent" => "5.0.0",
+    "cudaGraphEventWaitNodeGetEvent" => "5.0.0",
+    "cudaGraphEventRecordNodeSetEvent" => "5.0.0",
+    "cudaGraphEventRecordNodeGetEvent" => "5.0.0",
+    "cudaGraphDestroyNode" => "5.0.0",
+    "cudaGraphChildGraphNodeGetGraph" => "5.0.0",
+    "cudaGraphAddMemcpyNodeToSymbol" => "5.0.0",
+    "cudaGraphAddMemcpyNodeFromSymbol" => "5.0.0",
+    "cudaGraphAddHostNode" => "5.0.0",
+    "cudaGraphAddEventWaitNode" => "5.0.0",
+    "cudaGraphAddEventRecordNode" => "5.0.0",
+    "cudaGraphAddChildGraphNode" => "5.0.0",
     "cudaErrorIllegalState" => "5.0.0",
     "cudaErrorGraphExecUpdateFailure" => "5.0.0",
     "cuStreamUpdateCaptureDependencies" => "5.0.0",
@@ -718,8 +749,29 @@ my %experimental_funcs = (
     "cuPointerGetAttributes" => "5.0.0",
     "cuPointerGetAttribute" => "5.0.0",
     "cuGraphRemoveDependencies" => "5.0.0",
+    "cuGraphNodeGetType" => "5.0.0",
+    "cuGraphNodeGetDependentNodes" => "5.0.0",
     "cuGraphNodeGetDependencies" => "5.0.0",
+    "cuGraphNodeFindInClone" => "5.0.0",
+    "cuGraphInstantiateWithFlags" => "5.0.0",
+    "cuGraphHostNodeSetParams" => "5.0.0",
+    "cuGraphHostNodeGetParams" => "5.0.0",
     "cuGraphGetEdges" => "5.0.0",
+    "cuGraphExecUpdate" => "5.0.0",
+    "cuGraphExecHostNodeSetParams" => "5.0.0",
+    "cuGraphExecEventWaitNodeSetEvent" => "5.0.0",
+    "cuGraphExecEventRecordNodeSetEvent" => "5.0.0",
+    "cuGraphExecChildGraphNodeSetParams" => "5.0.0",
+    "cuGraphEventWaitNodeSetEvent" => "5.0.0",
+    "cuGraphEventWaitNodeGetEvent" => "5.0.0",
+    "cuGraphEventRecordNodeSetEvent" => "5.0.0",
+    "cuGraphEventRecordNodeGetEvent" => "5.0.0",
+    "cuGraphDestroyNode" => "5.0.0",
+    "cuGraphChildGraphNodeGetGraph" => "5.0.0",
+    "cuGraphAddHostNode" => "5.0.0",
+    "cuGraphAddEventWaitNode" => "5.0.0",
+    "cuGraphAddEventRecordNode" => "5.0.0",
+    "cuGraphAddChildGraphNode" => "5.0.0",
     "CUstreamUpdateCaptureDependencies_flags_enum" => "5.0.0",
     "CUstreamUpdateCaptureDependencies_flags" => "5.0.0",
     "CUpointer_attribute_enum" => "5.0.0",
@@ -862,11 +914,63 @@ sub experimentalSubstitutions {
     $ft{'stream'} += s/\bcuStreamUpdateCaptureDependencies\b/hipStreamUpdateCaptureDependencies/g;
     $ft{'stream'} += s/\bcudaStreamGetCaptureInfo\b/hipStreamGetCaptureInfo/g;
     $ft{'stream'} += s/\bcudaStreamIsCapturing\b/hipStreamIsCapturing/g;
+    $ft{'graph'} += s/\bcuGraphAddChildGraphNode\b/hipGraphAddChildGraphNode/g;
+    $ft{'graph'} += s/\bcuGraphAddEventRecordNode\b/hipGraphAddEventRecordNode/g;
+    $ft{'graph'} += s/\bcuGraphAddEventWaitNode\b/hipGraphAddEventWaitNode/g;
+    $ft{'graph'} += s/\bcuGraphAddHostNode\b/hipGraphAddHostNode/g;
+    $ft{'graph'} += s/\bcuGraphChildGraphNodeGetGraph\b/hipGraphChildGraphNodeGetGraph/g;
+    $ft{'graph'} += s/\bcuGraphDestroyNode\b/hipGraphDestroyNode/g;
+    $ft{'graph'} += s/\bcuGraphEventRecordNodeGetEvent\b/hipGraphEventRecordNodeGetEvent/g;
+    $ft{'graph'} += s/\bcuGraphEventRecordNodeSetEvent\b/hipGraphEventRecordNodeSetEvent/g;
+    $ft{'graph'} += s/\bcuGraphEventWaitNodeGetEvent\b/hipGraphEventWaitNodeGetEvent/g;
+    $ft{'graph'} += s/\bcuGraphEventWaitNodeSetEvent\b/hipGraphEventWaitNodeSetEvent/g;
+    $ft{'graph'} += s/\bcuGraphExecChildGraphNodeSetParams\b/hipGraphExecChildGraphNodeSetParams/g;
+    $ft{'graph'} += s/\bcuGraphExecEventRecordNodeSetEvent\b/hipGraphExecEventRecordNodeSetEvent/g;
+    $ft{'graph'} += s/\bcuGraphExecEventWaitNodeSetEvent\b/hipGraphExecEventWaitNodeSetEvent/g;
+    $ft{'graph'} += s/\bcuGraphExecHostNodeSetParams\b/hipGraphExecHostNodeSetParams/g;
+    $ft{'graph'} += s/\bcuGraphExecUpdate\b/hipGraphExecUpdate/g;
     $ft{'graph'} += s/\bcuGraphGetEdges\b/hipGraphGetEdges/g;
+    $ft{'graph'} += s/\bcuGraphHostNodeGetParams\b/hipGraphHostNodeGetParams/g;
+    $ft{'graph'} += s/\bcuGraphHostNodeSetParams\b/hipGraphHostNodeSetParams/g;
+    $ft{'graph'} += s/\bcuGraphInstantiateWithFlags\b/hipGraphInstantiateWithFlags/g;
+    $ft{'graph'} += s/\bcuGraphNodeFindInClone\b/hipGraphNodeFindInClone/g;
     $ft{'graph'} += s/\bcuGraphNodeGetDependencies\b/hipGraphNodeGetDependencies/g;
+    $ft{'graph'} += s/\bcuGraphNodeGetDependentNodes\b/hipGraphNodeGetDependentNodes/g;
+    $ft{'graph'} += s/\bcuGraphNodeGetType\b/hipGraphNodeGetType/g;
     $ft{'graph'} += s/\bcuGraphRemoveDependencies\b/hipGraphRemoveDependencies/g;
+    $ft{'graph'} += s/\bcudaGraphAddChildGraphNode\b/hipGraphAddChildGraphNode/g;
+    $ft{'graph'} += s/\bcudaGraphAddEventRecordNode\b/hipGraphAddEventRecordNode/g;
+    $ft{'graph'} += s/\bcudaGraphAddEventWaitNode\b/hipGraphAddEventWaitNode/g;
+    $ft{'graph'} += s/\bcudaGraphAddHostNode\b/hipGraphAddHostNode/g;
+    $ft{'graph'} += s/\bcudaGraphAddMemcpyNodeFromSymbol\b/hipGraphAddMemcpyNodeFromSymbol/g;
+    $ft{'graph'} += s/\bcudaGraphAddMemcpyNodeToSymbol\b/hipGraphAddMemcpyNodeToSymbol/g;
+    $ft{'graph'} += s/\bcudaGraphChildGraphNodeGetGraph\b/hipGraphChildGraphNodeGetGraph/g;
+    $ft{'graph'} += s/\bcudaGraphDestroyNode\b/hipGraphDestroyNode/g;
+    $ft{'graph'} += s/\bcudaGraphEventRecordNodeGetEvent\b/hipGraphEventRecordNodeGetEvent/g;
+    $ft{'graph'} += s/\bcudaGraphEventRecordNodeSetEvent\b/hipGraphEventRecordNodeSetEvent/g;
+    $ft{'graph'} += s/\bcudaGraphEventWaitNodeGetEvent\b/hipGraphEventWaitNodeGetEvent/g;
+    $ft{'graph'} += s/\bcudaGraphEventWaitNodeSetEvent\b/hipGraphEventWaitNodeSetEvent/g;
+    $ft{'graph'} += s/\bcudaGraphExecChildGraphNodeSetParams\b/hipGraphExecChildGraphNodeSetParams/g;
+    $ft{'graph'} += s/\bcudaGraphExecEventRecordNodeSetEvent\b/hipGraphExecEventRecordNodeSetEvent/g;
+    $ft{'graph'} += s/\bcudaGraphExecEventWaitNodeSetEvent\b/hipGraphExecEventWaitNodeSetEvent/g;
+    $ft{'graph'} += s/\bcudaGraphExecHostNodeSetParams\b/hipGraphExecHostNodeSetParams/g;
+    $ft{'graph'} += s/\bcudaGraphExecMemcpyNodeSetParams\b/hipGraphExecMemcpyNodeSetParams/g;
+    $ft{'graph'} += s/\bcudaGraphExecMemcpyNodeSetParams1D\b/hipGraphExecMemcpyNodeSetParams1D/g;
+    $ft{'graph'} += s/\bcudaGraphExecMemcpyNodeSetParamsFromSymbol\b/hipGraphExecMemcpyNodeSetParamsFromSymbol/g;
+    $ft{'graph'} += s/\bcudaGraphExecMemcpyNodeSetParamsToSymbol\b/hipGraphExecMemcpyNodeSetParamsToSymbol/g;
+    $ft{'graph'} += s/\bcudaGraphExecMemsetNodeSetParams\b/hipGraphExecMemsetNodeSetParams/g;
+    $ft{'graph'} += s/\bcudaGraphExecUpdate\b/hipGraphExecUpdate/g;
     $ft{'graph'} += s/\bcudaGraphGetEdges\b/hipGraphGetEdges/g;
+    $ft{'graph'} += s/\bcudaGraphHostNodeGetParams\b/hipGraphHostNodeGetParams/g;
+    $ft{'graph'} += s/\bcudaGraphHostNodeSetParams\b/hipGraphHostNodeSetParams/g;
+    $ft{'graph'} += s/\bcudaGraphInstantiateWithFlags\b/hipGraphInstantiateWithFlags/g;
+    $ft{'graph'} += s/\bcudaGraphMemcpyNodeSetParams1D\b/hipGraphMemcpyNodeSetParams1D/g;
+    $ft{'graph'} += s/\bcudaGraphMemcpyNodeSetParamsFromSymbol\b/hipGraphMemcpyNodeSetParamsFromSymbol/g;
+    $ft{'graph'} += s/\bcudaGraphMemcpyNodeSetParamsToSymbol\b/hipGraphMemcpyNodeSetParamsToSymbol/g;
+    $ft{'graph'} += s/\bcudaGraphNodeFindInClone\b/hipGraphNodeFindInClone/g;
     $ft{'graph'} += s/\bcudaGraphNodeGetDependencies\b/hipGraphNodeGetDependencies/g;
+    $ft{'graph'} += s/\bcudaGraphNodeGetDependentNodes\b/hipGraphNodeGetDependentNodes/g;
+    $ft{'graph'} += s/\bcudaGraphNodeGetType\b/hipGraphNodeGetType/g;
     $ft{'graph'} += s/\bcudaGraphRemoveDependencies\b/hipGraphRemoveDependencies/g;
     $ft{'type'} += s/\bCUpointer_attribute\b/hipPointer_attribute/g;
     $ft{'type'} += s/\bCUpointer_attribute_enum\b/hipPointer_attribute/g;
@@ -5244,12 +5348,6 @@ sub warnUnsupportedFunctions {
         "cudaGraphNodeTypeMemAlloc",
         "cudaGraphNodeTypeExtSemaphoreWait",
         "cudaGraphNodeTypeExtSemaphoreSignal",
-        "cudaGraphNodeGetType",
-        "cudaGraphNodeGetDependentNodes",
-        "cudaGraphNodeFindInClone",
-        "cudaGraphMemcpyNodeSetParamsToSymbol",
-        "cudaGraphMemcpyNodeSetParamsFromSymbol",
-        "cudaGraphMemcpyNodeSetParams1D",
         "cudaGraphMemFreeNodeGetParams",
         "cudaGraphMemAttributeType",
         "cudaGraphMemAttrUsedMemHigh",
@@ -5260,32 +5358,14 @@ sub warnUnsupportedFunctions {
         "cudaGraphKernelNodeSetAttribute",
         "cudaGraphKernelNodeGetAttribute",
         "cudaGraphKernelNodeCopyAttributes",
-        "cudaGraphInstantiateWithFlags",
         "cudaGraphInstantiateFlags",
         "cudaGraphInstantiateFlagAutoFreeOnLaunch",
-        "cudaGraphHostNodeSetParams",
-        "cudaGraphHostNodeGetParams",
         "cudaGraphExternalSemaphoresWaitNodeSetParams",
         "cudaGraphExternalSemaphoresWaitNodeGetParams",
         "cudaGraphExternalSemaphoresSignalNodeSetParams",
         "cudaGraphExternalSemaphoresSignalNodeGetParams",
-        "cudaGraphExecUpdate",
-        "cudaGraphExecMemsetNodeSetParams",
-        "cudaGraphExecMemcpyNodeSetParamsToSymbol",
-        "cudaGraphExecMemcpyNodeSetParamsFromSymbol",
-        "cudaGraphExecMemcpyNodeSetParams1D",
-        "cudaGraphExecMemcpyNodeSetParams",
-        "cudaGraphExecHostNodeSetParams",
         "cudaGraphExecExternalSemaphoresWaitNodeSetParams",
         "cudaGraphExecExternalSemaphoresSignalNodeSetParams",
-        "cudaGraphExecEventWaitNodeSetEvent",
-        "cudaGraphExecEventRecordNodeSetEvent",
-        "cudaGraphExecChildGraphNodeSetParams",
-        "cudaGraphEventWaitNodeSetEvent",
-        "cudaGraphEventWaitNodeGetEvent",
-        "cudaGraphEventRecordNodeSetEvent",
-        "cudaGraphEventRecordNodeGetEvent",
-        "cudaGraphDestroyNode",
         "cudaGraphDebugDotPrint",
         "cudaGraphDebugDotFlagsVerbose",
         "cudaGraphDebugDotFlagsMemsetNodeParams",
@@ -5299,17 +5379,10 @@ sub warnUnsupportedFunctions {
         "cudaGraphDebugDotFlagsEventNodeParams",
         "cudaGraphDebugDotFlags",
         "cudaGraphClone",
-        "cudaGraphChildGraphNodeGetGraph",
-        "cudaGraphAddMemcpyNodeToSymbol",
-        "cudaGraphAddMemcpyNodeFromSymbol",
         "cudaGraphAddMemFreeNode",
         "cudaGraphAddMemAllocNode",
-        "cudaGraphAddHostNode",
         "cudaGraphAddExternalSemaphoresWaitNode",
         "cudaGraphAddExternalSemaphoresSignalNode",
-        "cudaGraphAddEventWaitNode",
-        "cudaGraphAddEventRecordNode",
-        "cudaGraphAddChildGraphNode",
         "cudaGetSurfaceReference",
         "cudaGetSurfaceObjectResourceDesc",
         "cudaGetParameterBufferV2",
@@ -5826,48 +5899,27 @@ sub warnUnsupportedFunctions {
         "cuGraphUpload",
         "cuGraphRetainUserObject",
         "cuGraphReleaseUserObject",
-        "cuGraphNodeGetType",
-        "cuGraphNodeGetDependentNodes",
-        "cuGraphNodeFindInClone",
         "cuGraphMemFreeNodeGetParams",
         "cuGraphMemAllocNodeGetParams",
         "cuGraphKernelNodeSetAttribute",
         "cuGraphKernelNodeGetAttribute",
         "cuGraphKernelNodeCopyAttributes",
-        "cuGraphInstantiateWithFlags",
-        "cuGraphHostNodeSetParams",
-        "cuGraphHostNodeGetParams",
         "cuGraphExternalSemaphoresWaitNodeSetParams",
         "cuGraphExternalSemaphoresWaitNodeGetParams",
         "cuGraphExternalSemaphoresSignalNodeSetParams",
         "cuGraphExternalSemaphoresSignalNodeGetParams",
-        "cuGraphExecUpdate",
         "cuGraphExecMemsetNodeSetParams",
         "cuGraphExecMemcpyNodeSetParams",
-        "cuGraphExecHostNodeSetParams",
         "cuGraphExecExternalSemaphoresWaitNodeSetParams",
         "cuGraphExecExternalSemaphoresSignalNodeSetParams",
-        "cuGraphExecEventWaitNodeSetEvent",
-        "cuGraphExecEventRecordNodeSetEvent",
-        "cuGraphExecChildGraphNodeSetParams",
-        "cuGraphEventWaitNodeSetEvent",
-        "cuGraphEventWaitNodeGetEvent",
-        "cuGraphEventRecordNodeSetEvent",
-        "cuGraphEventRecordNodeGetEvent",
-        "cuGraphDestroyNode",
         "cuGraphDebugDotPrint",
         "cuGraphClone",
-        "cuGraphChildGraphNodeGetGraph",
         "cuGraphAddMemsetNode",
         "cuGraphAddMemcpyNode",
         "cuGraphAddMemFreeNode",
         "cuGraphAddMemAllocNode",
-        "cuGraphAddHostNode",
         "cuGraphAddExternalSemaphoresWaitNode",
         "cuGraphAddExternalSemaphoresSignalNode",
-        "cuGraphAddEventWaitNode",
-        "cuGraphAddEventRecordNode",
-        "cuGraphAddChildGraphNode",
         "cuGetProcAddress",
         "cuGetErrorString",
         "cuGetErrorName",

--- a/doc/markdown/CUDA_Driver_API_functions_supported_by_HIP.md
+++ b/doc/markdown/CUDA_Driver_API_functions_supported_by_HIP.md
@@ -1453,40 +1453,40 @@
 |`cuDeviceGetGraphMemAttribute`|11.4| | | | | | | |
 |`cuDeviceGraphMemTrim`|11.4| | | | | | | |
 |`cuDeviceSetGraphMemAttribute`|11.4| | | | | | | |
-|`cuGraphAddChildGraphNode`|10.0| | | | | | | |
+|`cuGraphAddChildGraphNode`|10.0| | |`hipGraphAddChildGraphNode`|5.0.0| | |5.0.0|
 |`cuGraphAddDependencies`|10.0| | |`hipGraphAddDependencies`|4.5.0| | | |
 |`cuGraphAddEmptyNode`|10.0| | |`hipGraphAddEmptyNode`|4.5.0| | | |
-|`cuGraphAddEventRecordNode`|11.1| | | | | | | |
-|`cuGraphAddEventWaitNode`|11.1| | | | | | | |
+|`cuGraphAddEventRecordNode`|11.1| | |`hipGraphAddEventRecordNode`|5.0.0| | |5.0.0|
+|`cuGraphAddEventWaitNode`|11.1| | |`hipGraphAddEventWaitNode`|5.0.0| | |5.0.0|
 |`cuGraphAddExternalSemaphoresSignalNode`|11.2| | | | | | | |
 |`cuGraphAddExternalSemaphoresWaitNode`|11.2| | | | | | | |
-|`cuGraphAddHostNode`|10.0| | | | | | | |
+|`cuGraphAddHostNode`|10.0| | |`hipGraphAddHostNode`|5.0.0| | |5.0.0|
 |`cuGraphAddKernelNode`|10.0| | |`hipGraphAddKernelNode`|4.3.0| | | |
 |`cuGraphAddMemAllocNode`|11.4| | | | | | | |
 |`cuGraphAddMemFreeNode`|11.4| | | | | | | |
 |`cuGraphAddMemcpyNode`|10.0| | | | | | | |
 |`cuGraphAddMemsetNode`|10.0| | | | | | | |
-|`cuGraphChildGraphNodeGetGraph`|10.0| | | | | | | |
+|`cuGraphChildGraphNodeGetGraph`|10.0| | |`hipGraphChildGraphNodeGetGraph`|5.0.0| | |5.0.0|
 |`cuGraphClone`|10.0| | | | | | | |
 |`cuGraphCreate`|10.0| | |`hipGraphCreate`|4.3.0| | | |
 |`cuGraphDebugDotPrint`|11.3| | | | | | | |
 |`cuGraphDestroy`|10.0| | |`hipGraphDestroy`|4.3.0| | | |
-|`cuGraphDestroyNode`|10.0| | | | | | | |
-|`cuGraphEventRecordNodeGetEvent`|11.1| | | | | | | |
-|`cuGraphEventRecordNodeSetEvent`|11.1| | | | | | | |
-|`cuGraphEventWaitNodeGetEvent`|11.1| | | | | | | |
-|`cuGraphEventWaitNodeSetEvent`|11.1| | | | | | | |
-|`cuGraphExecChildGraphNodeSetParams`|11.1| | | | | | | |
+|`cuGraphDestroyNode`|10.0| | |`hipGraphDestroyNode`|5.0.0| | |5.0.0|
+|`cuGraphEventRecordNodeGetEvent`|11.1| | |`hipGraphEventRecordNodeGetEvent`|5.0.0| | |5.0.0|
+|`cuGraphEventRecordNodeSetEvent`|11.1| | |`hipGraphEventRecordNodeSetEvent`|5.0.0| | |5.0.0|
+|`cuGraphEventWaitNodeGetEvent`|11.1| | |`hipGraphEventWaitNodeGetEvent`|5.0.0| | |5.0.0|
+|`cuGraphEventWaitNodeSetEvent`|11.1| | |`hipGraphEventWaitNodeSetEvent`|5.0.0| | |5.0.0|
+|`cuGraphExecChildGraphNodeSetParams`|11.1| | |`hipGraphExecChildGraphNodeSetParams`|5.0.0| | |5.0.0|
 |`cuGraphExecDestroy`|10.0| | |`hipGraphExecDestroy`|4.3.0| | | |
-|`cuGraphExecEventRecordNodeSetEvent`|11.1| | | | | | | |
-|`cuGraphExecEventWaitNodeSetEvent`|11.1| | | | | | | |
+|`cuGraphExecEventRecordNodeSetEvent`|11.1| | |`hipGraphExecEventRecordNodeSetEvent`|5.0.0| | |5.0.0|
+|`cuGraphExecEventWaitNodeSetEvent`|11.1| | |`hipGraphExecEventWaitNodeSetEvent`|5.0.0| | |5.0.0|
 |`cuGraphExecExternalSemaphoresSignalNodeSetParams`|11.2| | | | | | | |
 |`cuGraphExecExternalSemaphoresWaitNodeSetParams`|11.2| | | | | | | |
-|`cuGraphExecHostNodeSetParams`|10.2| | | | | | | |
+|`cuGraphExecHostNodeSetParams`|10.2| | |`hipGraphExecHostNodeSetParams`|5.0.0| | |5.0.0|
 |`cuGraphExecKernelNodeSetParams`|10.1| | |`hipGraphExecKernelNodeSetParams`|4.5.0| | | |
 |`cuGraphExecMemcpyNodeSetParams`|10.2| | | | | | | |
 |`cuGraphExecMemsetNodeSetParams`|10.2| | | | | | | |
-|`cuGraphExecUpdate`|10.2| | | | | | | |
+|`cuGraphExecUpdate`|10.2| | |`hipGraphExecUpdate`|5.0.0| | |5.0.0|
 |`cuGraphExternalSemaphoresSignalNodeGetParams`|11.2| | | | | | | |
 |`cuGraphExternalSemaphoresSignalNodeSetParams`|11.2| | | | | | | |
 |`cuGraphExternalSemaphoresWaitNodeGetParams`|11.2| | | | | | | |
@@ -1494,10 +1494,10 @@
 |`cuGraphGetEdges`|10.0| | |`hipGraphGetEdges`|5.0.0| | |5.0.0|
 |`cuGraphGetNodes`|10.0| | |`hipGraphGetNodes`|4.5.0| | | |
 |`cuGraphGetRootNodes`|10.0| | |`hipGraphGetRootNodes`|4.5.0| | | |
-|`cuGraphHostNodeGetParams`|10.0| | | | | | | |
-|`cuGraphHostNodeSetParams`|10.0| | | | | | | |
+|`cuGraphHostNodeGetParams`|10.0| | |`hipGraphHostNodeGetParams`|5.0.0| | |5.0.0|
+|`cuGraphHostNodeSetParams`|10.0| | |`hipGraphHostNodeSetParams`|5.0.0| | |5.0.0|
 |`cuGraphInstantiate`|10.0| | |`hipGraphInstantiate`|4.3.0| | | |
-|`cuGraphInstantiateWithFlags`|11.4| | | | | | | |
+|`cuGraphInstantiateWithFlags`|11.4| | |`hipGraphInstantiateWithFlags`|5.0.0| | |5.0.0|
 |`cuGraphInstantiate_v2`|11.0| | |`hipGraphInstantiate`|4.3.0| | | |
 |`cuGraphKernelNodeCopyAttributes`|11.0| | | | | | | |
 |`cuGraphKernelNodeGetAttribute`|11.0| | | | | | | |
@@ -1511,10 +1511,10 @@
 |`cuGraphMemcpyNodeSetParams`|10.0| | |`hipGraphMemcpyNodeSetParams`|4.5.0| | | |
 |`cuGraphMemsetNodeGetParams`|10.0| | |`hipGraphMemsetNodeGetParams`|4.5.0| | | |
 |`cuGraphMemsetNodeSetParams`|10.0| | |`hipGraphMemsetNodeSetParams`|4.5.0| | | |
-|`cuGraphNodeFindInClone`|10.0| | | | | | | |
+|`cuGraphNodeFindInClone`|10.0| | |`hipGraphNodeFindInClone`|5.0.0| | |5.0.0|
 |`cuGraphNodeGetDependencies`|10.0| | |`hipGraphNodeGetDependencies`|5.0.0| | |5.0.0|
-|`cuGraphNodeGetDependentNodes`|10.0| | | | | | | |
-|`cuGraphNodeGetType`|10.0| | | | | | | |
+|`cuGraphNodeGetDependentNodes`|10.0| | |`hipGraphNodeGetDependentNodes`|5.0.0| | |5.0.0|
+|`cuGraphNodeGetType`|10.0| | |`hipGraphNodeGetType`|5.0.0| | |5.0.0|
 |`cuGraphReleaseUserObject`|11.3| | | | | | | |
 |`cuGraphRemoveDependencies`|10.0| | |`hipGraphRemoveDependencies`|5.0.0| | |5.0.0|
 |`cuGraphRetainUserObject`|11.3| | | | | | | |

--- a/doc/markdown/CUDA_Runtime_API_functions_supported_by_HIP.md
+++ b/doc/markdown/CUDA_Runtime_API_functions_supported_by_HIP.md
@@ -419,46 +419,46 @@
 |`cudaDeviceGetGraphMemAttribute`|11.4| | | | | | | |
 |`cudaDeviceGraphMemTrim`|11.4| | | | | | | |
 |`cudaDeviceSetGraphMemAttribute`|11.4| | | | | | | |
-|`cudaGraphAddChildGraphNode`|10.0| | | | | | | |
+|`cudaGraphAddChildGraphNode`|10.0| | |`hipGraphAddChildGraphNode`|5.0.0| | |5.0.0|
 |`cudaGraphAddDependencies`|10.0| | |`hipGraphAddDependencies`|4.5.0| | | |
 |`cudaGraphAddEmptyNode`|10.0| | |`hipGraphAddEmptyNode`|4.5.0| | | |
-|`cudaGraphAddEventRecordNode`|11.1| | | | | | | |
-|`cudaGraphAddEventWaitNode`|11.1| | | | | | | |
+|`cudaGraphAddEventRecordNode`|11.1| | |`hipGraphAddEventRecordNode`|5.0.0| | |5.0.0|
+|`cudaGraphAddEventWaitNode`|11.1| | |`hipGraphAddEventWaitNode`|5.0.0| | |5.0.0|
 |`cudaGraphAddExternalSemaphoresSignalNode`|11.2| | | | | | | |
 |`cudaGraphAddExternalSemaphoresWaitNode`|11.2| | | | | | | |
-|`cudaGraphAddHostNode`|10.0| | | | | | | |
+|`cudaGraphAddHostNode`|10.0| | |`hipGraphAddHostNode`|5.0.0| | |5.0.0|
 |`cudaGraphAddKernelNode`|10.0| | |`hipGraphAddKernelNode`|4.3.0| | | |
 |`cudaGraphAddMemAllocNode`|11.4| | | | | | | |
 |`cudaGraphAddMemFreeNode`|11.4| | | | | | | |
 |`cudaGraphAddMemcpyNode`|10.0| | |`hipGraphAddMemcpyNode`|4.3.0| | | |
 |`cudaGraphAddMemcpyNode1D`|11.1| | |`hipGraphAddMemcpyNode1D`|4.5.0| | | |
-|`cudaGraphAddMemcpyNodeFromSymbol`|11.1| | | | | | | |
-|`cudaGraphAddMemcpyNodeToSymbol`|11.1| | | | | | | |
+|`cudaGraphAddMemcpyNodeFromSymbol`|11.1| | |`hipGraphAddMemcpyNodeFromSymbol`|5.0.0| | |5.0.0|
+|`cudaGraphAddMemcpyNodeToSymbol`|11.1| | |`hipGraphAddMemcpyNodeToSymbol`|5.0.0| | |5.0.0|
 |`cudaGraphAddMemsetNode`|10.0| | |`hipGraphAddMemsetNode`|4.3.0| | | |
-|`cudaGraphChildGraphNodeGetGraph`|10.0| | | | | | | |
+|`cudaGraphChildGraphNodeGetGraph`|10.0| | |`hipGraphChildGraphNodeGetGraph`|5.0.0| | |5.0.0|
 |`cudaGraphClone`|10.0| | | | | | | |
 |`cudaGraphCreate`|10.0| | |`hipGraphCreate`|4.3.0| | | |
 |`cudaGraphDebugDotPrint`|11.3| | | | | | | |
 |`cudaGraphDestroy`|10.0| | |`hipGraphDestroy`|4.3.0| | | |
-|`cudaGraphDestroyNode`|10.0| | | | | | | |
-|`cudaGraphEventRecordNodeGetEvent`|11.1| | | | | | | |
-|`cudaGraphEventRecordNodeSetEvent`|11.1| | | | | | | |
-|`cudaGraphEventWaitNodeGetEvent`|11.1| | | | | | | |
-|`cudaGraphEventWaitNodeSetEvent`|11.1| | | | | | | |
-|`cudaGraphExecChildGraphNodeSetParams`|11.1| | | | | | | |
+|`cudaGraphDestroyNode`|10.0| | |`hipGraphDestroyNode`|5.0.0| | |5.0.0|
+|`cudaGraphEventRecordNodeGetEvent`|11.1| | |`hipGraphEventRecordNodeGetEvent`|5.0.0| | |5.0.0|
+|`cudaGraphEventRecordNodeSetEvent`|11.1| | |`hipGraphEventRecordNodeSetEvent`|5.0.0| | |5.0.0|
+|`cudaGraphEventWaitNodeGetEvent`|11.1| | |`hipGraphEventWaitNodeGetEvent`|5.0.0| | |5.0.0|
+|`cudaGraphEventWaitNodeSetEvent`|11.1| | |`hipGraphEventWaitNodeSetEvent`|5.0.0| | |5.0.0|
+|`cudaGraphExecChildGraphNodeSetParams`|11.1| | |`hipGraphExecChildGraphNodeSetParams`|5.0.0| | |5.0.0|
 |`cudaGraphExecDestroy`|10.0| | |`hipGraphExecDestroy`|4.3.0| | | |
-|`cudaGraphExecEventRecordNodeSetEvent`|11.1| | | | | | | |
-|`cudaGraphExecEventWaitNodeSetEvent`|11.1| | | | | | | |
+|`cudaGraphExecEventRecordNodeSetEvent`|11.1| | |`hipGraphExecEventRecordNodeSetEvent`|5.0.0| | |5.0.0|
+|`cudaGraphExecEventWaitNodeSetEvent`|11.1| | |`hipGraphExecEventWaitNodeSetEvent`|5.0.0| | |5.0.0|
 |`cudaGraphExecExternalSemaphoresSignalNodeSetParams`|11.2| | | | | | | |
 |`cudaGraphExecExternalSemaphoresWaitNodeSetParams`|11.2| | | | | | | |
-|`cudaGraphExecHostNodeSetParams`|11.0| | | | | | | |
+|`cudaGraphExecHostNodeSetParams`|11.0| | |`hipGraphExecHostNodeSetParams`|5.0.0| | |5.0.0|
 |`cudaGraphExecKernelNodeSetParams`|11.0| | |`hipGraphExecKernelNodeSetParams`|4.5.0| | | |
-|`cudaGraphExecMemcpyNodeSetParams`|11.0| | | | | | | |
-|`cudaGraphExecMemcpyNodeSetParams1D`|11.1| | | | | | | |
-|`cudaGraphExecMemcpyNodeSetParamsFromSymbol`|11.1| | | | | | | |
-|`cudaGraphExecMemcpyNodeSetParamsToSymbol`|11.1| | | | | | | |
-|`cudaGraphExecMemsetNodeSetParams`|11.0| | | | | | | |
-|`cudaGraphExecUpdate`|11.0| | | | | | | |
+|`cudaGraphExecMemcpyNodeSetParams`|11.0| | |`hipGraphExecMemcpyNodeSetParams`|5.0.0| | |5.0.0|
+|`cudaGraphExecMemcpyNodeSetParams1D`|11.1| | |`hipGraphExecMemcpyNodeSetParams1D`|5.0.0| | |5.0.0|
+|`cudaGraphExecMemcpyNodeSetParamsFromSymbol`|11.1| | |`hipGraphExecMemcpyNodeSetParamsFromSymbol`|5.0.0| | |5.0.0|
+|`cudaGraphExecMemcpyNodeSetParamsToSymbol`|11.1| | |`hipGraphExecMemcpyNodeSetParamsToSymbol`|5.0.0| | |5.0.0|
+|`cudaGraphExecMemsetNodeSetParams`|11.0| | |`hipGraphExecMemsetNodeSetParams`|5.0.0| | |5.0.0|
+|`cudaGraphExecUpdate`|11.0| | |`hipGraphExecUpdate`|5.0.0| | |5.0.0|
 |`cudaGraphExternalSemaphoresSignalNodeGetParams`|11.2| | | | | | | |
 |`cudaGraphExternalSemaphoresSignalNodeSetParams`|11.2| | | | | | | |
 |`cudaGraphExternalSemaphoresWaitNodeGetParams`|11.2| | | | | | | |
@@ -466,10 +466,10 @@
 |`cudaGraphGetEdges`|10.0| | |`hipGraphGetEdges`|5.0.0| | |5.0.0|
 |`cudaGraphGetNodes`|10.0| | |`hipGraphGetNodes`|4.5.0| | | |
 |`cudaGraphGetRootNodes`|10.0| | |`hipGraphGetRootNodes`|4.5.0| | | |
-|`cudaGraphHostNodeGetParams`|10.0| | | | | | | |
-|`cudaGraphHostNodeSetParams`|10.0| | | | | | | |
+|`cudaGraphHostNodeGetParams`|10.0| | |`hipGraphHostNodeGetParams`|5.0.0| | |5.0.0|
+|`cudaGraphHostNodeSetParams`|10.0| | |`hipGraphHostNodeSetParams`|5.0.0| | |5.0.0|
 |`cudaGraphInstantiate`|10.0| | |`hipGraphInstantiate`|4.3.0| | | |
-|`cudaGraphInstantiateWithFlags`|11.4| | | | | | | |
+|`cudaGraphInstantiateWithFlags`|11.4| | |`hipGraphInstantiateWithFlags`|5.0.0| | |5.0.0|
 |`cudaGraphKernelNodeCopyAttributes`|11.0| | | | | | | |
 |`cudaGraphKernelNodeGetAttribute`|11.0| | | | | | | |
 |`cudaGraphKernelNodeGetParams`|11.0| | |`hipGraphKernelNodeGetParams`|4.5.0| | | |
@@ -480,15 +480,15 @@
 |`cudaGraphMemFreeNodeGetParams`|11.4| | | | | | | |
 |`cudaGraphMemcpyNodeGetParams`|11.0| | |`hipGraphMemcpyNodeGetParams`|4.5.0| | | |
 |`cudaGraphMemcpyNodeSetParams`|11.0| | |`hipGraphMemcpyNodeSetParams`|4.5.0| | | |
-|`cudaGraphMemcpyNodeSetParams1D`|11.1| | | | | | | |
-|`cudaGraphMemcpyNodeSetParamsFromSymbol`|11.1| | | | | | | |
-|`cudaGraphMemcpyNodeSetParamsToSymbol`|11.1| | | | | | | |
+|`cudaGraphMemcpyNodeSetParams1D`|11.1| | |`hipGraphMemcpyNodeSetParams1D`|5.0.0| | |5.0.0|
+|`cudaGraphMemcpyNodeSetParamsFromSymbol`|11.1| | |`hipGraphMemcpyNodeSetParamsFromSymbol`|5.0.0| | |5.0.0|
+|`cudaGraphMemcpyNodeSetParamsToSymbol`|11.1| | |`hipGraphMemcpyNodeSetParamsToSymbol`|5.0.0| | |5.0.0|
 |`cudaGraphMemsetNodeGetParams`|11.0| | |`hipGraphMemsetNodeGetParams`|4.5.0| | | |
 |`cudaGraphMemsetNodeSetParams`|11.0| | |`hipGraphMemsetNodeSetParams`|4.5.0| | | |
-|`cudaGraphNodeFindInClone`|11.0| | | | | | | |
+|`cudaGraphNodeFindInClone`|11.0| | |`hipGraphNodeFindInClone`|5.0.0| | |5.0.0|
 |`cudaGraphNodeGetDependencies`|11.0| | |`hipGraphNodeGetDependencies`|5.0.0| | |5.0.0|
-|`cudaGraphNodeGetDependentNodes`|11.0| | | | | | | |
-|`cudaGraphNodeGetType`|11.0| | | | | | | |
+|`cudaGraphNodeGetDependentNodes`|11.0| | |`hipGraphNodeGetDependentNodes`|5.0.0| | |5.0.0|
+|`cudaGraphNodeGetType`|11.0| | |`hipGraphNodeGetType`|5.0.0| | |5.0.0|
 |`cudaGraphReleaseUserObject`|11.3| | | | | | | |
 |`cudaGraphRemoveDependencies`|11.0| | |`hipGraphRemoveDependencies`|5.0.0| | |5.0.0|
 |`cudaGraphRetainUserObject`|11.3| | | | | | | |

--- a/src/CUDA2HIP_Driver_API_functions.cpp
+++ b/src/CUDA2HIP_Driver_API_functions.cpp
@@ -549,13 +549,13 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_FUNCTION_MAP {
 
   // 21. Graph Management
   // cudaGraphAddChildGraphNode
-  {"cuGraphAddChildGraphNode",                             {"hipGraphAddChildGraphNode",                               "", CONV_GRAPH, API_DRIVER, 21, HIP_UNSUPPORTED}},
+  {"cuGraphAddChildGraphNode",                             {"hipGraphAddChildGraphNode",                               "", CONV_GRAPH, API_DRIVER, 21, HIP_EXPERIMENTAL}},
   // cudaGraphAddDependencies
   {"cuGraphAddDependencies",                               {"hipGraphAddDependencies",                                 "", CONV_GRAPH, API_DRIVER, 21}},
   // cudaGraphAddEmptyNode
   {"cuGraphAddEmptyNode",                                  {"hipGraphAddEmptyNode",                                    "", CONV_GRAPH, API_DRIVER, 21}},
   // cudaGraphAddHostNode
-  {"cuGraphAddHostNode",                                   {"hipGraphAddHostNode",                                     "", CONV_GRAPH, API_DRIVER, 21, HIP_UNSUPPORTED}},
+  {"cuGraphAddHostNode",                                   {"hipGraphAddHostNode",                                     "", CONV_GRAPH, API_DRIVER, 21, HIP_EXPERIMENTAL}},
   // cudaGraphAddKernelNode
   {"cuGraphAddKernelNode",                                 {"hipGraphAddKernelNode",                                   "", CONV_GRAPH, API_DRIVER, 21}},
   // no analogue
@@ -569,7 +569,7 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_FUNCTION_MAP {
   // RUNTIME: cudaError_t CUDARTAPI cudaGraphAddMemcpyNode(cudaGraphNode_t *pGraphNode, cudaGraph_t graph, const cudaGraphNode_t *pDependencies, size_t numDependencies, const struct cudaMemcpy3DParms *pCopyParams);
   {"cuGraphAddMemsetNode",                                 {"hipGraphAddMemsetNode",                                   "", CONV_GRAPH, API_DRIVER, 21, HIP_UNSUPPORTED}},
   // cudaGraphChildGraphNodeGetGraph
-  {"cuGraphChildGraphNodeGetGraph",                        {"hipGraphChildGraphNodeGetGraph",                          "", CONV_GRAPH, API_DRIVER, 21, HIP_UNSUPPORTED}},
+  {"cuGraphChildGraphNodeGetGraph",                        {"hipGraphChildGraphNodeGetGraph",                          "", CONV_GRAPH, API_DRIVER, 21, HIP_EXPERIMENTAL}},
   // cudaGraphClone
   {"cuGraphClone",                                         {"hipGraphClone",                                           "", CONV_GRAPH, API_DRIVER, 21, HIP_UNSUPPORTED}},
   // cudaGraphCreate
@@ -579,7 +579,7 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_FUNCTION_MAP {
   // cudaGraphDestroy
   {"cuGraphDestroy",                                       {"hipGraphDestroy",                                         "", CONV_GRAPH, API_DRIVER, 21}},
   // cudaGraphDestroyNode
-  {"cuGraphDestroyNode",                                   {"hipGraphDestroyNode",                                     "", CONV_GRAPH, API_DRIVER, 21, HIP_UNSUPPORTED}},
+  {"cuGraphDestroyNode",                                   {"hipGraphDestroyNode",                                     "", CONV_GRAPH, API_DRIVER, 21, HIP_EXPERIMENTAL}},
   // cudaGraphExecDestroy
   {"cuGraphExecDestroy",                                   {"hipGraphExecDestroy",                                     "", CONV_GRAPH, API_DRIVER, 21}},
   // cudaGraphGetEdges
@@ -589,9 +589,9 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_FUNCTION_MAP {
   // cudaGraphGetRootNodes
   {"cuGraphGetRootNodes",                                  {"hipGraphGetRootNodes",                                    "", CONV_GRAPH, API_DRIVER, 21}},
   // cudaGraphHostNodeGetParams
-  {"cuGraphHostNodeGetParams",                             {"hipGraphHostNodeGetParams",                               "", CONV_GRAPH, API_DRIVER, 21, HIP_UNSUPPORTED}},
+  {"cuGraphHostNodeGetParams",                             {"hipGraphHostNodeGetParams",                               "", CONV_GRAPH, API_DRIVER, 21, HIP_EXPERIMENTAL}},
   // cudaGraphHostNodeSetParams
-  {"cuGraphHostNodeSetParams",                             {"hipGraphHostNodeSetParams",                               "", CONV_GRAPH, API_DRIVER, 21, HIP_UNSUPPORTED}},
+  {"cuGraphHostNodeSetParams",                             {"hipGraphHostNodeSetParams",                               "", CONV_GRAPH, API_DRIVER, 21, HIP_EXPERIMENTAL}},
   // cudaGraphInstantiate
   {"cuGraphInstantiate",                                   {"hipGraphInstantiate",                                     "", CONV_GRAPH, API_DRIVER, 21}},
   {"cuGraphInstantiate_v2",                                {"hipGraphInstantiate",                                     "", CONV_GRAPH, API_DRIVER, 21}},
@@ -618,41 +618,47 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_FUNCTION_MAP {
   // cudaGraphMemsetNodeSetParams
   {"cuGraphMemsetNodeSetParams",                           {"hipGraphMemsetNodeSetParams",                             "", CONV_GRAPH, API_DRIVER, 21}},
   // cudaGraphNodeFindInClone
-  {"cuGraphNodeFindInClone",                               {"hipGraphNodeFindInClone",                                 "", CONV_GRAPH, API_DRIVER, 21, HIP_UNSUPPORTED}},
+  {"cuGraphNodeFindInClone",                               {"hipGraphNodeFindInClone",                                 "", CONV_GRAPH, API_DRIVER, 21, HIP_EXPERIMENTAL}},
   // cudaGraphNodeGetDependencies
   {"cuGraphNodeGetDependencies",                           {"hipGraphNodeGetDependencies",                             "", CONV_GRAPH, API_DRIVER, 21, HIP_EXPERIMENTAL}},
   // cudaGraphNodeGetDependentNodes
-  {"cuGraphNodeGetDependentNodes",                         {"hipGraphNodeGetDependentNodes",                           "", CONV_GRAPH, API_DRIVER, 21, HIP_UNSUPPORTED}},
+  {"cuGraphNodeGetDependentNodes",                         {"hipGraphNodeGetDependentNodes",                           "", CONV_GRAPH, API_DRIVER, 21, HIP_EXPERIMENTAL}},
   // cudaGraphNodeGetType
-  {"cuGraphNodeGetType",                                   {"hipGraphNodeGetType",                                     "", CONV_GRAPH, API_DRIVER, 21, HIP_UNSUPPORTED}},
+  {"cuGraphNodeGetType",                                   {"hipGraphNodeGetType",                                     "", CONV_GRAPH, API_DRIVER, 21, HIP_EXPERIMENTAL}},
   // cudaGraphRemoveDependencies
   {"cuGraphRemoveDependencies",                            {"hipGraphRemoveDependencies",                              "", CONV_GRAPH, API_DRIVER, 21, HIP_EXPERIMENTAL}},
-  // cudaGraphExecMemcpyNodeSetParams
+  // no analogue
+  // NOTE: Not equal to cudaGraphExecMemcpyNodeSetParams due to different signatures:
+  // DRIVER: CUresult CUDAAPI cuGraphExecMemcpyNodeSetParams(CUgraphExec hGraphExec, CUgraphNode hNode, const CUDA_MEMCPY3D *copyParams, CUcontext ctx);
+  // RUNTIME: cudaError_t CUDARTAPI cudaGraphExecMemcpyNodeSetParams(cudaGraphExec_t hGraphExec, cudaGraphNode_t node, const struct cudaMemcpy3DParms *pNodeParams);
   {"cuGraphExecMemcpyNodeSetParams",                       {"hipGraphExecMemcpyNodeSetParams",                         "", CONV_GRAPH, API_DRIVER, 21, HIP_UNSUPPORTED}},
-  // cudaGraphExecMemsetNodeSetParams
+  // no analogue
+  // NOTE: Not equal to cudaGraphExecMemcpyNodeSetParams due to different signatures:
+  // DRIVER: CUresult CUDAAPI cuGraphExecMemsetNodeSetParams(CUgraphExec hGraphExec, CUgraphNode hNode, const CUDA_MEMSET_NODE_PARAMS *memsetParams, CUcontext ctx);
+  // RUNTIME: cudaError_t CUDARTAPI cudaGraphExecMemsetNodeSetParams(cudaGraphExec_t hGraphExec, cudaGraphNode_t node, const struct cudaMemsetParams *pNodeParams);
   {"cuGraphExecMemsetNodeSetParams",                       {"hipGraphExecMemsetNodeSetParams",                         "", CONV_GRAPH, API_DRIVER, 21, HIP_UNSUPPORTED}},
   // cudaGraphExecHostNodeSetParams
-  {"cuGraphExecHostNodeSetParams",                         {"hipGraphExecHostNodeSetParams",                           "", CONV_GRAPH, API_DRIVER, 21, HIP_UNSUPPORTED}},
+  {"cuGraphExecHostNodeSetParams",                         {"hipGraphExecHostNodeSetParams",                           "", CONV_GRAPH, API_DRIVER, 21, HIP_EXPERIMENTAL}},
   // cudaGraphExecUpdate
-  {"cuGraphExecUpdate",                                    {"hipGraphExecUpdate",                                      "", CONV_GRAPH, API_DRIVER, 21, HIP_UNSUPPORTED}},
+  {"cuGraphExecUpdate",                                    {"hipGraphExecUpdate",                                      "", CONV_GRAPH, API_DRIVER, 21, HIP_EXPERIMENTAL}},
   // cudaGraphAddEventRecordNode
-  {"cuGraphAddEventRecordNode",                            {"hipGraphAddEventRecordNode",                              "", CONV_GRAPH, API_DRIVER, 21, HIP_UNSUPPORTED}},
+  {"cuGraphAddEventRecordNode",                            {"hipGraphAddEventRecordNode",                              "", CONV_GRAPH, API_DRIVER, 21, HIP_EXPERIMENTAL}},
   // cudaGraphEventRecordNodeGetEvent
-  {"cuGraphEventRecordNodeGetEvent",                       {"hipGraphEventRecordNodeGetEvent",                         "", CONV_GRAPH, API_DRIVER, 21, HIP_UNSUPPORTED}},
+  {"cuGraphEventRecordNodeGetEvent",                       {"hipGraphEventRecordNodeGetEvent",                         "", CONV_GRAPH, API_DRIVER, 21, HIP_EXPERIMENTAL}},
   // cudaGraphEventRecordNodeSetEvent
-  {"cuGraphEventRecordNodeSetEvent",                       {"hipGraphEventRecordNodeSetEvent",                         "", CONV_GRAPH, API_DRIVER, 21, HIP_UNSUPPORTED}},
+  {"cuGraphEventRecordNodeSetEvent",                       {"hipGraphEventRecordNodeSetEvent",                         "", CONV_GRAPH, API_DRIVER, 21, HIP_EXPERIMENTAL}},
   // cudaGraphAddEventWaitNode
-  {"cuGraphAddEventWaitNode",                              {"hipGraphAddEventWaitNode",                                "", CONV_GRAPH, API_DRIVER, 21, HIP_UNSUPPORTED}},
+  {"cuGraphAddEventWaitNode",                              {"hipGraphAddEventWaitNode",                                "", CONV_GRAPH, API_DRIVER, 21, HIP_EXPERIMENTAL}},
   // cudaGraphEventWaitNodeGetEvent
-  {"cuGraphEventWaitNodeGetEvent",                         {"hipGraphEventWaitNodeGetEvent",                           "", CONV_GRAPH, API_DRIVER, 21, HIP_UNSUPPORTED}},
+  {"cuGraphEventWaitNodeGetEvent",                         {"hipGraphEventWaitNodeGetEvent",                           "", CONV_GRAPH, API_DRIVER, 21, HIP_EXPERIMENTAL}},
   // cudaGraphEventWaitNodeSetEvent
-  {"cuGraphEventWaitNodeSetEvent",                         {"hipGraphEventWaitNodeSetEvent",                           "", CONV_GRAPH, API_DRIVER, 21, HIP_UNSUPPORTED}},
+  {"cuGraphEventWaitNodeSetEvent",                         {"hipGraphEventWaitNodeSetEvent",                           "", CONV_GRAPH, API_DRIVER, 21, HIP_EXPERIMENTAL}},
   // cudaGraphExecChildGraphNodeSetParams
-  {"cuGraphExecChildGraphNodeSetParams",                   {"hipGraphExecChildGraphNodeSetParams",                     "", CONV_GRAPH, API_DRIVER, 21, HIP_UNSUPPORTED}},
+  {"cuGraphExecChildGraphNodeSetParams",                   {"hipGraphExecChildGraphNodeSetParams",                     "", CONV_GRAPH, API_DRIVER, 21, HIP_EXPERIMENTAL}},
   // cudaGraphExecEventRecordNodeSetEvent
-  {"cuGraphExecEventRecordNodeSetEvent",                   {"hipGraphExecEventRecordNodeSetEvent",                     "", CONV_GRAPH, API_DRIVER, 21, HIP_UNSUPPORTED}},
+  {"cuGraphExecEventRecordNodeSetEvent",                   {"hipGraphExecEventRecordNodeSetEvent",                     "", CONV_GRAPH, API_DRIVER, 21, HIP_EXPERIMENTAL}},
   // cudaGraphExecEventWaitNodeSetEvent
-  {"cuGraphExecEventWaitNodeSetEvent",                     {"hipGraphExecEventWaitNodeSetEvent",                       "", CONV_GRAPH, API_DRIVER, 21, HIP_UNSUPPORTED}},
+  {"cuGraphExecEventWaitNodeSetEvent",                     {"hipGraphExecEventWaitNodeSetEvent",                       "", CONV_GRAPH, API_DRIVER, 21, HIP_EXPERIMENTAL}},
   // cudaGraphUpload
   {"cuGraphUpload",                                        {"hipGraphUpload",                                          "", CONV_GRAPH, API_DRIVER, 21, HIP_UNSUPPORTED}},
   // cudaGraphAddExternalSemaphoresSignalNode
@@ -696,7 +702,7 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_FUNCTION_MAP {
   // cudaDeviceSetGraphMemAttribute
   {"cuDeviceSetGraphMemAttribute",                         {"hipDeviceSetGraphMemAttribute",                           "", CONV_GRAPH, API_DRIVER, 21, HIP_UNSUPPORTED}},
   // cudaGraphInstantiateWithFlags
-  {"cuGraphInstantiateWithFlags",                          {"hipGraphInstantiateWithFlags",                            "", CONV_GRAPH, API_DRIVER, 21, HIP_UNSUPPORTED}},
+  {"cuGraphInstantiateWithFlags",                          {"hipGraphInstantiateWithFlags",                            "", CONV_GRAPH, API_DRIVER, 21, HIP_EXPERIMENTAL}},
 
   // 22. Occupancy
   // cudaOccupancyAvailableDynamicSMemPerBlock

--- a/src/CUDA2HIP_Runtime_API_functions.cpp
+++ b/src/CUDA2HIP_Runtime_API_functions.cpp
@@ -660,21 +660,27 @@ const std::map<llvm::StringRef, hipCounter> CUDA_RUNTIME_FUNCTION_MAP {
 
   // 30. Graph Management
   // cuGraphAddChildGraphNode
-  {"cudaGraphAddChildGraphNode",                              {"hipGraphAddChildGraphNode",                              "", CONV_GRAPH, API_RUNTIME, 30, HIP_UNSUPPORTED}},
+  {"cudaGraphAddChildGraphNode",                              {"hipGraphAddChildGraphNode",                              "", CONV_GRAPH, API_RUNTIME, 30, HIP_EXPERIMENTAL}},
   // cuGraphAddDependencies
   {"cudaGraphAddDependencies",                                {"hipGraphAddDependencies",                                "", CONV_GRAPH, API_RUNTIME, 30}},
   // cuGraphAddEmptyNode
   {"cudaGraphAddEmptyNode",                                   {"hipGraphAddEmptyNode",                                   "", CONV_GRAPH, API_RUNTIME, 30}},
   // cuGraphAddHostNode
-  {"cudaGraphAddHostNode",                                    {"hipGraphAddHostNode",                                    "", CONV_GRAPH, API_RUNTIME, 30, HIP_UNSUPPORTED}},
+  {"cudaGraphAddHostNode",                                    {"hipGraphAddHostNode",                                    "", CONV_GRAPH, API_RUNTIME, 30, HIP_EXPERIMENTAL}},
   // cuGraphAddKernelNode
   {"cudaGraphAddKernelNode",                                  {"hipGraphAddKernelNode",                                  "", CONV_GRAPH, API_RUNTIME, 30}},
-  // cuGraphAddMemcpyNode
+  // no analogue
+  // NOTE: Not equal to cuGraphAddMemcpyNode due to different signatures:
+  // DRIVER: CUresult CUDAAPI cuGraphAddMemcpyNode(CUgraphNode *phGraphNode, CUgraph hGraph, const CUgraphNode *dependencies, size_t numDependencies, const CUDA_MEMCPY3D *copyParams, CUcontext ctx);
+  // RUNTIME: cudaError_t CUDARTAPI cudaGraphAddMemcpyNode(cudaGraphNode_t *pGraphNode, cudaGraph_t graph, const cudaGraphNode_t *pDependencies, size_t numDependencies, const struct cudaMemcpy3DParms *pCopyParams);
   {"cudaGraphAddMemcpyNode",                                  {"hipGraphAddMemcpyNode",                                  "", CONV_GRAPH, API_RUNTIME, 30}},
-  // cuGraphAddMemsetNode
+  // no analogue
+  // NOTE: Not equal to cuGraphAddMemsetNode due to different signatures:
+  // DRIVER: CUresult CUDAAPI cuGraphAddMemsetNode(CUgraphNode *phGraphNode, CUgraph hGraph, const CUgraphNode *dependencies, size_t numDependencies, const CUDA_MEMSET_NODE_PARAMS *memsetParams, CUcontext ctx);
+  // RUNTIME: cudaError_t CUDARTAPI cudaGraphAddMemcpyNode(cudaGraphNode_t *pGraphNode, cudaGraph_t graph, const cudaGraphNode_t *pDependencies, size_t numDependencies, const struct cudaMemcpy3DParms *pCopyParams);
   {"cudaGraphAddMemsetNode",                                  {"hipGraphAddMemsetNode",                                  "", CONV_GRAPH, API_RUNTIME, 30}},
   // cuGraphChildGraphNodeGetGraph
-  {"cudaGraphChildGraphNodeGetGraph",                         {"hipGraphChildGraphNodeGetGraph",                         "", CONV_GRAPH, API_RUNTIME, 30, HIP_UNSUPPORTED}},
+  {"cudaGraphChildGraphNodeGetGraph",                         {"hipGraphChildGraphNodeGetGraph",                         "", CONV_GRAPH, API_RUNTIME, 30, HIP_EXPERIMENTAL}},
   // cuGraphClone
   {"cudaGraphClone",                                          {"hipGraphClone",                                          "", CONV_GRAPH, API_RUNTIME, 30, HIP_UNSUPPORTED}},
   // cuGraphCreate
@@ -684,7 +690,7 @@ const std::map<llvm::StringRef, hipCounter> CUDA_RUNTIME_FUNCTION_MAP {
   // cuGraphDestroy
   {"cudaGraphDestroy",                                        {"hipGraphDestroy",                                        "", CONV_GRAPH, API_RUNTIME, 30}},
   // cuGraphDestroyNode
-  {"cudaGraphDestroyNode",                                    {"hipGraphDestroyNode",                                    "", CONV_GRAPH, API_RUNTIME, 30, HIP_UNSUPPORTED}},
+  {"cudaGraphDestroyNode",                                    {"hipGraphDestroyNode",                                    "", CONV_GRAPH, API_RUNTIME, 30, HIP_EXPERIMENTAL}},
   // cuGraphExecDestroy
   {"cudaGraphExecDestroy",                                    {"hipGraphExecDestroy",                                    "", CONV_GRAPH, API_RUNTIME, 30}},
   // cuGraphGetEdges
@@ -694,9 +700,9 @@ const std::map<llvm::StringRef, hipCounter> CUDA_RUNTIME_FUNCTION_MAP {
   // cuGraphGetRootNodes
   {"cudaGraphGetRootNodes",                                   {"hipGraphGetRootNodes",                                   "", CONV_GRAPH, API_RUNTIME, 30}},
   // cuGraphHostNodeGetParams
-  {"cudaGraphHostNodeGetParams",                              {"hipGraphHostNodeGetParams",                              "", CONV_GRAPH, API_RUNTIME, 30, HIP_UNSUPPORTED}},
+  {"cudaGraphHostNodeGetParams",                              {"hipGraphHostNodeGetParams",                              "", CONV_GRAPH, API_RUNTIME, 30, HIP_EXPERIMENTAL}},
   // cuGraphHostNodeSetParams
-  {"cudaGraphHostNodeSetParams",                              {"hipGraphHostNodeSetParams",                              "", CONV_GRAPH, API_RUNTIME, 30, HIP_UNSUPPORTED}},
+  {"cudaGraphHostNodeSetParams",                              {"hipGraphHostNodeSetParams",                              "", CONV_GRAPH, API_RUNTIME, 30, HIP_EXPERIMENTAL}},
   // cuGraphInstantiate
   {"cudaGraphInstantiate",                                    {"hipGraphInstantiate",                                    "", CONV_GRAPH, API_RUNTIME, 30}},
   // cuGraphKernelNodeCopyAttributes
@@ -707,14 +713,20 @@ const std::map<llvm::StringRef, hipCounter> CUDA_RUNTIME_FUNCTION_MAP {
   {"cudaGraphKernelNodeSetAttribute",                         {"hipGraphKernelNodeSetAttribute",                         "", CONV_GRAPH, API_RUNTIME, 30, HIP_UNSUPPORTED}},
   // cuGraphExecKernelNodeSetParams
   {"cudaGraphExecKernelNodeSetParams",                        {"hipGraphExecKernelNodeSetParams",                        "", CONV_GRAPH, API_RUNTIME, 30}},
-  // cuGraphExecMemcpyNodeSetParams
-  {"cudaGraphExecMemcpyNodeSetParams",                        {"hipGraphExecMemcpyNodeSetParams",                        "", CONV_GRAPH, API_RUNTIME, 30, HIP_UNSUPPORTED}},
-  // cuGraphExecMemsetNodeSetParams
-  {"cudaGraphExecMemsetNodeSetParams",                        {"hipGraphExecMemsetNodeSetParams",                        "", CONV_GRAPH, API_RUNTIME, 30, HIP_UNSUPPORTED}},
+  // no analogue
+  // NOTE: Not equal to cuGraphExecMemcpyNodeSetParams due to different signatures:
+  // DRIVER: CUresult CUDAAPI cuGraphExecMemcpyNodeSetParams(CUgraphExec hGraphExec, CUgraphNode hNode, const CUDA_MEMCPY3D *copyParams, CUcontext ctx);
+  // RUNTIME: cudaError_t CUDARTAPI cudaGraphExecMemcpyNodeSetParams(cudaGraphExec_t hGraphExec, cudaGraphNode_t node, const struct cudaMemcpy3DParms *pNodeParams);
+  {"cudaGraphExecMemcpyNodeSetParams",                        {"hipGraphExecMemcpyNodeSetParams",                        "", CONV_GRAPH, API_RUNTIME, 30, HIP_EXPERIMENTAL}},
+  // no analogue
+  // NOTE: Not equal to cuGraphExecMemsetNodeSetParams due to different signatures:
+  // DRIVER: CUresult CUDAAPI cuGraphExecMemsetNodeSetParams(CUgraphExec hGraphExec, CUgraphNode hNode, const CUDA_MEMSET_NODE_PARAMS *memsetParams, CUcontext ctx);
+  // RUNTIME: cudaError_t CUDARTAPI cudaGraphExecMemsetNodeSetParams(cudaGraphExec_t hGraphExec, cudaGraphNode_t node, const struct cudaMemsetParams *pNodeParams);
+  {"cudaGraphExecMemsetNodeSetParams",                        {"hipGraphExecMemsetNodeSetParams",                        "", CONV_GRAPH, API_RUNTIME, 30, HIP_EXPERIMENTAL}},
   // cuGraphExecHostNodeSetParams
-  {"cudaGraphExecHostNodeSetParams",                          {"hipGraphExecHostNodeSetParams",                          "", CONV_GRAPH, API_RUNTIME, 30, HIP_UNSUPPORTED}},
+  {"cudaGraphExecHostNodeSetParams",                          {"hipGraphExecHostNodeSetParams",                          "", CONV_GRAPH, API_RUNTIME, 30, HIP_EXPERIMENTAL}},
   // cuGraphExecUpdate
-  {"cudaGraphExecUpdate",                                     {"hipGraphExecUpdate",                                     "", CONV_GRAPH, API_RUNTIME, 30, HIP_UNSUPPORTED}},
+  {"cudaGraphExecUpdate",                                     {"hipGraphExecUpdate",                                     "", CONV_GRAPH, API_RUNTIME, 30, HIP_EXPERIMENTAL}},
   // cuGraphKernelNodeGetParams
   {"cudaGraphKernelNodeGetParams",                            {"hipGraphKernelNodeGetParams",                            "", CONV_GRAPH, API_RUNTIME, 30}},
   // cuGraphKernelNodeSetParams
@@ -730,51 +742,51 @@ const std::map<llvm::StringRef, hipCounter> CUDA_RUNTIME_FUNCTION_MAP {
   // cuGraphMemsetNodeSetParams
   {"cudaGraphMemsetNodeSetParams",                            {"hipGraphMemsetNodeSetParams",                            "", CONV_GRAPH, API_RUNTIME, 30}},
   // cuGraphNodeFindInClone
-  {"cudaGraphNodeFindInClone",                                {"hipGraphNodeFindInClone",                                "", CONV_GRAPH, API_RUNTIME, 30, HIP_UNSUPPORTED}},
+  {"cudaGraphNodeFindInClone",                                {"hipGraphNodeFindInClone",                                "", CONV_GRAPH, API_RUNTIME, 30, HIP_EXPERIMENTAL}},
   // cuGraphNodeGetDependencies
   {"cudaGraphNodeGetDependencies",                            {"hipGraphNodeGetDependencies",                            "", CONV_GRAPH, API_RUNTIME, 30, HIP_EXPERIMENTAL}},
   // cuGraphNodeGetDependentNodes
-  {"cudaGraphNodeGetDependentNodes",                          {"hipGraphNodeGetDependentNodes",                          "", CONV_GRAPH, API_RUNTIME, 30, HIP_UNSUPPORTED}},
+  {"cudaGraphNodeGetDependentNodes",                          {"hipGraphNodeGetDependentNodes",                          "", CONV_GRAPH, API_RUNTIME, 30, HIP_EXPERIMENTAL}},
   // cuGraphNodeGetType
-  {"cudaGraphNodeGetType",                                    {"hipGraphNodeGetType",                                    "", CONV_GRAPH, API_RUNTIME, 30, HIP_UNSUPPORTED}},
+  {"cudaGraphNodeGetType",                                    {"hipGraphNodeGetType",                                    "", CONV_GRAPH, API_RUNTIME, 30, HIP_EXPERIMENTAL}},
   // cuGraphRemoveDependencies
   {"cudaGraphRemoveDependencies",                             {"hipGraphRemoveDependencies",                             "", CONV_GRAPH, API_RUNTIME, 30, HIP_EXPERIMENTAL}},
   // no analogue
-  {"cudaGraphAddMemcpyNodeToSymbol",                          {"hipGraphAddMemcpyNodeToSymbol",                          "", CONV_GRAPH, API_RUNTIME, 30, HIP_UNSUPPORTED}},
+  {"cudaGraphAddMemcpyNodeToSymbol",                          {"hipGraphAddMemcpyNodeToSymbol",                          "", CONV_GRAPH, API_RUNTIME, 30, HIP_EXPERIMENTAL}},
   // no analogue
-  {"cudaGraphAddMemcpyNodeFromSymbol",                        {"hipGraphAddMemcpyNodeFromSymbol",                        "", CONV_GRAPH, API_RUNTIME, 30, HIP_UNSUPPORTED}},
+  {"cudaGraphAddMemcpyNodeFromSymbol",                        {"hipGraphAddMemcpyNodeFromSymbol",                        "", CONV_GRAPH, API_RUNTIME, 30, HIP_EXPERIMENTAL}},
   // no analogue
   {"cudaGraphAddMemcpyNode1D",                                {"hipGraphAddMemcpyNode1D",                                "", CONV_GRAPH, API_RUNTIME, 30}},
   // no analogue
-  {"cudaGraphMemcpyNodeSetParamsToSymbol",                    {"hipGraphMemcpyNodeSetParamsToSymbol",                    "", CONV_GRAPH, API_RUNTIME, 30, HIP_UNSUPPORTED}},
+  {"cudaGraphMemcpyNodeSetParamsToSymbol",                    {"hipGraphMemcpyNodeSetParamsToSymbol",                    "", CONV_GRAPH, API_RUNTIME, 30, HIP_EXPERIMENTAL}},
   // no analogue
-  {"cudaGraphMemcpyNodeSetParamsFromSymbol",                  {"hipGraphMemcpyNodeSetParamsFromSymbol",                  "", CONV_GRAPH, API_RUNTIME, 30, HIP_UNSUPPORTED}},
+  {"cudaGraphMemcpyNodeSetParamsFromSymbol",                  {"hipGraphMemcpyNodeSetParamsFromSymbol",                  "", CONV_GRAPH, API_RUNTIME, 30, HIP_EXPERIMENTAL}},
   // no analogue
-  {"cudaGraphMemcpyNodeSetParams1D",                          {"hipGraphMemcpyNodeSetParams1D",                          "", CONV_GRAPH, API_RUNTIME, 30, HIP_UNSUPPORTED}},
+  {"cudaGraphMemcpyNodeSetParams1D",                          {"hipGraphMemcpyNodeSetParams1D",                          "", CONV_GRAPH, API_RUNTIME, 30, HIP_EXPERIMENTAL}},
   // cuGraphAddEventRecordNode
-  {"cudaGraphAddEventRecordNode",                             {"hipGraphAddEventRecordNode",                             "", CONV_GRAPH, API_RUNTIME, 30, HIP_UNSUPPORTED}},
+  {"cudaGraphAddEventRecordNode",                             {"hipGraphAddEventRecordNode",                             "", CONV_GRAPH, API_RUNTIME, 30, HIP_EXPERIMENTAL}},
   // cuGraphEventRecordNodeGetEvent
-  {"cudaGraphEventRecordNodeGetEvent",                        {"hipGraphEventRecordNodeGetEvent",                        "", CONV_GRAPH, API_RUNTIME, 30, HIP_UNSUPPORTED}},
+  {"cudaGraphEventRecordNodeGetEvent",                        {"hipGraphEventRecordNodeGetEvent",                        "", CONV_GRAPH, API_RUNTIME, 30, HIP_EXPERIMENTAL}},
   // cuGraphEventRecordNodeSetEvent
-  {"cudaGraphEventRecordNodeSetEvent",                        {"hipGraphEventRecordNodeSetEvent",                        "", CONV_GRAPH, API_RUNTIME, 30, HIP_UNSUPPORTED}},
+  {"cudaGraphEventRecordNodeSetEvent",                        {"hipGraphEventRecordNodeSetEvent",                        "", CONV_GRAPH, API_RUNTIME, 30, HIP_EXPERIMENTAL}},
   // cuGraphAddEventWaitNode
-  {"cudaGraphAddEventWaitNode",                               {"hipGraphAddEventWaitNode",                               "", CONV_GRAPH, API_RUNTIME, 30, HIP_UNSUPPORTED}},
+  {"cudaGraphAddEventWaitNode",                               {"hipGraphAddEventWaitNode",                               "", CONV_GRAPH, API_RUNTIME, 30, HIP_EXPERIMENTAL}},
   // cuGraphEventWaitNodeGetEvent
-  {"cudaGraphEventWaitNodeGetEvent",                          {"hipGraphEventWaitNodeGetEvent",                          "", CONV_GRAPH, API_RUNTIME, 30, HIP_UNSUPPORTED}},
+  {"cudaGraphEventWaitNodeGetEvent",                          {"hipGraphEventWaitNodeGetEvent",                          "", CONV_GRAPH, API_RUNTIME, 30, HIP_EXPERIMENTAL}},
   // cuGraphEventWaitNodeSetEvent
-  {"cudaGraphEventWaitNodeSetEvent",                          {"hipGraphEventWaitNodeSetEvent",                          "", CONV_GRAPH, API_RUNTIME, 30, HIP_UNSUPPORTED}},
+  {"cudaGraphEventWaitNodeSetEvent",                          {"hipGraphEventWaitNodeSetEvent",                          "", CONV_GRAPH, API_RUNTIME, 30, HIP_EXPERIMENTAL}},
   // no analogue
-  {"cudaGraphExecMemcpyNodeSetParamsToSymbol",                {"hipGraphExecMemcpyNodeSetParamsToSymbol",                "", CONV_GRAPH, API_RUNTIME, 30, HIP_UNSUPPORTED}},
+  {"cudaGraphExecMemcpyNodeSetParamsToSymbol",                {"hipGraphExecMemcpyNodeSetParamsToSymbol",                "", CONV_GRAPH, API_RUNTIME, 30, HIP_EXPERIMENTAL}},
   // no analogue
-  {"cudaGraphExecMemcpyNodeSetParamsFromSymbol",              {"hipGraphExecMemcpyNodeSetParamsFromSymbol",              "", CONV_GRAPH, API_RUNTIME, 30, HIP_UNSUPPORTED}},
+  {"cudaGraphExecMemcpyNodeSetParamsFromSymbol",              {"hipGraphExecMemcpyNodeSetParamsFromSymbol",              "", CONV_GRAPH, API_RUNTIME, 30, HIP_EXPERIMENTAL}},
   // no analogue
-  {"cudaGraphExecMemcpyNodeSetParams1D",                      {"hipGraphExecMemcpyNodeSetParams1D",                      "", CONV_GRAPH, API_RUNTIME, 30, HIP_UNSUPPORTED}},
+  {"cudaGraphExecMemcpyNodeSetParams1D",                      {"hipGraphExecMemcpyNodeSetParams1D",                      "", CONV_GRAPH, API_RUNTIME, 30, HIP_EXPERIMENTAL}},
   // cuGraphExecChildGraphNodeSetParams
-  {"cudaGraphExecChildGraphNodeSetParams",                    {"hipGraphExecChildGraphNodeSetParams",                    "", CONV_GRAPH, API_RUNTIME, 30, HIP_UNSUPPORTED}},
+  {"cudaGraphExecChildGraphNodeSetParams",                    {"hipGraphExecChildGraphNodeSetParams",                    "", CONV_GRAPH, API_RUNTIME, 30, HIP_EXPERIMENTAL}},
   // cuGraphExecEventRecordNodeSetEvent
-  {"cudaGraphExecEventRecordNodeSetEvent",                    {"hipGraphExecEventRecordNodeSetEvent",                    "", CONV_GRAPH, API_RUNTIME, 30, HIP_UNSUPPORTED}},
+  {"cudaGraphExecEventRecordNodeSetEvent",                    {"hipGraphExecEventRecordNodeSetEvent",                    "", CONV_GRAPH, API_RUNTIME, 30, HIP_EXPERIMENTAL}},
   // cuGraphExecEventWaitNodeSetEvent
-  {"cudaGraphExecEventWaitNodeSetEvent",                      {"hipGraphExecEventWaitNodeSetEvent",                      "", CONV_GRAPH, API_RUNTIME, 30, HIP_UNSUPPORTED}},
+  {"cudaGraphExecEventWaitNodeSetEvent",                      {"hipGraphExecEventWaitNodeSetEvent",                      "", CONV_GRAPH, API_RUNTIME, 30, HIP_EXPERIMENTAL}},
   // cuGraphUpload
   {"cudaGraphUpload",                                         {"hipGraphUpload",                                         "", CONV_GRAPH, API_RUNTIME, 30, HIP_UNSUPPORTED}},
   // cuGraphAddExternalSemaphoresSignalNode
@@ -818,7 +830,7 @@ const std::map<llvm::StringRef, hipCounter> CUDA_RUNTIME_FUNCTION_MAP {
   // cuDeviceSetGraphMemAttribute
   {"cudaDeviceSetGraphMemAttribute",                          {"hipDeviceSetGraphMemAttribute",                          "", CONV_GRAPH, API_RUNTIME, 30, HIP_UNSUPPORTED}},
   // cuGraphInstantiateWithFlags
-  {"cudaGraphInstantiateWithFlags",                           {"hipGraphInstantiateWithFlags",                           "", CONV_GRAPH, API_RUNTIME, 30, HIP_UNSUPPORTED}},
+  {"cudaGraphInstantiateWithFlags",                           {"hipGraphInstantiateWithFlags",                           "", CONV_GRAPH, API_RUNTIME, 30, HIP_EXPERIMENTAL}},
 
   // 31. Driver Entry Point Access
   // cuGetProcAddress
@@ -1240,6 +1252,37 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_RUNTIME_FUNCTION_VER_MAP {
   {"hipGraphRemoveDependencies",                              {HIP_5000, HIP_0,    HIP_0,  HIP_LATEST}},
   {"hipGraphGetEdges",                                        {HIP_5000, HIP_0,    HIP_0,  HIP_LATEST}},
   {"hipGraphNodeGetDependencies",                             {HIP_5000, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipGraphNodeGetDependentNodes",                           {HIP_5000, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipGraphNodeGetType",                                     {HIP_5000, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipGraphDestroyNode",                                     {HIP_5000, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipGraphNodeFindInClone",                                 {HIP_5000, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipGraphInstantiateWithFlags",                            {HIP_5000, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipGraphExecUpdate",                                      {HIP_5000, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipGraphExecMemcpyNodeSetParams",                         {HIP_5000, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipGraphMemcpyNodeSetParams1D",                           {HIP_5000, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipGraphExecMemcpyNodeSetParams1D",                       {HIP_5000, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipGraphAddMemcpyNodeFromSymbol",                         {HIP_5000, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipGraphMemcpyNodeSetParamsFromSymbol",                   {HIP_5000, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipGraphExecMemcpyNodeSetParamsFromSymbol",               {HIP_5000, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipGraphAddMemcpyNodeToSymbol",                           {HIP_5000, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipGraphMemcpyNodeSetParamsToSymbol",                     {HIP_5000, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipGraphExecMemcpyNodeSetParamsToSymbol",                 {HIP_5000, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipGraphExecMemsetNodeSetParams",                         {HIP_5000, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipGraphAddHostNode",                                     {HIP_5000, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipGraphHostNodeGetParams",                               {HIP_5000, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipGraphHostNodeSetParams",                               {HIP_5000, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipGraphExecHostNodeSetParams",                           {HIP_5000, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipGraphAddChildGraphNode",                               {HIP_5000, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipGraphChildGraphNodeGetGraph",                          {HIP_5000, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipGraphExecChildGraphNodeSetParams",                     {HIP_5000, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipGraphAddEventRecordNode",                              {HIP_5000, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipGraphEventRecordNodeGetEvent",                         {HIP_5000, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipGraphEventRecordNodeSetEvent",                         {HIP_5000, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipGraphExecEventRecordNodeSetEvent",                     {HIP_5000, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipGraphAddEventWaitNode",                                {HIP_5000, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipGraphEventWaitNodeGetEvent",                           {HIP_5000, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipGraphEventWaitNodeSetEvent",                           {HIP_5000, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipGraphExecEventWaitNodeSetEvent",                       {HIP_5000, HIP_0,    HIP_0,  HIP_LATEST}},
 };
 
 const std::map<unsigned int, llvm::StringRef> CUDA_RUNTIME_API_SECTION_MAP {


### PR DESCRIPTION
+ Add new supported APIs, mark them as experimental
+ Update docs, tests, and hipify-perl accordingly

[NOTE] Some Graph functions in CUDA Driver API do not have analogues in CUDA Runtime API due to CUcontext as the last argument:
  cuGraphAddMemcpyNode, cuGraphAddMemsetNode, cuGraphExecMemcpyNodeSetParams, cuGraphExecMemsetNodeSetParams