### PR TITLE
[HIPIFY][tests] Add CUDA 11.6 samples support to lit.cfg

### DIFF
--- a/tests/lit.cfg
+++ b/tests/lit.cfg
@@ -113,16 +113,21 @@ if config.hipify_clang_tests_only and config.hipify_clang_tests_only != "0" and 
 else:
     hipify_path = obj_root
 
+inc_subfolder = ""
+if config.cuda_version_major < 11 or (config.cuda_version_major == 11 and config.cuda_version_minor < 6):
+    inc_subfolder = "/inc"
+
 if sys.platform in ['win32']:
     run_test_ext = ".bat"
     if not config.hipify_clang_tests_only or config.hipify_clang_tests_only == "0" or config.hipify_clang_tests_only.upper() == "OFF":
         hipify_path += "/" + config.build_type
     # CUDA SDK ROOT
-    clang_arguments += " -isystem'%s'/common/inc"
+    clang_arguments += " -isystem'%s'/common" + inc_subfolder
+
 else:
     run_test_ext = ".sh"
     # CUDA SDK ROOT
-    clang_arguments += " -isystem'%s'/samples/common/inc"
+    clang_arguments += " -isystem'%s'/samples/common" + inc_subfolder
 if config.pointer_size == 8:
     clang_arguments += " -D__LP64__"
 


### PR DESCRIPTION
[Reason] Starting with CUDA SDK Toolkit 11.6 Samples are released separately from SDK on GitHub: https://github.com/nvidia/cuda-samples

To test hipify-clang against CUDA 11.6 and newer, CUDA SDK samples of the corresponding version should be downloaded from https://github.com/NVIDIA/cuda-samples/releases, and the contains of the root folder in the archive should be extracted to the CUDA_TOOLKIT_ROOT_DIR corresponding to CUDA_SDK_ROOT_DIR (or equal to it in case of Linux)

P.S.
Actually, only `GL` subfolder is needed in CUDA SDK samples for synthetic tests dealing with GL interop (`#include <GL/glew.h>`)
