### PR TITLE
[HIPIFY][#585][tests] Fix lit testing by taking into account the LLVM version for calculating CUDA compute capability

### DIFF
--- a/tests/lit.cfg
+++ b/tests/lit.cfg
@@ -141,16 +141,17 @@ if config.cuda_version_major == 7:
 elif config.cuda_version_major == 8:
     clang_arguments += " --cuda-gpu-arch=sm_62"
 elif config.cuda_version_major == 9:
-    if config.cuda_version_minor == 2:
+    if config.cuda_version_minor == 2 and config.llvm_version_major >= 7 and config.llvm_version_major < 8:
         clang_arguments += " --cuda-gpu-arch=sm_72"
-    else:
+    elif config.llvm_version_major >= 6 and config.llvm_version_major < 7:
         clang_arguments += " --cuda-gpu-arch=sm_70"
 elif config.cuda_version_major == 10:
-    clang_arguments += " --cuda-gpu-arch=sm_75"
+    if config.llvm_version_major >= 8 and config.llvm_version_major < 11:
+        clang_arguments += " --cuda-gpu-arch=sm_75"
 elif config.cuda_version_major == 11:
-    if config.cuda_version_minor == 0:
+    if config.cuda_version_minor == 0 and config.llvm_version_major >= 11 and config.llvm_version_major < 13:
         clang_arguments += " --cuda-gpu-arch=sm_80"
-    if config.cuda_version_minor > 0:
+    if config.cuda_version_minor > 0 and config.llvm_version_major >= 13:
         clang_arguments += " --cuda-gpu-arch=sm_86"
 
 # cuDNN ROOT


### PR DESCRIPTION
**[Synopsis]**
+ For instance, if CUDA is of 11.4 version (which supports `sm_86`), but LLVM is 12.0.1, and the following error occurs while running hipify-clang unit testing:
`error: Unsupported CUDA gpu architecture: sm_86`
+ The error occurs because LLVM 12.0.1 supports only `sm_80`, but not `sm_86`

**[Solution]**
The maximum supported compute capability by LLVM is taken into account besides the CUDA version based on the following table:

|**LLVM min**|**LLVM max**|**SM max**|
|--:|--:|:-:|
|3.9.0|5.0.2|SM_62|
|6.0.0|6.0.1|SM_70|
|7.0.0|7.1.0|SM_72|
|8.0.0|10.0.1|SM_75|
|11.0.0|12.0.1|SM_80|
|13.0.0|trunk|SM_86|