### PR TITLE
[HIPIFY] Introduce `--hip-kernel-execution-syntax` option in `hipify-clang`

### DIFF
--- a/src/ArgParse.cpp
+++ b/src/ArgParse.cpp
@@ -161,13 +161,18 @@ cl::opt<std::string> DocFormat("doc-format",
   cl::cat(ToolTemplateCategory));
 
 cl::opt<bool> Experimental("experimental",
-  cl::desc("HIPIFY experimentally supported APIs"),
+  cl::desc("HIP APIs that are experimentally supported"),
   cl::value_desc("experimental"),
   cl::cat(ToolTemplateCategory));
 
 cl::opt<bool> CudaKernelExecutionSyntax("cuda-kernel-execution-syntax",
-  cl::desc("Do not transform CUDA kernel launches"),
+  cl::desc("Keep CUDA kernel launch syntax"),
   cl::value_desc("cuda-kernel-execution-syntax"),
+  cl::cat(ToolTemplateCategory));
+
+cl::opt<bool> HipKernelExecutionSyntax("hip-kernel-execution-syntax",
+  cl::desc("Transform CUDA kernel launch syntax to a regular HIP function call"),
+  cl::value_desc("hip-kernel-execution-syntax"),
   cl::cat(ToolTemplateCategory));
 
 cl::extrahelp CommonHelp(ct::CommonOptionsParser::HelpMessage);

--- a/src/ArgParse.h
+++ b/src/ArgParse.h
@@ -58,3 +58,4 @@ extern cl::opt<bool> GenerateCSV;
 extern cl::opt<std::string> DocFormat;
 extern cl::opt<bool> Experimental;
 extern cl::opt<bool> CudaKernelExecutionSyntax;
+extern cl::opt<bool> HipKernelExecutionSyntax;

--- a/src/HipifyAction.cpp
+++ b/src/HipifyAction.cpp
@@ -358,7 +358,7 @@ bool HipifyAction::cudaLaunchKernel(const mat::MatchFinder::MatchResult &Result)
   if (!caleeDecl) return false;
   auto *config = launchKernel->getConfig();
   if (!config) return false;
-  if (CudaKernelExecutionSyntax) return false;
+  if (CudaKernelExecutionSyntax && !HipKernelExecutionSyntax) return false;
   clang::SmallString<40> XStr;
   llvm::raw_svector_ostream OS(XStr);
   clang::LangOptions DefaultLangOptions;

--- a/tests/unit_tests/options/kernel-execution-syntax/both-kernel-execution-syntax.cu
+++ b/tests/unit_tests/options/kernel-execution-syntax/both-kernel-execution-syntax.cu
@@ -1,0 +1,45 @@
+// RUN: %run_test hipify "%s" "%t" %hipify_args 2 --cuda-kernel-execution-syntax --hip-kernel-execution-syntax %clang_args
+// CHECK: #include <hip/hip_runtime.h>
+#include <math.h>
+
+__global__
+void add(int n, float *x, float *y)
+{
+    int index = blockIdx.x * blockDim.x + threadIdx.x;
+    int stride = blockDim.x * gridDim.x;
+    for (int i = index; i < n; i += stride)
+        y[i] = x[i] + y[i];
+}
+
+int main(int argc, char *argv[])
+{
+    int numElements = 10;
+    bool testResult = true;
+    float *A, *B;
+    // CHECK: hipMallocManaged(&A, numElements * sizeof(float));
+    cudaMallocManaged(&A, numElements * sizeof(float));
+    // CHECK: hipMallocManaged(&B, numElements * sizeof(float));
+    cudaMallocManaged(&B, numElements * sizeof(float));
+    for (int i = 0; i < numElements; i++) {
+        A[i] = 1.0f;
+        B[i] = 2.0f;
+    }
+    int blockSize = 256;
+    int numBlocks = (numElements + blockSize - 1) / blockSize;
+    dim3 dimGrid(numBlocks, 1, 1);
+    dim3 dimBlock(blockSize, 1, 1);
+    // CHECK: hipLaunchKernelGGL(add, dim3(dimGrid), dim3(dimBlock), 0, 0, numElements, A, B);
+    add<<<dimGrid, dimBlock>>>(numElements, A, B);
+    // CHECK: hipDeviceSynchronize();
+    cudaDeviceSynchronize();
+    float maxError = 0.0f;
+    for (int i = 0; i < numElements; i++)
+        maxError = fmax(maxError, fabs(B[i]-3.0f));
+    // CHECK: hipFree(A);
+    cudaFree(A);
+    // CHECK: hipFree(B);
+    cudaFree(B);
+    if(maxError == 0.0f)
+        return 0;
+    return -1;
+}

