### PR TITLE
[HIPIFY] Sync with CUDA 11.8 - Part 5 - BLAS & Device API

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -1383,6 +1383,8 @@ sub rocSubstitutions {
     subst("cublasSideMode_t", "rocblas_side", "type");
     subst("cublasStatus", "rocblas_status", "type");
     subst("cublasStatus_t", "rocblas_status", "type");
+    subst("cudaDataType", "rocblas_datatype", "type");
+    subst("cudaDataType_t", "rocblas_datatype_", "type");
     subst("CUBLAS_ATOMICS_ALLOWED", "rocblas_atomics_allowed", "numeric_literal");
     subst("CUBLAS_ATOMICS_NOT_ALLOWED", "rocblas_atomics_not_allowed", "numeric_literal");
     subst("CUBLAS_DIAG_NON_UNIT", "rocblas_diagonal_non_unit", "numeric_literal");
@@ -1409,6 +1411,22 @@ sub rocSubstitutions {
     subst("CUBLAS_STATUS_NOT_INITIALIZED", "rocblas_status_invalid_handle", "numeric_literal");
     subst("CUBLAS_STATUS_NOT_SUPPORTED", "rocblas_status_perf_degraded", "numeric_literal");
     subst("CUBLAS_STATUS_SUCCESS", "rocblas_status_success", "numeric_literal");
+    subst("CUDA_C_16BF", "rocblas_datatype_bf16_c", "numeric_literal");
+    subst("CUDA_C_16F", "rocblas_datatype_f16_c", "numeric_literal");
+    subst("CUDA_C_32F", "rocblas_datatype_f32_c", "numeric_literal");
+    subst("CUDA_C_32I", "rocblas_datatype_i32_c", "numeric_literal");
+    subst("CUDA_C_32U", "rocblas_datatype_u32_c", "numeric_literal");
+    subst("CUDA_C_64F", "rocblas_datatype_f64_c", "numeric_literal");
+    subst("CUDA_C_8I", "rocblas_datatype_i8_c", "numeric_literal");
+    subst("CUDA_C_8U", "rocblas_datatype_u8_c", "numeric_literal");
+    subst("CUDA_R_16BF", "rocblas_datatype_bf16_r", "numeric_literal");
+    subst("CUDA_R_16F", "rocblas_datatype_f16_r", "numeric_literal");
+    subst("CUDA_R_32F", "rocblas_datatype_f32_r", "numeric_literal");
+    subst("CUDA_R_32I", "rocblas_datatype_i32_r", "numeric_literal");
+    subst("CUDA_R_32U", "rocblas_datatype_u32_r", "numeric_literal");
+    subst("CUDA_R_64F", "rocblas_datatype_f64_r", "numeric_literal");
+    subst("CUDA_R_8I", "rocblas_datatype_i8_r", "numeric_literal");
+    subst("CUDA_R_8U", "rocblas_datatype_u8_r", "numeric_literal");
 }
 
 sub simpleSubstitutions {
@@ -5388,6 +5406,16 @@ sub warnUnsupportedDeviceFunctions {
         "__pm2",
         "__pm1",
         "__pm0",
+        "__nv_cvt_halfraw_to_fp8",
+        "__nv_cvt_halfraw2_to_fp8x2",
+        "__nv_cvt_fp8x2_to_halfraw2",
+        "__nv_cvt_fp8_to_halfraw",
+        "__nv_cvt_float_to_fp8",
+        "__nv_cvt_float2_to_fp8x2",
+        "__nv_cvt_double_to_fp8",
+        "__nv_cvt_double2_to_fp8x2",
+        "__nv_cvt_bfloat16raw_to_fp8",
+        "__nv_cvt_bfloat16raw2_to_fp8x2",
         "__isnanl",
         "__isnanf",
         "__isnan",
@@ -7724,12 +7752,6 @@ sub warnUnsupportedFunctions {
         "CUDNN_ADV_INFER_PATCH",
         "CUDNN_ADV_INFER_MINOR",
         "CUDNN_ADV_INFER_MAJOR",
-        "CUDA_R_64U",
-        "CUDA_R_64I",
-        "CUDA_R_4U",
-        "CUDA_R_4I",
-        "CUDA_R_16U",
-        "CUDA_R_16I",
         "CUDA_POINTER_ATTRIBUTE_P2P_TOKENS_v1",
         "CUDA_POINTER_ATTRIBUTE_P2P_TOKENS_st",
         "CUDA_POINTER_ATTRIBUTE_P2P_TOKENS",
@@ -7787,12 +7809,6 @@ sub warnUnsupportedFunctions {
         "CUDA_ERROR_DEVICE_NOT_LICENSED",
         "CUDA_ERROR_COMPAT_NOT_SUPPORTED_ON_DEVICE",
         "CUDA_EGL_MAX_PLANES",
-        "CUDA_C_64U",
-        "CUDA_C_64I",
-        "CUDA_C_4U",
-        "CUDA_C_4I",
-        "CUDA_C_16U",
-        "CUDA_C_16I",
         "CUDA_CB",
         "CUDA_BATCH_MEM_OP_NODE_PARAMS_st",
         "CUDA_BATCH_MEM_OP_NODE_PARAMS",
@@ -7944,6 +7960,20 @@ sub warnHipOnlyUnsupportedFunctions {
         "cublasCgelsBatched",
         "cublasAsumEx",
         "cublasAlloc",
+        "CUDA_R_8F_E5M2",
+        "CUDA_R_8F_E4M3",
+        "CUDA_R_64U",
+        "CUDA_R_64I",
+        "CUDA_R_4U",
+        "CUDA_R_4I",
+        "CUDA_R_16U",
+        "CUDA_R_16I",
+        "CUDA_C_64U",
+        "CUDA_C_64I",
+        "CUDA_C_4U",
+        "CUDA_C_4I",
+        "CUDA_C_16U",
+        "CUDA_C_16I",
         "CUBLAS_VER_PATCH",
         "CUBLAS_VER_MINOR",
         "CUBLAS_VER_MAJOR",
@@ -8100,6 +8130,20 @@ sub warnRocOnlyUnsupportedFunctions {
         "cublasCgelsBatched",
         "cublasAsumEx",
         "cublasAlloc",
+        "CUDA_R_8F_E5M2",
+        "CUDA_R_8F_E4M3",
+        "CUDA_R_64U",
+        "CUDA_R_64I",
+        "CUDA_R_4U",
+        "CUDA_R_4I",
+        "CUDA_R_16U",
+        "CUDA_R_16I",
+        "CUDA_C_64U",
+        "CUDA_C_64I",
+        "CUDA_C_4U",
+        "CUDA_C_4I",
+        "CUDA_C_16U",
+        "CUDA_C_16I",
         "CUBLAS_VER_PATCH",
         "CUBLAS_VER_MINOR",
         "CUBLAS_VER_MAJOR",

--- a/doc/markdown/CUBLAS_API_supported_by_HIP.md
+++ b/doc/markdown/CUBLAS_API_supported_by_HIP.md
@@ -140,6 +140,8 @@
 |`CUDA_R_64F`|8.0| | |`HIPBLAS_R_64F`|1.8.2| | | |
 |`CUDA_R_64I`|11.0| | | | | | | |
 |`CUDA_R_64U`|11.0| | | | | | | |
+|`CUDA_R_8F_E4M3`|11.8| | | | | | | |
+|`CUDA_R_8F_E5M2`|11.8| | | | | | | |
 |`CUDA_R_8I`|8.0| | |`HIPBLAS_R_8I`|3.0.0| | | |
 |`CUDA_R_8U`|8.0| | |`HIPBLAS_R_8U`|3.0.0| | | |
 |`cudaDataType`|8.0| | |`hipblasDatatype_t`|1.8.2| | | |

--- a/doc/markdown/CUDA_Device_API_supported_by_HIP.md
+++ b/doc/markdown/CUDA_Device_API_supported_by_HIP.md
@@ -275,6 +275,16 @@
 |`__mul24`| | | |`__mul24`|1.6.0| | | |
 |`__mul64hi`| | | |`__mul64hi`|1.6.0| | | |
 |`__mulhi`| | | |`__mulhi`|1.6.0| | | |
+|`__nv_cvt_bfloat16raw2_to_fp8x2`|11.8| | | | | | | |
+|`__nv_cvt_bfloat16raw_to_fp8`|11.8| | | | | | | |
+|`__nv_cvt_double2_to_fp8x2`|11.8| | | | | | | |
+|`__nv_cvt_double_to_fp8`|11.8| | | | | | | |
+|`__nv_cvt_float2_to_fp8x2`|11.8| | | | | | | |
+|`__nv_cvt_float_to_fp8`|11.8| | | | | | | |
+|`__nv_cvt_fp8_to_halfraw`|11.8| | | | | | | |
+|`__nv_cvt_fp8x2_to_halfraw2`|11.8| | | | | | | |
+|`__nv_cvt_halfraw2_to_fp8x2`|11.8| | | | | | | |
+|`__nv_cvt_halfraw_to_fp8`|11.8| | | | | | | |
 |`__pm0`| | | | | | | | |
 |`__pm1`| | | | | | | | |
 |`__pm2`| | | | | | | | |

--- a/src/CUDA2HIP_BLAS_API_types.cpp
+++ b/src/CUDA2HIP_BLAS_API_types.cpp
@@ -138,36 +138,38 @@ const std::map<llvm::StringRef, hipCounter> CUDA_BLAS_TYPE_NAME_MAP {
   {"CUBLAS_GEMM_ALGO15_TENSOR_OP",   {"HIPBLAS_GEMM_ALGO15_TENSOR_OP",   "",                                      CONV_NUMERIC_LITERAL, API_BLAS, 2, UNSUPPORTED}},  // 115
 
   // TODO: rename hipblasDatatype_t to hipDataType_t and move from hipBLAS to HIP
-  {"cudaDataType_t",                 {"hipblasDatatype_t",               "rocblas_datatype_",                     CONV_TYPE, API_RUNTIME, 3}},
-  {"cudaDataType",                   {"hipblasDatatype_t",               "rocblas_datatype",                      CONV_TYPE, API_RUNTIME, 3}},
-  {"CUDA_R_16F",                     {"HIPBLAS_R_16F",                   "rocblas_datatype_f16_r",                CONV_NUMERIC_LITERAL, API_RUNTIME, 3}}, //  2 // 150
-  {"CUDA_C_16F",                     {"HIPBLAS_C_16F",                   "rocblas_datatype_f16_c",                CONV_NUMERIC_LITERAL, API_RUNTIME, 3}}, //  6 // 153
-  {"CUDA_R_32F",                     {"HIPBLAS_R_32F",                   "rocblas_datatype_f32_r",                CONV_NUMERIC_LITERAL, API_RUNTIME, 3}}, //  0 // 151
-  {"CUDA_C_32F",                     {"HIPBLAS_C_32F",                   "rocblas_datatype_f32_c",                CONV_NUMERIC_LITERAL, API_RUNTIME, 3}}, //  4 // 154
-  {"CUDA_R_64F",                     {"HIPBLAS_R_64F",                   "rocblas_datatype_f64_r",                CONV_NUMERIC_LITERAL, API_RUNTIME, 3}}, //  1 // 152
-  {"CUDA_C_64F",                     {"HIPBLAS_C_64F",                   "rocblas_datatype_f64_c",                CONV_NUMERIC_LITERAL, API_RUNTIME, 3}}, //  5 // 155
-  {"CUDA_R_8I",                      {"HIPBLAS_R_8I",                    "rocblas_datatype_i8_r",                 CONV_NUMERIC_LITERAL, API_RUNTIME, 3}}, //  3 // 160
-  {"CUDA_C_8I",                      {"HIPBLAS_C_8I",                    "rocblas_datatype_i8_c",                 CONV_NUMERIC_LITERAL, API_RUNTIME, 3}}, //  7 // 164
-  {"CUDA_R_8U",                      {"HIPBLAS_R_8U",                    "rocblas_datatype_u8_r",                 CONV_NUMERIC_LITERAL, API_RUNTIME, 3}}, //  8 // 161
-  {"CUDA_C_8U",                      {"HIPBLAS_C_8U",                    "rocblas_datatype_u8_c",                 CONV_NUMERIC_LITERAL, API_RUNTIME, 3}}, //  9 // 165
-  {"CUDA_R_32I",                     {"HIPBLAS_R_32I",                   "rocblas_datatype_i32_r",                CONV_NUMERIC_LITERAL, API_RUNTIME, 3}}, // 10 // 162
-  {"CUDA_C_32I",                     {"HIPBLAS_C_32I",                   "rocblas_datatype_i32_c",                CONV_NUMERIC_LITERAL, API_RUNTIME, 3}}, // 11 // 166
-  {"CUDA_R_32U",                     {"HIPBLAS_R_32U",                   "rocblas_datatype_u32_r",                CONV_NUMERIC_LITERAL, API_RUNTIME, 3}}, // 12 // 163
-  {"CUDA_C_32U",                     {"HIPBLAS_C_32U",                   "rocblas_datatype_u32_c",                CONV_NUMERIC_LITERAL, API_RUNTIME, 3}}, // 13 // 167
-  {"CUDA_R_16BF",                    {"HIPBLAS_R_16B",                   "rocblas_datatype_bf16_r",               CONV_NUMERIC_LITERAL, API_RUNTIME, 3}}, // 14 // 168
-  {"CUDA_C_16BF",                    {"HIPBLAS_C_16B",                   "rocblas_datatype_bf16_c",               CONV_NUMERIC_LITERAL, API_RUNTIME, 3}}, // 15 // 169
-  {"CUDA_R_4I",                      {"HIPBLAS_R_4I",                    "",                                      CONV_NUMERIC_LITERAL, API_RUNTIME, 3, UNSUPPORTED}}, // 16
-  {"CUDA_C_4I",                      {"HIPBLAS_C_4I",                    "",                                      CONV_NUMERIC_LITERAL, API_RUNTIME, 3, UNSUPPORTED}}, // 17
-  {"CUDA_R_4U",                      {"HIPBLAS_R_4U",                    "",                                      CONV_NUMERIC_LITERAL, API_RUNTIME, 3, UNSUPPORTED}}, // 18
-  {"CUDA_C_4U",                      {"HIPBLAS_C_4U",                    "",                                      CONV_NUMERIC_LITERAL, API_RUNTIME, 3, UNSUPPORTED}}, // 19
-  {"CUDA_R_16I",                     {"HIPBLAS_R_16I",                   "",                                      CONV_NUMERIC_LITERAL, API_RUNTIME, 3, UNSUPPORTED}}, // 20
-  {"CUDA_C_16I",                     {"HIPBLAS_C_16I",                   "",                                      CONV_NUMERIC_LITERAL, API_RUNTIME, 3, UNSUPPORTED}}, // 21
-  {"CUDA_R_16U",                     {"HIPBLAS_R_16U",                   "",                                      CONV_NUMERIC_LITERAL, API_RUNTIME, 3, UNSUPPORTED}}, // 22
-  {"CUDA_C_16U",                     {"HIPBLAS_C_16U",                   "",                                      CONV_NUMERIC_LITERAL, API_RUNTIME, 3, UNSUPPORTED}}, // 23
-  {"CUDA_R_64I",                     {"HIPBLAS_R_64I",                   "",                                      CONV_NUMERIC_LITERAL, API_RUNTIME, 3, UNSUPPORTED}}, // 24
-  {"CUDA_C_64I",                     {"HIPBLAS_C_64I",                   "",                                      CONV_NUMERIC_LITERAL, API_RUNTIME, 3, UNSUPPORTED}}, // 25
-  {"CUDA_R_64U",                     {"HIPBLAS_R_64U",                   "",                                      CONV_NUMERIC_LITERAL, API_RUNTIME, 3, UNSUPPORTED}}, // 26
-  {"CUDA_C_64U",                     {"HIPBLAS_C_64U",                   "",                                      CONV_NUMERIC_LITERAL, API_RUNTIME, 3, UNSUPPORTED}}, // 27
+  {"cudaDataType_t",                 {"hipblasDatatype_t",               "rocblas_datatype_",                     CONV_TYPE, API_BLAS, 3}},
+  {"cudaDataType",                   {"hipblasDatatype_t",               "rocblas_datatype",                      CONV_TYPE, API_BLAS, 3}},
+  {"CUDA_R_16F",                     {"HIPBLAS_R_16F",                   "rocblas_datatype_f16_r",                CONV_NUMERIC_LITERAL, API_BLAS, 3}}, //  2 // 150
+  {"CUDA_C_16F",                     {"HIPBLAS_C_16F",                   "rocblas_datatype_f16_c",                CONV_NUMERIC_LITERAL, API_BLAS, 3}}, //  6 // 153
+  {"CUDA_R_32F",                     {"HIPBLAS_R_32F",                   "rocblas_datatype_f32_r",                CONV_NUMERIC_LITERAL, API_BLAS, 3}}, //  0 // 151
+  {"CUDA_C_32F",                     {"HIPBLAS_C_32F",                   "rocblas_datatype_f32_c",                CONV_NUMERIC_LITERAL, API_BLAS, 3}}, //  4 // 154
+  {"CUDA_R_64F",                     {"HIPBLAS_R_64F",                   "rocblas_datatype_f64_r",                CONV_NUMERIC_LITERAL, API_BLAS, 3}}, //  1 // 152
+  {"CUDA_C_64F",                     {"HIPBLAS_C_64F",                   "rocblas_datatype_f64_c",                CONV_NUMERIC_LITERAL, API_BLAS, 3}}, //  5 // 155
+  {"CUDA_R_8I",                      {"HIPBLAS_R_8I",                    "rocblas_datatype_i8_r",                 CONV_NUMERIC_LITERAL, API_BLAS, 3}}, //  3 // 160
+  {"CUDA_C_8I",                      {"HIPBLAS_C_8I",                    "rocblas_datatype_i8_c",                 CONV_NUMERIC_LITERAL, API_BLAS, 3}}, //  7 // 164
+  {"CUDA_R_8U",                      {"HIPBLAS_R_8U",                    "rocblas_datatype_u8_r",                 CONV_NUMERIC_LITERAL, API_BLAS, 3}}, //  8 // 161
+  {"CUDA_C_8U",                      {"HIPBLAS_C_8U",                    "rocblas_datatype_u8_c",                 CONV_NUMERIC_LITERAL, API_BLAS, 3}}, //  9 // 165
+  {"CUDA_R_32I",                     {"HIPBLAS_R_32I",                   "rocblas_datatype_i32_r",                CONV_NUMERIC_LITERAL, API_BLAS, 3}}, // 10 // 162
+  {"CUDA_C_32I",                     {"HIPBLAS_C_32I",                   "rocblas_datatype_i32_c",                CONV_NUMERIC_LITERAL, API_BLAS, 3}}, // 11 // 166
+  {"CUDA_R_32U",                     {"HIPBLAS_R_32U",                   "rocblas_datatype_u32_r",                CONV_NUMERIC_LITERAL, API_BLAS, 3}}, // 12 // 163
+  {"CUDA_C_32U",                     {"HIPBLAS_C_32U",                   "rocblas_datatype_u32_c",                CONV_NUMERIC_LITERAL, API_BLAS, 3}}, // 13 // 167
+  {"CUDA_R_16BF",                    {"HIPBLAS_R_16B",                   "rocblas_datatype_bf16_r",               CONV_NUMERIC_LITERAL, API_BLAS, 3}}, // 14 // 168
+  {"CUDA_C_16BF",                    {"HIPBLAS_C_16B",                   "rocblas_datatype_bf16_c",               CONV_NUMERIC_LITERAL, API_BLAS, 3}}, // 15 // 169
+  {"CUDA_R_4I",                      {"HIPBLAS_R_4I",                    "",                                      CONV_NUMERIC_LITERAL, API_BLAS, 3, UNSUPPORTED}}, // 16
+  {"CUDA_C_4I",                      {"HIPBLAS_C_4I",                    "",                                      CONV_NUMERIC_LITERAL, API_BLAS, 3, UNSUPPORTED}}, // 17
+  {"CUDA_R_4U",                      {"HIPBLAS_R_4U",                    "",                                      CONV_NUMERIC_LITERAL, API_BLAS, 3, UNSUPPORTED}}, // 18
+  {"CUDA_C_4U",                      {"HIPBLAS_C_4U",                    "",                                      CONV_NUMERIC_LITERAL, API_BLAS, 3, UNSUPPORTED}}, // 19
+  {"CUDA_R_16I",                     {"HIPBLAS_R_16I",                   "",                                      CONV_NUMERIC_LITERAL, API_BLAS, 3, UNSUPPORTED}}, // 20
+  {"CUDA_C_16I",                     {"HIPBLAS_C_16I",                   "",                                      CONV_NUMERIC_LITERAL, API_BLAS, 3, UNSUPPORTED}}, // 21
+  {"CUDA_R_16U",                     {"HIPBLAS_R_16U",                   "",                                      CONV_NUMERIC_LITERAL, API_BLAS, 3, UNSUPPORTED}}, // 22
+  {"CUDA_C_16U",                     {"HIPBLAS_C_16U",                   "",                                      CONV_NUMERIC_LITERAL, API_BLAS, 3, UNSUPPORTED}}, // 23
+  {"CUDA_R_64I",                     {"HIPBLAS_R_64I",                   "",                                      CONV_NUMERIC_LITERAL, API_BLAS, 3, UNSUPPORTED}}, // 24
+  {"CUDA_C_64I",                     {"HIPBLAS_C_64I",                   "",                                      CONV_NUMERIC_LITERAL, API_BLAS, 3, UNSUPPORTED}}, // 25
+  {"CUDA_R_64U",                     {"HIPBLAS_R_64U",                   "",                                      CONV_NUMERIC_LITERAL, API_BLAS, 3, UNSUPPORTED}}, // 26
+  {"CUDA_C_64U",                     {"HIPBLAS_C_64U",                   "",                                      CONV_NUMERIC_LITERAL, API_BLAS, 3, UNSUPPORTED}}, // 27
+  {"CUDA_R_8F_E4M3",                 {"HIPBLAS_R_8F_E4M3",               "",                                      CONV_NUMERIC_LITERAL, API_BLAS, 3, UNSUPPORTED}}, // 28
+  {"CUDA_R_8F_E5M2",                 {"HIPBLAS_R_8F_E5M2",               "",                                      CONV_NUMERIC_LITERAL, API_BLAS, 3, UNSUPPORTED}}, // 29
 
   {"cublasHandle_t",                 {"hipblasHandle_t",                 "rocblas_handle",                        CONV_TYPE, API_BLAS, 2}},
   // TODO: dereferencing: typedef struct cublasContext *cublasHandle_t;
@@ -290,6 +292,8 @@ const std::map<llvm::StringRef, cudaAPIversions> CUDA_BLAS_TYPE_NAME_VER_MAP {
   {"CUDA_C_64I",                                       {CUDA_110, CUDA_0, CUDA_0}},
   {"CUDA_R_64U",                                       {CUDA_110, CUDA_0, CUDA_0}},
   {"CUDA_C_64U",                                       {CUDA_110, CUDA_0, CUDA_0}},
+  {"CUDA_R_8F_E4M3",                                   {CUDA_118, CUDA_0, CUDA_0}},
+  {"CUDA_R_8F_E5M2",                                   {CUDA_118, CUDA_0, CUDA_0}},
 };
 
 const std::map<llvm::StringRef, hipAPIversions> HIP_BLAS_TYPE_NAME_VER_MAP {

--- a/src/CUDA2HIP_Device_functions.cpp
+++ b/src/CUDA2HIP_Device_functions.cpp
@@ -704,13 +704,34 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DEVICE_FUNCTION_MAP {
   // common functions
   {"__assert_fail",       {"__assert_fail",        "", CONV_DEVICE_FUNC, API_RUNTIME, 1}},
   {"__assertfail",        {"__assertfail",         "", CONV_DEVICE_FUNC, API_RUNTIME, 1}},
+  // fp8 functions
+  {"__nv_cvt_double_to_fp8",        {"__hip_cvt_double_to_fp8",         "", CONV_DEVICE_FUNC, API_RUNTIME, 1, HIP_UNSUPPORTED}},
+  {"__nv_cvt_double2_to_fp8x2",     {"__hip_cvt_double2_to_fp8x2",      "", CONV_DEVICE_FUNC, API_RUNTIME, 1, HIP_UNSUPPORTED}},
+  {"__nv_cvt_float_to_fp8",         {"__hip_cvt_float_to_fp8",          "", CONV_DEVICE_FUNC, API_RUNTIME, 1, HIP_UNSUPPORTED}},
+  {"__nv_cvt_float2_to_fp8x2",      {"__hip_cvt_float2_to_fp8x2",       "", CONV_DEVICE_FUNC, API_RUNTIME, 1, HIP_UNSUPPORTED}},
+  {"__nv_cvt_halfraw_to_fp8",       {"__hip_cvt_halfraw_to_fp8",        "", CONV_DEVICE_FUNC, API_RUNTIME, 1, HIP_UNSUPPORTED}},
+  {"__nv_cvt_halfraw2_to_fp8x2",    {"__hip_cvt_halfraw2_to_fp8x2",     "", CONV_DEVICE_FUNC, API_RUNTIME, 1, HIP_UNSUPPORTED}},
+  {"__nv_cvt_bfloat16raw_to_fp8",   {"__hip_cvt_bfloat16raw_to_fp8",    "", CONV_DEVICE_FUNC, API_RUNTIME, 1, HIP_UNSUPPORTED}},
+  {"__nv_cvt_bfloat16raw2_to_fp8x2",{"__hip_cvt_bfloat16raw2_to_fp8x2", "", CONV_DEVICE_FUNC, API_RUNTIME, 1, HIP_UNSUPPORTED}},
+  {"__nv_cvt_fp8_to_halfraw",       {"__hip_cvt_fp8_to_halfraw",        "", CONV_DEVICE_FUNC, API_RUNTIME, 1, HIP_UNSUPPORTED}},
+  {"__nv_cvt_fp8x2_to_halfraw2",    {"__hip_cvt_fp8x2_to_halfraw2",     "", CONV_DEVICE_FUNC, API_RUNTIME, 1, HIP_UNSUPPORTED}},
 };
 
 const std::map<llvm::StringRef, cudaAPIversions> CUDA_DEVICE_FUNCTION_VER_MAP {
-  {"__shfl",              {CUDA_75,  CUDA_90,  CUDA_0  }},
-  {"__shfl_up",           {CUDA_75,  CUDA_90,  CUDA_0  }},
-  {"__shfl_down",         {CUDA_75,  CUDA_90,  CUDA_0  }},
-  {"__shfl_xor",          {CUDA_75,  CUDA_90,  CUDA_0  }},
+  {"__shfl",                          {CUDA_75,  CUDA_90,  CUDA_0  }},
+  {"__shfl_up",                       {CUDA_75,  CUDA_90,  CUDA_0  }},
+  {"__shfl_down",                     {CUDA_75,  CUDA_90,  CUDA_0  }},
+  {"__shfl_xor",                      {CUDA_75,  CUDA_90,  CUDA_0  }},
+  {"__nv_cvt_double_to_fp8",          {CUDA_118, CUDA_0,   CUDA_0  }},
+  {"__nv_cvt_double2_to_fp8x2",       {CUDA_118, CUDA_0,   CUDA_0  }},
+  {"__nv_cvt_float_to_fp8",           {CUDA_118, CUDA_0,   CUDA_0  }},
+  {"__nv_cvt_float2_to_fp8x2",        {CUDA_118, CUDA_0,   CUDA_0  }},
+  {"__nv_cvt_halfraw_to_fp8",         {CUDA_118, CUDA_0,   CUDA_0  }},
+  {"__nv_cvt_halfraw2_to_fp8x2",      {CUDA_118, CUDA_0,   CUDA_0  }},
+  {"__nv_cvt_bfloat16raw_to_fp8",     {CUDA_118, CUDA_0,   CUDA_0  }},
+  {"__nv_cvt_bfloat16raw2_to_fp8x2",  {CUDA_118, CUDA_0,   CUDA_0  }},
+  {"__nv_cvt_fp8_to_halfraw",         {CUDA_118, CUDA_0,   CUDA_0  }},
+  {"__nv_cvt_fp8x2_to_halfraw2",      {CUDA_118, CUDA_0,   CUDA_0  }},
 };
 
 const std::map<llvm::StringRef, hipAPIversions> HIP_DEVICE_FUNCTION_VER_MAP {


### PR DESCRIPTION
+ Introduce CUDA's fp8 device functions
+ Update regenerated hipify-perl and CUDA2HIP Markdown docs accordingly
+ Minor fixes and formatting
