### PR TITLE
[HIPIFY][BLAS][fix] Fix hipBLAS and rocBLAS TRMM functions support types

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -1076,8 +1076,8 @@ sub rocSubstitutions {
     subst("cublasCtpmv_v2", "rocblas_ctpmv", "library");
     subst("cublasCtpsv", "rocblas_ctpsv", "library");
     subst("cublasCtpsv_v2", "rocblas_ctpsv", "library");
-    subst("cublasCtrmm", "rocblas_ctrmm", "library");
-    subst("cublasCtrmm_v2", "rocblas_ctrmm", "library");
+    subst("cublasCtrmm", "rocblas_ctrmm_outofplace", "library");
+    subst("cublasCtrmm_v2", "rocblas_ctrmm_outofplace", "library");
     subst("cublasCtrmv", "rocblas_ctrmv", "library");
     subst("cublasCtrmv_v2", "rocblas_ctrmv", "library");
     subst("cublasCtrsm", "rocblas_ctrsm", "library");
@@ -1152,8 +1152,8 @@ sub rocSubstitutions {
     subst("cublasDtpmv_v2", "rocblas_dtpmv", "library");
     subst("cublasDtpsv", "rocblas_dtpsv", "library");
     subst("cublasDtpsv_v2", "rocblas_dtpsv", "library");
-    subst("cublasDtrmm", "rocblas_dtrmm", "library");
-    subst("cublasDtrmm_v2", "rocblas_dtrmm", "library");
+    subst("cublasDtrmm", "rocblas_dtrmm_outofplace", "library");
+    subst("cublasDtrmm_v2", "rocblas_dtrmm_outofplace", "library");
     subst("cublasDtrmv", "rocblas_dtrmv", "library");
     subst("cublasDtrmv_v2", "rocblas_dtrmv", "library");
     subst("cublasDtrsm", "rocblas_dtrsm", "library");
@@ -1273,8 +1273,8 @@ sub rocSubstitutions {
     subst("cublasStpmv_v2", "rocblas_stpmv", "library");
     subst("cublasStpsv", "rocblas_stpsv", "library");
     subst("cublasStpsv_v2", "rocblas_stpsv", "library");
-    subst("cublasStrmm", "rocblas_strmm", "library");
-    subst("cublasStrmm_v2", "rocblas_strmm", "library");
+    subst("cublasStrmm", "rocblas_strmm_outofplace", "library");
+    subst("cublasStrmm_v2", "rocblas_strmm_outofplace", "library");
     subst("cublasStrmv", "rocblas_strmv", "library");
     subst("cublasStrmv_v2", "rocblas_strmv", "library");
     subst("cublasStrsm", "rocblas_strsm", "library");
@@ -1358,8 +1358,8 @@ sub rocSubstitutions {
     subst("cublasZtpmv_v2", "rocblas_ztpmv", "library");
     subst("cublasZtpsv", "rocblas_ztpsv", "library");
     subst("cublasZtpsv_v2", "rocblas_ztpsv", "library");
-    subst("cublasZtrmm", "rocblas_ztrmm", "library");
-    subst("cublasZtrmm_v2", "rocblas_ztrmm", "library");
+    subst("cublasZtrmm", "rocblas_ztrmm_outofplace", "library");
+    subst("cublasZtrmm_v2", "rocblas_ztrmm_outofplace", "library");
     subst("cublasZtrmv", "rocblas_ztrmv", "library");
     subst("cublasZtrmv_v2", "rocblas_ztrmv", "library");
     subst("cublasZtrsm", "rocblas_ztrsm", "library");
@@ -2047,8 +2047,6 @@ sub simpleSubstitutions {
     subst("cublasCtpmv_v2", "hipblasCtpmv", "library");
     subst("cublasCtpsv", "hipblasCtpsv", "library");
     subst("cublasCtpsv_v2", "hipblasCtpsv", "library");
-    subst("cublasCtrmm", "hipblasCtrmm", "library");
-    subst("cublasCtrmm_v2", "hipblasCtrmm", "library");
     subst("cublasCtrmv", "hipblasCtrmv", "library");
     subst("cublasCtrmv_v2", "hipblasCtrmv", "library");
     subst("cublasCtrsm", "hipblasCtrsm", "library");
@@ -2127,8 +2125,6 @@ sub simpleSubstitutions {
     subst("cublasDtpmv_v2", "hipblasDtpmv", "library");
     subst("cublasDtpsv", "hipblasDtpsv", "library");
     subst("cublasDtpsv_v2", "hipblasDtpsv", "library");
-    subst("cublasDtrmm", "hipblasDtrmm", "library");
-    subst("cublasDtrmm_v2", "hipblasDtrmm", "library");
     subst("cublasDtrmv", "hipblasDtrmv", "library");
     subst("cublasDtrmv_v2", "hipblasDtrmv", "library");
     subst("cublasDtrsm", "hipblasDtrsm", "library");
@@ -2254,8 +2250,6 @@ sub simpleSubstitutions {
     subst("cublasStpmv_v2", "hipblasStpmv", "library");
     subst("cublasStpsv", "hipblasStpsv", "library");
     subst("cublasStpsv_v2", "hipblasStpsv", "library");
-    subst("cublasStrmm", "hipblasStrmm", "library");
-    subst("cublasStrmm_v2", "hipblasStrmm", "library");
     subst("cublasStrmv", "hipblasStrmv", "library");
     subst("cublasStrmv_v2", "hipblasStrmv", "library");
     subst("cublasStrsm", "hipblasStrsm", "library");
@@ -2343,8 +2337,6 @@ sub simpleSubstitutions {
     subst("cublasZtpmv_v2", "hipblasZtpmv", "library");
     subst("cublasZtpsv", "hipblasZtpsv", "library");
     subst("cublasZtpsv_v2", "hipblasZtpsv", "library");
-    subst("cublasZtrmm", "hipblasZtrmm", "library");
-    subst("cublasZtrmm_v2", "hipblasZtrmm", "library");
     subst("cublasZtrmv", "hipblasZtrmv", "library");
     subst("cublasZtrmv_v2", "hipblasZtrmv", "library");
     subst("cublasZtrsm", "hipblasZtrsm", "library");
@@ -7651,6 +7643,8 @@ sub warnHipOnlyUnsupportedFunctions {
     my $k = 0;
     foreach $func (
         "cublasZtrttp",
+        "cublasZtrmm_v2",
+        "cublasZtrmm",
         "cublasZtpttr",
         "cublasZmatinvBatched",
         "cublasZgemm3m",
@@ -7659,6 +7653,8 @@ sub warnHipOnlyUnsupportedFunctions {
         "cublasUint8gemmBias",
         "cublasSwapEx",
         "cublasStrttp",
+        "cublasStrmm_v2",
+        "cublasStrmm",
         "cublasStpttr",
         "cublasSmatinvBatched",
         "cublasShutdown",
@@ -7690,10 +7686,14 @@ sub warnHipOnlyUnsupportedFunctions {
         "cublasGetCudartVersion",
         "cublasFree",
         "cublasDtrttp",
+        "cublasDtrmm_v2",
+        "cublasDtrmm",
         "cublasDtpttr",
         "cublasDmatinvBatched",
         "cublasDgelsBatched",
         "cublasCtrttp",
+        "cublasCtrmm_v2",
+        "cublasCtrmm",
         "cublasCtpttr",
         "cublasCsyrkEx",
         "cublasCsyrk3mEx",

--- a/doc/markdown/CUBLAS_API_supported_by_HIP.md
+++ b/doc/markdown/CUBLAS_API_supported_by_HIP.md
@@ -483,8 +483,8 @@
 |`cublasCsyrk`| | | |`hipblasCsyrk`|3.5.0| | | |
 |`cublasCsyrk_v2`| | | |`hipblasCsyrk`|3.5.0| | | |
 |`cublasCsyrkx`| | | |`hipblasCsyrkx`|3.5.0| | | |
-|`cublasCtrmm`| | | |`hipblasCtrmm`|3.5.0| | | |
-|`cublasCtrmm_v2`| | | |`hipblasCtrmm`|3.5.0| | | |
+|`cublasCtrmm`| | | | | | | | |
+|`cublasCtrmm_v2`| | | | | | | | |
 |`cublasCtrsm`| | | |`hipblasCtrsm`|3.5.0| | | |
 |`cublasCtrsm_v2`| | | |`hipblasCtrsm`|3.5.0| | | |
 |`cublasDgemm`| | | |`hipblasDgemm`|1.8.2| | | |
@@ -498,8 +498,8 @@
 |`cublasDsyrk`| | | |`hipblasDsyrk`|3.5.0| | | |
 |`cublasDsyrk_v2`| | | |`hipblasDsyrk`|3.5.0| | | |
 |`cublasDsyrkx`| | | |`hipblasDsyrkx`|3.5.0| | | |
-|`cublasDtrmm`| | | |`hipblasDtrmm`|3.2.0| | | |
-|`cublasDtrmm_v2`| | | |`hipblasDtrmm`|3.2.0| | | |
+|`cublasDtrmm`| | | | | | | | |
+|`cublasDtrmm_v2`| | | | | | | | |
 |`cublasDtrsm`| | | |`hipblasDtrsm`|1.8.2| | | |
 |`cublasDtrsm_v2`| | | |`hipblasDtrsm`|1.8.2| | | |
 |`cublasHgemm`|7.5| | |`hipblasHgemm`|1.8.2| | | |
@@ -516,8 +516,8 @@
 |`cublasSsyrk`| | | |`hipblasSsyrk`|3.5.0| | | |
 |`cublasSsyrk_v2`| | | |`hipblasSsyrk`|3.5.0| | | |
 |`cublasSsyrkx`| | | |`hipblasSsyrkx`|3.5.0| | | |
-|`cublasStrmm`| | | |`hipblasStrmm`|3.2.0| | | |
-|`cublasStrmm_v2`| | | |`hipblasStrmm`|3.2.0| | | |
+|`cublasStrmm`| | | | | | | | |
+|`cublasStrmm_v2`| | | | | | | | |
 |`cublasStrsm`| | | |`hipblasStrsm`|1.8.2| | | |
 |`cublasStrsm_v2`| | | |`hipblasStrsm`|1.8.2| | | |
 |`cublasZgemm`| | | |`hipblasZgemm`|1.8.2| | | |
@@ -539,8 +539,8 @@
 |`cublasZsyrk`| | | |`hipblasZsyrk`|3.5.0| | | |
 |`cublasZsyrk_v2`| | | |`hipblasZsyrk`|3.5.0| | | |
 |`cublasZsyrkx`| | | |`hipblasZsyrkx`|3.5.0| | | |
-|`cublasZtrmm`| | | |`hipblasZtrmm`|3.5.0| | | |
-|`cublasZtrmm_v2`| | | |`hipblasZtrmm`|3.5.0| | | |
+|`cublasZtrmm`| | | | | | | | |
+|`cublasZtrmm_v2`| | | | | | | | |
 |`cublasZtrsm`| | | |`hipblasZtrsm`|3.5.0| | | |
 |`cublasZtrsm_v2`| | | |`hipblasZtrsm`|3.5.0| | | |
 

--- a/src/CUDA2HIP_BLAS_API_functions.cpp
+++ b/src/CUDA2HIP_BLAS_API_functions.cpp
@@ -334,10 +334,10 @@ const std::map<llvm::StringRef, hipCounter> CUDA_BLAS_FUNCTION_MAP {
   {"cublasZtrsm",                    {"hipblasZtrsm",                    "rocblas_ztrsm",                            CONV_LIB_FUNC, API_BLAS, 7, HIP_SUPPORTED_V2_ONLY}},
 
   // TRMM
-  {"cublasStrmm",                    {"hipblasStrmm",                    "rocblas_strmm",                            CONV_LIB_FUNC, API_BLAS, 7}},
-  {"cublasDtrmm",                    {"hipblasDtrmm",                    "rocblas_dtrmm",                            CONV_LIB_FUNC, API_BLAS, 7}},
-  {"cublasCtrmm",                    {"hipblasCtrmm",                    "rocblas_ctrmm",                            CONV_LIB_FUNC, API_BLAS, 7}},
-  {"cublasZtrmm",                    {"hipblasZtrmm",                    "rocblas_ztrmm",                            CONV_LIB_FUNC, API_BLAS, 7}},
+  {"cublasStrmm",                    {"hipblasStrmm",                    "rocblas_strmm_outofplace",                 CONV_LIB_FUNC, API_BLAS, 7, HIP_SUPPORTED_V2_ONLY | HIP_UNSUPPORTED}},
+  {"cublasDtrmm",                    {"hipblasDtrmm",                    "rocblas_dtrmm_outofplace",                 CONV_LIB_FUNC, API_BLAS, 7, HIP_SUPPORTED_V2_ONLY | HIP_UNSUPPORTED}},
+  {"cublasCtrmm",                    {"hipblasCtrmm",                    "rocblas_ctrmm_outofplace",                 CONV_LIB_FUNC, API_BLAS, 7, HIP_SUPPORTED_V2_ONLY | HIP_UNSUPPORTED}},
+  {"cublasZtrmm",                    {"hipblasZtrmm",                    "rocblas_ztrmm_outofplace",                 CONV_LIB_FUNC, API_BLAS, 7, HIP_SUPPORTED_V2_ONLY | HIP_UNSUPPORTED}},
 
   // ------------------------ CUBLAS BLAS - like extension (cublas_api.h)
   // GEAM
@@ -575,10 +575,10 @@ const std::map<llvm::StringRef, hipCounter> CUDA_BLAS_FUNCTION_MAP {
   {"cublasZtrsm_v2",                 {"hipblasZtrsm",                    "rocblas_ztrsm",                            CONV_LIB_FUNC, API_BLAS, 7}},
 
   // TRMM
-  {"cublasStrmm_v2",                 {"hipblasStrmm",                    "rocblas_strmm",                            CONV_LIB_FUNC, API_BLAS, 7}},
-  {"cublasDtrmm_v2",                 {"hipblasDtrmm",                    "rocblas_dtrmm",                            CONV_LIB_FUNC, API_BLAS, 7}},
-  {"cublasCtrmm_v2",                 {"hipblasCtrmm",                    "rocblas_ctrmm",                            CONV_LIB_FUNC, API_BLAS, 7}},
-  {"cublasZtrmm_v2",                 {"hipblasZtrmm",                    "rocblas_ztrmm",                            CONV_LIB_FUNC, API_BLAS, 7}},
+  {"cublasStrmm_v2",                 {"hipblasStrmm",                    "rocblas_strmm_outofplace",                 CONV_LIB_FUNC, API_BLAS, 7, HIP_SUPPORTED_V2_ONLY | HIP_UNSUPPORTED}},
+  {"cublasDtrmm_v2",                 {"hipblasDtrmm",                    "rocblas_dtrmm_outofplace",                 CONV_LIB_FUNC, API_BLAS, 7, HIP_SUPPORTED_V2_ONLY | HIP_UNSUPPORTED}},
+  {"cublasCtrmm_v2",                 {"hipblasCtrmm",                    "rocblas_ctrmm_outofplace",                 CONV_LIB_FUNC, API_BLAS, 7, HIP_SUPPORTED_V2_ONLY | HIP_UNSUPPORTED}},
+  {"cublasZtrmm_v2",                 {"hipblasZtrmm",                    "rocblas_ztrmm_outofplace",                 CONV_LIB_FUNC, API_BLAS, 7, HIP_SUPPORTED_V2_ONLY | HIP_UNSUPPORTED}},
 
   // NRM2
   {"cublasSnrm2_v2",                 {"hipblasSnrm2",                    "rocblas_snrm2",                            CONV_LIB_FUNC, API_BLAS, 5}},


### PR DESCRIPTION
**[IMP]**
+ Mark rocBLAS TRMM functions `rocblas_(s|d|c|z)trmm_outofplace`, as supported only for TRMM v2 CUDA analogues (`HIP_SUPPORTED_V2_ONLY` - works for roc* APIs as well)
+ Mark hipBLAS TRMM functions `hipblas(S|D|C|Z)trmm` as `HIP_UNSUPPORTED`
+ Regenerate and update docs and hipify-perl accordingly

**[Reasons]**
+ hipBLAS TRMM functions `hipblas(S|D|C|Z)trmm`, actually, do not match neither cublas TRMM functions, nor cublas TRMM _v2 functions: https://github.com/ROCmSoftwarePlatform/hipBLAS/issues/524
+ There is a correspondence between cuBLAS `cublas(S|D|C|Z)trmm` and rocBLAS TRMM `rocblas_(s|d|c|z)trmm_outofplace`, not `rocblas_(s|d|c|z)trmm`: fixed it

**[ToDo]**
+ Close https://github.com/ROCmSoftwarePlatform/rocBLAS/issues/1265 as erroneous
+ Remove `HIP_UNSUPPORTED` mark from `hipblas(S|D|C|Z)trmm` functions after merging https://github.com/ROCmSoftwarePlatform/hipBLAS/pull/504
+ Add `cublas2rocblas` and update `cublas2hipblas` synthetic tests