### PR TITLE
[HIPIFY][#507][fix] Link with `LLVMWindowsDriver` lib if LLVM version >= 15.0.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,7 +55,6 @@ target_link_libraries(hipify-clang PRIVATE
     LLVMMCParser
     LLVMMC
     LLVMBitReader
-    LLVMWindowsDriver
     LLVMOption
     LLVMCore)
 
@@ -65,6 +64,10 @@ endif()
 
 if(LLVM_PACKAGE_VERSION VERSION_GREATER "9.0.1")
     target_link_libraries(hipify-clang PRIVATE LLVMFrontendOpenMP)
+endif()
+
+if(LLVM_PACKAGE_VERSION VERSION_EQUAL "15.0.0" OR LLVM_PACKAGE_VERSION VERSION_GREATER "15.0.0")
+    target_link_libraries(hipify-clang PRIVATE LLVMWindowsDriver)
 endif()
 
 if(MSVC)


### PR DESCRIPTION
[The affecting LLVM change]
____
SHA-1: c5fb05f663f2ac0cbedb318d03b91d44900ab9de

* Reland: Make lld-link work in a non-MSVC shell, add /winsysroot:

This relands 73e585e44d (and 0574b5fc657451), with a fix for
the failing test (by using Optional<StringRef>s instead of
making StringRef::empty() mean absence of value).

Differential Revision: https://reviews.llvm.org/D118070
____
+ This change shouldn't be presented in 14.x.x LLVM releases
+ To link hipify-clang correctly with LLVM >= 15 pull the latest LLVM sources