### PR TITLE
[HIPIFY][doc] LLVM 15.0.0 is the latest supported LLVM release

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ After applying all the matchers, the output HIP source is produced.
 
 `hipify-clang` requires:
 
-1. [**LLVM+CLANG**](http://releases.llvm.org) of at least version [4.0.0](http://releases.llvm.org/download.html#4.0.0); the latest stable and recommended release: [**14.0.6**](https://github.com/llvm/llvm-project/releases/tag/llvmorg-14.0.6).
+1. [**LLVM+CLANG**](http://releases.llvm.org) of at least version [4.0.0](http://releases.llvm.org/download.html#4.0.0); the latest stable and recommended release: [**15.0.0**](https://github.com/llvm/llvm-project/releases/tag/llvmorg-15.0.0).
 
 2. [**CUDA**](https://developer.nvidia.com/cuda-downloads) of at least version [8.0](https://developer.nvidia.com/cuda-80-ga2-download-archive), the latest supported version is [**11.7.1**](https://developer.nvidia.com/cuda-downloads).
 
@@ -170,7 +170,8 @@ After applying all the matchers, the output HIP source is produced.
       <td><b>+</b></td>
     <tr align="center">
       <td><a href="https://github.com/llvm/llvm-project/releases/tag/llvmorg-14.0.5">14.0.5</a>,
-          <a href="https://github.com/llvm/llvm-project/releases/tag/llvmorg-14.0.6"><b>14.0.6</b></a></td>
+          <a href="https://github.com/llvm/llvm-project/releases/tag/llvmorg-14.0.6">14.0.6</a>,
+          <a href="https://github.com/llvm/llvm-project/releases/tag/llvmorg-15.0.0"><b>15.0.0</b></a></td>
       <td bgcolor="eefaeb"><a href="https://developer.nvidia.com/cuda-downloads"><b>11.7.1</b></a></td>
       <td colspan=2 bgcolor="eefaeb"><font color="green"><b>LATEST STABLE CONFIG</b></font></td>
     </tr>
@@ -186,7 +187,7 @@ After applying all the matchers, the output HIP source is produced.
 In most cases, you can get a suitable version of `LLVM+CLANG` with your package manager.
 
 Failing that or having multiple versions of `LLVM`, you can [download a release archive](http://releases.llvm.org/), build or install it, and set
-[CMAKE_PREFIX_PATH](https://cmake.org/cmake/help/v3.5/variable/CMAKE_PREFIX_PATH.html) so `cmake` can find it; for instance: `-DCMAKE_PREFIX_PATH=d:\LLVM\14.0.6\dist`
+[CMAKE_PREFIX_PATH](https://cmake.org/cmake/help/v3.5/variable/CMAKE_PREFIX_PATH.html) so `cmake` can find it; for instance: `-DCMAKE_PREFIX_PATH=d:\LLVM\15.0.0\dist`
 
 ### <a name="hipify-clang-usage"></a> hipify-clang: usage
 
@@ -284,7 +285,7 @@ Run `Visual Studio 16 2019`, open the generated `LLVM.sln`, build all, and build
 
 **LLVM >= 10.0.0:**
 
-1. download [`LLVM project`](https://github.com/llvm/llvm-project/releases/tag/llvmorg-14.0.6) sources;
+1. download [`LLVM project`](https://github.com/llvm/llvm-project/releases/tag/llvmorg-15.0.0) sources;
 2. build [`LLVM project`](http://llvm.org/docs/CMake.html):
 
 ```bash
@@ -349,21 +350,21 @@ Run `Visual Studio 17 2022`, open the generated `LLVM.sln`, build all, build pro
 
     * Install `lit` into `python`:
 
-        - ***Linux***: `python /usr/llvm/14.0.6/llvm-project/llvm/utils/lit/setup.py install`
+        - ***Linux***: `python /usr/llvm/15.0.0/llvm-project/llvm/utils/lit/setup.py install`
 
-        - ***Windows***: `python d:/LLVM/14.0.6/llvm-project/llvm/utils/lit/setup.py install`
+        - ***Windows***: `python d:/LLVM/15.0.0/llvm-project/llvm/utils/lit/setup.py install`
 
     * Starting with LLVM 6.0.1 path to `llvm-lit` python script should be specified by the `LLVM_EXTERNAL_LIT` option:
 
-        - ***Linux***: `-DLLVM_EXTERNAL_LIT=/usr/llvm/14.0.6/build/bin/llvm-lit`
+        - ***Linux***: `-DLLVM_EXTERNAL_LIT=/usr/llvm/15.0.0/build/bin/llvm-lit`
 
-        - ***Windows***: `-DLLVM_EXTERNAL_LIT=d:/LLVM/14.0.6/build/Release/bin/llvm-lit.py`
+        - ***Windows***: `-DLLVM_EXTERNAL_LIT=d:/LLVM/15.0.0/build/Release/bin/llvm-lit.py`
 
     * `FileCheck`:
 
-        - ***Linux***: copy from `/usr/llvm/14.0.6/build/bin/` to `CMAKE_INSTALL_PREFIX/dist/bin`
+        - ***Linux***: copy from `/usr/llvm/15.0.0/build/bin/` to `CMAKE_INSTALL_PREFIX/dist/bin`
 
-        - ***Windows***: copy from `d:/LLVM/14.0.6/build/Release/bin` to `CMAKE_INSTALL_PREFIX/dist/bin`
+        - ***Windows***: copy from `d:/LLVM/15.0.0/build/Release/bin` to `CMAKE_INSTALL_PREFIX/dist/bin`
 
         - Or specify the path to `FileCheck` in `CMAKE_INSTALL_PREFIX` option
 
@@ -385,7 +386,7 @@ Ubuntu 14: LLVM 4.0.0 - 7.1.0, CUDA 7.0 - 9.0, cuDNN 5.0.5 - 7.6.5
 
 Ubuntu 16-18: LLVM 8.0.0 - 14.0.6, CUDA 8.0 - 10.2, cuDNN 5.1.10 - 8.0.5
 
-Ubuntu 20-21: LLVM 9.0.0 - 14.0.6, CUDA 8.0 - 11.7.1, cuDNN 5.1.10 - 8.4.1
+Ubuntu 20-21: LLVM 9.0.0 - 15.0.0, CUDA 8.0 - 11.7.1, cuDNN 5.1.10 - 8.4.1
 
 Minimum build system requirements for the above configurations:
 
@@ -402,11 +403,11 @@ cmake
  -DHIPIFY_CLANG_TESTS=1 \
  -DCMAKE_BUILD_TYPE=Release \
  -DCMAKE_INSTALL_PREFIX=../dist \
- -DCMAKE_PREFIX_PATH=/usr/llvm/14.0.6/dist \
+ -DCMAKE_PREFIX_PATH=/usr/llvm/15.0.0/dist \
  -DCUDA_TOOLKIT_ROOT_DIR=/usr/local/cuda \
  -DCUDA_DNN_ROOT_DIR=/usr/local/cuda \
  -DCUDA_CUB_ROOT_DIR=/usr/CUB \
- -DLLVM_EXTERNAL_LIT=/usr/llvm/14.0.6/build/bin/llvm-lit \
+ -DLLVM_EXTERNAL_LIT=/usr/llvm/15.0.0/build/bin/llvm-lit \
  ../hipify
 ```
 *A corresponding successful output:*
@@ -424,14 +425,14 @@ cmake
 -- Detecting CXX compile features
 -- Detecting CXX compile features - done
 -- Found ZLIB: /usr/lib/x86_64-linux-gnu/libz.so (found version "1.2.11")
--- Found LLVM 14.0.6:
---    - CMake module path: /usr/llvm/14.0.6/dist/lib/cmake/llvm
---    - Include path     : /usr/llvm/14.0.6/dist/include
---    - Binary path      : /usr/llvm/14.0.6/dist/bin
+-- Found LLVM 15.0.0:
+--    - CMake module path: /usr/llvm/15.0.0/dist/lib/cmake/llvm
+--    - Include path     : /usr/llvm/15.0.0/dist/include
+--    - Binary path      : /usr/llvm/15.0.0/dist/bin
 -- Linker detection: GNU ld
 -- Found PythonInterp: /usr/bin/python (found suitable version "3.9.7", minimum required is "2.7")
 -- Found lit: /usr/local/bin/lit
--- Found FileCheck: /usr/llvm/14.0.6/dist/bin/FileCheck
+-- Found FileCheck: /usr/llvm/15.0.0/dist/bin/FileCheck
 -- Looking for pthread.h
 -- Looking for pthread.h - found
 -- Performing Test CMAKE_HAVE_LIBC_PTHREAD
@@ -450,7 +451,7 @@ make test-hipify
 Running HIPify regression tests
 ========================================
 CUDA 11.7 - will be used for testing
-LLVM 14.0.6 - will be used for testing
+LLVM 15.0.0 - will be used for testing
 x86_64 - Platform architecture
 Linux 5.13.0-21-generic - Platform OS
 64 - hipify-clang binary bitness
@@ -564,7 +565,8 @@ Testing Time: 6.22s
 | 11.0.1 - 11.1.0 | 7.0 - 11.2.2 | 7.6.5  - 8.0.5 | 2017.15.9.31, 2019.16.8.4                | 3.19.3         | 3.9.2        |
 | 12.0.0 - 13.0.1 | 7.0 - 11.5.1 | 7.6.5  - 8.3.2 | 2017.15.9.43, 2019.16.11.9               | 3.22.2         | 3.10.2       |
 | 14.0.0 - 14.0.6 | 7.0 - 11.7.1 | 8.0.5  - 8.4.1 | 2017.15.9.49, 2019.16.11.17, 2022.17.2.6 | 3.24.0         | 3.10.6       |
-| 16.0.0git       | 7.0 - 11.7.1 | 8.0.5  - 8.4.1 | 2017.15.9.50, 2019.16.11.18, 2022.17.3.0 | 3.24.0         | 3.10.6       |
+| 15.0.0          | 7.0 - 11.7.1 | 8.0.5  - 8.4.1 | 2017.15.9.50, 2019.16.11.18, 2022.17.3.3 | 3.24.1         | 3.10.6       |
+| 16.0.0git       | 7.0 - 11.7.1 | 8.0.5  - 8.4.1 | 2017.15.9.50, 2019.16.11.18, 2022.17.3.3 | 3.24.1         | 3.10.6       |
 
 *Building with testing support by `Visual Studio 17 2022` on `Windows 10`:*
 
@@ -576,23 +578,23 @@ cmake
  -DHIPIFY_CLANG_TESTS=1 \
  -DCMAKE_BUILD_TYPE=Release \
  -DCMAKE_INSTALL_PREFIX=../dist \
- -DCMAKE_PREFIX_PATH=d:/LLVM/14.0.6/dist \
+ -DCMAKE_PREFIX_PATH=d:/LLVM/15.0.0/dist \
  -DCUDA_TOOLKIT_ROOT_DIR="c:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v11.7" \
  -DCUDA_SDK_ROOT_DIR="c:/ProgramData/NVIDIA Corporation/CUDA Samples/v11.7" \
  -DCUDA_DNN_ROOT_DIR=d:/CUDNN/cudnn-11.7-windows-x64-v8.4.1 \
  -DCUDA_CUB_ROOT_DIR=d:/GIT/cub \
- -DLLVM_EXTERNAL_LIT=d:/LLVM/14.0.6/build/Release/bin/llvm-lit.py \
+ -DLLVM_EXTERNAL_LIT=d:/LLVM/15.0.0/build/Release/bin/llvm-lit.py \
  ../hipify
 ```
 *A corresponding successful output:*
 ```shell
--- Found LLVM 14.0.6:
---    - CMake module path: d:/LLVM/14.0.6/dist/lib/cmake/llvm
---    - Include path     : d:/LLVM/14.0.6/dist/include
---    - Binary path      : d:/LLVM/14.0.6/dist/bin
+-- Found LLVM 15.0.0:
+--    - CMake module path: d:/LLVM/15.0.0/dist/lib/cmake/llvm
+--    - Include path     : d:/LLVM/15.0.0/dist/include
+--    - Binary path      : d:/LLVM/15.0.0/dist/bin
 -- Found PythonInterp: c:/Program Files/Python39/python.exe (found suitable version "3.9.5", minimum required is "3.6")
 -- Found lit: c:/Program Files/Python39/Scripts/lit.exe
--- Found FileCheck: d:/LLVM/14.0.6/dist/bin/FileCheck.exe
+-- Found FileCheck: d:/LLVM/15.0.0/dist/bin/FileCheck.exe
 -- Found CUDA: c:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v11.7 (found version "11.7")
 -- Configuring done
 -- Generating done


### PR DESCRIPTION
+ No patches are needed
+ Update README.md accordingly
+ Tested on Windows 10 and Ubuntu 21.10