### PR TITLE
[HIPIFY] Sync with the upcoming HIP-rocm-5.1.0

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -703,102 +703,11 @@ my %removed_funcs = (
 );
 
 my %experimental_funcs = (
-    "cudaStreamUpdateCaptureDependenciesFlags" => "5.0.0",
-    "cudaStreamSetCaptureDependencies" => "5.0.0",
-    "cudaStreamIsCapturing" => "5.0.0",
-    "cudaStreamGetCaptureInfo" => "5.0.0",
-    "cudaStreamAddCaptureDependencies" => "5.0.0",
-    "cudaGraphRemoveDependencies" => "5.0.0",
-    "cudaGraphNodeGetType" => "5.0.0",
-    "cudaGraphNodeGetDependentNodes" => "5.0.0",
-    "cudaGraphNodeGetDependencies" => "5.0.0",
-    "cudaGraphNodeFindInClone" => "5.0.0",
-    "cudaGraphMemcpyNodeSetParamsToSymbol" => "5.0.0",
-    "cudaGraphMemcpyNodeSetParamsFromSymbol" => "5.0.0",
-    "cudaGraphMemcpyNodeSetParams1D" => "5.0.0",
-    "cudaGraphInstantiateWithFlags" => "5.0.0",
-    "cudaGraphHostNodeSetParams" => "5.0.0",
-    "cudaGraphHostNodeGetParams" => "5.0.0",
-    "cudaGraphGetEdges" => "5.0.0",
-    "cudaGraphExecUpdate" => "5.0.0",
-    "cudaGraphExecMemsetNodeSetParams" => "5.0.0",
-    "cudaGraphExecMemcpyNodeSetParamsToSymbol" => "5.0.0",
-    "cudaGraphExecMemcpyNodeSetParamsFromSymbol" => "5.0.0",
-    "cudaGraphExecMemcpyNodeSetParams1D" => "5.0.0",
-    "cudaGraphExecMemcpyNodeSetParams" => "5.0.0",
-    "cudaGraphExecHostNodeSetParams" => "5.0.0",
-    "cudaGraphExecEventWaitNodeSetEvent" => "5.0.0",
-    "cudaGraphExecEventRecordNodeSetEvent" => "5.0.0",
-    "cudaGraphExecChildGraphNodeSetParams" => "5.0.0",
-    "cudaGraphEventWaitNodeSetEvent" => "5.0.0",
-    "cudaGraphEventWaitNodeGetEvent" => "5.0.0",
-    "cudaGraphEventRecordNodeSetEvent" => "5.0.0",
-    "cudaGraphEventRecordNodeGetEvent" => "5.0.0",
-    "cudaGraphDestroyNode" => "5.0.0",
-    "cudaGraphChildGraphNodeGetGraph" => "5.0.0",
-    "cudaGraphAddMemcpyNodeToSymbol" => "5.0.0",
-    "cudaGraphAddMemcpyNodeFromSymbol" => "5.0.0",
-    "cudaGraphAddHostNode" => "5.0.0",
-    "cudaGraphAddEventWaitNode" => "5.0.0",
-    "cudaGraphAddEventRecordNode" => "5.0.0",
-    "cudaGraphAddChildGraphNode" => "5.0.0",
-    "cudaErrorIllegalState" => "5.0.0",
-    "cudaErrorGraphExecUpdateFailure" => "5.0.0",
-    "cuStreamUpdateCaptureDependencies" => "5.0.0",
-    "cuStreamIsCapturing" => "5.0.0",
-    "cuStreamGetCaptureInfo_v2" => "5.0.0",
-    "cuStreamGetCaptureInfo" => "5.0.0",
-    "cuPointerGetAttributes" => "5.0.0",
-    "cuPointerGetAttribute" => "5.0.0",
-    "cuGraphRemoveDependencies" => "5.0.0",
-    "cuGraphNodeGetType" => "5.0.0",
-    "cuGraphNodeGetDependentNodes" => "5.0.0",
-    "cuGraphNodeGetDependencies" => "5.0.0",
-    "cuGraphNodeFindInClone" => "5.0.0",
-    "cuGraphInstantiateWithFlags" => "5.0.0",
-    "cuGraphHostNodeSetParams" => "5.0.0",
-    "cuGraphHostNodeGetParams" => "5.0.0",
-    "cuGraphGetEdges" => "5.0.0",
-    "cuGraphExecUpdate" => "5.0.0",
-    "cuGraphExecHostNodeSetParams" => "5.0.0",
-    "cuGraphExecEventWaitNodeSetEvent" => "5.0.0",
-    "cuGraphExecEventRecordNodeSetEvent" => "5.0.0",
-    "cuGraphExecChildGraphNodeSetParams" => "5.0.0",
-    "cuGraphEventWaitNodeSetEvent" => "5.0.0",
-    "cuGraphEventWaitNodeGetEvent" => "5.0.0",
-    "cuGraphEventRecordNodeSetEvent" => "5.0.0",
-    "cuGraphEventRecordNodeGetEvent" => "5.0.0",
-    "cuGraphDestroyNode" => "5.0.0",
-    "cuGraphChildGraphNodeGetGraph" => "5.0.0",
-    "cuGraphAddHostNode" => "5.0.0",
-    "cuGraphAddEventWaitNode" => "5.0.0",
-    "cuGraphAddEventRecordNode" => "5.0.0",
-    "cuGraphAddChildGraphNode" => "5.0.0",
-    "CUstreamUpdateCaptureDependencies_flags_enum" => "5.0.0",
-    "CUstreamUpdateCaptureDependencies_flags" => "5.0.0",
-    "CUpointer_attribute_enum" => "5.0.0",
-    "CUpointer_attribute" => "5.0.0",
-    "CU_STREAM_SET_CAPTURE_DEPENDENCIES" => "5.0.0",
-    "CU_STREAM_ADD_CAPTURE_DEPENDENCIES" => "5.0.0",
-    "CU_POINTER_ATTRIBUTE_SYNC_MEMOPS" => "5.0.0",
-    "CU_POINTER_ATTRIBUTE_RANGE_START_ADDR" => "5.0.0",
-    "CU_POINTER_ATTRIBUTE_RANGE_SIZE" => "5.0.0",
-    "CU_POINTER_ATTRIBUTE_P2P_TOKENS" => "5.0.0",
-    "CU_POINTER_ATTRIBUTE_MEMPOOL_HANDLE" => "5.0.0",
-    "CU_POINTER_ATTRIBUTE_MEMORY_TYPE" => "5.0.0",
-    "CU_POINTER_ATTRIBUTE_MAPPED" => "5.0.0",
-    "CU_POINTER_ATTRIBUTE_IS_MANAGED" => "5.0.0",
-    "CU_POINTER_ATTRIBUTE_IS_LEGACY_CUDA_IPC_CAPABLE" => "5.0.0",
-    "CU_POINTER_ATTRIBUTE_IS_GPU_DIRECT_RDMA_CAPABLE" => "5.0.0",
-    "CU_POINTER_ATTRIBUTE_HOST_POINTER" => "5.0.0",
-    "CU_POINTER_ATTRIBUTE_DEVICE_POINTER" => "5.0.0",
-    "CU_POINTER_ATTRIBUTE_DEVICE_ORDINAL" => "5.0.0",
-    "CU_POINTER_ATTRIBUTE_CONTEXT" => "5.0.0",
-    "CU_POINTER_ATTRIBUTE_BUFFER_ID" => "5.0.0",
-    "CU_POINTER_ATTRIBUTE_ALLOWED_HANDLE_TYPES" => "5.0.0",
-    "CU_POINTER_ATTRIBUTE_ACCESS_FLAGS" => "5.0.0",
-    "CUDA_ERROR_ILLEGAL_STATE" => "5.0.0",
-    "CUDA_ERROR_GRAPH_EXEC_UPDATE_FAILURE" => "5.0.0"
+    "cudaGraphicsSubResourceGetMappedArray" => "5.1.0",
+    "cuGraphicsSubResourceGetMappedArray" => "5.1.0",
+    "cuGraphicsGLRegisterImage" => "5.1.0",
+    "GLuint" => "5.1.0",
+    "GLenum" => "5.1.0"
 );
 
 $print_stats = 1 if $examine;
