### PR TITLE
[HIPIFY][#407][tests][fix] Synthetic test for CUDA Runtime API functions - Part 11 - final

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -3242,7 +3242,7 @@ sub simpleSubstitutions {
     subst("channel_descriptor.h", "hip\/channel_descriptor.h", "include");
     subst("cooperative_groups.h", "hip\/hip_cooperative_groups.h", "include");
     subst("cuda_fp16.h", "hip\/hip_fp16.h", "include");
-    subst("cuda_profiler_api.h", "hip\/hip_profile.h", "include");
+    subst("cuda_profiler_api.h", "hip\/hip_runtime_api.h", "include");
     subst("cuda_runtime_api.h", "hip\/hip_runtime_api.h", "include");
     subst("cuda_texture_types.h", "hip\/hip_texture_types.h", "include");
     subst("cufftXt.h", "hipfftXt.h", "include");

--- a/src/CUDA2HIP.cpp
+++ b/src/CUDA2HIP.cpp
@@ -35,7 +35,7 @@ const std::map <llvm::StringRef, hipCounter> CUDA_INCLUDE_MAP {
   {"cuda_texture_types.h",      {"hip/hip_texture_types.h",      "", CONV_INCLUDE,             API_RUNTIME, 0}},
   {"texture_fetch_functions.h", {"",                             "", CONV_INCLUDE,             API_RUNTIME, 0}},
   {"vector_types.h",            {"hip/hip_vector_types.h",       "", CONV_INCLUDE,             API_RUNTIME, 0}},
-  {"cuda_profiler_api.h",       {"hip/hip_profile.h",            "", CONV_INCLUDE,             API_RUNTIME, 0}},
+  {"cuda_profiler_api.h",       {"hip/hip_runtime_api.h",        "", CONV_INCLUDE,             API_RUNTIME, 0}},
   {"cooperative_groups.h",      {"hip/hip_cooperative_groups.h", "", CONV_INCLUDE,             API_RUNTIME, 0}},
   // cuComplex includes
   {"cuComplex.h",               {"hip/hip_complex.h",            "", CONV_INCLUDE_CUDA_MAIN_H, API_COMPLEX, 0}},

--- a/src/CUDA2HIP_Runtime_API_functions.cpp
+++ b/src/CUDA2HIP_Runtime_API_functions.cpp
@@ -833,7 +833,7 @@ const std::map<llvm::StringRef, hipCounter> CUDA_RUNTIME_FUNCTION_MAP {
   // cuGraphInstantiateWithFlags
   {"cudaGraphInstantiateWithFlags",                           {"hipGraphInstantiateWithFlags",                           "", CONV_GRAPH, API_RUNTIME, 30}},
   // cuGraphNodeSetEnabled
-  {"cudaGraphNodeSetEnabled",                                {"hipGraphNodeSetEnabled",                                  "", CONV_GRAPH, API_RUNTIME, 30, HIP_UNSUPPORTED}},
+  {"cudaGraphNodeSetEnabled",                                 {"hipGraphNodeSetEnabled",                                 "", CONV_GRAPH, API_RUNTIME, 30, HIP_UNSUPPORTED}},
 
   // 31. Driver Entry Point Access
   // cuGetProcAddress

--- a/tests/unit_tests/samples/2_Cookbook/2_Profiler/Profiler.cpp
+++ b/tests/unit_tests/samples/2_Cookbook/2_Profiler/Profiler.cpp
@@ -30,7 +30,7 @@ THE SOFTWARE.
 
 // CHECK: #include <hip/hip_runtime.h>
 #include <cuda.h>
-// CHECK: #include <hip/hip_profile.h>
+// CHECK: #include <hip/hip_runtime_api.h>
 #include <cuda_profiler_api.h>
 
 #define WIDTH 1024


### PR DESCRIPTION
+ Use `hip_runtime_api.h` instead of `hip_profile.h`
+ Updated tests and regenerated hipify-perl
+ Finished with synthetic tests for CUDA Runtime and Driver API
