### PR TITLE
[HIPIFY][#584][DNN][MIOpen] cuDNN -> MIOpen - Part 2

### DIFF
--- a/src/CUDA2HIP_DNN_API_functions.cpp
+++ b/src/CUDA2HIP_DNN_API_functions.cpp
@@ -25,17 +25,18 @@ THE SOFTWARE.
 // Map of all functions
 const std::map<llvm::StringRef, hipCounter> CUDA_DNN_FUNCTION_MAP {
 
-  {"cudnnGetVersion",                                     {"hipdnnGetVersion",                                     "", CONV_LIB_FUNC, API_DNN, 2}},
+  // NOTE: MIOPEN_EXPORT miopenStatus_t miopenGetVersion(size_t* major, size_t* minor, size_t* patch) and size_t CUDNNWINAPI cudnnGetVersion(void) have different signatures
+  {"cudnnGetVersion",                                     {"hipdnnGetVersion",                                     "", CONV_LIB_FUNC, API_DNN, 2, ROC_UNSUPPORTED}},
   {"cudnnGetCudartVersion",                               {"hipdnnGetCudartVersion",                               "", CONV_LIB_FUNC, API_DNN, 2, HIP_UNSUPPORTED}},
   {"cudnnGetMaxDeviceVersion",                            {"hipdnnGetMaxDeviceVersion",                            "", CONV_LIB_FUNC, API_DNN, 2, HIP_UNSUPPORTED}},
   {"cudnnQueryRuntimeError",                              {"hipdnnQueryRuntimeError",                              "", CONV_LIB_FUNC, API_DNN, 2, HIP_UNSUPPORTED}},
   {"cudnnGetProperty",                                    {"hipdnnGetProperty",                                    "", CONV_LIB_FUNC, API_DNN, 2, HIP_UNSUPPORTED}},
-  {"cudnnGetErrorString",                                 {"hipdnnGetErrorString",                                 "", CONV_LIB_FUNC, API_DNN, 2}},
+  {"cudnnGetErrorString",                                 {"hipdnnGetErrorString",                                 "miopenGetErrorString",                                 CONV_LIB_FUNC, API_DNN, 2}},
   {"cudnnIm2Col",                                         {"hipdnnIm2Col",                                         "", CONV_LIB_FUNC, API_DNN, 2, HIP_UNSUPPORTED}},
-  {"cudnnCreate",                                         {"hipdnnCreate",                                         "", CONV_LIB_FUNC, API_DNN, 2}},
-  {"cudnnDestroy",                                        {"hipdnnDestroy",                                        "", CONV_LIB_FUNC, API_DNN, 2}},
-  {"cudnnSetStream",                                      {"hipdnnSetStream",                                      "", CONV_LIB_FUNC, API_DNN, 2}},
-  {"cudnnGetStream",                                      {"hipdnnGetStream",                                      "", CONV_LIB_FUNC, API_DNN, 2}},
+  {"cudnnCreate",                                         {"hipdnnCreate",                                         "miopenCreate",                                         CONV_LIB_FUNC, API_DNN, 2}},
+  {"cudnnDestroy",                                        {"hipdnnDestroy",                                        "miopenDestroy",                                        CONV_LIB_FUNC, API_DNN, 2}},
+  {"cudnnSetStream",                                      {"hipdnnSetStream",                                      "miopenSetStream",                                      CONV_LIB_FUNC, API_DNN, 2}},
+  {"cudnnGetStream",                                      {"hipdnnGetStream",                                      "miopenGetStream",                                      CONV_LIB_FUNC, API_DNN, 2}},
   {"cudnnSetCallback",                                    {"hipdnnSetCallback",                                    "", CONV_LIB_FUNC, API_DNN, 2, HIP_UNSUPPORTED}},
   {"cudnnGetCallback",                                    {"hipdnnGetCallback",                                    "", CONV_LIB_FUNC, API_DNN, 2, HIP_UNSUPPORTED}},
   {"cudnnAdvInferVersionCheck",                           {"hipdnnAdvInferVersionCheck",                           "", CONV_LIB_FUNC, API_DNN, 2, HIP_UNSUPPORTED}},

--- a/src/CUDA2HIP_DNN_API_types.cpp
+++ b/src/CUDA2HIP_DNN_API_types.cpp
@@ -773,7 +773,7 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DNN_TYPE_NAME_MAP {
 
   // cuDNN types
   {"cudnnContext",                                                   {"hipdnnContext",                                                   "", CONV_TYPE, API_DNN, 1, HIP_UNSUPPORTED}},
-  {"cudnnHandle_t",                                                  {"hipdnnHandle_t",                                                  "", CONV_TYPE, API_DNN, 1}},
+  {"cudnnHandle_t",                                                  {"hipdnnHandle_t",                                                  "miopenHandle_t",                                                  CONV_TYPE, API_DNN, 1}},
   {"cudnnTensorStruct",                                              {"hipdnnTensorStruct",                                              "", CONV_TYPE, API_DNN, 1, HIP_UNSUPPORTED}},
   {"cudnnTensorDescriptor_t",                                        {"hipdnnTensorDescriptor_t",                                        "", CONV_TYPE, API_DNN, 1}},
   {"cudnnConvolutionStruct",                                         {"hipdnnConvolutionStruct",                                         "", CONV_TYPE, API_DNN, 1, HIP_UNSUPPORTED}},

--- a/src/CUDA2HIP_Runtime_API_types.cpp
+++ b/src/CUDA2HIP_Runtime_API_types.cpp
@@ -182,7 +182,7 @@ const std::map<llvm::StringRef, hipCounter> CUDA_RUNTIME_TYPE_NAME_MAP {
   // the same - CUstream_st
   {"CUstream_st",                                                      {"ihipStream_t",                                             "", CONV_TYPE, API_RUNTIME, 36}},
   // CUstream
-  {"cudaStream_t",                                                     {"hipStream_t",                                              "", CONV_TYPE, API_RUNTIME, 36}},
+  {"cudaStream_t",                                                     {"hipStream_t",                                              "miopenAcceleratorQueue_t", CONV_TYPE, API_RUNTIME, 36}},
 
   // CUfunction
   {"cudaFunction_t",                                                   {"hipFunction_t",                                            "", CONV_TYPE, API_RUNTIME}},

--- a/src/HipifyAction.cpp
+++ b/src/HipifyAction.cpp
@@ -210,7 +210,7 @@ void HipifyAction::FindAndReplace(StringRef name,
   if (!bReplace) {
     return;
   }
-  StringRef repName = Statistics::isToRoc(found->second) ? found->second.rocName : found->second.hipName;
+  StringRef repName = Statistics::isToRoc(found->second) ? (found->second.rocName.empty() ? found->second.hipName : found->second.rocName) : found->second.hipName;
   auto &SM = getCompilerInstance().getSourceManager();
   ct::Replacement Rep(SM, sl, name.size(), repName.str());
   clang::FullSourceLoc fullSL(sl, SM);
@@ -359,7 +359,7 @@ void HipifyAction::InclusionDirective(clang::SourceLocation hash_loc,
   // Keep the same include type that the user gave.
   if (!exclude) {
     clang::SmallString<128> includeBuffer;
-    llvm::StringRef name = Statistics::isToRoc(found->second) ? found->second.rocName : found->second.hipName;
+    llvm::StringRef name = Statistics::isToRoc(found->second) ? (found->second.rocName.empty() ? found->second.hipName : found->second.rocName) : found->second.hipName;
     if (is_angled) newInclude = llvm::Twine("<" + name+ ">").toStringRef(includeBuffer);
     else           newInclude = llvm::Twine("\"" + name + "\"").toStringRef(includeBuffer);
   } else {

--- a/src/Statistics.cpp
+++ b/src/Statistics.cpp
@@ -349,7 +349,7 @@ void Statistics::setActive(const std::string &name) {
 }
 
 bool Statistics::isToRoc(const hipCounter &counter) {
-  return TranslateToRoc && (counter.apiType == API_BLAS || counter.apiType == API_DNN);
+  return TranslateToRoc && (counter.apiType == API_BLAS || counter.apiType == API_DNN || counter.apiType == API_RUNTIME);
 }
 
 bool Statistics::isHipExperimental(const hipCounter& counter) {

--- a/tests/unit_tests/synthetic/libraries/cudnn2miopen.cu
+++ b/tests/unit_tests/synthetic/libraries/cudnn2miopen.cu
@@ -26,5 +26,41 @@ int main() {
   cudnnStatus_t STATUS_INVALID_VALUE = CUDNN_STATUS_INVALID_VALUE;
   cudnnStatus_t STATUS_NOT_SUPPORTED = CUDNN_STATUS_NOT_SUPPORTED;
 
+  // CHECK: miopenStatus_t status;
+  cudnnStatus_t status;
+
+  // CHECK: miopenHandle_t handle;
+  cudnnHandle_t handle;
+
+  // CUDA: cudnnStatus_t CUDNNWINAPI cudnnCreate(cudnnHandle_t *handle);
+  // MIOPEN: MIOPEN_EXPORT miopenStatus_t miopenCreate(miopenHandle_t* handle);
+  // CHECK: status = miopenCreate(&handle);
+  status = cudnnCreate(&handle);
+
+  // CUDA: cudnnStatus_t CUDNNWINAPI cudnnDestroy(cudnnHandle_t handle);
+  // MIOPEN: MIOPEN_EXPORT miopenStatus_t miopenDestroy(miopenHandle_t handle);
+  // CHECK: status = miopenDestroy(handle);
+  status = cudnnDestroy(handle);
+
+  const char* const_ch = nullptr;
+
+  // CUDA: const char *CUDNNWINAPI cudnnGetErrorString(cudnnStatus_t status);
+  // MIOPEN: MIOPEN_EXPORT const char* miopenGetErrorString(miopenStatus_t error);
+  // CHECK: const_ch = miopenGetErrorString(status);
+  const_ch = cudnnGetErrorString(status);
+
+  // CHECK: miopenAcceleratorQueue_t streamId;
+  cudaStream_t streamId;
+
+  // CUDA: cudnnStatus_t CUDNNWINAPI cudnnSetStream(cudnnHandle_t handle, cudaStream_t streamId);
+  // MIOPEN: MIOPEN_EXPORT miopenStatus_t miopenSetStream(miopenHandle_t handle, miopenAcceleratorQueue_t streamID);
+  // CHECK: status = miopenSetStream(handle, streamId);
+  status = cudnnSetStream(handle, streamId);
+
+  // CUDA: cudnnStatus_t CUDNNWINAPI cudnnGetStream(cudnnHandle_t handle, cudaStream_t *streamId);
+  // MIOPEN: MIOPEN_EXPORT miopenStatus_t miopenGetStream(miopenHandle_t handle, miopenAcceleratorQueue_t* streamID);
+  // CHECK: status = miopenGetStream(handle, &streamId);
+  status = cudnnGetStream(handle, &streamId);
+
   return 0;
 }


### PR DESCRIPTION
+ Continued supporting hipification to MIOpen based on `miopen.h`
+ Updated the synthetic test `cudnn2miopen.cu` accordingly
+ MIOpen has its own types, equal to HIP ones but without any connection (like redefines, for instance):
  + Example: cudaStream_t / hipStream_t / miopenAcceleratorQueue_t
  + [Solution] Started to use the "roc" mapping for Runtime APIs as well, which is used only under the `--roc` option

**[ToDo]**
+ Form the above solution as a standalone function instead of an ad-hock workaround
+ Add the needed changes in the `hipify-perl` script generation
+ Start to generate yet another CUDA2HIP Markdown doc regarding cuDNN support in MIOpen
+ Decide what to do with the still being generated but not being published `CUDNN_API_supported_by_HIP.md` for cuDNN support in the obsolete hipDNN