### PR TITLE
[HIPIFY][#499][fix] Change `cudaMallocHost` mapping to `hipHostMalloc`

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -1168,7 +1168,7 @@ sub simpleSubstitutions {
     $ft{'memory'} += s/\bcudaMalloc3D\b/hipMalloc3D/g;
     $ft{'memory'} += s/\bcudaMalloc3DArray\b/hipMalloc3DArray/g;
     $ft{'memory'} += s/\bcudaMallocArray\b/hipMallocArray/g;
-    $ft{'memory'} += s/\bcudaMallocHost\b/hipMallocHost/g;
+    $ft{'memory'} += s/\bcudaMallocHost\b/hipHostMalloc/g;
     $ft{'memory'} += s/\bcudaMallocManaged\b/hipMallocManaged/g;
     $ft{'memory'} += s/\bcudaMallocMipmappedArray\b/hipMallocMipmappedArray/g;
     $ft{'memory'} += s/\bcudaMallocPitch\b/hipMallocPitch/g;

--- a/doc/markdown/CUDA_Runtime_API_functions_supported_by_HIP.md
+++ b/doc/markdown/CUDA_Runtime_API_functions_supported_by_HIP.md
@@ -161,7 +161,7 @@
 |`cudaMalloc3D`| | | |`hipMalloc3D`|1.9.0| | | |
 |`cudaMalloc3DArray`| | | |`hipMalloc3DArray`|1.7.0| | | |
 |`cudaMallocArray`| | | |`hipMallocArray`|1.6.0| | | |
-|`cudaMallocHost`| | | |`hipMallocHost`| | | | |
+|`cudaMallocHost`| | | |`hipHostMalloc`|1.6.0| | | |
 |`cudaMallocManaged`| | | |`hipMallocManaged`|2.5.0| | | |
 |`cudaMallocMipmappedArray`| | | |`hipMallocMipmappedArray`|3.5.0| | | |
 |`cudaMallocPitch`| | | |`hipMallocPitch`|1.6.0| | | |

--- a/src/CUDA2HIP_Runtime_API_functions.cpp
+++ b/src/CUDA2HIP_Runtime_API_functions.cpp
@@ -284,7 +284,7 @@ const std::map<llvm::StringRef, hipCounter> CUDA_RUNTIME_FUNCTION_MAP {
   // no analogue
   {"cudaMallocArray",                                         {"hipMallocArray",                                         "", CONV_MEMORY, API_RUNTIME, 9}},
   // cuMemHostAlloc
-  {"cudaMallocHost",                                          {"hipMallocHost",                                          "", CONV_MEMORY, API_RUNTIME, 9}},
+  {"cudaMallocHost",                                          {"hipHostMalloc",                                          "", CONV_MEMORY, API_RUNTIME, 9}},
   // cuMemAllocManaged
   {"cudaMallocManaged",                                       {"hipMallocManaged",                                       "", CONV_MEMORY, API_RUNTIME, 9}},
   // no analogue

--- a/tests/unit_tests/device/device_symbols.cu
+++ b/tests/unit_tests/device/device_symbols.cu
@@ -57,9 +57,9 @@ int main() {
     }
     // CHECK: hipMalloc((void**)&Ad, SIZE);
     cudaMalloc((void**)&Ad, SIZE);
-    // CHECK: hipMallocHost((void**)&Am, SIZE);
+    // CHECK: hipHostMalloc((void**)&Am, SIZE);
     cudaMallocHost((void**)&Am, SIZE);
-    // CHECK: hipMallocHost((void**)&Cm, SIZE);
+    // CHECK: hipHostMalloc((void**)&Cm, SIZE);
     cudaMallocHost((void**)&Cm, SIZE);
     for (int i = 0; i < NUM; ++i) {
         Am[i] = -1 * i;


### PR DESCRIPTION
+ `hipMallocHost` to which `cudaMallocHost` was erroneously mapped before has even different signature
+ Update tests, docs, and hipify-perl accordingly
