### PR TITLE
[HIPIFY][SWDEV-310152][package][build][fix] Remove rpath from binary files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -136,8 +136,6 @@ if(UNIX)
 
     #get rid of any RPATH definations already
     set_target_properties(hipify-clang PROPERTIES INSTALL_RPATH "")
-    #set RPATH for the binary
-    set_target_properties(hipify-clang PROPERTIES LINK_FLAGS "-Wl,--disable-new-dtags -Wl,--rpath,$ORIGIN/../lib" )
 
     if(FILE_REORG_BACKWARD_COMPATIBILITY)
         include(hipify-backward-compat.cmake)


### PR DESCRIPTION
SWDEV-310152:
- Single version package: add ldconfig, no RPATH/RUNPATH in either binaries or libraries 
- Multi version package: use RPATH for binaries, no RPATH/RUNPATH for libraries 
- amdclang/clang/hipcc compilers shall not add RPATH/RUNPATH to produced binaries or libraries unless explicitly requested by an option

Versioning scripts will take care of adding rpath to binaries for multi version package