### PR TITLE
[HIPIFY][build][SWDEV-364233][fix] Wrong `RUNPATH` in hipify-clang executable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,12 +24,12 @@ if(MSVC AND MSVC_VERSION VERSION_LESS "1900")
 endif()
 
 include_directories(${LLVM_INCLUDE_DIRS})
-link_directories(${LLVM_LIBRARY_DIRS})
 add_definitions(${LLVM_DEFINITIONS})
 
 file(GLOB_RECURSE HIPIFY_SOURCES src/*.cpp)
 file(GLOB_RECURSE HIPIFY_HEADERS src/*.h)
 add_llvm_executable(hipify-clang ${HIPIFY_SOURCES} ${HIPIFY_HEADERS})
+target_link_directories(hipify-clang PRIVATE ${LLVM_LIBRARY_DIRS})
 
 set(CMAKE_CXX_COMPILER ${LLVM_TOOLS_BINARY_DIR}/clang++)
 set(CMAKE_C_COMPILER ${LLVM_TOOLS_BINARY_DIR}/clang)
@@ -131,7 +131,14 @@ install(
     PATTERN "openmp_wrappers" EXCLUDE)
 
 option(FILE_REORG_BACKWARD_COMPATIBILITY "Enable File Reorg with backward compatibility" ON)
+
 if(UNIX)
+
+    #get rid of any RPATH definations already
+    set_target_properties(hipify-clang PROPERTIES INSTALL_RPATH "")
+    #set RPATH for the binary
+    set_target_properties(hipify-clang PROPERTIES LINK_FLAGS "-Wl,--disable-new-dtags -Wl,--rpath,$ORIGIN/../lib" )
+
     if(FILE_REORG_BACKWARD_COMPATIBILITY)
         include(hipify-backward-compat.cmake)
     endif()


### PR DESCRIPTION
Correcting runpath of hipify-clang from
runpath to correct rpath

Signed-off-by: Ashutosh Mishra <ashutosh.mishra@amd.com>


Changes : 

1) Updated the link directories by removing 
link_directories(${LLVM_LIBRARY_DIRS})
and adding target_link_directories(hipify-clang PRIVATE ${LLVM_LIBRARY_DIRS})  because the documentation ( https://cmake.org/cmake/help/latest/command/link_directories.html) states that : " This command is rarely necessary and should be avoided where there are other choices"


2) Corrected the RPATH
     by removing the INSTALL_RPATH and using --disable-new-dtags


Tested for the corrected rpath