### PR TITLE
[HIPIFY][fix] Get rid of `reinterpret_cast` for hipified function arguments

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -4738,18 +4738,6 @@ sub transformHostFunctions {
         $k += s/(?<!\/\/ CHECK: )($func)\s*\(\s*([^,]+)\s*,\s*([^,\)]+)\s*(,\s*|\))\s*/$func\($2, HIP_SYMBOL\($3\)$4/g;
     }
     foreach $func (
-        "hipFuncSetCacheConfig"
-    )
-    {
-        $k += s/(?<!\/\/ CHECK: )($func)\s*\(\s*([^,]+)\s*,/$func\(reinterpret_cast<const void*>\($2\),/g
-    }
-    foreach $func (
-        "hipFuncGetAttributes"
-    )
-    {
-        $k += s/(?<!\/\/ CHECK: )($func)\s*\(\s*([^,]+)\s*,\s*([^,\)]+)\s*(,\s*|\))\s*/$func\($2, reinterpret_cast<const void*>\($3\)$4/g;
-    }
-    foreach $func (
         "hipModuleOccupancyMaxPotentialBlockSize",
         "hipModuleOccupancyMaxPotentialBlockSizeWithFlags"
     )

--- a/src/CUDA2HIP_Perl.cpp
+++ b/src/CUDA2HIP_Perl.cpp
@@ -509,7 +509,6 @@ namespace perl {
     }
     set<string>& funcSet = DeviceSymbolFunctions0;
     for (int i = 0; i < 5; ++i) {
-      *streamPtr.get() << tab + foreach_func;
       switch (i) {
         case 1:  funcSet = DeviceSymbolFunctions1; break;
         case 2:  funcSet = ReinterpretFunctions0; break;
@@ -517,6 +516,8 @@ namespace perl {
         case 4:  funcSet = RemoveArgFunctions3; break;
         default: funcSet = DeviceSymbolFunctions0;
       }
+      if (funcSet.empty()) continue;
+      *streamPtr.get() << tab + foreach_func;
       unsigned int count = 0;
       string sHIPName;
       for (auto &f : funcSet) {

--- a/src/HipifyAction.cpp
+++ b/src/HipifyAction.cpp
@@ -58,12 +58,6 @@ const std::string sCudaGetSymbolSize = "cudaGetSymbolSize";
 const std::string sCudaGetSymbolAddress = "cudaGetSymbolAddress";
 const std::string sCudaMemcpyFromSymbol = "cudaMemcpyFromSymbol";
 const std::string sCudaMemcpyFromSymbolAsync = "cudaMemcpyFromSymbolAsync";
-const std::string sCudaFuncSetCacheConfig = "cudaFuncSetCacheConfig";
-const std::string sCudaFuncSetSharedMemConfig = "cudaFuncSetSharedMemConfig";
-const std::string sCudaFuncGetAttributes = "cudaFuncGetAttributes";
-const std::string sCudaFuncSetAttribute = "cudaFuncSetAttribute";
-const std::string sCudaLaunchKernelStr = "cudaLaunchKernel";
-const std::string sCudaLaunchCooperativeKernel = "cudaLaunchCooperativeKernel";
 const std::string sCuOccupancyMaxPotentialBlockSize = "cuOccupancyMaxPotentialBlockSize";
 const std::string sCuOccupancyMaxPotentialBlockSizeWithFlags = "cuOccupancyMaxPotentialBlockSizeWithFlags";
 // Matchers' names
@@ -92,12 +86,6 @@ std::map<std::string, ArgCastMap> FuncArgCasts {
   {sCudaGetSymbolAddress, {{1, {e_HIP_SYMBOL, cw_None}}}},
   {sCudaMemcpyFromSymbol, {{1, {e_HIP_SYMBOL, cw_None}}}},
   {sCudaMemcpyFromSymbolAsync, {{1, {e_HIP_SYMBOL, cw_None}}}},
-  {sCudaFuncSetCacheConfig, {{0, {e_reinterpret_cast, cw_None}}}},
-  {sCudaFuncSetSharedMemConfig, {{0, {e_reinterpret_cast, cw_None}}}},
-  {sCudaFuncGetAttributes, {{1, {e_reinterpret_cast, cw_None}}}},
-  {sCudaFuncSetAttribute, {{0, {e_reinterpret_cast, cw_None}}}},
-  {sCudaLaunchKernelStr, {{0, {e_reinterpret_cast, cw_None}}}},
-  {sCudaLaunchCooperativeKernel, {{0, {e_reinterpret_cast, cw_None}}}},
   {sCuOccupancyMaxPotentialBlockSize, {{3, {e_remove_argument, cw_DataLoss}}}},
   {sCuOccupancyMaxPotentialBlockSizeWithFlags, {{3, {e_remove_argument, cw_DataLoss}}}},
 };
@@ -579,12 +567,6 @@ std::unique_ptr<clang::ASTConsumer> HipifyAction::CreateASTConsumer(clang::Compi
             sCudaMemcpyFromSymbolAsync,
             sCudaMemcpyToSymbol,
             sCudaMemcpyToSymbolAsync,
-            sCudaFuncSetCacheConfig,
-            sCudaFuncSetSharedMemConfig,
-            sCudaFuncGetAttributes,
-            sCudaFuncSetAttribute,
-            sCudaLaunchKernelStr,
-            sCudaLaunchCooperativeKernel,
             sCuOccupancyMaxPotentialBlockSize,
             sCuOccupancyMaxPotentialBlockSizeWithFlags
           )

--- a/tests/unit_tests/casts/reinterpret_cast.cu
+++ b/tests/unit_tests/casts/reinterpret_cast.cu
@@ -367,11 +367,11 @@ int main() {
   // CHECK: hipFuncCache_t cacheConfig;
   cudaFuncCache cacheConfig;
   void* func;
-  // CHECK: hipFuncSetCacheConfig(reinterpret_cast<const void*>(func), cacheConfig);
+  // CHECK: hipFuncSetCacheConfig(func, cacheConfig);
   cudaFuncSetCacheConfig(func, cacheConfig);
   // CHECK: hipFuncAttributes attr{};
   cudaFuncAttributes attr{};
-  // CHECK: auto r = hipFuncGetAttributes(&attr, reinterpret_cast<const void*>(&fn));
+  // CHECK: auto r = hipFuncGetAttributes(&attr, &fn);
   auto r = cudaFuncGetAttributes(&attr, &fn);
   // CHECK: if (r != hipSuccess || attr.maxThreadsPerBlock == 0) {
   if (r != cudaSuccess || attr.maxThreadsPerBlock == 0) {

--- a/tests/unit_tests/synthetic/runtime_functions.cu
+++ b/tests/unit_tests/synthetic/runtime_functions.cu
@@ -569,7 +569,7 @@ int main() {
 
   // CUDA: extern __host__ __cudart_builtin__ cudaError_t CUDARTAPI cudaFuncGetAttributes(struct cudaFuncAttributes *attr, const void *func);
   // HIP: hipError_t hipFuncGetAttributes(struct hipFuncAttributes* attr, const void* func);
-  // CHECK: result = hipFuncGetAttributes(&FuncAttributes, reinterpret_cast<const void*>(func));
+  // CHECK: result = hipFuncGetAttributes(&FuncAttributes, func);
   result = cudaFuncGetAttributes(&FuncAttributes, func);
 
 #if CUDA_VERSION >= 9000
@@ -581,12 +581,12 @@ int main() {
 
   // CUDA: extern __host__ __cudart_builtin__ cudaError_t CUDARTAPI cudaFuncSetAttribute(const void *func, enum cudaFuncAttribute attr, int value);
   // HIP: hipError_t hipFuncSetAttribute(const void* func, hipFuncAttribute attr, int value);
-  // CHECK: result = hipFuncSetAttribute(reinterpret_cast<const void*>(func), FuncAttribute, intVal);
+  // CHECK: result = hipFuncSetAttribute(func, FuncAttribute, intVal);
   result = cudaFuncSetAttribute(func, FuncAttribute, intVal);
 
   // CUDA: extern __host__ cudaError_t CUDARTAPI cudaLaunchCooperativeKernel(const void *func, dim3 gridDim, dim3 blockDim, void **args, size_t sharedMem, cudaStream_t stream);
   // HIP: hipError_t hipLaunchCooperativeKernel(const void* f, dim3 gridDim, dim3 blockDimX, void** kernelParams, unsigned int sharedMemBytes, hipStream_t stream);
-  // CHECK: result = hipLaunchCooperativeKernel(reinterpret_cast<const void*>(func), gridDim, blockDim, &image, flags, stream);
+  // CHECK: result = hipLaunchCooperativeKernel(func, gridDim, blockDim, &image, flags, stream);
   result = cudaLaunchCooperativeKernel(func, gridDim, blockDim, &image, flags, stream);
 
   // CUDA: extern __CUDA_DEPRECATED __host__ cudaError_t CUDARTAPI cudaLaunchCooperativeKernelMultiDevice(struct cudaLaunchParams *launchParamsList, unsigned int numDevices, unsigned int flags  __dv(0));
@@ -597,17 +597,17 @@ int main() {
 
   // CUDA: extern __host__ cudaError_t CUDARTAPI cudaFuncSetCacheConfig(const void *func, enum cudaFuncCache cacheConfig);
   // HIP: hipError_t hipFuncSetCacheConfig(const void* func, hipFuncCache_t config);
-  // CHECK: result = hipFuncSetCacheConfig(reinterpret_cast<const void*>(func), FuncCache);
+  // CHECK: result = hipFuncSetCacheConfig(func, FuncCache);
   result = cudaFuncSetCacheConfig(func, FuncCache);
 
   // CUDA: extern __host__ cudaError_t CUDARTAPI cudaFuncSetSharedMemConfig(const void *func, enum cudaSharedMemConfig config);
   // HIP: hipError_t hipFuncSetSharedMemConfig(const void* func, hipSharedMemConfig config);
-  // CHECK: result = hipFuncSetSharedMemConfig(reinterpret_cast<const void*>(func), SharedMemConfig);
+  // CHECK: result = hipFuncSetSharedMemConfig(func, SharedMemConfig);
   result = cudaFuncSetSharedMemConfig(func, SharedMemConfig);
 
   // CUDA: extern __host__ cudaError_t CUDARTAPI cudaLaunchKernel(const void *func, dim3 gridDim, dim3 blockDim, void **args, size_t sharedMem, cudaStream_t stream);
   // HIP: hipError_t hipLaunchKernel(const void* function_address, dim3 numBlocks, dim3 dimBlocks, void** args, size_t sharedMemBytes __dparm(0), hipStream_t stream __dparm(0));
-  // CHECK: result = hipLaunchKernel(reinterpret_cast<const void*>(func), gridDim, blockDim, &image, bytes, stream);
+  // CHECK: result = hipLaunchKernel(func, gridDim, blockDim, &image, bytes, stream);
   result = cudaLaunchKernel(func, gridDim, blockDim, &image, bytes, stream);
 
   // CUDA: extern __host__ __cudart_builtin__ cudaError_t CUDARTAPI cudaOccupancyMaxActiveBlocksPerMultiprocessor(int *numBlocks, const void *func, int blockSize, size_t dynamicSMemSize);


### PR DESCRIPTION
**[Reason]**
+ The following HIP APIs have started to use the same types of arguments as their CUDA analogues, so `reinterpret_cast<const void*>(...)` is not needed anymore:

`cudaFuncGetAttributes` -> `hipFuncGetAttributes`
`cudaFuncSetAttribute` -> `hipFuncSetAttribute`
`cudaFuncSetCacheConfig` -> `hipFuncSetCacheConfig`
`cudaFuncSetSharedMemConfig` -> `hipFuncSetSharedMemConfig`
`cudaLaunchKernel` -> `hipLaunchKernel`
`cudaLaunchCooperativeKernel` -> `hipLaunchCooperativeKernel`

+ Update the affected tests and hipify-perl