### PR TITLE
[HIPIFY][tests][fix][Linux] Fix failure in driver_functions.cu due to CUDA's `cuuint64_t`

### DIFF
--- a/tests/unit_tests/synthetic/driver_functions.cu
+++ b/tests/unit_tests/synthetic/driver_functions.cu
@@ -19,7 +19,11 @@ int main() {
   float ms = 0;
   int* value = 0;
   int* value_2 = 0;
-  unsigned long long ull =0;
+#if defined(_WIN32)
+  unsigned long long ull = 0;
+#else
+  unsigned long ull = 0;
+#endif
   // CHECK: hipDevice_t device;
   // CHECK-NEXT: hipCtx_t context;
   // CHECK-NEXT: hipFuncCache_t func_cache;


### PR DESCRIPTION
[Failure][Linux]
```shell
/tmp/driver_functions.cu-50e2d3.hip:984:12: error: no matching function for call to 'cuStreamGetCaptureInfo'
  result = cuStreamGetCaptureInfo(stream, &streamCaptureStatus, &ull);
           ^~~~~~~~~~~~~~~~~~~~~~
/usr/local/cuda/include/cuda.h:11677:18: note: candidate function not viable: no known conversion from 'unsigned long long *' to 'cuuint64_t *' (aka 'unsigned long *') for 3rd argument
CUresult CUDAAPI cuStreamGetCaptureInfo(CUstream hStream, CUstreamCaptureStatus *captureStatus_out, cuuint64_t *id_out);
                 ^
/tmp/driver_functions.cu-50e2d3.hip:1055:12: error: no matching function for call to 'cuStreamGetCaptureInfo_v2'
  result = cuStreamGetCaptureInfo_v2(stream, &streamCaptureStatus, &ull, &graph, &pGraphNode, &bytes);
           ^~~~~~~~~~~~~~~~~~~~~~~~~
/usr/local/cuda/include/cuda.h:11731:18: note: candidate function not viable: no known conversion from 'unsigned long long *' to 'cuuint64_t *' (aka 'unsigned long *') for 3rd argument
CUresult CUDAAPI cuStreamGetCaptureInfo_v2(CUstream hStream, CUstreamCaptureStatus *captureStatus_out,
                 ^
/tmp/driver_functions.cu-50e2d3.hip:1078:71: warning: Possible data loss in 4 argument.
  result = cuOccupancyMaxPotentialBlockSize(value, value_2, function, occupancyB2DSize, bytes, iBlockSize);
                                                                      ^
/tmp/driver_functions.cu-50e2d3.hip:1083:80: warning: Possible data loss in 4 argument.
  result = cuOccupancyMaxPotentialBlockSizeWithFlags(value, value_2, function, occupancyB2DSize, bytes, iBlockSize, iBlockSize_2);
                                                                               ^
3 warnings and 2 errors generated when compiling for host.
Error while processing /tmp/driver_functions.cu-50e2d3.hip.
error: command failed with exit status: 1
********************
Failed Tests (1):
  hipify :: unit_tests/synthetic/driver_functions.cu
```

[Solution] Treat `cuuint64_t` as `unsigned long long` on Windows and as `unsigned long` on Linux