### PR TITLE
[HIPIFY] Set keeping CUDA kernel execution syntax by default

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -34,13 +34,13 @@ my $USAGE =<<USAGE;
 
     OPTIONS:
 
-      -cuda-kernel-execution-syntax - Keep CUDA kernel launch syntax
+      -cuda-kernel-execution-syntax - Keep CUDA kernel launch syntax (default)
       -examine                      - Combines -no-output and -print-stats options
       -exclude-dirs=s               - Exclude directories
       -exclude-files=s              - Exclude files
       -experimental                 - HIPIFY experimentally supported APIs
       -help                         - Display available options
-      -hip-kernel-execution-syntax  - Transform CUDA kernel launch syntax to a regular HIP function call
+      -hip-kernel-execution-syntax  - Transform CUDA kernel launch syntax to a regular HIP function call (overrides "--cuda-kernel-execution-syntax")
       -inplace                      - Backup the input file in .prehip file, modify the input file inplace
       -no-output                    - Don't write any translated output to stdout
       -o=s                          - Output filename
@@ -70,13 +70,13 @@ my %convertedTags = ();
 my %convertedTagsTotal = ();
 
 GetOptions(
-      "cuda-kernel-execution-syntax" => \$cuda_kernel_execution_syntax  # Keep CUDA kernel launch syntax
+      "cuda-kernel-execution-syntax" => \$cuda_kernel_execution_syntax  # Keep CUDA kernel launch syntax (default)
     , "examine" => \$examine                                            # Combines -no-output and -print-stats options
     , "exclude-dirs=s" => \$exclude_dirs                                # Exclude directories
     , "exclude-files=s" => \$exclude_files                              # Exclude files
     , "experimental" => \$experimental                                  # HIPIFY experimentally supported APIs
     , "help" => \$help                                                  # Display available options
-    , "hip-kernel-execution-syntax" => \$hip_kernel_execution_syntax    # Transform CUDA kernel launch syntax to a regular HIP function call
+    , "hip-kernel-execution-syntax" => \$hip_kernel_execution_syntax    # Transform CUDA kernel launch syntax to a regular HIP function call (overrides "--cuda-kernel-execution-syntax")
     , "inplace" => \$inplace                                            # Backup the input file in .prehip file, modify the input file inplace
     , "no-output" => \$no_output                                        # Don't write any translated output to stdout
     , "o=s" => \$hipFileName                                            # Output filename
@@ -86,6 +86,8 @@ GetOptions(
     , "version" => \$version                                            # The supported HIP version
     , "whitelist=s" => \$whitelist                                      # Whitelist of identifiers
 );
+
+$cuda_kernel_execution_syntax = 1;
 
 my %deprecated_funcs = (
     "cusparseZsctr" => "11.0",
@@ -8087,7 +8089,7 @@ while (@ARGV) {
                             redo if s/\b$w\b/ZAP/
                         }
                         my $tag;
-                        if ((/(\bcuda[A-Z]\w+)/) or (/<<<.*>>>/)) {
+                        if ((/(\bcuda[A-Z]\w+)/) or ((/<<<.*>>>/) and ($hip_kernel_execution_syntax))) {
                             # Flag any remaining code that look like cuda API calls: may want to add these to hipify
                             $tag = (defined $1) ? $1 : "Launch";
                         }

--- a/src/ArgParse.cpp
+++ b/src/ArgParse.cpp
@@ -166,12 +166,13 @@ cl::opt<bool> Experimental("experimental",
   cl::cat(ToolTemplateCategory));
 
 cl::opt<bool> CudaKernelExecutionSyntax("cuda-kernel-execution-syntax",
-  cl::desc("Keep CUDA kernel launch syntax"),
+  cl::desc("Keep CUDA kernel launch syntax (default)"),
   cl::value_desc("cuda-kernel-execution-syntax"),
+  cl::init(true),
   cl::cat(ToolTemplateCategory));
 
 cl::opt<bool> HipKernelExecutionSyntax("hip-kernel-execution-syntax",
-  cl::desc("Transform CUDA kernel launch syntax to a regular HIP function call"),
+  cl::desc("Transform CUDA kernel launch syntax to a regular HIP function call (overrides \"--cuda-kernel-execution-syntax\")"),
   cl::value_desc("hip-kernel-execution-syntax"),
   cl::cat(ToolTemplateCategory));
 

--- a/src/CUDA2HIP_Perl.cpp
+++ b/src/CUDA2HIP_Perl.cpp
@@ -175,13 +175,13 @@ namespace perl {
     *streamPtr.get() << "    hipify-perl is a tool to translate CUDA source code into portable HIP C++" << endl_2;
     *streamPtr.get() << "    USAGE: hipify-perl [OPTIONS] INPUT_FILE" << endl_2;
     *streamPtr.get() << "    OPTIONS:" << endl_2;
-    *streamPtr.get() << "      -cuda-kernel-execution-syntax - Keep CUDA kernel launch syntax" << endl;
+    *streamPtr.get() << "      -cuda-kernel-execution-syntax - Keep CUDA kernel launch syntax (default)" << endl;
     *streamPtr.get() << "      -examine                      - Combines -no-output and -print-stats options" << endl;
     *streamPtr.get() << "      -exclude-dirs=s               - Exclude directories" << endl;
     *streamPtr.get() << "      -exclude-files=s              - Exclude files" << endl;
     *streamPtr.get() << "      -experimental                 - HIPIFY experimentally supported APIs" << endl;
     *streamPtr.get() << "      -help                         - Display available options" << endl;
-    *streamPtr.get() << "      -hip-kernel-execution-syntax  - Transform CUDA kernel launch syntax to a regular HIP function call" << endl;
+    *streamPtr.get() << "      -hip-kernel-execution-syntax  - Transform CUDA kernel launch syntax to a regular HIP function call (overrides \"--cuda-kernel-execution-syntax\")" << endl;
     *streamPtr.get() << "      -inplace                      - Backup the input file in .prehip file, modify the input file inplace" << endl;
     *streamPtr.get() << "      -no-output                    - Don't write any translated output to stdout" << endl;
     *streamPtr.get() << "      -o=s                          - Output filename" << endl;
@@ -210,13 +210,13 @@ namespace perl {
     *streamPtr.get() << my << "%convertedTags = ();" << endl;
     *streamPtr.get() << my << "%convertedTagsTotal = ();" << endl_2;
     *streamPtr.get() << "GetOptions(" << endl;
-    *streamPtr.get() << tab << "  \"cuda-kernel-execution-syntax\" => \\$cuda_kernel_execution_syntax  # Keep CUDA kernel launch syntax" << endl;
+    *streamPtr.get() << tab << "  \"cuda-kernel-execution-syntax\" => \\$cuda_kernel_execution_syntax  # Keep CUDA kernel launch syntax (default)" << endl;
     *streamPtr.get() << tab << ", \"examine\" => \\$examine                                            # Combines -no-output and -print-stats options" << endl;
     *streamPtr.get() << tab << ", \"exclude-dirs=s\" => \\$exclude_dirs                                # Exclude directories" << endl;
     *streamPtr.get() << tab << ", \"exclude-files=s\" => \\$exclude_files                              # Exclude files" << endl;
     *streamPtr.get() << tab << ", \"experimental\" => \\$experimental                                  # HIPIFY experimentally supported APIs" << endl;
     *streamPtr.get() << tab << ", \"help\" => \\$help                                                  # Display available options" << endl;
-    *streamPtr.get() << tab << ", \"hip-kernel-execution-syntax\" => \\$hip_kernel_execution_syntax    # Transform CUDA kernel launch syntax to a regular HIP function call" << endl;
+    *streamPtr.get() << tab << ", \"hip-kernel-execution-syntax\" => \\$hip_kernel_execution_syntax    # Transform CUDA kernel launch syntax to a regular HIP function call (overrides \"--cuda-kernel-execution-syntax\")" << endl;
     *streamPtr.get() << tab << ", \"inplace\" => \\$inplace                                            # Backup the input file in .prehip file, modify the input file inplace" << endl;
     *streamPtr.get() << tab << ", \"no-output\" => \\$no_output                                        # Don't write any translated output to stdout" << endl;
     *streamPtr.get() << tab << ", \"o=s\" => \\$hipFileName                                            # Output filename" << endl;
@@ -226,6 +226,7 @@ namespace perl {
     *streamPtr.get() << tab << ", \"version\" => \\$version                                            # The supported HIP version" << endl;
     *streamPtr.get() << tab << ", \"whitelist=s\" => \\$whitelist                                      # Whitelist of identifiers" << endl;
     *streamPtr.get() << ");" << endl_2;
+    *streamPtr.get() << "$cuda_kernel_execution_syntax = 1;" << endl_2;
     stringstream deprecated, removed, experimental, common;
     deprecated << my << "%deprecated_funcs = (" << endl;
     removed << my << "%removed_funcs = (" << endl;
@@ -802,7 +803,7 @@ namespace perl {
     *streamPtr.get() << tab_6 << foreach << "$w (@whitelist) {" << endl;
     *streamPtr.get() << tab_7 << "redo if s/\\b$w\\b/ZAP/" << endl_tab_6 << "}" << endl;
     *streamPtr.get() << tab_6 << my << "$tag;" << endl;
-    *streamPtr.get() << tab_6 << "if ((/(\\bcuda[A-Z]\\w+)/) or (/<<<.*>>>/)) {" << endl;
+    *streamPtr.get() << tab_6 << "if ((/(\\bcuda[A-Z]\\w+)/) or ((/<<<.*>>>/) and ($hip_kernel_execution_syntax))) {" << endl;
     *streamPtr.get() << tab_7 << "# Flag any remaining code that look like cuda API calls: may want to add these to hipify" << endl;
     *streamPtr.get() << tab_7 << "$tag = (defined $1) ? $1 : \"Launch\";" << endl_tab_6 << "}" << endl;
     *streamPtr.get() << tab_6 << "if (defined $tag) {" << endl;

--- a/tests/unit_tests/device/atomics.cu
+++ b/tests/unit_tests/device/atomics.cu
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %hipify_args 1 --skip-excluded-preprocessor-conditional-blocks %clang_args "-Xclang" "-fcuda-allow-variadic-functions"
+// RUN: %run_test hipify "%s" "%t" %hipify_args 2 --skip-excluded-preprocessor-conditional-blocks --hip-kernel-execution-syntax %clang_args "-Xclang" "-fcuda-allow-variadic-functions"
 
 /*
 Copyright (c) 2015-present Advanced Micro Devices, Inc. All rights reserved.

--- a/tests/unit_tests/device/device_symbols.cu
+++ b/tests/unit_tests/device/device_symbols.cu
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %hipify_args %clang_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args 1 --hip-kernel-execution-syntax %clang_args
 
 /*
 Copyright (c) 2015-present Advanced Micro Devices, Inc. All rights reserved.

--- a/tests/unit_tests/device/math_functions.cu
+++ b/tests/unit_tests/device/math_functions.cu
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %hipify_args %clang_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args 1 --hip-kernel-execution-syntax %clang_args
 // Synthetic test to warn only on device functions umin and umax as unsupported, but not on user defined ones.
 // ToDo: change lit testing in order to parse the output.
 

--- a/tests/unit_tests/kernel_launch/kernel_launch_01.cu
+++ b/tests/unit_tests/kernel_launch/kernel_launch_01.cu
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %hipify_args %clang_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args 1 --hip-kernel-execution-syntax %clang_args
 // Synthetic test to warn only on device functions umin and umax as unsupported, but not on user defined ones.
 // ToDo: change lit testing in order to parse the output.
 

--- a/tests/unit_tests/kernel_launch/kernel_launch_syntax.cu
+++ b/tests/unit_tests/kernel_launch/kernel_launch_syntax.cu
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %hipify_args %clang_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args 1 --hip-kernel-execution-syntax %clang_args
 
 #include <iostream>
 #include <algorithm>

--- a/tests/unit_tests/libraries/CUB/cub_01.cu
+++ b/tests/unit_tests/libraries/CUB/cub_01.cu
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %hipify_args %clang_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args 1 --hip-kernel-execution-syntax %clang_args
 // CHECK: #include <hip/hip_runtime.h>
 #include <iostream>
 // CHECK: #include <hiprand.h>

--- a/tests/unit_tests/libraries/CUB/cub_02.cu
+++ b/tests/unit_tests/libraries/CUB/cub_02.cu
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %hipify_args %clang_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args 1 --hip-kernel-execution-syntax %clang_args
 // CHECK: #include <hip/hip_runtime.h>
 #include <iostream>
 // CHECK: #include <hiprand.h>

--- a/tests/unit_tests/libraries/cuRAND/benchmark_curand_kernel.cpp
+++ b/tests/unit_tests/libraries/cuRAND/benchmark_curand_kernel.cpp
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %hipify_args %clang_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args 1 --hip-kernel-execution-syntax %clang_args
 
 // Copyright (c) 2017 Advanced Micro Devices, Inc. All rights reserved.
 //

--- a/tests/unit_tests/libraries/cuRAND/poisson_api_example.cu
+++ b/tests/unit_tests/libraries/cuRAND/poisson_api_example.cu
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %hipify_args %clang_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args 1 --hip-kernel-execution-syntax %clang_args
 
 // Taken from: http://docs.nvidia.com/cuda/curand/device-api-overview.html#poisson-api-example
 /*

--- a/tests/unit_tests/namespace/ns_kernel_launch.cu
+++ b/tests/unit_tests/namespace/ns_kernel_launch.cu
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %hipify_args %clang_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args 1 --hip-kernel-execution-syntax %clang_args
 // CHECK: #include <hip/hip_runtime.h>
 #include <cuda.h>
 

--- a/tests/unit_tests/options/kernel-execution-syntax/none-kernel-execution-syntax.cu
+++ b/tests/unit_tests/options/kernel-execution-syntax/none-kernel-execution-syntax.cu
@@ -28,7 +28,7 @@ int main(int argc, char *argv[])
     int numBlocks = (numElements + blockSize - 1) / blockSize;
     dim3 dimGrid(numBlocks, 1, 1);
     dim3 dimBlock(blockSize, 1, 1);
-    // CHECK: hipLaunchKernelGGL(add, dim3(dimGrid), dim3(dimBlock), 0, 0, numElements, A, B);
+    // CHECK: add<<<dimGrid, dimBlock>>>(numElements, A, B);
     add<<<dimGrid, dimBlock>>>(numElements, A, B);
     // CHECK: hipDeviceSynchronize();
     cudaDeviceSynchronize();

--- a/tests/unit_tests/pp/pp_if_else_conditionals.cu
+++ b/tests/unit_tests/pp/pp_if_else_conditionals.cu
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %hipify_args 1 --skip-excluded-preprocessor-conditional-blocks %clang_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args 2 --skip-excluded-preprocessor-conditional-blocks --hip-kernel-execution-syntax %clang_args
 // CHECK: #include <hip/hip_runtime.h>
 
 #include <cuda.h>

--- a/tests/unit_tests/pp/pp_if_else_conditionals_01.cu
+++ b/tests/unit_tests/pp/pp_if_else_conditionals_01.cu
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %hipify_args 1 --skip-excluded-preprocessor-conditional-blocks %clang_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args 2 --skip-excluded-preprocessor-conditional-blocks --hip-kernel-execution-syntax %clang_args
 // CHECK: #include <hip/hip_runtime.h>
 
 __global__ void axpy_kernel(float a, float* x, float* y) {

--- a/tests/unit_tests/pp/pp_if_else_conditionals_01_LLVM_10.cu
+++ b/tests/unit_tests/pp/pp_if_else_conditionals_01_LLVM_10.cu
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %hipify_args %clang_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args 1 --hip-kernel-execution-syntax %clang_args
 // CHECK: #include <hip/hip_runtime.h>
 
 __global__ void axpy_kernel(float a, float* x, float* y) {

--- a/tests/unit_tests/pp/pp_if_else_conditionals_LLVM_10.cu
+++ b/tests/unit_tests/pp/pp_if_else_conditionals_LLVM_10.cu
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %hipify_args %clang_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args 1 --hip-kernel-execution-syntax %clang_args
 // CHECK: #include <hip/hip_runtime.h>
 
 #include <cuda.h>

--- a/tests/unit_tests/samples/2_Cookbook/0_MatrixTranspose/MatrixTranspose.cpp
+++ b/tests/unit_tests/samples/2_Cookbook/0_MatrixTranspose/MatrixTranspose.cpp
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %hipify_args %clang_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args 1 --hip-kernel-execution-syntax %clang_args
 /*
 Copyright (c) 2015-present Advanced Micro Devices, Inc. All rights reserved.
 

--- a/tests/unit_tests/samples/2_Cookbook/13_occupancy/occupancy.cpp
+++ b/tests/unit_tests/samples/2_Cookbook/13_occupancy/occupancy.cpp
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %hipify_args %clang_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args 1 --hip-kernel-execution-syntax %clang_args
 /*
 Copyright (c) 2015-present Advanced Micro Devices, Inc. All rights reserved.
 Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/tests/unit_tests/samples/2_Cookbook/1_hipEvent/hipEvent.cpp
+++ b/tests/unit_tests/samples/2_Cookbook/1_hipEvent/hipEvent.cpp
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %hipify_args %clang_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args 1 --hip-kernel-execution-syntax %clang_args
 /*
 Copyright (c) 2015-present Advanced Micro Devices, Inc. All rights reserved.
 

--- a/tests/unit_tests/samples/2_Cookbook/2_Profiler/Profiler.cpp
+++ b/tests/unit_tests/samples/2_Cookbook/2_Profiler/Profiler.cpp
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %hipify_args %clang_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args 1 --hip-kernel-execution-syntax %clang_args
 /*
 Copyright (c) 2015-present Advanced Micro Devices, Inc. All rights reserved.
 

--- a/tests/unit_tests/samples/2_Cookbook/7_streams/stream.cpp
+++ b/tests/unit_tests/samples/2_Cookbook/7_streams/stream.cpp
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %hipify_args %clang_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args 1 --hip-kernel-execution-syntax %clang_args
 /*
 Copyright (c) 2015-present Advanced Micro Devices, Inc. All rights reserved.
 

--- a/tests/unit_tests/samples/2_Cookbook/8_peer2peer/peer2peer.cpp
+++ b/tests/unit_tests/samples/2_Cookbook/8_peer2peer/peer2peer.cpp
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %hipify_args %clang_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args 1 --hip-kernel-execution-syntax %clang_args
 /*
 Copyright (c) 2015-present Advanced Micro Devices, Inc. All rights reserved.
 

--- a/tests/unit_tests/samples/MallocManaged.cpp
+++ b/tests/unit_tests/samples/MallocManaged.cpp
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %hipify_args %clang_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args 1 --hip-kernel-execution-syntax %clang_args
 // CHECK: #include <hip/hip_runtime.h>
 #include <math.h>
 

--- a/tests/unit_tests/samples/allocators.cu
+++ b/tests/unit_tests/samples/allocators.cu
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %hipify_args %clang_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args 1 --hip-kernel-execution-syntax %clang_args
 
 #pragma once
 // CHECK: #include <hip/hip_runtime.h>

--- a/tests/unit_tests/samples/axpy.cu
+++ b/tests/unit_tests/samples/axpy.cu
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %hipify_args %clang_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args 1 --hip-kernel-execution-syntax %clang_args
 
 #include <iostream>
 

--- a/tests/unit_tests/samples/coalescing.cu
+++ b/tests/unit_tests/samples/coalescing.cu
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %hipify_args %clang_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args 1 --hip-kernel-execution-syntax %clang_args
 
 // To measure effects of memory coalescing. Coalescing.cu
 // B. Wilkinson Jan 30, 2011

--- a/tests/unit_tests/samples/cudaRegister.cu
+++ b/tests/unit_tests/samples/cudaRegister.cu
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %hipify_args %clang_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args 1 --hip-kernel-execution-syntax %clang_args
 
 /*
 Copyright (c) 2015-2016 Advanced Micro Devices, Inc. All rights reserved.

--- a/tests/unit_tests/samples/dynamic_shared_memory.cu
+++ b/tests/unit_tests/samples/dynamic_shared_memory.cu
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %hipify_args %clang_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args 1 --hip-kernel-execution-syntax %clang_args
 
 // Taken from Jonathan Hui blog https://jhui.github.io/2017/03/06/CUDA
 

--- a/tests/unit_tests/samples/intro.cu
+++ b/tests/unit_tests/samples/intro.cu
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %hipify_args %clang_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args 1 --hip-kernel-execution-syntax %clang_args
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/tests/unit_tests/samples/square.cu
+++ b/tests/unit_tests/samples/square.cu
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %hipify_args %clang_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args 1 --hip-kernel-execution-syntax %clang_args
 
 /*
 Copyright (c) 2015-2016 Advanced Micro Devices, Inc. All rights reserved.

--- a/tests/unit_tests/samples/static_shared_memory.cu
+++ b/tests/unit_tests/samples/static_shared_memory.cu
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %hipify_args %clang_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args 1 --hip-kernel-execution-syntax %clang_args
 
 // Taken from Jonathan Hui blog https://jhui.github.io/2017/03/06/CUDA
 

--- a/tests/unit_tests/samples/vec_add.cu
+++ b/tests/unit_tests/samples/vec_add.cu
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %hipify_args %clang_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args 1 --hip-kernel-execution-syntax %clang_args
 
 // Kernel definition
 __global__ void  vecAdd(float* A, float* B, float* C)


### PR DESCRIPTION
**[Explanation]**
+ `--cuda-kernel-execution-syntax` is set to `true` by default now
+ It means that CUDA kernel execution syntax, aka `kern<<<...>>>(...)`, is not translated to HIP syntax by default anymore
+ This default behaviour can be changed by setting `--hip-kernel-execution-syntax` in `hipify-clang` or `hipify-perl` command line
+ It will override the default behaviour: all `kern<<<...>>>(...)` will be transformed to a regular call of `hipLaunchKernelGGL(...)`

**[IMP]**
+ Update regenerated `hipify-perl`
+ Update tests by explicitly setting `--hip-kernel-execution-syntax` for their hipification
+ hipify-perl: do not warn on the left unchanged `kern<<<...>>>(...)` when `--hip-kernel-execution-syntax` is true