### PR TITLE
[HIPIFY][#607][BLAS][feature] Introduce v1/v2 API support approach

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -967,7 +967,7 @@ push(@exclude_filelist, split(',', $exclude_files));
 %exclude_dirhash = map { $_ => 1 } @exclude_dirlist;
 %exclude_filehash = map { $_ => 1 } @exclude_filelist;
 
-@statNames = ("error", "init", "version", "device", "context", "module", "memory", "virtual_memory", "stream_ordered_memory", "addressing", "stream", "event", "external_resource_interop", "stream_memory", "execution", "graph", "occupancy", "texture", "surface", "peer", "graphics", "interactions", "profiler", "openGL", "D3D9", "D3D10", "D3D11", "VDPAU", "EGL", "thread", "complex", "library", "device_library", "device_function", "include", "include_cuda_main_header", "type", "literal", "numeric_literal", "define", "extern_shared", "kernel_launch");
+@statNames = ("error", "init", "version", "device", "context", "module", "memory", "virtual_memory", "stream_ordered_memory", "addressing", "stream", "event", "external_resource_interop", "stream_memory", "execution", "graph", "occupancy", "texture", "surface", "peer", "graphics", "interactions", "profiler", "openGL", "D3D9", "D3D10", "D3D11", "VDPAU", "EGL", "thread", "complex", "library", "device_library", "device_function", "include", "include_cuda_main_header", "include_cuda_main_header_v2", "type", "literal", "numeric_literal", "define", "extern_shared", "kernel_launch");
 
 sub totalStats {
     my %count = %{shift()};
@@ -1338,6 +1338,7 @@ sub rocSubstitutions {
     subst("cublasDgemv_v2", "rocblas_dgemv", "library");
     subst("cublasDger", "rocblas_dger", "library");
     subst("cublasDger_v2", "rocblas_dger", "library");
+    subst("cublasDnrm2", "rocblas_dnrm2", "library");
     subst("cublasDnrm2_v2", "rocblas_dnrm2", "library");
     subst("cublasDotEx", "rocblas_dot_ex", "library");
     subst("cublasDotcEx", "rocblas_dotc_ex", "library");
@@ -1393,6 +1394,7 @@ sub rocSubstitutions {
     subst("cublasDtrsv_v2", "rocblas_dtrsv", "library");
     subst("cublasDzasum", "rocblas_dzasum", "library");
     subst("cublasDzasum_v2", "rocblas_dzasum", "library");
+    subst("cublasDznrm2", "rocblas_dznrm2", "library");
     subst("cublasDznrm2_v2", "rocblas_dznrm2", "library");
     subst("cublasGemmBatchedEx", "rocblas_gemm_batched_ex", "library");
     subst("cublasGemmEx", "rocblas_gemm_ex", "library");
@@ -1433,6 +1435,7 @@ sub rocSubstitutions {
     subst("cublasScalEx", "rocblas_scal_ex", "library");
     subst("cublasScasum", "rocblas_scasum", "library");
     subst("cublasScasum_v2", "rocblas_scasum", "library");
+    subst("cublasScnrm2", "rocblas_scnrm2", "library");
     subst("cublasScnrm2_v2", "rocblas_scnrm2", "library");
     subst("cublasScopy", "rocblas_scopy", "library");
     subst("cublasScopy_v2", "rocblas_scopy", "library");
@@ -1458,6 +1461,7 @@ sub rocSubstitutions {
     subst("cublasSgemv_v2", "rocblas_sgemv", "library");
     subst("cublasSger", "rocblas_sger", "library");
     subst("cublasSger_v2", "rocblas_sger", "library");
+    subst("cublasSnrm2", "rocblas_snrm2", "library");
     subst("cublasSnrm2_v2", "rocblas_snrm2", "library");
     subst("cublasSrot", "rocblas_srot", "library");
     subst("cublasSrot_v2", "rocblas_srot", "library");
@@ -1595,7 +1599,6 @@ sub rocSubstitutions {
     subst("cublasZtrsv", "rocblas_ztrsv", "library");
     subst("cublasZtrsv_v2", "rocblas_ztrsv", "library");
     subst("cublas.h", "rocblas.h", "include_cuda_main_header");
-    subst("cublas_v2.h", "rocblas.h", "include_cuda_main_header");
     subst("cublasAtomicsMode_t", "rocblas_atomics_mode", "type");
     subst("cublasContext", "_rocblas_handle", "type");
     subst("cublasDataType_t", "rocblas_datatype", "type");
@@ -2251,6 +2254,7 @@ sub simpleSubstitutions {
     subst("cublasDgetrfBatched", "hipblasDgetrfBatched", "library");
     subst("cublasDgetriBatched", "hipblasDgetriBatched", "library");
     subst("cublasDgetrsBatched", "hipblasDgetrsBatched", "library");
+    subst("cublasDnrm2", "hipblasDnrm2", "library");
     subst("cublasDnrm2_v2", "hipblasDnrm2", "library");
     subst("cublasDotEx", "hipblasDotEx", "library");
     subst("cublasDotcEx", "hipblasDotcEx", "library");
@@ -2306,6 +2310,7 @@ sub simpleSubstitutions {
     subst("cublasDtrsv_v2", "hipblasDtrsv", "library");
     subst("cublasDzasum", "hipblasDzasum", "library");
     subst("cublasDzasum_v2", "hipblasDzasum", "library");
+    subst("cublasDznrm2", "hipblasDznrm2", "library");
     subst("cublasDznrm2_v2", "hipblasDznrm2", "library");
     subst("cublasGemmBatchedEx", "hipblasGemmBatchedEx", "library");
     subst("cublasGemmEx", "hipblasGemmEx", "library");
@@ -2347,6 +2352,7 @@ sub simpleSubstitutions {
     subst("cublasScalEx", "hipblasScalEx", "library");
     subst("cublasScasum", "hipblasScasum", "library");
     subst("cublasScasum_v2", "hipblasScasum", "library");
+    subst("cublasScnrm2", "hipblasScnrm2", "library");
     subst("cublasScnrm2_v2", "hipblasScnrm2", "library");
     subst("cublasScopy", "hipblasScopy", "library");
     subst("cublasScopy_v2", "hipblasScopy", "library");
@@ -2377,6 +2383,7 @@ sub simpleSubstitutions {
     subst("cublasSgetrfBatched", "hipblasSgetrfBatched", "library");
     subst("cublasSgetriBatched", "hipblasSgetriBatched", "library");
     subst("cublasSgetrsBatched", "hipblasSgetrsBatched", "library");
+    subst("cublasSnrm2", "hipblasSnrm2", "library");
     subst("cublasSnrm2_v2", "hipblasSnrm2", "library");
     subst("cublasSrot", "hipblasSrot", "library");
     subst("cublasSrot_v2", "hipblasSrot", "library");
@@ -3233,6 +3240,7 @@ sub simpleSubstitutions {
     subst("caffe2\/operators\/spatial_batch_norm_op.h", "caffe2\/operators\/hip\/spatial_batch_norm_op_miopen.hip", "include");
     subst("channel_descriptor.h", "hip\/channel_descriptor.h", "include");
     subst("cooperative_groups.h", "hip\/hip_cooperative_groups.h", "include");
+    subst("cublas_api.h", "hipblas.h", "include");
     subst("cuda_fp16.h", "hip\/hip_fp16.h", "include");
     subst("cuda_profiler_api.h", "hip\/hip_runtime_api.h", "include");
     subst("cuda_runtime_api.h", "hip\/hip_runtime_api.h", "include");
@@ -3261,7 +3269,6 @@ sub simpleSubstitutions {
     subst("cuComplex.h", "hip\/hip_complex.h", "include_cuda_main_header");
     subst("cub\/cub.cuh", "hipcub\/hipcub.hpp", "include_cuda_main_header");
     subst("cublas.h", "hipblas.h", "include_cuda_main_header");
-    subst("cublas_v2.h", "hipblas.h", "include_cuda_main_header");
     subst("cuda.h", "hip\/hip_runtime.h", "include_cuda_main_header");
     subst("cuda_runtime.h", "hip\/hip_runtime.h", "include_cuda_main_header");
     subst("cudnn.h", "hipDNN.h", "include_cuda_main_header");
@@ -7763,7 +7770,6 @@ sub warnHipOnlyUnsupportedFunctions {
         "cublasSwapEx",
         "cublasStrttp",
         "cublasStpttr",
-        "cublasSnrm2",
         "cublasSmatinvBatched",
         "cublasShutdown",
         "cublasSgemmEx",
@@ -7772,7 +7778,6 @@ sub warnHipOnlyUnsupportedFunctions {
         "cublasSetMathMode",
         "cublasSetLoggerCallback",
         "cublasSetKernelStream",
-        "cublasScnrm2",
         "cublasRotmgEx",
         "cublasRotmEx",
         "cublasRotgEx",
@@ -7794,10 +7799,8 @@ sub warnHipOnlyUnsupportedFunctions {
         "cublasGetError",
         "cublasGetCudartVersion",
         "cublasFree",
-        "cublasDznrm2",
         "cublasDtrttp",
         "cublasDtpttr",
-        "cublasDnrm2",
         "cublasDmatinvBatched",
         "cublasDgelsBatched",
         "cublasCtrttp",
@@ -7911,7 +7914,6 @@ sub warnRocOnlyUnsupportedFunctions {
         "cublasSwapEx",
         "cublasStrttp",
         "cublasStpttr",
-        "cublasSnrm2",
         "cublasSmatinvBatched",
         "cublasShutdown",
         "cublasSgetrsBatched",
@@ -7925,7 +7927,6 @@ sub warnRocOnlyUnsupportedFunctions {
         "cublasSetLoggerCallback",
         "cublasSetKernelStream",
         "cublasSetAtomicsMode",
-        "cublasScnrm2",
         "cublasRotmgEx",
         "cublasRotmEx",
         "cublasRotgEx",
@@ -7948,10 +7949,8 @@ sub warnRocOnlyUnsupportedFunctions {
         "cublasGetCudartVersion",
         "cublasGetAtomicsMode",
         "cublasFree",
-        "cublasDznrm2",
         "cublasDtrttp",
         "cublasDtpttr",
-        "cublasDnrm2",
         "cublasDmatinvBatched",
         "cublasDgetrsBatched",
         "cublasDgetriBatched",
@@ -8195,7 +8194,7 @@ while (@ARGV) {
             transformHostFunctions();
             # TODO: would like to move this code outside loop but it uses $_ which contains the whole file
             unless ($no_output) {
-                my $apiCalls   = $ft{'error'} + $ft{'init'} + $ft{'version'} + $ft{'device'} + $ft{'context'} + $ft{'module'} + $ft{'memory'} + $ft{'virtual_memory'} + $ft{'stream_ordered_memory'} + $ft{'addressing'} + $ft{'stream'} + $ft{'event'} + $ft{'external_resource_interop'} + $ft{'stream_memory'} + $ft{'execution'} + $ft{'graph'} + $ft{'occupancy'} + $ft{'texture'} + $ft{'surface'} + $ft{'peer'} + $ft{'graphics'} + $ft{'interactions'} + $ft{'profiler'} + $ft{'openGL'} + $ft{'D3D9'} + $ft{'D3D10'} + $ft{'D3D11'} + $ft{'VDPAU'} + $ft{'EGL'} + $ft{'thread'} + $ft{'complex'} + $ft{'library'} + $ft{'device_library'} + $ft{'include'} + $ft{'include_cuda_main_header'} + $ft{'type'} + $ft{'literal'} + $ft{'numeric_literal'} + $ft{'define'};
+                my $apiCalls   = $ft{'error'} + $ft{'init'} + $ft{'version'} + $ft{'device'} + $ft{'context'} + $ft{'module'} + $ft{'memory'} + $ft{'virtual_memory'} + $ft{'stream_ordered_memory'} + $ft{'addressing'} + $ft{'stream'} + $ft{'event'} + $ft{'external_resource_interop'} + $ft{'stream_memory'} + $ft{'execution'} + $ft{'graph'} + $ft{'occupancy'} + $ft{'texture'} + $ft{'surface'} + $ft{'peer'} + $ft{'graphics'} + $ft{'interactions'} + $ft{'profiler'} + $ft{'openGL'} + $ft{'D3D9'} + $ft{'D3D10'} + $ft{'D3D11'} + $ft{'VDPAU'} + $ft{'EGL'} + $ft{'thread'} + $ft{'complex'} + $ft{'library'} + $ft{'device_library'} + $ft{'include'} + $ft{'include_cuda_main_header'} + $ft{'include_cuda_main_header_v2'} + $ft{'type'} + $ft{'literal'} + $ft{'numeric_literal'} + $ft{'define'};
                 my $kernStuff  = $hasDeviceCode + $ft{'kernel_launch'} + $ft{'device_function'};
                 my $totalCalls = $apiCalls + $kernStuff;
                 $is_dos = m/\r\n$/;

--- a/doc/markdown/CUBLAS_API_supported_by_HIP.md
+++ b/doc/markdown/CUBLAS_API_supported_by_HIP.md
@@ -226,7 +226,7 @@
 |`cublasDcopy_v2`| | | |`hipblasDcopy`|1.8.2| | | |
 |`cublasDdot`| | | |`hipblasDdot`|3.0.0| | | |
 |`cublasDdot_v2`| | | |`hipblasDdot`|3.0.0| | | |
-|`cublasDnrm2`| | | | | | | | |
+|`cublasDnrm2`| | | |`hipblasDnrm2`|1.8.2| | | |
 |`cublasDnrm2_v2`| | | |`hipblasDnrm2`|1.8.2| | | |
 |`cublasDrot`| | | |`hipblasDrot`|3.0.0| | | |
 |`cublasDrot_v2`| | | |`hipblasDrot`|3.0.0| | | |
@@ -242,7 +242,7 @@
 |`cublasDswap_v2`| | | |`hipblasDswap`|3.0.0| | | |
 |`cublasDzasum`| | | |`hipblasDzasum`|3.0.0| | | |
 |`cublasDzasum_v2`| | | |`hipblasDzasum`|3.0.0| | | |
-|`cublasDznrm2`| | | | | | | | |
+|`cublasDznrm2`| | | |`hipblasDznrm2`|3.0.0| | | |
 |`cublasDznrm2_v2`| | | |`hipblasDznrm2`|3.0.0| | | |
 |`cublasIcamax`| | | |`hipblasIcamax`|3.0.0| | | |
 |`cublasIcamax_v2`| | | |`hipblasIcamax`|3.0.0| | | |
@@ -267,13 +267,13 @@
 |`cublasSaxpy_v2`| | | |`hipblasSaxpy`|1.8.2| | | |
 |`cublasScasum`| | | |`hipblasScasum`|3.0.0| | | |
 |`cublasScasum_v2`| | | |`hipblasScasum`|3.0.0| | | |
-|`cublasScnrm2`| | | | | | | | |
+|`cublasScnrm2`| | | |`hipblasScnrm2`|3.0.0| | | |
 |`cublasScnrm2_v2`| | | |`hipblasScnrm2`|3.0.0| | | |
 |`cublasScopy`| | | |`hipblasScopy`|1.8.2| | | |
 |`cublasScopy_v2`| | | |`hipblasScopy`|1.8.2| | | |
 |`cublasSdot`| | | |`hipblasSdot`|3.0.0| | | |
 |`cublasSdot_v2`| | | |`hipblasSdot`|3.0.0| | | |
-|`cublasSnrm2`| | | | | | | | |
+|`cublasSnrm2`| | | |`hipblasSnrm2`|1.8.2| | | |
 |`cublasSnrm2_v2`| | | |`hipblasSnrm2`|1.8.2| | | |
 |`cublasSrot`| | | |`hipblasSrot`|3.0.0| | | |
 |`cublasSrot_v2`| | | |`hipblasSrot`|3.0.0| | | |

--- a/src/CUDA2HIP.cpp
+++ b/src/CUDA2HIP.cpp
@@ -41,7 +41,7 @@ const std::map <llvm::StringRef, hipCounter> CUDA_INCLUDE_MAP {
   {"cuComplex.h",               {"hip/hip_complex.h",            "", CONV_INCLUDE_CUDA_MAIN_H, API_COMPLEX, 0}},
   // cuBLAS includes
   {"cublas.h",                  {"hipblas.h",                    "rocblas.h", CONV_INCLUDE_CUDA_MAIN_H, API_BLAS, 0}},
-  {"cublas_v2.h",               {"hipblas.h",                    "rocblas.h", CONV_INCLUDE_CUDA_MAIN_H, API_BLAS, 0}},
+  {"cublas_v2.h",               {"hipblas.h",                    "rocblas.h", CONV_INCLUDE_CUDA_MAIN_V2_H, API_BLAS, 0}},
   {"cublas_api.h",              {"hipblas.h",                    "rocblas.h", CONV_INCLUDE, API_BLAS, 0}},
   // cuRAND includes
   {"curand.h",                  {"hiprand.h",                    "", CONV_INCLUDE_CUDA_MAIN_H, API_RAND, 0}},

--- a/src/CUDA2HIP_BLAS_API_functions.cpp
+++ b/src/CUDA2HIP_BLAS_API_functions.cpp
@@ -78,31 +78,30 @@ const std::map<llvm::StringRef, hipCounter> CUDA_BLAS_FUNCTION_MAP {
   {"cublasGetCudartVersion",         {"hipblasGetCudartVersion",         "",                                         CONV_LIB_FUNC, API_BLAS, 4, UNSUPPORTED}},
 
   // NRM2
-  // cublasSnrm2 signature differs from cublasSnrm2_v2 signature, hipblasSnrm2 and rocblas_snrm2 have mapping to cublasSnrm2_v2 only
-  {"cublasSnrm2",                    {"hipblasSnrm2_v1",                 "rocblas_snrm2_v1",                         CONV_LIB_FUNC, API_BLAS, 5, UNSUPPORTED}},
-  // cublasDnrm2 signature differs from cublasDnrm2_v2 signature, hipblasDnrm2 and rocblas_dnrm2 have mapping to cublasDnrm2_v2 only
-  {"cublasDnrm2",                    {"hipblasDnrm2_v1",                 "rocblas_dnrm2_v1",                         CONV_LIB_FUNC, API_BLAS, 5, UNSUPPORTED}},
-  // cublasScnrm2 signature differs from cublasScnrm2_v2 signature, hipblasScnrm2 and rocblas_scnrm2 have mapping to cublasScnrm2_v2 only
-  {"cublasScnrm2",                   {"hipblasScnrm2_v1",                "rocblas_scnrm2_v1",                        CONV_LIB_FUNC, API_BLAS, 5, UNSUPPORTED}},
-  // cublasDznrm2 signature differs from cublasDznrm2_v2 signature, hipblasDznrm2 and rocblas_dznrm2 have mapping to cublasDznrm2_v2 only
-  {"cublasDznrm2",                   {"hipblasDznrm2_v1",                "rocblas_dznrm2_v1",                        CONV_LIB_FUNC, API_BLAS, 5, UNSUPPORTED}},
+  // NRM2 functions' signatures differ from _v2 ones, hipblas and rocblas NRM2 functions have mapping to NRM2_v2 functions only
+  {"cublasSnrm2",                    {"hipblasSnrm2",                    "rocblas_snrm2",                            CONV_LIB_FUNC, API_BLAS, 5, HIP_SUPPORTED_V2_ONLY}},
+  {"cublasDnrm2",                    {"hipblasDnrm2",                    "rocblas_dnrm2",                            CONV_LIB_FUNC, API_BLAS, 5, HIP_SUPPORTED_V2_ONLY}},
+  {"cublasScnrm2",                   {"hipblasScnrm2",                   "rocblas_scnrm2",                           CONV_LIB_FUNC, API_BLAS, 5, HIP_SUPPORTED_V2_ONLY}},
+  {"cublasDznrm2",                   {"hipblasDznrm2",                   "rocblas_dznrm2",                           CONV_LIB_FUNC, API_BLAS, 5, HIP_SUPPORTED_V2_ONLY}},
   {"cublasNrm2Ex",                   {"hipblasNrm2Ex",                   "rocblas_nrm2_ex",                          CONV_LIB_FUNC, API_BLAS, 5}},
 
   // DOT
-  {"cublasSdot",                     {"hipblasSdot",                     "rocblas_sdot",                             CONV_LIB_FUNC, API_BLAS, 5}},
-  {"cublasDdot",                     {"hipblasDdot",                     "rocblas_ddot",                             CONV_LIB_FUNC, API_BLAS, 5}},
-  {"cublasCdotu",                    {"hipblasCdotu",                    "rocblas_cdotu",                            CONV_LIB_FUNC, API_BLAS, 5}},
-  {"cublasCdotc",                    {"hipblasCdotc",                    "rocblas_cdotc",                            CONV_LIB_FUNC, API_BLAS, 5}},
-  {"cublasZdotu",                    {"hipblasZdotu",                    "rocblas_zdotu",                            CONV_LIB_FUNC, API_BLAS, 5}},
-  {"cublasZdotc",                    {"hipblasZdotc",                    "rocblas_zdotc",                            CONV_LIB_FUNC, API_BLAS, 5}},
+  // DOT functions' signatures differ from _v2 ones, hipblas and rocblas DOT functions have mapping to DOT_v2 functions only
+  {"cublasSdot",                     {"hipblasSdot",                     "rocblas_sdot",                             CONV_LIB_FUNC, API_BLAS, 5, HIP_SUPPORTED_V2_ONLY}},
+  {"cublasDdot",                     {"hipblasDdot",                     "rocblas_ddot",                             CONV_LIB_FUNC, API_BLAS, 5, HIP_SUPPORTED_V2_ONLY}},
+  {"cublasCdotu",                    {"hipblasCdotu",                    "rocblas_cdotu",                            CONV_LIB_FUNC, API_BLAS, 5, HIP_SUPPORTED_V2_ONLY}},
+  {"cublasCdotc",                    {"hipblasCdotc",                    "rocblas_cdotc",                            CONV_LIB_FUNC, API_BLAS, 5, HIP_SUPPORTED_V2_ONLY}},
+  {"cublasZdotu",                    {"hipblasZdotu",                    "rocblas_zdotu",                            CONV_LIB_FUNC, API_BLAS, 5, HIP_SUPPORTED_V2_ONLY}},
+  {"cublasZdotc",                    {"hipblasZdotc",                    "rocblas_zdotc",                            CONV_LIB_FUNC, API_BLAS, 5, HIP_SUPPORTED_V2_ONLY}},
 
   // SCAL
-  {"cublasSscal",                    {"hipblasSscal",                    "rocblas_sscal",                            CONV_LIB_FUNC, API_BLAS, 5}},
-  {"cublasDscal",                    {"hipblasDscal",                    "rocblas_dscal",                            CONV_LIB_FUNC, API_BLAS, 5}},
-  {"cublasCscal",                    {"hipblasCscal",                    "rocblas_cscal",                            CONV_LIB_FUNC, API_BLAS, 5}},
-  {"cublasCsscal",                   {"hipblasCsscal",                   "rocblas_csscal",                           CONV_LIB_FUNC, API_BLAS, 5}},
-  {"cublasZscal",                    {"hipblasZscal",                    "rocblas_zscal",                            CONV_LIB_FUNC, API_BLAS, 5}},
-  {"cublasZdscal",                   {"hipblasZdscal",                   "rocblas_zdscal",                           CONV_LIB_FUNC, API_BLAS, 5}},
+  // SCAL functions' signatures differ from _v2 ones, hipblas and rocblas SCAL functions have mapping to SCAL_v2 functions only
+  {"cublasSscal",                    {"hipblasSscal",                    "rocblas_sscal",                            CONV_LIB_FUNC, API_BLAS, 5, HIP_SUPPORTED_V2_ONLY}},
+  {"cublasDscal",                    {"hipblasDscal",                    "rocblas_dscal",                            CONV_LIB_FUNC, API_BLAS, 5, HIP_SUPPORTED_V2_ONLY}},
+  {"cublasCscal",                    {"hipblasCscal",                    "rocblas_cscal",                            CONV_LIB_FUNC, API_BLAS, 5, HIP_SUPPORTED_V2_ONLY}},
+  {"cublasCsscal",                   {"hipblasCsscal",                   "rocblas_csscal",                           CONV_LIB_FUNC, API_BLAS, 5, HIP_SUPPORTED_V2_ONLY}},
+  {"cublasZscal",                    {"hipblasZscal",                    "rocblas_zscal",                            CONV_LIB_FUNC, API_BLAS, 5, HIP_SUPPORTED_V2_ONLY}},
+  {"cublasZdscal",                   {"hipblasZdscal",                   "rocblas_zdscal",                           CONV_LIB_FUNC, API_BLAS, 5, HIP_SUPPORTED_V2_ONLY}},
 
   // AXPY
   {"cublasSaxpy",                    {"hipblasSaxpy",                    "rocblas_saxpy",                            CONV_LIB_FUNC, API_BLAS, 5}},

--- a/src/HipifyAction.h
+++ b/src/HipifyAction.h
@@ -49,6 +49,7 @@ private:
   // This approach means we do the best it's possible to do w.r.t preserving the user's include order.
   bool insertedRuntimeHeader = false;
   bool insertedBLASHeader = false;
+  bool insertedBLASHeader_V2 = false;
   bool insertedRANDHeader = false;
   bool insertedRAND_kernelHeader = false;
   bool insertedDNNHeader = false;

--- a/src/Statistics.cpp
+++ b/src/Statistics.cpp
@@ -64,6 +64,7 @@ const char *counterNames[NUM_CONV_TYPES] = {
   "device_function", // CONV_DEVICE_FUNC
   "include", // CONV_INCLUDE
   "include_cuda_main_header", // CONV_INCLUDE_CUDA_MAIN_H
+  "include_cuda_main_header_v2", // CONV_INCLUDE_CUDA_MAIN_V2_H
   "type", // CONV_TYPE
   "literal", // CONV_LITERAL
   "numeric_literal", // CONV_NUMERIC_LITERAL
@@ -108,6 +109,7 @@ const char *counterTypes[NUM_CONV_TYPES] = {
   "CONV_LIB_DEVICE_FUNC",
   "CONV_INCLUDE",
   "CONV_INCLUDE_CUDA_MAIN_H",
+  "CONV_INCLUDE_CUDA_MAIN_V2_H",
   "CONV_TYPE",
   "CONV_LITERAL",
   "CONV_NUMERIC_LITERAL",
@@ -397,6 +399,10 @@ bool Statistics::isRemoved(const hipCounter &counter) {
   return REMOVED == (counter.supportDegree & REMOVED) || (
          CUDA_REMOVED == (counter.supportDegree & CUDA_REMOVED) &&
          HIP_REMOVED == (counter.supportDegree & HIP_REMOVED));
+}
+
+bool Statistics::isHipSupportedV2Only(const hipCounter& counter) {
+  return HIP_SUPPORTED_V2_ONLY == (counter.supportDegree & HIP_SUPPORTED_V2_ONLY);
 }
 
 std::string Statistics::getCudaVersion(const cudaVersions& ver) {

--- a/src/Statistics.h
+++ b/src/Statistics.h
@@ -121,6 +121,7 @@ enum ConvTypes {
   CONV_DEVICE_FUNC,
   CONV_INCLUDE,
   CONV_INCLUDE_CUDA_MAIN_H,
+  CONV_INCLUDE_CUDA_MAIN_V2_H,
   CONV_TYPE,
   CONV_LITERAL,
   CONV_NUMERIC_LITERAL,
@@ -158,7 +159,8 @@ enum SupportDegree {
   CUDA_REMOVED = 0x40,
   HIP_REMOVED = 0x80,
   REMOVED = 0x100,
-  HIP_EXPERIMENTAL = 0x200
+  HIP_EXPERIMENTAL = 0x200,
+  HIP_SUPPORTED_V2_ONLY = 0x400
 };
 
 enum cudaVersions {
@@ -411,6 +413,8 @@ public:
   static bool isHipRemoved(const hipCounter& counter);
   // Check whether the counter is REMOVED or not.
   static bool isRemoved(const hipCounter& counter);
+  // Check whether the counter is HIP_SUPPORTED_V2_ONLY or not.
+  static bool isHipSupportedV2Only(const hipCounter& counter);
   // Get string CUDA version.
   static std::string getCudaVersion(const cudaVersions &ver);
   // Get string HIP version.

--- a/tests/unit_tests/libraries/cuBLAS/cublas_v1.cu
+++ b/tests/unit_tests/libraries/cuBLAS/cublas_v1.cu
@@ -5,25 +5,18 @@
 #include <stdlib.h>
 #include <math.h>
 // CHECK: #include "hipblas.h"
-// CHECK-NOT: #include "cublas_v2.h"
 #include "cublas.h"
-#include "cublas_v2.h"
-// CHECK-NOT: #include "hipblas.h"
 #define M 6
 #define N 5
 #define IDX2C(i,j,ld) (((j)*(ld))+(i))
-static __inline__ void modify(float *m, int ldm, int n, int p, int q, float
+static __inline__ void modify(float* m, int ldm, int n, int p, int q, float
   alpha, float beta) {
-  // CHECK: hipblasHandle_t blasHandle;
-  cublasHandle_t blasHandle;
-  // CHECK: hipblasStatus_t blasStatus = hipblasCreate(&blasHandle);
-  cublasStatus blasStatus = cublasCreate(&blasHandle);
-  // CHECK: hipblasSscal(blasHandle, n - p, &alpha, &m[IDX2C(p, q, ldm)], ldm);
-  cublasSscal(blasHandle, n - p, &alpha, &m[IDX2C(p, q, ldm)], ldm);
-  // CHECK: hipblasSscal(blasHandle, ldm - p, &beta, &m[IDX2C(p, q, ldm)], 1);
-  cublasSscal(blasHandle, ldm - p, &beta, &m[IDX2C(p, q, ldm)], 1);
-  // CHECK: hipblasDestroy(blasHandle);
-  cublasDestroy(blasHandle);
+  // CHECK-NOT: hipblasSscal(n - p, alpha, &m[IDX2C(p, q, ldm)], ldm);
+  // CHECK-NOT: hipblasSscal(ldm - p, beta, &m[IDX2C(p, q, ldm)], 1);
+  // CHECK: cublasSscal(n - p, alpha, &m[IDX2C(p, q, ldm)], ldm);
+  // CHECK: cublasSscal(ldm - p, beta, &m[IDX2C(p, q, ldm)], 1);
+  cublasSscal(n - p, alpha, &m[IDX2C(p, q, ldm)], ldm);
+  cublasSscal(ldm - p, beta, &m[IDX2C(p, q, ldm)], 1);
 }
 int main(void) {
   int i, j;
@@ -31,7 +24,7 @@ int main(void) {
   cublasStatus stat;
   float* devPtrA;
   float* a = 0;
-  a = (float *)malloc(M * N * sizeof(*a));
+  a = (float*)malloc(M * N * sizeof(*a));
   if (!a) {
     printf("host memory allocation failed");
     return EXIT_FAILURE;
@@ -44,7 +37,7 @@ int main(void) {
   // cublasInit is not supported yet
   cublasInit();
   // cublasAlloc is not supported yet
-  stat = cublasAlloc(M*N, sizeof(*a), (void**)&devPtrA);
+  stat = cublasAlloc(M * N, sizeof(*a), (void**)&devPtrA);
   // CHECK: if (stat != HIPBLAS_STATUS_SUCCESS) {
   if (stat != CUBLAS_STATUS_SUCCESS) {
     printf("device memory allocation failed");

--- a/tests/unit_tests/libraries/cuBLAS/rocBLAS/cublas_0_based_indexing_rocblas.cu
+++ b/tests/unit_tests/libraries/cuBLAS/rocBLAS/cublas_0_based_indexing_rocblas.cu
@@ -5,16 +5,25 @@
 #include <stdlib.h>
 #include <math.h>
 // CHECK: #include "rocblas.h"
+// CHECK-NOT: #include "cublas_v2.h"
 #include "cublas.h"
+#include "cublas_v2.h"
+// CHECK-NOT: #include "rocblas.h"
 #define M 6
 #define N 5
 #define IDX2C(i,j,ld) (((j)*(ld))+(i))
 static __inline__ void modify(float *m, int ldm, int n, int p, int q, float
   alpha, float beta) {
-  // CHECK: rocblas_sscal(n - p, alpha, &m[IDX2C(p, q, ldm)], ldm);
-  // CHECK: rocblas_sscal(ldm - p, beta, &m[IDX2C(p, q, ldm)], 1);
-  cublasSscal(n - p, alpha, &m[IDX2C(p, q, ldm)], ldm);
-  cublasSscal(ldm - p, beta, &m[IDX2C(p, q, ldm)], 1);
+  // CHECK: rocblas_handle blasHandle;
+  cublasHandle_t blasHandle;
+  // CHECK: rocblas_status blasStatus = rocblas_create_handle(&blasHandle);
+  cublasStatus blasStatus = cublasCreate(&blasHandle);
+  // CHECK: rocblas_sscal(blasHandle, n - p, &alpha, &m[IDX2C(p, q, ldm)], ldm);
+  // CHECK: rocblas_sscal(blasHandle, ldm - p, &beta, &m[IDX2C(p, q, ldm)], 1);
+  cublasSscal(blasHandle, n - p, &alpha, &m[IDX2C(p, q, ldm)], ldm);
+  cublasSscal(blasHandle, ldm - p, &beta, &m[IDX2C(p, q, ldm)], 1);
+  // CHECK: rocblas_destroy_handle(blasHandle);
+  cublasDestroy(blasHandle);
 }
 int main(void) {
   int i, j;


### PR DESCRIPTION
**[IMP]**
+ Introduce the `HIP_SUPPORTED_V2_ONLY` flag for API which is supported only if the `_v2` version of CUDA API is proposed; if the corresponding CUDA header is included, where `_v1` (as a rule without `_v1` suffix) to `v2` defines are redefined
+ Populate a few cuBLAS to hipBLAS mapping items with `HIP_SUPPORTED_V2_ONLY` to test the feature
+ Provide a corresponding function `isHipSupportedV2Only` for checking an API for the `HIP_SUPPORTED_V2_ONLY` flag
+ Introduce the `CONV_INCLUDE_CUDA_MAIN_V2_H` marker for `_v2` header files like `cublas_v2.h`
+ Track `_v2` headers includes
+ Warn about the identifier, supported only for the `_v2` version of it; warn only in case of absence of the corresponding `_v2` header file; warn and do not hipify if the `_v2` header is not included; hipify otherwise.
+ Update the existing cuBLAS/rocBLAS tests
+ Add new cuBLAS/rocBLAS tests for `_v1` cases only
+ Update regenerated hipify-perl and CUBLAS_API_supported_by_HIP.md

**[TODO]**
+ Update the rest of  the `HIP_SUPPORTED_V2_ONLY` APIs
+ Add the corresponding synthetic tests
+ Provide the same or similar functionality in hipify-perl