### PR TITLE
[HIPIFY][fix] Fix `cleanupHipifyOptions` function

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -57,29 +57,29 @@ void cleanupHipifyOptions(std::vector<const char*> &args) {
                                             "-skip-excluded-preprocessor-conditional-blocks",
                                             "-md", "-csv", "-doc-format", "-experimental"};
   for (const auto &a : hipifyOptions) {
-    args.erase(std::remove(args.begin(), args.end(), a), args.end());
     args.erase(std::remove(args.begin(), args.end(), "-" + a), args.end());
+    args.erase(std::remove(args.begin(), args.end(), a), args.end());
   }
   std::vector<std::string> hipifyDirOptions = {"-o-dir", "-o-hipify-perl-dir", "-o-stats",
                                                "-o-python-map-dir", "-temp-dir"};
   for (const auto &a : hipifyDirOptions) {
-    // remove all pairs of arguments "-option value"
-    auto it = args.erase(std::remove(args.begin(), args.end(), a), args.end());
-    if (it != args.end()) {
-      args.erase(it);
-    }
-    // remove all pairs of arguments "--option value"
-    it = args.erase(std::remove(args.begin(), args.end(), "-" + a), args.end());
-    if (it != args.end()) {
-      args.erase(it);
-    }
     // remove all "-option=value" and "--option=value"
     args.erase(
       std::remove_if(args.begin(), args.end(),
-        [a](const std::string &s) { return s.find(a + "=") == 0 || s.find("-" + a + "=") == 0; }
+        [a](const std::string &s) { return s.find("-" + a + "=") == 0 || s.find(a + "=") == 0; }
       ),
       args.end()
     );
+    // remove all pairs of arguments "--option value" and "-option value"
+    auto it = args.erase(
+      std::remove_if(args.begin(), args.end(),
+        [a](const std::string &s) { return s.find("-" + a) == 0 || s.find(a) == 0; }
+      ),
+      args.end()
+    );
+    if (it != args.end()) {
+        args.erase(it);
+    }
   }
 }
 


### PR DESCRIPTION
+ Fix the order of checking and exclusion
+ The order was wrong and could lead to the erroneous partial exclusion of `-option` from `--option` in clang's command line (clang-based tools support `-` and `--` option prefixes for the same option)
