### PR TITLE
[HIPIFY][tests][fix] Pass `hipify-clang` specific options to tests with JSON Compilation Database

### DIFF
--- a/tests/run_test.bat
+++ b/tests/run_test.bat
@@ -36,7 +36,7 @@ set json_out=%test_dir%%compile_commands%
 
 if exist %json_in% (
   powershell -Command "(gc %json_in%) -replace '<test dir>', '%test_dir%' -replace '<CUDA dir>', '%CUDA_ROOT%' | Out-File -encoding ASCII %json_out%"
-  %HIPIFY% -o=%TMP_FILE% %IN_FILE% %CUDA_ROOT% -p=%test_dir% -D_ALLOW_COMPILER_AND_STL_VERSION_MISMATCH=1
+  %HIPIFY% -o=%TMP_FILE% %IN_FILE% %CUDA_ROOT% -p=%test_dir% %HIPIFY_OPTS% -D_ALLOW_COMPILER_AND_STL_VERSION_MISMATCH=1
 ) else (
   %HIPIFY% -o=%TMP_FILE% %IN_FILE% %CUDA_ROOT% %HIPIFY_OPTS% -D_ALLOW_COMPILER_AND_STL_VERSION_MISMATCH=1 -- %clang_args%
 )

--- a/tests/run_test.sh
+++ b/tests/run_test.sh
@@ -39,7 +39,7 @@ if [ -e $json_in ]
 then
 cp $json_in $json_out
 sed -i -e "s|<test dir>|${test_dir}|g; s|<CUDA dir>|${CUDA_ROOT}|g" $json_out
-$HIPIFY -o=$TMP_FILE $IN_FILE $CUDA_ROOT -p=$test_dir && cat $TMP_FILE | sed -Ee 's|//.+|// |g' | FileCheck $IN_FILE
+$HIPIFY -o=$TMP_FILE $IN_FILE $CUDA_ROOT -p=$test_dir $HIPIFY_OPTS && cat $TMP_FILE | sed -Ee 's|//.+|// |g' | FileCheck $IN_FILE
 else
 $HIPIFY -o=$TMP_FILE $IN_FILE $CUDA_ROOT $HIPIFY_OPTS -- $@ && cat $TMP_FILE | sed -Ee 's|//.+|// |g' | FileCheck $IN_FILE
 fi

--- a/tests/unit_tests/compilation_database/cd_intro.cu
+++ b/tests/unit_tests/compilation_database/cd_intro.cu
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %hipify_args %clang_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args 1 --hip-kernel-execution-syntax %clang_args
 
 #include <stdio.h>
 #include <stdlib.h>


### PR DESCRIPTION
+ Fix `hipify-clang` specific options bypassing in run_test scripts
+ cd_intro.cu is the test with JSON Compilation Database to which compilation the option `--hip-kernel-execution-syntax` was not passed before the fix
