### PR TITLE
[HIPIFY] Sync with the upcoming HIP-rocm-5.2.0 - Part 1 - Types

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -709,11 +709,25 @@ my %removed_funcs = (
 );
 
 my %experimental_funcs = (
-    "cudaGraphicsSubResourceGetMappedArray" => "5.1.0",
-    "cuGraphicsSubResourceGetMappedArray" => "5.1.0",
-    "cuGraphicsGLRegisterImage" => "5.1.0",
-    "GLuint" => "5.1.0",
-    "GLenum" => "5.1.0"
+    "cudaUUID_t" => "5.2.0",
+    "cudaKernelNodeAttributeCooperative" => "5.2.0",
+    "cudaKernelNodeAttributeAccessPolicyWindow" => "5.2.0",
+    "cudaKernelNodeAttrID" => "5.2.0",
+    "cudaAccessPropertyStreaming" => "5.2.0",
+    "cudaAccessPropertyPersisting" => "5.2.0",
+    "cudaAccessPropertyNormal" => "5.2.0",
+    "cudaAccessProperty" => "5.2.0",
+    "CUuuid_st" => "5.2.0",
+    "CUuuid" => "5.2.0",
+    "CUkernelNodeAttrID_enum" => "5.2.0",
+    "CUkernelNodeAttrID" => "5.2.0",
+    "CUaccessProperty_enum" => "5.2.0",
+    "CUaccessProperty" => "5.2.0",
+    "CU_KERNEL_NODE_ATTRIBUTE_COOPERATIVE" => "5.2.0",
+    "CU_KERNEL_NODE_ATTRIBUTE_ACCESS_POLICY_WINDOW" => "5.2.0",
+    "CU_ACCESS_PROPERTY_STREAMING" => "5.2.0",
+    "CU_ACCESS_PROPERTY_PERSISTING" => "5.2.0",
+    "CU_ACCESS_PROPERTY_NORMAL" => "5.2.0"
 );
 
 $print_stats = 1 if $examine;
