### PR TITLE
[HIPIFY][#591][CUB][doc][fix] Introduce CUB documentation generation

### DIFF
--- a/src/CUDA2HIP.cpp
+++ b/src/CUDA2HIP.cpp
@@ -109,6 +109,7 @@ const std::map<llvm::StringRef, hipCounter> &CUDA_RENAMES_MAP() {
   ret.insert(CUDA_CAFFE2_TYPE_NAME_MAP.begin(), CUDA_CAFFE2_TYPE_NAME_MAP.end());
   ret.insert(CUDA_CAFFE2_FUNCTION_MAP.begin(), CUDA_CAFFE2_FUNCTION_MAP.end());
   ret.insert(CUDA_CUB_TYPE_NAME_MAP.begin(), CUDA_CUB_TYPE_NAME_MAP.end());
+  ret.insert(CUDA_CUB_FUNCTION_MAP.begin(), CUDA_CUB_FUNCTION_MAP.end());
   ret.insert(CUDA_RTC_TYPE_NAME_MAP.begin(), CUDA_RTC_TYPE_NAME_MAP.end());
   ret.insert(CUDA_RTC_FUNCTION_MAP.begin(), CUDA_RTC_FUNCTION_MAP.end());
   return ret;
@@ -122,7 +123,6 @@ const std::map<llvm::StringRef, cudaAPIversions> &CUDA_VERSIONS_MAP() {
   ret.insert(CUDA_DRIVER_TYPE_NAME_VER_MAP.begin(), CUDA_DRIVER_TYPE_NAME_VER_MAP.end());
   ret.insert(CUDA_DRIVER_FUNCTION_VER_MAP.begin(), CUDA_DRIVER_FUNCTION_VER_MAP.end());
   ret.insert(CUDA_RUNTIME_TYPE_NAME_VER_MAP.begin(), CUDA_RUNTIME_TYPE_NAME_VER_MAP.end());
-  ret.insert(CUDA_RUNTIME_FUNCTION_VER_MAP.begin(), CUDA_RUNTIME_FUNCTION_VER_MAP.end());
   ret.insert(CUDA_RUNTIME_FUNCTION_VER_MAP.begin(), CUDA_RUNTIME_FUNCTION_VER_MAP.end());
   ret.insert(CUDA_COMPLEX_TYPE_NAME_VER_MAP.begin(), CUDA_COMPLEX_TYPE_NAME_VER_MAP.end());
   ret.insert(CUDA_COMPLEX_FUNCTION_VER_MAP.begin(), CUDA_COMPLEX_FUNCTION_VER_MAP.end());
@@ -141,6 +141,7 @@ const std::map<llvm::StringRef, cudaAPIversions> &CUDA_VERSIONS_MAP() {
   ret.insert(CUDA_DEVICE_TYPE_NAME_VER_MAP.begin(), CUDA_DEVICE_TYPE_NAME_VER_MAP.end());
   ret.insert(CUDA_DEVICE_FUNCTION_VER_MAP.begin(), CUDA_DEVICE_FUNCTION_VER_MAP.end());
   ret.insert(CUDA_CUB_TYPE_NAME_VER_MAP.begin(), CUDA_CUB_TYPE_NAME_VER_MAP.end());
+  ret.insert(CUDA_CUB_FUNCTION_VER_MAP.begin(), CUDA_CUB_FUNCTION_VER_MAP.end());
   ret.insert(CUDA_RTC_TYPE_NAME_VER_MAP.begin(), CUDA_RTC_TYPE_NAME_VER_MAP.end());
   ret.insert(CUDA_RTC_FUNCTION_VER_MAP.begin(), CUDA_RTC_FUNCTION_VER_MAP.end());
   return ret;
@@ -154,7 +155,6 @@ const std::map<llvm::StringRef, hipAPIversions> &HIP_VERSIONS_MAP() {
   ret.insert(HIP_DRIVER_TYPE_NAME_VER_MAP.begin(), HIP_DRIVER_TYPE_NAME_VER_MAP.end());
   ret.insert(HIP_DRIVER_FUNCTION_VER_MAP.begin(), HIP_DRIVER_FUNCTION_VER_MAP.end());
   ret.insert(HIP_RUNTIME_TYPE_NAME_VER_MAP.begin(), HIP_RUNTIME_TYPE_NAME_VER_MAP.end());
-  ret.insert(HIP_RUNTIME_FUNCTION_VER_MAP.begin(), HIP_RUNTIME_FUNCTION_VER_MAP.end());
   ret.insert(HIP_RUNTIME_FUNCTION_VER_MAP.begin(), HIP_RUNTIME_FUNCTION_VER_MAP.end());
   ret.insert(HIP_COMPLEX_TYPE_NAME_VER_MAP.begin(), HIP_COMPLEX_TYPE_NAME_VER_MAP.end());
   ret.insert(HIP_COMPLEX_FUNCTION_VER_MAP.begin(), HIP_COMPLEX_FUNCTION_VER_MAP.end());
@@ -173,6 +173,7 @@ const std::map<llvm::StringRef, hipAPIversions> &HIP_VERSIONS_MAP() {
   ret.insert(HIP_DEVICE_TYPE_NAME_VER_MAP.begin(), HIP_DEVICE_TYPE_NAME_VER_MAP.end());
   ret.insert(HIP_DEVICE_FUNCTION_VER_MAP.begin(), HIP_DEVICE_FUNCTION_VER_MAP.end());
   ret.insert(HIP_CUB_TYPE_NAME_VER_MAP.begin(), HIP_CUB_TYPE_NAME_VER_MAP.end());
+  ret.insert(HIP_CUB_FUNCTION_VER_MAP.begin(), HIP_CUB_FUNCTION_VER_MAP.end());
   ret.insert(HIP_RTC_TYPE_NAME_VER_MAP.begin(), HIP_RTC_TYPE_NAME_VER_MAP.end());
   ret.insert(HIP_RTC_FUNCTION_VER_MAP.begin(), HIP_RTC_FUNCTION_VER_MAP.end());
   return ret;

--- a/src/CUDA2HIP.h
+++ b/src/CUDA2HIP.h
@@ -67,12 +67,14 @@ extern const std::map<llvm::StringRef, hipCounter> CUDA_SPARSE_FUNCTION_MAP;
 extern const std::map<llvm::StringRef, hipCounter> CUDA_CAFFE2_TYPE_NAME_MAP;
 // Maps the names of CUDA CAFFE2 API functions to the corresponding HIP functions
 extern const std::map<llvm::StringRef, hipCounter> CUDA_CAFFE2_FUNCTION_MAP;
-// Maps the names of CUDA Device functions to the corresponding HIP functions
-extern const std::map<llvm::StringRef, hipCounter> CUDA_DEVICE_FUNCTION_MAP;
 // Maps the names of CUDA Device types to the corresponding HIP types
 extern const std::map<llvm::StringRef, hipCounter> CUDA_DEVICE_TYPE_NAME_MAP;
+// Maps the names of CUDA Device functions to the corresponding HIP functions
+extern const std::map<llvm::StringRef, hipCounter> CUDA_DEVICE_FUNCTION_MAP;
 // Maps the names of CUDA CUB API types to the corresponding HIP types
 extern const std::map<llvm::StringRef, hipCounter> CUDA_CUB_TYPE_NAME_MAP;
+// Maps the names of CUDA CUB API functions to the corresponding HIP functions
+extern const std::map<llvm::StringRef, hipCounter> CUDA_CUB_FUNCTION_MAP;
 // Maps the names of CUDA CUB namespaces to the corresponding HIP namespaces
 extern const std::map<llvm::StringRef, hipCounter> CUDA_CUB_NAMESPACE_MAP;
 // Maps the names of CUDA RTC API types to the corresponding HIP types
@@ -111,6 +113,7 @@ extern const std::map<llvm::StringRef, cudaAPIversions> CUDA_CAFFE2_FUNCTION_VER
 extern const std::map<llvm::StringRef, cudaAPIversions> CUDA_DEVICE_TYPE_NAME_VER_MAP;
 extern const std::map<llvm::StringRef, cudaAPIversions> CUDA_DEVICE_FUNCTION_VER_MAP;
 extern const std::map<llvm::StringRef, cudaAPIversions> CUDA_CUB_TYPE_NAME_VER_MAP;
+extern const std::map<llvm::StringRef, cudaAPIversions> CUDA_CUB_FUNCTION_VER_MAP;
 extern const std::map<llvm::StringRef, cudaAPIversions> CUDA_RTC_TYPE_NAME_VER_MAP;
 extern const std::map<llvm::StringRef, cudaAPIversions> CUDA_RTC_FUNCTION_VER_MAP;
 
@@ -141,6 +144,7 @@ extern const std::map<llvm::StringRef, hipAPIversions> HIP_CAFFE2_FUNCTION_VER_M
 extern const std::map<llvm::StringRef, hipAPIversions> HIP_DEVICE_TYPE_NAME_VER_MAP;
 extern const std::map<llvm::StringRef, hipAPIversions> HIP_DEVICE_FUNCTION_VER_MAP;
 extern const std::map<llvm::StringRef, hipAPIversions> HIP_CUB_TYPE_NAME_VER_MAP;
+extern const std::map<llvm::StringRef, hipAPIversions> HIP_CUB_FUNCTION_VER_MAP;
 extern const std::map<llvm::StringRef, hipAPIversions> HIP_RTC_TYPE_NAME_VER_MAP;
 extern const std::map<llvm::StringRef, hipAPIversions> HIP_RTC_FUNCTION_VER_MAP;
 
@@ -160,3 +164,4 @@ extern const std::map<unsigned int, llvm::StringRef> CUDA_FFT_API_SECTION_MAP;
 extern const std::map<unsigned int, llvm::StringRef> CUDA_SPARSE_API_SECTION_MAP;
 extern const std::map<unsigned int, llvm::StringRef> CUDA_DEVICE_FUNCTION_API_SECTION_MAP;
 extern const std::map<unsigned int, llvm::StringRef> CUDA_RTC_API_SECTION_MAP;
+extern const std::map<unsigned int, llvm::StringRef> CUDA_CUB_API_SECTION_MAP;

--- a/src/CUDA2HIP_Doc.cpp
+++ b/src/CUDA2HIP_Doc.cpp
@@ -94,7 +94,12 @@ namespace doc {
   const string sRTC = "CUDA_RTC_API_supported_by_HIP";
   const string sRTC_md = sRTC + md_ext;
   const string sRTC_csv = sRTC + csv_ext;
-  const string c = "CUDA RTC";
+  const string sCURTC = "CUDA RTC";
+
+  const string sCUB = "CUB_API_supported_by_HIP";
+  const string sCUB_md = sCUB + md_ext;
+  const string sCUB_csv = sCUB + csv_ext;
+  const string sCUCUB = "CUB";
 
   const string sAPI_supported = "API supported by HIP";
   const string sCUDA = "CUDA";
@@ -561,13 +566,36 @@ namespace doc {
       const hipVersionMap &getHipFunctionVersions() const override { return HIP_RTC_FUNCTION_VER_MAP; }
       const versionMap &getTypeVersions() const override { return CUDA_RTC_TYPE_NAME_VER_MAP; }
       const hipVersionMap &getHipTypeVersions() const override { return HIP_RTC_TYPE_NAME_VER_MAP; }
-      const string &getName() const override { return sRTC; }
+      const string &getName() const override { return sCURTC; }
       const string &getFileName(docType format) const override {
         switch (format) {
           case none:
           default: return sEmpty;
           case md: return sRTC_md;
           case csv: return sRTC_csv;
+        }
+      }
+  };
+
+   class CUB : public DOC {
+    public:
+      CUB(const string &outDir): DOC(outDir) {}
+      virtual ~CUB() {}
+    protected:
+      const sectionMap &getSections() const override { return CUDA_CUB_API_SECTION_MAP; }
+      const functionMap &getFunctions() const override { return CUDA_CUB_FUNCTION_MAP; }
+      const typeMap &getTypes() const override { return CUDA_CUB_TYPE_NAME_MAP; }
+      const versionMap &getFunctionVersions() const override { return CUDA_CUB_FUNCTION_VER_MAP; }
+      const hipVersionMap &getHipFunctionVersions() const override { return HIP_CUB_FUNCTION_VER_MAP; }
+      const versionMap &getTypeVersions() const override { return CUDA_CUB_TYPE_NAME_VER_MAP; }
+      const hipVersionMap &getHipTypeVersions() const override { return HIP_CUB_TYPE_NAME_VER_MAP; }
+      const string &getName() const override { return sCUCUB; }
+      const string &getFileName(docType format) const override {
+        switch (format) {
+          case none:
+          default: return sEmpty;
+          case md: return sCUB_md;
+          case csv: return sCUB_csv;
         }
       }
   };
@@ -613,6 +641,8 @@ namespace doc {
     docs.addDoc(&device);
     RTC rtc(sOut);
     docs.addDoc(&rtc);
+    CUB cub(sOut);
+    docs.addDoc(&cub);
     return docs.generate();
   }
 


### PR DESCRIPTION
+ `CUB_API_supported_by_HIP` md and csv docs are generated now along with all other docs
+ Fixed typo in `RTC` documentation generation
+ Removed excessive `RUNTIME_FUNCTION_VER_MAP`s from searching

[TODO]
+ Provide the generated `CUB` doc to the `README.md` and the official AMD ROCm docs later
