### PR TITLE
[HIPIFY][perl][#498][#501][fix] Add anchoring for the compared functions to make sure that an entire function name is actually matched

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -5265,7 +5265,7 @@ sub countSupportedDeviceFunctions {
         # match device function from the list, except those, which have a namespace prefix (aka somenamespace::umin(...));
         # function with only global namespace qualifier '::' (aka ::umin(...)) should be treated as a device function (and warned as well as without such qualifier);
         my $mt_namespace = m/(\w+)::($func)\s*\(\s*.*\s*\)/g;
-        my $mt = m/($func)\s*\(\s*.*\s*\)/g;
+        my $mt = m/\b($func)\b\s*\(\s*.*\s*\)/g;
         if ($mt && !$mt_namespace) {
             $k += $mt;
         }
@@ -5449,7 +5449,7 @@ sub warnUnsupportedDeviceFunctions {
         # match device function from the list, except those, which have a namespace prefix (aka somenamespace::umin(...));
         # function with only global namespace qualifier '::' (aka ::umin(...)) should be treated as a device function (and warned as well as without such qualifier);
         my $mt_namespace = m/(\w+)::($func)\s*\(\s*.*\s*\)/g;
-        my $mt = m/($func)\s*\(\s*.*\s*\)/g;
+        my $mt = m/\b($func)\b\s*\(\s*.*\s*\)/g;
         if ($mt && !$mt_namespace) {
             $k += $mt;
             print STDERR "  warning: $fileName:$line_num: unsupported device function \"$func\": $_\n";

--- a/src/CUDA2HIP_Perl.cpp
+++ b/src/CUDA2HIP_Perl.cpp
@@ -630,7 +630,7 @@ namespace perl {
       subCommon << tab_2 << "# match device function from the list, except those, which have a namespace prefix (aka somenamespace::umin(...));" << endl;
       subCommon << tab_2 << "# function with only global namespace qualifier '::' (aka ::umin(...)) should be treated as a device function (and warned as well as without such qualifier);" << endl;
       subCommon << tab_2 << my << "$mt_namespace = m/(\\w+)::($func)\\s*\\(\\s*.*\\s*\\)/g;" << endl;
-      subCommon << tab_2 << my << "$mt = m/($func)\\s*\\(\\s*.*\\s*\\)/g;" << endl;
+      subCommon << tab_2 << my << "$mt = m/\\b($func)\\b\\s*\\(\\s*.*\\s*\\)/g;" << endl;
       subCommon << tab_2 << "if ($mt && !$mt_namespace) {" << endl;
       subCommon << tab_3 << "$k += $mt;" << endl;
     }


### PR DESCRIPTION
+ This PR fixes incorrect supported and unsupported device functions detection in hipify-perl
+ Update hipify-perl accordingly
