### PR TITLE
[HIPIFY][tests][fix] Synthetic test for CUDA Runtime API functions - Part 8

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -3647,6 +3647,7 @@ sub simpleSubstitutions {
     subst("nvrtcResult", "hiprtcResult", "type");
     subst("pruneInfo_t", "pruneInfo_t", "type");
     subst("surfaceReference", "surfaceReference", "type");
+    subst("textureReference", "textureReference", "type");
     subst("CUBLAS_ATOMICS_ALLOWED", "HIPBLAS_ATOMICS_ALLOWED", "numeric_literal");
     subst("CUBLAS_ATOMICS_NOT_ALLOWED", "HIPBLAS_ATOMICS_NOT_ALLOWED", "numeric_literal");
     subst("CUBLAS_DIAG_NON_UNIT", "HIPBLAS_DIAG_NON_UNIT", "numeric_literal");

--- a/doc/markdown/CUDA_Runtime_API_functions_supported_by_HIP.md
+++ b/doc/markdown/CUDA_Runtime_API_functions_supported_by_HIP.md
@@ -1341,6 +1341,7 @@ Unsupported
 |`libraryPropertyType`|8.0| | | | | | | |
 |`libraryPropertyType_t`|8.0| | | | | | | |
 |`surfaceReference`| | | |`surfaceReference`|1.9.0| | | |
+|`textureReference`| | | |`textureReference`|1.6.0| | | |
 
 ## **37. Execution Control [REMOVED]**
 

--- a/src/CUDA2HIP_Runtime_API_types.cpp
+++ b/src/CUDA2HIP_Runtime_API_types.cpp
@@ -122,6 +122,9 @@ const std::map<llvm::StringRef, hipCounter> CUDA_RUNTIME_TYPE_NAME_MAP {
   // NOTE: possibly CUsurfref is analogue
   {"surfaceReference",                                                 {"surfaceReference",                                         "", CONV_TYPE, API_RUNTIME, 36}},
 
+  // NOTE: possibly CUtexref_st is analogue
+  {"textureReference",                                                 {"textureReference",                                         "", CONV_TYPE, API_RUNTIME, 36}},
+
   // the same - CUevent_st
   {"CUevent_st",                                                       {"ihipEvent_t",                                              "", CONV_TYPE, API_RUNTIME, 36}},
   // CUevent


### PR DESCRIPTION
+ Added missing `textureReference` type
+ Update docs and hipify-perl accordingly
+ TODO: Implement `const struct textureReference **texref` correct mapping to HIP for `hipGetTextureReference()`
