### PR TITLE
[HIPIFY][fix] Remove the absolute paths in post install scripts

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,6 +113,8 @@ install(
 
 if(UNIX)
     set(CPACK_PACKAGING_INSTALL_PREFIX "/opt/rocm/hip" CACHE PATH "HIP Package Installation Path")
+    set(HIPBINDIR ${CPACK_PACKAGING_INSTALL_PREFIX}/bin)
+    set(ROCMBINDIR ${CPACK_PACKAGING_INSTALL_PREFIX}/../bin)
     set(BUILD_DIR ${CMAKE_CURRENT_BINARY_DIR}/packages/hipify-clang)
     configure_file(packaging/hipify-clang.txt ${BUILD_DIR}/CMakeLists.txt @ONLY)
     configure_file(packaging/hipify-clang.postinst ${BUILD_DIR}/postinst @ONLY)

--- a/packaging/hipify-clang.postinst
+++ b/packaging/hipify-clang.postinst
@@ -3,8 +3,8 @@
 set -e
 
 # Soft-link to bin files
-HIPBINDIR="/opt/rocm/hip/bin"
-ROCMBINDIR="/opt/rocm/bin"
+HIPBINDIR=@CPACK_PACKAGING_INSTALL_PREFIX@/bin
+ROCMBINDIR=@CPACK_PACKAGING_INSTALL_PREFIX@/../bin
 
 case "$1" in
   abort-deconfigure|abort-remove|abort-upgrade)

--- a/packaging/hipify-clang.postinst
+++ b/packaging/hipify-clang.postinst
@@ -3,25 +3,23 @@
 set -e
 
 # Soft-link to bin files
-HIPBINDIR=@CPACK_PACKAGING_INSTALL_PREFIX@/bin
-ROCMBINDIR=@CPACK_PACKAGING_INSTALL_PREFIX@/../bin
 
 case "$1" in
   abort-deconfigure|abort-remove|abort-upgrade)
     echo "$1"
   ;;
   configure)
-    mkdir -p $ROCMBINDIR
+    mkdir -p @ROCMBINDIR@
     CURRENTDIR=`pwd`
-    cd $ROCMBINDIR
-        ln -r -s -f $HIPBINDIR/hipify-perl $ROCMBINDIR/hipify-perl
-        ln -r -s -f $HIPBINDIR/hipify-clang $ROCMBINDIR/hipify-clang
-        ln -r -s -f $HIPBINDIR/hipconvertinplace-perl.sh $ROCMBINDIR/hipconvertinplace-perl.sh
-        ln -r -s -f $HIPBINDIR/hipconvertinplace.sh $ROCMBINDIR/hipconvertinplace.sh
-        ln -r -s -f $HIPBINDIR/hipexamine-perl.sh $ROCMBINDIR/hipexamine-perl.sh
-        ln -r -s -f $HIPBINDIR/hipexamine.sh $ROCMBINDIR/hipexamine.sh
-        ln -r -s -f $HIPBINDIR/findcode.sh $ROCMBINDIR/findcode.sh
-        ln -r -s -f $HIPBINDIR/finduncodep.sh $ROCMBINDIR/finduncodep.sh
+    cd @ROCMBINDIR@
+        ln -r -s -f @HIPBINDIR@/hipify-perl @ROCMBINDIR@/hipify-perl
+        ln -r -s -f @HIPBINDIR@/hipify-clang @ROCMBINDIR@/hipify-clang
+        ln -r -s -f @HIPBINDIR@/hipconvertinplace-perl.sh @ROCMBINDIR@/hipconvertinplace-perl.sh
+        ln -r -s -f @HIPBINDIR@/hipconvertinplace.sh @ROCMBINDIR@/hipconvertinplace.sh
+        ln -r -s -f @HIPBINDIR@/hipexamine-perl.sh @ROCMBINDIR@/hipexamine-perl.sh
+        ln -r -s -f @HIPBINDIR@/hipexamine.sh @ROCMBINDIR@/hipexamine.sh
+        ln -r -s -f @HIPBINDIR@/findcode.sh @ROCMBINDIR@/findcode.sh
+        ln -r -s -f @HIPBINDIR@/finduncodep.sh @ROCMBINDIR@/finduncodep.sh
     cd $CURRENTDIR
   ;;
   *)

