### PR TITLE
[HIPIFY][perl][fix] Add missing functions that need `HIP_SYMBOL()` macros for their arguments after hipification

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -4726,23 +4726,49 @@ sub transformHostFunctions {
         "hipMemcpyToSymbolAsync"
     )
     {
-        $k += s/(?<!\/\/ CHECK: )($func)\s*\(\s*([^,]+)\s*,/$func\(HIP_SYMBOL\($2\),/g
+        $k += s/(?<!\/\/ CHECK: )($func)\s*\(([^,\)]+),/$func\(HIP_SYMBOL\($2\),/g;
     }
     foreach $func (
         "hipGetSymbolAddress",
         "hipGetSymbolSize",
+        "hipGraphMemcpyNodeSetParamsToSymbol",
         "hipMemcpyFromSymbol",
         "hipMemcpyFromSymbolAsync"
     )
     {
-        $k += s/(?<!\/\/ CHECK: )($func)\s*\(\s*([^,]+)\s*,\s*([^,\)]+)\s*(,\s*|\))\s*/$func\($2, HIP_SYMBOL\($3\)$4/g;
+        $k += s/(?<!\/\/ CHECK: )($func)\s*\(([^,\)]+),([\s]*)([^,\)]+)(,\s*|\))/$func\($2,$3HIP_SYMBOL\($4\)$5/g;
+    }
+    foreach $func (
+        "hipGraphExecMemcpyNodeSetParamsToSymbol",
+        "hipGraphMemcpyNodeSetParamsFromSymbol"
+    )
+    {
+        $k += s/(?<!\/\/ CHECK: )($func)\s*\(([^,\)]+),([^,\)]+),([\s]*)([^,\)]+)(,\s*|\))/$func\($2,$3,$4HIP_SYMBOL\($5\)$6/g;
     }
     foreach $func (
         "hipModuleOccupancyMaxPotentialBlockSize",
         "hipModuleOccupancyMaxPotentialBlockSizeWithFlags"
     )
     {
-        $k += s/(?<!\/\/ CHECK: )($func)\s*\((\s*[^,\)]+\s*),(\s*[^,\)]+\s*),(\s*[^,\)]+\s*),(\s*[^,\)]+\s*)\s*(,\s*|\))\s*/$func\($2,$3,$4$6/g;
+        $k += s/(?<!\/\/ CHECK: )($func)\s*\(([^,\)]+),([^,\)]+),([^,\)]+),([\s]*)([^,\)]+)(,\s*|\))/$func\($2,$3,$4$7/g;
+    }
+    foreach $func (
+        "hipGraphExecMemcpyNodeSetParamsFromSymbol"
+    )
+    {
+        $k += s/(?<!\/\/ CHECK: )($func)\s*\(([^,\)]+),([^,\)]+),([^,\)]+),([\s]*)([^,\)]+)(,\s*|\))/$func\($2,$3,$4,$5HIP_SYMBOL\($6\)$7/g;
+    }
+    foreach $func (
+        "hipGraphAddMemcpyNodeToSymbol"
+    )
+    {
+        $k += s/(?<!\/\/ CHECK: )($func)\s*\(([^,\)]+),([^,\)]+),([^,\)]+),([^,\)]+),([\s]*)([^,\)]+)(,\s*|\))/$func\($2,$3,$4,$5,$6HIP_SYMBOL\($7\)$8/g;
+    }
+    foreach $func (
+        "hipGraphAddMemcpyNodeFromSymbol"
+    )
+    {
+        $k += s/(?<!\/\/ CHECK: )($func)\s*\(([^,\)]+),([^,\)]+),([^,\)]+),([^,\)]+),([^,\)]+),([\s]*)([^,\)]+)(,\s*|\))/$func\($2,$3,$4,$5,$6,$7HIP_SYMBOL\($8\)$9/g;
     }
     return $k;
 }

