### PR TITLE
[HIPIFY][#502][fix] Change `cuMemAllocHost` mapping to `hipMemAllocHost`

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -1094,8 +1094,8 @@ sub simpleSubstitutions {
     $ft{'memory'} += s/\bcuIpcOpenEventHandle\b/hipIpcOpenEventHandle/g;
     $ft{'memory'} += s/\bcuIpcOpenMemHandle\b/hipIpcOpenMemHandle/g;
     $ft{'memory'} += s/\bcuMemAlloc\b/hipMalloc/g;
-    $ft{'memory'} += s/\bcuMemAllocHost\b/hipHostAlloc/g;
-    $ft{'memory'} += s/\bcuMemAllocHost_v2\b/hipHostAlloc/g;
+    $ft{'memory'} += s/\bcuMemAllocHost\b/hipMemAllocHost/g;
+    $ft{'memory'} += s/\bcuMemAllocHost_v2\b/hipMemAllocHost/g;
     $ft{'memory'} += s/\bcuMemAllocManaged\b/hipMallocManaged/g;
     $ft{'memory'} += s/\bcuMemAllocPitch\b/hipMemAllocPitch/g;
     $ft{'memory'} += s/\bcuMemAllocPitch_v2\b/hipMemAllocPitch/g;

--- a/doc/markdown/CUDA_Driver_API_functions_supported_by_HIP.md
+++ b/doc/markdown/CUDA_Driver_API_functions_supported_by_HIP.md
@@ -1226,8 +1226,8 @@
 |`cuIpcOpenEventHandle`| | | |`hipIpcOpenEventHandle`|1.6.0| | | |
 |`cuIpcOpenMemHandle`| | | |`hipIpcOpenMemHandle`|1.6.0| | | |
 |`cuMemAlloc`| | | |`hipMalloc`|1.5.0| | | |
-|`cuMemAllocHost`| | | |`hipHostAlloc`| | | | |
-|`cuMemAllocHost_v2`| | | |`hipHostAlloc`| | | | |
+|`cuMemAllocHost`| | | |`hipMemAllocHost`|3.0.0|3.0.0| | |
+|`cuMemAllocHost_v2`| | | |`hipMemAllocHost`|3.0.0|3.0.0| | |
 |`cuMemAllocManaged`| | | |`hipMallocManaged`|2.5.0| | | |
 |`cuMemAllocPitch`| | | |`hipMemAllocPitch`|3.0.0| | | |
 |`cuMemAllocPitch_v2`| | | |`hipMemAllocPitch`|3.0.0| | | |

--- a/src/CUDA2HIP_Driver_API_functions.cpp
+++ b/src/CUDA2HIP_Driver_API_functions.cpp
@@ -188,8 +188,8 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_FUNCTION_MAP {
   {"cuMemAlloc",                                           {"hipMalloc",                                               "", CONV_MEMORY, API_DRIVER, 11}},
   {"cuMemAlloc_v2",                                        {"hipMalloc",                                               "", CONV_MEMORY, API_DRIVER, 11}},
   //
-  {"cuMemAllocHost",                                       {"hipHostAlloc",                                            "", CONV_MEMORY, API_DRIVER, 11}},
-  {"cuMemAllocHost_v2",                                    {"hipHostAlloc",                                            "", CONV_MEMORY, API_DRIVER, 11}},
+  {"cuMemAllocHost",                                       {"hipMemAllocHost",                                         "", CONV_MEMORY, API_DRIVER, 11}},
+  {"cuMemAllocHost_v2",                                    {"hipMemAllocHost",                                         "", CONV_MEMORY, API_DRIVER, 11}},
   // cudaMallocManaged
   {"cuMemAllocManaged",                                    {"hipMallocManaged",                                        "", CONV_MEMORY, API_DRIVER, 11}},
   // no analogue
@@ -1286,6 +1286,7 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_DRIVER_FUNCTION_VER_MAP {
   {"hipArray3DCreate",                                     {HIP_1071, HIP_0,    HIP_0   }},
   {"hipArrayCreate",                                       {HIP_1090, HIP_0,    HIP_0   }},
   {"hipMemAllocPitch",                                     {HIP_3000, HIP_0,    HIP_0   }},
+  {"hipMemAllocHost",                                      {HIP_3000, HIP_3000, HIP_0   }},
   {"hipMemcpyParam2D",                                     {HIP_1070, HIP_0,    HIP_0   }},
   {"hipMemcpyParam2DAsync",                                {HIP_2080, HIP_0,    HIP_0   }},
   {"hipDrvMemcpy3D",                                       {HIP_3050, HIP_0,    HIP_0   }},

--- a/tests/unit_tests/synthetic/driver_functions.cu
+++ b/tests/unit_tests/synthetic/driver_functions.cu
@@ -406,15 +406,10 @@ int main() {
   result = cuMemAlloc(&deviceptr, bytes);
   result = cuMemAlloc_v2(&deviceptr, bytes);
 
-  ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-  ///////////// TODO: Get rid of additional attribute 'unsigned int flags' used by HIP without a default value ///////
-  ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-
   // CUDA: CUresult CUDAAPI cuMemAllocHost(void **pp, size_t bytesize);
-  // HIP: DEPRECATED("use hipHostMalloc instead") hipError_t hipHostAlloc(void** ptr, size_t size, unsigned int flags);
-  // TODO: should be hipHostAlloc(&image, bytes, 0);
-  // CHECK: result = hipHostAlloc(&image, bytes);
-  // CHECK-NEXT: result = hipHostAlloc(&image, bytes);
+  // HIP: DEPRECATED("use hipHostMalloc instead") hipError_t hipMemAllocHost(void** ptr, size_t size);
+  // CHECK: result = hipMemAllocHost(&image, bytes);
+  // CHECK-NEXT: result = hipMemAllocHost(&image, bytes);
   result = cuMemAllocHost(&image, bytes);
   result = cuMemAllocHost_v2(&image, bytes);
 


### PR DESCRIPTION
+ `hipHostAlloc` to which `cuMemAllocHost` was erroneously mapped before has even different signature
+ Perform the mapping change although `hipMemAllocHost` has been deprecated since its first appearance in ROCm HIP 3.0.0
+ Update tests, docs, and hipify-perl accordingly