### PR TITLE
[HIPIFY][#531][SWDEV_331863][temporary][workaround] Add a workaround for the `SWDEV_331863` blocker

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,6 +85,12 @@ else()
     set(addr_var )
 endif()
 
+# [ToDo] Remove SWDEV_331863 related guards from CMakeLists.txt and HipifyAction.cpp when the blocker SWDEV_331863 is overcome
+option (SWDEV_331863 "Enables SWDEV-331863 blocker workaround" OFF)
+if(SWDEV_331863)
+    add_definitions(-DSWDEV_331863)
+endif()
+
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${EXTRA_CFLAGS} ${addr_var}")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${EXTRA_CFLAGS} -DHIPIFY_CLANG_RES=\\\"${LLVM_LIBRARY_DIRS}/clang/${LLVM_VERSION_MAJOR}.${LLVM_VERSION_MINOR}.${LLVM_VERSION_PATCH}\\\" ${addr_var}")
 

--- a/src/HipifyAction.cpp
+++ b/src/HipifyAction.cpp
@@ -681,10 +681,10 @@ class PPCallbackProxy : public clang::PPCallbacks {
 
 public:
   explicit PPCallbackProxy(HipifyAction &action): hipifyAction(action) {}
-
+  // [ToDo] Remove SWDEV_331863 related guards from CMakeLists.txt and HipifyAction.cpp when the blocker SWDEV_331863 is overcome
   void InclusionDirective(clang::SourceLocation hash_loc, const clang::Token &include_token,
                           StringRef file_name, bool is_angled, clang::CharSourceRange filename_range,
-#if LLVM_VERSION_MAJOR < 15
+#if (LLVM_VERSION_MAJOR < 15) || (LLVM_VERSION_MAJOR == 15 && SWDEV_331863)
                           const clang::FileEntry *file,
 #else
                           Optional<clang::FileEntryRef> file,
@@ -695,7 +695,7 @@ public:
                         , clang::SrcMgr::CharacteristicKind FileType
 #endif
                          ) override {
-#if LLVM_VERSION_MAJOR < 15
+#if (LLVM_VERSION_MAJOR < 15) || (LLVM_VERSION_MAJOR == 15 && SWDEV_331863)
     auto f = file;
 #else
     auto f = &file->getFileEntry();


### PR DESCRIPTION
+ To build hipify-clang against `trunk LLVM (15.0.0git)` nothing to do else
+ To build hipify-clang against `trunk LLVM (15.0.0git)` older than `d79ad2f1dbc2db63121620f55d6cfa915f2733ac` (2022.04.11, DR: https://reviews.llvm.org/D123574) `-DSWDEV_331863=ON` should be added to hipify-clang's cmake command line

[ToDo] Remove `SWDEV_331863` related guards from `CMakeLists.txt` and `HipifyAction.cpp` when the blocker `SWDEV_331863` is overcome