### PR TITLE
[HIPIFY][package] Delete hip folder after uninstallation if empty

### DIFF
--- a/packaging/hipify-clang.rpm_postun
+++ b/packaging/hipify-clang.rpm_postun
@@ -1,5 +1,3 @@
-HIPDIR=@CPACK_PACKAGING_INSTALL_PREFIX@
-
 if [ $1 -eq 0 ]; then
   rm -f @ROCMBINDIR@/hipify-perl
   rm -f @ROCMBINDIR@/hipify-clang
@@ -11,5 +9,5 @@ if [ $1 -eq 0 ]; then
   rm -f @ROCMBINDIR@/finduncodep.sh
   rmdir --ignore-fail-on-non-empty @ROCMBINDIR@
   rmdir --ignore-fail-on-non-empty @HIPBINDIR@
-  rmdir --ignore-fail-on-non-empty ${HIPDIR}
+  rmdir --ignore-fail-on-non-empty @CPACK_PACKAGING_INSTALL_PREFIX@
 fi


### PR DESCRIPTION
Delete hip folder after uninstall; ignore if not empty.
Temporary workaround so that hip folder isn't left in /opt/rocm-x.y.z path after driver uninstall