### PR TITLE
[HIPIFY][#603][clang][fix] Fix the linking error

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,7 +68,7 @@ if(LLVM_PACKAGE_VERSION VERSION_GREATER "9.0.1")
 endif()
 
 if(LLVM_PACKAGE_VERSION VERSION_EQUAL "15.0.0" OR LLVM_PACKAGE_VERSION VERSION_GREATER "15.0.0")
-    target_link_libraries(hipify-clang PRIVATE LLVMWindowsDriver)
+    target_link_libraries(hipify-clang PRIVATE LLVMWindowsDriver clangSupport)
 endif()
 
 if(MSVC)


### PR DESCRIPTION
**[Synopsis]**
+ The affecting LLVM change:
  `SHA-1: 7a5cb15ea6facd82756adafae76d60f36a0b60fd` * [RISCV] Lazily add RVV C intrinsics (2022.07.13)
  when `clangSema` has got a dependency on `clangSupport` lib
+ `clangSupport` lib was introduced in LLVM with:
  `SHA-1: f26c41e8dd28d86030cd0f5a6e9c11036acea5d2` * [RISCV] Moving RVV intrinsic type related util to clang/Support (2022.04.14)

**[IMP]**
+ This PR eliminates the #603 issue, but only for LLVM ToT
+ If another linking error about the missing lib `clangSupport` occurs, then the LLVM trunk is very outdated (older than 2022.04.14) and should be updated to the latest and rebuilt
+ Sync with the latest LLVM ToT for resolving the #603 issue or any possible `clangSupport`-related issues