### PR TITLE
[HIPIFY] Sync with the upcoming HIP-rocm-5.2.0 - Part 6 (final) - Types

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -764,15 +764,26 @@ my %experimental_funcs = (
     "CUmemPoolProps_st" => "5.2.0",
     "CUmemPoolProps" => "5.2.0",
     "CUmemPoolHandle_st" => "5.2.0",
+    "CUmemOperationType_enum" => "5.2.0",
+    "CUmemOperationType" => "5.2.0",
     "CUmemLocation_v1" => "5.2.0",
     "CUmemLocation_st" => "5.2.0",
     "CUmemLocationType_enum" => "5.2.0",
     "CUmemLocationType" => "5.2.0",
     "CUmemLocation" => "5.2.0",
+    "CUmemHandleType_enum" => "5.2.0",
+    "CUmemHandleType" => "5.2.0",
+    "CUmemGenericAllocationHandle_v1" => "5.2.0",
+    "CUmemGenericAllocationHandle" => "5.2.0",
     "CUmemAllocationType_enum" => "5.2.0",
     "CUmemAllocationType" => "5.2.0",
+    "CUmemAllocationProp_v1" => "5.2.0",
+    "CUmemAllocationProp_st" => "5.2.0",
+    "CUmemAllocationProp" => "5.2.0",
     "CUmemAllocationHandleType_enum" => "5.2.0",
     "CUmemAllocationHandleType" => "5.2.0",
+    "CUmemAllocationGranularity_flags_enum" => "5.2.0",
+    "CUmemAllocationGranularity_flags" => "5.2.0",
     "CUmemAccess_flags_enum" => "5.2.0",
     "CUmemAccess_flags" => "5.2.0",
     "CUmemAccessDesc_v1" => "5.2.0",
@@ -785,16 +796,23 @@ my %experimental_funcs = (
     "CUkernelNodeAttrID" => "5.2.0",
     "CUgraphInstantiate_flags_enum" => "5.2.0",
     "CUgraphInstantiate_flags" => "5.2.0",
+    "CUarraySparseSubresourceType_enum" => "5.2.0",
+    "CUarraySparseSubresourceType" => "5.2.0",
     "CUaccessProperty_enum" => "5.2.0",
     "CUaccessProperty" => "5.2.0",
     "CUaccessPolicyWindow_st" => "5.2.0",
     "CUaccessPolicyWindow" => "5.2.0",
+    "CU_MEM_OPERATION_TYPE_UNMAP" => "5.2.0",
+    "CU_MEM_OPERATION_TYPE_MAP" => "5.2.0",
     "CU_MEM_LOCATION_TYPE_INVALID" => "5.2.0",
     "CU_MEM_LOCATION_TYPE_DEVICE" => "5.2.0",
     "CU_MEM_HANDLE_TYPE_WIN32_KMT" => "5.2.0",
     "CU_MEM_HANDLE_TYPE_WIN32" => "5.2.0",
     "CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR" => "5.2.0",
     "CU_MEM_HANDLE_TYPE_NONE" => "5.2.0",
+    "CU_MEM_HANDLE_TYPE_GENERIC" => "5.2.0",
+    "CU_MEM_ALLOC_GRANULARITY_RECOMMENDED" => "5.2.0",
+    "CU_MEM_ALLOC_GRANULARITY_MINIMUM" => "5.2.0",
     "CU_MEM_ALLOCATION_TYPE_PINNED" => "5.2.0",
     "CU_MEM_ALLOCATION_TYPE_MAX" => "5.2.0",
     "CU_MEM_ALLOCATION_TYPE_INVALID" => "5.2.0",
@@ -812,6 +830,8 @@ my %experimental_funcs = (
     "CU_KERNEL_NODE_ATTRIBUTE_COOPERATIVE" => "5.2.0",
     "CU_KERNEL_NODE_ATTRIBUTE_ACCESS_POLICY_WINDOW" => "5.2.0",
     "CU_DEVICE_ATTRIBUTE_MEMORY_POOLS_SUPPORTED" => "5.2.0",
+    "CU_ARRAY_SPARSE_SUBRESOURCE_TYPE_SPARSE_LEVEL" => "5.2.0",
+    "CU_ARRAY_SPARSE_SUBRESOURCE_TYPE_MIPTAIL" => "5.2.0",
     "CU_ACCESS_PROPERTY_STREAMING" => "5.2.0",
     "CU_ACCESS_PROPERTY_PERSISTING" => "5.2.0",
     "CU_ACCESS_PROPERTY_NORMAL" => "5.2.0",
@@ -957,6 +977,11 @@ sub experimentalSubstitutions {
     subst("CUaccessPolicyWindow_st", "hipAccessPolicyWindow", "type");
     subst("CUaccessProperty", "hipAccessProperty", "type");
     subst("CUaccessProperty_enum", "hipAccessProperty", "type");
+    subst("CUarrayMapInfo", "hipArrayMapInfo", "type");
+    subst("CUarrayMapInfo_st", "hipArrayMapInfo", "type");
+    subst("CUarrayMapInfo_v1", "hipArrayMapInfo", "type");
+    subst("CUarraySparseSubresourceType", "hipArraySparseSubresourceType", "type");
+    subst("CUarraySparseSubresourceType_enum", "hipArraySparseSubresourceType", "type");
     subst("CUgraphInstantiate_flags", "hipGraphInstantiateFlags", "type");
     subst("CUgraphInstantiate_flags_enum", "hipGraphInstantiateFlags", "type");
     subst("CUkernelNodeAttrID", "hipKernelNodeAttrID", "type");
@@ -969,15 +994,26 @@ sub experimentalSubstitutions {
     subst("CUmemAccessDesc_v1", "hipMemAccessDesc", "type");
     subst("CUmemAccess_flags", "hipMemAccessFlags", "type");
     subst("CUmemAccess_flags_enum", "hipMemAccessFlags", "type");
+    subst("CUmemAllocationGranularity_flags", "hipMemAllocationGranularity_flags", "type");
+    subst("CUmemAllocationGranularity_flags_enum", "hipMemAllocationGranularity_flags", "type");
     subst("CUmemAllocationHandleType", "hipMemAllocationHandleType", "type");
     subst("CUmemAllocationHandleType_enum", "hipMemAllocationHandleType", "type");
+    subst("CUmemAllocationProp", "hipMemAllocationProp", "type");
+    subst("CUmemAllocationProp_st", "hipMemAllocationProp", "type");
+    subst("CUmemAllocationProp_v1", "hipMemAllocationProp", "type");
     subst("CUmemAllocationType", "hipMemAllocationType", "type");
     subst("CUmemAllocationType_enum", "hipMemAllocationType", "type");
+    subst("CUmemGenericAllocationHandle", "hipMemGenericAllocationHandle", "type");
+    subst("CUmemGenericAllocationHandle_v1", "hipMemGenericAllocationHandle", "type");
+    subst("CUmemHandleType", "hipMemHandleType", "type");
+    subst("CUmemHandleType_enum", "hipMemHandleType", "type");
     subst("CUmemLocation", "hipMemLocation", "type");
     subst("CUmemLocationType", "hipMemLocationType", "type");
     subst("CUmemLocationType_enum", "hipMemLocationType", "type");
     subst("CUmemLocation_st", "hipMemLocation", "type");
     subst("CUmemLocation_v1", "hipMemLocation", "type");
+    subst("CUmemOperationType", "hipMemOperationType", "type");
+    subst("CUmemOperationType_enum", "hipMemOperationType", "type");
     subst("CUmemPoolHandle_st", "ihipMemPoolHandle_t", "type");
     subst("CUmemPoolProps", "hipMemPoolProps", "type");
     subst("CUmemPoolProps_st", "hipMemPoolProps", "type");
@@ -1010,6 +1046,8 @@ sub experimentalSubstitutions {
     subst("CU_ACCESS_PROPERTY_NORMAL", "hipAccessPropertyNormal", "numeric_literal");
     subst("CU_ACCESS_PROPERTY_PERSISTING", "hipAccessPropertyPersisting", "numeric_literal");
     subst("CU_ACCESS_PROPERTY_STREAMING", "hipAccessPropertyStreaming", "numeric_literal");
+    subst("CU_ARRAY_SPARSE_SUBRESOURCE_TYPE_MIPTAIL", "hipArraySparseSubresourceTypeMiptail", "numeric_literal");
+    subst("CU_ARRAY_SPARSE_SUBRESOURCE_TYPE_SPARSE_LEVEL", "hipArraySparseSubresourceTypeSparseLevel", "numeric_literal");
     subst("CU_DEVICE_ATTRIBUTE_MEMORY_POOLS_SUPPORTED", "hipDeviceAttributeMemoryPoolsSupported", "numeric_literal");
     subst("CU_KERNEL_NODE_ATTRIBUTE_ACCESS_POLICY_WINDOW", "hipKernelNodeAttributeAccessPolicyWindow", "numeric_literal");
     subst("CU_KERNEL_NODE_ATTRIBUTE_COOPERATIVE", "hipKernelNodeAttributeCooperative", "numeric_literal");
@@ -1027,12 +1065,17 @@ sub experimentalSubstitutions {
     subst("CU_MEM_ALLOCATION_TYPE_INVALID", "hipMemAllocationTypeInvalid", "numeric_literal");
     subst("CU_MEM_ALLOCATION_TYPE_MAX", "hipMemAllocationTypeMax", "numeric_literal");
     subst("CU_MEM_ALLOCATION_TYPE_PINNED", "hipMemAllocationTypePinned", "numeric_literal");
+    subst("CU_MEM_ALLOC_GRANULARITY_MINIMUM", "hipMemAllocationGranularityMinimum", "numeric_literal");
+    subst("CU_MEM_ALLOC_GRANULARITY_RECOMMENDED", "hipMemAllocationGranularityRecommended", "numeric_literal");
+    subst("CU_MEM_HANDLE_TYPE_GENERIC", "hipMemHandleTypeGeneric", "numeric_literal");
     subst("CU_MEM_HANDLE_TYPE_NONE", "hipMemHandleTypeNone", "numeric_literal");
     subst("CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR", "hipMemHandleTypePosixFileDescriptor", "numeric_literal");
     subst("CU_MEM_HANDLE_TYPE_WIN32", "hipMemHandleTypeWin32", "numeric_literal");
     subst("CU_MEM_HANDLE_TYPE_WIN32_KMT", "hipMemHandleTypeWin32Kmt", "numeric_literal");
     subst("CU_MEM_LOCATION_TYPE_DEVICE", "hipMemLocationTypeDevice", "numeric_literal");
     subst("CU_MEM_LOCATION_TYPE_INVALID", "hipMemLocationTypeInvalid", "numeric_literal");
+    subst("CU_MEM_OPERATION_TYPE_MAP", "hipMemOperationTypeMap", "numeric_literal");
+    subst("CU_MEM_OPERATION_TYPE_UNMAP", "hipMemOperationTypeUnmap", "numeric_literal");
     subst("cudaAccessPropertyNormal", "hipAccessPropertyNormal", "numeric_literal");
     subst("cudaAccessPropertyPersisting", "hipAccessPropertyPersisting", "numeric_literal");
     subst("cudaAccessPropertyStreaming", "hipAccessPropertyStreaming", "numeric_literal");
@@ -6564,19 +6607,8 @@ sub warnUnsupportedFunctions {
         "CUshared_carveout",
         "CUoccupancy_flags_enum",
         "CUoccupancy_flags",
-        "CUmemOperationType_enum",
-        "CUmemOperationType",
-        "CUmemHandleType_enum",
-        "CUmemHandleType",
-        "CUmemGenericAllocationHandle_v1",
-        "CUmemGenericAllocationHandle",
         "CUmemAttach_flags_enum",
         "CUmemAttach_flags",
-        "CUmemAllocationProp_v1",
-        "CUmemAllocationProp_st",
-        "CUmemAllocationProp",
-        "CUmemAllocationGranularity_flags_enum",
-        "CUmemAllocationGranularity_flags",
         "CUjit_target_enum",
         "CUjit_target",
         "CUjit_fallback_enum",
@@ -6648,11 +6680,6 @@ sub warnUnsupportedFunctions {
         "CUctx_flags",
         "CUarray_cubemap_face_enum",
         "CUarray_cubemap_face",
-        "CUarraySparseSubresourceType_enum",
-        "CUarraySparseSubresourceType",
-        "CUarrayMapInfo_v1",
-        "CUarrayMapInfo_st",
-        "CUarrayMapInfo",
         "CU_USER_OBJECT_NO_DESTRUCTOR_SYNC",
         "CU_TRSF_SEAMLESS_CUBEMAP",
         "CU_TRSF_DISABLE_TRILINEAR_OPTIMIZATION",
@@ -6703,14 +6730,9 @@ sub warnUnsupportedFunctions {
         "CU_POINTER_ATTRIBUTE_ACCESS_FLAG_NONE",
         "CU_PARAM_TR_DEFAULT",
         "CU_OCCUPANCY_DISABLE_CACHING_OVERRIDE",
-        "CU_MEM_OPERATION_TYPE_UNMAP",
-        "CU_MEM_OPERATION_TYPE_MAP",
         "CU_MEM_LOCATION_TYPE_MAX",
         "CU_MEM_HANDLE_TYPE_MAX",
-        "CU_MEM_HANDLE_TYPE_GENERIC",
         "CU_MEM_CREATE_USAGE_TILE_POOL",
-        "CU_MEM_ALLOC_GRANULARITY_RECOMMENDED",
-        "CU_MEM_ALLOC_GRANULARITY_MINIMUM",
         "CU_MEM_ACCESS_FLAGS_PROT_MAX",
         "CU_MEMHOSTREGISTER_READ_ONLY",
         "CU_LIMIT_STACK_SIZE",
@@ -6924,8 +6946,6 @@ sub warnUnsupportedFunctions {
         "CU_CUBEMAP_FACE_NEGATIVE_Y",
         "CU_CUBEMAP_FACE_NEGATIVE_X",
         "CU_CTX_FLAGS_MASK",
-        "CU_ARRAY_SPARSE_SUBRESOURCE_TYPE_SPARSE_LEVEL",
-        "CU_ARRAY_SPARSE_SUBRESOURCE_TYPE_MIPTAIL",
         "CU_ARRAY_SPARSE_PROPERTIES_SINGLE_MIPTAIL",
         "CU_AD_FORMAT_UNORM_INT8X4",
         "CU_AD_FORMAT_UNORM_INT8X2",

--- a/doc/markdown/CUDA_Driver_API_functions_supported_by_HIP.md
+++ b/doc/markdown/CUDA_Driver_API_functions_supported_by_HIP.md
@@ -233,8 +233,8 @@
 |`CU_AD_FORMAT_UNSIGNED_INT32`| | | |`HIP_AD_FORMAT_UNSIGNED_INT32`|1.7.0| | | |
 |`CU_AD_FORMAT_UNSIGNED_INT8`| | | |`HIP_AD_FORMAT_UNSIGNED_INT8`|1.7.0| | | |
 |`CU_ARRAY_SPARSE_PROPERTIES_SINGLE_MIPTAIL`|11.1| | | | | | | |
-|`CU_ARRAY_SPARSE_SUBRESOURCE_TYPE_MIPTAIL`|11.1| | | | | | | |
-|`CU_ARRAY_SPARSE_SUBRESOURCE_TYPE_SPARSE_LEVEL`|11.1| | | | | | | |
+|`CU_ARRAY_SPARSE_SUBRESOURCE_TYPE_MIPTAIL`|11.1| | |`hipArraySparseSubresourceTypeMiptail`|5.2.0| | |5.2.0|
+|`CU_ARRAY_SPARSE_SUBRESOURCE_TYPE_SPARSE_LEVEL`|11.1| | |`hipArraySparseSubresourceTypeSparseLevel`|5.2.0| | |5.2.0|
 |`CU_COMPUTEMODE_DEFAULT`| | | |`hipComputeModeDefault`|1.9.0| | | |
 |`CU_COMPUTEMODE_EXCLUSIVE`| | |8.0|`hipComputeModeExclusive`|1.9.0| | | |
 |`CU_COMPUTEMODE_EXCLUSIVE_PROCESS`| | | |`hipComputeModeExclusiveProcess`|2.0.0| | | |
@@ -676,13 +676,13 @@
 |`CU_MEM_ALLOCATION_TYPE_INVALID`|10.2| | |`hipMemAllocationTypeInvalid`|5.2.0| | |5.2.0|
 |`CU_MEM_ALLOCATION_TYPE_MAX`|10.2| | |`hipMemAllocationTypeMax`|5.2.0| | |5.2.0|
 |`CU_MEM_ALLOCATION_TYPE_PINNED`|10.2| | |`hipMemAllocationTypePinned`|5.2.0| | |5.2.0|
-|`CU_MEM_ALLOC_GRANULARITY_MINIMUM`|10.2| | | | | | | |
-|`CU_MEM_ALLOC_GRANULARITY_RECOMMENDED`|10.2| | | | | | | |
+|`CU_MEM_ALLOC_GRANULARITY_MINIMUM`|10.2| | |`hipMemAllocationGranularityMinimum`|5.2.0| | |5.2.0|
+|`CU_MEM_ALLOC_GRANULARITY_RECOMMENDED`|10.2| | |`hipMemAllocationGranularityRecommended`|5.2.0| | |5.2.0|
 |`CU_MEM_ATTACH_GLOBAL`| | | |`hipMemAttachGlobal`|2.5.0| | | |
 |`CU_MEM_ATTACH_HOST`| | | |`hipMemAttachHost`|2.5.0| | | |
 |`CU_MEM_ATTACH_SINGLE`| | | |`hipMemAttachSingle`|3.7.0| | | |
 |`CU_MEM_CREATE_USAGE_TILE_POOL`|11.1| | | | | | | |
-|`CU_MEM_HANDLE_TYPE_GENERIC`|11.1| | | | | | | |
+|`CU_MEM_HANDLE_TYPE_GENERIC`|11.1| | |`hipMemHandleTypeGeneric`|5.2.0| | |5.2.0|
 |`CU_MEM_HANDLE_TYPE_MAX`|10.2| | | | | | | |
 |`CU_MEM_HANDLE_TYPE_NONE`|11.2| | |`hipMemHandleTypeNone`|5.2.0| | |5.2.0|
 |`CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR`|10.2| | |`hipMemHandleTypePosixFileDescriptor`|5.2.0| | |5.2.0|
@@ -691,8 +691,8 @@
 |`CU_MEM_LOCATION_TYPE_DEVICE`|10.2| | |`hipMemLocationTypeDevice`|5.2.0| | |5.2.0|
 |`CU_MEM_LOCATION_TYPE_INVALID`|10.2| | |`hipMemLocationTypeInvalid`|5.2.0| | |5.2.0|
 |`CU_MEM_LOCATION_TYPE_MAX`|10.2| | | | | | | |
-|`CU_MEM_OPERATION_TYPE_MAP`|11.1| | | | | | | |
-|`CU_MEM_OPERATION_TYPE_UNMAP`|11.1| | | | | | | |
+|`CU_MEM_OPERATION_TYPE_MAP`|11.1| | |`hipMemOperationTypeMap`|5.2.0| | |5.2.0|
+|`CU_MEM_OPERATION_TYPE_UNMAP`|11.1| | |`hipMemOperationTypeUnmap`|5.2.0| | |5.2.0|
 |`CU_MEM_RANGE_ATTRIBUTE_ACCESSED_BY`|8.0| | |`hipMemRangeAttributeAccessedBy`|3.7.0| | | |
 |`CU_MEM_RANGE_ATTRIBUTE_LAST_PREFETCH_LOCATION`|8.0| | |`hipMemRangeAttributeLastPrefetchLocation`|3.7.0| | | |
 |`CU_MEM_RANGE_ATTRIBUTE_PREFERRED_LOCATION`|8.0| | |`hipMemRangeAttributePreferredLocation`|3.7.0| | | |
@@ -839,11 +839,11 @@
 |`CUaddress_mode`| | | |`HIPaddress_mode`|3.5.0| | | |
 |`CUaddress_mode_enum`| | | |`HIPaddress_mode_enum`|3.5.0| | | |
 |`CUarray`| | | |`hipArray_t`|1.7.0| | | |
-|`CUarrayMapInfo`|11.1| | | | | | | |
-|`CUarrayMapInfo_st`|11.1| | | | | | | |
-|`CUarrayMapInfo_v1`|11.3| | | | | | | |
-|`CUarraySparseSubresourceType`|11.1| | | | | | | |
-|`CUarraySparseSubresourceType_enum`|11.1| | | | | | | |
+|`CUarrayMapInfo`|11.1| | |`hipArrayMapInfo`| | | | |
+|`CUarrayMapInfo_st`|11.1| | |`hipArrayMapInfo`| | | | |
+|`CUarrayMapInfo_v1`|11.3| | |`hipArrayMapInfo`| | | | |
+|`CUarraySparseSubresourceType`|11.1| | |`hipArraySparseSubresourceType`|5.2.0| | |5.2.0|
+|`CUarraySparseSubresourceType_enum`|11.1| | |`hipArraySparseSubresourceType`|5.2.0| | |5.2.0|
 |`CUarray_cubemap_face`| | | | | | | | |
 |`CUarray_cubemap_face_enum`| | | | | | | | |
 |`CUarray_format`| | | |`hipArray_Format`|1.7.0| | | |
@@ -982,28 +982,28 @@
 |`CUmemAccessDesc_v1`|11.3| | |`hipMemAccessDesc`|5.2.0| | |5.2.0|
 |`CUmemAccess_flags`|10.2| | |`hipMemAccessFlags`|5.2.0| | |5.2.0|
 |`CUmemAccess_flags_enum`|10.2| | |`hipMemAccessFlags`|5.2.0| | |5.2.0|
-|`CUmemAllocationGranularity_flags`|10.2| | | | | | | |
-|`CUmemAllocationGranularity_flags_enum`|10.2| | | | | | | |
+|`CUmemAllocationGranularity_flags`|10.2| | |`hipMemAllocationGranularity_flags`|5.2.0| | |5.2.0|
+|`CUmemAllocationGranularity_flags_enum`|10.2| | |`hipMemAllocationGranularity_flags`|5.2.0| | |5.2.0|
 |`CUmemAllocationHandleType`|10.2| | |`hipMemAllocationHandleType`|5.2.0| | |5.2.0|
 |`CUmemAllocationHandleType_enum`|10.2| | |`hipMemAllocationHandleType`|5.2.0| | |5.2.0|
-|`CUmemAllocationProp`|10.2| | | | | | | |
-|`CUmemAllocationProp_st`|10.2| | | | | | | |
-|`CUmemAllocationProp_v1`|11.3| | | | | | | |
+|`CUmemAllocationProp`|10.2| | |`hipMemAllocationProp`|5.2.0| | |5.2.0|
+|`CUmemAllocationProp_st`|10.2| | |`hipMemAllocationProp`|5.2.0| | |5.2.0|
+|`CUmemAllocationProp_v1`|11.3| | |`hipMemAllocationProp`|5.2.0| | |5.2.0|
 |`CUmemAllocationType`|10.2| | |`hipMemAllocationType`|5.2.0| | |5.2.0|
 |`CUmemAllocationType_enum`|10.2| | |`hipMemAllocationType`|5.2.0| | |5.2.0|
 |`CUmemAttach_flags`| | | | | | | | |
 |`CUmemAttach_flags_enum`| | | | | | | | |
-|`CUmemGenericAllocationHandle`|10.2| | | | | | | |
-|`CUmemGenericAllocationHandle_v1`|11.3| | | | | | | |
-|`CUmemHandleType`|11.1| | | | | | | |
-|`CUmemHandleType_enum`|11.1| | | | | | | |
+|`CUmemGenericAllocationHandle`|10.2| | |`hipMemGenericAllocationHandle`|5.2.0| | |5.2.0|
+|`CUmemGenericAllocationHandle_v1`|11.3| | |`hipMemGenericAllocationHandle`|5.2.0| | |5.2.0|
+|`CUmemHandleType`|11.1| | |`hipMemHandleType`|5.2.0| | |5.2.0|
+|`CUmemHandleType_enum`|11.1| | |`hipMemHandleType`|5.2.0| | |5.2.0|
 |`CUmemLocation`|10.2| | |`hipMemLocation`|5.2.0| | |5.2.0|
 |`CUmemLocationType`|10.2| | |`hipMemLocationType`|5.2.0| | |5.2.0|
 |`CUmemLocationType_enum`|10.2| | |`hipMemLocationType`|5.2.0| | |5.2.0|
 |`CUmemLocation_st`|10.2| | |`hipMemLocation`|5.2.0| | |5.2.0|
 |`CUmemLocation_v1`|11.3| | |`hipMemLocation`|5.2.0| | |5.2.0|
-|`CUmemOperationType`|11.1| | | | | | | |
-|`CUmemOperationType_enum`|11.1| | | | | | | |
+|`CUmemOperationType`|11.1| | |`hipMemOperationType`|5.2.0| | |5.2.0|
+|`CUmemOperationType_enum`|11.1| | |`hipMemOperationType`|5.2.0| | |5.2.0|
 |`CUmemPoolHandle_st`|11.2| | |`ihipMemPoolHandle_t`|5.2.0| | |5.2.0|
 |`CUmemPoolProps`|11.2| | |`hipMemPoolProps`|5.2.0| | |5.2.0|
 |`CUmemPoolProps_st`|11.2| | |`hipMemPoolProps`|5.2.0| | |5.2.0|

--- a/src/CUDA2HIP_Driver_API_types.cpp
+++ b/src/CUDA2HIP_Driver_API_types.cpp
@@ -232,9 +232,9 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_TYPE_NAME_MAP {
   {"CUmemLocation_v1",                                                 {"hipMemLocation",                                           "", CONV_TYPE, API_DRIVER, 1, HIP_EXPERIMENTAL}},
 
   // no analogue
-  {"CUmemAllocationProp_st",                                           {"hipMemoryAllocationProperties",                            "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
-  {"CUmemAllocationProp",                                              {"hipMemoryAllocationProperties",                            "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
-  {"CUmemAllocationProp_v1",                                           {"hipMemoryAllocationProperties",                            "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
+  {"CUmemAllocationProp_st",                                           {"hipMemAllocationProp",                                     "", CONV_TYPE, API_DRIVER, 1, HIP_EXPERIMENTAL}},
+  {"CUmemAllocationProp",                                              {"hipMemAllocationProp",                                     "", CONV_TYPE, API_DRIVER, 1, HIP_EXPERIMENTAL}},
+  {"CUmemAllocationProp_v1",                                           {"hipMemAllocationProp",                                     "", CONV_TYPE, API_DRIVER, 1, HIP_EXPERIMENTAL}},
 
   // cudaMemAccessDesc
   {"CUmemAccessDesc_st",                                               {"hipMemAccessDesc",                                         "", CONV_TYPE, API_DRIVER, 1, HIP_EXPERIMENTAL}},
@@ -250,9 +250,10 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_TYPE_NAME_MAP {
   {"CUDA_ARRAY_SPARSE_PROPERTIES",                                     {"hipArraySparseProperties",                                 "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
   {"CUDA_ARRAY_SPARSE_PROPERTIES_v1",                                  {"hipArraySparseProperties",                                 "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
 
-  {"CUarrayMapInfo_st",                                                {"hipArrayMapInfo",                                          "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
-  {"CUarrayMapInfo",                                                   {"hipArrayMapInfo",                                          "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
-  {"CUarrayMapInfo_v1",                                                {"hipArrayMapInfo",                                          "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
+  // no analogue
+  {"CUarrayMapInfo_st",                                                {"hipArrayMapInfo",                                          "", CONV_TYPE, API_DRIVER, 1, HIP_EXPERIMENTAL}},
+  {"CUarrayMapInfo",                                                   {"hipArrayMapInfo",                                          "", CONV_TYPE, API_DRIVER, 1, HIP_EXPERIMENTAL}},
+  {"CUarrayMapInfo_v1",                                                {"hipArrayMapInfo",                                          "", CONV_TYPE, API_DRIVER, 1, HIP_EXPERIMENTAL}},
 
   //
   {"CUmemPoolHandle_st",                                               {"ihipMemPoolHandle_t",                                      "", CONV_TYPE, API_DRIVER, 1, HIP_EXPERIMENTAL}},
@@ -1806,11 +1807,11 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_TYPE_NAME_MAP {
   {"CU_MEM_ALLOCATION_TYPE_MAX",                                       {"hipMemAllocationTypeMax",                                  "", CONV_NUMERIC_LITERAL, API_DRIVER, 1, HIP_EXPERIMENTAL}}, // 0x7FFFFFFF
 
   // no analogue
-  {"CUmemAllocationGranularity_flags",                                 {"hipMemoryAllocationGranularityFlags",                      "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
-  {"CUmemAllocationGranularity_flags_enum",                            {"hipMemoryLocationType",                                    "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
+  {"CUmemAllocationGranularity_flags",                                 {"hipMemAllocationGranularity_flags",                        "", CONV_TYPE, API_DRIVER, 1, HIP_EXPERIMENTAL}},
+  {"CUmemAllocationGranularity_flags_enum",                            {"hipMemAllocationGranularity_flags",                        "", CONV_TYPE, API_DRIVER, 1, HIP_EXPERIMENTAL}},
   // CUmemAllocationGranularity_flags enum values
-  {"CU_MEM_ALLOC_GRANULARITY_MINIMUM",                                 {"HIP_MEM_ALLOC_GRANULARITY_MINIMUM",                        "", CONV_NUMERIC_LITERAL, API_DRIVER, 1, HIP_UNSUPPORTED}}, // 0x0
-  {"CU_MEM_ALLOC_GRANULARITY_RECOMMENDED",                             {"HIP_MEM_ALLOC_GRANULARITY_RECOMMENDED",                    "", CONV_NUMERIC_LITERAL, API_DRIVER, 1, HIP_UNSUPPORTED}}, // 0x1
+  {"CU_MEM_ALLOC_GRANULARITY_MINIMUM",                                 {"hipMemAllocationGranularityMinimum",                       "", CONV_NUMERIC_LITERAL, API_DRIVER, 1, HIP_EXPERIMENTAL}}, // 0x0
+  {"CU_MEM_ALLOC_GRANULARITY_RECOMMENDED",                             {"hipMemAllocationGranularityRecommended",                   "", CONV_NUMERIC_LITERAL, API_DRIVER, 1, HIP_EXPERIMENTAL}}, // 0x1
 
   // cudaAccessProperty
   {"CUaccessProperty",                                                 {"hipAccessProperty",                                        "", CONV_TYPE, API_DRIVER, 1, HIP_EXPERIMENTAL}},
@@ -1881,24 +1882,24 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_TYPE_NAME_MAP {
   {"CU_POINTER_ATTRIBUTE_ACCESS_FLAG_READWRITE",                       {"HIP_POINTER_ATTRIBUTE_ACCESS_FLAG_READWRITE",              "", CONV_NUMERIC_LITERAL, API_DRIVER, 1, HIP_UNSUPPORTED}}, // 0x3
 
   // no analogue
-  {"CUarraySparseSubresourceType",                                     {"hipArraySparseSubresourceType",                            "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
-  {"CUarraySparseSubresourceType_enum",                                {"hipArraySparseSubresourceType",                            "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
+  {"CUarraySparseSubresourceType",                                     {"hipArraySparseSubresourceType",                            "", CONV_TYPE, API_DRIVER, 1, HIP_EXPERIMENTAL}},
+  {"CUarraySparseSubresourceType_enum",                                {"hipArraySparseSubresourceType",                            "", CONV_TYPE, API_DRIVER, 1, HIP_EXPERIMENTAL}},
   // CUarraySparseSubresourceType enum values
-  {"CU_ARRAY_SPARSE_SUBRESOURCE_TYPE_SPARSE_LEVEL",                    {"HIP_ARRAY_SPARSE_SUBRESOURCE_TYPE_SPARSE_LEVEL",           "", CONV_NUMERIC_LITERAL, API_DRIVER, 1, HIP_UNSUPPORTED}}, // 0
-  {"CU_ARRAY_SPARSE_SUBRESOURCE_TYPE_MIPTAIL",                         {"HIP_ARRAY_SPARSE_SUBRESOURCE_TYPE_MIPTAIL",                "", CONV_NUMERIC_LITERAL, API_DRIVER, 1, HIP_UNSUPPORTED}}, // 1
+  {"CU_ARRAY_SPARSE_SUBRESOURCE_TYPE_SPARSE_LEVEL",                    {"hipArraySparseSubresourceTypeSparseLevel",                 "", CONV_NUMERIC_LITERAL, API_DRIVER, 1, HIP_EXPERIMENTAL}}, // 0
+  {"CU_ARRAY_SPARSE_SUBRESOURCE_TYPE_MIPTAIL",                         {"hipArraySparseSubresourceTypeMiptail",                     "", CONV_NUMERIC_LITERAL, API_DRIVER, 1, HIP_EXPERIMENTAL}}, // 1
 
   // no analogue
-  {"CUmemOperationType",                                               {"hipMemOperationType",                                      "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
-  {"CUmemOperationType_enum",                                          {"hipMemOperationType",                                      "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
+  {"CUmemOperationType",                                               {"hipMemOperationType",                                      "", CONV_TYPE, API_DRIVER, 1, HIP_EXPERIMENTAL}},
+  {"CUmemOperationType_enum",                                          {"hipMemOperationType",                                      "", CONV_TYPE, API_DRIVER, 1, HIP_EXPERIMENTAL}},
   // CUmemOperationType enum values
-  {"CU_MEM_OPERATION_TYPE_MAP",                                        {"HIP_MEM_OPERATION_TYPE_MAP",                               "", CONV_NUMERIC_LITERAL, API_DRIVER, 1, HIP_UNSUPPORTED}}, // 1
-  {"CU_MEM_OPERATION_TYPE_UNMAP",                                      {"HIP_MEM_OPERATION_TYPE_UNMAP",                             "", CONV_NUMERIC_LITERAL, API_DRIVER, 1, HIP_UNSUPPORTED}}, // 2
+  {"CU_MEM_OPERATION_TYPE_MAP",                                        {"hipMemOperationTypeMap",                                   "", CONV_NUMERIC_LITERAL, API_DRIVER, 1, HIP_EXPERIMENTAL}}, // 1
+  {"CU_MEM_OPERATION_TYPE_UNMAP",                                      {"hipMemOperationTypeUnmap",                                 "", CONV_NUMERIC_LITERAL, API_DRIVER, 1, HIP_EXPERIMENTAL}}, // 2
 
   // no analogue
-  {"CUmemHandleType",                                                  {"hipMemHandleType",                                         "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
-  {"CUmemHandleType_enum",                                             {"hipMemHandleType",                                         "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
+  {"CUmemHandleType",                                                  {"hipMemHandleType",                                         "", CONV_TYPE, API_DRIVER, 1, HIP_EXPERIMENTAL}},
+  {"CUmemHandleType_enum",                                             {"hipMemHandleType",                                         "", CONV_TYPE, API_DRIVER, 1, HIP_EXPERIMENTAL}},
   // CUmemHandleType enum values
-  {"CU_MEM_HANDLE_TYPE_GENERIC",                                       {"HIP_MEM_HANDLE_TYPE_GENERIC",                              "", CONV_NUMERIC_LITERAL, API_DRIVER, 1, HIP_UNSUPPORTED}}, // 0
+  {"CU_MEM_HANDLE_TYPE_GENERIC",                                       {"hipMemHandleTypeGeneric",                                  "", CONV_NUMERIC_LITERAL, API_DRIVER, 1, HIP_EXPERIMENTAL}}, // 0
 
   // cudaMemPoolAttr
   {"CUmemPool_attribute",                                              {"hipMemPoolAttr",                                           "", CONV_TYPE, API_DRIVER, 1, HIP_EXPERIMENTAL}},
@@ -2075,9 +2076,9 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_TYPE_NAME_MAP {
   {"CUtexObject",                                                      {"hipTextureObject_t",                                       "", CONV_TYPE, API_DRIVER, 1}},
   {"CUtexObject_v1",                                                   {"hipTextureObject_t",                                       "", CONV_TYPE, API_DRIVER, 1}},
 
-  //
-  {"CUmemGenericAllocationHandle",                                     {"hipMemGenericAllocationHandle",                            "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
-  {"CUmemGenericAllocationHandle_v1",                                  {"hipMemGenericAllocationHandle",                            "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
+  // no analogue
+  {"CUmemGenericAllocationHandle",                                     {"hipMemGenericAllocationHandle",                            "", CONV_TYPE, API_DRIVER, 1, HIP_EXPERIMENTAL}},
+  {"CUmemGenericAllocationHandle_v1",                                  {"hipMemGenericAllocationHandle",                            "", CONV_TYPE, API_DRIVER, 1, HIP_EXPERIMENTAL}},
 
   // GLuint
   {"GLuint",                                                           {"GLuint",                                                   "", CONV_TYPE, API_DRIVER, 1}},
@@ -3172,4 +3173,17 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_DRIVER_TYPE_NAME_VER_MAP {
   {"GLuint",                                                           {HIP_5010, HIP_0,    HIP_0   }},
   {"GLenum",                                                           {HIP_5010, HIP_0,    HIP_0   }},
   {"ihipMemPoolHandle_t",                                              {HIP_5020, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipMemAllocationProp",                                             {HIP_5020, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipMemGenericAllocationHandle",                                    {HIP_5020, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipMemAllocationGranularity_flags",                                {HIP_5020, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipMemAllocationGranularityMinimum",                               {HIP_5020, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipMemAllocationGranularityRecommended",                           {HIP_5020, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipMemHandleType",                                                 {HIP_5020, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipMemHandleTypeGeneric",                                          {HIP_5020, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipMemOperationType",                                              {HIP_5020, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipMemOperationTypeMap",                                           {HIP_5020, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipMemOperationTypeUnmap",                                         {HIP_5020, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipArraySparseSubresourceType",                                    {HIP_5020, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipArraySparseSubresourceTypeSparseLevel",                         {HIP_5020, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipArraySparseSubresourceTypeMiptail",                             {HIP_5020, HIP_0,    HIP_0,  HIP_LATEST}},
 };

--- a/tests/unit_tests/synthetic/driver_enums.cu
+++ b/tests/unit_tests/synthetic/driver_enums.cu
@@ -1023,5 +1023,47 @@ int main() {
   CUgraphInstantiate_flags GRAPH_INSTANTIATE_FLAG_AUTO_FREE_ON_LAUNCH = CUDA_GRAPH_INSTANTIATE_FLAG_AUTO_FREE_ON_LAUNCH;
 #endif
 
+#if CUDA_VERSION >= 10020
+  // CHECK: hipMemAllocationGranularity_flags memAllocationGranularity_flags;
+  // CHECK-NEXT: hipMemAllocationGranularity_flags memAllocationGranularity_flags_enum;
+  // CHECK-NEXT: hipMemAllocationGranularity_flags MEM_ALLOC_GRANULARITY_MINIMUM = hipMemAllocationGranularityMinimum;
+  // CHECK-NEXT: hipMemAllocationGranularity_flags MEM_ALLOC_GRANULARITY_RECOMMENDED = hipMemAllocationGranularityRecommended;
+  CUmemAllocationGranularity_flags memAllocationGranularity_flags;
+  CUmemAllocationGranularity_flags_enum memAllocationGranularity_flags_enum;
+  CUmemAllocationGranularity_flags MEM_ALLOC_GRANULARITY_MINIMUM = CU_MEM_ALLOC_GRANULARITY_MINIMUM;
+  CUmemAllocationGranularity_flags MEM_ALLOC_GRANULARITY_RECOMMENDED = CU_MEM_ALLOC_GRANULARITY_RECOMMENDED;
+#endif
+
+#if CUDA_VERSION >= 11010
+  // CHECK: hipMemHandleType memHandleType;
+  // CHECK-NEXT: hipMemHandleType memHandleType_enum;
+  // CHECK-NEXT: hipMemHandleType MEM_HANDLE_TYPE_GENERIC = hipMemHandleTypeGeneric;
+  CUmemHandleType memHandleType;
+  CUmemHandleType_enum memHandleType_enum;
+  CUmemHandleType MEM_HANDLE_TYPE_GENERIC = CU_MEM_HANDLE_TYPE_GENERIC;
+#endif
+
+#if CUDA_VERSION >= 11010
+  // CHECK: hipMemOperationType memOperationType;
+  // CHECK-NEXT: hipMemOperationType memOperationType_enum;
+  // CHECK-NEXT: hipMemOperationType MEM_OPERATION_TYPE_MAP = hipMemOperationTypeMap;
+  // CHECK-NEXT: hipMemOperationType MEM_OPERATION_TYPE_UNMAP = hipMemOperationTypeUnmap;
+  CUmemOperationType memOperationType;
+  CUmemOperationType_enum memOperationType_enum;
+  CUmemOperationType MEM_OPERATION_TYPE_MAP = CU_MEM_OPERATION_TYPE_MAP;
+  CUmemOperationType MEM_OPERATION_TYPE_UNMAP = CU_MEM_OPERATION_TYPE_UNMAP;
+#endif
+
+#if CUDA_VERSION >= 11010
+  // CHECK: hipArraySparseSubresourceType arraySparseSubresourceType;
+  // CHECK-NEXT: hipArraySparseSubresourceType arraySparseSubresourceType_enum;
+  // CHECK-NEXT: hipArraySparseSubresourceType ARRAY_SPARSE_SUBRESOURCE_TYPE_SPARSE_LEVEL = hipArraySparseSubresourceTypeSparseLevel;
+  // CHECK-NEXT: hipArraySparseSubresourceType ARRAY_SPARSE_SUBRESOURCE_TYPE_MIPTAIL = hipArraySparseSubresourceTypeMiptail;
+  CUarraySparseSubresourceType arraySparseSubresourceType;
+  CUarraySparseSubresourceType_enum arraySparseSubresourceType_enum;
+  CUarraySparseSubresourceType ARRAY_SPARSE_SUBRESOURCE_TYPE_SPARSE_LEVEL = CU_ARRAY_SPARSE_SUBRESOURCE_TYPE_SPARSE_LEVEL;
+  CUarraySparseSubresourceType ARRAY_SPARSE_SUBRESOURCE_TYPE_MIPTAIL = CU_ARRAY_SPARSE_SUBRESOURCE_TYPE_MIPTAIL;
+#endif
+
   return 0;
 }

--- a/tests/unit_tests/synthetic/driver_structs.cu
+++ b/tests/unit_tests/synthetic/driver_structs.cu
@@ -288,5 +288,29 @@ int main() {
   CUmemPoolPtrExportData_v1 memPoolPtrExportData_v1;
 #endif
 
+#if CUDA_VERSION >= 10020
+  // CHECK: hipMemAllocationProp memAllocationProp_st;
+  // CHECK-NEXT: hipMemAllocationProp memAllocationProp;
+  CUmemAllocationProp_st memAllocationProp_st;
+  CUmemAllocationProp memAllocationProp;
+#endif
+
+#if CUDA_VERSION >= 11030
+  // CHECK: hipMemAllocationProp memAllocationProp_v1;
+  CUmemAllocationProp_v1 memAllocationProp_v1;
+#endif
+
+#if CUDA_VERSION >= 11010
+  // CHECK: hipArrayMapInfo arrayMapInfo_st;
+  // CHECK-NEXT: hipArrayMapInfo arrayMapInfo;
+  CUarrayMapInfo_st arrayMapInfo_st;
+  CUarrayMapInfo arrayMapInfo;
+#endif
+
+#if CUDA_VERSION >= 11030
+  // CHECK: hipArrayMapInfo arrayMapInfo_v1;
+  CUarrayMapInfo_v1 arrayMapInfo_v1;
+#endif
+
   return 0;
 }

--- a/tests/unit_tests/synthetic/driver_typedefs.cu
+++ b/tests/unit_tests/synthetic/driver_typedefs.cu
@@ -48,5 +48,15 @@ int main() {
   // CHECK: hipUUID uuid;
   CUuuid uuid;
 
+#if CUDA_VERSION > 10020
+  // CHECK: hipMemGenericAllocationHandle memGenericAllocationHandle;
+  CUmemGenericAllocationHandle memGenericAllocationHandle;
+#endif
+
+#if CUDA_VERSION > 11030
+  // CHECK: hipMemGenericAllocationHandle memGenericAllocationHandle_v1;
+  CUmemGenericAllocationHandle_v1 memGenericAllocationHandle_v1;
+#endif
+
   return 0;
 }


### PR DESCRIPTION
+ Add new supported APIs and mark them as experimental
+ Rename some HIP APIs
+ Update docs, tests, and hipify-perl accordingly