### PR TITLE
[HIPIFY] Implement arg removal from a function call

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -2667,6 +2667,7 @@ sub simpleSubstitutions {
     $ft{'type'} += s/\bCUmipmappedArray_st\b/hipMipmappedArray/g;
     $ft{'type'} += s/\bCUmod_st\b/ihipModule_t/g;
     $ft{'type'} += s/\bCUmodule\b/hipModule_t/g;
+    $ft{'type'} += s/\bCUoccupancyB2DSize\b/void*/g;
     $ft{'type'} += s/\bCUresourceViewFormat\b/HIPresourceViewFormat/g;
     $ft{'type'} += s/\bCUresourceViewFormat_enum\b/HIPresourceViewFormat_enum/g;
     $ft{'type'} += s/\bCUresourcetype\b/HIPresourcetype/g;
@@ -6083,7 +6084,6 @@ sub warnUnsupportedFunctions {
         "CUshared_carveout",
         "CUoccupancy_flags_enum",
         "CUoccupancy_flags",
-        "CUoccupancyB2DSize",
         "CUmemoryPool",
         "CUmemPool_attribute_enum",
         "CUmemPool_attribute",

--- a/doc/markdown/CUDA_Driver_API_functions_supported_by_HIP.md
+++ b/doc/markdown/CUDA_Driver_API_functions_supported_by_HIP.md
@@ -1017,7 +1017,7 @@
 |`CUmipmappedArray_st`| | | |`hipMipmappedArray`|1.7.0| | | |
 |`CUmod_st`| | | |`ihipModule_t`|1.6.0| | | |
 |`CUmodule`| | | |`hipModule_t`|1.6.0| | | |
-|`CUoccupancyB2DSize`| | | | | | | | |
+|`CUoccupancyB2DSize`| | | |`void*`| | | | |
 |`CUoccupancy_flags`| | | | | | | | |
 |`CUoccupancy_flags_enum`| | | | | | | | |
 |`CUpointer_attribute`| | | |`hipPointer_attribute`|5.0.0| | |5.0.0|

--- a/src/CUDA2HIP_Driver_API_types.cpp
+++ b/src/CUDA2HIP_Driver_API_types.cpp
@@ -2053,7 +2053,7 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_TYPE_NAME_MAP {
   {"CUhostFn",                                                         {"hipHostFn_t",                                              "", CONV_TYPE, API_DRIVER, 1}},
 
   // no analogue
-  {"CUoccupancyB2DSize",                                               {"hipOccupancyB2DSize",                                      "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
+  {"CUoccupancyB2DSize",                                               {"void*",                                                    "", CONV_TYPE, API_DRIVER, 1}},
 
   // cudaStreamCallback_t
   {"CUstreamCallback",                                                 {"hipStreamCallback_t",                                      "", CONV_TYPE, API_DRIVER, 1}},

--- a/src/CUDA2HIP_Scripting.h
+++ b/src/CUDA2HIP_Scripting.h
@@ -27,6 +27,7 @@ enum CastTypes {
   e_reinterpret_cast,
   e_int32_t,
   e_int64_t,
+  e_remove_argument,
 };
 
 enum CastWarning {

--- a/tests/unit_tests/synthetic/driver_functions.cu
+++ b/tests/unit_tests/synthetic/driver_functions.cu
@@ -9,6 +9,7 @@ int main() {
   printf("09. CUDA Driver API Functions synthetic test\n");
 
   unsigned int flags = 0;
+  int iBlockSize = 0;
   size_t bytes = 0;
   size_t bytes_2 = 0;
   void* image = nullptr;
@@ -16,6 +17,7 @@ int main() {
   uint32_t u_value = 0;
   float ms = 0;
   int* value = 0;
+  int* value_2 = 0;
   unsigned long long ull =0;
   // CHECK: hipDevice_t device;
   // CHECK-NEXT: hipCtx_t context;
@@ -43,6 +45,7 @@ int main() {
   // CHECK-NEXT: hipMipmappedArray_t mipmappedArray;
   // CHECK-NEXT: hipStreamCallback_t streamCallback;
   // CHECK-NEXT: hipPointer_attribute pointer_attribute;
+  // CHECK-NEXT: void* occupancyB2DSize;
   CUdevice device;
   CUcontext context;
   CUfunc_cache func_cache;
@@ -69,7 +72,7 @@ int main() {
   CUmipmappedArray mipmappedArray;
   CUstreamCallback streamCallback;
   CUpointer_attribute pointer_attribute;
-
+  CUoccupancyB2DSize occupancyB2DSize;
 #if CUDA_VERSION > 7050
   // CHECK: hipMemRangeAttribute MemoryRangeAttribute;
   // CHECK-NEXT: hipMemoryAdvise MemoryAdvise;
@@ -1062,6 +1065,16 @@ int main() {
   // CHECK: result = hipGraphInstantiateWithFlags(&graphExec, graph, ull);
   result = cuGraphInstantiateWithFlags(&graphExec, graph, ull);
 #endif
+
+  // CUDA: CUresult CUDAAPI cuOccupancyMaxActiveBlocksPerMultiprocessor(int *numBlocks, CUfunction func, int blockSize, size_t dynamicSMemSize);
+  // HIP: hipError_t hipModuleOccupancyMaxActiveBlocksPerMultiprocessor(int* numBlocks, hipFunction_t f, int blockSize, size_t dynSharedMemPerBlk);
+  // CHECK: result = hipModuleOccupancyMaxActiveBlocksPerMultiprocessor(value, function, iBlockSize, bytes);
+  result = cuOccupancyMaxActiveBlocksPerMultiprocessor(value, function, iBlockSize, bytes);
+
+  // CUDA: CUresult CUDAAPI cuOccupancyMaxPotentialBlockSize(int *minGridSize, int *blockSize, CUfunction func, CUoccupancyB2DSize blockSizeToDynamicSMemSize, size_t dynamicSMemSize, int blockSizeLimit);
+  // HIP: hipError_t hipModuleOccupancyMaxPotentialBlockSize(int* gridSize, int* blockSize, hipFunction_t f, size_t dynSharedMemPerBlk, int blockSizeLimit);
+  // CHECK: result = hipModuleOccupancyMaxPotentialBlockSize(value, value_2, function, bytes, iBlockSize);
+  result = cuOccupancyMaxPotentialBlockSize(value, value_2, function, occupancyB2DSize, bytes, iBlockSize);
 
   return 0;
 }


### PR DESCRIPTION
For now, there was only typecasting of function arguments when hipifying CUDA function calls.
`cuOccupancyMaxPotentialBlockSize` is the first precedent when one of the arguments has to be removed from the function call.
Here is its implementation in HIP Runtime for the fallback NVIDIA path:

```c++
//TODO - Match CUoccupancyB2DSize
inline static hipError_t hipModuleOccupancyMaxPotentialBlockSize(int* gridSize, int* blockSize,
                                             hipFunction_t f, size_t dynSharedMemPerBlk,
                                             int blockSizeLimit){
    return hipCUResultTohipError(cuOccupancyMaxPotentialBlockSize(gridSize, blockSize, f, NULL,
                                 dynSharedMemPerBlk, blockSizeLimit));
}
```
`CUoccupancyB2DSize` data type is not implemented currently in HIP RT. Nonetheless, to perform hipification from `cuOccupancyMaxPotentialBlockSize` to `hipModuleOccupancyMaxPotentialBlockSize` the porting of `CUoccupancyB2DSize` to `void*` is implemented in HIPIFY tools.
In the hipified `hipModuleOccupancyMaxPotentialBlockSize()` function call, its 4th argument is removed, the warning about possible data loss is reported.

+ Add the corresponding test in driver_functions.cu; update the corresponding doc and hipify-perl
+ [ToDo] Implement arg removal from a function call in hipify-perl generation