--- a/tests/unit_tests/options/kernel-execution-syntax/cuda-kernel-execution-syntax.cu
+++ b/tests/unit_tests/options/kernel-execution-syntax/cuda-kernel-execution-syntax.cu
@@ -1,0 +1,45 @@
+// RUN: %run_test hipify "%s" "%t" %hipify_args 1 --cuda-kernel-execution-syntax %clang_args
+// CHECK: #include <hip/hip_runtime.h>
+#include <math.h>
+
+__global__
+void add(int n, float *x, float *y)
+{
+    int index = blockIdx.x * blockDim.x + threadIdx.x;
+    int stride = blockDim.x * gridDim.x;
+    for (int i = index; i < n; i += stride)
+        y[i] = x[i] + y[i];
+}
+
+int main(int argc, char *argv[])
+{
+    int numElements = 10;
+    bool testResult = true;
+    float *A, *B;
+    // CHECK: hipMallocManaged(&A, numElements * sizeof(float));
+    cudaMallocManaged(&A, numElements * sizeof(float));
+    // CHECK: hipMallocManaged(&B, numElements * sizeof(float));
+    cudaMallocManaged(&B, numElements * sizeof(float));
+    for (int i = 0; i < numElements; i++) {
+        A[i] = 1.0f;
+        B[i] = 2.0f;
+    }
+    int blockSize = 256;
+    int numBlocks = (numElements + blockSize - 1) / blockSize;
+    dim3 dimGrid(numBlocks, 1, 1);
+    dim3 dimBlock(blockSize, 1, 1);
+    // CHECK: add<<<dimGrid, dimBlock>>>(numElements, A, B);
+    add<<<dimGrid, dimBlock>>>(numElements, A, B);
+    // CHECK: hipDeviceSynchronize();
+    cudaDeviceSynchronize();
+    float maxError = 0.0f;
+    for (int i = 0; i < numElements; i++)
+        maxError = fmax(maxError, fabs(B[i]-3.0f));
+    // CHECK: hipFree(A);
+    cudaFree(A);
+    // CHECK: hipFree(B);
+    cudaFree(B);
+    if(maxError == 0.0f)
+        return 0;
+    return -1;
+}