@@ -851,11 +865,25 @@ sub subst {
 }
 
 sub experimentalSubstitutions {
-    subst("cuGraphicsSubResourceGetMappedArray", "hipGraphicsSubResourceGetMappedArray", "graphics");
-    subst("cudaGraphicsSubResourceGetMappedArray", "hipGraphicsSubResourceGetMappedArray", "graphics");
-    subst("cuGraphicsGLRegisterImage", "hipGraphicsGLRegisterImage", "openGL");
-    subst("GLenum", "GLenum", "type");
-    subst("GLuint", "GLuint", "type");
+    subst("CUaccessProperty", "hipAccessProperty", "type");
+    subst("CUaccessProperty_enum", "hipAccessProperty", "type");
+    subst("CUkernelNodeAttrID", "hipKernelNodeAttrID", "type");
+    subst("CUkernelNodeAttrID_enum", "hipKernelNodeAttrID", "type");
+    subst("CUuuid", "hipUUID", "type");
+    subst("CUuuid_st", "hipUUID_t", "type");
+    subst("cudaAccessProperty", "hipAccessProperty", "type");
+    subst("cudaKernelNodeAttrID", "hipKernelNodeAttrID", "type");
+    subst("cudaUUID_t", "hipUUID", "type");
+    subst("CU_ACCESS_PROPERTY_NORMAL", "hipAccessPropertyNormal", "numeric_literal");
+    subst("CU_ACCESS_PROPERTY_PERSISTING", "hipAccessPropertyPersisting", "numeric_literal");
+    subst("CU_ACCESS_PROPERTY_STREAMING", "hipAccessPropertyStreaming", "numeric_literal");
+    subst("CU_KERNEL_NODE_ATTRIBUTE_ACCESS_POLICY_WINDOW", "hipKernelNodeAttributeAccessPolicyWindow", "numeric_literal");
+    subst("CU_KERNEL_NODE_ATTRIBUTE_COOPERATIVE", "hipKernelNodeAttributeCooperative", "numeric_literal");
+    subst("cudaAccessPropertyNormal", "hipAccessPropertyNormal", "numeric_literal");
+    subst("cudaAccessPropertyPersisting", "hipAccessPropertyPersisting", "numeric_literal");
+    subst("cudaAccessPropertyStreaming", "hipAccessPropertyStreaming", "numeric_literal");
+    subst("cudaKernelNodeAttributeAccessPolicyWindow", "hipKernelNodeAttributeAccessPolicyWindow", "numeric_literal");
+    subst("cudaKernelNodeAttributeCooperative", "hipKernelNodeAttributeCooperative", "numeric_literal");
 }
 
 sub rocSubstitutions {
@@ -1716,10 +1744,12 @@ sub simpleSubstitutions {
     subst("cuGraphicsMapResources", "hipGraphicsMapResources", "graphics");
     subst("cuGraphicsResourceGetMappedPointer", "hipGraphicsResourceGetMappedPointer", "graphics");
     subst("cuGraphicsResourceGetMappedPointer_v2", "hipGraphicsResourceGetMappedPointer", "graphics");
+    subst("cuGraphicsSubResourceGetMappedArray", "hipGraphicsSubResourceGetMappedArray", "graphics");
     subst("cuGraphicsUnmapResources", "hipGraphicsUnmapResources", "graphics");
     subst("cuGraphicsUnregisterResource", "hipGraphicsUnregisterResource", "graphics");
     subst("cudaGraphicsMapResources", "hipGraphicsMapResources", "graphics");
     subst("cudaGraphicsResourceGetMappedPointer", "hipGraphicsResourceGetMappedPointer", "graphics");
+    subst("cudaGraphicsSubResourceGetMappedArray", "hipGraphicsSubResourceGetMappedArray", "graphics");
     subst("cudaGraphicsUnmapResources", "hipGraphicsUnmapResources", "graphics");
     subst("cudaGraphicsUnregisterResource", "hipGraphicsUnregisterResource", "graphics");
     subst("cuProfilerStart", "hipProfilerStart", "profiler");
@@ -1728,6 +1758,7 @@ sub simpleSubstitutions {
     subst("cudaProfilerStop", "hipProfilerStop", "profiler");
     subst("cuGLGetDevices", "hipGLGetDevices", "openGL");
     subst("cuGraphicsGLRegisterBuffer", "hipGraphicsGLRegisterBuffer", "openGL");
+    subst("cuGraphicsGLRegisterImage", "hipGraphicsGLRegisterImage", "openGL");
     subst("cudaGLGetDevices", "hipGLGetDevices", "openGL");
     subst("cudaGraphicsGLRegisterBuffer", "hipGraphicsGLRegisterBuffer", "openGL");
     subst("cudaGraphicsGLRegisterImage", "hipGraphicsGLRegisterImage", "openGL");
@@ -3042,6 +3073,8 @@ sub simpleSubstitutions {
     subst("CUtexObject_v1", "hipTextureObject_t", "type");
     subst("CUtexref", "hipTexRef", "type");
     subst("CUtexref_st", "textureReference", "type");
+    subst("GLenum", "GLenum", "type");
+    subst("GLuint", "GLuint", "type");
     subst("bsric02Info_t", "bsric02Info_t", "type");
     subst("bsrilu02Info_t", "bsrilu02Info_t", "type");
     subst("bsrsm2Info", "bsrsm2Info", "type");
@@ -5619,7 +5652,6 @@ sub warnUnsupportedFunctions {
         "cudaUserObjectNoDestructorSync",
         "cudaUserObjectFlags",
         "cudaUserObjectCreate",
-        "cudaUUID_t",
         "cudaThreadSetLimit",
         "cudaThreadGetLimit",
         "cudaThreadExchangeStreamCaptureMode",
@@ -5713,10 +5745,7 @@ sub warnUnsupportedFunctions {
         "cudaLimitDevRuntimePendingLaunchCount",
         "cudaLaunchHostFunc",
         "cudaKeyValuePair",
-        "cudaKernelNodeAttributeCooperative",
-        "cudaKernelNodeAttributeAccessPolicyWindow",
         "cudaKernelNodeAttrValue",
-        "cudaKernelNodeAttrID",
         "cudaHostRegisterReadOnly",
         "cudaGraphicsVDPAURegisterVideoSurface",
         "cudaGraphicsVDPAURegisterOutputSurface",
@@ -6124,10 +6153,6 @@ sub warnUnsupportedFunctions {
         "cudaArrayGetInfo",
         "cudaArrayDeferredMapping",
         "cudaArrayColorAttachment",
-        "cudaAccessPropertyStreaming",
-        "cudaAccessPropertyPersisting",
-        "cudaAccessPropertyNormal",
-        "cudaAccessProperty",
         "cudaAccessPolicyWindow",
         "cuWGLGetDevice",
         "cuVDPAUGetDevice",
@@ -6368,8 +6393,6 @@ sub warnUnsupportedFunctions {
         "MINOR_VERSION",
         "MAX_CUFFT_ERROR",
         "MAJOR_VERSION",
-        "CUuuid_st",
-        "CUuuid",
         "CUuserObject_st",
         "CUuserObject_flags_enum",
         "CUuserObject_flags",
@@ -6440,8 +6463,6 @@ sub warnUnsupportedFunctions {
         "CUkernelNodeAttrValue_v1",
         "CUkernelNodeAttrValue_union",
         "CUkernelNodeAttrValue",
-        "CUkernelNodeAttrID_enum",
-        "CUkernelNodeAttrID",
         "CUjit_target_enum",
         "CUjit_target",
         "CUjit_fallback_enum",
@@ -6520,8 +6541,6 @@ sub warnUnsupportedFunctions {
         "CUarrayMapInfo_v1",
         "CUarrayMapInfo_st",
         "CUarrayMapInfo",
-        "CUaccessProperty_enum",
-        "CUaccessProperty",
         "CUaccessPolicyWindow_st",
         "CUaccessPolicyWindow",
         "CU_USER_OBJECT_NO_DESTRUCTOR_SYNC",
@@ -6610,8 +6629,6 @@ sub warnUnsupportedFunctions {
         "CU_LIMIT_MAX",
         "CU_LIMIT_DEV_RUNTIME_SYNC_DEPTH",
         "CU_LIMIT_DEV_RUNTIME_PENDING_LAUNCH_COUNT",
-        "CU_KERNEL_NODE_ATTRIBUTE_COOPERATIVE",
-        "CU_KERNEL_NODE_ATTRIBUTE_ACCESS_POLICY_WINDOW",
         "CU_JIT_PREC_SQRT",
         "CU_JIT_PREC_DIV",
         "CU_JIT_NUM_INPUT_TYPES",
@@ -6848,9 +6865,6 @@ sub warnUnsupportedFunctions {
         "CU_AD_FORMAT_BC2_UNORM",
         "CU_AD_FORMAT_BC1_UNORM_SRGB",
         "CU_AD_FORMAT_BC1_UNORM",
-        "CU_ACCESS_PROPERTY_STREAMING",
-        "CU_ACCESS_PROPERTY_PERSISTING",
-        "CU_ACCESS_PROPERTY_NORMAL",
         "CUSPARSE_VER_PATCH",
         "CUSPARSE_VER_MINOR",
         "CUSPARSE_VER_MAJOR",

--- a/doc/markdown/CUDA_Driver_API_functions_supported_by_HIP.md
+++ b/doc/markdown/CUDA_Driver_API_functions_supported_by_HIP.md
@@ -194,9 +194,9 @@
 |`CUGLmap_flags_enum`| | | | | | | | |
 |`CUGPUDirectRDMAWritesOrdering`|11.3| | | | | | | |
 |`CUGPUDirectRDMAWritesOrdering_enum`|11.3| | | | | | | |
-|`CU_ACCESS_PROPERTY_NORMAL`|11.0| | | | | | | |
-|`CU_ACCESS_PROPERTY_PERSISTING`|11.0| | | | | | | |
-|`CU_ACCESS_PROPERTY_STREAMING`|11.0| | | | | | | |
+|`CU_ACCESS_PROPERTY_NORMAL`|11.0| | |`hipAccessPropertyNormal`|5.2.0| | |5.2.0|
+|`CU_ACCESS_PROPERTY_PERSISTING`|11.0| | |`hipAccessPropertyPersisting`|5.2.0| | |5.2.0|
+|`CU_ACCESS_PROPERTY_STREAMING`|11.0| | |`hipAccessPropertyStreaming`|5.2.0| | |5.2.0|
 |`CU_AD_FORMAT_BC1_UNORM`|11.5| | | | | | | |
 |`CU_AD_FORMAT_BC1_UNORM_SRGB`|11.5| | | | | | | |
 |`CU_AD_FORMAT_BC2_UNORM`|11.5| | | | | | | |
@@ -631,8 +631,8 @@
 |`CU_JIT_TARGET_FROM_CUCONTEXT`| | | |`hipJitOptionTargetFromContext`|1.6.0| | | |
 |`CU_JIT_THREADS_PER_BLOCK`| | | |`hipJitOptionThreadsPerBlock`|1.6.0| | | |
 |`CU_JIT_WALL_TIME`| | | |`hipJitOptionWallTime`|1.6.0| | | |
-|`CU_KERNEL_NODE_ATTRIBUTE_ACCESS_POLICY_WINDOW`|11.0| | | | | | | |
-|`CU_KERNEL_NODE_ATTRIBUTE_COOPERATIVE`|11.0| | | | | | | |
+|`CU_KERNEL_NODE_ATTRIBUTE_ACCESS_POLICY_WINDOW`|11.0| | |`hipKernelNodeAttributeAccessPolicyWindow`|5.2.0| | |5.2.0|
+|`CU_KERNEL_NODE_ATTRIBUTE_COOPERATIVE`|11.0| | |`hipKernelNodeAttributeCooperative`|5.2.0| | |5.2.0|
 |`CU_LAUNCH_PARAM_BUFFER_POINTER`| | | |`HIP_LAUNCH_PARAM_BUFFER_POINTER`|1.6.0| | | |
 |`CU_LAUNCH_PARAM_BUFFER_SIZE`| | | |`HIP_LAUNCH_PARAM_BUFFER_SIZE`|1.6.0| | | |
 |`CU_LAUNCH_PARAM_END`| | | |`HIP_LAUNCH_PARAM_END`|1.6.0| | | |
@@ -834,8 +834,8 @@
 |`CU_USER_OBJECT_NO_DESTRUCTOR_SYNC`|11.3| | | | | | | |
 |`CUaccessPolicyWindow`|11.0| | | | | | | |
 |`CUaccessPolicyWindow_st`|11.0| | | | | | | |
-|`CUaccessProperty`|11.0| | | | | | | |
-|`CUaccessProperty_enum`|11.0| | | | | | | |
+|`CUaccessProperty`|11.0| | |`hipAccessProperty`|5.2.0| | |5.2.0|
+|`CUaccessProperty_enum`|11.0| | |`hipAccessProperty`|5.2.0| | |5.2.0|
 |`CUaddress_mode`| | | |`HIPaddress_mode`|3.5.0| | | |
 |`CUaddress_mode_enum`| | | |`HIPaddress_mode_enum`|3.5.0| | | |
 |`CUarray`| | | |`hipArray_t`|1.7.0| | | |
@@ -970,8 +970,8 @@
 |`CUjit_option_enum`| | | |`hipJitOption`|1.6.0| | | |
 |`CUjit_target`| | | | | | | | |
 |`CUjit_target_enum`| | | | | | | | |
-|`CUkernelNodeAttrID`|11.0| | | | | | | |
-|`CUkernelNodeAttrID_enum`|11.0| | | | | | | |
+|`CUkernelNodeAttrID`|11.0| | |`hipKernelNodeAttrID`|5.2.0| | |5.2.0|
+|`CUkernelNodeAttrID_enum`|11.0| | |`hipKernelNodeAttrID`|5.2.0| | |5.2.0|
 |`CUkernelNodeAttrValue`|11.0| | | | | | | |
 |`CUkernelNodeAttrValue_union`|11.0| | | | | | | |
 |`CUkernelNodeAttrValue_v1`|11.3| | | | | | | |
@@ -1079,10 +1079,10 @@
 |`CUuserObject_flags`|11.3| | | | | | | |
 |`CUuserObject_flags_enum`|11.3| | | | | | | |
 |`CUuserObject_st`|11.3| | | | | | | |
-|`CUuuid`| | | | | | | | |
-|`CUuuid_st`| | | | | | | | |
-|`GLenum`| | | |`GLenum`|5.1.0| | |5.1.0|
-|`GLuint`| | | |`GLuint`|5.1.0| | |5.1.0|
+|`CUuuid`| | | |`hipUUID`|5.2.0| | |5.2.0|
+|`CUuuid_st`| | | |`hipUUID_t`|5.2.0| | |5.2.0|
+|`GLenum`| | | |`GLenum`|5.1.0| | | |
+|`GLuint`| | | |`GLuint`|5.1.0| | | |
 |`__CUDACC__`| | | |`__HIPCC__`|1.6.0| | | |
 |`cudaError_enum`| | | |`hipError_t`|1.5.0| | | |
 
@@ -1626,7 +1626,7 @@
 |`cuGraphicsResourceGetMappedPointer_v2`| | | |`hipGraphicsResourceGetMappedPointer`|4.5.0| | | |
 |`cuGraphicsResourceSetMapFlags`| | | | | | | | |
 |`cuGraphicsResourceSetMapFlags_v2`| | | | | | | | |
-|`cuGraphicsSubResourceGetMappedArray`| | | |`hipGraphicsSubResourceGetMappedArray`|5.1.0| | |5.1.0|
+|`cuGraphicsSubResourceGetMappedArray`| | | |`hipGraphicsSubResourceGetMappedArray`|5.1.0| | | |
 |`cuGraphicsUnmapResources`| | | |`hipGraphicsUnmapResources`|4.5.0| | | |
 |`cuGraphicsUnregisterResource`| | | |`hipGraphicsUnregisterResource`|4.5.0| | | |
 
@@ -1665,7 +1665,7 @@
 |`cuGLUnmapBufferObjectAsync`| |9.2| | | | | | |
 |`cuGLUnregisterBufferObject`| |9.2| | | | | | |
 |`cuGraphicsGLRegisterBuffer`| | | |`hipGraphicsGLRegisterBuffer`|4.5.0| | | |
-|`cuGraphicsGLRegisterImage`| | | |`hipGraphicsGLRegisterImage`|5.1.0| | |5.1.0|
+|`cuGraphicsGLRegisterImage`| | | |`hipGraphicsGLRegisterImage`|5.1.0| | | |
 |`cuWGLGetDevice`| | | | | | | | |
 
 ## **33. VDPAU Interoperability**

--- a/doc/markdown/CUDA_Runtime_API_functions_supported_by_HIP.md
+++ b/doc/markdown/CUDA_Runtime_API_functions_supported_by_HIP.md
@@ -248,7 +248,7 @@
 |:--|:-:|:-:|:-:|:--|:-:|:-:|:-:|:-:|
 |`cudaGLGetDevices`| | | |`hipGLGetDevices`|4.5.0| | | |
 |`cudaGraphicsGLRegisterBuffer`| | | |`hipGraphicsGLRegisterBuffer`|4.5.0| | | |
-|`cudaGraphicsGLRegisterImage`| | | |`hipGraphicsGLRegisterImage`|5.1.0| | |5.1.0|
+|`cudaGraphicsGLRegisterImage`| | | |`hipGraphicsGLRegisterImage`|5.1.0| | | |
 |`cudaWGLGetDevice`| | | | | | | | |
 
 ## **15. OpenGL Interoperability [DEPRECATED]**
@@ -363,7 +363,7 @@
 |`cudaGraphicsResourceGetMappedMipmappedArray`| | | | | | | | |
 |`cudaGraphicsResourceGetMappedPointer`| | | |`hipGraphicsResourceGetMappedPointer`|4.5.0| | | |
 |`cudaGraphicsResourceSetMapFlags`| | | | | | | | |
-|`cudaGraphicsSubResourceGetMappedArray`| | | |`hipGraphicsSubResourceGetMappedArray`|5.1.0| | |5.1.0|
+|`cudaGraphicsSubResourceGetMappedArray`| | | |`hipGraphicsSubResourceGetMappedArray`|5.1.0| | | |
 |`cudaGraphicsUnmapResources`| | | |`hipGraphicsUnmapResources`|4.5.0| | | |
 |`cudaGraphicsUnregisterResource`| | | |`hipGraphicsUnregisterResource`|4.5.0| | | |
 
@@ -542,15 +542,15 @@ Unsupported
 |`CUgraphNode_st`|10.0| | |`hipGraphNode`|4.3.0| | | |
 |`CUgraph_st`|10.0| | |`ihipGraph`|4.3.0| | | |
 |`CUstream_st`| | | |`ihipStream_t`|1.5.0| | | |
-|`CUuuid_st`| | | | | | | | |
+|`CUuuid_st`| | | |`hipUUID_t`|5.2.0| | |5.2.0|
 |`MAJOR_VERSION`|8.0| | | | | | | |
 |`MINOR_VERSION`|8.0| | | | | | | |
 |`PATCH_LEVEL`|8.0| | | | | | | |
 |`cudaAccessPolicyWindow`|11.0| | | | | | | |
-|`cudaAccessProperty`|11.0| | | | | | | |
-|`cudaAccessPropertyNormal`|11.0| | | | | | | |
-|`cudaAccessPropertyPersisting`|11.0| | | | | | | |
-|`cudaAccessPropertyStreaming`|11.0| | | | | | | |
+|`cudaAccessProperty`|11.0| | |`hipAccessProperty`|5.2.0| | |5.2.0|
+|`cudaAccessPropertyNormal`|11.0| | |`hipAccessPropertyNormal`|5.2.0| | |5.2.0|
+|`cudaAccessPropertyPersisting`|11.0| | |`hipAccessPropertyPersisting`|5.2.0| | |5.2.0|
+|`cudaAccessPropertyStreaming`|11.0| | |`hipAccessPropertyStreaming`|5.2.0| | |5.2.0|
 |`cudaAddressModeBorder`| | | |`hipAddressModeBorder`|1.7.0| | | |
 |`cudaAddressModeClamp`| | | |`hipAddressModeClamp`|1.7.0| | | |
 |`cudaAddressModeMirror`| | | |`hipAddressModeMirror`|1.7.0| | | |
@@ -1149,10 +1149,10 @@ Unsupported
 |`cudaIpcMemHandle_st`| | | |`hipIpcMemHandle_st`|1.6.0| | | |
 |`cudaIpcMemHandle_t`| | | |`hipIpcMemHandle_t`|1.6.0| | | |
 |`cudaIpcMemLazyEnablePeerAccess`| | | |`hipIpcMemLazyEnablePeerAccess`|1.6.0| | | |
-|`cudaKernelNodeAttrID`|11.0| | | | | | | |
+|`cudaKernelNodeAttrID`|11.0| | |`hipKernelNodeAttrID`|5.2.0| | |5.2.0|
 |`cudaKernelNodeAttrValue`|11.0| | | | | | | |
-|`cudaKernelNodeAttributeAccessPolicyWindow`|11.0| | | | | | | |
-|`cudaKernelNodeAttributeCooperative`|11.0| | | | | | | |
+|`cudaKernelNodeAttributeAccessPolicyWindow`|11.0| | |`hipKernelNodeAttributeAccessPolicyWindow`|5.2.0| | |5.2.0|
+|`cudaKernelNodeAttributeCooperative`|11.0| | |`hipKernelNodeAttributeCooperative`|5.2.0| | |5.2.0|
 |`cudaKernelNodeParams`|10.0| | |`hipKernelNodeParams`|4.3.0| | | |
 |`cudaKeyValuePair`| | | | | | | | |
 |`cudaLaunchParams`|9.0| | |`hipLaunchParams`|2.6.0| | | |
@@ -1331,7 +1331,7 @@ Unsupported
 |`cudaTextureType3D`| | | |`hipTextureType3D`|1.7.0| | | |
 |`cudaTextureTypeCubemap`| | | |`hipTextureTypeCubemap`|1.7.0| | | |
 |`cudaTextureTypeCubemapLayered`| | | |`hipTextureTypeCubemapLayered`|1.7.0| | | |
-|`cudaUUID_t`| | | | | | | | |
+|`cudaUUID_t`| | | |`hipUUID`|5.2.0| | |5.2.0|
 |`cudaUserObjectFlags`|11.3| | | | | | | |
 |`cudaUserObjectNoDestructorSync`|11.3| | | | | | | |
 |`cudaUserObjectRetainFlags`|11.3| | | | | | | |

--- a/src/CUDA2HIP_Driver_API_functions.cpp
+++ b/src/CUDA2HIP_Driver_API_functions.cpp
@@ -815,7 +815,7 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_FUNCTION_MAP {
   // cudaGraphicsResourceSetMapFlags
   {"cuGraphicsResourceSetMapFlags_v2",                     {"hipGraphicsResourceSetMapFlags",                          "", CONV_GRAPHICS, API_DRIVER, 28, HIP_UNSUPPORTED}},
   // cudaGraphicsSubResourceGetMappedArray
-  {"cuGraphicsSubResourceGetMappedArray",                  {"hipGraphicsSubResourceGetMappedArray",                    "", CONV_GRAPHICS, API_DRIVER, 28, HIP_EXPERIMENTAL}},
+  {"cuGraphicsSubResourceGetMappedArray",                  {"hipGraphicsSubResourceGetMappedArray",                    "", CONV_GRAPHICS, API_DRIVER, 28}},
   // cudaGraphicsUnmapResources
   {"cuGraphicsUnmapResources",                             {"hipGraphicsUnmapResources",                               "", CONV_GRAPHICS, API_DRIVER, 28}},
   // cudaGraphicsUnregisterResource
@@ -843,7 +843,7 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_FUNCTION_MAP {
   // cudaGraphicsGLRegisterBuffer
   {"cuGraphicsGLRegisterBuffer",                           {"hipGraphicsGLRegisterBuffer",                             "", CONV_OPENGL, API_DRIVER, 32}},
   // cudaGraphicsGLRegisterImage
-  {"cuGraphicsGLRegisterImage",                            {"hipGraphicsGLRegisterImage",                              "", CONV_OPENGL, API_DRIVER, 32, HIP_EXPERIMENTAL}},
+  {"cuGraphicsGLRegisterImage",                            {"hipGraphicsGLRegisterImage",                              "", CONV_OPENGL, API_DRIVER, 32}},
   // cudaWGLGetDevice
   {"cuWGLGetDevice",                                       {"hipWGLGetDevice",                                         "", CONV_OPENGL, API_DRIVER, 32, HIP_UNSUPPORTED}},
 
@@ -1358,8 +1358,8 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_DRIVER_FUNCTION_VER_MAP {
   {"hipStreamGetCaptureInfo_v2",                           {HIP_5000, HIP_0,    HIP_0   }},
   {"hipStreamIsCapturing",                                 {HIP_5000, HIP_0,    HIP_0   }},
   {"hipStreamUpdateCaptureDependencies",                   {HIP_5000, HIP_0,    HIP_0   }},
-  {"hipGraphicsGLRegisterImage",                           {HIP_5010, HIP_0,    HIP_0,  HIP_LATEST}},
-  {"hipGraphicsSubResourceGetMappedArray",                 {HIP_5010, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipGraphicsGLRegisterImage",                           {HIP_5010, HIP_0,    HIP_0   }},
+  {"hipGraphicsSubResourceGetMappedArray",                 {HIP_5010, HIP_0,    HIP_0   }},
 };
 
 const std::map<unsigned int, llvm::StringRef> CUDA_DRIVER_API_SECTION_MAP {

--- a/src/CUDA2HIP_Driver_API_types.cpp
+++ b/src/CUDA2HIP_Driver_API_types.cpp
@@ -223,9 +223,8 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_TYPE_NAME_MAP {
   {"CUtexref",                                                         {"hipTexRef",                                                "", CONV_TYPE, API_DRIVER, 1}},
 
   // CUuuid_st
-  // NOTE: the same struct and its name
-  {"CUuuid_st",                                                        {"hipUUID",                                                  "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
-  {"CUuuid",                                                           {"hipUUID",                                                  "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
+  {"CUuuid_st",                                                        {"hipUUID_t",                                                "", CONV_TYPE, API_DRIVER, 1, HIP_EXPERIMENTAL}},
+  {"CUuuid",                                                           {"hipUUID",                                                  "", CONV_TYPE, API_DRIVER, 1, HIP_EXPERIMENTAL}},
 
   // cudaMemLocation
   {"CUmemLocation_st",                                                 {"hipMemoryLocation",                                        "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
@@ -1814,15 +1813,15 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_TYPE_NAME_MAP {
   {"CU_MEM_ALLOC_GRANULARITY_RECOMMENDED",                             {"HIP_MEM_ALLOC_GRANULARITY_RECOMMENDED",                    "", CONV_NUMERIC_LITERAL, API_DRIVER, 1, HIP_UNSUPPORTED}}, // 0x1
 
   // cudaAccessProperty
-  {"CUaccessProperty",                                                 {"hipAccessProperty",                                        "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
-  {"CUaccessProperty_enum",                                            {"hipAccessProperty",                                        "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
+  {"CUaccessProperty",                                                 {"hipAccessProperty",                                        "", CONV_TYPE, API_DRIVER, 1, HIP_EXPERIMENTAL}},
+  {"CUaccessProperty_enum",                                            {"hipAccessProperty",                                        "", CONV_TYPE, API_DRIVER, 1, HIP_EXPERIMENTAL}},
   // CUaccessProperty_enum enum values
   // cudaAccessPropertyNormal
-  {"CU_ACCESS_PROPERTY_NORMAL",                                        {"hipAccessPropertyNormal",                                  "", CONV_NUMERIC_LITERAL, API_DRIVER, 1, HIP_UNSUPPORTED}}, // 0
+  {"CU_ACCESS_PROPERTY_NORMAL",                                        {"hipAccessPropertyNormal",                                  "", CONV_NUMERIC_LITERAL, API_DRIVER, 1, HIP_EXPERIMENTAL}}, // 0
   // cudaAccessPropertyStreaming
-  {"CU_ACCESS_PROPERTY_STREAMING",                                     {"hipAccessPropertyStreaming",                               "", CONV_NUMERIC_LITERAL, API_DRIVER, 1, HIP_UNSUPPORTED}}, // 1
+  {"CU_ACCESS_PROPERTY_STREAMING",                                     {"hipAccessPropertyStreaming",                               "", CONV_NUMERIC_LITERAL, API_DRIVER, 1, HIP_EXPERIMENTAL}}, // 1
   // cudaAccessPropertyPersisting
-  {"CU_ACCESS_PROPERTY_PERSISTING",                                    {"hipAccessPropertyPersisting",                              "", CONV_NUMERIC_LITERAL, API_DRIVER, 1, HIP_UNSUPPORTED}}, // 2
+  {"CU_ACCESS_PROPERTY_PERSISTING",                                    {"hipAccessPropertyPersisting",                              "", CONV_NUMERIC_LITERAL, API_DRIVER, 1, HIP_EXPERIMENTAL}}, // 2
 
   // cudaSynchronizationPolicy
   {"CUsynchronizationPolicy",                                          {"hipSynchronizationPolicy",                                 "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
@@ -1838,12 +1837,13 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_TYPE_NAME_MAP {
   {"CU_SYNC_POLICY_BLOCKING_SYNC",                                     {"hipSyncPolicyBlockingSync",                                "", CONV_NUMERIC_LITERAL, API_DRIVER, 1, HIP_UNSUPPORTED}}, // 4
 
   // cudaKernelNodeAttrID
-  {"CUkernelNodeAttrID",                                               {"hipKernelNodeAttrID",                                      "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
-  {"CUkernelNodeAttrID_enum",                                          {"hipKernelNodeAttrID",                                      "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
+  {"CUkernelNodeAttrID",                                               {"hipKernelNodeAttrID",                                      "", CONV_TYPE, API_DRIVER, 1, HIP_EXPERIMENTAL}},
+  {"CUkernelNodeAttrID_enum",                                          {"hipKernelNodeAttrID",                                      "", CONV_TYPE, API_DRIVER, 1, HIP_EXPERIMENTAL}},
   // CUkernelNodeAttrID_enum enum values
-  {"CU_KERNEL_NODE_ATTRIBUTE_ACCESS_POLICY_WINDOW",                    {"hipKernelNodeAttributeAccessPolicyWindow",                 "", CONV_NUMERIC_LITERAL, API_DRIVER, 1, HIP_UNSUPPORTED}}, // 1
+  // cudaKernelNodeAttributeAccessPolicyWindow
+  {"CU_KERNEL_NODE_ATTRIBUTE_ACCESS_POLICY_WINDOW",                    {"hipKernelNodeAttributeAccessPolicyWindow",                 "", CONV_NUMERIC_LITERAL, API_DRIVER, 1, HIP_EXPERIMENTAL}}, // 1
   // cudaKernelNodeAttributeCooperative
-  {"CU_KERNEL_NODE_ATTRIBUTE_COOPERATIVE",                             {"hipKernelNodeAttributeCooperative",                        "", CONV_NUMERIC_LITERAL, API_DRIVER, 1, HIP_UNSUPPORTED}}, // 2
+  {"CU_KERNEL_NODE_ATTRIBUTE_COOPERATIVE",                             {"hipKernelNodeAttributeCooperative",                        "", CONV_NUMERIC_LITERAL, API_DRIVER, 1, HIP_EXPERIMENTAL}}, // 2
 
   // cudaStreamAttrID
   {"CUstreamAttrID",                                                   {"hipStreamAttrID",                                          "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
@@ -2080,10 +2080,10 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_TYPE_NAME_MAP {
   {"CUmemGenericAllocationHandle_v1",                                  {"hipMemGenericAllocationHandle",                            "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
 
   // GLuint
-  {"GLuint",                                                           {"GLuint",                                                   "", CONV_TYPE, API_DRIVER, 1, HIP_EXPERIMENTAL}},
+  {"GLuint",                                                           {"GLuint",                                                   "", CONV_TYPE, API_DRIVER, 1}},
 
   // GLenum
-  {"GLenum",                                                           {"GLenum",                                                   "", CONV_TYPE, API_DRIVER, 1, HIP_EXPERIMENTAL}},
+  {"GLenum",                                                           {"GLenum",                                                   "", CONV_TYPE, API_DRIVER, 1}},
 
   // 5. Defines
 
@@ -3169,6 +3169,6 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_DRIVER_TYPE_NAME_VER_MAP {
   {"hipStreamUpdateCaptureDependenciesFlags",                          {HIP_5000, HIP_0,    HIP_0   }},
   {"hipStreamAddCaptureDependencies",                                  {HIP_5000, HIP_0,    HIP_0   }},
   {"hipStreamSetCaptureDependencies",                                  {HIP_5000, HIP_0,    HIP_0   }},
-  {"GLuint",                                                           {HIP_5010, HIP_0,    HIP_0,  HIP_LATEST}},
-  {"GLenum",                                                           {HIP_5010, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"GLuint",                                                           {HIP_5010, HIP_0,    HIP_0   }},
+  {"GLenum",                                                           {HIP_5010, HIP_0,    HIP_0   }},
 };

--- a/src/CUDA2HIP_Runtime_API_functions.cpp
+++ b/src/CUDA2HIP_Runtime_API_functions.cpp
@@ -595,7 +595,7 @@ const std::map<llvm::StringRef, hipCounter> CUDA_RUNTIME_FUNCTION_MAP {
   // cuGraphicsResourceSetMapFlags
   {"cudaGraphicsResourceSetMapFlags",                         {"hipGraphicsResourceSetMapFlags",                         "", CONV_GRAPHICS, API_RUNTIME, 24, HIP_UNSUPPORTED}},
   // cuGraphicsSubResourceGetMappedArray
-  {"cudaGraphicsSubResourceGetMappedArray",                   {"hipGraphicsSubResourceGetMappedArray",                   "", CONV_GRAPHICS, API_RUNTIME, 24, HIP_EXPERIMENTAL}},
+  {"cudaGraphicsSubResourceGetMappedArray",                   {"hipGraphicsSubResourceGetMappedArray",                   "", CONV_GRAPHICS, API_RUNTIME, 24}},
   // cuGraphicsUnmapResources
   {"cudaGraphicsUnmapResources",                              {"hipGraphicsUnmapResources",                              "", CONV_GRAPHICS, API_RUNTIME, 24}},
   // cuGraphicsUnregisterResource

--- a/src/CUDA2HIP_Runtime_API_types.cpp
+++ b/src/CUDA2HIP_Runtime_API_types.cpp
@@ -117,7 +117,7 @@ const std::map<llvm::StringRef, hipCounter> CUDA_RUNTIME_TYPE_NAME_MAP {
   {"cudaTextureDesc",                                                  {"hipTextureDesc",                                           "", CONV_TYPE, API_RUNTIME, 36}},
 
   // NOTE: the same struct and its name
-  {"CUuuid_st",                                                        {"hipUUID",                                                  "", CONV_TYPE, API_RUNTIME, 36, HIP_UNSUPPORTED}},
+  {"CUuuid_st",                                                        {"hipUUID_t",                                                "", CONV_TYPE, API_RUNTIME, 36, HIP_EXPERIMENTAL}},
 
   // NOTE: possibly CUsurfref is analogue
   {"surfaceReference",                                                 {"surfaceReference",                                         "", CONV_TYPE, API_RUNTIME, 36}},
@@ -1481,13 +1481,13 @@ const std::map<llvm::StringRef, hipCounter> CUDA_RUNTIME_TYPE_NAME_MAP {
   {"PATCH_LEVEL",                                                      {"hipLibraryPatchVersion",                                   "", CONV_NUMERIC_LITERAL, API_RUNTIME, 36, HIP_UNSUPPORTED}},
 
   // CUaccessProperty
-  {"cudaAccessProperty",                                               {"hipAccessProperty",                                        "", CONV_TYPE, API_RUNTIME, 36, HIP_UNSUPPORTED}},
+  {"cudaAccessProperty",                                               {"hipAccessProperty",                                        "", CONV_TYPE, API_RUNTIME, 36, HIP_EXPERIMENTAL}},
   // CU_ACCESS_PROPERTY_NORMAL
-  {"cudaAccessPropertyNormal",                                         {"hipAccessPropertyNormal",                                  "", CONV_NUMERIC_LITERAL, API_RUNTIME, 36, HIP_UNSUPPORTED}}, // 0
+  {"cudaAccessPropertyNormal",                                         {"hipAccessPropertyNormal",                                  "", CONV_NUMERIC_LITERAL, API_RUNTIME, 36, HIP_EXPERIMENTAL}}, // 0
   // CU_ACCESS_PROPERTY_STREAMING
-  {"cudaAccessPropertyStreaming",                                      {"hipAccessPropertyStreaming",                               "", CONV_NUMERIC_LITERAL, API_RUNTIME, 36, HIP_UNSUPPORTED}}, // 1
+  {"cudaAccessPropertyStreaming",                                      {"hipAccessPropertyStreaming",                               "", CONV_NUMERIC_LITERAL, API_RUNTIME, 36, HIP_EXPERIMENTAL}}, // 1
   // CU_ACCESS_PROPERTY_PERSISTING
-  {"cudaAccessPropertyPersisting",                                     {"hipAccessPropertyPersisting",                              "", CONV_NUMERIC_LITERAL, API_RUNTIME, 36, HIP_UNSUPPORTED}}, // 2
+  {"cudaAccessPropertyPersisting",                                     {"hipAccessPropertyPersisting",                              "", CONV_NUMERIC_LITERAL, API_RUNTIME, 36, HIP_EXPERIMENTAL}}, // 2
 
   // CUsynchronizationPolicy
   {"cudaSynchronizationPolicy",                                        {"hipSynchronizationPolicy",                                 "", CONV_TYPE, API_RUNTIME, 36, HIP_UNSUPPORTED}},
@@ -1508,11 +1508,11 @@ const std::map<llvm::StringRef, hipCounter> CUDA_RUNTIME_TYPE_NAME_MAP {
   {"cudaStreamAttributeSynchronizationPolicy",                         {"hipStreamAttributeSynchronizationPolicy",                  "", CONV_NUMERIC_LITERAL, API_RUNTIME, 36, HIP_UNSUPPORTED}}, // 3
 
   // CUkernelNodeAttrID
-  {"cudaKernelNodeAttrID",                                             {"hipKernelNodeAttrID",                                      "", CONV_TYPE, API_RUNTIME, 36, HIP_UNSUPPORTED}},
+  {"cudaKernelNodeAttrID",                                             {"hipKernelNodeAttrID",                                      "", CONV_TYPE, API_RUNTIME, 36, HIP_EXPERIMENTAL}},
   // CU_KERNEL_NODE_ATTRIBUTE_ACCESS_POLICY_WINDOW
-  {"cudaKernelNodeAttributeAccessPolicyWindow",                        {"hipKernelNodeAttributeAccessPolicyWindow",                 "", CONV_NUMERIC_LITERAL, API_RUNTIME, 36, HIP_UNSUPPORTED}}, // 1
+  {"cudaKernelNodeAttributeAccessPolicyWindow",                        {"hipKernelNodeAttributeAccessPolicyWindow",                 "", CONV_NUMERIC_LITERAL, API_RUNTIME, 36, HIP_EXPERIMENTAL}}, // 1
   // CU_KERNEL_NODE_ATTRIBUTE_COOPERATIVE
-  {"cudaKernelNodeAttributeCooperative",                               {"hipKernelNodeAttributeCooperative",                        "", CONV_NUMERIC_LITERAL, API_RUNTIME, 36, HIP_UNSUPPORTED}}, // 2
+  {"cudaKernelNodeAttributeCooperative",                               {"hipKernelNodeAttributeCooperative",                        "", CONV_NUMERIC_LITERAL, API_RUNTIME, 36, HIP_EXPERIMENTAL}}, // 2
 
   // CUmemPool_attribute
   {"cudaMemPoolAttr",                                                  {"hipMemPoolAttr",                                           "", CONV_TYPE, API_RUNTIME, 36, HIP_UNSUPPORTED}},
@@ -1693,7 +1693,7 @@ const std::map<llvm::StringRef, hipCounter> CUDA_RUNTIME_TYPE_NAME_MAP {
   {"cudaTextureObject_t",                                              {"hipTextureObject_t",                                       "", CONV_TYPE, API_RUNTIME, 36}},
 
   // CUuuid
-  {"cudaUUID_t",                                                       {"hipUUID_t",                                                "", CONV_TYPE, API_RUNTIME, 36, HIP_UNSUPPORTED}},
+  {"cudaUUID_t",                                                       {"hipUUID",                                                  "", CONV_TYPE, API_RUNTIME, 36, HIP_EXPERIMENTAL}},
 
   // CUmemoryPool
   {"cudaMemPool_t",                                                    {"hipMemoryPool",                                            "", CONV_TYPE, API_RUNTIME, 36, HIP_UNSUPPORTED}},
@@ -2423,4 +2423,14 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_RUNTIME_TYPE_NAME_VER_MAP {
   {"hipGraphicsRegisterFlagsTextureGather",                            {HIP_4040, HIP_0,    HIP_0   }},
   {"hipErrorIllegalState",                                             {HIP_5000, HIP_0,    HIP_0   }},
   {"hipErrorGraphExecUpdateFailure",                                   {HIP_5000, HIP_0,    HIP_0   }},
+  {"hipDeviceAttributeMultiGpuBoardGroupID",                           {HIP_5000, HIP_0,    HIP_0   }},
+  {"hipUUID",                                                          {HIP_5020, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipUUID_t",                                                        {HIP_5020, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipKernelNodeAttrID",                                              {HIP_5020, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipKernelNodeAttributeAccessPolicyWindow",                         {HIP_5020, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipKernelNodeAttributeCooperative",                                {HIP_5020, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipAccessProperty",                                                {HIP_5020, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipAccessPropertyNormal",                                          {HIP_5020, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipAccessPropertyStreaming",                                       {HIP_5020, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipAccessPropertyPersisting",                                      {HIP_5020, HIP_0,    HIP_0,  HIP_LATEST}},
 };

--- a/src/Statistics.cpp
+++ b/src/Statistics.cpp
@@ -528,6 +528,8 @@ std::string Statistics::getHipVersion(const hipVersions& ver) {
     case HIP_5001: return "5.0.1";
     case HIP_5002: return "5.0.2";
     case HIP_5010: return "5.1.0";
+    case HIP_5011: return "5.1.1";
+    case HIP_5020: return "5.2.0";
   }
   return "";
 }

--- a/src/Statistics.h
+++ b/src/Statistics.h
@@ -284,7 +284,9 @@ enum hipVersions {
   HIP_5001 = 5001,
   HIP_5002 = 5002,
   HIP_5010 = 5010,
-  HIP_LATEST = HIP_5010,
+  HIP_5011 = 5011,
+  HIP_5020 = 5020,
+  HIP_LATEST = HIP_5020,
 };
 
 struct cudaAPIversions {

--- a/tests/unit_tests/synthetic/driver_enums.cu
+++ b/tests/unit_tests/synthetic/driver_enums.cu
@@ -905,5 +905,29 @@ int main() {
   typedef struct CUgraphicsResource_st *graphicsResource_st;
   CUgraphicsResource graphicsResource;
 
+#if CUDA_VERSION >= 11000
+  // CHECK: hipKernelNodeAttrID kernelNodeAttrID;
+  // CHECK-NEXT: hipKernelNodeAttrID kernelNodeAttrID_enum;
+  // CHECK-NEXT: hipKernelNodeAttrID KERNEL_NODE_ATTRIBUTE_ACCESS_POLICY_WINDOW = hipKernelNodeAttributeAccessPolicyWindow;
+  // CHECK-NEXT: hipKernelNodeAttrID KERNEL_NODE_ATTRIBUTE_COOPERATIVE = hipKernelNodeAttributeCooperative;
+  CUkernelNodeAttrID kernelNodeAttrID;
+  CUkernelNodeAttrID_enum kernelNodeAttrID_enum;
+  CUkernelNodeAttrID KERNEL_NODE_ATTRIBUTE_ACCESS_POLICY_WINDOW = CU_KERNEL_NODE_ATTRIBUTE_ACCESS_POLICY_WINDOW;
+  CUkernelNodeAttrID KERNEL_NODE_ATTRIBUTE_COOPERATIVE = CU_KERNEL_NODE_ATTRIBUTE_COOPERATIVE;
+#endif
+
+#if CUDA_VERSION >= 11000
+  // CHECK: hipAccessProperty accessProperty;
+  // CHECK-NEXT: hipAccessProperty accessProperty_enum;
+  // CHECK-NEXT: hipAccessProperty ACCESS_PROPERTY_NORMAL = hipAccessPropertyNormal;
+  // CHECK-NEXT: hipAccessProperty ACCESS_PROPERTY_STREAMING = hipAccessPropertyStreaming;
+  // CHECK-NEXT: hipAccessProperty ACCESS_PROPERTY_PERSISTING = hipAccessPropertyPersisting;
+  CUaccessProperty accessProperty;
+  CUaccessProperty_enum accessProperty_enum;
+  CUaccessProperty ACCESS_PROPERTY_NORMAL = CU_ACCESS_PROPERTY_NORMAL;
+  CUaccessProperty ACCESS_PROPERTY_STREAMING = CU_ACCESS_PROPERTY_STREAMING;
+  CUaccessProperty ACCESS_PROPERTY_PERSISTING = CU_ACCESS_PROPERTY_PERSISTING;
+#endif
+
   return 0;
 }

--- a/tests/unit_tests/synthetic/driver_structs.cu
+++ b/tests/unit_tests/synthetic/driver_structs.cu
@@ -223,5 +223,8 @@ int main() {
   CUgraphicsResource_st* graphicsResource_st;
   CUgraphicsResource graphicsResource;
 
+  // CHECK: hipUUID_t uuid_st;
+  CUuuid_st uuid_st;
+
   return 0;
 }

--- a/tests/unit_tests/synthetic/driver_typedefs.cu
+++ b/tests/unit_tests/synthetic/driver_typedefs.cu
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %hipify_args 1 --skip-excluded-preprocessor-conditional-blocks %clang_args -D__CUDA_API_VERSION_INTERNAL
+// RUN: %run_test hipify "%s" "%t" %hipify_args 2 --skip-excluded-preprocessor-conditional-blocks --experimental %clang_args -D__CUDA_API_VERSION_INTERNAL
 
 // CHECK: #include <hip/hip_runtime.h>
 #include <cuda.h>
@@ -44,6 +44,9 @@ int main() {
   // CHECK: hipTextureObject_t texObject_v1;
   CUtexObject_v1 texObject_v1;
 #endif
+
+  // CHECK: hipUUID uuid;
+  CUuuid uuid;
 
   return 0;
 }

--- a/tests/unit_tests/synthetic/runtime_enums.cu
+++ b/tests/unit_tests/synthetic/runtime_enums.cu
@@ -737,5 +737,25 @@ int main() {
   cudaStreamUpdateCaptureDependenciesFlags StreamSetCaptureDependencies = cudaStreamSetCaptureDependencies;
 #endif
 
+#if CUDA_VERSION >= 11000
+  // CHECK: hipKernelNodeAttrID kernelNodeAttrID;
+  // CHECK-NEXT: hipKernelNodeAttrID KernelNodeAttributeAccessPolicyWindow = hipKernelNodeAttributeAccessPolicyWindow;
+  // CHECK-NEXT: hipKernelNodeAttrID KernelNodeAttributeCooperative = hipKernelNodeAttributeCooperative;
+  cudaKernelNodeAttrID kernelNodeAttrID;
+  cudaKernelNodeAttrID KernelNodeAttributeAccessPolicyWindow = cudaKernelNodeAttributeAccessPolicyWindow;
+  cudaKernelNodeAttrID KernelNodeAttributeCooperative = cudaKernelNodeAttributeCooperative;
+#endif
+
+#if CUDA_VERSION >= 11000
+  // CHECK: hipAccessProperty accessProperty;
+  // CHECK-NEXT: hipAccessProperty AccessPropertyNormal = hipAccessPropertyNormal;
+  // CHECK-NEXT: hipAccessProperty AccessPropertyStreaming = hipAccessPropertyStreaming;
+  // CHECK-NEXT: hipAccessProperty AccessPropertyPersisting = hipAccessPropertyPersisting;
+  cudaAccessProperty accessProperty;
+  cudaAccessProperty AccessPropertyNormal = cudaAccessPropertyNormal;
+  cudaAccessProperty AccessPropertyStreaming = cudaAccessPropertyStreaming;
+  cudaAccessProperty AccessPropertyPersisting = cudaAccessPropertyPersisting;
+#endif
+
   return 0;
 }

--- a/tests/unit_tests/synthetic/runtime_structs.cu
+++ b/tests/unit_tests/synthetic/runtime_structs.cu
@@ -161,5 +161,8 @@ int main() {
   cudaFunction_t func;
 #endif
 
+  // CHECK: hipUUID_t uuid_st;
+  CUuuid_st uuid_st;
+
   return 0;
 }

--- a/tests/unit_tests/synthetic/runtime_typedefs.cu
+++ b/tests/unit_tests/synthetic/runtime_typedefs.cu
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %hipify_args 1 --skip-excluded-preprocessor-conditional-blocks %clang_args -D__CUDA_API_VERSION_INTERNAL
+// RUN: %run_test hipify "%s" "%t" %hipify_args 2 --skip-excluded-preprocessor-conditional-blocks --experimental %clang_args -D__CUDA_API_VERSION_INTERNAL
 
 // CHECK: #include <hip/hip_runtime.h>
 #include <cuda_runtime_api.h>
@@ -18,6 +18,9 @@ int main() {
   cudaStreamCallback_t StreamCallback_t;
   cudaSurfaceObject_t SurfaceObject_t;
   cudaTextureObject_t TextureObject_t;
+
+  // CHECK: hipUUID uuid;
+  cudaUUID_t uuid;
 
   return 0;
 }


### PR DESCRIPTION
+ Add new HIP versions 5.1.1 (no changes in APIs) and 5.2.0 (API changes in progress)
+ Unmark experimental APIs
+ Add new supported APIs and mark them as experimental
+ Update docs, tests, and hipify-perl accordingly
+ Fix APIs with missing HIP versions