--- a/src/CUDA2HIP_Perl.cpp
+++ b/src/CUDA2HIP_Perl.cpp
@@ -471,11 +471,18 @@ namespace perl {
   void generateHostFunctions(unique_ptr<ostream> &streamPtr) {
     *streamPtr.get() << endl << sub << "transformHostFunctions" << " {" << endl_tab << my_k << endl;
     const string s = "$k += s/(?<!\\/\\/ CHECK: )($func)\\s*";
-    const string s0 = s + "\\(\\s*([^,]+)\\s*,/$func\\(";
-    const string s1 = s + "\\(\\s*([^,]+)\\s*,\\s*([^,\\)]+)\\s*(,\\s*|\\))\\s*/$func\\($2, ";
-    const string s3 = s + "\\((\\s*[^,\\)]+\\s*),(\\s*[^,\\)]+\\s*),(\\s*[^,\\)]+\\s*),(\\s*[^,\\)]+\\s*)\\s*(,\\s*|\\))\\s*/$func\\($2,$3,$4$6/g;";
+    const string s0 = s + "\\(([^,\\)]+),/$func\\(";
+    const string s1 = s + "\\(([^,\\)]+),([\\s]*)([^,\\)]+)(,\\s*|\\))/$func\\($2,$3";
+    const string s2 = s + "\\(([^,\\)]+),([^,\\)]+),([\\s]*)([^,\\)]+)(,\\s*|\\))/$func\\($2,$3,$4";
+    const string s3 = s + "\\(([^,\\)]+),([^,\\)]+),([^,\\)]+),([\\s]*)([^,\\)]+)(,\\s*|\\))/$func\\($2,$3,$4";
+    const string s4 = s + "\\(([^,\\)]+),([^,\\)]+),([^,\\)]+),([^,\\)]+),([\\s]*)([^,\\)]+)(,\\s*|\\))/$func\\($2,$3,$4,$5,$6";
+    const string s5 = s + "\\(([^,\\)]+),([^,\\)]+),([^,\\)]+),([^,\\)]+),([^,\\)]+),([\\s]*)([^,\\)]+)(,\\s*|\\))/$func\\($2,$3,$4,$5,$6,$7";
     set<string> DeviceSymbolFunctions0;
     set<string> DeviceSymbolFunctions1;
+    set<string> DeviceSymbolFunctions2;
+    set<string> DeviceSymbolFunctions3;
+    set<string> DeviceSymbolFunctions4;
+    set<string> DeviceSymbolFunctions5;
     set<string> ReinterpretFunctions0;
     set<string> ReinterpretFunctions1;
     set<string> RemoveArgFunctions3;
@@ -497,10 +504,29 @@ namespace perl {
               default: break;
             }
             break;
+          case 2:
+            switch (c.second.castType) {
+              case e_HIP_SYMBOL: DeviceSymbolFunctions2.insert(f.first); break;
+              default: break;
+            }
+            break;
           case 3:
             switch (c.second.castType) {
+              case e_HIP_SYMBOL: DeviceSymbolFunctions3.insert(f.first); break;
               case e_remove_argument: RemoveArgFunctions3.insert(f.first); break;
               default: break;
+            }
+            break;
+          case 4:
+            switch (c.second.castType) {
+            case e_HIP_SYMBOL: DeviceSymbolFunctions4.insert(f.first); break;
+            default: break;
+            }
+            break;
+          case 5:
+            switch (c.second.castType) {
+            case e_HIP_SYMBOL: DeviceSymbolFunctions5.insert(f.first); break;
+            default: break;
             }
             break;
           default: break;
@@ -508,13 +534,17 @@ namespace perl {
       }
     }
     set<string>& funcSet = DeviceSymbolFunctions0;
-    for (int i = 0; i < 5; ++i) {
+    for (int i = 0; i < 9; ++i) {
       switch (i) {
+        default: funcSet = DeviceSymbolFunctions0; break;
         case 1:  funcSet = DeviceSymbolFunctions1; break;
         case 2:  funcSet = ReinterpretFunctions0; break;
         case 3:  funcSet = ReinterpretFunctions1; break;
-        case 4:  funcSet = RemoveArgFunctions3; break;
-        default: funcSet = DeviceSymbolFunctions0;
+        case 4:  funcSet = DeviceSymbolFunctions2; break;
+        case 5:  funcSet = RemoveArgFunctions3; break;
+        case 6:  funcSet = DeviceSymbolFunctions3; break;
+        case 7:  funcSet = DeviceSymbolFunctions4; break;
+        case 8:  funcSet = DeviceSymbolFunctions5; break;
       }
       if (funcSet.empty()) continue;
       *streamPtr.get() << tab + foreach_func;
@@ -533,11 +563,15 @@ namespace perl {
       *streamPtr.get() << endl_tab << ")" << endl_tab << "{" << endl_tab_2;
       switch (i) {
         case 0:
-        default: *streamPtr.get() << s0 << getCastType(e_HIP_SYMBOL) << "\\($2\\),/g" << endl; break;
-        case 1:  *streamPtr.get() << s1 << getCastType(e_HIP_SYMBOL) << "\\($3\\)$4/g;" << endl; break;
-        case 2:  *streamPtr.get() << s0 << getCastType(e_reinterpret_cast) << "\\($2\\),/g" << endl; break;
-        case 3:  *streamPtr.get() << s1 << getCastType(e_reinterpret_cast) << "\\($3\\)$4/g;" << endl; break;
-        case 4:  *streamPtr.get() << s3 << endl; break;
+        default: *streamPtr.get() << s0 << getCastType(e_HIP_SYMBOL) << "\\($2\\),/g;" << endl; break;
+        case 1:  *streamPtr.get() << s1 << getCastType(e_HIP_SYMBOL) << "\\($4\\)$5/g;" << endl; break;
+        case 2:  *streamPtr.get() << s0 << getCastType(e_reinterpret_cast) << "\\($2\\),/g;" << endl; break;
+        case 3:  *streamPtr.get() << s1 << getCastType(e_reinterpret_cast) << "\\($4\\)$5/g;" << endl; break;
+        case 4:  *streamPtr.get() << s2 << getCastType(e_HIP_SYMBOL) << "\\($5\\)$6/g;" << endl; break;
+        case 5:  *streamPtr.get() << s3 << "$7/g;" << endl; break;
+        case 6:  *streamPtr.get() << s3 << ",$5" << getCastType(e_HIP_SYMBOL) << "\\($6\\)$7/g;" << endl; break;
+        case 7:  *streamPtr.get() << s4 << getCastType(e_HIP_SYMBOL) << "\\($7\\)$8/g;" << endl; break;
+        case 8:  *streamPtr.get() << s5 << getCastType(e_HIP_SYMBOL) << "\\($8\\)$9/g;" << endl; break;
       }
       *streamPtr.get() << tab << "}" << endl;
     }


### PR DESCRIPTION
+ Update the regenerated hipify-perl script