### PR TITLE
[HIPIFY][BLAS][tests] Satisfy CUDA 11.7.1 restriction

### DIFF
--- a/tests/unit_tests/headers/headers_test_07.cu
+++ b/tests/unit_tests/headers/headers_test_07.cu
@@ -1,8 +1,11 @@
 // RUN: %run_test hipify "%s" "%t" %hipify_args %clang_args
 
+// CHECK: #include <hip/hip_runtime.h>
 // CHECK: #include "hipblas.h"
 // CHECK-NOT: #include "cublas.h"
+// CHECK-NOT: #include "cublas_v2.h"
 // CHECK: #include <stdio.h>
-#include "cublas_v2.h"
 #include "cublas.h"
+#include "cublas_v2.h"
+// CHECK-NOT: #include "hipblas.h"
 #include <stdio.h>

--- a/tests/unit_tests/headers/headers_test_08.cu
+++ b/tests/unit_tests/headers/headers_test_08.cu
@@ -1,14 +1,18 @@
 // RUN: %run_test hipify "%s" "%t" %hipify_args %clang_args
 
 // CHECK: #include <hip/hip_runtime.h>
-// CHECK-NOT: #include <cuda_runtime.h>
 // CHECK: #include <iostream>
 // CHECK: #include "hipblas.h"
 // CHECK-NOT: #include "cublas.h"
+// CHECK-NOT: #include "cublas_v2.h"
 // CHECK: #include <stdio.h>
+// CHECK-NOT: #include <cuda.h>
 #include <cuda.h>
+// CHECK-NOT: #include <cuda_runtime.h>
 #include <cuda_runtime.h>
+// CHECK-NOT: #include <hip/hip_runtime.h>
 #include <iostream>
-#include "cublas_v2.h"
 #include "cublas.h"
+#include "cublas_v2.h"
+// CHECK-NOT: #include "hipblas.h"
 #include <stdio.h>

--- a/tests/unit_tests/headers/headers_test_09.cu
+++ b/tests/unit_tests/headers/headers_test_09.cu
@@ -19,6 +19,7 @@
 
 // CHECK: #include "hipblas.h"
 // CHECK-NOT: #include "cublas.h"
+// CHECK-NOT: #include "cublas_v2.h"
 
 // CHECK: #include <stdio.h>
 
@@ -51,10 +52,12 @@
 // CHECK: #include "hipsparse.h"
 
 #include <cuda.h>
+// CHECK-NOT: #include <hip/hip_runtime.h>
 
 #include <memory>
 
 #include <cuda_runtime.h>
+// CHECK-NOT: #include <hip/hip_runtime.h>
 
 #include "cuda_runtime_api.h"
 #include "channel_descriptor.h"
@@ -67,8 +70,9 @@
 
 #include <iostream>
 
-#include "cublas_v2.h"
 #include "cublas.h"
+#include "cublas_v2.h"
+// CHECK-NOT: #include "hipblas.h"
 
 #include <stdio.h>
 


### PR DESCRIPTION
[Restriction]
+ If both `cublas.h` and `cublas_v2.h` are included the following error occurs:
  `cublas.h(61,2): error: "It is an error to include both cublas.h and cublas_v2.h"`

[Solution]
+ Swap `cublas_v2.h` and `cublas.h` includes if `cublas_v2.h` goes first
+ Actually, CUDA error message is misleading: erroneous to include `cublas_v2.h` before `cublas.h` only;
+ On the other hand, including them both is correct and only possible, when v1 and v2 APIs are needed to be used, cause
  not every API from `cublas.h` has a corresponding v2 analogue in `cublas_v2.h`