### PR TITLE
[HIPIFY][rocBLAS][fix] Sync with rocBLAS - data types only - Part 2 - final

### DIFF
--- a/src/CUDA2HIP_BLAS_API_types.cpp
+++ b/src/CUDA2HIP_BLAS_API_types.cpp
@@ -391,4 +391,12 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_BLAS_TYPE_NAME_VER_MAP {
   {"rocblas_datatype_u32_c",                           {HIP_2000, HIP_0,    HIP_0   }},
   {"rocblas_datatype_bf16_r",                          {HIP_3050, HIP_0,    HIP_0   }},
   {"rocblas_datatype_bf16_c",                          {HIP_3050, HIP_0,    HIP_0   }},
+  {"rocblas_pointer_mode",                             {HIP_1060, HIP_0,    HIP_0   }},
+  {"rocblas_pointer_mode_host",                        {HIP_1060, HIP_0,    HIP_0   }},
+  {"rocblas_pointer_mode_device",                      {HIP_1060, HIP_0,    HIP_0   }},
+  {"rocblas_atomics_mode",                             {HIP_3080, HIP_0,    HIP_0   }},
+  {"rocblas_atomics_not_allowed",                      {HIP_3080, HIP_0,    HIP_0   }},
+  {"rocblas_atomics_allowed",                          {HIP_3080, HIP_0,    HIP_0   }},
+  {"rocblas_gemm_algo",                                {HIP_1082, HIP_0,    HIP_0   }},
+  {"rocblas_gemm_algo_standard",                       {HIP_1082, HIP_0,    HIP_0   }},
 };

--- a/src/CUDA2HIP_Complex_API_types.cpp
+++ b/src/CUDA2HIP_Complex_API_types.cpp
@@ -24,9 +24,9 @@ THE SOFTWARE.
 
 // Maps the names of CUDA Complex API types to the corresponding HIP types
 const std::map<llvm::StringRef, hipCounter> CUDA_COMPLEX_TYPE_NAME_MAP {
-  {"cuFloatComplex",  {"hipFloatComplex",  "", CONV_TYPE, API_COMPLEX, 1}},
-  {"cuDoubleComplex", {"hipDoubleComplex", "", CONV_TYPE, API_COMPLEX, 1}},
-  {"cuComplex",       {"hipComplex",       "", CONV_TYPE, API_COMPLEX, 1}},
+  {"cuFloatComplex",  {"hipFloatComplex",  "rocblas_float_complex",  CONV_TYPE, API_COMPLEX, 1}},
+  {"cuDoubleComplex", {"hipDoubleComplex", "rocblas_double_complex", CONV_TYPE, API_COMPLEX, 1}},
+  {"cuComplex",       {"hipComplex",       "rocblas_float_complex",  CONV_TYPE, API_COMPLEX, 1}},
 };
 
 const std::map<llvm::StringRef, cudaAPIversions> CUDA_COMPLEX_TYPE_NAME_VER_MAP {

--- a/src/Statistics.cpp
+++ b/src/Statistics.cpp
@@ -349,7 +349,7 @@ void Statistics::setActive(const std::string &name) {
 }
 
 bool Statistics::isToRoc(const hipCounter &counter) {
-  return TranslateToRoc && (counter.apiType == API_BLAS || counter.apiType == API_DNN || counter.apiType == API_RUNTIME);
+  return TranslateToRoc && (counter.apiType == API_BLAS || counter.apiType == API_DNN || counter.apiType == API_RUNTIME || counter.apiType == API_COMPLEX);
 }
 
 bool Statistics::isHipExperimental(const hipCounter& counter) {


### PR DESCRIPTION
+ Finished syncing with the latest rocBLAS
+ Finished populating rocBLAS APIs with HIP versions
+ Provided roc-specific mappings:
    `cuComplex` -> `rocblas_float_complex`
    `cuFloatComplex` -> `rocblas_float_complex`
    `cuDoubleComplex` -> `rocblas_double_complex`

[ToDo]
+ [#643] Synthetic tests for full coverage of cuBLAS APIs supported by rocBLAS