### PR TITLE
[HIPIFY][HIP][5.3.0][fix] Sync - Remove `cuGetErrorName` and `cuGetErrorString`

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -755,8 +755,6 @@ my %experimental_funcs = (
     "cuGraphUpload" => "5.3.0",
     "cuGraphRetainUserObject" => "5.3.0",
     "cuGraphReleaseUserObject" => "5.3.0",
-    "cuGetErrorString" => "5.3.0",
-    "cuGetErrorName" => "5.3.0",
     "cuDeviceSetGraphMemAttribute" => "5.3.0",
     "cuDeviceGraphMemTrim" => "5.3.0",
     "cuDeviceGetGraphMemAttribute" => "5.3.0",
@@ -925,8 +923,6 @@ sub subst {
 }
 
 sub experimentalSubstitutions {
-    subst("cuGetErrorName", "hipDrvGetErrorName", "error");
-    subst("cuGetErrorString", "hipDrvGetErrorString", "error");
     subst("cudaDeviceSetLimit", "hipDeviceSetLimit", "device");
     subst("cuCtxSetLimit", "hipDeviceSetLimit", "context");
     subst("cuLinkAddData", "hiprtcLinkAddData", "module");
@@ -6510,6 +6506,8 @@ sub warnUnsupportedFunctions {
         "cuGraphAddExternalSemaphoresSignalNode",
         "cuGraphAddBatchMemOpNode",
         "cuGetProcAddress",
+        "cuGetErrorString",
+        "cuGetErrorName",
         "cuGLUnregisterBufferObject",
         "cuGLUnmapBufferObjectAsync",
         "cuGLUnmapBufferObject",

--- a/doc/markdown/CUDA_Driver_API_functions_supported_by_HIP.md
+++ b/doc/markdown/CUDA_Driver_API_functions_supported_by_HIP.md
@@ -1129,8 +1129,8 @@
 
 |**CUDA**|**A**|**D**|**R**|**HIP**|**A**|**D**|**R**|**E**|
 |:--|:-:|:-:|:-:|:--|:-:|:-:|:-:|:-:|
-|`cuGetErrorName`| | | |`hipDrvGetErrorName`|5.3.0| | |5.3.0|
-|`cuGetErrorString`| | | |`hipDrvGetErrorString`|5.3.0| | |5.3.0|
+|`cuGetErrorName`| | | | | | | | |
+|`cuGetErrorString`| | | | | | | | |
 
 ## **3. Initialization**
 

--- a/src/CUDA2HIP_Driver_API_functions.cpp
+++ b/src/CUDA2HIP_Driver_API_functions.cpp
@@ -27,10 +27,10 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_FUNCTION_MAP {
   // 2. Error Handling
   // no analogue
   // NOTE: cudaGetErrorName and cuGetErrorName have different signatures
-  {"cuGetErrorName",                                       {"hipDrvGetErrorName",                                      "", CONV_ERROR, API_DRIVER, 2, HIP_EXPERIMENTAL}},
+  {"cuGetErrorName",                                       {"hipDrvGetErrorName",                                      "", CONV_ERROR, API_DRIVER, 2, HIP_UNSUPPORTED}},
   // no analogue
   // NOTE: cudaGetErrorString and cuGetErrorString have different signatures
-  {"cuGetErrorString",                                     {"hipDrvGetErrorString",                                    "", CONV_ERROR, API_DRIVER, 2, HIP_EXPERIMENTAL}},
+  {"cuGetErrorString",                                     {"hipDrvGetErrorString",                                    "", CONV_ERROR, API_DRIVER, 2, HIP_UNSUPPORTED}},
 
   // 3. Initialization
   // no analogue
@@ -1410,8 +1410,6 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_DRIVER_FUNCTION_VER_MAP {
   {"hipMemRetainAllocationHandle",                         {HIP_5020, HIP_0,    HIP_0   }},
   {"hipMemSetAccess",                                      {HIP_5020, HIP_0,    HIP_0   }},
   {"hipMemUnmap",                                          {HIP_5020, HIP_0,    HIP_0   }},
-  {"hipDrvGetErrorName",                                   {HIP_5030, HIP_0,    HIP_0,  HIP_LATEST}},
-  {"hipDrvGetErrorString",                                 {HIP_5030, HIP_0,    HIP_0,  HIP_LATEST}},
   {"hiprtcLinkCreate",                                     {HIP_5030, HIP_0,    HIP_0,  HIP_LATEST}},
   {"hiprtcLinkAddFile",                                    {HIP_5030, HIP_0,    HIP_0,  HIP_LATEST}},
   {"hiprtcLinkAddData",                                    {HIP_5030, HIP_0,    HIP_0,  HIP_LATEST}},

--- a/tests/unit_tests/synthetic/driver_functions.cu
+++ b/tests/unit_tests/synthetic/driver_functions.cu
@@ -1652,15 +1652,5 @@ int main() {
   CUresult result_2;
   const char* ret = NULL;
 
-  // CUDA: CUresult CUDAAPI cuGetErrorName(CUresult error, const char **pStr);
-  // HIP:  hipError_t hipDrvGetErrorName(hipError_t hipError, const char** errorString);
-  // CHECK: result = hipDrvGetErrorName(result_2, &ret);
-  result = cuGetErrorName(result_2, &ret);
-
-  // CUDA: CUresult CUDAAPI cuGetErrorString(CUresult error, const char **pStr);
-  // HIP:  hipError_t hipDrvGetErrorString(hipError_t hipError, const char** errorString);
-  // CHECK: result = hipDrvGetErrorString(result_2, &ret);
-  result = cuGetErrorString(result_2, &ret);
-
   return 0;
 }


### PR DESCRIPTION
[Reason] These two functions will be released in 5.4

Update regenerated hipify-perl, synthetic tests, and CUDA_Driver_API_functions_supported_by_HIP.md
