### PR TITLE
[HIPIFY][#591][CUB] Introduce CUB types mapping besides mapping of namespaces

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -4607,6 +4607,7 @@ sub simpleSubstitutions {
     subst("cudaStreamCaptureStatusNone", "hipStreamCaptureStatusNone", "numeric_literal");
     subst("cudaStreamSetCaptureDependencies", "hipStreamSetCaptureDependencies", "numeric_literal");
     subst("cudaSuccess", "hipSuccess", "numeric_literal");
+    subst("CUB_STDERR", "HIPCUB_STDERR", "define");
     subst("CUDA_ARRAY3D_CUBEMAP", "hipArrayCubemap", "define");
     subst("CUDA_ARRAY3D_LAYERED", "hipArrayLayered", "define");
     subst("CUDA_ARRAY3D_SURFACE_LDST", "hipArraySurfaceLoadStore", "define");
@@ -4632,8 +4633,10 @@ sub simpleSubstitutions {
     subst("CU_TRSF_NORMALIZED_COORDINATES", "HIP_TRSF_NORMALIZED_COORDINATES", "define");
     subst("CU_TRSF_READ_AS_INTEGER", "HIP_TRSF_READ_AS_INTEGER", "define");
     subst("CU_TRSF_SRGB", "HIP_TRSF_SRGB", "define");
+    subst("CubDebug", "HipcubDebug", "define");
     subst("REGISTER_CUDA_OPERATOR", "REGISTER_HIP_OPERATOR", "define");
     subst("REGISTER_CUDA_OPERATOR_CREATOR", "REGISTER_HIP_OPERATOR_CREATOR", "define");
+    subst("_CubLog", "_HipcubLog", "define");
     subst("__CUDACC__", "__HIPCC__", "define");
     subst("cudaArrayCubemap", "hipArrayCubemap", "define");
     subst("cudaArrayDefault", "hipArrayDefault", "define");

--- a/src/CUDA2HIP.cpp
+++ b/src/CUDA2HIP.cpp
@@ -108,6 +108,7 @@ const std::map<llvm::StringRef, hipCounter> &CUDA_RENAMES_MAP() {
   ret.insert(CUDA_SPARSE_FUNCTION_MAP.begin(), CUDA_SPARSE_FUNCTION_MAP.end());
   ret.insert(CUDA_CAFFE2_TYPE_NAME_MAP.begin(), CUDA_CAFFE2_TYPE_NAME_MAP.end());
   ret.insert(CUDA_CAFFE2_FUNCTION_MAP.begin(), CUDA_CAFFE2_FUNCTION_MAP.end());
+  ret.insert(CUDA_CUB_TYPE_NAME_MAP.begin(), CUDA_CUB_TYPE_NAME_MAP.end());
   ret.insert(CUDA_RTC_TYPE_NAME_MAP.begin(), CUDA_RTC_TYPE_NAME_MAP.end());
   ret.insert(CUDA_RTC_FUNCTION_MAP.begin(), CUDA_RTC_FUNCTION_MAP.end());
   return ret;

--- a/src/CUDA2HIP.h
+++ b/src/CUDA2HIP.h
@@ -73,6 +73,8 @@ extern const std::map<llvm::StringRef, hipCounter> CUDA_DEVICE_FUNCTION_MAP;
 extern const std::map<llvm::StringRef, hipCounter> CUDA_DEVICE_TYPE_NAME_MAP;
 // Maps the names of CUDA CUB API types to the corresponding HIP types
 extern const std::map<llvm::StringRef, hipCounter> CUDA_CUB_TYPE_NAME_MAP;
+// Maps the names of CUDA CUB namespaces to the corresponding HIP namespaces
+extern const std::map<llvm::StringRef, hipCounter> CUDA_CUB_NAMESPACE_MAP;
 // Maps the names of CUDA RTC API types to the corresponding HIP types
 extern const std::map<llvm::StringRef, hipCounter> CUDA_RTC_TYPE_NAME_MAP;
 // Maps the names of CUDA RTC API functions to the corresponding HIP functions

--- a/src/CUDA2HIP_CUB_API_types.cpp
+++ b/src/CUDA2HIP_CUB_API_types.cpp
@@ -23,14 +23,25 @@ THE SOFTWARE.
 #include "CUDA2HIP.h"
 
 // Maps the names of CUDA CUB API types to the corresponding HIP types
+const std::map<llvm::StringRef, hipCounter> CUDA_CUB_NAMESPACE_MAP {
+  {"cub",                               {"hipcub",                             "", CONV_TYPE, API_CUB, 1}},
+};
+
+// Maps the names of CUDA CUB API types to the corresponding HIP types
 const std::map<llvm::StringRef, hipCounter> CUDA_CUB_TYPE_NAME_MAP {
-  {"cub",  {"hipcub",  "", CONV_TYPE, API_CUB, 1}},
+  // 5. Defines
+  {"CUB_STDERR",                        {"HIPCUB_STDERR",                      "", CONV_DEFINE, API_CUB, 1}},
+  {"CubDebug",                          {"HipcubDebug",                        "", CONV_DEFINE, API_CUB, 1}},
+  {"_CubLog",                           {"_HipcubLog",                         "", CONV_DEFINE, API_CUB, 1}},
 };
 
 const std::map<llvm::StringRef, cudaAPIversions> CUDA_CUB_TYPE_NAME_VER_MAP {
 };
 
 const std::map<llvm::StringRef, hipAPIversions> HIP_CUB_TYPE_NAME_VER_MAP {
+  {"HIPCUB_STDERR",                          {HIP_2050, HIP_0,    HIP_0   }},
+  {"HipcubDebug",                            {HIP_2050, HIP_0,    HIP_0   }},
+  {"_HipcubLog",                             {HIP_2050, HIP_0,    HIP_0   }},
 };
 
 const std::map<unsigned int, llvm::StringRef> CUDA_CUB_API_SECTION_MAP {

--- a/src/HipifyAction.cpp
+++ b/src/HipifyAction.cpp
@@ -380,8 +380,8 @@ bool HipifyAction::cudaLaunchKernel(const mat::MatchFinder::MatchResult &Result)
     OS << sHIP_KERNEL_NAME << "(";
     std::string cub = sCub + "::";
     std::string hipcub;
-    const auto found = CUDA_CUB_TYPE_NAME_MAP.find(sCub);
-    if (found != CUDA_CUB_TYPE_NAME_MAP.end()) {
+    const auto found = CUDA_CUB_NAMESPACE_MAP.find(sCub);
+    if (found != CUDA_CUB_NAMESPACE_MAP.end()) {
       hipcub = found->second.hipName.str() + "::";
     } else {
       hipcub = sHipcub + "::";
@@ -461,7 +461,7 @@ bool HipifyAction::cubNamespacePrefix(const mat::MatchFinder::MatchResult &Resul
     const clang::TypeLoc tloc = si->getTypeLoc();
     const clang::SourceRange sr = tloc.getSourceRange();
     std::string name = nsd->getDeclName().getAsString();
-    FindAndReplace(name, GetSubstrLocation(name, sr), CUDA_CUB_TYPE_NAME_MAP);
+    FindAndReplace(name, GetSubstrLocation(name, sr), CUDA_CUB_NAMESPACE_MAP);
     return true;
   }
   return false;
@@ -470,7 +470,7 @@ bool HipifyAction::cubNamespacePrefix(const mat::MatchFinder::MatchResult &Resul
 bool HipifyAction::cubUsingNamespaceDecl(const mat::MatchFinder::MatchResult &Result) {
   if (auto *decl = Result.Nodes.getNodeAs<clang::UsingDirectiveDecl>(sCubUsingNamespaceDecl)) {
     if (auto nsd = decl->getNominatedNamespace()) {
-      FindAndReplace(nsd->getDeclName().getAsString(), decl->getIdentLocation(), CUDA_CUB_TYPE_NAME_MAP);
+      FindAndReplace(nsd->getDeclName().getAsString(), decl->getIdentLocation(), CUDA_CUB_NAMESPACE_MAP);
       return true;
     }
   }
@@ -495,7 +495,7 @@ bool HipifyAction::cubFunctionTemplateDecl(const mat::MatchFinder::MatchResult &
       if (!nsd) continue;
       const clang::SourceRange sr = valueDecl->getSourceRange();
       std::string name = nsd->getDeclName().getAsString();
-      FindAndReplace(name, GetSubstrLocation(name, sr), CUDA_CUB_TYPE_NAME_MAP);
+      FindAndReplace(name, GetSubstrLocation(name, sr), CUDA_CUB_NAMESPACE_MAP);
       ret = true;
     }
     return ret;


### PR DESCRIPTION
+ Renamed former `CUDA_CUB_TYPE_NAME_MAP` map to `CUDA_CUB_NAMESPACE_MAP` and left it for namespace mapping only as it is implemented explicitly in hipify-clang
+ Update regenerated hipify-perl

[TODO]
+ Add CUB synthetic tests
+ Generate CUB_API_supported_by_HIP.md