### PR TITLE
[HIPIFY][#551][fix] Fix the failed synthetic test `driver_functions.cu`

### DIFF
--- a/tests/unit_tests/synthetic/driver_functions.cu
+++ b/tests/unit_tests/synthetic/driver_functions.cu
@@ -32,6 +32,7 @@ int main() {
 #else
   unsigned long ull = 0;
 #endif
+  unsigned long long ull_2 = 0;
   // CHECK: hipDevice_t device;
   // CHECK-NEXT: hipCtx_t context;
   // CHECK-NEXT: hipFuncCache_t func_cache;
@@ -1179,8 +1180,8 @@ int main() {
 
   // CUDA: CUresult CUDAAPI cuMemGetAccess(unsigned long long *flags, const CUmemLocation *location, CUdeviceptr ptr);
   // HIP: hipError_t hipMemGetAccess(unsigned long long* flags, const hipMemLocation* location, void* ptr);
-  // CHECK: result = hipMemGetAccess(&ull, &memLocation, deviceptr);
-  result = cuMemGetAccess(&ull, &memLocation, deviceptr);
+  // CHECK: result = hipMemGetAccess(&ull_2, &memLocation, deviceptr);
+  result = cuMemGetAccess(&ull_2, &memLocation, deviceptr);
 
   // CUDA: CUresult CUDAAPI cuMemGetAllocationGranularity(size_t *granularity, const CUmemAllocationProp *prop, CUmemAllocationGranularity_flags option);
   // HIP: hipError_t hipMemGetAllocationGranularity(size_t* granularity, const hipMemAllocationProp* prop, hipMemAllocationGranularity_flags option);


### PR DESCRIPTION
+ Use `unsigned long long` type in CUDA functions, where it is used as `unsigned long long`
+ Situations where `cuuint64_t` are used left unchanged in tests:
```cpp
#ifdef _MSC_VER
  typedef unsigned __int32 cuuint32_t;
  typedef unsigned __int64 cuuint64_t;
#else
  #include <stdint.h>
  typedef uint32_t cuuint32_t;
  typedef uint64_t cuuint64_t;
#endif
```
So, for 64bit compilation `unsigned __int64` for `cuuint64_t` on Windows is always defined as `unsigned long long`; `uint64_t` for `cuuint64_t` on Linux is defined as `unsigned long`