--- a/packaging/hipify-clang.prerm
+++ b/packaging/hipify-clang.prerm
@@ -10,15 +10,15 @@ case "$1" in
   purge)
   ;;
   remove)
-    rm -f $ROCMBINDIR/hipify-perl
-    rm -f $ROCMBINDIR/hipify-clang
-    rm -f $ROCMBINDIR/hipconvertinplace-perl.sh
-    rm -f $ROCMBINDIR/hipconvertinplace.sh
-    rm -f $ROCMBINDIR/hipexamine-perl.sh
-    rm -f $ROCMBINDIR/hipexamine.sh
-    rm -f $ROCMBINDIR/findcode.sh
-    rm -f $ROCMBINDIR/finduncodep.sh
-    rmdir --ignore-fail-on-non-empty $ROCMBINDIR
+    rm -f @ROCMBINDIR@/hipify-perl
+    rm -f @ROCMBINDIR@/hipify-clang
+    rm -f @ROCMBINDIR@/hipconvertinplace-perl.sh
+    rm -f @ROCMBINDIR@/hipconvertinplace.sh
+    rm -f @ROCMBINDIR@/hipexamine-perl.sh
+    rm -f @ROCMBINDIR@/hipexamine.sh
+    rm -f @ROCMBINDIR@/findcode.sh
+    rm -f @ROCMBINDIR@/finduncodep.sh
+    rmdir --ignore-fail-on-non-empty @ROCMBINDIR@
   ;;
   *)
     exit 0

--- a/packaging/hipify-clang.prerm
+++ b/packaging/hipify-clang.prerm
@@ -2,10 +2,10 @@
 
 set -e
 
-# Soft-link to bin files
-HIPBINDIR="/opt/rocm/hip/bin"
-ROCMBINDIR="/opt/rocm/bin"
+HIPBINDIR=@CPACK_PACKAGING_INSTALL_PREFIX@/bin
+ROCMBINDIR=@CPACK_PACKAGING_INSTALL_PREFIX@/../bin
 
+# Remove soft-link to bin files
 case "$1" in
   purge)
   ;;

--- a/packaging/hipify-clang.rpm_post
+++ b/packaging/hipify-clang.rpm_post
@@ -1,17 +1,14 @@
 # Soft-link to bin files
 
-HIPBINDIR=@CPACK_PACKAGING_INSTALL_PREFIX@/bin
-ROCMBINDIR=@CPACK_PACKAGING_INSTALL_PREFIX@/../bin
-
-mkdir -p $ROCMBINDIR
+mkdir -p @ROCMBINDIR@
 CURRENTDIR=`pwd`
-cd $ROCMBINDIR
-ln -r -s -f $HIPBINDIR/hipify-perl $ROCMBINDIR/hipify-perl
-ln -r -s -f $HIPBINDIR/hipify-clang $ROCMBINDIR/hipify-clang
-ln -r -s -f $HIPBINDIR/hipconvertinplace-perl.sh $ROCMBINDIR/hipconvertinplace-perl.sh
-ln -r -s -f $HIPBINDIR/hipconvertinplace.sh $ROCMBINDIR/hipconvertinplace.sh
-ln -r -s -f $HIPBINDIR/hipexamine-perl.sh $ROCMBINDIR/hipexamine-perl.sh
-ln -r -s -f $HIPBINDIR/hipexamine.sh $ROCMBINDIR/hipexamine.sh
-ln -r -s -f $HIPBINDIR/findcode.sh $ROCMBINDIR/findcode.sh
-ln -r -s -f $HIPBINDIR/finduncodep.sh $ROCMBINDIR/finduncodep.sh
+cd @ROCMBINDIR@
+ln -r -s -f @HIPBINDIR@/hipify-perl @ROCMBINDIR@/hipify-perl
+ln -r -s -f @HIPBINDIR@/hipify-clang @ROCMBINDIR@/hipify-clang
+ln -r -s -f @HIPBINDIR@/hipconvertinplace-perl.sh @ROCMBINDIR@/hipconvertinplace-perl.sh
+ln -r -s -f @HIPBINDIR@/hipconvertinplace.sh @ROCMBINDIR@/hipconvertinplace.sh
+ln -r -s -f @HIPBINDIR@/hipexamine-perl.sh @ROCMBINDIR@/hipexamine-perl.sh
+ln -r -s -f @HIPBINDIR@/hipexamine.sh @ROCMBINDIR@/hipexamine.sh
+ln -r -s -f @HIPBINDIR@/findcode.sh @ROCMBINDIR@/findcode.sh
+ln -r -s -f @HIPBINDIR@/finduncodep.sh @ROCMBINDIR@/finduncodep.sh
 cd $CURRENTDIR