--- a/tests/unit_tests/options/kernel-execution-syntax/hip-kernel-execution-syntax.cu
+++ b/tests/unit_tests/options/kernel-execution-syntax/hip-kernel-execution-syntax.cu
@@ -1,0 +1,45 @@
+// RUN: %run_test hipify "%s" "%t" %hipify_args 1 --hip-kernel-execution-syntax %clang_args
+// CHECK: #include <hip/hip_runtime.h>
+#include <math.h>
+
+__global__
+void add(int n, float *x, float *y)
+{
+    int index = blockIdx.x * blockDim.x + threadIdx.x;
+    int stride = blockDim.x * gridDim.x;
+    for (int i = index; i < n; i += stride)
+        y[i] = x[i] + y[i];
+}
+
+int main(int argc, char *argv[])
+{
+    int numElements = 10;
+    bool testResult = true;
+    float *A, *B;
+    // CHECK: hipMallocManaged(&A, numElements * sizeof(float));
+    cudaMallocManaged(&A, numElements * sizeof(float));
+    // CHECK: hipMallocManaged(&B, numElements * sizeof(float));
+    cudaMallocManaged(&B, numElements * sizeof(float));
+    for (int i = 0; i < numElements; i++) {
+        A[i] = 1.0f;
+        B[i] = 2.0f;
+    }
+    int blockSize = 256;
+    int numBlocks = (numElements + blockSize - 1) / blockSize;
+    dim3 dimGrid(numBlocks, 1, 1);
+    dim3 dimBlock(blockSize, 1, 1);
+    // CHECK: hipLaunchKernelGGL(add, dim3(dimGrid), dim3(dimBlock), 0, 0, numElements, A, B);
+    add<<<dimGrid, dimBlock>>>(numElements, A, B);
+    // CHECK: hipDeviceSynchronize();
+    cudaDeviceSynchronize();
+    float maxError = 0.0f;
+    for (int i = 0; i < numElements; i++)
+        maxError = fmax(maxError, fabs(B[i]-3.0f));
+    // CHECK: hipFree(A);
+    cudaFree(A);
+    // CHECK: hipFree(B);
+    cudaFree(B);
+    if(maxError == 0.0f)
+        return 0;
+    return -1;
+}

--- a/tests/unit_tests/options/kernel-execution-syntax/none-kernel-execution-syntax.cu
+++ b/tests/unit_tests/options/kernel-execution-syntax/none-kernel-execution-syntax.cu
@@ -1,0 +1,45 @@
+// RUN: %run_test hipify "%s" "%t" %hipify_args %clang_args
+// CHECK: #include <hip/hip_runtime.h>
+#include <math.h>
+
+__global__
+void add(int n, float *x, float *y)
+{
+    int index = blockIdx.x * blockDim.x + threadIdx.x;
+    int stride = blockDim.x * gridDim.x;
+    for (int i = index; i < n; i += stride)
+        y[i] = x[i] + y[i];
+}
+
+int main(int argc, char *argv[])
+{
+    int numElements = 10;
+    bool testResult = true;
+    float *A, *B;
+    // CHECK: hipMallocManaged(&A, numElements * sizeof(float));
+    cudaMallocManaged(&A, numElements * sizeof(float));
+    // CHECK: hipMallocManaged(&B, numElements * sizeof(float));
+    cudaMallocManaged(&B, numElements * sizeof(float));
+    for (int i = 0; i < numElements; i++) {
+        A[i] = 1.0f;
+        B[i] = 2.0f;
+    }
+    int blockSize = 256;
+    int numBlocks = (numElements + blockSize - 1) / blockSize;
+    dim3 dimGrid(numBlocks, 1, 1);
+    dim3 dimBlock(blockSize, 1, 1);
+    // CHECK: hipLaunchKernelGGL(add, dim3(dimGrid), dim3(dimBlock), 0, 0, numElements, A, B);
+    add<<<dimGrid, dimBlock>>>(numElements, A, B);
+    // CHECK: hipDeviceSynchronize();
+    cudaDeviceSynchronize();
+    float maxError = 0.0f;
+    for (int i = 0; i < numElements; i++)
+        maxError = fmax(maxError, fabs(B[i]-3.0f));
+    // CHECK: hipFree(A);
+    cudaFree(A);
+    // CHECK: hipFree(B);
+    cudaFree(B);
+    if(maxError == 0.0f)
+        return 0;
+    return -1;
+}


### PR DESCRIPTION
[Reason]
+ Set `--cuda-kernel-execution-syntax` by default soon with keeping the possibility of using an old HIP kernel launch syntax

[Misc]
+ Add four tests on `--hip-kernel-execution-syntax`, `--cuda-kernel-execution-syntax`, and their combinations

[ToDo]
+ Implement both options in `hipify-perl`
+ Set `--cuda-kernel-execution-syntax` for both tools by default