@@ -908,102 +817,11 @@ sub clearStats {
 }
 
 sub experimentalSubstitutions {
-    $ft{'addressing'} += s/\bcuPointerGetAttribute\b/hipPointerGetAttribute/g;
-    $ft{'addressing'} += s/\bcuPointerGetAttributes\b/hipDrvPointerGetAttributes/g;
-    $ft{'stream'} += s/\bcuStreamGetCaptureInfo\b/hipStreamGetCaptureInfo/g;
-    $ft{'stream'} += s/\bcuStreamGetCaptureInfo_v2\b/hipStreamGetCaptureInfo_v2/g;
-    $ft{'stream'} += s/\bcuStreamIsCapturing\b/hipStreamIsCapturing/g;
-    $ft{'stream'} += s/\bcuStreamUpdateCaptureDependencies\b/hipStreamUpdateCaptureDependencies/g;
-    $ft{'stream'} += s/\bcudaStreamGetCaptureInfo\b/hipStreamGetCaptureInfo/g;
-    $ft{'stream'} += s/\bcudaStreamIsCapturing\b/hipStreamIsCapturing/g;
-    $ft{'graph'} += s/\bcuGraphAddChildGraphNode\b/hipGraphAddChildGraphNode/g;
-    $ft{'graph'} += s/\bcuGraphAddEventRecordNode\b/hipGraphAddEventRecordNode/g;
-    $ft{'graph'} += s/\bcuGraphAddEventWaitNode\b/hipGraphAddEventWaitNode/g;
-    $ft{'graph'} += s/\bcuGraphAddHostNode\b/hipGraphAddHostNode/g;
-    $ft{'graph'} += s/\bcuGraphChildGraphNodeGetGraph\b/hipGraphChildGraphNodeGetGraph/g;
-    $ft{'graph'} += s/\bcuGraphDestroyNode\b/hipGraphDestroyNode/g;
-    $ft{'graph'} += s/\bcuGraphEventRecordNodeGetEvent\b/hipGraphEventRecordNodeGetEvent/g;
-    $ft{'graph'} += s/\bcuGraphEventRecordNodeSetEvent\b/hipGraphEventRecordNodeSetEvent/g;
-    $ft{'graph'} += s/\bcuGraphEventWaitNodeGetEvent\b/hipGraphEventWaitNodeGetEvent/g;
-    $ft{'graph'} += s/\bcuGraphEventWaitNodeSetEvent\b/hipGraphEventWaitNodeSetEvent/g;
-    $ft{'graph'} += s/\bcuGraphExecChildGraphNodeSetParams\b/hipGraphExecChildGraphNodeSetParams/g;
-    $ft{'graph'} += s/\bcuGraphExecEventRecordNodeSetEvent\b/hipGraphExecEventRecordNodeSetEvent/g;
-    $ft{'graph'} += s/\bcuGraphExecEventWaitNodeSetEvent\b/hipGraphExecEventWaitNodeSetEvent/g;
-    $ft{'graph'} += s/\bcuGraphExecHostNodeSetParams\b/hipGraphExecHostNodeSetParams/g;
-    $ft{'graph'} += s/\bcuGraphExecUpdate\b/hipGraphExecUpdate/g;
-    $ft{'graph'} += s/\bcuGraphGetEdges\b/hipGraphGetEdges/g;
-    $ft{'graph'} += s/\bcuGraphHostNodeGetParams\b/hipGraphHostNodeGetParams/g;
-    $ft{'graph'} += s/\bcuGraphHostNodeSetParams\b/hipGraphHostNodeSetParams/g;
-    $ft{'graph'} += s/\bcuGraphInstantiateWithFlags\b/hipGraphInstantiateWithFlags/g;
-    $ft{'graph'} += s/\bcuGraphNodeFindInClone\b/hipGraphNodeFindInClone/g;
-    $ft{'graph'} += s/\bcuGraphNodeGetDependencies\b/hipGraphNodeGetDependencies/g;
-    $ft{'graph'} += s/\bcuGraphNodeGetDependentNodes\b/hipGraphNodeGetDependentNodes/g;
-    $ft{'graph'} += s/\bcuGraphNodeGetType\b/hipGraphNodeGetType/g;
-    $ft{'graph'} += s/\bcuGraphRemoveDependencies\b/hipGraphRemoveDependencies/g;
-    $ft{'graph'} += s/\bcudaGraphAddChildGraphNode\b/hipGraphAddChildGraphNode/g;
-    $ft{'graph'} += s/\bcudaGraphAddEventRecordNode\b/hipGraphAddEventRecordNode/g;
-    $ft{'graph'} += s/\bcudaGraphAddEventWaitNode\b/hipGraphAddEventWaitNode/g;
-    $ft{'graph'} += s/\bcudaGraphAddHostNode\b/hipGraphAddHostNode/g;
-    $ft{'graph'} += s/\bcudaGraphAddMemcpyNodeFromSymbol\b/hipGraphAddMemcpyNodeFromSymbol/g;
-    $ft{'graph'} += s/\bcudaGraphAddMemcpyNodeToSymbol\b/hipGraphAddMemcpyNodeToSymbol/g;
-    $ft{'graph'} += s/\bcudaGraphChildGraphNodeGetGraph\b/hipGraphChildGraphNodeGetGraph/g;
-    $ft{'graph'} += s/\bcudaGraphDestroyNode\b/hipGraphDestroyNode/g;
-    $ft{'graph'} += s/\bcudaGraphEventRecordNodeGetEvent\b/hipGraphEventRecordNodeGetEvent/g;
-    $ft{'graph'} += s/\bcudaGraphEventRecordNodeSetEvent\b/hipGraphEventRecordNodeSetEvent/g;
-    $ft{'graph'} += s/\bcudaGraphEventWaitNodeGetEvent\b/hipGraphEventWaitNodeGetEvent/g;
-    $ft{'graph'} += s/\bcudaGraphEventWaitNodeSetEvent\b/hipGraphEventWaitNodeSetEvent/g;
-    $ft{'graph'} += s/\bcudaGraphExecChildGraphNodeSetParams\b/hipGraphExecChildGraphNodeSetParams/g;
-    $ft{'graph'} += s/\bcudaGraphExecEventRecordNodeSetEvent\b/hipGraphExecEventRecordNodeSetEvent/g;
-    $ft{'graph'} += s/\bcudaGraphExecEventWaitNodeSetEvent\b/hipGraphExecEventWaitNodeSetEvent/g;
-    $ft{'graph'} += s/\bcudaGraphExecHostNodeSetParams\b/hipGraphExecHostNodeSetParams/g;
-    $ft{'graph'} += s/\bcudaGraphExecMemcpyNodeSetParams\b/hipGraphExecMemcpyNodeSetParams/g;
-    $ft{'graph'} += s/\bcudaGraphExecMemcpyNodeSetParams1D\b/hipGraphExecMemcpyNodeSetParams1D/g;
-    $ft{'graph'} += s/\bcudaGraphExecMemcpyNodeSetParamsFromSymbol\b/hipGraphExecMemcpyNodeSetParamsFromSymbol/g;
-    $ft{'graph'} += s/\bcudaGraphExecMemcpyNodeSetParamsToSymbol\b/hipGraphExecMemcpyNodeSetParamsToSymbol/g;
-    $ft{'graph'} += s/\bcudaGraphExecMemsetNodeSetParams\b/hipGraphExecMemsetNodeSetParams/g;
-    $ft{'graph'} += s/\bcudaGraphExecUpdate\b/hipGraphExecUpdate/g;
-    $ft{'graph'} += s/\bcudaGraphGetEdges\b/hipGraphGetEdges/g;
-    $ft{'graph'} += s/\bcudaGraphHostNodeGetParams\b/hipGraphHostNodeGetParams/g;
-    $ft{'graph'} += s/\bcudaGraphHostNodeSetParams\b/hipGraphHostNodeSetParams/g;
-    $ft{'graph'} += s/\bcudaGraphInstantiateWithFlags\b/hipGraphInstantiateWithFlags/g;
-    $ft{'graph'} += s/\bcudaGraphMemcpyNodeSetParams1D\b/hipGraphMemcpyNodeSetParams1D/g;
-    $ft{'graph'} += s/\bcudaGraphMemcpyNodeSetParamsFromSymbol\b/hipGraphMemcpyNodeSetParamsFromSymbol/g;
-    $ft{'graph'} += s/\bcudaGraphMemcpyNodeSetParamsToSymbol\b/hipGraphMemcpyNodeSetParamsToSymbol/g;
-    $ft{'graph'} += s/\bcudaGraphNodeFindInClone\b/hipGraphNodeFindInClone/g;
-    $ft{'graph'} += s/\bcudaGraphNodeGetDependencies\b/hipGraphNodeGetDependencies/g;
-    $ft{'graph'} += s/\bcudaGraphNodeGetDependentNodes\b/hipGraphNodeGetDependentNodes/g;
-    $ft{'graph'} += s/\bcudaGraphNodeGetType\b/hipGraphNodeGetType/g;
-    $ft{'graph'} += s/\bcudaGraphRemoveDependencies\b/hipGraphRemoveDependencies/g;
-    $ft{'type'} += s/\bCUpointer_attribute\b/hipPointer_attribute/g;
-    $ft{'type'} += s/\bCUpointer_attribute_enum\b/hipPointer_attribute/g;
-    $ft{'type'} += s/\bCUstreamUpdateCaptureDependencies_flags\b/hipStreamUpdateCaptureDependenciesFlags/g;
-    $ft{'type'} += s/\bCUstreamUpdateCaptureDependencies_flags_enum\b/hipStreamUpdateCaptureDependenciesFlags/g;
-    $ft{'type'} += s/\bcudaStreamUpdateCaptureDependenciesFlags\b/hipStreamUpdateCaptureDependenciesFlags/g;
-    $ft{'numeric_literal'} += s/\bCUDA_ERROR_GRAPH_EXEC_UPDATE_FAILURE\b/hipErrorGraphExecUpdateFailure/g;
-    $ft{'numeric_literal'} += s/\bCUDA_ERROR_ILLEGAL_STATE\b/hipErrorIllegalState/g;
-    $ft{'numeric_literal'} += s/\bCU_POINTER_ATTRIBUTE_ACCESS_FLAGS\b/HIP_POINTER_ATTRIBUTE_ACCESS_FLAGS/g;
-    $ft{'numeric_literal'} += s/\bCU_POINTER_ATTRIBUTE_ALLOWED_HANDLE_TYPES\b/HIP_POINTER_ATTRIBUTE_ALLOWED_HANDLE_TYPES/g;
-    $ft{'numeric_literal'} += s/\bCU_POINTER_ATTRIBUTE_BUFFER_ID\b/HIP_POINTER_ATTRIBUTE_BUFFER_ID/g;
-    $ft{'numeric_literal'} += s/\bCU_POINTER_ATTRIBUTE_CONTEXT\b/HIP_POINTER_ATTRIBUTE_CONTEXT/g;
-    $ft{'numeric_literal'} += s/\bCU_POINTER_ATTRIBUTE_DEVICE_ORDINAL\b/HIP_POINTER_ATTRIBUTE_DEVICE_ORDINAL/g;
-    $ft{'numeric_literal'} += s/\bCU_POINTER_ATTRIBUTE_DEVICE_POINTER\b/HIP_POINTER_ATTRIBUTE_DEVICE_POINTER/g;
-    $ft{'numeric_literal'} += s/\bCU_POINTER_ATTRIBUTE_HOST_POINTER\b/HIP_POINTER_ATTRIBUTE_HOST_POINTER/g;
-    $ft{'numeric_literal'} += s/\bCU_POINTER_ATTRIBUTE_IS_GPU_DIRECT_RDMA_CAPABLE\b/HIP_POINTER_ATTRIBUTE_IS_GPU_DIRECT_RDMA_CAPABLE/g;
-    $ft{'numeric_literal'} += s/\bCU_POINTER_ATTRIBUTE_IS_LEGACY_CUDA_IPC_CAPABLE\b/HIP_POINTER_ATTRIBUTE_IS_LEGACY_HIP_IPC_CAPABLE/g;
-    $ft{'numeric_literal'} += s/\bCU_POINTER_ATTRIBUTE_IS_MANAGED\b/HIP_POINTER_ATTRIBUTE_IS_MANAGED/g;
-    $ft{'numeric_literal'} += s/\bCU_POINTER_ATTRIBUTE_MAPPED\b/HIP_POINTER_ATTRIBUTE_MAPPED/g;
-    $ft{'numeric_literal'} += s/\bCU_POINTER_ATTRIBUTE_MEMORY_TYPE\b/HIP_POINTER_ATTRIBUTE_MEMORY_TYPE/g;
-    $ft{'numeric_literal'} += s/\bCU_POINTER_ATTRIBUTE_MEMPOOL_HANDLE\b/HIP_POINTER_ATTRIBUTE_MEMPOOL_HANDLE/g;
-    $ft{'numeric_literal'} += s/\bCU_POINTER_ATTRIBUTE_P2P_TOKENS\b/HIP_POINTER_ATTRIBUTE_P2P_TOKENS/g;
-    $ft{'numeric_literal'} += s/\bCU_POINTER_ATTRIBUTE_RANGE_SIZE\b/HIP_POINTER_ATTRIBUTE_RANGE_SIZE/g;
-    $ft{'numeric_literal'} += s/\bCU_POINTER_ATTRIBUTE_RANGE_START_ADDR\b/HIP_POINTER_ATTRIBUTE_RANGE_START_ADDR/g;
-    $ft{'numeric_literal'} += s/\bCU_POINTER_ATTRIBUTE_SYNC_MEMOPS\b/HIP_POINTER_ATTRIBUTE_SYNC_MEMOPS/g;
-    $ft{'numeric_literal'} += s/\bCU_STREAM_ADD_CAPTURE_DEPENDENCIES\b/hipStreamAddCaptureDependencies/g;
-    $ft{'numeric_literal'} += s/\bCU_STREAM_SET_CAPTURE_DEPENDENCIES\b/hipStreamSetCaptureDependencies/g;
-    $ft{'numeric_literal'} += s/\bcudaErrorGraphExecUpdateFailure\b/hipErrorGraphExecUpdateFailure/g;
-    $ft{'numeric_literal'} += s/\bcudaErrorIllegalState\b/hipErrorIllegalState/g;
-    $ft{'numeric_literal'} += s/\bcudaStreamAddCaptureDependencies\b/hipStreamAddCaptureDependencies/g;
-    $ft{'numeric_literal'} += s/\bcudaStreamSetCaptureDependencies\b/hipStreamSetCaptureDependencies/g;
+    $ft{'graphics'} += s/\bcuGraphicsSubResourceGetMappedArray\b/hipGraphicsSubResourceGetMappedArray/g;
+    $ft{'graphics'} += s/\bcudaGraphicsSubResourceGetMappedArray\b/hipGraphicsSubResourceGetMappedArray/g;
+    $ft{'openGL'} += s/\bcuGraphicsGLRegisterImage\b/hipGraphicsGLRegisterImage/g;
+    $ft{'type'} += s/\bGLenum\b/GLenum/g;
+    $ft{'type'} += s/\bGLuint\b/GLuint/g;
 }
 
 sub rocSubstitutions {
@@ -1623,6 +1441,8 @@ sub simpleSubstitutions {
     $ft{'addressing'} += s/\bcuMemPrefetchAsync\b/hipMemPrefetchAsync/g;
     $ft{'addressing'} += s/\bcuMemRangeGetAttribute\b/hipMemRangeGetAttribute/g;
     $ft{'addressing'} += s/\bcuMemRangeGetAttributes\b/hipMemRangeGetAttributes/g;
+    $ft{'addressing'} += s/\bcuPointerGetAttribute\b/hipPointerGetAttribute/g;
+    $ft{'addressing'} += s/\bcuPointerGetAttributes\b/hipDrvPointerGetAttributes/g;
     $ft{'addressing'} += s/\bcudaPointerGetAttributes\b/hipPointerGetAttributes/g;
     $ft{'stream'} += s/\bcuStreamAddCallback\b/hipStreamAddCallback/g;
     $ft{'stream'} += s/\bcuStreamAttachMemAsync\b/hipStreamAttachMemAsync/g;
@@ -1633,10 +1453,14 @@ sub simpleSubstitutions {
     $ft{'stream'} += s/\bcuStreamDestroy\b/hipStreamDestroy/g;
     $ft{'stream'} += s/\bcuStreamDestroy_v2\b/hipStreamDestroy/g;
     $ft{'stream'} += s/\bcuStreamEndCapture\b/hipStreamEndCapture/g;
+    $ft{'stream'} += s/\bcuStreamGetCaptureInfo\b/hipStreamGetCaptureInfo/g;
+    $ft{'stream'} += s/\bcuStreamGetCaptureInfo_v2\b/hipStreamGetCaptureInfo_v2/g;
     $ft{'stream'} += s/\bcuStreamGetFlags\b/hipStreamGetFlags/g;
     $ft{'stream'} += s/\bcuStreamGetPriority\b/hipStreamGetPriority/g;
+    $ft{'stream'} += s/\bcuStreamIsCapturing\b/hipStreamIsCapturing/g;
     $ft{'stream'} += s/\bcuStreamQuery\b/hipStreamQuery/g;
     $ft{'stream'} += s/\bcuStreamSynchronize\b/hipStreamSynchronize/g;
+    $ft{'stream'} += s/\bcuStreamUpdateCaptureDependencies\b/hipStreamUpdateCaptureDependencies/g;
     $ft{'stream'} += s/\bcuStreamWaitEvent\b/hipStreamWaitEvent/g;
     $ft{'stream'} += s/\bcudaStreamAddCallback\b/hipStreamAddCallback/g;
     $ft{'stream'} += s/\bcudaStreamAttachMemAsync\b/hipStreamAttachMemAsync/g;
@@ -1646,8 +1470,10 @@ sub simpleSubstitutions {
     $ft{'stream'} += s/\bcudaStreamCreateWithPriority\b/hipStreamCreateWithPriority/g;
     $ft{'stream'} += s/\bcudaStreamDestroy\b/hipStreamDestroy/g;
     $ft{'stream'} += s/\bcudaStreamEndCapture\b/hipStreamEndCapture/g;
+    $ft{'stream'} += s/\bcudaStreamGetCaptureInfo\b/hipStreamGetCaptureInfo/g;
     $ft{'stream'} += s/\bcudaStreamGetFlags\b/hipStreamGetFlags/g;
     $ft{'stream'} += s/\bcudaStreamGetPriority\b/hipStreamGetPriority/g;
+    $ft{'stream'} += s/\bcudaStreamIsCapturing\b/hipStreamIsCapturing/g;
     $ft{'stream'} += s/\bcudaStreamQuery\b/hipStreamQuery/g;
     $ft{'stream'} += s/\bcudaStreamSynchronize\b/hipStreamSynchronize/g;
     $ft{'stream'} += s/\bcudaStreamWaitEvent\b/hipStreamWaitEvent/g;
@@ -1694,16 +1520,35 @@ sub simpleSubstitutions {
     $ft{'execution'} += s/\bcudaLaunchCooperativeKernelMultiDevice\b/hipLaunchCooperativeKernelMultiDevice/g;
     $ft{'execution'} += s/\bcudaLaunchKernel\b/hipLaunchKernel/g;
     $ft{'execution'} += s/\bcudaSetupArgument\b/hipSetupArgument/g;
+    $ft{'graph'} += s/\bcuGraphAddChildGraphNode\b/hipGraphAddChildGraphNode/g;
     $ft{'graph'} += s/\bcuGraphAddDependencies\b/hipGraphAddDependencies/g;
     $ft{'graph'} += s/\bcuGraphAddEmptyNode\b/hipGraphAddEmptyNode/g;
+    $ft{'graph'} += s/\bcuGraphAddEventRecordNode\b/hipGraphAddEventRecordNode/g;
+    $ft{'graph'} += s/\bcuGraphAddEventWaitNode\b/hipGraphAddEventWaitNode/g;
+    $ft{'graph'} += s/\bcuGraphAddHostNode\b/hipGraphAddHostNode/g;
     $ft{'graph'} += s/\bcuGraphAddKernelNode\b/hipGraphAddKernelNode/g;
+    $ft{'graph'} += s/\bcuGraphChildGraphNodeGetGraph\b/hipGraphChildGraphNodeGetGraph/g;
     $ft{'graph'} += s/\bcuGraphCreate\b/hipGraphCreate/g;
     $ft{'graph'} += s/\bcuGraphDestroy\b/hipGraphDestroy/g;
+    $ft{'graph'} += s/\bcuGraphDestroyNode\b/hipGraphDestroyNode/g;
+    $ft{'graph'} += s/\bcuGraphEventRecordNodeGetEvent\b/hipGraphEventRecordNodeGetEvent/g;
+    $ft{'graph'} += s/\bcuGraphEventRecordNodeSetEvent\b/hipGraphEventRecordNodeSetEvent/g;
+    $ft{'graph'} += s/\bcuGraphEventWaitNodeGetEvent\b/hipGraphEventWaitNodeGetEvent/g;
+    $ft{'graph'} += s/\bcuGraphEventWaitNodeSetEvent\b/hipGraphEventWaitNodeSetEvent/g;
+    $ft{'graph'} += s/\bcuGraphExecChildGraphNodeSetParams\b/hipGraphExecChildGraphNodeSetParams/g;
     $ft{'graph'} += s/\bcuGraphExecDestroy\b/hipGraphExecDestroy/g;
+    $ft{'graph'} += s/\bcuGraphExecEventRecordNodeSetEvent\b/hipGraphExecEventRecordNodeSetEvent/g;
+    $ft{'graph'} += s/\bcuGraphExecEventWaitNodeSetEvent\b/hipGraphExecEventWaitNodeSetEvent/g;
+    $ft{'graph'} += s/\bcuGraphExecHostNodeSetParams\b/hipGraphExecHostNodeSetParams/g;
     $ft{'graph'} += s/\bcuGraphExecKernelNodeSetParams\b/hipGraphExecKernelNodeSetParams/g;
+    $ft{'graph'} += s/\bcuGraphExecUpdate\b/hipGraphExecUpdate/g;
+    $ft{'graph'} += s/\bcuGraphGetEdges\b/hipGraphGetEdges/g;
     $ft{'graph'} += s/\bcuGraphGetNodes\b/hipGraphGetNodes/g;
     $ft{'graph'} += s/\bcuGraphGetRootNodes\b/hipGraphGetRootNodes/g;
+    $ft{'graph'} += s/\bcuGraphHostNodeGetParams\b/hipGraphHostNodeGetParams/g;
+    $ft{'graph'} += s/\bcuGraphHostNodeSetParams\b/hipGraphHostNodeSetParams/g;
     $ft{'graph'} += s/\bcuGraphInstantiate\b/hipGraphInstantiate/g;
+    $ft{'graph'} += s/\bcuGraphInstantiateWithFlags\b/hipGraphInstantiateWithFlags/g;
     $ft{'graph'} += s/\bcuGraphInstantiate_v2\b/hipGraphInstantiate/g;
     $ft{'graph'} += s/\bcuGraphKernelNodeGetParams\b/hipGraphKernelNodeGetParams/g;
     $ft{'graph'} += s/\bcuGraphKernelNodeSetParams\b/hipGraphKernelNodeSetParams/g;
@@ -1712,26 +1557,65 @@ sub simpleSubstitutions {
     $ft{'graph'} += s/\bcuGraphMemcpyNodeSetParams\b/hipGraphMemcpyNodeSetParams/g;
     $ft{'graph'} += s/\bcuGraphMemsetNodeGetParams\b/hipGraphMemsetNodeGetParams/g;
     $ft{'graph'} += s/\bcuGraphMemsetNodeSetParams\b/hipGraphMemsetNodeSetParams/g;
+    $ft{'graph'} += s/\bcuGraphNodeFindInClone\b/hipGraphNodeFindInClone/g;
+    $ft{'graph'} += s/\bcuGraphNodeGetDependencies\b/hipGraphNodeGetDependencies/g;
+    $ft{'graph'} += s/\bcuGraphNodeGetDependentNodes\b/hipGraphNodeGetDependentNodes/g;
+    $ft{'graph'} += s/\bcuGraphNodeGetType\b/hipGraphNodeGetType/g;
+    $ft{'graph'} += s/\bcuGraphRemoveDependencies\b/hipGraphRemoveDependencies/g;
+    $ft{'graph'} += s/\bcudaGraphAddChildGraphNode\b/hipGraphAddChildGraphNode/g;
     $ft{'graph'} += s/\bcudaGraphAddDependencies\b/hipGraphAddDependencies/g;
     $ft{'graph'} += s/\bcudaGraphAddEmptyNode\b/hipGraphAddEmptyNode/g;
+    $ft{'graph'} += s/\bcudaGraphAddEventRecordNode\b/hipGraphAddEventRecordNode/g;
+    $ft{'graph'} += s/\bcudaGraphAddEventWaitNode\b/hipGraphAddEventWaitNode/g;
+    $ft{'graph'} += s/\bcudaGraphAddHostNode\b/hipGraphAddHostNode/g;
     $ft{'graph'} += s/\bcudaGraphAddKernelNode\b/hipGraphAddKernelNode/g;
     $ft{'graph'} += s/\bcudaGraphAddMemcpyNode\b/hipGraphAddMemcpyNode/g;
     $ft{'graph'} += s/\bcudaGraphAddMemcpyNode1D\b/hipGraphAddMemcpyNode1D/g;
+    $ft{'graph'} += s/\bcudaGraphAddMemcpyNodeFromSymbol\b/hipGraphAddMemcpyNodeFromSymbol/g;
+    $ft{'graph'} += s/\bcudaGraphAddMemcpyNodeToSymbol\b/hipGraphAddMemcpyNodeToSymbol/g;
     $ft{'graph'} += s/\bcudaGraphAddMemsetNode\b/hipGraphAddMemsetNode/g;
+    $ft{'graph'} += s/\bcudaGraphChildGraphNodeGetGraph\b/hipGraphChildGraphNodeGetGraph/g;
     $ft{'graph'} += s/\bcudaGraphCreate\b/hipGraphCreate/g;
     $ft{'graph'} += s/\bcudaGraphDestroy\b/hipGraphDestroy/g;
+    $ft{'graph'} += s/\bcudaGraphDestroyNode\b/hipGraphDestroyNode/g;
+    $ft{'graph'} += s/\bcudaGraphEventRecordNodeGetEvent\b/hipGraphEventRecordNodeGetEvent/g;
+    $ft{'graph'} += s/\bcudaGraphEventRecordNodeSetEvent\b/hipGraphEventRecordNodeSetEvent/g;
+    $ft{'graph'} += s/\bcudaGraphEventWaitNodeGetEvent\b/hipGraphEventWaitNodeGetEvent/g;
+    $ft{'graph'} += s/\bcudaGraphEventWaitNodeSetEvent\b/hipGraphEventWaitNodeSetEvent/g;
+    $ft{'graph'} += s/\bcudaGraphExecChildGraphNodeSetParams\b/hipGraphExecChildGraphNodeSetParams/g;
     $ft{'graph'} += s/\bcudaGraphExecDestroy\b/hipGraphExecDestroy/g;
+    $ft{'graph'} += s/\bcudaGraphExecEventRecordNodeSetEvent\b/hipGraphExecEventRecordNodeSetEvent/g;
+    $ft{'graph'} += s/\bcudaGraphExecEventWaitNodeSetEvent\b/hipGraphExecEventWaitNodeSetEvent/g;
+    $ft{'graph'} += s/\bcudaGraphExecHostNodeSetParams\b/hipGraphExecHostNodeSetParams/g;
     $ft{'graph'} += s/\bcudaGraphExecKernelNodeSetParams\b/hipGraphExecKernelNodeSetParams/g;
+    $ft{'graph'} += s/\bcudaGraphExecMemcpyNodeSetParams\b/hipGraphExecMemcpyNodeSetParams/g;
+    $ft{'graph'} += s/\bcudaGraphExecMemcpyNodeSetParams1D\b/hipGraphExecMemcpyNodeSetParams1D/g;
+    $ft{'graph'} += s/\bcudaGraphExecMemcpyNodeSetParamsFromSymbol\b/hipGraphExecMemcpyNodeSetParamsFromSymbol/g;
+    $ft{'graph'} += s/\bcudaGraphExecMemcpyNodeSetParamsToSymbol\b/hipGraphExecMemcpyNodeSetParamsToSymbol/g;
+    $ft{'graph'} += s/\bcudaGraphExecMemsetNodeSetParams\b/hipGraphExecMemsetNodeSetParams/g;
+    $ft{'graph'} += s/\bcudaGraphExecUpdate\b/hipGraphExecUpdate/g;
+    $ft{'graph'} += s/\bcudaGraphGetEdges\b/hipGraphGetEdges/g;
     $ft{'graph'} += s/\bcudaGraphGetNodes\b/hipGraphGetNodes/g;
     $ft{'graph'} += s/\bcudaGraphGetRootNodes\b/hipGraphGetRootNodes/g;
+    $ft{'graph'} += s/\bcudaGraphHostNodeGetParams\b/hipGraphHostNodeGetParams/g;
+    $ft{'graph'} += s/\bcudaGraphHostNodeSetParams\b/hipGraphHostNodeSetParams/g;
     $ft{'graph'} += s/\bcudaGraphInstantiate\b/hipGraphInstantiate/g;
+    $ft{'graph'} += s/\bcudaGraphInstantiateWithFlags\b/hipGraphInstantiateWithFlags/g;
     $ft{'graph'} += s/\bcudaGraphKernelNodeGetParams\b/hipGraphKernelNodeGetParams/g;
     $ft{'graph'} += s/\bcudaGraphKernelNodeSetParams\b/hipGraphKernelNodeSetParams/g;
     $ft{'graph'} += s/\bcudaGraphLaunch\b/hipGraphLaunch/g;
     $ft{'graph'} += s/\bcudaGraphMemcpyNodeGetParams\b/hipGraphMemcpyNodeGetParams/g;
     $ft{'graph'} += s/\bcudaGraphMemcpyNodeSetParams\b/hipGraphMemcpyNodeSetParams/g;
+    $ft{'graph'} += s/\bcudaGraphMemcpyNodeSetParams1D\b/hipGraphMemcpyNodeSetParams1D/g;
+    $ft{'graph'} += s/\bcudaGraphMemcpyNodeSetParamsFromSymbol\b/hipGraphMemcpyNodeSetParamsFromSymbol/g;
+    $ft{'graph'} += s/\bcudaGraphMemcpyNodeSetParamsToSymbol\b/hipGraphMemcpyNodeSetParamsToSymbol/g;
     $ft{'graph'} += s/\bcudaGraphMemsetNodeGetParams\b/hipGraphMemsetNodeGetParams/g;
     $ft{'graph'} += s/\bcudaGraphMemsetNodeSetParams\b/hipGraphMemsetNodeSetParams/g;
+    $ft{'graph'} += s/\bcudaGraphNodeFindInClone\b/hipGraphNodeFindInClone/g;
+    $ft{'graph'} += s/\bcudaGraphNodeGetDependencies\b/hipGraphNodeGetDependencies/g;
+    $ft{'graph'} += s/\bcudaGraphNodeGetDependentNodes\b/hipGraphNodeGetDependentNodes/g;
+    $ft{'graph'} += s/\bcudaGraphNodeGetType\b/hipGraphNodeGetType/g;
+    $ft{'graph'} += s/\bcudaGraphRemoveDependencies\b/hipGraphRemoveDependencies/g;
     $ft{'occupancy'} += s/\bcuOccupancyMaxActiveBlocksPerMultiprocessor\b/hipModuleOccupancyMaxActiveBlocksPerMultiprocessor/g;
     $ft{'occupancy'} += s/\bcuOccupancyMaxActiveBlocksPerMultiprocessorWithFlags\b/hipModuleOccupancyMaxActiveBlocksPerMultiprocessorWithFlags/g;
     $ft{'occupancy'} += s/\bcuOccupancyMaxPotentialBlockSize\b/hipModuleOccupancyMaxPotentialBlockSize/g;
@@ -1812,6 +1696,7 @@ sub simpleSubstitutions {
     $ft{'openGL'} += s/\bcuGraphicsGLRegisterBuffer\b/hipGraphicsGLRegisterBuffer/g;
     $ft{'openGL'} += s/\bcudaGLGetDevices\b/hipGLGetDevices/g;
     $ft{'openGL'} += s/\bcudaGraphicsGLRegisterBuffer\b/hipGraphicsGLRegisterBuffer/g;
+    $ft{'openGL'} += s/\bcudaGraphicsGLRegisterImage\b/hipGraphicsGLRegisterImage/g;
     $ft{'thread'} += s/\bcudaThreadExit\b/hipDeviceReset/g;
     $ft{'thread'} += s/\bcudaThreadGetCacheConfig\b/hipDeviceGetCacheConfig/g;
     $ft{'thread'} += s/\bcudaThreadSetCacheConfig\b/hipDeviceSetCacheConfig/g;
@@ -3083,6 +2968,8 @@ sub simpleSubstitutions {
     $ft{'type'} += s/\bCUmod_st\b/ihipModule_t/g;
     $ft{'type'} += s/\bCUmodule\b/hipModule_t/g;
     $ft{'type'} += s/\bCUoccupancyB2DSize\b/void*/g;
+    $ft{'type'} += s/\bCUpointer_attribute\b/hipPointer_attribute/g;
+    $ft{'type'} += s/\bCUpointer_attribute_enum\b/hipPointer_attribute/g;
     $ft{'type'} += s/\bCUresourceViewFormat\b/HIPresourceViewFormat/g;
     $ft{'type'} += s/\bCUresourceViewFormat_enum\b/HIPresourceViewFormat_enum/g;
     $ft{'type'} += s/\bCUresourcetype\b/HIPresourcetype/g;
@@ -3096,6 +2983,8 @@ sub simpleSubstitutions {
     $ft{'type'} += s/\bCUstreamCaptureMode_enum\b/hipStreamCaptureMode/g;
     $ft{'type'} += s/\bCUstreamCaptureStatus\b/hipStreamCaptureStatus/g;
     $ft{'type'} += s/\bCUstreamCaptureStatus_enum\b/hipStreamCaptureStatus/g;
+    $ft{'type'} += s/\bCUstreamUpdateCaptureDependencies_flags\b/hipStreamUpdateCaptureDependenciesFlags/g;
+    $ft{'type'} += s/\bCUstreamUpdateCaptureDependencies_flags_enum\b/hipStreamUpdateCaptureDependenciesFlags/g;
     $ft{'type'} += s/\bCUstream_st\b/ihipStream_t/g;
     $ft{'type'} += s/\bCUsurfObject\b/hipSurfaceObject_t/g;
     $ft{'type'} += s/\bCUsurfObject_v1\b/hipSurfaceObject_t/g;
@@ -3197,6 +3086,7 @@ sub simpleSubstitutions {
     $ft{'type'} += s/\bcudaStreamCallback_t\b/hipStreamCallback_t/g;
     $ft{'type'} += s/\bcudaStreamCaptureMode\b/hipStreamCaptureMode/g;
     $ft{'type'} += s/\bcudaStreamCaptureStatus\b/hipStreamCaptureStatus/g;
+    $ft{'type'} += s/\bcudaStreamUpdateCaptureDependenciesFlags\b/hipStreamUpdateCaptureDependenciesFlags/g;
     $ft{'type'} += s/\bcudaStream_t\b/hipStream_t/g;
     $ft{'type'} += s/\bcudaSurfaceBoundaryMode\b/hipSurfaceBoundaryMode/g;
     $ft{'type'} += s/\bcudaSurfaceObject_t\b/hipSurfaceObject_t/g;
@@ -3370,9 +3260,11 @@ sub simpleSubstitutions {
     $ft{'numeric_literal'} += s/\bCUDA_ERROR_DEINITIALIZED\b/hipErrorDeinitialized/g;
     $ft{'numeric_literal'} += s/\bCUDA_ERROR_ECC_UNCORRECTABLE\b/hipErrorECCNotCorrectable/g;
     $ft{'numeric_literal'} += s/\bCUDA_ERROR_FILE_NOT_FOUND\b/hipErrorFileNotFound/g;
+    $ft{'numeric_literal'} += s/\bCUDA_ERROR_GRAPH_EXEC_UPDATE_FAILURE\b/hipErrorGraphExecUpdateFailure/g;
     $ft{'numeric_literal'} += s/\bCUDA_ERROR_HOST_MEMORY_ALREADY_REGISTERED\b/hipErrorHostMemoryAlreadyRegistered/g;
     $ft{'numeric_literal'} += s/\bCUDA_ERROR_HOST_MEMORY_NOT_REGISTERED\b/hipErrorHostMemoryNotRegistered/g;
     $ft{'numeric_literal'} += s/\bCUDA_ERROR_ILLEGAL_ADDRESS\b/hipErrorIllegalAddress/g;
+    $ft{'numeric_literal'} += s/\bCUDA_ERROR_ILLEGAL_STATE\b/hipErrorIllegalState/g;
     $ft{'numeric_literal'} += s/\bCUDA_ERROR_INVALID_CONTEXT\b/hipErrorInvalidContext/g;
     $ft{'numeric_literal'} += s/\bCUDA_ERROR_INVALID_DEVICE\b/hipErrorInvalidDevice/g;
     $ft{'numeric_literal'} += s/\bCUDA_ERROR_INVALID_GRAPHICS_CONTEXT\b/hipErrorInvalidGraphicsContext/g;
@@ -3893,6 +3785,23 @@ sub simpleSubstitutions {
     $ft{'numeric_literal'} += s/\bCU_MEM_RANGE_ATTRIBUTE_PREFERRED_LOCATION\b/hipMemRangeAttributePreferredLocation/g;
     $ft{'numeric_literal'} += s/\bCU_MEM_RANGE_ATTRIBUTE_READ_MOSTLY\b/hipMemRangeAttributeReadMostly/g;
     $ft{'numeric_literal'} += s/\bCU_OCCUPANCY_DEFAULT\b/hipOccupancyDefault/g;
+    $ft{'numeric_literal'} += s/\bCU_POINTER_ATTRIBUTE_ACCESS_FLAGS\b/HIP_POINTER_ATTRIBUTE_ACCESS_FLAGS/g;
+    $ft{'numeric_literal'} += s/\bCU_POINTER_ATTRIBUTE_ALLOWED_HANDLE_TYPES\b/HIP_POINTER_ATTRIBUTE_ALLOWED_HANDLE_TYPES/g;
+    $ft{'numeric_literal'} += s/\bCU_POINTER_ATTRIBUTE_BUFFER_ID\b/HIP_POINTER_ATTRIBUTE_BUFFER_ID/g;
+    $ft{'numeric_literal'} += s/\bCU_POINTER_ATTRIBUTE_CONTEXT\b/HIP_POINTER_ATTRIBUTE_CONTEXT/g;
+    $ft{'numeric_literal'} += s/\bCU_POINTER_ATTRIBUTE_DEVICE_ORDINAL\b/HIP_POINTER_ATTRIBUTE_DEVICE_ORDINAL/g;
+    $ft{'numeric_literal'} += s/\bCU_POINTER_ATTRIBUTE_DEVICE_POINTER\b/HIP_POINTER_ATTRIBUTE_DEVICE_POINTER/g;
+    $ft{'numeric_literal'} += s/\bCU_POINTER_ATTRIBUTE_HOST_POINTER\b/HIP_POINTER_ATTRIBUTE_HOST_POINTER/g;
+    $ft{'numeric_literal'} += s/\bCU_POINTER_ATTRIBUTE_IS_GPU_DIRECT_RDMA_CAPABLE\b/HIP_POINTER_ATTRIBUTE_IS_GPU_DIRECT_RDMA_CAPABLE/g;
+    $ft{'numeric_literal'} += s/\bCU_POINTER_ATTRIBUTE_IS_LEGACY_CUDA_IPC_CAPABLE\b/HIP_POINTER_ATTRIBUTE_IS_LEGACY_HIP_IPC_CAPABLE/g;
+    $ft{'numeric_literal'} += s/\bCU_POINTER_ATTRIBUTE_IS_MANAGED\b/HIP_POINTER_ATTRIBUTE_IS_MANAGED/g;
+    $ft{'numeric_literal'} += s/\bCU_POINTER_ATTRIBUTE_MAPPED\b/HIP_POINTER_ATTRIBUTE_MAPPED/g;
+    $ft{'numeric_literal'} += s/\bCU_POINTER_ATTRIBUTE_MEMORY_TYPE\b/HIP_POINTER_ATTRIBUTE_MEMORY_TYPE/g;
+    $ft{'numeric_literal'} += s/\bCU_POINTER_ATTRIBUTE_MEMPOOL_HANDLE\b/HIP_POINTER_ATTRIBUTE_MEMPOOL_HANDLE/g;
+    $ft{'numeric_literal'} += s/\bCU_POINTER_ATTRIBUTE_P2P_TOKENS\b/HIP_POINTER_ATTRIBUTE_P2P_TOKENS/g;
+    $ft{'numeric_literal'} += s/\bCU_POINTER_ATTRIBUTE_RANGE_SIZE\b/HIP_POINTER_ATTRIBUTE_RANGE_SIZE/g;
+    $ft{'numeric_literal'} += s/\bCU_POINTER_ATTRIBUTE_RANGE_START_ADDR\b/HIP_POINTER_ATTRIBUTE_RANGE_START_ADDR/g;
+    $ft{'numeric_literal'} += s/\bCU_POINTER_ATTRIBUTE_SYNC_MEMOPS\b/HIP_POINTER_ATTRIBUTE_SYNC_MEMOPS/g;
     $ft{'numeric_literal'} += s/\bCU_RESOURCE_TYPE_ARRAY\b/HIP_RESOURCE_TYPE_ARRAY/g;
     $ft{'numeric_literal'} += s/\bCU_RESOURCE_TYPE_LINEAR\b/HIP_RESOURCE_TYPE_LINEAR/g;
     $ft{'numeric_literal'} += s/\bCU_RESOURCE_TYPE_MIPMAPPED_ARRAY\b/HIP_RESOURCE_TYPE_MIPMAPPED_ARRAY/g;
@@ -3935,6 +3844,7 @@ sub simpleSubstitutions {
     $ft{'numeric_literal'} += s/\bCU_SHARED_MEM_CONFIG_DEFAULT_BANK_SIZE\b/hipSharedMemBankSizeDefault/g;
     $ft{'numeric_literal'} += s/\bCU_SHARED_MEM_CONFIG_EIGHT_BYTE_BANK_SIZE\b/hipSharedMemBankSizeEightByte/g;
     $ft{'numeric_literal'} += s/\bCU_SHARED_MEM_CONFIG_FOUR_BYTE_BANK_SIZE\b/hipSharedMemBankSizeFourByte/g;
+    $ft{'numeric_literal'} += s/\bCU_STREAM_ADD_CAPTURE_DEPENDENCIES\b/hipStreamAddCaptureDependencies/g;
     $ft{'numeric_literal'} += s/\bCU_STREAM_CAPTURE_MODE_GLOBAL\b/hipStreamCaptureModeGlobal/g;
     $ft{'numeric_literal'} += s/\bCU_STREAM_CAPTURE_MODE_RELAXED\b/hipStreamCaptureModeRelaxed/g;
     $ft{'numeric_literal'} += s/\bCU_STREAM_CAPTURE_MODE_THREAD_LOCAL\b/hipStreamCaptureModeThreadLocal/g;
@@ -3943,6 +3853,7 @@ sub simpleSubstitutions {
     $ft{'numeric_literal'} += s/\bCU_STREAM_CAPTURE_STATUS_NONE\b/hipStreamCaptureStatusNone/g;
     $ft{'numeric_literal'} += s/\bCU_STREAM_DEFAULT\b/hipStreamDefault/g;
     $ft{'numeric_literal'} += s/\bCU_STREAM_NON_BLOCKING\b/hipStreamNonBlocking/g;
+    $ft{'numeric_literal'} += s/\bCU_STREAM_SET_CAPTURE_DEPENDENCIES\b/hipStreamSetCaptureDependencies/g;
     $ft{'numeric_literal'} += s/\bCU_STREAM_WAIT_VALUE_AND\b/hipStreamWaitValueAnd/g;
     $ft{'numeric_literal'} += s/\bCU_STREAM_WAIT_VALUE_EQ\b/hipStreamWaitValueEq/g;
     $ft{'numeric_literal'} += s/\bCU_STREAM_WAIT_VALUE_GEQ\b/hipStreamWaitValueGte/g;
@@ -4087,9 +3998,11 @@ sub simpleSubstitutions {
     $ft{'numeric_literal'} += s/\bcudaErrorDeviceUninitialized\b/hipErrorInvalidContext/g;
     $ft{'numeric_literal'} += s/\bcudaErrorECCUncorrectable\b/hipErrorECCNotCorrectable/g;
     $ft{'numeric_literal'} += s/\bcudaErrorFileNotFound\b/hipErrorFileNotFound/g;
+    $ft{'numeric_literal'} += s/\bcudaErrorGraphExecUpdateFailure\b/hipErrorGraphExecUpdateFailure/g;
     $ft{'numeric_literal'} += s/\bcudaErrorHostMemoryAlreadyRegistered\b/hipErrorHostMemoryAlreadyRegistered/g;
     $ft{'numeric_literal'} += s/\bcudaErrorHostMemoryNotRegistered\b/hipErrorHostMemoryNotRegistered/g;
     $ft{'numeric_literal'} += s/\bcudaErrorIllegalAddress\b/hipErrorIllegalAddress/g;
+    $ft{'numeric_literal'} += s/\bcudaErrorIllegalState\b/hipErrorIllegalState/g;
     $ft{'numeric_literal'} += s/\bcudaErrorInitializationError\b/hipErrorNotInitialized/g;
     $ft{'numeric_literal'} += s/\bcudaErrorInsufficientDriver\b/hipErrorInsufficientDriver/g;
     $ft{'numeric_literal'} += s/\bcudaErrorInvalidConfiguration\b/hipErrorInvalidConfiguration/g;
@@ -4250,12 +4163,14 @@ sub simpleSubstitutions {
     $ft{'numeric_literal'} += s/\bcudaSharedMemBankSizeDefault\b/hipSharedMemBankSizeDefault/g;
     $ft{'numeric_literal'} += s/\bcudaSharedMemBankSizeEightByte\b/hipSharedMemBankSizeEightByte/g;
     $ft{'numeric_literal'} += s/\bcudaSharedMemBankSizeFourByte\b/hipSharedMemBankSizeFourByte/g;
+    $ft{'numeric_literal'} += s/\bcudaStreamAddCaptureDependencies\b/hipStreamAddCaptureDependencies/g;
     $ft{'numeric_literal'} += s/\bcudaStreamCaptureModeGlobal\b/hipStreamCaptureModeGlobal/g;
     $ft{'numeric_literal'} += s/\bcudaStreamCaptureModeRelaxed\b/hipStreamCaptureModeRelaxed/g;
     $ft{'numeric_literal'} += s/\bcudaStreamCaptureModeThreadLocal\b/hipStreamCaptureModeThreadLocal/g;
     $ft{'numeric_literal'} += s/\bcudaStreamCaptureStatusActive\b/hipStreamCaptureStatusActive/g;
     $ft{'numeric_literal'} += s/\bcudaStreamCaptureStatusInvalidated\b/hipStreamCaptureStatusInvalidated/g;
     $ft{'numeric_literal'} += s/\bcudaStreamCaptureStatusNone\b/hipStreamCaptureStatusNone/g;
+    $ft{'numeric_literal'} += s/\bcudaStreamSetCaptureDependencies\b/hipStreamSetCaptureDependencies/g;
     $ft{'numeric_literal'} += s/\bcudaSuccess\b/hipSuccess/g;
     $ft{'define'} += s/\bCUDA_ARRAY3D_CUBEMAP\b/hipArrayCubemap/g;
     $ft{'define'} += s/\bCUDA_ARRAY3D_LAYERED\b/hipArrayLayered/g;
@@ -5771,7 +5686,6 @@ sub warnUnsupportedFunctions {
         "cudaHostRegisterReadOnly",
         "cudaGraphicsVDPAURegisterVideoSurface",
         "cudaGraphicsVDPAURegisterOutputSurface",
-        "cudaGraphicsSubResourceGetMappedArray",
         "cudaGraphicsResourceSetMapFlags",
         "cudaGraphicsResourceGetMappedMipmappedArray",
         "cudaGraphicsResourceGetMappedEglFrame",
@@ -5779,7 +5693,6 @@ sub warnUnsupportedFunctions {
         "cudaGraphicsMapFlagsReadOnly",
         "cudaGraphicsMapFlagsNone",
         "cudaGraphicsMapFlags",
-        "cudaGraphicsGLRegisterImage",
         "cudaGraphicsEGLRegisterImage",
         "cudaGraphicsD3D9RegisterResource",
         "cudaGraphicsD3D11RegisterResource",
@@ -6283,12 +6196,10 @@ sub warnUnsupportedFunctions {
         "cuLaunch",
         "cuGraphicsVDPAURegisterVideoSurface",
         "cuGraphicsVDPAURegisterOutputSurface",
-        "cuGraphicsSubResourceGetMappedArray",
         "cuGraphicsResourceSetMapFlags_v2",
         "cuGraphicsResourceSetMapFlags",
         "cuGraphicsResourceGetMappedMipmappedArray",
         "cuGraphicsResourceGetMappedEglFrame",
-        "cuGraphicsGLRegisterImage",
         "cuGraphicsEGLRegisterImage",
         "cuGraphicsD3D9RegisterResource",
         "cuGraphicsD3D11RegisterResource",

--- a/doc/markdown/CUDA_Driver_API_functions_supported_by_HIP.md
+++ b/doc/markdown/CUDA_Driver_API_functions_supported_by_HIP.md
@@ -45,13 +45,13 @@
 |`CUDA_ERROR_ECC_UNCORRECTABLE`| | | |`hipErrorECCNotCorrectable`|1.6.0| | | |
 |`CUDA_ERROR_EXTERNAL_DEVICE`|11.4| | | | | | | |
 |`CUDA_ERROR_FILE_NOT_FOUND`| | | |`hipErrorFileNotFound`|1.6.0| | | |
-|`CUDA_ERROR_GRAPH_EXEC_UPDATE_FAILURE`|10.2| | |`hipErrorGraphExecUpdateFailure`|5.0.0| | |5.0.0|
+|`CUDA_ERROR_GRAPH_EXEC_UPDATE_FAILURE`|10.2| | |`hipErrorGraphExecUpdateFailure`|5.0.0| | | |
 |`CUDA_ERROR_HARDWARE_STACK_ERROR`| | | | | | | | |
 |`CUDA_ERROR_HOST_MEMORY_ALREADY_REGISTERED`| | | |`hipErrorHostMemoryAlreadyRegistered`|1.6.0| | | |
 |`CUDA_ERROR_HOST_MEMORY_NOT_REGISTERED`| | | |`hipErrorHostMemoryNotRegistered`|1.6.0| | | |
 |`CUDA_ERROR_ILLEGAL_ADDRESS`| | | |`hipErrorIllegalAddress`|1.6.0| | | |
 |`CUDA_ERROR_ILLEGAL_INSTRUCTION`| | | | | | | | |
-|`CUDA_ERROR_ILLEGAL_STATE`|10.0| | |`hipErrorIllegalState`|5.0.0| | |5.0.0|
+|`CUDA_ERROR_ILLEGAL_STATE`|10.0| | |`hipErrorIllegalState`|5.0.0| | | |
 |`CUDA_ERROR_INVALID_ADDRESS_SPACE`| | | | | | | | |
 |`CUDA_ERROR_INVALID_CONTEXT`| | | |`hipErrorInvalidContext`|1.6.0| | | |
 |`CUDA_ERROR_INVALID_DEVICE`| | | |`hipErrorInvalidDevice`|1.6.0| | | |
@@ -700,26 +700,26 @@
 |`CU_OCCUPANCY_DEFAULT`| | | |`hipOccupancyDefault`|3.2.0| | | |
 |`CU_OCCUPANCY_DISABLE_CACHING_OVERRIDE`| | | | | | | | |
 |`CU_PARAM_TR_DEFAULT`| | | | | | | | |
-|`CU_POINTER_ATTRIBUTE_ACCESS_FLAGS`|11.1| | |`HIP_POINTER_ATTRIBUTE_ACCESS_FLAGS`|5.0.0| | |5.0.0|
+|`CU_POINTER_ATTRIBUTE_ACCESS_FLAGS`|11.1| | |`HIP_POINTER_ATTRIBUTE_ACCESS_FLAGS`|5.0.0| | | |
 |`CU_POINTER_ATTRIBUTE_ACCESS_FLAG_NONE`|11.1| | | | | | | |
 |`CU_POINTER_ATTRIBUTE_ACCESS_FLAG_READ`|11.1| | | | | | | |
 |`CU_POINTER_ATTRIBUTE_ACCESS_FLAG_READWRITE`|11.1| | | | | | | |
-|`CU_POINTER_ATTRIBUTE_ALLOWED_HANDLE_TYPES`|10.2| | |`HIP_POINTER_ATTRIBUTE_ALLOWED_HANDLE_TYPES`|5.0.0| | |5.0.0|
-|`CU_POINTER_ATTRIBUTE_BUFFER_ID`| | | |`HIP_POINTER_ATTRIBUTE_BUFFER_ID`|5.0.0| | |5.0.0|
-|`CU_POINTER_ATTRIBUTE_CONTEXT`| | | |`HIP_POINTER_ATTRIBUTE_CONTEXT`|5.0.0| | |5.0.0|
-|`CU_POINTER_ATTRIBUTE_DEVICE_ORDINAL`|9.2| | |`HIP_POINTER_ATTRIBUTE_DEVICE_ORDINAL`|5.0.0| | |5.0.0|
-|`CU_POINTER_ATTRIBUTE_DEVICE_POINTER`| | | |`HIP_POINTER_ATTRIBUTE_DEVICE_POINTER`|5.0.0| | |5.0.0|
-|`CU_POINTER_ATTRIBUTE_HOST_POINTER`| | | |`HIP_POINTER_ATTRIBUTE_HOST_POINTER`|5.0.0| | |5.0.0|
-|`CU_POINTER_ATTRIBUTE_IS_GPU_DIRECT_RDMA_CAPABLE`|11.0| | |`HIP_POINTER_ATTRIBUTE_IS_GPU_DIRECT_RDMA_CAPABLE`|5.0.0| | |5.0.0|
-|`CU_POINTER_ATTRIBUTE_IS_LEGACY_CUDA_IPC_CAPABLE`|10.2| | |`HIP_POINTER_ATTRIBUTE_IS_LEGACY_HIP_IPC_CAPABLE`|5.0.0| | |5.0.0|
-|`CU_POINTER_ATTRIBUTE_IS_MANAGED`| | | |`HIP_POINTER_ATTRIBUTE_IS_MANAGED`|5.0.0| | |5.0.0|
-|`CU_POINTER_ATTRIBUTE_MAPPED`|10.2| | |`HIP_POINTER_ATTRIBUTE_MAPPED`|5.0.0| | |5.0.0|
-|`CU_POINTER_ATTRIBUTE_MEMORY_TYPE`| | | |`HIP_POINTER_ATTRIBUTE_MEMORY_TYPE`|5.0.0| | |5.0.0|
-|`CU_POINTER_ATTRIBUTE_MEMPOOL_HANDLE`|11.3| | |`HIP_POINTER_ATTRIBUTE_MEMPOOL_HANDLE`|5.0.0| | |5.0.0|
-|`CU_POINTER_ATTRIBUTE_P2P_TOKENS`| | | |`HIP_POINTER_ATTRIBUTE_P2P_TOKENS`|5.0.0| | |5.0.0|
-|`CU_POINTER_ATTRIBUTE_RANGE_SIZE`|10.2| | |`HIP_POINTER_ATTRIBUTE_RANGE_SIZE`|5.0.0| | |5.0.0|
-|`CU_POINTER_ATTRIBUTE_RANGE_START_ADDR`|10.2| | |`HIP_POINTER_ATTRIBUTE_RANGE_START_ADDR`|5.0.0| | |5.0.0|
-|`CU_POINTER_ATTRIBUTE_SYNC_MEMOPS`| | | |`HIP_POINTER_ATTRIBUTE_SYNC_MEMOPS`|5.0.0| | |5.0.0|
+|`CU_POINTER_ATTRIBUTE_ALLOWED_HANDLE_TYPES`|10.2| | |`HIP_POINTER_ATTRIBUTE_ALLOWED_HANDLE_TYPES`|5.0.0| | | |
+|`CU_POINTER_ATTRIBUTE_BUFFER_ID`| | | |`HIP_POINTER_ATTRIBUTE_BUFFER_ID`|5.0.0| | | |
+|`CU_POINTER_ATTRIBUTE_CONTEXT`| | | |`HIP_POINTER_ATTRIBUTE_CONTEXT`|5.0.0| | | |
+|`CU_POINTER_ATTRIBUTE_DEVICE_ORDINAL`|9.2| | |`HIP_POINTER_ATTRIBUTE_DEVICE_ORDINAL`|5.0.0| | | |
+|`CU_POINTER_ATTRIBUTE_DEVICE_POINTER`| | | |`HIP_POINTER_ATTRIBUTE_DEVICE_POINTER`|5.0.0| | | |
+|`CU_POINTER_ATTRIBUTE_HOST_POINTER`| | | |`HIP_POINTER_ATTRIBUTE_HOST_POINTER`|5.0.0| | | |
+|`CU_POINTER_ATTRIBUTE_IS_GPU_DIRECT_RDMA_CAPABLE`|11.0| | |`HIP_POINTER_ATTRIBUTE_IS_GPU_DIRECT_RDMA_CAPABLE`|5.0.0| | | |
+|`CU_POINTER_ATTRIBUTE_IS_LEGACY_CUDA_IPC_CAPABLE`|10.2| | |`HIP_POINTER_ATTRIBUTE_IS_LEGACY_HIP_IPC_CAPABLE`|5.0.0| | | |
+|`CU_POINTER_ATTRIBUTE_IS_MANAGED`| | | |`HIP_POINTER_ATTRIBUTE_IS_MANAGED`|5.0.0| | | |
+|`CU_POINTER_ATTRIBUTE_MAPPED`|10.2| | |`HIP_POINTER_ATTRIBUTE_MAPPED`|5.0.0| | | |
+|`CU_POINTER_ATTRIBUTE_MEMORY_TYPE`| | | |`HIP_POINTER_ATTRIBUTE_MEMORY_TYPE`|5.0.0| | | |
+|`CU_POINTER_ATTRIBUTE_MEMPOOL_HANDLE`|11.3| | |`HIP_POINTER_ATTRIBUTE_MEMPOOL_HANDLE`|5.0.0| | | |
+|`CU_POINTER_ATTRIBUTE_P2P_TOKENS`| | | |`HIP_POINTER_ATTRIBUTE_P2P_TOKENS`|5.0.0| | | |
+|`CU_POINTER_ATTRIBUTE_RANGE_SIZE`|10.2| | |`HIP_POINTER_ATTRIBUTE_RANGE_SIZE`|5.0.0| | | |
+|`CU_POINTER_ATTRIBUTE_RANGE_START_ADDR`|10.2| | |`HIP_POINTER_ATTRIBUTE_RANGE_START_ADDR`|5.0.0| | | |
+|`CU_POINTER_ATTRIBUTE_SYNC_MEMOPS`| | | |`HIP_POINTER_ATTRIBUTE_SYNC_MEMOPS`|5.0.0| | | |
 |`CU_PREFER_BINARY`| | | | | | | | |
 |`CU_PREFER_PTX`| | | | | | | | |
 |`CU_RESOURCE_TYPE_ARRAY`| | | |`HIP_RESOURCE_TYPE_ARRAY`|3.5.0| | | |
@@ -767,7 +767,7 @@
 |`CU_SHARED_MEM_CONFIG_DEFAULT_BANK_SIZE`| | | |`hipSharedMemBankSizeDefault`|1.6.0| | | |
 |`CU_SHARED_MEM_CONFIG_EIGHT_BYTE_BANK_SIZE`| | | |`hipSharedMemBankSizeEightByte`|1.6.0| | | |
 |`CU_SHARED_MEM_CONFIG_FOUR_BYTE_BANK_SIZE`| | | |`hipSharedMemBankSizeFourByte`|1.6.0| | | |
-|`CU_STREAM_ADD_CAPTURE_DEPENDENCIES`|11.3| | |`hipStreamAddCaptureDependencies`|5.0.0| | |5.0.0|
+|`CU_STREAM_ADD_CAPTURE_DEPENDENCIES`|11.3| | |`hipStreamAddCaptureDependencies`|5.0.0| | | |
 |`CU_STREAM_ATTRIBUTE_ACCESS_POLICY_WINDOW`|11.0| | | | | | | |
 |`CU_STREAM_ATTRIBUTE_SYNCHRONIZATION_POLICY`|11.0| | | | | | | |
 |`CU_STREAM_CAPTURE_MODE_GLOBAL`|10.1| | |`hipStreamCaptureModeGlobal`|4.3.0| | | |
@@ -785,7 +785,7 @@
 |`CU_STREAM_MEM_OP_WRITE_VALUE_64`|9.0| | | | | | | |
 |`CU_STREAM_NON_BLOCKING`| | | |`hipStreamNonBlocking`|1.6.0| | | |
 |`CU_STREAM_PER_THREAD`| | | |`hipStreamPerThread`|4.5.0| | | |
-|`CU_STREAM_SET_CAPTURE_DEPENDENCIES`|11.3| | |`hipStreamSetCaptureDependencies`|5.0.0| | |5.0.0|
+|`CU_STREAM_SET_CAPTURE_DEPENDENCIES`|11.3| | |`hipStreamSetCaptureDependencies`|5.0.0| | | |
 |`CU_STREAM_WAIT_VALUE_AND`|8.0| | |`hipStreamWaitValueAnd`|4.2.0| | | |
 |`CU_STREAM_WAIT_VALUE_EQ`|8.0| | |`hipStreamWaitValueEq`|4.2.0| | | |
 |`CU_STREAM_WAIT_VALUE_FLUSH`|8.0| | | | | | | |
@@ -1027,8 +1027,8 @@
 |`CUoccupancyB2DSize`| | | |`void*`| | | | |
 |`CUoccupancy_flags`| | | | | | | | |
 |`CUoccupancy_flags_enum`| | | | | | | | |
-|`CUpointer_attribute`| | | |`hipPointer_attribute`|5.0.0| | |5.0.0|
-|`CUpointer_attribute_enum`| | | |`hipPointer_attribute`|5.0.0| | |5.0.0|
+|`CUpointer_attribute`| | | |`hipPointer_attribute`|5.0.0| | | |
+|`CUpointer_attribute_enum`| | | |`hipPointer_attribute`|5.0.0| | | |
 |`CUresourceViewFormat`| | | |`HIPresourceViewFormat`|3.5.0| | | |
 |`CUresourceViewFormat_enum`| | | |`HIPresourceViewFormat_enum`|3.5.0| | | |
 |`CUresourcetype`| | | |`HIPresourcetype`|3.5.0| | | |
@@ -1054,8 +1054,8 @@
 |`CUstreamCaptureMode_enum`|10.1| | |`hipStreamCaptureMode`|4.3.0| | | |
 |`CUstreamCaptureStatus`|10.0| | |`hipStreamCaptureStatus`|4.3.0| | | |
 |`CUstreamCaptureStatus_enum`|10.0| | |`hipStreamCaptureStatus`|4.3.0| | | |
-|`CUstreamUpdateCaptureDependencies_flags`|11.3| | |`hipStreamUpdateCaptureDependenciesFlags`|5.0.0| | |5.0.0|
-|`CUstreamUpdateCaptureDependencies_flags_enum`|11.3| | |`hipStreamUpdateCaptureDependenciesFlags`|5.0.0| | |5.0.0|
+|`CUstreamUpdateCaptureDependencies_flags`|11.3| | |`hipStreamUpdateCaptureDependenciesFlags`|5.0.0| | | |
+|`CUstreamUpdateCaptureDependencies_flags_enum`|11.3| | |`hipStreamUpdateCaptureDependenciesFlags`|5.0.0| | | |
 |`CUstreamWaitValue_flags`|8.0| | | | | | | |
 |`CUstreamWaitValue_flags_enum`|8.0| | | | | | | |
 |`CUstreamWriteValue_flags`|8.0| | | | | | | |
@@ -1357,8 +1357,8 @@
 |`cuMemPrefetchAsync`|8.0| | |`hipMemPrefetchAsync`|3.7.0| | | |
 |`cuMemRangeGetAttribute`|8.0| | |`hipMemRangeGetAttribute`|3.7.0| | | |
 |`cuMemRangeGetAttributes`|8.0| | |`hipMemRangeGetAttributes`|3.7.0| | | |
-|`cuPointerGetAttribute`| | | |`hipPointerGetAttribute`|5.0.0| | |5.0.0|
-|`cuPointerGetAttributes`| | | |`hipDrvPointerGetAttributes`|5.0.0| | |5.0.0|
+|`cuPointerGetAttribute`| | | |`hipPointerGetAttribute`|5.0.0| | | |
+|`cuPointerGetAttributes`| | | |`hipDrvPointerGetAttributes`|5.0.0| | | |
 |`cuPointerSetAttribute`| | | | | | | | |
 
 ## **15. Stream Management**
@@ -1377,16 +1377,16 @@
 |`cuStreamDestroy_v2`| | | |`hipStreamDestroy`|1.6.0| | | |
 |`cuStreamEndCapture`|10.0| | |`hipStreamEndCapture`|4.3.0| | | |
 |`cuStreamGetAttribute`|11.0| | | | | | | |
-|`cuStreamGetCaptureInfo`|10.1| | |`hipStreamGetCaptureInfo`|5.0.0| | |5.0.0|
-|`cuStreamGetCaptureInfo_v2`|11.3| | |`hipStreamGetCaptureInfo_v2`|5.0.0| | |5.0.0|
+|`cuStreamGetCaptureInfo`|10.1| | |`hipStreamGetCaptureInfo`|5.0.0| | | |
+|`cuStreamGetCaptureInfo_v2`|11.3| | |`hipStreamGetCaptureInfo_v2`|5.0.0| | | |
 |`cuStreamGetCtx`|9.2| | | | | | | |
 |`cuStreamGetFlags`| | | |`hipStreamGetFlags`|1.6.0| | | |
 |`cuStreamGetPriority`| | | |`hipStreamGetPriority`|2.0.0| | | |
-|`cuStreamIsCapturing`|10.0| | |`hipStreamIsCapturing`|5.0.0| | |5.0.0|
+|`cuStreamIsCapturing`|10.0| | |`hipStreamIsCapturing`|5.0.0| | | |
 |`cuStreamQuery`| | | |`hipStreamQuery`|1.6.0| | | |
 |`cuStreamSetAttribute`|11.0| | | | | | | |
 |`cuStreamSynchronize`| | | |`hipStreamSynchronize`|1.6.0| | | |
-|`cuStreamUpdateCaptureDependencies`|11.3| | |`hipStreamUpdateCaptureDependencies`|5.0.0| | |5.0.0|
+|`cuStreamUpdateCaptureDependencies`|11.3| | |`hipStreamUpdateCaptureDependencies`|5.0.0| | | |
 |`cuStreamWaitEvent`| | | |`hipStreamWaitEvent`|1.6.0| | | |
 |`cuThreadExchangeStreamCaptureMode`|10.1| | | | | | | |
 
@@ -1462,51 +1462,51 @@
 |`cuDeviceGetGraphMemAttribute`|11.4| | | | | | | |
 |`cuDeviceGraphMemTrim`|11.4| | | | | | | |
 |`cuDeviceSetGraphMemAttribute`|11.4| | | | | | | |
-|`cuGraphAddChildGraphNode`|10.0| | |`hipGraphAddChildGraphNode`|5.0.0| | |5.0.0|
+|`cuGraphAddChildGraphNode`|10.0| | |`hipGraphAddChildGraphNode`|5.0.0| | | |
 |`cuGraphAddDependencies`|10.0| | |`hipGraphAddDependencies`|4.5.0| | | |
 |`cuGraphAddEmptyNode`|10.0| | |`hipGraphAddEmptyNode`|4.5.0| | | |
-|`cuGraphAddEventRecordNode`|11.1| | |`hipGraphAddEventRecordNode`|5.0.0| | |5.0.0|
-|`cuGraphAddEventWaitNode`|11.1| | |`hipGraphAddEventWaitNode`|5.0.0| | |5.0.0|
+|`cuGraphAddEventRecordNode`|11.1| | |`hipGraphAddEventRecordNode`|5.0.0| | | |
+|`cuGraphAddEventWaitNode`|11.1| | |`hipGraphAddEventWaitNode`|5.0.0| | | |
 |`cuGraphAddExternalSemaphoresSignalNode`|11.2| | | | | | | |
 |`cuGraphAddExternalSemaphoresWaitNode`|11.2| | | | | | | |
-|`cuGraphAddHostNode`|10.0| | |`hipGraphAddHostNode`|5.0.0| | |5.0.0|
+|`cuGraphAddHostNode`|10.0| | |`hipGraphAddHostNode`|5.0.0| | | |
 |`cuGraphAddKernelNode`|10.0| | |`hipGraphAddKernelNode`|4.3.0| | | |
 |`cuGraphAddMemAllocNode`|11.4| | | | | | | |
 |`cuGraphAddMemFreeNode`|11.4| | | | | | | |
 |`cuGraphAddMemcpyNode`|10.0| | | | | | | |
 |`cuGraphAddMemsetNode`|10.0| | | | | | | |
-|`cuGraphChildGraphNodeGetGraph`|10.0| | |`hipGraphChildGraphNodeGetGraph`|5.0.0| | |5.0.0|
+|`cuGraphChildGraphNodeGetGraph`|10.0| | |`hipGraphChildGraphNodeGetGraph`|5.0.0| | | |
 |`cuGraphClone`|10.0| | | | | | | |
 |`cuGraphCreate`|10.0| | |`hipGraphCreate`|4.3.0| | | |
 |`cuGraphDebugDotPrint`|11.3| | | | | | | |
 |`cuGraphDestroy`|10.0| | |`hipGraphDestroy`|4.3.0| | | |
-|`cuGraphDestroyNode`|10.0| | |`hipGraphDestroyNode`|5.0.0| | |5.0.0|
-|`cuGraphEventRecordNodeGetEvent`|11.1| | |`hipGraphEventRecordNodeGetEvent`|5.0.0| | |5.0.0|
-|`cuGraphEventRecordNodeSetEvent`|11.1| | |`hipGraphEventRecordNodeSetEvent`|5.0.0| | |5.0.0|
-|`cuGraphEventWaitNodeGetEvent`|11.1| | |`hipGraphEventWaitNodeGetEvent`|5.0.0| | |5.0.0|
-|`cuGraphEventWaitNodeSetEvent`|11.1| | |`hipGraphEventWaitNodeSetEvent`|5.0.0| | |5.0.0|
-|`cuGraphExecChildGraphNodeSetParams`|11.1| | |`hipGraphExecChildGraphNodeSetParams`|5.0.0| | |5.0.0|
+|`cuGraphDestroyNode`|10.0| | |`hipGraphDestroyNode`|5.0.0| | | |
+|`cuGraphEventRecordNodeGetEvent`|11.1| | |`hipGraphEventRecordNodeGetEvent`|5.0.0| | | |
+|`cuGraphEventRecordNodeSetEvent`|11.1| | |`hipGraphEventRecordNodeSetEvent`|5.0.0| | | |
+|`cuGraphEventWaitNodeGetEvent`|11.1| | |`hipGraphEventWaitNodeGetEvent`|5.0.0| | | |
+|`cuGraphEventWaitNodeSetEvent`|11.1| | |`hipGraphEventWaitNodeSetEvent`|5.0.0| | | |
+|`cuGraphExecChildGraphNodeSetParams`|11.1| | |`hipGraphExecChildGraphNodeSetParams`|5.0.0| | | |
 |`cuGraphExecDestroy`|10.0| | |`hipGraphExecDestroy`|4.3.0| | | |
-|`cuGraphExecEventRecordNodeSetEvent`|11.1| | |`hipGraphExecEventRecordNodeSetEvent`|5.0.0| | |5.0.0|
-|`cuGraphExecEventWaitNodeSetEvent`|11.1| | |`hipGraphExecEventWaitNodeSetEvent`|5.0.0| | |5.0.0|
+|`cuGraphExecEventRecordNodeSetEvent`|11.1| | |`hipGraphExecEventRecordNodeSetEvent`|5.0.0| | | |
+|`cuGraphExecEventWaitNodeSetEvent`|11.1| | |`hipGraphExecEventWaitNodeSetEvent`|5.0.0| | | |
 |`cuGraphExecExternalSemaphoresSignalNodeSetParams`|11.2| | | | | | | |
 |`cuGraphExecExternalSemaphoresWaitNodeSetParams`|11.2| | | | | | | |
-|`cuGraphExecHostNodeSetParams`|10.2| | |`hipGraphExecHostNodeSetParams`|5.0.0| | |5.0.0|
+|`cuGraphExecHostNodeSetParams`|10.2| | |`hipGraphExecHostNodeSetParams`|5.0.0| | | |
 |`cuGraphExecKernelNodeSetParams`|10.1| | |`hipGraphExecKernelNodeSetParams`|4.5.0| | | |
 |`cuGraphExecMemcpyNodeSetParams`|10.2| | | | | | | |
 |`cuGraphExecMemsetNodeSetParams`|10.2| | | | | | | |
-|`cuGraphExecUpdate`|10.2| | |`hipGraphExecUpdate`|5.0.0| | |5.0.0|
+|`cuGraphExecUpdate`|10.2| | |`hipGraphExecUpdate`|5.0.0| | | |
 |`cuGraphExternalSemaphoresSignalNodeGetParams`|11.2| | | | | | | |
 |`cuGraphExternalSemaphoresSignalNodeSetParams`|11.2| | | | | | | |
 |`cuGraphExternalSemaphoresWaitNodeGetParams`|11.2| | | | | | | |
 |`cuGraphExternalSemaphoresWaitNodeSetParams`|11.2| | | | | | | |
-|`cuGraphGetEdges`|10.0| | |`hipGraphGetEdges`|5.0.0| | |5.0.0|
+|`cuGraphGetEdges`|10.0| | |`hipGraphGetEdges`|5.0.0| | | |
 |`cuGraphGetNodes`|10.0| | |`hipGraphGetNodes`|4.5.0| | | |
 |`cuGraphGetRootNodes`|10.0| | |`hipGraphGetRootNodes`|4.5.0| | | |
-|`cuGraphHostNodeGetParams`|10.0| | |`hipGraphHostNodeGetParams`|5.0.0| | |5.0.0|
-|`cuGraphHostNodeSetParams`|10.0| | |`hipGraphHostNodeSetParams`|5.0.0| | |5.0.0|
+|`cuGraphHostNodeGetParams`|10.0| | |`hipGraphHostNodeGetParams`|5.0.0| | | |
+|`cuGraphHostNodeSetParams`|10.0| | |`hipGraphHostNodeSetParams`|5.0.0| | | |
 |`cuGraphInstantiate`|10.0| | |`hipGraphInstantiate`|4.3.0| | | |
-|`cuGraphInstantiateWithFlags`|11.4| | |`hipGraphInstantiateWithFlags`|5.0.0| | |5.0.0|
+|`cuGraphInstantiateWithFlags`|11.4| | |`hipGraphInstantiateWithFlags`|5.0.0| | | |
 |`cuGraphInstantiate_v2`|11.0| | |`hipGraphInstantiate`|4.3.0| | | |
 |`cuGraphKernelNodeCopyAttributes`|11.0| | | | | | | |
 |`cuGraphKernelNodeGetAttribute`|11.0| | | | | | | |
@@ -1520,14 +1520,14 @@
 |`cuGraphMemcpyNodeSetParams`|10.0| | |`hipGraphMemcpyNodeSetParams`|4.5.0| | | |
 |`cuGraphMemsetNodeGetParams`|10.0| | |`hipGraphMemsetNodeGetParams`|4.5.0| | | |
 |`cuGraphMemsetNodeSetParams`|10.0| | |`hipGraphMemsetNodeSetParams`|4.5.0| | | |
-|`cuGraphNodeFindInClone`|10.0| | |`hipGraphNodeFindInClone`|5.0.0| | |5.0.0|
-|`cuGraphNodeGetDependencies`|10.0| | |`hipGraphNodeGetDependencies`|5.0.0| | |5.0.0|
-|`cuGraphNodeGetDependentNodes`|10.0| | |`hipGraphNodeGetDependentNodes`|5.0.0| | |5.0.0|
+|`cuGraphNodeFindInClone`|10.0| | |`hipGraphNodeFindInClone`|5.0.0| | | |
+|`cuGraphNodeGetDependencies`|10.0| | |`hipGraphNodeGetDependencies`|5.0.0| | | |
+|`cuGraphNodeGetDependentNodes`|10.0| | |`hipGraphNodeGetDependentNodes`|5.0.0| | | |
 |`cuGraphNodeGetEnabled`|11.6| | | | | | | |
-|`cuGraphNodeGetType`|10.0| | |`hipGraphNodeGetType`|5.0.0| | |5.0.0|
+|`cuGraphNodeGetType`|10.0| | |`hipGraphNodeGetType`|5.0.0| | | |
 |`cuGraphNodeSetEnabled`|11.6| | | | | | | |
 |`cuGraphReleaseUserObject`|11.3| | | | | | | |
-|`cuGraphRemoveDependencies`|10.0| | |`hipGraphRemoveDependencies`|5.0.0| | |5.0.0|
+|`cuGraphRemoveDependencies`|10.0| | |`hipGraphRemoveDependencies`|5.0.0| | | |
 |`cuGraphRetainUserObject`|11.3| | | | | | | |
 |`cuGraphUpload`|11.1| | | | | | | |
 |`cuUserObjectCreate`|11.3| | | | | | | |
@@ -1624,7 +1624,7 @@
 |`cuGraphicsResourceGetMappedPointer_v2`| | | |`hipGraphicsResourceGetMappedPointer`|4.5.0| | | |
 |`cuGraphicsResourceSetMapFlags`| | | | | | | | |
 |`cuGraphicsResourceSetMapFlags_v2`| | | | | | | | |
-|`cuGraphicsSubResourceGetMappedArray`| | | | | | | | |
+|`cuGraphicsSubResourceGetMappedArray`| | | |`hipGraphicsSubResourceGetMappedArray`|5.1.0| | |5.1.0|
 |`cuGraphicsUnmapResources`| | | |`hipGraphicsUnmapResources`|4.5.0| | | |
 |`cuGraphicsUnregisterResource`| | | |`hipGraphicsUnregisterResource`|4.5.0| | | |
 
@@ -1663,7 +1663,7 @@
 |`cuGLUnmapBufferObjectAsync`| |9.2| | | | | | |
 |`cuGLUnregisterBufferObject`| |9.2| | | | | | |
 |`cuGraphicsGLRegisterBuffer`| | | |`hipGraphicsGLRegisterBuffer`|4.5.0| | | |
-|`cuGraphicsGLRegisterImage`| | | | | | | | |
+|`cuGraphicsGLRegisterImage`| | | |`hipGraphicsGLRegisterImage`|5.1.0| | |5.1.0|
 |`cuWGLGetDevice`| | | | | | | | |
 
 ## **33. VDPAU Interoperability**

--- a/doc/markdown/CUDA_Driver_API_functions_supported_by_HIP.md
+++ b/doc/markdown/CUDA_Driver_API_functions_supported_by_HIP.md
@@ -1081,6 +1081,8 @@
 |`CUuserObject_st`|11.3| | | | | | | |
 |`CUuuid`| | | | | | | | |
 |`CUuuid_st`| | | | | | | | |
+|`GLenum`| | | |`GLenum`|5.1.0| | |5.1.0|
+|`GLuint`| | | |`GLuint`|5.1.0| | |5.1.0|
 |`__CUDACC__`| | | |`__HIPCC__`|1.6.0| | | |
 |`cudaError_enum`| | | |`hipError_t`|1.5.0| | | |
 

--- a/doc/markdown/CUDA_Runtime_API_functions_supported_by_HIP.md
+++ b/doc/markdown/CUDA_Runtime_API_functions_supported_by_HIP.md
@@ -72,10 +72,10 @@
 |`cudaStreamDestroy`| | | |`hipStreamDestroy`|1.6.0| | | |
 |`cudaStreamEndCapture`|10.0| | |`hipStreamEndCapture`|4.3.0| | | |
 |`cudaStreamGetAttribute`|11.0| | | | | | | |
-|`cudaStreamGetCaptureInfo`|10.1| | |`hipStreamGetCaptureInfo`|5.0.0| | |5.0.0|
+|`cudaStreamGetCaptureInfo`|10.1| | |`hipStreamGetCaptureInfo`|5.0.0| | | |
 |`cudaStreamGetFlags`| | | |`hipStreamGetFlags`|1.6.0| | | |
 |`cudaStreamGetPriority`| | | |`hipStreamGetPriority`|2.0.0| | | |
-|`cudaStreamIsCapturing`|10.0| | |`hipStreamIsCapturing`|5.0.0| | |5.0.0|
+|`cudaStreamIsCapturing`|10.0| | |`hipStreamIsCapturing`|5.0.0| | | |
 |`cudaStreamQuery`| | | |`hipStreamQuery`|1.6.0| | | |
 |`cudaStreamSetAttribute`|11.0| | | | | | | |
 |`cudaStreamSynchronize`| | | |`hipStreamSynchronize`|1.6.0| | | |
@@ -248,7 +248,7 @@
 |:--|:-:|:-:|:-:|:--|:-:|:-:|:-:|:-:|
 |`cudaGLGetDevices`| | | |`hipGLGetDevices`|4.5.0| | | |
 |`cudaGraphicsGLRegisterBuffer`| | | |`hipGraphicsGLRegisterBuffer`|4.5.0| | | |
-|`cudaGraphicsGLRegisterImage`| | | | | | | | |
+|`cudaGraphicsGLRegisterImage`| | | |`hipGraphicsGLRegisterImage`|5.1.0| | |5.1.0|
 |`cudaWGLGetDevice`| | | | | | | | |
 
 ## **15. OpenGL Interoperability [DEPRECATED]**
@@ -363,7 +363,7 @@
 |`cudaGraphicsResourceGetMappedMipmappedArray`| | | | | | | | |
 |`cudaGraphicsResourceGetMappedPointer`| | | |`hipGraphicsResourceGetMappedPointer`|4.5.0| | | |
 |`cudaGraphicsResourceSetMapFlags`| | | | | | | | |
-|`cudaGraphicsSubResourceGetMappedArray`| | | | | | | | |
+|`cudaGraphicsSubResourceGetMappedArray`| | | |`hipGraphicsSubResourceGetMappedArray`|5.1.0| | |5.1.0|
 |`cudaGraphicsUnmapResources`| | | |`hipGraphicsUnmapResources`|4.5.0| | | |
 |`cudaGraphicsUnregisterResource`| | | |`hipGraphicsUnregisterResource`|4.5.0| | | |
 
@@ -420,57 +420,57 @@
 |`cudaDeviceGetGraphMemAttribute`|11.4| | | | | | | |
 |`cudaDeviceGraphMemTrim`|11.4| | | | | | | |
 |`cudaDeviceSetGraphMemAttribute`|11.4| | | | | | | |
-|`cudaGraphAddChildGraphNode`|10.0| | |`hipGraphAddChildGraphNode`|5.0.0| | |5.0.0|
+|`cudaGraphAddChildGraphNode`|10.0| | |`hipGraphAddChildGraphNode`|5.0.0| | | |
 |`cudaGraphAddDependencies`|10.0| | |`hipGraphAddDependencies`|4.5.0| | | |
 |`cudaGraphAddEmptyNode`|10.0| | |`hipGraphAddEmptyNode`|4.5.0| | | |
-|`cudaGraphAddEventRecordNode`|11.1| | |`hipGraphAddEventRecordNode`|5.0.0| | |5.0.0|
-|`cudaGraphAddEventWaitNode`|11.1| | |`hipGraphAddEventWaitNode`|5.0.0| | |5.0.0|
+|`cudaGraphAddEventRecordNode`|11.1| | |`hipGraphAddEventRecordNode`|5.0.0| | | |
+|`cudaGraphAddEventWaitNode`|11.1| | |`hipGraphAddEventWaitNode`|5.0.0| | | |
 |`cudaGraphAddExternalSemaphoresSignalNode`|11.2| | | | | | | |
 |`cudaGraphAddExternalSemaphoresWaitNode`|11.2| | | | | | | |
-|`cudaGraphAddHostNode`|10.0| | |`hipGraphAddHostNode`|5.0.0| | |5.0.0|
+|`cudaGraphAddHostNode`|10.0| | |`hipGraphAddHostNode`|5.0.0| | | |
 |`cudaGraphAddKernelNode`|10.0| | |`hipGraphAddKernelNode`|4.3.0| | | |
 |`cudaGraphAddMemAllocNode`|11.4| | | | | | | |
 |`cudaGraphAddMemFreeNode`|11.4| | | | | | | |
 |`cudaGraphAddMemcpyNode`|10.0| | |`hipGraphAddMemcpyNode`|4.3.0| | | |
 |`cudaGraphAddMemcpyNode1D`|11.1| | |`hipGraphAddMemcpyNode1D`|4.5.0| | | |
-|`cudaGraphAddMemcpyNodeFromSymbol`|11.1| | |`hipGraphAddMemcpyNodeFromSymbol`|5.0.0| | |5.0.0|
-|`cudaGraphAddMemcpyNodeToSymbol`|11.1| | |`hipGraphAddMemcpyNodeToSymbol`|5.0.0| | |5.0.0|
+|`cudaGraphAddMemcpyNodeFromSymbol`|11.1| | |`hipGraphAddMemcpyNodeFromSymbol`|5.0.0| | | |
+|`cudaGraphAddMemcpyNodeToSymbol`|11.1| | |`hipGraphAddMemcpyNodeToSymbol`|5.0.0| | | |
 |`cudaGraphAddMemsetNode`|10.0| | |`hipGraphAddMemsetNode`|4.3.0| | | |
-|`cudaGraphChildGraphNodeGetGraph`|10.0| | |`hipGraphChildGraphNodeGetGraph`|5.0.0| | |5.0.0|
+|`cudaGraphChildGraphNodeGetGraph`|10.0| | |`hipGraphChildGraphNodeGetGraph`|5.0.0| | | |
 |`cudaGraphClone`|10.0| | | | | | | |
 |`cudaGraphCreate`|10.0| | |`hipGraphCreate`|4.3.0| | | |
 |`cudaGraphDebugDotPrint`|11.3| | | | | | | |
 |`cudaGraphDestroy`|10.0| | |`hipGraphDestroy`|4.3.0| | | |
-|`cudaGraphDestroyNode`|10.0| | |`hipGraphDestroyNode`|5.0.0| | |5.0.0|
-|`cudaGraphEventRecordNodeGetEvent`|11.1| | |`hipGraphEventRecordNodeGetEvent`|5.0.0| | |5.0.0|
-|`cudaGraphEventRecordNodeSetEvent`|11.1| | |`hipGraphEventRecordNodeSetEvent`|5.0.0| | |5.0.0|
-|`cudaGraphEventWaitNodeGetEvent`|11.1| | |`hipGraphEventWaitNodeGetEvent`|5.0.0| | |5.0.0|
-|`cudaGraphEventWaitNodeSetEvent`|11.1| | |`hipGraphEventWaitNodeSetEvent`|5.0.0| | |5.0.0|
-|`cudaGraphExecChildGraphNodeSetParams`|11.1| | |`hipGraphExecChildGraphNodeSetParams`|5.0.0| | |5.0.0|
+|`cudaGraphDestroyNode`|10.0| | |`hipGraphDestroyNode`|5.0.0| | | |
+|`cudaGraphEventRecordNodeGetEvent`|11.1| | |`hipGraphEventRecordNodeGetEvent`|5.0.0| | | |
+|`cudaGraphEventRecordNodeSetEvent`|11.1| | |`hipGraphEventRecordNodeSetEvent`|5.0.0| | | |
+|`cudaGraphEventWaitNodeGetEvent`|11.1| | |`hipGraphEventWaitNodeGetEvent`|5.0.0| | | |
+|`cudaGraphEventWaitNodeSetEvent`|11.1| | |`hipGraphEventWaitNodeSetEvent`|5.0.0| | | |
+|`cudaGraphExecChildGraphNodeSetParams`|11.1| | |`hipGraphExecChildGraphNodeSetParams`|5.0.0| | | |
 |`cudaGraphExecDestroy`|10.0| | |`hipGraphExecDestroy`|4.3.0| | | |
-|`cudaGraphExecEventRecordNodeSetEvent`|11.1| | |`hipGraphExecEventRecordNodeSetEvent`|5.0.0| | |5.0.0|
-|`cudaGraphExecEventWaitNodeSetEvent`|11.1| | |`hipGraphExecEventWaitNodeSetEvent`|5.0.0| | |5.0.0|
+|`cudaGraphExecEventRecordNodeSetEvent`|11.1| | |`hipGraphExecEventRecordNodeSetEvent`|5.0.0| | | |
+|`cudaGraphExecEventWaitNodeSetEvent`|11.1| | |`hipGraphExecEventWaitNodeSetEvent`|5.0.0| | | |
 |`cudaGraphExecExternalSemaphoresSignalNodeSetParams`|11.2| | | | | | | |
 |`cudaGraphExecExternalSemaphoresWaitNodeSetParams`|11.2| | | | | | | |
-|`cudaGraphExecHostNodeSetParams`|11.0| | |`hipGraphExecHostNodeSetParams`|5.0.0| | |5.0.0|
+|`cudaGraphExecHostNodeSetParams`|11.0| | |`hipGraphExecHostNodeSetParams`|5.0.0| | | |
 |`cudaGraphExecKernelNodeSetParams`|11.0| | |`hipGraphExecKernelNodeSetParams`|4.5.0| | | |
-|`cudaGraphExecMemcpyNodeSetParams`|11.0| | |`hipGraphExecMemcpyNodeSetParams`|5.0.0| | |5.0.0|
-|`cudaGraphExecMemcpyNodeSetParams1D`|11.1| | |`hipGraphExecMemcpyNodeSetParams1D`|5.0.0| | |5.0.0|
-|`cudaGraphExecMemcpyNodeSetParamsFromSymbol`|11.1| | |`hipGraphExecMemcpyNodeSetParamsFromSymbol`|5.0.0| | |5.0.0|
-|`cudaGraphExecMemcpyNodeSetParamsToSymbol`|11.1| | |`hipGraphExecMemcpyNodeSetParamsToSymbol`|5.0.0| | |5.0.0|
-|`cudaGraphExecMemsetNodeSetParams`|11.0| | |`hipGraphExecMemsetNodeSetParams`|5.0.0| | |5.0.0|
-|`cudaGraphExecUpdate`|11.0| | |`hipGraphExecUpdate`|5.0.0| | |5.0.0|
+|`cudaGraphExecMemcpyNodeSetParams`|11.0| | |`hipGraphExecMemcpyNodeSetParams`|5.0.0| | | |
+|`cudaGraphExecMemcpyNodeSetParams1D`|11.1| | |`hipGraphExecMemcpyNodeSetParams1D`|5.0.0| | | |
+|`cudaGraphExecMemcpyNodeSetParamsFromSymbol`|11.1| | |`hipGraphExecMemcpyNodeSetParamsFromSymbol`|5.0.0| | | |
+|`cudaGraphExecMemcpyNodeSetParamsToSymbol`|11.1| | |`hipGraphExecMemcpyNodeSetParamsToSymbol`|5.0.0| | | |
+|`cudaGraphExecMemsetNodeSetParams`|11.0| | |`hipGraphExecMemsetNodeSetParams`|5.0.0| | | |
+|`cudaGraphExecUpdate`|11.0| | |`hipGraphExecUpdate`|5.0.0| | | |
 |`cudaGraphExternalSemaphoresSignalNodeGetParams`|11.2| | | | | | | |
 |`cudaGraphExternalSemaphoresSignalNodeSetParams`|11.2| | | | | | | |
 |`cudaGraphExternalSemaphoresWaitNodeGetParams`|11.2| | | | | | | |
 |`cudaGraphExternalSemaphoresWaitNodeSetParams`|11.2| | | | | | | |
-|`cudaGraphGetEdges`|10.0| | |`hipGraphGetEdges`|5.0.0| | |5.0.0|
+|`cudaGraphGetEdges`|10.0| | |`hipGraphGetEdges`|5.0.0| | | |
 |`cudaGraphGetNodes`|10.0| | |`hipGraphGetNodes`|4.5.0| | | |
 |`cudaGraphGetRootNodes`|10.0| | |`hipGraphGetRootNodes`|4.5.0| | | |
-|`cudaGraphHostNodeGetParams`|10.0| | |`hipGraphHostNodeGetParams`|5.0.0| | |5.0.0|
-|`cudaGraphHostNodeSetParams`|10.0| | |`hipGraphHostNodeSetParams`|5.0.0| | |5.0.0|
+|`cudaGraphHostNodeGetParams`|10.0| | |`hipGraphHostNodeGetParams`|5.0.0| | | |
+|`cudaGraphHostNodeSetParams`|10.0| | |`hipGraphHostNodeSetParams`|5.0.0| | | |
 |`cudaGraphInstantiate`|10.0| | |`hipGraphInstantiate`|4.3.0| | | |
-|`cudaGraphInstantiateWithFlags`|11.4| | |`hipGraphInstantiateWithFlags`|5.0.0| | |5.0.0|
+|`cudaGraphInstantiateWithFlags`|11.4| | |`hipGraphInstantiateWithFlags`|5.0.0| | | |
 |`cudaGraphKernelNodeCopyAttributes`|11.0| | | | | | | |
 |`cudaGraphKernelNodeGetAttribute`|11.0| | | | | | | |
 |`cudaGraphKernelNodeGetParams`|11.0| | |`hipGraphKernelNodeGetParams`|4.5.0| | | |
@@ -481,18 +481,18 @@
 |`cudaGraphMemFreeNodeGetParams`|11.4| | | | | | | |
 |`cudaGraphMemcpyNodeGetParams`|11.0| | |`hipGraphMemcpyNodeGetParams`|4.5.0| | | |
 |`cudaGraphMemcpyNodeSetParams`|11.0| | |`hipGraphMemcpyNodeSetParams`|4.5.0| | | |
-|`cudaGraphMemcpyNodeSetParams1D`|11.1| | |`hipGraphMemcpyNodeSetParams1D`|5.0.0| | |5.0.0|
-|`cudaGraphMemcpyNodeSetParamsFromSymbol`|11.1| | |`hipGraphMemcpyNodeSetParamsFromSymbol`|5.0.0| | |5.0.0|
-|`cudaGraphMemcpyNodeSetParamsToSymbol`|11.1| | |`hipGraphMemcpyNodeSetParamsToSymbol`|5.0.0| | |5.0.0|
+|`cudaGraphMemcpyNodeSetParams1D`|11.1| | |`hipGraphMemcpyNodeSetParams1D`|5.0.0| | | |
+|`cudaGraphMemcpyNodeSetParamsFromSymbol`|11.1| | |`hipGraphMemcpyNodeSetParamsFromSymbol`|5.0.0| | | |
+|`cudaGraphMemcpyNodeSetParamsToSymbol`|11.1| | |`hipGraphMemcpyNodeSetParamsToSymbol`|5.0.0| | | |
 |`cudaGraphMemsetNodeGetParams`|11.0| | |`hipGraphMemsetNodeGetParams`|4.5.0| | | |
 |`cudaGraphMemsetNodeSetParams`|11.0| | |`hipGraphMemsetNodeSetParams`|4.5.0| | | |
-|`cudaGraphNodeFindInClone`|11.0| | |`hipGraphNodeFindInClone`|5.0.0| | |5.0.0|
-|`cudaGraphNodeGetDependencies`|11.0| | |`hipGraphNodeGetDependencies`|5.0.0| | |5.0.0|
-|`cudaGraphNodeGetDependentNodes`|11.0| | |`hipGraphNodeGetDependentNodes`|5.0.0| | |5.0.0|
-|`cudaGraphNodeGetType`|11.0| | |`hipGraphNodeGetType`|5.0.0| | |5.0.0|
+|`cudaGraphNodeFindInClone`|11.0| | |`hipGraphNodeFindInClone`|5.0.0| | | |
+|`cudaGraphNodeGetDependencies`|11.0| | |`hipGraphNodeGetDependencies`|5.0.0| | | |
+|`cudaGraphNodeGetDependentNodes`|11.0| | |`hipGraphNodeGetDependentNodes`|5.0.0| | | |
+|`cudaGraphNodeGetType`|11.0| | |`hipGraphNodeGetType`|5.0.0| | | |
 |`cudaGraphNodeSetEnabled`|11.6| | | | | | | |
 |`cudaGraphReleaseUserObject`|11.3| | | | | | | |
-|`cudaGraphRemoveDependencies`|11.0| | |`hipGraphRemoveDependencies`|5.0.0| | |5.0.0|
+|`cudaGraphRemoveDependencies`|11.0| | |`hipGraphRemoveDependencies`|5.0.0| | | |
 |`cudaGraphRetainUserObject`|11.3| | | | | | | |
 |`cudaGraphUpload`|11.1| | | | | | | |
 |`cudaUserObjectCreate`|11.3| | | | | | | |
@@ -886,13 +886,13 @@ Unsupported
 |`cudaErrorECCUncorrectable`| | | |`hipErrorECCNotCorrectable`|1.6.0| | | |
 |`cudaErrorExternalDevice`| | | | | | | | |
 |`cudaErrorFileNotFound`|10.1| | |`hipErrorFileNotFound`|1.6.0| | | |
-|`cudaErrorGraphExecUpdateFailure`|10.2| | |`hipErrorGraphExecUpdateFailure`|5.0.0| | |5.0.0|
+|`cudaErrorGraphExecUpdateFailure`|10.2| | |`hipErrorGraphExecUpdateFailure`|5.0.0| | | |
 |`cudaErrorHardwareStackError`| | | | | | | | |
 |`cudaErrorHostMemoryAlreadyRegistered`| | | |`hipErrorHostMemoryAlreadyRegistered`|1.6.0| | | |
 |`cudaErrorHostMemoryNotRegistered`| | | |`hipErrorHostMemoryNotRegistered`|1.6.0| | | |
 |`cudaErrorIllegalAddress`| | | |`hipErrorIllegalAddress`|1.6.0| | | |
 |`cudaErrorIllegalInstruction`| | | | | | | | |
-|`cudaErrorIllegalState`|10.0| | |`hipErrorIllegalState`|5.0.0| | |5.0.0|
+|`cudaErrorIllegalState`|10.0| | |`hipErrorIllegalState`|5.0.0| | | |
 |`cudaErrorIncompatibleDriverContext`| | | | | | | | |
 |`cudaErrorInitializationError`| | | |`hipErrorNotInitialized`|1.6.0| | | |
 |`cudaErrorInsufficientDriver`| | | |`hipErrorInsufficientDriver`|1.7.0| | | |
@@ -1289,7 +1289,7 @@ Unsupported
 |`cudaSharedmemCarveoutDefault`|9.0| | | | | | | |
 |`cudaSharedmemCarveoutMaxL1`|9.0| | | | | | | |
 |`cudaSharedmemCarveoutMaxShared`|9.0| | | | | | | |
-|`cudaStreamAddCaptureDependencies`|11.3| | |`hipStreamAddCaptureDependencies`|5.0.0| | |5.0.0|
+|`cudaStreamAddCaptureDependencies`|11.3| | |`hipStreamAddCaptureDependencies`|5.0.0| | | |
 |`cudaStreamAttrID`|11.0| | | | | | | |
 |`cudaStreamAttrValue`|11.0| | | | | | | |
 |`cudaStreamAttributeAccessPolicyWindow`|11.0| | | | | | | |
@@ -1307,8 +1307,8 @@ Unsupported
 |`cudaStreamLegacy`| | | | | | | | |
 |`cudaStreamNonBlocking`| | | |`hipStreamNonBlocking`|1.6.0| | | |
 |`cudaStreamPerThread`| | | |`hipStreamPerThread`|4.5.0| | | |
-|`cudaStreamSetCaptureDependencies`|11.3| | |`hipStreamSetCaptureDependencies`|5.0.0| | |5.0.0|
-|`cudaStreamUpdateCaptureDependenciesFlags`|11.3| | |`hipStreamUpdateCaptureDependenciesFlags`|5.0.0| | |5.0.0|
+|`cudaStreamSetCaptureDependencies`|11.3| | |`hipStreamSetCaptureDependencies`|5.0.0| | | |
+|`cudaStreamUpdateCaptureDependenciesFlags`|11.3| | |`hipStreamUpdateCaptureDependenciesFlags`|5.0.0| | | |
 |`cudaStream_t`| | | |`hipStream_t`|1.5.0| | | |
 |`cudaSuccess`| | | |`hipSuccess`|1.5.0| | | |
 |`cudaSurfaceBoundaryMode`| | | |`hipSurfaceBoundaryMode`|1.9.0| | | |

--- a/src/CUDA2HIP_Driver_API_functions.cpp
+++ b/src/CUDA2HIP_Driver_API_functions.cpp
@@ -397,10 +397,10 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_FUNCTION_MAP {
   // cudaMemRangeGetAttributes
   {"cuMemRangeGetAttributes",                              {"hipMemRangeGetAttributes",                                "", CONV_ADDRESSING, API_DRIVER, 14}},
   // no analogue
-  {"cuPointerGetAttribute",                                {"hipPointerGetAttribute",                                  "", CONV_ADDRESSING, API_DRIVER, 14, HIP_EXPERIMENTAL}},
+  {"cuPointerGetAttribute",                                {"hipPointerGetAttribute",                                  "", CONV_ADDRESSING, API_DRIVER, 14}},
   // no analogue
   // NOTE: Not equal to cudaPointerGetAttributes due to different signatures
-  {"cuPointerGetAttributes",                               {"hipDrvPointerGetAttributes",                              "", CONV_ADDRESSING, API_DRIVER, 14, HIP_EXPERIMENTAL}},
+  {"cuPointerGetAttributes",                               {"hipDrvPointerGetAttributes",                              "", CONV_ADDRESSING, API_DRIVER, 14}},
   // no analogue
   {"cuPointerSetAttribute",                                {"hipPointerSetAttribute",                                  "", CONV_ADDRESSING, API_DRIVER, 14, HIP_UNSUPPORTED}},
 
@@ -427,10 +427,10 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_FUNCTION_MAP {
   // cudaStreamGetAttribute
   {"cuStreamGetAttribute",                                 {"hipStreamGetAttribute",                                   "", CONV_STREAM, API_DRIVER, 15, HIP_UNSUPPORTED}},
   // cudaStreamGetCaptureInfo
-  {"cuStreamGetCaptureInfo",                               {"hipStreamGetCaptureInfo",                                 "", CONV_STREAM, API_DRIVER, 15, HIP_EXPERIMENTAL}},
-  {"cuStreamGetCaptureInfo_v2",                            {"hipStreamGetCaptureInfo_v2",                              "", CONV_STREAM, API_DRIVER, 15, HIP_EXPERIMENTAL}},
+  {"cuStreamGetCaptureInfo",                               {"hipStreamGetCaptureInfo",                                 "", CONV_STREAM, API_DRIVER, 15}},
+  {"cuStreamGetCaptureInfo_v2",                            {"hipStreamGetCaptureInfo_v2",                              "", CONV_STREAM, API_DRIVER, 15}},
   //
-  {"cuStreamUpdateCaptureDependencies",                    {"hipStreamUpdateCaptureDependencies",                      "", CONV_STREAM, API_DRIVER, 15, HIP_EXPERIMENTAL}},
+  {"cuStreamUpdateCaptureDependencies",                    {"hipStreamUpdateCaptureDependencies",                      "", CONV_STREAM, API_DRIVER, 15}},
   // no analogue
   {"cuStreamGetCtx",                                       {"hipStreamGetContext",                                     "", CONV_STREAM, API_DRIVER, 15, HIP_UNSUPPORTED}},
   // cudaStreamGetFlags
@@ -438,7 +438,7 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_FUNCTION_MAP {
   // cudaStreamGetPriority
   {"cuStreamGetPriority",                                  {"hipStreamGetPriority",                                    "", CONV_STREAM, API_DRIVER, 15}},
   // cudaStreamIsCapturing
-  {"cuStreamIsCapturing",                                  {"hipStreamIsCapturing",                                    "", CONV_STREAM, API_DRIVER, 15, HIP_EXPERIMENTAL}},
+  {"cuStreamIsCapturing",                                  {"hipStreamIsCapturing",                                    "", CONV_STREAM, API_DRIVER, 15}},
   // cudaStreamQuery
   {"cuStreamQuery",                                        {"hipStreamQuery",                                          "", CONV_STREAM, API_DRIVER, 15}},
   // cudaStreamSetAttribute
@@ -553,13 +553,13 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_FUNCTION_MAP {
 
   // 21. Graph Management
   // cudaGraphAddChildGraphNode
-  {"cuGraphAddChildGraphNode",                             {"hipGraphAddChildGraphNode",                               "", CONV_GRAPH, API_DRIVER, 21, HIP_EXPERIMENTAL}},
+  {"cuGraphAddChildGraphNode",                             {"hipGraphAddChildGraphNode",                               "", CONV_GRAPH, API_DRIVER, 21}},
   // cudaGraphAddDependencies
   {"cuGraphAddDependencies",                               {"hipGraphAddDependencies",                                 "", CONV_GRAPH, API_DRIVER, 21}},
   // cudaGraphAddEmptyNode
   {"cuGraphAddEmptyNode",                                  {"hipGraphAddEmptyNode",                                    "", CONV_GRAPH, API_DRIVER, 21}},
   // cudaGraphAddHostNode
-  {"cuGraphAddHostNode",                                   {"hipGraphAddHostNode",                                     "", CONV_GRAPH, API_DRIVER, 21, HIP_EXPERIMENTAL}},
+  {"cuGraphAddHostNode",                                   {"hipGraphAddHostNode",                                     "", CONV_GRAPH, API_DRIVER, 21}},
   // cudaGraphAddKernelNode
   {"cuGraphAddKernelNode",                                 {"hipGraphAddKernelNode",                                   "", CONV_GRAPH, API_DRIVER, 21}},
   // no analogue
@@ -573,7 +573,7 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_FUNCTION_MAP {
   // RUNTIME: cudaError_t CUDARTAPI cudaGraphAddMemcpyNode(cudaGraphNode_t *pGraphNode, cudaGraph_t graph, const cudaGraphNode_t *pDependencies, size_t numDependencies, const struct cudaMemcpy3DParms *pCopyParams);
   {"cuGraphAddMemsetNode",                                 {"hipGraphAddMemsetNode",                                   "", CONV_GRAPH, API_DRIVER, 21, HIP_UNSUPPORTED}},
   // cudaGraphChildGraphNodeGetGraph
-  {"cuGraphChildGraphNodeGetGraph",                        {"hipGraphChildGraphNodeGetGraph",                          "", CONV_GRAPH, API_DRIVER, 21, HIP_EXPERIMENTAL}},
+  {"cuGraphChildGraphNodeGetGraph",                        {"hipGraphChildGraphNodeGetGraph",                          "", CONV_GRAPH, API_DRIVER, 21}},
   // cudaGraphClone
   {"cuGraphClone",                                         {"hipGraphClone",                                           "", CONV_GRAPH, API_DRIVER, 21, HIP_UNSUPPORTED}},
   // cudaGraphCreate
@@ -583,19 +583,19 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_FUNCTION_MAP {
   // cudaGraphDestroy
   {"cuGraphDestroy",                                       {"hipGraphDestroy",                                         "", CONV_GRAPH, API_DRIVER, 21}},
   // cudaGraphDestroyNode
-  {"cuGraphDestroyNode",                                   {"hipGraphDestroyNode",                                     "", CONV_GRAPH, API_DRIVER, 21, HIP_EXPERIMENTAL}},
+  {"cuGraphDestroyNode",                                   {"hipGraphDestroyNode",                                     "", CONV_GRAPH, API_DRIVER, 21}},
   // cudaGraphExecDestroy
   {"cuGraphExecDestroy",                                   {"hipGraphExecDestroy",                                     "", CONV_GRAPH, API_DRIVER, 21}},
   // cudaGraphGetEdges
-  {"cuGraphGetEdges",                                      {"hipGraphGetEdges",                                        "", CONV_GRAPH, API_DRIVER, 21, HIP_EXPERIMENTAL}},
+  {"cuGraphGetEdges",                                      {"hipGraphGetEdges",                                        "", CONV_GRAPH, API_DRIVER, 21}},
   // cudaGraphGetNodes
   {"cuGraphGetNodes",                                      {"hipGraphGetNodes",                                        "", CONV_GRAPH, API_DRIVER, 21}},
   // cudaGraphGetRootNodes
   {"cuGraphGetRootNodes",                                  {"hipGraphGetRootNodes",                                    "", CONV_GRAPH, API_DRIVER, 21}},
   // cudaGraphHostNodeGetParams
-  {"cuGraphHostNodeGetParams",                             {"hipGraphHostNodeGetParams",                               "", CONV_GRAPH, API_DRIVER, 21, HIP_EXPERIMENTAL}},
+  {"cuGraphHostNodeGetParams",                             {"hipGraphHostNodeGetParams",                               "", CONV_GRAPH, API_DRIVER, 21}},
   // cudaGraphHostNodeSetParams
-  {"cuGraphHostNodeSetParams",                             {"hipGraphHostNodeSetParams",                               "", CONV_GRAPH, API_DRIVER, 21, HIP_EXPERIMENTAL}},
+  {"cuGraphHostNodeSetParams",                             {"hipGraphHostNodeSetParams",                               "", CONV_GRAPH, API_DRIVER, 21}},
   // cudaGraphInstantiate
   {"cuGraphInstantiate",                                   {"hipGraphInstantiate",                                     "", CONV_GRAPH, API_DRIVER, 21}},
   {"cuGraphInstantiate_v2",                                {"hipGraphInstantiate",                                     "", CONV_GRAPH, API_DRIVER, 21}},
@@ -622,19 +622,19 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_FUNCTION_MAP {
   // cudaGraphMemsetNodeSetParams
   {"cuGraphMemsetNodeSetParams",                           {"hipGraphMemsetNodeSetParams",                             "", CONV_GRAPH, API_DRIVER, 21}},
   // cudaGraphNodeFindInClone
-  {"cuGraphNodeFindInClone",                               {"hipGraphNodeFindInClone",                                 "", CONV_GRAPH, API_DRIVER, 21, HIP_EXPERIMENTAL}},
+  {"cuGraphNodeFindInClone",                               {"hipGraphNodeFindInClone",                                 "", CONV_GRAPH, API_DRIVER, 21}},
   // cudaGraphNodeGetDependencies
-  {"cuGraphNodeGetDependencies",                           {"hipGraphNodeGetDependencies",                             "", CONV_GRAPH, API_DRIVER, 21, HIP_EXPERIMENTAL}},
+  {"cuGraphNodeGetDependencies",                           {"hipGraphNodeGetDependencies",                             "", CONV_GRAPH, API_DRIVER, 21}},
   // cudaGraphNodeGetDependentNodes
-  {"cuGraphNodeGetDependentNodes",                         {"hipGraphNodeGetDependentNodes",                           "", CONV_GRAPH, API_DRIVER, 21, HIP_EXPERIMENTAL}},
+  {"cuGraphNodeGetDependentNodes",                         {"hipGraphNodeGetDependentNodes",                           "", CONV_GRAPH, API_DRIVER, 21}},
   //
   {"cuGraphNodeGetEnabled",                                {"hipGraphNodeGetEnabled",                                  "", CONV_GRAPH, API_DRIVER, 21, HIP_UNSUPPORTED}},
   // cudaGraphNodeGetType
-  {"cuGraphNodeGetType",                                   {"hipGraphNodeGetType",                                     "", CONV_GRAPH, API_DRIVER, 21, HIP_EXPERIMENTAL}},
+  {"cuGraphNodeGetType",                                   {"hipGraphNodeGetType",                                     "", CONV_GRAPH, API_DRIVER, 21}},
   // cudaGraphNodeSetEnabled
   {"cuGraphNodeSetEnabled",                                {"hipGraphNodeSetEnabled",                                  "", CONV_GRAPH, API_DRIVER, 21, HIP_UNSUPPORTED}},
   // cudaGraphRemoveDependencies
-  {"cuGraphRemoveDependencies",                            {"hipGraphRemoveDependencies",                              "", CONV_GRAPH, API_DRIVER, 21, HIP_EXPERIMENTAL}},
+  {"cuGraphRemoveDependencies",                            {"hipGraphRemoveDependencies",                              "", CONV_GRAPH, API_DRIVER, 21}},
   // no analogue
   // NOTE: Not equal to cudaGraphExecMemcpyNodeSetParams due to different signatures:
   // DRIVER: CUresult CUDAAPI cuGraphExecMemcpyNodeSetParams(CUgraphExec hGraphExec, CUgraphNode hNode, const CUDA_MEMCPY3D *copyParams, CUcontext ctx);
@@ -646,27 +646,27 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_FUNCTION_MAP {
   // RUNTIME: cudaError_t CUDARTAPI cudaGraphExecMemsetNodeSetParams(cudaGraphExec_t hGraphExec, cudaGraphNode_t node, const struct cudaMemsetParams *pNodeParams);
   {"cuGraphExecMemsetNodeSetParams",                       {"hipGraphExecMemsetNodeSetParams",                         "", CONV_GRAPH, API_DRIVER, 21, HIP_UNSUPPORTED}},
   // cudaGraphExecHostNodeSetParams
-  {"cuGraphExecHostNodeSetParams",                         {"hipGraphExecHostNodeSetParams",                           "", CONV_GRAPH, API_DRIVER, 21, HIP_EXPERIMENTAL}},
+  {"cuGraphExecHostNodeSetParams",                         {"hipGraphExecHostNodeSetParams",                           "", CONV_GRAPH, API_DRIVER, 21}},
   // cudaGraphExecUpdate
-  {"cuGraphExecUpdate",                                    {"hipGraphExecUpdate",                                      "", CONV_GRAPH, API_DRIVER, 21, HIP_EXPERIMENTAL}},
+  {"cuGraphExecUpdate",                                    {"hipGraphExecUpdate",                                      "", CONV_GRAPH, API_DRIVER, 21}},
   // cudaGraphAddEventRecordNode
-  {"cuGraphAddEventRecordNode",                            {"hipGraphAddEventRecordNode",                              "", CONV_GRAPH, API_DRIVER, 21, HIP_EXPERIMENTAL}},
+  {"cuGraphAddEventRecordNode",                            {"hipGraphAddEventRecordNode",                              "", CONV_GRAPH, API_DRIVER, 21}},
   // cudaGraphEventRecordNodeGetEvent
-  {"cuGraphEventRecordNodeGetEvent",                       {"hipGraphEventRecordNodeGetEvent",                         "", CONV_GRAPH, API_DRIVER, 21, HIP_EXPERIMENTAL}},
+  {"cuGraphEventRecordNodeGetEvent",                       {"hipGraphEventRecordNodeGetEvent",                         "", CONV_GRAPH, API_DRIVER, 21}},
   // cudaGraphEventRecordNodeSetEvent
-  {"cuGraphEventRecordNodeSetEvent",                       {"hipGraphEventRecordNodeSetEvent",                         "", CONV_GRAPH, API_DRIVER, 21, HIP_EXPERIMENTAL}},
+  {"cuGraphEventRecordNodeSetEvent",                       {"hipGraphEventRecordNodeSetEvent",                         "", CONV_GRAPH, API_DRIVER, 21}},
   // cudaGraphAddEventWaitNode
-  {"cuGraphAddEventWaitNode",                              {"hipGraphAddEventWaitNode",                                "", CONV_GRAPH, API_DRIVER, 21, HIP_EXPERIMENTAL}},
+  {"cuGraphAddEventWaitNode",                              {"hipGraphAddEventWaitNode",                                "", CONV_GRAPH, API_DRIVER, 21}},
   // cudaGraphEventWaitNodeGetEvent
-  {"cuGraphEventWaitNodeGetEvent",                         {"hipGraphEventWaitNodeGetEvent",                           "", CONV_GRAPH, API_DRIVER, 21, HIP_EXPERIMENTAL}},
+  {"cuGraphEventWaitNodeGetEvent",                         {"hipGraphEventWaitNodeGetEvent",                           "", CONV_GRAPH, API_DRIVER, 21}},
   // cudaGraphEventWaitNodeSetEvent
-  {"cuGraphEventWaitNodeSetEvent",                         {"hipGraphEventWaitNodeSetEvent",                           "", CONV_GRAPH, API_DRIVER, 21, HIP_EXPERIMENTAL}},
+  {"cuGraphEventWaitNodeSetEvent",                         {"hipGraphEventWaitNodeSetEvent",                           "", CONV_GRAPH, API_DRIVER, 21}},
   // cudaGraphExecChildGraphNodeSetParams
-  {"cuGraphExecChildGraphNodeSetParams",                   {"hipGraphExecChildGraphNodeSetParams",                     "", CONV_GRAPH, API_DRIVER, 21, HIP_EXPERIMENTAL}},
+  {"cuGraphExecChildGraphNodeSetParams",                   {"hipGraphExecChildGraphNodeSetParams",                     "", CONV_GRAPH, API_DRIVER, 21}},
   // cudaGraphExecEventRecordNodeSetEvent
-  {"cuGraphExecEventRecordNodeSetEvent",                   {"hipGraphExecEventRecordNodeSetEvent",                     "", CONV_GRAPH, API_DRIVER, 21, HIP_EXPERIMENTAL}},
+  {"cuGraphExecEventRecordNodeSetEvent",                   {"hipGraphExecEventRecordNodeSetEvent",                     "", CONV_GRAPH, API_DRIVER, 21}},
   // cudaGraphExecEventWaitNodeSetEvent
-  {"cuGraphExecEventWaitNodeSetEvent",                     {"hipGraphExecEventWaitNodeSetEvent",                       "", CONV_GRAPH, API_DRIVER, 21, HIP_EXPERIMENTAL}},
+  {"cuGraphExecEventWaitNodeSetEvent",                     {"hipGraphExecEventWaitNodeSetEvent",                       "", CONV_GRAPH, API_DRIVER, 21}},
   // cudaGraphUpload
   {"cuGraphUpload",                                        {"hipGraphUpload",                                          "", CONV_GRAPH, API_DRIVER, 21, HIP_UNSUPPORTED}},
   // cudaGraphAddExternalSemaphoresSignalNode
@@ -710,7 +710,7 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_FUNCTION_MAP {
   // cudaDeviceSetGraphMemAttribute
   {"cuDeviceSetGraphMemAttribute",                         {"hipDeviceSetGraphMemAttribute",                           "", CONV_GRAPH, API_DRIVER, 21, HIP_UNSUPPORTED}},
   // cudaGraphInstantiateWithFlags
-  {"cuGraphInstantiateWithFlags",                          {"hipGraphInstantiateWithFlags",                            "", CONV_GRAPH, API_DRIVER, 21, HIP_EXPERIMENTAL}},
+  {"cuGraphInstantiateWithFlags",                          {"hipGraphInstantiateWithFlags",                            "", CONV_GRAPH, API_DRIVER, 21}},
 
   // 22. Occupancy
   // cudaOccupancyAvailableDynamicSMemPerBlock
@@ -815,7 +815,7 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_FUNCTION_MAP {
   // cudaGraphicsResourceSetMapFlags
   {"cuGraphicsResourceSetMapFlags_v2",                     {"hipGraphicsResourceSetMapFlags",                          "", CONV_GRAPHICS, API_DRIVER, 28, HIP_UNSUPPORTED}},
   // cudaGraphicsSubResourceGetMappedArray
-  {"cuGraphicsSubResourceGetMappedArray",                  {"hipGraphicsSubResourceGetMappedArray",                    "", CONV_GRAPHICS, API_DRIVER, 28, HIP_UNSUPPORTED}},
+  {"cuGraphicsSubResourceGetMappedArray",                  {"hipGraphicsSubResourceGetMappedArray",                    "", CONV_GRAPHICS, API_DRIVER, 28, HIP_EXPERIMENTAL}},
   // cudaGraphicsUnmapResources
   {"cuGraphicsUnmapResources",                             {"hipGraphicsUnmapResources",                               "", CONV_GRAPHICS, API_DRIVER, 28}},
   // cudaGraphicsUnregisterResource
@@ -843,7 +843,7 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_FUNCTION_MAP {
   // cudaGraphicsGLRegisterBuffer
   {"cuGraphicsGLRegisterBuffer",                           {"hipGraphicsGLRegisterBuffer",                             "", CONV_OPENGL, API_DRIVER, 32}},
   // cudaGraphicsGLRegisterImage
-  {"cuGraphicsGLRegisterImage",                            {"hipGraphicsGLRegisterImage",                              "", CONV_OPENGL, API_DRIVER, 32, HIP_UNSUPPORTED}},
+  {"cuGraphicsGLRegisterImage",                            {"hipGraphicsGLRegisterImage",                              "", CONV_OPENGL, API_DRIVER, 32, HIP_EXPERIMENTAL}},
   // cudaWGLGetDevice
   {"cuWGLGetDevice",                                       {"hipWGLGetDevice",                                         "", CONV_OPENGL, API_DRIVER, 32, HIP_UNSUPPORTED}},
 
@@ -1352,12 +1352,14 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_DRIVER_FUNCTION_VER_MAP {
   {"hipStreamWriteValue64",                                {HIP_4020, HIP_0,    HIP_0   }},
   {"hipArrayDestroy",                                      {HIP_4020, HIP_0,    HIP_0   }},
   {"hipDrvMemcpy2DUnaligned",                              {HIP_4020, HIP_0,    HIP_0   }},
-  {"hipPointerGetAttribute",                               {HIP_5000, HIP_0,    HIP_0,  HIP_LATEST}},
-  {"hipDrvPointerGetAttributes",                           {HIP_5000, HIP_0,    HIP_0,  HIP_LATEST}},
-  {"hipStreamGetCaptureInfo",                              {HIP_5000, HIP_0,    HIP_0,  HIP_LATEST}},
-  {"hipStreamGetCaptureInfo_v2",                           {HIP_5000, HIP_0,    HIP_0,  HIP_LATEST}},
-  {"hipStreamIsCapturing",                                 {HIP_5000, HIP_0,    HIP_0,  HIP_LATEST}},
-  {"hipStreamUpdateCaptureDependencies",                   {HIP_5000, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipPointerGetAttribute",                               {HIP_5000, HIP_0,    HIP_0   }},
+  {"hipDrvPointerGetAttributes",                           {HIP_5000, HIP_0,    HIP_0   }},
+  {"hipStreamGetCaptureInfo",                              {HIP_5000, HIP_0,    HIP_0   }},
+  {"hipStreamGetCaptureInfo_v2",                           {HIP_5000, HIP_0,    HIP_0   }},
+  {"hipStreamIsCapturing",                                 {HIP_5000, HIP_0,    HIP_0   }},
+  {"hipStreamUpdateCaptureDependencies",                   {HIP_5000, HIP_0,    HIP_0   }},
+  {"hipGraphicsGLRegisterImage",                           {HIP_5010, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipGraphicsSubResourceGetMappedArray",                 {HIP_5010, HIP_0,    HIP_0,  HIP_LATEST}},
 };
 
 const std::map<unsigned int, llvm::StringRef> CUDA_DRIVER_API_SECTION_MAP {

--- a/src/CUDA2HIP_Driver_API_types.cpp
+++ b/src/CUDA2HIP_Driver_API_types.cpp
@@ -2076,14 +2076,14 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_TYPE_NAME_MAP {
   {"CUtexObject_v1",                                                   {"hipTextureObject_t",                                       "", CONV_TYPE, API_DRIVER, 1}},
 
   //
-  {"CUmemGenericAllocationHandle",                                     {"hipMemGenericAllocationHandle",                            "", CONV_DEFINE, API_DRIVER, 1, HIP_UNSUPPORTED}},
-  {"CUmemGenericAllocationHandle_v1",                                  {"hipMemGenericAllocationHandle",                            "", CONV_DEFINE, API_DRIVER, 1, HIP_UNSUPPORTED}},
+  {"CUmemGenericAllocationHandle",                                     {"hipMemGenericAllocationHandle",                            "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
+  {"CUmemGenericAllocationHandle_v1",                                  {"hipMemGenericAllocationHandle",                            "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
 
   // GLuint
-  {"GLuint",                                                           {"GLuint",                                                   "", CONV_TYPE, API_DRIVER, 36, HIP_EXPERIMENTAL}},
+  {"GLuint",                                                           {"GLuint",                                                   "", CONV_TYPE, API_DRIVER, 1, HIP_EXPERIMENTAL}},
 
   // GLenum
-  {"GLenum",                                                           {"GLenum",                                                   "", CONV_TYPE, API_DRIVER, 36, HIP_EXPERIMENTAL}},
+  {"GLenum",                                                           {"GLenum",                                                   "", CONV_TYPE, API_DRIVER, 1, HIP_EXPERIMENTAL}},
 
   // 5. Defines
 

--- a/src/CUDA2HIP_Driver_API_types.cpp
+++ b/src/CUDA2HIP_Driver_API_types.cpp
@@ -1286,26 +1286,26 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_TYPE_NAME_MAP {
   {"CU_OCCUPANCY_DISABLE_CACHING_OVERRIDE",                            {"hipOccupancyDisableCachingOverride",                       "", CONV_NUMERIC_LITERAL, API_DRIVER, 1, HIP_UNSUPPORTED}}, // 0x01
 
   // no analogue
-  {"CUpointer_attribute",                                              {"hipPointer_attribute",                                     "", CONV_TYPE, API_DRIVER, 1, HIP_EXPERIMENTAL}},
-  {"CUpointer_attribute_enum",                                         {"hipPointer_attribute",                                     "", CONV_TYPE, API_DRIVER, 1, HIP_EXPERIMENTAL}},
+  {"CUpointer_attribute",                                              {"hipPointer_attribute",                                     "", CONV_TYPE, API_DRIVER, 1}},
+  {"CUpointer_attribute_enum",                                         {"hipPointer_attribute",                                     "", CONV_TYPE, API_DRIVER, 1}},
   // CUpointer_attribute enum values
-  {"CU_POINTER_ATTRIBUTE_CONTEXT",                                     {"HIP_POINTER_ATTRIBUTE_CONTEXT",                            "", CONV_NUMERIC_LITERAL, API_DRIVER, 1, HIP_EXPERIMENTAL}}, // 1
-  {"CU_POINTER_ATTRIBUTE_MEMORY_TYPE",                                 {"HIP_POINTER_ATTRIBUTE_MEMORY_TYPE",                        "", CONV_NUMERIC_LITERAL, API_DRIVER, 1, HIP_EXPERIMENTAL}}, // 2
-  {"CU_POINTER_ATTRIBUTE_DEVICE_POINTER",                              {"HIP_POINTER_ATTRIBUTE_DEVICE_POINTER",                     "", CONV_NUMERIC_LITERAL, API_DRIVER, 1, HIP_EXPERIMENTAL}}, // 3
-  {"CU_POINTER_ATTRIBUTE_HOST_POINTER",                                {"HIP_POINTER_ATTRIBUTE_HOST_POINTER",                       "", CONV_NUMERIC_LITERAL, API_DRIVER, 1, HIP_EXPERIMENTAL}}, // 4
-  {"CU_POINTER_ATTRIBUTE_P2P_TOKENS",                                  {"HIP_POINTER_ATTRIBUTE_P2P_TOKENS",                         "", CONV_NUMERIC_LITERAL, API_DRIVER, 1, HIP_EXPERIMENTAL}}, // 5
-  {"CU_POINTER_ATTRIBUTE_SYNC_MEMOPS",                                 {"HIP_POINTER_ATTRIBUTE_SYNC_MEMOPS",                        "", CONV_NUMERIC_LITERAL, API_DRIVER, 1, HIP_EXPERIMENTAL}}, // 6
-  {"CU_POINTER_ATTRIBUTE_BUFFER_ID",                                   {"HIP_POINTER_ATTRIBUTE_BUFFER_ID",                          "", CONV_NUMERIC_LITERAL, API_DRIVER, 1, HIP_EXPERIMENTAL}}, // 7
-  {"CU_POINTER_ATTRIBUTE_IS_MANAGED",                                  {"HIP_POINTER_ATTRIBUTE_IS_MANAGED",                         "", CONV_NUMERIC_LITERAL, API_DRIVER, 1, HIP_EXPERIMENTAL}}, // 8
-  {"CU_POINTER_ATTRIBUTE_DEVICE_ORDINAL",                              {"HIP_POINTER_ATTRIBUTE_DEVICE_ORDINAL",                     "", CONV_NUMERIC_LITERAL, API_DRIVER, 1, HIP_EXPERIMENTAL}}, // 9
-  {"CU_POINTER_ATTRIBUTE_IS_LEGACY_CUDA_IPC_CAPABLE",                  {"HIP_POINTER_ATTRIBUTE_IS_LEGACY_HIP_IPC_CAPABLE",          "", CONV_NUMERIC_LITERAL, API_DRIVER, 1, HIP_EXPERIMENTAL}}, // 10
-  {"CU_POINTER_ATTRIBUTE_RANGE_START_ADDR",                            {"HIP_POINTER_ATTRIBUTE_RANGE_START_ADDR",                   "", CONV_NUMERIC_LITERAL, API_DRIVER, 1, HIP_EXPERIMENTAL}}, // 11
-  {"CU_POINTER_ATTRIBUTE_RANGE_SIZE",                                  {"HIP_POINTER_ATTRIBUTE_RANGE_SIZE",                         "", CONV_NUMERIC_LITERAL, API_DRIVER, 1, HIP_EXPERIMENTAL}}, // 12
-  {"CU_POINTER_ATTRIBUTE_MAPPED",                                      {"HIP_POINTER_ATTRIBUTE_MAPPED",                             "", CONV_NUMERIC_LITERAL, API_DRIVER, 1, HIP_EXPERIMENTAL}}, // 13
-  {"CU_POINTER_ATTRIBUTE_ALLOWED_HANDLE_TYPES",                        {"HIP_POINTER_ATTRIBUTE_ALLOWED_HANDLE_TYPES",               "", CONV_NUMERIC_LITERAL, API_DRIVER, 1, HIP_EXPERIMENTAL}}, // 14
-  {"CU_POINTER_ATTRIBUTE_IS_GPU_DIRECT_RDMA_CAPABLE",                  {"HIP_POINTER_ATTRIBUTE_IS_GPU_DIRECT_RDMA_CAPABLE",         "", CONV_NUMERIC_LITERAL, API_DRIVER, 1, HIP_EXPERIMENTAL}}, // 15
-  {"CU_POINTER_ATTRIBUTE_ACCESS_FLAGS",                                {"HIP_POINTER_ATTRIBUTE_ACCESS_FLAGS",                       "", CONV_NUMERIC_LITERAL, API_DRIVER, 1, HIP_EXPERIMENTAL}}, // 16
-  {"CU_POINTER_ATTRIBUTE_MEMPOOL_HANDLE",                              {"HIP_POINTER_ATTRIBUTE_MEMPOOL_HANDLE",                     "", CONV_NUMERIC_LITERAL, API_DRIVER, 1, HIP_EXPERIMENTAL}}, // 17
+  {"CU_POINTER_ATTRIBUTE_CONTEXT",                                     {"HIP_POINTER_ATTRIBUTE_CONTEXT",                            "", CONV_NUMERIC_LITERAL, API_DRIVER, 1}}, // 1
+  {"CU_POINTER_ATTRIBUTE_MEMORY_TYPE",                                 {"HIP_POINTER_ATTRIBUTE_MEMORY_TYPE",                        "", CONV_NUMERIC_LITERAL, API_DRIVER, 1}}, // 2
+  {"CU_POINTER_ATTRIBUTE_DEVICE_POINTER",                              {"HIP_POINTER_ATTRIBUTE_DEVICE_POINTER",                     "", CONV_NUMERIC_LITERAL, API_DRIVER, 1}}, // 3
+  {"CU_POINTER_ATTRIBUTE_HOST_POINTER",                                {"HIP_POINTER_ATTRIBUTE_HOST_POINTER",                       "", CONV_NUMERIC_LITERAL, API_DRIVER, 1}}, // 4
+  {"CU_POINTER_ATTRIBUTE_P2P_TOKENS",                                  {"HIP_POINTER_ATTRIBUTE_P2P_TOKENS",                         "", CONV_NUMERIC_LITERAL, API_DRIVER, 1}}, // 5
+  {"CU_POINTER_ATTRIBUTE_SYNC_MEMOPS",                                 {"HIP_POINTER_ATTRIBUTE_SYNC_MEMOPS",                        "", CONV_NUMERIC_LITERAL, API_DRIVER, 1}}, // 6
+  {"CU_POINTER_ATTRIBUTE_BUFFER_ID",                                   {"HIP_POINTER_ATTRIBUTE_BUFFER_ID",                          "", CONV_NUMERIC_LITERAL, API_DRIVER, 1}}, // 7
+  {"CU_POINTER_ATTRIBUTE_IS_MANAGED",                                  {"HIP_POINTER_ATTRIBUTE_IS_MANAGED",                         "", CONV_NUMERIC_LITERAL, API_DRIVER, 1}}, // 8
+  {"CU_POINTER_ATTRIBUTE_DEVICE_ORDINAL",                              {"HIP_POINTER_ATTRIBUTE_DEVICE_ORDINAL",                     "", CONV_NUMERIC_LITERAL, API_DRIVER, 1}}, // 9
+  {"CU_POINTER_ATTRIBUTE_IS_LEGACY_CUDA_IPC_CAPABLE",                  {"HIP_POINTER_ATTRIBUTE_IS_LEGACY_HIP_IPC_CAPABLE",          "", CONV_NUMERIC_LITERAL, API_DRIVER, 1}}, // 10
+  {"CU_POINTER_ATTRIBUTE_RANGE_START_ADDR",                            {"HIP_POINTER_ATTRIBUTE_RANGE_START_ADDR",                   "", CONV_NUMERIC_LITERAL, API_DRIVER, 1}}, // 11
+  {"CU_POINTER_ATTRIBUTE_RANGE_SIZE",                                  {"HIP_POINTER_ATTRIBUTE_RANGE_SIZE",                         "", CONV_NUMERIC_LITERAL, API_DRIVER, 1}}, // 12
+  {"CU_POINTER_ATTRIBUTE_MAPPED",                                      {"HIP_POINTER_ATTRIBUTE_MAPPED",                             "", CONV_NUMERIC_LITERAL, API_DRIVER, 1}}, // 13
+  {"CU_POINTER_ATTRIBUTE_ALLOWED_HANDLE_TYPES",                        {"HIP_POINTER_ATTRIBUTE_ALLOWED_HANDLE_TYPES",               "", CONV_NUMERIC_LITERAL, API_DRIVER, 1}}, // 14
+  {"CU_POINTER_ATTRIBUTE_IS_GPU_DIRECT_RDMA_CAPABLE",                  {"HIP_POINTER_ATTRIBUTE_IS_GPU_DIRECT_RDMA_CAPABLE",         "", CONV_NUMERIC_LITERAL, API_DRIVER, 1}}, // 15
+  {"CU_POINTER_ATTRIBUTE_ACCESS_FLAGS",                                {"HIP_POINTER_ATTRIBUTE_ACCESS_FLAGS",                       "", CONV_NUMERIC_LITERAL, API_DRIVER, 1}}, // 16
+  {"CU_POINTER_ATTRIBUTE_MEMPOOL_HANDLE",                              {"HIP_POINTER_ATTRIBUTE_MEMPOOL_HANDLE",                     "", CONV_NUMERIC_LITERAL, API_DRIVER, 1}}, // 17
 
   // TODO [HIP]: HIPresourcetype_enum and all its values should be hipResourceType as long as they are equal
   // cudaResourceType
@@ -1490,7 +1490,7 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_TYPE_NAME_MAP {
   // cudaErrorInvalidResourceHandle
   {"CUDA_ERROR_INVALID_HANDLE",                                        {"hipErrorInvalidHandle",                                    "", CONV_NUMERIC_LITERAL, API_DRIVER, 1}}, // 400
   // cudaErrorIllegalState
-  {"CUDA_ERROR_ILLEGAL_STATE",                                         {"hipErrorIllegalState",                                     "", CONV_NUMERIC_LITERAL, API_DRIVER, 1, HIP_EXPERIMENTAL}}, // 401
+  {"CUDA_ERROR_ILLEGAL_STATE",                                         {"hipErrorIllegalState",                                     "", CONV_NUMERIC_LITERAL, API_DRIVER, 1}}, // 401
   // cudaErrorSymbolNotFound
   {"CUDA_ERROR_NOT_FOUND",                                             {"hipErrorNotFound",                                         "", CONV_NUMERIC_LITERAL, API_DRIVER, 1}}, // 500
   // cudaErrorNotReady
@@ -1574,7 +1574,7 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_TYPE_NAME_MAP {
   // cudaErrorTimeout
   {"CUDA_ERROR_TIMEOUT",                                               {"hipErrorTimeout",                                          "", CONV_NUMERIC_LITERAL, API_DRIVER, 1, HIP_UNSUPPORTED}}, // 909
   // cudaErrorGraphExecUpdateFailure
-  {"CUDA_ERROR_GRAPH_EXEC_UPDATE_FAILURE",                             {"hipErrorGraphExecUpdateFailure",                           "", CONV_NUMERIC_LITERAL, API_DRIVER, 1, HIP_EXPERIMENTAL}}, // 910
+  {"CUDA_ERROR_GRAPH_EXEC_UPDATE_FAILURE",                             {"hipErrorGraphExecUpdateFailure",                           "", CONV_NUMERIC_LITERAL, API_DRIVER, 1}}, // 910
   // cudaErrorExternalDevice
   {"CUDA_ERROR_EXTERNAL_DEVICE",                                       {"hipErrorExternalDevice",                                   "", CONV_NUMERIC_LITERAL, API_DRIVER, 1, HIP_UNSUPPORTED}}, // 911
   // cudaErrorUnknown
@@ -1922,13 +1922,13 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_TYPE_NAME_MAP {
   {"CU_MEMPOOL_ATTR_USED_MEM_HIGH",                                    {"hipMemPoolAttrUsedMemHigh",                                "", CONV_NUMERIC_LITERAL, API_DRIVER, 1, HIP_UNSUPPORTED}},
 
   // cudaStreamUpdateCaptureDependenciesFlags
-  {"CUstreamUpdateCaptureDependencies_flags",                          {"hipStreamUpdateCaptureDependenciesFlags",                  "", CONV_TYPE, API_DRIVER, 1, HIP_EXPERIMENTAL}},
-  {"CUstreamUpdateCaptureDependencies_flags_enum",                     {"hipStreamUpdateCaptureDependenciesFlags",                  "", CONV_TYPE, API_DRIVER, 1, HIP_EXPERIMENTAL}},
+  {"CUstreamUpdateCaptureDependencies_flags",                          {"hipStreamUpdateCaptureDependenciesFlags",                  "", CONV_TYPE, API_DRIVER, 1}},
+  {"CUstreamUpdateCaptureDependencies_flags_enum",                     {"hipStreamUpdateCaptureDependenciesFlags",                  "", CONV_TYPE, API_DRIVER, 1}},
   // CUstreamUpdateCaptureDependencies_flags enum values
   // cudaStreamAddCaptureDependencies
-  {"CU_STREAM_ADD_CAPTURE_DEPENDENCIES",                               {"hipStreamAddCaptureDependencies",                          "", CONV_NUMERIC_LITERAL, API_DRIVER, 1, HIP_EXPERIMENTAL}}, // 0x0
+  {"CU_STREAM_ADD_CAPTURE_DEPENDENCIES",                               {"hipStreamAddCaptureDependencies",                          "", CONV_NUMERIC_LITERAL, API_DRIVER, 1}}, // 0x0
   // cudaStreamSetCaptureDependencies
-  {"CU_STREAM_SET_CAPTURE_DEPENDENCIES",                               {"hipStreamSetCaptureDependencies",                          "", CONV_NUMERIC_LITERAL, API_DRIVER, 1, HIP_EXPERIMENTAL}}, // 0x1
+  {"CU_STREAM_SET_CAPTURE_DEPENDENCIES",                               {"hipStreamSetCaptureDependencies",                          "", CONV_NUMERIC_LITERAL, API_DRIVER, 1}}, // 0x1
 
   // cudaGetDriverEntryPointFlags
   {"CUdriverProcAddress_flags",                                        {"hipDriverProcAddress",                                     "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
@@ -2078,6 +2078,12 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_TYPE_NAME_MAP {
   //
   {"CUmemGenericAllocationHandle",                                     {"hipMemGenericAllocationHandle",                            "", CONV_DEFINE, API_DRIVER, 1, HIP_UNSUPPORTED}},
   {"CUmemGenericAllocationHandle_v1",                                  {"hipMemGenericAllocationHandle",                            "", CONV_DEFINE, API_DRIVER, 1, HIP_UNSUPPORTED}},
+
+  // GLuint
+  {"GLuint",                                                           {"GLuint",                                                   "", CONV_TYPE, API_DRIVER, 36, HIP_EXPERIMENTAL}},
+
+  // GLenum
+  {"GLenum",                                                           {"GLenum",                                                   "", CONV_TYPE, API_DRIVER, 36, HIP_EXPERIMENTAL}},
 
   // 5. Defines
 
@@ -3142,25 +3148,27 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_DRIVER_TYPE_NAME_VER_MAP {
   {"hipExternalSemaphoreHandleTypeD3D12Fence",                         {HIP_4040, HIP_0,    HIP_0   }},
   {"hipLimitPrintfFifoSize",                                           {HIP_4050, HIP_0,    HIP_0   }},
   {"hipStreamPerThread",                                               {HIP_4050, HIP_0,    HIP_0   }},
-  {"hipPointer_attribute",                                             {HIP_5000, HIP_0,    HIP_0,  HIP_LATEST}},
-  {"HIP_POINTER_ATTRIBUTE_CONTEXT",                                    {HIP_5000, HIP_0,    HIP_0,  HIP_LATEST}},
-  {"HIP_POINTER_ATTRIBUTE_MEMORY_TYPE",                                {HIP_5000, HIP_0,    HIP_0,  HIP_LATEST}},
-  {"HIP_POINTER_ATTRIBUTE_DEVICE_POINTER",                             {HIP_5000, HIP_0,    HIP_0,  HIP_LATEST}},
-  {"HIP_POINTER_ATTRIBUTE_HOST_POINTER",                               {HIP_5000, HIP_0,    HIP_0,  HIP_LATEST}},
-  {"HIP_POINTER_ATTRIBUTE_P2P_TOKENS",                                 {HIP_5000, HIP_0,    HIP_0,  HIP_LATEST}},
-  {"HIP_POINTER_ATTRIBUTE_SYNC_MEMOPS",                                {HIP_5000, HIP_0,    HIP_0,  HIP_LATEST}},
-  {"HIP_POINTER_ATTRIBUTE_BUFFER_ID",                                  {HIP_5000, HIP_0,    HIP_0,  HIP_LATEST}},
-  {"HIP_POINTER_ATTRIBUTE_IS_MANAGED",                                 {HIP_5000, HIP_0,    HIP_0,  HIP_LATEST}},
-  {"HIP_POINTER_ATTRIBUTE_DEVICE_ORDINAL",                             {HIP_5000, HIP_0,    HIP_0,  HIP_LATEST}},
-  {"HIP_POINTER_ATTRIBUTE_IS_LEGACY_HIP_IPC_CAPABLE",                  {HIP_5000, HIP_0,    HIP_0,  HIP_LATEST}},
-  {"HIP_POINTER_ATTRIBUTE_RANGE_START_ADDR",                           {HIP_5000, HIP_0,    HIP_0,  HIP_LATEST}},
-  {"HIP_POINTER_ATTRIBUTE_RANGE_SIZE",                                 {HIP_5000, HIP_0,    HIP_0,  HIP_LATEST}},
-  {"HIP_POINTER_ATTRIBUTE_MAPPED",                                     {HIP_5000, HIP_0,    HIP_0,  HIP_LATEST}},
-  {"HIP_POINTER_ATTRIBUTE_ALLOWED_HANDLE_TYPES",                       {HIP_5000, HIP_0,    HIP_0,  HIP_LATEST}},
-  {"HIP_POINTER_ATTRIBUTE_IS_GPU_DIRECT_RDMA_CAPABLE",                 {HIP_5000, HIP_0,    HIP_0,  HIP_LATEST}},
-  {"HIP_POINTER_ATTRIBUTE_ACCESS_FLAGS",                               {HIP_5000, HIP_0,    HIP_0,  HIP_LATEST}},
-  {"HIP_POINTER_ATTRIBUTE_MEMPOOL_HANDLE",                             {HIP_5000, HIP_0,    HIP_0,  HIP_LATEST}},
-  {"hipStreamUpdateCaptureDependenciesFlags",                          {HIP_5000, HIP_0,    HIP_0,  HIP_LATEST}},
-  {"hipStreamAddCaptureDependencies",                                  {HIP_5000, HIP_0,    HIP_0,  HIP_LATEST}},
-  {"hipStreamSetCaptureDependencies",                                  {HIP_5000, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipPointer_attribute",                                             {HIP_5000, HIP_0,    HIP_0   }},
+  {"HIP_POINTER_ATTRIBUTE_CONTEXT",                                    {HIP_5000, HIP_0,    HIP_0   }},
+  {"HIP_POINTER_ATTRIBUTE_MEMORY_TYPE",                                {HIP_5000, HIP_0,    HIP_0   }},
+  {"HIP_POINTER_ATTRIBUTE_DEVICE_POINTER",                             {HIP_5000, HIP_0,    HIP_0   }},
+  {"HIP_POINTER_ATTRIBUTE_HOST_POINTER",                               {HIP_5000, HIP_0,    HIP_0   }},
+  {"HIP_POINTER_ATTRIBUTE_P2P_TOKENS",                                 {HIP_5000, HIP_0,    HIP_0   }},
+  {"HIP_POINTER_ATTRIBUTE_SYNC_MEMOPS",                                {HIP_5000, HIP_0,    HIP_0   }},
+  {"HIP_POINTER_ATTRIBUTE_BUFFER_ID",                                  {HIP_5000, HIP_0,    HIP_0   }},
+  {"HIP_POINTER_ATTRIBUTE_IS_MANAGED",                                 {HIP_5000, HIP_0,    HIP_0   }},
+  {"HIP_POINTER_ATTRIBUTE_DEVICE_ORDINAL",                             {HIP_5000, HIP_0,    HIP_0   }},
+  {"HIP_POINTER_ATTRIBUTE_IS_LEGACY_HIP_IPC_CAPABLE",                  {HIP_5000, HIP_0,    HIP_0   }},
+  {"HIP_POINTER_ATTRIBUTE_RANGE_START_ADDR",                           {HIP_5000, HIP_0,    HIP_0   }},
+  {"HIP_POINTER_ATTRIBUTE_RANGE_SIZE",                                 {HIP_5000, HIP_0,    HIP_0   }},
+  {"HIP_POINTER_ATTRIBUTE_MAPPED",                                     {HIP_5000, HIP_0,    HIP_0   }},
+  {"HIP_POINTER_ATTRIBUTE_ALLOWED_HANDLE_TYPES",                       {HIP_5000, HIP_0,    HIP_0   }},
+  {"HIP_POINTER_ATTRIBUTE_IS_GPU_DIRECT_RDMA_CAPABLE",                 {HIP_5000, HIP_0,    HIP_0   }},
+  {"HIP_POINTER_ATTRIBUTE_ACCESS_FLAGS",                               {HIP_5000, HIP_0,    HIP_0   }},
+  {"HIP_POINTER_ATTRIBUTE_MEMPOOL_HANDLE",                             {HIP_5000, HIP_0,    HIP_0   }},
+  {"hipStreamUpdateCaptureDependenciesFlags",                          {HIP_5000, HIP_0,    HIP_0   }},
+  {"hipStreamAddCaptureDependencies",                                  {HIP_5000, HIP_0,    HIP_0   }},
+  {"hipStreamSetCaptureDependencies",                                  {HIP_5000, HIP_0,    HIP_0   }},
+  {"GLuint",                                                           {HIP_5010, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"GLenum",                                                           {HIP_5010, HIP_0,    HIP_0,  HIP_LATEST}},
 };

--- a/src/CUDA2HIP_Runtime_API_functions.cpp
+++ b/src/CUDA2HIP_Runtime_API_functions.cpp
@@ -149,9 +149,9 @@ const std::map<llvm::StringRef, hipCounter> CUDA_RUNTIME_FUNCTION_MAP {
   // cuStreamGetPriority
   {"cudaStreamGetPriority",                                   {"hipStreamGetPriority",                                   "", CONV_STREAM, API_RUNTIME, 4}},
   // cuStreamIsCapturing
-  {"cudaStreamIsCapturing",                                   {"hipStreamIsCapturing",                                   "", CONV_STREAM, API_RUNTIME, 4, HIP_EXPERIMENTAL}},
+  {"cudaStreamIsCapturing",                                   {"hipStreamIsCapturing",                                   "", CONV_STREAM, API_RUNTIME, 4}},
   // cuStreamGetCaptureInfo
-  {"cudaStreamGetCaptureInfo",                                {"hipStreamGetCaptureInfo",                                "", CONV_STREAM, API_RUNTIME, 4, HIP_EXPERIMENTAL}},
+  {"cudaStreamGetCaptureInfo",                                {"hipStreamGetCaptureInfo",                                "", CONV_STREAM, API_RUNTIME, 4}},
   // cuStreamQuery
   {"cudaStreamQuery",                                         {"hipStreamQuery",                                         "", CONV_STREAM, API_RUNTIME, 4}},
   // cuStreamSynchronize
@@ -442,7 +442,7 @@ const std::map<llvm::StringRef, hipCounter> CUDA_RUNTIME_FUNCTION_MAP {
   // cuGraphicsGLRegisterBuffer
   {"cudaGraphicsGLRegisterBuffer",                            {"hipGraphicsGLRegisterBuffer",                            "", CONV_OPENGL, API_RUNTIME, 14}},
   // cuGraphicsGLRegisterImage
-  {"cudaGraphicsGLRegisterImage",                             {"hipGraphicsGLRegisterImage",                             "", CONV_OPENGL, API_RUNTIME, 14, HIP_UNSUPPORTED}},
+  {"cudaGraphicsGLRegisterImage",                             {"hipGraphicsGLRegisterImage",                             "", CONV_OPENGL, API_RUNTIME, 14}},
   // cuWGLGetDevice
   {"cudaWGLGetDevice",                                        {"hipWGLGetDevice",                                        "", CONV_OPENGL, API_RUNTIME, 14, HIP_UNSUPPORTED}},
 
@@ -595,7 +595,7 @@ const std::map<llvm::StringRef, hipCounter> CUDA_RUNTIME_FUNCTION_MAP {
   // cuGraphicsResourceSetMapFlags
   {"cudaGraphicsResourceSetMapFlags",                         {"hipGraphicsResourceSetMapFlags",                         "", CONV_GRAPHICS, API_RUNTIME, 24, HIP_UNSUPPORTED}},
   // cuGraphicsSubResourceGetMappedArray
-  {"cudaGraphicsSubResourceGetMappedArray",                   {"hipGraphicsSubResourceGetMappedArray",                   "", CONV_GRAPHICS, API_RUNTIME, 24, HIP_UNSUPPORTED}},
+  {"cudaGraphicsSubResourceGetMappedArray",                   {"hipGraphicsSubResourceGetMappedArray",                   "", CONV_GRAPHICS, API_RUNTIME, 24, HIP_EXPERIMENTAL}},
   // cuGraphicsUnmapResources
   {"cudaGraphicsUnmapResources",                              {"hipGraphicsUnmapResources",                              "", CONV_GRAPHICS, API_RUNTIME, 24}},
   // cuGraphicsUnregisterResource
@@ -662,13 +662,13 @@ const std::map<llvm::StringRef, hipCounter> CUDA_RUNTIME_FUNCTION_MAP {
 
   // 30. Graph Management
   // cuGraphAddChildGraphNode
-  {"cudaGraphAddChildGraphNode",                              {"hipGraphAddChildGraphNode",                              "", CONV_GRAPH, API_RUNTIME, 30, HIP_EXPERIMENTAL}},
+  {"cudaGraphAddChildGraphNode",                              {"hipGraphAddChildGraphNode",                              "", CONV_GRAPH, API_RUNTIME, 30}},
   // cuGraphAddDependencies
   {"cudaGraphAddDependencies",                                {"hipGraphAddDependencies",                                "", CONV_GRAPH, API_RUNTIME, 30}},
   // cuGraphAddEmptyNode
   {"cudaGraphAddEmptyNode",                                   {"hipGraphAddEmptyNode",                                   "", CONV_GRAPH, API_RUNTIME, 30}},
   // cuGraphAddHostNode
-  {"cudaGraphAddHostNode",                                    {"hipGraphAddHostNode",                                    "", CONV_GRAPH, API_RUNTIME, 30, HIP_EXPERIMENTAL}},
+  {"cudaGraphAddHostNode",                                    {"hipGraphAddHostNode",                                    "", CONV_GRAPH, API_RUNTIME, 30}},
   // cuGraphAddKernelNode
   {"cudaGraphAddKernelNode",                                  {"hipGraphAddKernelNode",                                  "", CONV_GRAPH, API_RUNTIME, 30}},
   // no analogue
@@ -682,7 +682,7 @@ const std::map<llvm::StringRef, hipCounter> CUDA_RUNTIME_FUNCTION_MAP {
   // RUNTIME: cudaError_t CUDARTAPI cudaGraphAddMemcpyNode(cudaGraphNode_t *pGraphNode, cudaGraph_t graph, const cudaGraphNode_t *pDependencies, size_t numDependencies, const struct cudaMemcpy3DParms *pCopyParams);
   {"cudaGraphAddMemsetNode",                                  {"hipGraphAddMemsetNode",                                  "", CONV_GRAPH, API_RUNTIME, 30}},
   // cuGraphChildGraphNodeGetGraph
-  {"cudaGraphChildGraphNodeGetGraph",                         {"hipGraphChildGraphNodeGetGraph",                         "", CONV_GRAPH, API_RUNTIME, 30, HIP_EXPERIMENTAL}},
+  {"cudaGraphChildGraphNodeGetGraph",                         {"hipGraphChildGraphNodeGetGraph",                         "", CONV_GRAPH, API_RUNTIME, 30}},
   // cuGraphClone
   {"cudaGraphClone",                                          {"hipGraphClone",                                          "", CONV_GRAPH, API_RUNTIME, 30, HIP_UNSUPPORTED}},
   // cuGraphCreate
@@ -692,19 +692,19 @@ const std::map<llvm::StringRef, hipCounter> CUDA_RUNTIME_FUNCTION_MAP {
   // cuGraphDestroy
   {"cudaGraphDestroy",                                        {"hipGraphDestroy",                                        "", CONV_GRAPH, API_RUNTIME, 30}},
   // cuGraphDestroyNode
-  {"cudaGraphDestroyNode",                                    {"hipGraphDestroyNode",                                    "", CONV_GRAPH, API_RUNTIME, 30, HIP_EXPERIMENTAL}},
+  {"cudaGraphDestroyNode",                                    {"hipGraphDestroyNode",                                    "", CONV_GRAPH, API_RUNTIME, 30}},
   // cuGraphExecDestroy
   {"cudaGraphExecDestroy",                                    {"hipGraphExecDestroy",                                    "", CONV_GRAPH, API_RUNTIME, 30}},
   // cuGraphGetEdges
-  {"cudaGraphGetEdges",                                       {"hipGraphGetEdges",                                       "", CONV_GRAPH, API_RUNTIME, 30, HIP_EXPERIMENTAL}},
+  {"cudaGraphGetEdges",                                       {"hipGraphGetEdges",                                       "", CONV_GRAPH, API_RUNTIME, 30}},
   // cuGraphGetNodes
   {"cudaGraphGetNodes",                                       {"hipGraphGetNodes",                                       "", CONV_GRAPH, API_RUNTIME, 30}},
   // cuGraphGetRootNodes
   {"cudaGraphGetRootNodes",                                   {"hipGraphGetRootNodes",                                   "", CONV_GRAPH, API_RUNTIME, 30}},
   // cuGraphHostNodeGetParams
-  {"cudaGraphHostNodeGetParams",                              {"hipGraphHostNodeGetParams",                              "", CONV_GRAPH, API_RUNTIME, 30, HIP_EXPERIMENTAL}},
+  {"cudaGraphHostNodeGetParams",                              {"hipGraphHostNodeGetParams",                              "", CONV_GRAPH, API_RUNTIME, 30}},
   // cuGraphHostNodeSetParams
-  {"cudaGraphHostNodeSetParams",                              {"hipGraphHostNodeSetParams",                              "", CONV_GRAPH, API_RUNTIME, 30, HIP_EXPERIMENTAL}},
+  {"cudaGraphHostNodeSetParams",                              {"hipGraphHostNodeSetParams",                              "", CONV_GRAPH, API_RUNTIME, 30}},
   // cuGraphInstantiate
   {"cudaGraphInstantiate",                                    {"hipGraphInstantiate",                                    "", CONV_GRAPH, API_RUNTIME, 30}},
   // cuGraphKernelNodeCopyAttributes
@@ -719,16 +719,16 @@ const std::map<llvm::StringRef, hipCounter> CUDA_RUNTIME_FUNCTION_MAP {
   // NOTE: Not equal to cuGraphExecMemcpyNodeSetParams due to different signatures:
   // DRIVER: CUresult CUDAAPI cuGraphExecMemcpyNodeSetParams(CUgraphExec hGraphExec, CUgraphNode hNode, const CUDA_MEMCPY3D *copyParams, CUcontext ctx);
   // RUNTIME: cudaError_t CUDARTAPI cudaGraphExecMemcpyNodeSetParams(cudaGraphExec_t hGraphExec, cudaGraphNode_t node, const struct cudaMemcpy3DParms *pNodeParams);
-  {"cudaGraphExecMemcpyNodeSetParams",                        {"hipGraphExecMemcpyNodeSetParams",                        "", CONV_GRAPH, API_RUNTIME, 30, HIP_EXPERIMENTAL}},
+  {"cudaGraphExecMemcpyNodeSetParams",                        {"hipGraphExecMemcpyNodeSetParams",                        "", CONV_GRAPH, API_RUNTIME, 30}},
   // no analogue
   // NOTE: Not equal to cuGraphExecMemsetNodeSetParams due to different signatures:
   // DRIVER: CUresult CUDAAPI cuGraphExecMemsetNodeSetParams(CUgraphExec hGraphExec, CUgraphNode hNode, const CUDA_MEMSET_NODE_PARAMS *memsetParams, CUcontext ctx);
   // RUNTIME: cudaError_t CUDARTAPI cudaGraphExecMemsetNodeSetParams(cudaGraphExec_t hGraphExec, cudaGraphNode_t node, const struct cudaMemsetParams *pNodeParams);
-  {"cudaGraphExecMemsetNodeSetParams",                        {"hipGraphExecMemsetNodeSetParams",                        "", CONV_GRAPH, API_RUNTIME, 30, HIP_EXPERIMENTAL}},
+  {"cudaGraphExecMemsetNodeSetParams",                        {"hipGraphExecMemsetNodeSetParams",                        "", CONV_GRAPH, API_RUNTIME, 30}},
   // cuGraphExecHostNodeSetParams
-  {"cudaGraphExecHostNodeSetParams",                          {"hipGraphExecHostNodeSetParams",                          "", CONV_GRAPH, API_RUNTIME, 30, HIP_EXPERIMENTAL}},
+  {"cudaGraphExecHostNodeSetParams",                          {"hipGraphExecHostNodeSetParams",                          "", CONV_GRAPH, API_RUNTIME, 30}},
   // cuGraphExecUpdate
-  {"cudaGraphExecUpdate",                                     {"hipGraphExecUpdate",                                     "", CONV_GRAPH, API_RUNTIME, 30, HIP_EXPERIMENTAL}},
+  {"cudaGraphExecUpdate",                                     {"hipGraphExecUpdate",                                     "", CONV_GRAPH, API_RUNTIME, 30}},
   // cuGraphKernelNodeGetParams
   {"cudaGraphKernelNodeGetParams",                            {"hipGraphKernelNodeGetParams",                            "", CONV_GRAPH, API_RUNTIME, 30}},
   // cuGraphKernelNodeSetParams
@@ -744,51 +744,51 @@ const std::map<llvm::StringRef, hipCounter> CUDA_RUNTIME_FUNCTION_MAP {
   // cuGraphMemsetNodeSetParams
   {"cudaGraphMemsetNodeSetParams",                            {"hipGraphMemsetNodeSetParams",                            "", CONV_GRAPH, API_RUNTIME, 30}},
   // cuGraphNodeFindInClone
-  {"cudaGraphNodeFindInClone",                                {"hipGraphNodeFindInClone",                                "", CONV_GRAPH, API_RUNTIME, 30, HIP_EXPERIMENTAL}},
+  {"cudaGraphNodeFindInClone",                                {"hipGraphNodeFindInClone",                                "", CONV_GRAPH, API_RUNTIME, 30}},
   // cuGraphNodeGetDependencies
-  {"cudaGraphNodeGetDependencies",                            {"hipGraphNodeGetDependencies",                            "", CONV_GRAPH, API_RUNTIME, 30, HIP_EXPERIMENTAL}},
+  {"cudaGraphNodeGetDependencies",                            {"hipGraphNodeGetDependencies",                            "", CONV_GRAPH, API_RUNTIME, 30}},
   // cuGraphNodeGetDependentNodes
-  {"cudaGraphNodeGetDependentNodes",                          {"hipGraphNodeGetDependentNodes",                          "", CONV_GRAPH, API_RUNTIME, 30, HIP_EXPERIMENTAL}},
+  {"cudaGraphNodeGetDependentNodes",                          {"hipGraphNodeGetDependentNodes",                          "", CONV_GRAPH, API_RUNTIME, 30}},
   // cuGraphNodeGetType
-  {"cudaGraphNodeGetType",                                    {"hipGraphNodeGetType",                                    "", CONV_GRAPH, API_RUNTIME, 30, HIP_EXPERIMENTAL}},
+  {"cudaGraphNodeGetType",                                    {"hipGraphNodeGetType",                                    "", CONV_GRAPH, API_RUNTIME, 30}},
   // cuGraphRemoveDependencies
-  {"cudaGraphRemoveDependencies",                             {"hipGraphRemoveDependencies",                             "", CONV_GRAPH, API_RUNTIME, 30, HIP_EXPERIMENTAL}},
+  {"cudaGraphRemoveDependencies",                             {"hipGraphRemoveDependencies",                             "", CONV_GRAPH, API_RUNTIME, 30}},
   // no analogue
-  {"cudaGraphAddMemcpyNodeToSymbol",                          {"hipGraphAddMemcpyNodeToSymbol",                          "", CONV_GRAPH, API_RUNTIME, 30, HIP_EXPERIMENTAL}},
+  {"cudaGraphAddMemcpyNodeToSymbol",                          {"hipGraphAddMemcpyNodeToSymbol",                          "", CONV_GRAPH, API_RUNTIME, 30}},
   // no analogue
-  {"cudaGraphAddMemcpyNodeFromSymbol",                        {"hipGraphAddMemcpyNodeFromSymbol",                        "", CONV_GRAPH, API_RUNTIME, 30, HIP_EXPERIMENTAL}},
+  {"cudaGraphAddMemcpyNodeFromSymbol",                        {"hipGraphAddMemcpyNodeFromSymbol",                        "", CONV_GRAPH, API_RUNTIME, 30}},
   // no analogue
   {"cudaGraphAddMemcpyNode1D",                                {"hipGraphAddMemcpyNode1D",                                "", CONV_GRAPH, API_RUNTIME, 30}},
   // no analogue
-  {"cudaGraphMemcpyNodeSetParamsToSymbol",                    {"hipGraphMemcpyNodeSetParamsToSymbol",                    "", CONV_GRAPH, API_RUNTIME, 30, HIP_EXPERIMENTAL}},
+  {"cudaGraphMemcpyNodeSetParamsToSymbol",                    {"hipGraphMemcpyNodeSetParamsToSymbol",                    "", CONV_GRAPH, API_RUNTIME, 30}},
   // no analogue
-  {"cudaGraphMemcpyNodeSetParamsFromSymbol",                  {"hipGraphMemcpyNodeSetParamsFromSymbol",                  "", CONV_GRAPH, API_RUNTIME, 30, HIP_EXPERIMENTAL}},
+  {"cudaGraphMemcpyNodeSetParamsFromSymbol",                  {"hipGraphMemcpyNodeSetParamsFromSymbol",                  "", CONV_GRAPH, API_RUNTIME, 30}},
   // no analogue
-  {"cudaGraphMemcpyNodeSetParams1D",                          {"hipGraphMemcpyNodeSetParams1D",                          "", CONV_GRAPH, API_RUNTIME, 30, HIP_EXPERIMENTAL}},
+  {"cudaGraphMemcpyNodeSetParams1D",                          {"hipGraphMemcpyNodeSetParams1D",                          "", CONV_GRAPH, API_RUNTIME, 30}},
   // cuGraphAddEventRecordNode
-  {"cudaGraphAddEventRecordNode",                             {"hipGraphAddEventRecordNode",                             "", CONV_GRAPH, API_RUNTIME, 30, HIP_EXPERIMENTAL}},
+  {"cudaGraphAddEventRecordNode",                             {"hipGraphAddEventRecordNode",                             "", CONV_GRAPH, API_RUNTIME, 30}},
   // cuGraphEventRecordNodeGetEvent
-  {"cudaGraphEventRecordNodeGetEvent",                        {"hipGraphEventRecordNodeGetEvent",                        "", CONV_GRAPH, API_RUNTIME, 30, HIP_EXPERIMENTAL}},
+  {"cudaGraphEventRecordNodeGetEvent",                        {"hipGraphEventRecordNodeGetEvent",                        "", CONV_GRAPH, API_RUNTIME, 30}},
   // cuGraphEventRecordNodeSetEvent
-  {"cudaGraphEventRecordNodeSetEvent",                        {"hipGraphEventRecordNodeSetEvent",                        "", CONV_GRAPH, API_RUNTIME, 30, HIP_EXPERIMENTAL}},
+  {"cudaGraphEventRecordNodeSetEvent",                        {"hipGraphEventRecordNodeSetEvent",                        "", CONV_GRAPH, API_RUNTIME, 30}},
   // cuGraphAddEventWaitNode
-  {"cudaGraphAddEventWaitNode",                               {"hipGraphAddEventWaitNode",                               "", CONV_GRAPH, API_RUNTIME, 30, HIP_EXPERIMENTAL}},
+  {"cudaGraphAddEventWaitNode",                               {"hipGraphAddEventWaitNode",                               "", CONV_GRAPH, API_RUNTIME, 30}},
   // cuGraphEventWaitNodeGetEvent
-  {"cudaGraphEventWaitNodeGetEvent",                          {"hipGraphEventWaitNodeGetEvent",                          "", CONV_GRAPH, API_RUNTIME, 30, HIP_EXPERIMENTAL}},
+  {"cudaGraphEventWaitNodeGetEvent",                          {"hipGraphEventWaitNodeGetEvent",                          "", CONV_GRAPH, API_RUNTIME, 30}},
   // cuGraphEventWaitNodeSetEvent
-  {"cudaGraphEventWaitNodeSetEvent",                          {"hipGraphEventWaitNodeSetEvent",                          "", CONV_GRAPH, API_RUNTIME, 30, HIP_EXPERIMENTAL}},
+  {"cudaGraphEventWaitNodeSetEvent",                          {"hipGraphEventWaitNodeSetEvent",                          "", CONV_GRAPH, API_RUNTIME, 30}},
   // no analogue
-  {"cudaGraphExecMemcpyNodeSetParamsToSymbol",                {"hipGraphExecMemcpyNodeSetParamsToSymbol",                "", CONV_GRAPH, API_RUNTIME, 30, HIP_EXPERIMENTAL}},
+  {"cudaGraphExecMemcpyNodeSetParamsToSymbol",                {"hipGraphExecMemcpyNodeSetParamsToSymbol",                "", CONV_GRAPH, API_RUNTIME, 30}},
   // no analogue
-  {"cudaGraphExecMemcpyNodeSetParamsFromSymbol",              {"hipGraphExecMemcpyNodeSetParamsFromSymbol",              "", CONV_GRAPH, API_RUNTIME, 30, HIP_EXPERIMENTAL}},
+  {"cudaGraphExecMemcpyNodeSetParamsFromSymbol",              {"hipGraphExecMemcpyNodeSetParamsFromSymbol",              "", CONV_GRAPH, API_RUNTIME, 30}},
   // no analogue
-  {"cudaGraphExecMemcpyNodeSetParams1D",                      {"hipGraphExecMemcpyNodeSetParams1D",                      "", CONV_GRAPH, API_RUNTIME, 30, HIP_EXPERIMENTAL}},
+  {"cudaGraphExecMemcpyNodeSetParams1D",                      {"hipGraphExecMemcpyNodeSetParams1D",                      "", CONV_GRAPH, API_RUNTIME, 30}},
   // cuGraphExecChildGraphNodeSetParams
-  {"cudaGraphExecChildGraphNodeSetParams",                    {"hipGraphExecChildGraphNodeSetParams",                    "", CONV_GRAPH, API_RUNTIME, 30, HIP_EXPERIMENTAL}},
+  {"cudaGraphExecChildGraphNodeSetParams",                    {"hipGraphExecChildGraphNodeSetParams",                    "", CONV_GRAPH, API_RUNTIME, 30}},
   // cuGraphExecEventRecordNodeSetEvent
-  {"cudaGraphExecEventRecordNodeSetEvent",                    {"hipGraphExecEventRecordNodeSetEvent",                    "", CONV_GRAPH, API_RUNTIME, 30, HIP_EXPERIMENTAL}},
+  {"cudaGraphExecEventRecordNodeSetEvent",                    {"hipGraphExecEventRecordNodeSetEvent",                    "", CONV_GRAPH, API_RUNTIME, 30}},
   // cuGraphExecEventWaitNodeSetEvent
-  {"cudaGraphExecEventWaitNodeSetEvent",                      {"hipGraphExecEventWaitNodeSetEvent",                      "", CONV_GRAPH, API_RUNTIME, 30, HIP_EXPERIMENTAL}},
+  {"cudaGraphExecEventWaitNodeSetEvent",                      {"hipGraphExecEventWaitNodeSetEvent",                      "", CONV_GRAPH, API_RUNTIME, 30}},
   // cuGraphUpload
   {"cudaGraphUpload",                                         {"hipGraphUpload",                                         "", CONV_GRAPH, API_RUNTIME, 30, HIP_UNSUPPORTED}},
   // cuGraphAddExternalSemaphoresSignalNode
@@ -832,7 +832,7 @@ const std::map<llvm::StringRef, hipCounter> CUDA_RUNTIME_FUNCTION_MAP {
   // cuDeviceSetGraphMemAttribute
   {"cudaDeviceSetGraphMemAttribute",                          {"hipDeviceSetGraphMemAttribute",                          "", CONV_GRAPH, API_RUNTIME, 30, HIP_UNSUPPORTED}},
   // cuGraphInstantiateWithFlags
-  {"cudaGraphInstantiateWithFlags",                           {"hipGraphInstantiateWithFlags",                           "", CONV_GRAPH, API_RUNTIME, 30, HIP_EXPERIMENTAL}},
+  {"cudaGraphInstantiateWithFlags",                           {"hipGraphInstantiateWithFlags",                           "", CONV_GRAPH, API_RUNTIME, 30}},
   // cuGraphNodeSetEnabled
   {"cudaGraphNodeSetEnabled",                                {"hipGraphNodeSetEnabled",                                  "", CONV_GRAPH, API_RUNTIME, 30, HIP_UNSUPPORTED}},
 
@@ -1255,40 +1255,40 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_RUNTIME_FUNCTION_VER_MAP {
   {"hipGraphicsResourceGetMappedPointer",                     {HIP_4050, HIP_0,    HIP_0   }},
   {"hipGraphicsUnmapResources",                               {HIP_4050, HIP_0,    HIP_0   }},
   {"hipGraphicsUnregisterResource",                           {HIP_4050, HIP_0,    HIP_0   }},
-  {"hipGraphRemoveDependencies",                              {HIP_5000, HIP_0,    HIP_0,  HIP_LATEST}},
-  {"hipGraphGetEdges",                                        {HIP_5000, HIP_0,    HIP_0,  HIP_LATEST}},
-  {"hipGraphNodeGetDependencies",                             {HIP_5000, HIP_0,    HIP_0,  HIP_LATEST}},
-  {"hipGraphNodeGetDependentNodes",                           {HIP_5000, HIP_0,    HIP_0,  HIP_LATEST}},
-  {"hipGraphNodeGetType",                                     {HIP_5000, HIP_0,    HIP_0,  HIP_LATEST}},
-  {"hipGraphDestroyNode",                                     {HIP_5000, HIP_0,    HIP_0,  HIP_LATEST}},
-  {"hipGraphNodeFindInClone",                                 {HIP_5000, HIP_0,    HIP_0,  HIP_LATEST}},
-  {"hipGraphInstantiateWithFlags",                            {HIP_5000, HIP_0,    HIP_0,  HIP_LATEST}},
-  {"hipGraphExecUpdate",                                      {HIP_5000, HIP_0,    HIP_0,  HIP_LATEST}},
-  {"hipGraphExecMemcpyNodeSetParams",                         {HIP_5000, HIP_0,    HIP_0,  HIP_LATEST}},
-  {"hipGraphMemcpyNodeSetParams1D",                           {HIP_5000, HIP_0,    HIP_0,  HIP_LATEST}},
-  {"hipGraphExecMemcpyNodeSetParams1D",                       {HIP_5000, HIP_0,    HIP_0,  HIP_LATEST}},
-  {"hipGraphAddMemcpyNodeFromSymbol",                         {HIP_5000, HIP_0,    HIP_0,  HIP_LATEST}},
-  {"hipGraphMemcpyNodeSetParamsFromSymbol",                   {HIP_5000, HIP_0,    HIP_0,  HIP_LATEST}},
-  {"hipGraphExecMemcpyNodeSetParamsFromSymbol",               {HIP_5000, HIP_0,    HIP_0,  HIP_LATEST}},
-  {"hipGraphAddMemcpyNodeToSymbol",                           {HIP_5000, HIP_0,    HIP_0,  HIP_LATEST}},
-  {"hipGraphMemcpyNodeSetParamsToSymbol",                     {HIP_5000, HIP_0,    HIP_0,  HIP_LATEST}},
-  {"hipGraphExecMemcpyNodeSetParamsToSymbol",                 {HIP_5000, HIP_0,    HIP_0,  HIP_LATEST}},
-  {"hipGraphExecMemsetNodeSetParams",                         {HIP_5000, HIP_0,    HIP_0,  HIP_LATEST}},
-  {"hipGraphAddHostNode",                                     {HIP_5000, HIP_0,    HIP_0,  HIP_LATEST}},
-  {"hipGraphHostNodeGetParams",                               {HIP_5000, HIP_0,    HIP_0,  HIP_LATEST}},
-  {"hipGraphHostNodeSetParams",                               {HIP_5000, HIP_0,    HIP_0,  HIP_LATEST}},
-  {"hipGraphExecHostNodeSetParams",                           {HIP_5000, HIP_0,    HIP_0,  HIP_LATEST}},
-  {"hipGraphAddChildGraphNode",                               {HIP_5000, HIP_0,    HIP_0,  HIP_LATEST}},
-  {"hipGraphChildGraphNodeGetGraph",                          {HIP_5000, HIP_0,    HIP_0,  HIP_LATEST}},
-  {"hipGraphExecChildGraphNodeSetParams",                     {HIP_5000, HIP_0,    HIP_0,  HIP_LATEST}},
-  {"hipGraphAddEventRecordNode",                              {HIP_5000, HIP_0,    HIP_0,  HIP_LATEST}},
-  {"hipGraphEventRecordNodeGetEvent",                         {HIP_5000, HIP_0,    HIP_0,  HIP_LATEST}},
-  {"hipGraphEventRecordNodeSetEvent",                         {HIP_5000, HIP_0,    HIP_0,  HIP_LATEST}},
-  {"hipGraphExecEventRecordNodeSetEvent",                     {HIP_5000, HIP_0,    HIP_0,  HIP_LATEST}},
-  {"hipGraphAddEventWaitNode",                                {HIP_5000, HIP_0,    HIP_0,  HIP_LATEST}},
-  {"hipGraphEventWaitNodeGetEvent",                           {HIP_5000, HIP_0,    HIP_0,  HIP_LATEST}},
-  {"hipGraphEventWaitNodeSetEvent",                           {HIP_5000, HIP_0,    HIP_0,  HIP_LATEST}},
-  {"hipGraphExecEventWaitNodeSetEvent",                       {HIP_5000, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipGraphRemoveDependencies",                              {HIP_5000, HIP_0,    HIP_0   }},
+  {"hipGraphGetEdges",                                        {HIP_5000, HIP_0,    HIP_0   }},
+  {"hipGraphNodeGetDependencies",                             {HIP_5000, HIP_0,    HIP_0   }},
+  {"hipGraphNodeGetDependentNodes",                           {HIP_5000, HIP_0,    HIP_0   }},
+  {"hipGraphNodeGetType",                                     {HIP_5000, HIP_0,    HIP_0   }},
+  {"hipGraphDestroyNode",                                     {HIP_5000, HIP_0,    HIP_0   }},
+  {"hipGraphNodeFindInClone",                                 {HIP_5000, HIP_0,    HIP_0   }},
+  {"hipGraphInstantiateWithFlags",                            {HIP_5000, HIP_0,    HIP_0   }},
+  {"hipGraphExecUpdate",                                      {HIP_5000, HIP_0,    HIP_0   }},
+  {"hipGraphExecMemcpyNodeSetParams",                         {HIP_5000, HIP_0,    HIP_0   }},
+  {"hipGraphMemcpyNodeSetParams1D",                           {HIP_5000, HIP_0,    HIP_0   }},
+  {"hipGraphExecMemcpyNodeSetParams1D",                       {HIP_5000, HIP_0,    HIP_0   }},
+  {"hipGraphAddMemcpyNodeFromSymbol",                         {HIP_5000, HIP_0,    HIP_0   }},
+  {"hipGraphMemcpyNodeSetParamsFromSymbol",                   {HIP_5000, HIP_0,    HIP_0   }},
+  {"hipGraphExecMemcpyNodeSetParamsFromSymbol",               {HIP_5000, HIP_0,    HIP_0   }},
+  {"hipGraphAddMemcpyNodeToSymbol",                           {HIP_5000, HIP_0,    HIP_0   }},
+  {"hipGraphMemcpyNodeSetParamsToSymbol",                     {HIP_5000, HIP_0,    HIP_0   }},
+  {"hipGraphExecMemcpyNodeSetParamsToSymbol",                 {HIP_5000, HIP_0,    HIP_0   }},
+  {"hipGraphExecMemsetNodeSetParams",                         {HIP_5000, HIP_0,    HIP_0   }},
+  {"hipGraphAddHostNode",                                     {HIP_5000, HIP_0,    HIP_0   }},
+  {"hipGraphHostNodeGetParams",                               {HIP_5000, HIP_0,    HIP_0   }},
+  {"hipGraphHostNodeSetParams",                               {HIP_5000, HIP_0,    HIP_0   }},
+  {"hipGraphExecHostNodeSetParams",                           {HIP_5000, HIP_0,    HIP_0   }},
+  {"hipGraphAddChildGraphNode",                               {HIP_5000, HIP_0,    HIP_0   }},
+  {"hipGraphChildGraphNodeGetGraph",                          {HIP_5000, HIP_0,    HIP_0   }},
+  {"hipGraphExecChildGraphNodeSetParams",                     {HIP_5000, HIP_0,    HIP_0   }},
+  {"hipGraphAddEventRecordNode",                              {HIP_5000, HIP_0,    HIP_0   }},
+  {"hipGraphEventRecordNodeGetEvent",                         {HIP_5000, HIP_0,    HIP_0   }},
+  {"hipGraphEventRecordNodeSetEvent",                         {HIP_5000, HIP_0,    HIP_0   }},
+  {"hipGraphExecEventRecordNodeSetEvent",                     {HIP_5000, HIP_0,    HIP_0   }},
+  {"hipGraphAddEventWaitNode",                                {HIP_5000, HIP_0,    HIP_0   }},
+  {"hipGraphEventWaitNodeGetEvent",                           {HIP_5000, HIP_0,    HIP_0   }},
+  {"hipGraphEventWaitNodeSetEvent",                           {HIP_5000, HIP_0,    HIP_0   }},
+  {"hipGraphExecEventWaitNodeSetEvent",                       {HIP_5000, HIP_0,    HIP_0   }},
 };
 
 const std::map<unsigned int, llvm::StringRef> CUDA_RUNTIME_API_SECTION_MAP {

--- a/src/CUDA2HIP_Runtime_API_types.cpp
+++ b/src/CUDA2HIP_Runtime_API_types.cpp
@@ -897,7 +897,7 @@ const std::map<llvm::StringRef, hipCounter> CUDA_RUNTIME_TYPE_NAME_MAP {
   // CUDA_ERROR_INVALID_HANDLE
   {"cudaErrorInvalidResourceHandle",                                   {"hipErrorInvalidHandle",                                    "", CONV_NUMERIC_LITERAL, API_RUNTIME, 36}}, // 400
   // CUDA_ERROR_ILLEGAL_STATE
-  {"cudaErrorIllegalState",                                            {"hipErrorIllegalState",                                     "", CONV_NUMERIC_LITERAL, API_RUNTIME, 36, HIP_EXPERIMENTAL}}, // 401
+  {"cudaErrorIllegalState",                                            {"hipErrorIllegalState",                                     "", CONV_NUMERIC_LITERAL, API_RUNTIME, 36}}, // 401
   // CUDA_ERROR_NOT_FOUND
   {"cudaErrorSymbolNotFound",                                          {"hipErrorNotFound",                                         "", CONV_NUMERIC_LITERAL, API_RUNTIME, 36}}, // 500
   // CUDA_ERROR_NOT_READY
@@ -981,7 +981,7 @@ const std::map<llvm::StringRef, hipCounter> CUDA_RUNTIME_TYPE_NAME_MAP {
   // CUDA_ERROR_TIMEOUT
   {"cudaErrorTimeout",                                                 {"hipErrorTimeout",                                          "", CONV_NUMERIC_LITERAL, API_RUNTIME, 36, HIP_UNSUPPORTED}}, // 909
   // CUDA_ERROR_GRAPH_EXEC_UPDATE_FAILURE
-  {"cudaErrorGraphExecUpdateFailure",                                  {"hipErrorGraphExecUpdateFailure",                           "", CONV_NUMERIC_LITERAL, API_RUNTIME, 36, HIP_EXPERIMENTAL}}, // 910
+  {"cudaErrorGraphExecUpdateFailure",                                  {"hipErrorGraphExecUpdateFailure",                           "", CONV_NUMERIC_LITERAL, API_RUNTIME, 36}}, // 910
   // CUDA_ERROR_EXTERNAL_DEVICE
   {"cudaErrorExternalDevice",                                          {"hipErrorExternalDevice",                                   "", CONV_NUMERIC_LITERAL, API_RUNTIME, 36, HIP_UNSUPPORTED}}, // 911
   // CUDA_ERROR_UNKNOWN
@@ -1575,12 +1575,12 @@ const std::map<llvm::StringRef, hipCounter> CUDA_RUNTIME_TYPE_NAME_MAP {
   {"cudaMemHandleTypeWin32Kmt",                                        {"hipMemoryHandleTypeWin32Kmt",                              "", CONV_NUMERIC_LITERAL, API_RUNTIME, 36, HIP_UNSUPPORTED}}, // 4
 
   // CUstreamUpdateCaptureDependencies_flags
-  {"cudaStreamUpdateCaptureDependenciesFlags",                         {"hipStreamUpdateCaptureDependenciesFlags",                  "", CONV_TYPE, API_RUNTIME, 36, HIP_EXPERIMENTAL}},
+  {"cudaStreamUpdateCaptureDependenciesFlags",                         {"hipStreamUpdateCaptureDependenciesFlags",                  "", CONV_TYPE, API_RUNTIME, 36}},
   // cudaStreamUpdateCaptureDependenciesFlags enum values
   // CU_STREAM_ADD_CAPTURE_DEPENDENCIES
-  {"cudaStreamAddCaptureDependencies",                                 {"hipStreamAddCaptureDependencies",                          "", CONV_NUMERIC_LITERAL, API_RUNTIME, 36, HIP_EXPERIMENTAL}}, // 0x0
+  {"cudaStreamAddCaptureDependencies",                                 {"hipStreamAddCaptureDependencies",                          "", CONV_NUMERIC_LITERAL, API_RUNTIME, 36}}, // 0x0
   // CU_STREAM_SET_CAPTURE_DEPENDENCIES
-  {"cudaStreamSetCaptureDependencies",                                 {"hipStreamSetCaptureDependencies",                          "", CONV_NUMERIC_LITERAL, API_RUNTIME, 36, HIP_EXPERIMENTAL}}, // 0x1
+  {"cudaStreamSetCaptureDependencies",                                 {"hipStreamSetCaptureDependencies",                          "", CONV_NUMERIC_LITERAL, API_RUNTIME, 36}}, // 0x1
 
   // CUuserObject_flags
   {"cudaUserObjectFlags",                                              {"hipUserObjectFlags",                                       "", CONV_TYPE, API_RUNTIME, 36, HIP_UNSUPPORTED}},
@@ -2421,6 +2421,6 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_RUNTIME_TYPE_NAME_VER_MAP {
   {"hipGraphicsRegisterFlagsWriteDiscard",                             {HIP_4040, HIP_0,    HIP_0   }},
   {"hipGraphicsRegisterFlagsSurfaceLoadStore",                         {HIP_4040, HIP_0,    HIP_0   }},
   {"hipGraphicsRegisterFlagsTextureGather",                            {HIP_4040, HIP_0,    HIP_0   }},
-  {"hipErrorIllegalState",                                             {HIP_5000, HIP_0,    HIP_0,  HIP_LATEST}},
-  {"hipErrorGraphExecUpdateFailure",                                   {HIP_5000, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipErrorIllegalState",                                             {HIP_5000, HIP_0,    HIP_0   }},
+  {"hipErrorGraphExecUpdateFailure",                                   {HIP_5000, HIP_0,    HIP_0   }},
 };

--- a/src/Statistics.cpp
+++ b/src/Statistics.cpp
@@ -525,6 +525,9 @@ std::string Statistics::getHipVersion(const hipVersions& ver) {
     case HIP_4051: return "4.5.1";
     case HIP_4052: return "4.5.2";
     case HIP_5000: return "5.0.0";
+    case HIP_5001: return "5.0.1";
+    case HIP_5002: return "5.0.2";
+    case HIP_5010: return "5.1.0";
   }
   return "";
 }

--- a/src/Statistics.h
+++ b/src/Statistics.h
@@ -281,7 +281,10 @@ enum hipVersions {
   HIP_4051 = 4051,
   HIP_4052 = 4052,
   HIP_5000 = 5000,
-  HIP_LATEST = HIP_5000,
+  HIP_5001 = 5001,
+  HIP_5002 = 5002,
+  HIP_5010 = 5010,
+  HIP_LATEST = HIP_5010,
 };
 
 struct cudaAPIversions {

--- a/tests/unit_tests/synthetic/driver_enums.cu
+++ b/tests/unit_tests/synthetic/driver_enums.cu
@@ -4,8 +4,8 @@
 #include <cuda.h>
 #include <stdio.h>
 #if defined(_WIN32)
-#include "windows.h"
-#include <GL/glew.h>
+  #include "windows.h"
+  #include <GL/glew.h>
 #endif
 #include "cudaGL.h"
 
@@ -899,6 +899,11 @@ int main() {
   CUstreamUpdateCaptureDependencies_flags STREAM_ADD_CAPTURE_DEPENDENCIES = CU_STREAM_ADD_CAPTURE_DEPENDENCIES;
   CUstreamUpdateCaptureDependencies_flags STREAM_SET_CAPTURE_DEPENDENCIES = CU_STREAM_SET_CAPTURE_DEPENDENCIES;
 #endif
+
+  // CHECK: typedef struct hipGraphicsResource *graphicsResource_st;
+  // CHECK-NEXT: hipGraphicsResource_t graphicsResource;
+  typedef struct CUgraphicsResource_st *graphicsResource_st;
+  CUgraphicsResource graphicsResource;
 
   return 0;
 }

--- a/tests/unit_tests/synthetic/driver_functions.cu
+++ b/tests/unit_tests/synthetic/driver_functions.cu
@@ -4,11 +4,17 @@
 #include <cuda.h>
 #include <string>
 #include <stdio.h>
+#if defined(_WIN32)
+  #include "windows.h"
+  #include <GL/glew.h>
+#endif
+#include "cudaGL.h"
 
 int main() {
   printf("09. CUDA Driver API Functions synthetic test\n");
 
   unsigned int flags = 0;
+  unsigned int flags_2 = 0;
   int iBlockSize = 0;
   int iBlockSize_2 = 0;
   size_t bytes = 0;
@@ -19,6 +25,8 @@ int main() {
   float ms = 0;
   int* value = 0;
   int* value_2 = 0;
+  GLuint gl_uint = 0;
+  GLenum gl_enum = 0;
 #if defined(_WIN32)
   unsigned long long ull = 0;
 #else
@@ -51,6 +59,7 @@ int main() {
   // CHECK-NEXT: hipStreamCallback_t streamCallback;
   // CHECK-NEXT: hipPointer_attribute pointer_attribute;
   // CHECK-NEXT: void* occupancyB2DSize;
+  // CHECK-NEXT: hipGraphicsResource_t graphicsResource;
   CUdevice device;
   CUcontext context;
   CUfunc_cache func_cache;
@@ -78,6 +87,7 @@ int main() {
   CUstreamCallback streamCallback;
   CUpointer_attribute pointer_attribute;
   CUoccupancyB2DSize occupancyB2DSize;
+  CUgraphicsResource graphicsResource;
 #if CUDA_VERSION > 7050
   // CHECK: hipMemRangeAttribute MemoryRangeAttribute;
   // CHECK-NEXT: hipMemoryAdvise MemoryAdvise;
@@ -1080,6 +1090,16 @@ int main() {
   // HIP: hipError_t hipModuleOccupancyMaxPotentialBlockSizeWithFlags(int* gridSize, int* blockSize, hipFunction_t f, size_t dynSharedMemPerBlk, int blockSizeLimit, unsigned int  flags);
   // CHECK: result = hipModuleOccupancyMaxPotentialBlockSizeWithFlags(value, value_2, function, bytes, iBlockSize, iBlockSize_2);
   result = cuOccupancyMaxPotentialBlockSizeWithFlags(value, value_2, function, occupancyB2DSize, bytes, iBlockSize, iBlockSize_2);
+
+  // CUDA: CUresult CUDAAPI cuGraphicsGLRegisterImage(CUgraphicsResource *pCudaResource, GLuint image, GLenum target, unsigned int Flags);
+  // HIP: hipError_t hipGraphicsGLRegisterImage(hipGraphicsResource** resource, GLuint image, GLenum target, unsigned int flags);
+  // CHECK: result = hipGraphicsGLRegisterImage(&graphicsResource, gl_uint, gl_enum, flags);
+  result = cuGraphicsGLRegisterImage(&graphicsResource, gl_uint, gl_enum, flags);
+
+  // CUDA: CUresult CUDAAPI cuGraphicsSubResourceGetMappedArray(CUarray *pArray, CUgraphicsResource resource, unsigned int arrayIndex, unsigned int mipLevel);
+  // HIP: hipError_t hipGraphicsSubResourceGetMappedArray(hipArray_t* array, hipGraphicsResource_t resource, unsigned int arrayIndex, unsigned int mipLevel);
+  // CHECK: result = hipGraphicsSubResourceGetMappedArray(&array_, graphicsResource, flags, flags_2);
+  result = cuGraphicsSubResourceGetMappedArray(&array_, graphicsResource, flags, flags_2);
 
   return 0;
 }


### PR DESCRIPTION
+ Remove mark `HIP_EXPERIMENTAL` from all HIP-rocm-5.0.0 APIs
+ Add newly supported APIs, mark them as `HIP_EXPERIMENTAL`
+ Update docs, tests, and hipify-perl accordingly