--- a/packaging/hipify-clang.rpm_post
+++ b/packaging/hipify-clang.rpm_post
@@ -1,7 +1,7 @@
 # Soft-link to bin files
 
-HIPBINDIR="/opt/rocm/hip/bin"
-ROCMBINDIR="/opt/rocm/bin"
+HIPBINDIR=@CPACK_PACKAGING_INSTALL_PREFIX@/bin
+ROCMBINDIR=@CPACK_PACKAGING_INSTALL_PREFIX@/../bin
 
 mkdir -p $ROCMBINDIR
 CURRENTDIR=`pwd`

--- a/packaging/hipify-clang.rpm_postun
+++ b/packaging/hipify-clang.rpm_postun
@@ -2,13 +2,13 @@ HIPBINDIR=@CPACK_PACKAGING_INSTALL_PREFIX@/bin
 ROCMBINDIR=@CPACK_PACKAGING_INSTALL_PREFIX@/../bin
 
 if [ $1 -eq 0 ]; then
-  rm -f $ROCMBINDIR/hipify-perl
-  rm -f $ROCMBINDIR/hipify-clang
-  rm -f $ROCMBINDIR/hipconvertinplace-perl.sh
-  rm -f $ROCMBINDIR/hipconvertinplace.sh
-  rm -f $ROCMBINDIR/hipexamine-perl.sh
-  rm -f $ROCMBINDIR/hipexamine.sh
-  rm -f $ROCMBINDIR/findcode.sh
-  rm -f $ROCMBINDIR/finduncodep.sh
-  rmdir --ignore-fail-on-non-empty $ROCMBINDIR
+  rm -f @ROCMBINDIR@/hipify-perl
+  rm -f @ROCMBINDIR@/hipify-clang
+  rm -f @ROCMBINDIR@/hipconvertinplace-perl.sh
+  rm -f @ROCMBINDIR@/hipconvertinplace.sh
+  rm -f @ROCMBINDIR@/hipexamine-perl.sh
+  rm -f @ROCMBINDIR@/hipexamine.sh
+  rm -f @ROCMBINDIR@/findcode.sh
+  rm -f @ROCMBINDIR@/finduncodep.sh
+  rmdir --ignore-fail-on-non-empty @ROCMBINDIR@
 fi

--- a/packaging/hipify-clang.rpm_postun
+++ b/packaging/hipify-clang.rpm_postun
@@ -1,5 +1,5 @@
-HIPBINDIR="/opt/rocm/hip/bin"
-ROCMBINDIR="/opt/rocm/bin"
+HIPBINDIR=@CPACK_PACKAGING_INSTALL_PREFIX@/bin
+ROCMBINDIR=@CPACK_PACKAGING_INSTALL_PREFIX@/../bin
 
 if [ $1 -eq 0 ]; then
   rm -f $ROCMBINDIR/hipify-perl


### PR DESCRIPTION
Make use of the CPACK_PACKAGING_INSTALL_PREFIX instead of the absolute paths introduced by the post  install scripts in -
https://github.com/ROCm-Developer-Tools/HIPIFY/commit/cf84714be4f4c6eef0c1bc6c7939630917d52084