### PR TITLE
[HIPIFY][fix] Add missing `HIP_SYMBOL()` macro to `hipGetTextureReference` function's symbol argument

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -4738,6 +4738,7 @@ sub transformHostFunctions {
     foreach $func (
         "hipGetSymbolAddress",
         "hipGetSymbolSize",
+        "hipGetTextureReference",
         "hipGraphMemcpyNodeSetParamsToSymbol",
         "hipMemcpyFromSymbol",
         "hipMemcpyFromSymbolAsync"

--- a/src/HipifyAction.cpp
+++ b/src/HipifyAction.cpp
@@ -66,6 +66,7 @@ const std::string sCudaGraphExecMemcpyNodeSetParamsToSymbol = "cudaGraphExecMemc
 const std::string sCudaGraphExecMemcpyNodeSetParamsFromSymbol = "cudaGraphExecMemcpyNodeSetParamsFromSymbol";
 const std::string sCuOccupancyMaxPotentialBlockSize = "cuOccupancyMaxPotentialBlockSize";
 const std::string sCuOccupancyMaxPotentialBlockSizeWithFlags = "cuOccupancyMaxPotentialBlockSizeWithFlags";
+const std::string sCudaGetTextureReference = "cudaGetTextureReference";
 // Matchers' names
 const StringRef sCudaLaunchKernel = "cudaLaunchKernel";
 const StringRef sCudaHostFuncCall = "cudaHostFuncCall";
@@ -98,6 +99,7 @@ std::map<std::string, ArgCastMap> FuncArgCasts {
   {sCudaGraphMemcpyNodeSetParamsFromSymbol, {{2, {e_HIP_SYMBOL, cw_None}}}},
   {sCudaGraphExecMemcpyNodeSetParamsToSymbol, {{2, {e_HIP_SYMBOL, cw_None}}}},
   {sCudaGraphExecMemcpyNodeSetParamsFromSymbol, {{3, {e_HIP_SYMBOL, cw_None}}}},
+  {sCudaGetTextureReference, {{1, {e_HIP_SYMBOL, cw_None}}}},
   {sCuOccupancyMaxPotentialBlockSize, {{3, {e_remove_argument, cw_DataLoss}}}},
   {sCuOccupancyMaxPotentialBlockSizeWithFlags, {{3, {e_remove_argument, cw_DataLoss}}}},
 };
@@ -586,7 +588,8 @@ std::unique_ptr<clang::ASTConsumer> HipifyAction::CreateASTConsumer(clang::Compi
             sCudaGraphExecMemcpyNodeSetParamsToSymbol,
             sCudaGraphExecMemcpyNodeSetParamsFromSymbol,
             sCuOccupancyMaxPotentialBlockSize,
-            sCuOccupancyMaxPotentialBlockSizeWithFlags
+            sCuOccupancyMaxPotentialBlockSizeWithFlags,
+            sCudaGetTextureReference
           )
         )
       )

--- a/tests/unit_tests/synthetic/runtime_functions.cu
+++ b/tests/unit_tests/synthetic/runtime_functions.cu
@@ -1048,11 +1048,10 @@ int main() {
   // CHECK: result = hipGetTextureAlignmentOffset(&wOffset, texref);
   result = cudaGetTextureAlignmentOffset(&wOffset, texref);
 
-  // TODO: Implement `const struct textureReference **texref` correct mapping to HIP
   // CUDA: extern __CUDA_DEPRECATED __host__ cudaError_t CUDARTAPI cudaGetTextureReference(const struct textureReference **texref, const void *symbol);
   // HIP:  hipError_t hipGetTextureReference(const textureReference** texref, const void* symbol);
-  // result = hipGetTextureReference(&texref, HIP_SYMBOL(image));
-  // result = cudaGetTextureReference(&texref, image);
+  // CHECK: result = hipGetTextureReference(const_cast<const textureReference**>(&texref), HIP_SYMBOL(image));
+  result = cudaGetTextureReference(const_cast<const textureReference**>(&texref), image);
 
   // CUDA: extern __CUDA_DEPRECATED __host__ cudaError_t CUDARTAPI cudaUnbindTexture(const struct textureReference *texref);
   // HIP:  DEPRECATED(DEPRECATED_MSG) hipError_t hipUnbindTexture(const textureReference* tex);


### PR DESCRIPTION
+ Update the `runtime_functions.cu` test and regenerated hipify-perl script
