### PR TITLE
[HIPIFY][HIP][RTC][5.3.0] Sync - Part 2 - functions

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -715,6 +715,8 @@ my %removed_funcs = (
 );
 
 my %experimental_funcs = (
+    "nvrtcGetCUBINSize" => "5.3.0",
+    "nvrtcGetCUBIN" => "5.3.0",
     "cudaUserObject_t" => "5.3.0",
     "cudaUserObjectRetainFlags" => "5.3.0",
     "cudaUserObjectRetain" => "5.3.0",
@@ -742,6 +744,14 @@ my %experimental_funcs = (
     "cuUserObjectRetain" => "5.3.0",
     "cuUserObjectRelease" => "5.3.0",
     "cuUserObjectCreate" => "5.3.0",
+    "cuLinkDestroy" => "5.3.0",
+    "cuLinkCreate_v2" => "5.3.0",
+    "cuLinkCreate" => "5.3.0",
+    "cuLinkComplete" => "5.3.0",
+    "cuLinkAddFile_v2" => "5.3.0",
+    "cuLinkAddFile" => "5.3.0",
+    "cuLinkAddData_v2" => "5.3.0",
+    "cuLinkAddData" => "5.3.0",
     "cuGraphUpload" => "5.3.0",
     "cuGraphRetainUserObject" => "5.3.0",
     "cuGraphReleaseUserObject" => "5.3.0",
@@ -919,6 +929,14 @@ sub experimentalSubstitutions {
     subst("cuGetErrorString", "hipDrvGetErrorString", "error");
     subst("cudaDeviceSetLimit", "hipDeviceSetLimit", "device");
     subst("cuCtxSetLimit", "hipDeviceSetLimit", "context");
+    subst("cuLinkAddData", "hiprtcLinkAddData", "module");
+    subst("cuLinkAddData_v2", "hiprtcLinkAddData", "module");
+    subst("cuLinkAddFile", "hiprtcLinkAddFile", "module");
+    subst("cuLinkAddFile_v2", "hiprtcLinkAddFile", "module");
+    subst("cuLinkComplete", "hiprtcLinkComplete", "module");
+    subst("cuLinkCreate", "hiprtcLinkCreate", "module");
+    subst("cuLinkCreate_v2", "hiprtcLinkCreate", "module");
+    subst("cuLinkDestroy", "hiprtcLinkDestroy", "module");
     subst("cuDeviceGetGraphMemAttribute", "hipDeviceGetGraphMemAttribute", "graph");
     subst("cuDeviceGraphMemTrim", "hipDeviceGraphMemTrim", "graph");
     subst("cuDeviceSetGraphMemAttribute", "hipDeviceSetGraphMemAttribute", "graph");
@@ -937,6 +955,8 @@ sub experimentalSubstitutions {
     subst("cudaUserObjectCreate", "hipUserObjectCreate", "graph");
     subst("cudaUserObjectRelease", "hipUserObjectRelease", "graph");
     subst("cudaUserObjectRetain", "hipUserObjectRetain", "graph");
+    subst("nvrtcGetCUBIN", "hiprtcGetBitcode", "library");
+    subst("nvrtcGetCUBINSize", "hiprtcGetBitcodeSize", "library");
     subst("CUgraphMem_attribute", "hipGraphMemAttributeType", "type");
     subst("CUgraphMem_attribute_enum", "hipGraphMemAttributeType", "type");
     subst("CUjitInputType", "hiprtcJITInputType", "type");
@@ -3220,6 +3240,8 @@ sub simpleSubstitutions {
     subst("CUkernelNodeAttrValue_v1", "hipKernelNodeAttrValue", "type");
     subst("CUlimit", "hipLimit_t", "type");
     subst("CUlimit_enum", "hipLimit_t", "type");
+    subst("CUlinkState", "hiprtcLinkState", "type");
+    subst("CUlinkState_st", "ihiprtcLinkState", "type");
     subst("CUmemAccessDesc", "hipMemAccessDesc", "type");
     subst("CUmemAccessDesc_st", "hipMemAccessDesc", "type");
     subst("CUmemAccessDesc_v1", "hipMemAccessDesc", "type");
@@ -5503,8 +5525,6 @@ sub warnUnsupportedFunctions {
         "nvrtcGetNumSupportedArchs",
         "nvrtcGetNVVMSize",
         "nvrtcGetNVVM",
-        "nvrtcGetCUBINSize",
-        "nvrtcGetCUBIN",
         "memoryBarrier",
         "libraryPropertyType_t",
         "libraryPropertyType",
@@ -6450,14 +6470,6 @@ sub warnUnsupportedFunctions {
         "cuMemcpy3DPeer",
         "cuMemcpy",
         "cuMemGetHandleForAddressRange",
-        "cuLinkDestroy",
-        "cuLinkCreate_v2",
-        "cuLinkCreate",
-        "cuLinkComplete",
-        "cuLinkAddFile_v2",
-        "cuLinkAddFile",
-        "cuLinkAddData_v2",
-        "cuLinkAddData",
         "cuLaunchGridAsync",
         "cuLaunchGrid",
         "cuLaunchCooperativeKernelMultiDevice",

--- a/doc/markdown/CUDA_Driver_API_functions_supported_by_HIP.md
+++ b/doc/markdown/CUDA_Driver_API_functions_supported_by_HIP.md
@@ -1006,6 +1006,8 @@
 |`CUkernelNodeAttrValue_v1`|11.3| | |`hipKernelNodeAttrValue`|5.2.0| | | |
 |`CUlimit`| | | |`hipLimit_t`|1.6.0| | | |
 |`CUlimit_enum`| | | |`hipLimit_t`|1.6.0| | | |
+|`CUlinkState`| | | |`hiprtcLinkState`|5.3.0| | |5.3.0|
+|`CUlinkState_st`| | | |`ihiprtcLinkState`|5.3.0| | |5.3.0|
 |`CUmemAccessDesc`|10.2| | |`hipMemAccessDesc`|5.2.0| | | |
 |`CUmemAccessDesc_st`|10.2| | |`hipMemAccessDesc`|5.2.0| | | |
 |`CUmemAccessDesc_v1`|11.3| | |`hipMemAccessDesc`|5.2.0| | | |
@@ -1222,14 +1224,14 @@
 
 |**CUDA**|**A**|**D**|**R**|**HIP**|**A**|**D**|**R**|**E**|
 |:--|:-:|:-:|:-:|:--|:-:|:-:|:-:|:-:|
-|`cuLinkAddData`| | | | | | | | |
-|`cuLinkAddData_v2`| | | | | | | | |
-|`cuLinkAddFile`| | | | | | | | |
-|`cuLinkAddFile_v2`| | | | | | | | |
-|`cuLinkComplete`| | | | | | | | |
-|`cuLinkCreate`| | | | | | | | |
-|`cuLinkCreate_v2`| | | | | | | | |
-|`cuLinkDestroy`| | | | | | | | |
+|`cuLinkAddData`| | | |`hiprtcLinkAddData`|5.3.0| | |5.3.0|
+|`cuLinkAddData_v2`| | | |`hiprtcLinkAddData`|5.3.0| | |5.3.0|
+|`cuLinkAddFile`| | | |`hiprtcLinkAddFile`|5.3.0| | |5.3.0|
+|`cuLinkAddFile_v2`| | | |`hiprtcLinkAddFile`|5.3.0| | |5.3.0|
+|`cuLinkComplete`| | | |`hiprtcLinkComplete`|5.3.0| | |5.3.0|
+|`cuLinkCreate`| | | |`hiprtcLinkCreate`|5.3.0| | |5.3.0|
+|`cuLinkCreate_v2`| | | |`hiprtcLinkCreate`|5.3.0| | |5.3.0|
+|`cuLinkDestroy`| | | |`hiprtcLinkDestroy`|5.3.0| | |5.3.0|
 |`cuModuleGetFunction`| | | |`hipModuleGetFunction`|1.6.0| | | |
 |`cuModuleGetGlobal`| | | |`hipModuleGetGlobal`|1.6.0| | | |
 |`cuModuleGetGlobal_v2`| | | |`hipModuleGetGlobal`|1.6.0| | | |

--- a/doc/markdown/CUDA_RTC_API_supported_by_HIP.md
+++ b/doc/markdown/CUDA_RTC_API_supported_by_HIP.md
@@ -27,8 +27,8 @@
 |`nvrtcCompileProgram`| | | |`hiprtcCompileProgram`|2.6.0| | | |
 |`nvrtcCreateProgram`| | | |`hiprtcCreateProgram`|2.6.0| | | |
 |`nvrtcDestroyProgram`| | | |`hiprtcDestroyProgram`|2.6.0| | | |
-|`nvrtcGetCUBIN`|11.1| | | | | | | |
-|`nvrtcGetCUBINSize`|11.1| | | | | | | |
+|`nvrtcGetCUBIN`|11.1| | |`hiprtcGetBitcode`|5.3.0| | |5.3.0|
+|`nvrtcGetCUBINSize`|11.1| | |`hiprtcGetBitcodeSize`|5.3.0| | |5.3.0|
 |`nvrtcGetErrorString`| | | |`hiprtcGetErrorString`|2.6.0| | | |
 |`nvrtcGetLoweredName`|8.0| | |`hiprtcGetLoweredName`|2.6.0| | | |
 |`nvrtcGetNVVM`|11.4| | | | | | | |

--- a/src/CUDA2HIP_Driver_API_functions.cpp
+++ b/src/CUDA2HIP_Driver_API_functions.cpp
@@ -136,14 +136,14 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_FUNCTION_MAP {
 
   // 10. Module Management
   // no analogues
-  {"cuLinkAddData",                                        {"hipLinkAddData",                                          "", CONV_MODULE, API_DRIVER, 10, HIP_UNSUPPORTED}},
-  {"cuLinkAddData_v2",                                     {"hipLinkAddData",                                          "", CONV_MODULE, API_DRIVER, 10, HIP_UNSUPPORTED}},
-  {"cuLinkAddFile",                                        {"hipLinkAddFile",                                          "", CONV_MODULE, API_DRIVER, 10, HIP_UNSUPPORTED}},
-  {"cuLinkAddFile_v2",                                     {"hipLinkAddFile",                                          "", CONV_MODULE, API_DRIVER, 10, HIP_UNSUPPORTED}},
-  {"cuLinkComplete",                                       {"hipLinkComplete",                                         "", CONV_MODULE, API_DRIVER, 10, HIP_UNSUPPORTED}},
-  {"cuLinkCreate",                                         {"hipLinkCreate",                                           "", CONV_MODULE, API_DRIVER, 10, HIP_UNSUPPORTED}},
-  {"cuLinkCreate_v2",                                      {"hipLinkCreate",                                           "", CONV_MODULE, API_DRIVER, 10, HIP_UNSUPPORTED}},
-  {"cuLinkDestroy",                                        {"hipLinkDestroy",                                          "", CONV_MODULE, API_DRIVER, 10, HIP_UNSUPPORTED}},
+  {"cuLinkAddData",                                        {"hiprtcLinkAddData",                                       "", CONV_MODULE, API_DRIVER, 10, HIP_EXPERIMENTAL}},
+  {"cuLinkAddData_v2",                                     {"hiprtcLinkAddData",                                       "", CONV_MODULE, API_DRIVER, 10, HIP_EXPERIMENTAL}},
+  {"cuLinkAddFile",                                        {"hiprtcLinkAddFile",                                       "", CONV_MODULE, API_DRIVER, 10, HIP_EXPERIMENTAL}},
+  {"cuLinkAddFile_v2",                                     {"hiprtcLinkAddFile",                                       "", CONV_MODULE, API_DRIVER, 10, HIP_EXPERIMENTAL}},
+  {"cuLinkComplete",                                       {"hiprtcLinkComplete",                                      "", CONV_MODULE, API_DRIVER, 10, HIP_EXPERIMENTAL}},
+  {"cuLinkCreate",                                         {"hiprtcLinkCreate",                                        "", CONV_MODULE, API_DRIVER, 10, HIP_EXPERIMENTAL}},
+  {"cuLinkCreate_v2",                                      {"hiprtcLinkCreate",                                        "", CONV_MODULE, API_DRIVER, 10, HIP_EXPERIMENTAL}},
+  {"cuLinkDestroy",                                        {"hiprtcLinkDestroy",                                       "", CONV_MODULE, API_DRIVER, 10, HIP_EXPERIMENTAL}},
   {"cuModuleGetFunction",                                  {"hipModuleGetFunction",                                    "", CONV_MODULE, API_DRIVER, 10}},
   {"cuModuleGetGlobal",                                    {"hipModuleGetGlobal",                                      "", CONV_MODULE, API_DRIVER, 10}},
   {"cuModuleGetGlobal_v2",                                 {"hipModuleGetGlobal",                                      "", CONV_MODULE, API_DRIVER, 10}},
@@ -1412,6 +1412,11 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_DRIVER_FUNCTION_VER_MAP {
   {"hipMemUnmap",                                          {HIP_5020, HIP_0,    HIP_0   }},
   {"hipDrvGetErrorName",                                   {HIP_5030, HIP_0,    HIP_0,  HIP_LATEST}},
   {"hipDrvGetErrorString",                                 {HIP_5030, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hiprtcLinkCreate",                                     {HIP_5030, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hiprtcLinkAddFile",                                    {HIP_5030, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hiprtcLinkAddData",                                    {HIP_5030, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hiprtcLinkComplete",                                   {HIP_5030, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hiprtcLinkDestroy",                                    {HIP_5030, HIP_0,    HIP_0,  HIP_LATEST}},
 };
 
 const std::map<unsigned int, llvm::StringRef> CUDA_DRIVER_API_SECTION_MAP {

--- a/src/CUDA2HIP_Driver_API_types.cpp
+++ b/src/CUDA2HIP_Driver_API_types.cpp
@@ -328,6 +328,10 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_TYPE_NAME_MAP {
   {"CUstreamAttrValue_v1",                                             {"hipStreamAttrValue",                                       "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
   {"CUstreamAttrValue_union",                                          {"hipStreamAttrValue",                                       "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
 
+    // no analogue
+  {"CUlinkState_st",                                                   {"ihiprtcLinkState",                                         "", CONV_TYPE, API_DRIVER, 1}},
+  {"CUlinkState",                                                      {"hiprtcLinkState",                                          "", CONV_TYPE, API_DRIVER, 1}},
+
   // 3. Enums
   // TODO: HIPaddress_mode_enum and all its values should be hipTextureAddressMode as long as they are equal.
   {"CUaddress_mode",                                                   {"HIPaddress_mode",                                          "", CONV_TYPE, API_DRIVER, 1}},
@@ -3295,4 +3299,6 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_DRIVER_TYPE_NAME_VER_MAP {
   {"HIPRTC_JIT_INPUT_LIBRARY",                                         {HIP_5030, HIP_0,    HIP_0,  HIP_LATEST}},
   {"HIPRTC_JIT_INPUT_NVVM",                                            {HIP_5030, HIP_0,    HIP_0,  HIP_LATEST}},
   {"HIPRTC_JIT_NUM_LEGACY_INPUT_TYPES",                                {HIP_5030, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"ihiprtcLinkState",                                                 {HIP_5030, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hiprtcLinkState",                                                  {HIP_5030, HIP_0,    HIP_0,  HIP_LATEST}},
 };

--- a/src/CUDA2HIP_RTC_API_functions.cpp
+++ b/src/CUDA2HIP_RTC_API_functions.cpp
@@ -33,8 +33,8 @@ const std::map<llvm::StringRef, hipCounter> CUDA_RTC_FUNCTION_MAP {
   {"nvrtcCompileProgram",                         {"hiprtcCompileProgram",                         "", CONV_LIB_FUNC, API_RTC, 2}},
   {"nvrtcGetPTXSize",                             {"hiprtcGetCodeSize",                            "", CONV_LIB_FUNC, API_RTC, 2}},
   {"nvrtcGetPTX",                                 {"hiprtcGetCode",                                "", CONV_LIB_FUNC, API_RTC, 2}},
-  {"nvrtcGetCUBINSize",                           {"hiprtcGetCUBINSize",                           "", CONV_LIB_FUNC, API_RTC, 2, HIP_UNSUPPORTED}},
-  {"nvrtcGetCUBIN",                               {"hiprtcGetCUBIN",                               "", CONV_LIB_FUNC, API_RTC, 2, HIP_UNSUPPORTED}},
+  {"nvrtcGetCUBINSize",                           {"hiprtcGetBitcodeSize",                         "", CONV_LIB_FUNC, API_RTC, 2, HIP_EXPERIMENTAL}},
+  {"nvrtcGetCUBIN",                               {"hiprtcGetBitcode",                             "", CONV_LIB_FUNC, API_RTC, 2, HIP_EXPERIMENTAL}},
   {"nvrtcGetNVVMSize",                            {"hiprtcGetNVVMSize",                            "", CONV_LIB_FUNC, API_RTC, 2, HIP_UNSUPPORTED}},
   {"nvrtcGetNVVM",                                {"hiprtcGetNVVM",                                "", CONV_LIB_FUNC, API_RTC, 2, HIP_UNSUPPORTED}},
   {"nvrtcGetProgramLogSize",                      {"hiprtcGetProgramLogSize",                      "", CONV_LIB_FUNC, API_RTC, 2}},
@@ -66,6 +66,8 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_RTC_FUNCTION_VER_MAP {
   {"hiprtcGetProgramLog",                         {HIP_2060, HIP_0,    HIP_0   }},
   {"hiprtcAddNameExpression",                     {HIP_2060, HIP_0,    HIP_0   }},
   {"hiprtcGetLoweredName",                        {HIP_2060, HIP_0,    HIP_0   }},
+  {"hiprtcGetBitcode",                            {HIP_5030, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hiprtcGetBitcodeSize",                        {HIP_5030, HIP_0,    HIP_0,  HIP_LATEST}},
 };
 
 const std::map<unsigned int, llvm::StringRef> CUDA_RTC_API_SECTION_MAP {

--- a/tests/unit_tests/synthetic/driver_structs.cu
+++ b/tests/unit_tests/synthetic/driver_structs.cu
@@ -104,6 +104,11 @@ int main() {
   // CHECK: hipUUID_t uuid_st;
   CUuuid_st uuid_st;
 
+  // CHECK: ihiprtcLinkState* linkState_ptr;
+  // CHECK-NEXT: hiprtcLinkState linkState;
+  CUlinkState_st* linkState_ptr;
+  CUlinkState linkState;
+
 #if CUDA_VERSION >= 10000
   // CHECK: hipExternalMemoryBufferDesc_st ext_mem_buff_st;
   // CHECK-NEXT: hipExternalMemoryBufferDesc ext_mem_buff;

--- a/tests/unit_tests/synthetic/driver_typedefs.cu
+++ b/tests/unit_tests/synthetic/driver_typedefs.cu
@@ -49,9 +49,7 @@ int main() {
 
   // CHECK: hipTextureObject_t texObject_v1;
   CUtexObject_v1 texObject_v1;
-#endif
 
-#if CUDA_VERSION >= 11040
   // CHECK: hipMemGenericAllocationHandle_t memGenericAllocationHandle_v1;
   CUmemGenericAllocationHandle_v1 memGenericAllocationHandle_v1;
 #endif


### PR DESCRIPTION
+ Introduce hipRTC functions
+ Add the missing data type `CUlinkState`
+ Update regenerated hipify-perl, affected docs, and tests

[ToDo]
+ [feature] Add an additional marker for an API entry for inserting a corresponding HIP header file include
+ [workaround] Get rid of 2 identical enums in HIP: `hiprtcJIT_option` and `hipJitOption`
+ [tests] Synthetic tests for nvRTC -> hipRTC