### PR TITLE
[HIPIFY][#601][BLAS][tests] Synthetic test for cuBLAS API - Part 2

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -1338,7 +1338,6 @@ sub rocSubstitutions {
     subst("cublasDgemv_v2", "rocblas_dgemv", "library");
     subst("cublasDger", "rocblas_dger", "library");
     subst("cublasDger_v2", "rocblas_dger", "library");
-    subst("cublasDnrm2", "rocblas_dnrm2", "library");
     subst("cublasDnrm2_v2", "rocblas_dnrm2", "library");
     subst("cublasDotEx", "rocblas_dot_ex", "library");
     subst("cublasDotcEx", "rocblas_dotc_ex", "library");
@@ -1394,7 +1393,6 @@ sub rocSubstitutions {
     subst("cublasDtrsv_v2", "rocblas_dtrsv", "library");
     subst("cublasDzasum", "rocblas_dzasum", "library");
     subst("cublasDzasum_v2", "rocblas_dzasum", "library");
-    subst("cublasDznrm2", "rocblas_dznrm2", "library");
     subst("cublasDznrm2_v2", "rocblas_dznrm2", "library");
     subst("cublasGemmBatchedEx", "rocblas_gemm_batched_ex", "library");
     subst("cublasGemmEx", "rocblas_gemm_ex", "library");
@@ -1435,7 +1433,6 @@ sub rocSubstitutions {
     subst("cublasScalEx", "rocblas_scal_ex", "library");
     subst("cublasScasum", "rocblas_scasum", "library");
     subst("cublasScasum_v2", "rocblas_scasum", "library");
-    subst("cublasScnrm2", "rocblas_scnrm2", "library");
     subst("cublasScnrm2_v2", "rocblas_scnrm2", "library");
     subst("cublasScopy", "rocblas_scopy", "library");
     subst("cublasScopy_v2", "rocblas_scopy", "library");
@@ -1461,7 +1458,6 @@ sub rocSubstitutions {
     subst("cublasSgemv_v2", "rocblas_sgemv", "library");
     subst("cublasSger", "rocblas_sger", "library");
     subst("cublasSger_v2", "rocblas_sger", "library");
-    subst("cublasSnrm2", "rocblas_snrm2", "library");
     subst("cublasSnrm2_v2", "rocblas_snrm2", "library");
     subst("cublasSrot", "rocblas_srot", "library");
     subst("cublasSrot_v2", "rocblas_srot", "library");
@@ -2255,7 +2251,6 @@ sub simpleSubstitutions {
     subst("cublasDgetrfBatched", "hipblasDgetrfBatched", "library");
     subst("cublasDgetriBatched", "hipblasDgetriBatched", "library");
     subst("cublasDgetrsBatched", "hipblasDgetrsBatched", "library");
-    subst("cublasDnrm2", "hipblasDnrm2", "library");
     subst("cublasDnrm2_v2", "hipblasDnrm2", "library");
     subst("cublasDotEx", "hipblasDotEx", "library");
     subst("cublasDotcEx", "hipblasDotcEx", "library");
@@ -2311,7 +2306,6 @@ sub simpleSubstitutions {
     subst("cublasDtrsv_v2", "hipblasDtrsv", "library");
     subst("cublasDzasum", "hipblasDzasum", "library");
     subst("cublasDzasum_v2", "hipblasDzasum", "library");
-    subst("cublasDznrm2", "hipblasDznrm2", "library");
     subst("cublasDznrm2_v2", "hipblasDznrm2", "library");
     subst("cublasGemmBatchedEx", "hipblasGemmBatchedEx", "library");
     subst("cublasGemmEx", "hipblasGemmEx", "library");
@@ -2353,7 +2347,6 @@ sub simpleSubstitutions {
     subst("cublasScalEx", "hipblasScalEx", "library");
     subst("cublasScasum", "hipblasScasum", "library");
     subst("cublasScasum_v2", "hipblasScasum", "library");
-    subst("cublasScnrm2", "hipblasScnrm2", "library");
     subst("cublasScnrm2_v2", "hipblasScnrm2", "library");
     subst("cublasScopy", "hipblasScopy", "library");
     subst("cublasScopy_v2", "hipblasScopy", "library");
@@ -2384,7 +2377,6 @@ sub simpleSubstitutions {
     subst("cublasSgetrfBatched", "hipblasSgetrfBatched", "library");
     subst("cublasSgetriBatched", "hipblasSgetriBatched", "library");
     subst("cublasSgetrsBatched", "hipblasSgetrsBatched", "library");
-    subst("cublasSnrm2", "hipblasSnrm2", "library");
     subst("cublasSnrm2_v2", "hipblasSnrm2", "library");
     subst("cublasSrot", "hipblasSrot", "library");
     subst("cublasSrot_v2", "hipblasSrot", "library");
@@ -7771,6 +7763,7 @@ sub warnHipOnlyUnsupportedFunctions {
         "cublasSwapEx",
         "cublasStrttp",
         "cublasStpttr",
+        "cublasSnrm2",
         "cublasSmatinvBatched",
         "cublasShutdown",
         "cublasSgemmEx",
@@ -7779,6 +7772,7 @@ sub warnHipOnlyUnsupportedFunctions {
         "cublasSetMathMode",
         "cublasSetLoggerCallback",
         "cublasSetKernelStream",
+        "cublasScnrm2",
         "cublasRotmgEx",
         "cublasRotmEx",
         "cublasRotgEx",
@@ -7800,8 +7794,10 @@ sub warnHipOnlyUnsupportedFunctions {
         "cublasGetError",
         "cublasGetCudartVersion",
         "cublasFree",
+        "cublasDznrm2",
         "cublasDtrttp",
         "cublasDtpttr",
+        "cublasDnrm2",
         "cublasDmatinvBatched",
         "cublasDgelsBatched",
         "cublasCtrttp",
@@ -7915,6 +7911,7 @@ sub warnRocOnlyUnsupportedFunctions {
         "cublasSwapEx",
         "cublasStrttp",
         "cublasStpttr",
+        "cublasSnrm2",
         "cublasSmatinvBatched",
         "cublasShutdown",
         "cublasSgetrsBatched",
@@ -7928,6 +7925,7 @@ sub warnRocOnlyUnsupportedFunctions {
         "cublasSetLoggerCallback",
         "cublasSetKernelStream",
         "cublasSetAtomicsMode",
+        "cublasScnrm2",
         "cublasRotmgEx",
         "cublasRotmEx",
         "cublasRotgEx",
@@ -7950,8 +7948,10 @@ sub warnRocOnlyUnsupportedFunctions {
         "cublasGetCudartVersion",
         "cublasGetAtomicsMode",
         "cublasFree",
+        "cublasDznrm2",
         "cublasDtrttp",
         "cublasDtpttr",
+        "cublasDnrm2",
         "cublasDmatinvBatched",
         "cublasDgetrsBatched",
         "cublasDgetriBatched",

--- a/doc/markdown/CUBLAS_API_supported_by_HIP.md
+++ b/doc/markdown/CUBLAS_API_supported_by_HIP.md
@@ -226,7 +226,7 @@
 |`cublasDcopy_v2`| | | |`hipblasDcopy`|1.8.2| | | |
 |`cublasDdot`| | | |`hipblasDdot`|3.0.0| | | |
 |`cublasDdot_v2`| | | |`hipblasDdot`|3.0.0| | | |
-|`cublasDnrm2`| | | |`hipblasDnrm2`|1.8.2| | | |
+|`cublasDnrm2`| | | | | | | | |
 |`cublasDnrm2_v2`| | | |`hipblasDnrm2`|1.8.2| | | |
 |`cublasDrot`| | | |`hipblasDrot`|3.0.0| | | |
 |`cublasDrot_v2`| | | |`hipblasDrot`|3.0.0| | | |
@@ -242,7 +242,7 @@
 |`cublasDswap_v2`| | | |`hipblasDswap`|3.0.0| | | |
 |`cublasDzasum`| | | |`hipblasDzasum`|3.0.0| | | |
 |`cublasDzasum_v2`| | | |`hipblasDzasum`|3.0.0| | | |
-|`cublasDznrm2`| | | |`hipblasDznrm2`|3.0.0| | | |
+|`cublasDznrm2`| | | | | | | | |
 |`cublasDznrm2_v2`| | | |`hipblasDznrm2`|3.0.0| | | |
 |`cublasIcamax`| | | |`hipblasIcamax`|3.0.0| | | |
 |`cublasIcamax_v2`| | | |`hipblasIcamax`|3.0.0| | | |
@@ -267,13 +267,13 @@
 |`cublasSaxpy_v2`| | | |`hipblasSaxpy`|1.8.2| | | |
 |`cublasScasum`| | | |`hipblasScasum`|3.0.0| | | |
 |`cublasScasum_v2`| | | |`hipblasScasum`|3.0.0| | | |
-|`cublasScnrm2`| | | |`hipblasScnrm2`|3.0.0| | | |
+|`cublasScnrm2`| | | | | | | | |
 |`cublasScnrm2_v2`| | | |`hipblasScnrm2`|3.0.0| | | |
 |`cublasScopy`| | | |`hipblasScopy`|1.8.2| | | |
 |`cublasScopy_v2`| | | |`hipblasScopy`|1.8.2| | | |
 |`cublasSdot`| | | |`hipblasSdot`|3.0.0| | | |
 |`cublasSdot_v2`| | | |`hipblasSdot`|3.0.0| | | |
-|`cublasSnrm2`| | | |`hipblasSnrm2`|1.8.2| | | |
+|`cublasSnrm2`| | | | | | | | |
 |`cublasSnrm2_v2`| | | |`hipblasSnrm2`|1.8.2| | | |
 |`cublasSrot`| | | |`hipblasSrot`|3.0.0| | | |
 |`cublasSrot_v2`| | | |`hipblasSrot`|3.0.0| | | |

--- a/src/CUDA2HIP.cpp
+++ b/src/CUDA2HIP.cpp
@@ -42,6 +42,7 @@ const std::map <llvm::StringRef, hipCounter> CUDA_INCLUDE_MAP {
   // cuBLAS includes
   {"cublas.h",                  {"hipblas.h",                    "rocblas.h", CONV_INCLUDE_CUDA_MAIN_H, API_BLAS, 0}},
   {"cublas_v2.h",               {"hipblas.h",                    "rocblas.h", CONV_INCLUDE_CUDA_MAIN_H, API_BLAS, 0}},
+  {"cublas_api.h",              {"hipblas.h",                    "rocblas.h", CONV_INCLUDE, API_BLAS, 0}},
   // cuRAND includes
   {"curand.h",                  {"hiprand.h",                    "", CONV_INCLUDE_CUDA_MAIN_H, API_RAND, 0}},
   {"curand_kernel.h",           {"hiprand_kernel.h",             "", CONV_INCLUDE,             API_RAND, 0}},

--- a/src/CUDA2HIP_BLAS_API_functions.cpp
+++ b/src/CUDA2HIP_BLAS_API_functions.cpp
@@ -78,10 +78,14 @@ const std::map<llvm::StringRef, hipCounter> CUDA_BLAS_FUNCTION_MAP {
   {"cublasGetCudartVersion",         {"hipblasGetCudartVersion",         "",                                         CONV_LIB_FUNC, API_BLAS, 4, UNSUPPORTED}},
 
   // NRM2
-  {"cublasSnrm2",                    {"hipblasSnrm2",                    "rocblas_snrm2",                            CONV_LIB_FUNC, API_BLAS, 5}},
-  {"cublasDnrm2",                    {"hipblasDnrm2",                    "rocblas_dnrm2",                            CONV_LIB_FUNC, API_BLAS, 5}},
-  {"cublasScnrm2",                   {"hipblasScnrm2",                   "rocblas_scnrm2",                           CONV_LIB_FUNC, API_BLAS, 5}},
-  {"cublasDznrm2",                   {"hipblasDznrm2",                   "rocblas_dznrm2",                           CONV_LIB_FUNC, API_BLAS, 5}},
+  // cublasSnrm2 signature differs from cublasSnrm2_v2 signature, hipblasSnrm2 and rocblas_snrm2 have mapping to cublasSnrm2_v2 only
+  {"cublasSnrm2",                    {"hipblasSnrm2_v1",                 "rocblas_snrm2_v1",                         CONV_LIB_FUNC, API_BLAS, 5, UNSUPPORTED}},
+  // cublasDnrm2 signature differs from cublasDnrm2_v2 signature, hipblasDnrm2 and rocblas_dnrm2 have mapping to cublasDnrm2_v2 only
+  {"cublasDnrm2",                    {"hipblasDnrm2_v1",                 "rocblas_dnrm2_v1",                         CONV_LIB_FUNC, API_BLAS, 5, UNSUPPORTED}},
+  // cublasScnrm2 signature differs from cublasScnrm2_v2 signature, hipblasScnrm2 and rocblas_scnrm2 have mapping to cublasScnrm2_v2 only
+  {"cublasScnrm2",                   {"hipblasScnrm2_v1",                "rocblas_scnrm2_v1",                        CONV_LIB_FUNC, API_BLAS, 5, UNSUPPORTED}},
+  // cublasDznrm2 signature differs from cublasDznrm2_v2 signature, hipblasDznrm2 and rocblas_dznrm2 have mapping to cublasDznrm2_v2 only
+  {"cublasDznrm2",                   {"hipblasDznrm2_v1",                "rocblas_dznrm2_v1",                        CONV_LIB_FUNC, API_BLAS, 5, UNSUPPORTED}},
   {"cublasNrm2Ex",                   {"hipblasNrm2Ex",                   "rocblas_nrm2_ex",                          CONV_LIB_FUNC, API_BLAS, 5}},
 
   // DOT

--- a/tests/unit_tests/synthetic/libraries/cublas2hipblas.cu
+++ b/tests/unit_tests/synthetic/libraries/cublas2hipblas.cu
@@ -3,7 +3,10 @@
 // CHECK: #include <hip/hip_runtime.h>
 #include <cuda_runtime.h>
 // CHECK: #include "hipblas.h"
+// CHECK-NOT: #include "cublas_v2.h"
 #include "cublas.h"
+#include "cublas_v2.h"
+// CHECK-NOT: #include "hipblas.h"
 
 int main() {
   printf("14. cuBLAS API to hipBLAS API synthetic test\n");
@@ -143,6 +146,129 @@ int main() {
 
   // CHECK: hipblasHandle_t blasHandle;
   cublasHandle_t blasHandle;
+
+// Functions
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasGetAtomicsMode(cublasHandle_t handle, cublasAtomicsMode_t* mode);
+  // HIP: HIPBLAS_EXPORT hipblasStatus_t hipblasGetAtomicsMode(hipblasHandle_t handle, hipblasAtomicsMode_t* atomics_mode);
+  // CHECK: blasStatus = hipblasGetAtomicsMode(blasHandle, &blasAtomicsMode);
+  blasStatus = cublasGetAtomicsMode(blasHandle, &blasAtomicsMode);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasSetAtomicsMode(cublasHandle_t handle, cublasAtomicsMode_t mode);
+  // HIP: HIPBLAS_EXPORT hipblasStatus_t hipblasSetAtomicsMode(hipblasHandle_t handle, hipblasAtomicsMode_t atomics_mode);
+  // CHECK: blasStatus = hipblasSetAtomicsMode(blasHandle, blasAtomicsMode);
+  blasStatus = cublasSetAtomicsMode(blasHandle, blasAtomicsMode);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasCreate_v2(cublasHandle_t* handle);
+  // CUDA: #define cublasCreate cublasCreate_v2
+  // HIP: HIPBLAS_EXPORT hipblasStatus_t hipblasCreate(hipblasHandle_t* handle);
+  // CHECK: blasStatus = hipblasCreate(&blasHandle);
+  // CHECK-NEXT: blasStatus = hipblasCreate(&blasHandle);
+  blasStatus = cublasCreate(&blasHandle);
+  blasStatus = cublasCreate_v2(&blasHandle);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasDestroy_v2(cublasHandle_t handle);
+  // CUDA: #define cublasDestroy cublasDestroy_v2
+  // HIP: HIPBLAS_EXPORT hipblasStatus_t hipblasDestroy(hipblasHandle_t handle);
+  // CHECK: blasStatus = hipblasDestroy(blasHandle);
+  // CHECK-NEXT: blasStatus = hipblasDestroy(blasHandle);
+  blasStatus = cublasDestroy(blasHandle);
+  blasStatus = cublasDestroy_v2(blasHandle);
+
+  // CHECK: hipStream_t stream;
+  cudaStream_t stream;
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasSetStream_v2(cublasHandle_t handle, cudaStream_t streamId);
+  // CUDA: #define cublasSetStream cublasSetStream_v2
+  // HIP: HIPBLAS_EXPORT hipblasStatus_t hipblasSetStream(hipblasHandle_t handle, hipStream_t streamId);
+  // CHECK: blasStatus = hipblasSetStream(blasHandle, stream);
+  // CHECK-NEXT: blasStatus = hipblasSetStream(blasHandle, stream);
+  blasStatus = cublasSetStream(blasHandle, stream);
+  blasStatus = cublasSetStream_v2(blasHandle, stream);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasGetStream_v2(cublasHandle_t handle, cudaStream_t* streamId);
+  // CUDA: #define cublasGetStream cublasGetStream_v2
+  // HIP: HIPBLAS_EXPORT hipblasStatus_t hipblasGetStream(hipblasHandle_t handle, hipStream_t* streamId);
+  // CHECK: blasStatus = hipblasGetStream(blasHandle, &stream);
+  // CHECK-NEXT: blasStatus = hipblasGetStream(blasHandle, &stream);
+  blasStatus = cublasGetStream(blasHandle, &stream);
+  blasStatus = cublasGetStream_v2(blasHandle, &stream);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasSetPointerMode_v2(cublasHandle_t handle, cublasPointerMode_t mode);
+  // CUDA: #define cublasSetPointerMode cublasSetPointerMode_v2
+  // HIP: HIPBLAS_EXPORT hipblasStatus_t hipblasSetPointerMode(hipblasHandle_t handle, hipblasPointerMode_t mode);
+  // CHECK: blasStatus = hipblasSetPointerMode(blasHandle, blasPointerMode);
+  // CHECK-NEXT: blasStatus = hipblasSetPointerMode(blasHandle, blasPointerMode);
+  blasStatus = cublasSetPointerMode(blasHandle, blasPointerMode);
+  blasStatus = cublasSetPointerMode_v2(blasHandle, blasPointerMode);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasGetPointerMode_v2(cublasHandle_t handle, cublasPointerMode_t* mode);
+  // CUDA: #define cublasGetPointerMode cublasGetPointerMode_v2
+  // HIP: HIPBLAS_EXPORT hipblasStatus_t hipblasGetPointerMode(hipblasHandle_t handle, hipblasPointerMode_t* mode);
+  // CHECK: blasStatus = hipblasGetPointerMode(blasHandle, &blasPointerMode);
+  // CHECK-NEXT: blasStatus = hipblasGetPointerMode(blasHandle, &blasPointerMode);
+  blasStatus = cublasGetPointerMode(blasHandle, &blasPointerMode);
+  blasStatus = cublasGetPointerMode_v2(blasHandle, &blasPointerMode);
+
+  int n = 0;
+  int num = 0;
+  int incx = 0;
+  int incy = 0;
+  void* image = nullptr;
+  void* image_2 = nullptr;
+  void* deviceptr = nullptr;
+
+  // CUDA: cublasStatus_t CUBLASWINAPI cublasSetVector(int n, int elemSize, const void* x, int incx, void* devicePtr, int incy);
+  // HIP: HIPBLAS_EXPORT hipblasStatus_t hipblasSetVector(int n, int elemSize, const void* x, int incx, void* y, int incy);
+  // CHECK: blasStatus = hipblasSetVector(n, num, image, incx, image_2, incy);
+  blasStatus = cublasSetVector(n, num, image, incx, image_2, incy);
+
+  // CUDA: cublasStatus_t CUBLASWINAPI cublasGetVector(int n, int elemSize, const void* x, int incx, void* y, int incy);
+  // HIP: HIPBLAS_EXPORT hipblasStatus_t hipblasGetVector(int n, int elemSize, const void* x, int incx, void* y, int incy);
+  // CHECK: blasStatus = hipblasGetVector(n, num, image, incx, image_2, incy);
+  blasStatus = cublasGetVector(n, num, image, incx, image_2, incy);
+
+  // CUDA: cublasStatus_t CUBLASWINAPI cublasSetVectorAsync(int n, int elemSize, const void* hostPtr, int incx, void* devicePtr, int incy, cudaStream_t stream);
+  // HIP: HIPBLAS_EXPORT hipblasStatus_t hipblasSetVectorAsync(int n, int elemSize, const void* x, int incx, void* y, int incy, hipStream_t stream);
+  // CHECK: blasStatus = hipblasSetVectorAsync(n, num, image, incx, image_2, incy, stream);
+  blasStatus = cublasSetVectorAsync(n, num, image, incx, image_2, incy, stream);
+
+  // CUDA: cublasStatus_t CUBLASWINAPI cublasGetVectorAsync(int n, int elemSize, const void* devicePtr, int incx, void* hostPtr, int incy, cudaStream_t stream);
+  // HIP: HIPBLAS_EXPORT hipblasStatus_t hipblasGetVectorAsync(int n, int elemSize, const void* x, int incx, void* y, int incy, hipStream_t stream);
+  // CHECK: blasStatus = hipblasGetVectorAsync(n, num, image, incx, image_2, incy, stream);
+  blasStatus = cublasGetVectorAsync(n, num, image, incx, image_2, incy, stream);
+
+  int rows = 0;
+  int cols = 0;
+
+  // CUDA: cublasStatus_t CUBLASWINAPI cublasSetMatrix(int rows, int cols, int elemSize, const void* A, int lda, void* B, int ldb);
+  // HIP: HIPBLAS_EXPORT hipblasStatus_t hipblasSetMatrix(int rows, int cols, int elemSize, const void* AP, int lda, void* BP, int ldb);
+  // CHECK: blasStatus = hipblasSetMatrix(rows, cols, num, image, incx, image_2, incy);
+  blasStatus = cublasSetMatrix(rows, cols, num, image, incx, image_2, incy);
+
+  // CUDA: cublasStatus_t CUBLASWINAPI cublasGetMatrix(int rows, int cols, int elemSize, const void* A, int lda, void* B, int ldb);
+  // HIP: HIPBLAS_EXPORT hipblasStatus_t hipblasGetMatrix(int rows, int cols, int elemSize, const void* AP, int lda, void* BP, int ldb);
+  // CHECK: blasStatus = hipblasGetMatrix(rows, cols, num, image, incx, image_2, incy);
+  blasStatus = cublasGetMatrix(rows, cols, num, image, incx, image_2, incy);
+
+  // CUDA: cublasStatus_t CUBLASWINAPI cublasSetMatrixAsync(int rows, int cols, int elemSize, const void* A, int lda, void* B, int ldb, cudaStream_t stream);
+  // HIP: HIPBLAS_EXPORT hipblasStatus_t hipblasSetMatrixAsync(int rows, int cols, int elemSize, const void* AP, int lda, void* BP, int ldb, hipStream_t stream);
+  // CHECK: blasStatus = hipblasSetMatrixAsync(rows, cols, num, image, incx, image_2, incy, stream);
+  blasStatus = cublasSetMatrixAsync(rows, cols, num, image, incx, image_2, incy, stream);
+
+  // CUDA: cublasStatus_t CUBLASWINAPI cublasGetMatrixAsync(int rows, int cols, int elemSize, const void* A, int lda, void* B, int ldb, cudaStream_t stream);
+  // HIP: HIPBLAS_EXPORT hipblasStatus_t hipblasGetMatrixAsync(int rows, int cols, int elemSize, const void* AP, int lda, void* BP, int ldb, hipStream_t stream);
+  // CHECK: blasStatus = hipblasGetMatrixAsync(rows, cols, num, image, incx, image_2, incy, stream);
+  blasStatus = cublasGetMatrixAsync(rows, cols, num, image, incx, image_2, incy, stream);
+
+  cudaDataType DataType_2, DataType_3;
+
+#if CUDA_VERSION >= 8000
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasNrm2Ex(cublasHandle_t handle, int n, const void* x, cudaDataType xType, int incx, void* result, cudaDataType resultType, cudaDataType executionType);
+  // HIP: HIPBLAS_EXPORT hipblasStatus_t hipblasNrm2Ex(hipblasHandle_t handle, int n, const void* x, hipblasDatatype_t xType, int incx, void* result, hipblasDatatype_t resultType, hipblasDatatype_t executionType);
+  // CHECK: blasStatus = hipblasNrm2Ex(blasHandle, n, image, DataType, incx, image_2, DataType_2, DataType_3);
+  blasStatus = cublasNrm2Ex(blasHandle, n, image, DataType, incx, image_2, DataType_2, DataType_3);
+#endif
 
   return 0;
 }


### PR DESCRIPTION
+ cuBLAS API to hipBLAS API functions (the beginning)
+ Took `cublas_api.h` into account
+ Revised `NRM2` functions: only _v2 functions are supported by HIP
+ Regenerated and updated hipify-perl and cuBLAS doc correspondingly