### PR TITLE
[HIPIFY][#643][rocBLAS][test] Synthetic tests for full coverage of cuBLAS APIs supported by rocBLAS - Part 2

### DIFF
--- a/src/ArgParse.cpp
+++ b/src/ArgParse.cpp
@@ -79,6 +79,12 @@ cl::opt<bool> TranslateToRoc("roc",
   cl::value_desc("roc"),
   cl::cat(ToolTemplateCategory));
 
+cl::opt<bool> TranslateToMIOpen("miopen",
+  cl::desc("Translate to miopen instead of hip where it is possible"),
+  cl::value_desc("miopen"),
+  cl::init(false),
+  cl::cat(ToolTemplateCategory));
+
 cl::opt<bool> Inplace("inplace",
   cl::desc("Modify input file inplace, replacing input with hipified output, save backup in .prehip file"),
   cl::value_desc("inplace"),
@@ -187,6 +193,7 @@ const std::vector<std::string> hipifyOptions {
   std::string(GeneratePerl.ArgStr),
   std::string(GeneratePython.ArgStr),
   std::string(TranslateToRoc.ArgStr),
+  std::string(TranslateToMIOpen.ArgStr),
   std::string(GenerateMarkdown.ArgStr),
   std::string(GenerateCSV.ArgStr),
   std::string(NoBackup.ArgStr),

--- a/src/ArgParse.h
+++ b/src/ArgParse.h
@@ -50,6 +50,7 @@ extern cl::opt<std::string> OutputStatsFilename;
 extern cl::opt<bool> Examine;
 extern cl::extrahelp CommonHelp;
 extern cl::opt<bool> TranslateToRoc;
+extern cl::opt<bool> TranslateToMIOpen;
 extern cl::opt<bool> DashDash;
 extern cl::opt<bool> SkipExcludedPPConditionalBlocks;
 extern cl::opt<std::string> CudaGpuArch;

--- a/src/CUDA2HIP_Runtime_API_types.cpp
+++ b/src/CUDA2HIP_Runtime_API_types.cpp
@@ -182,7 +182,7 @@ const std::map<llvm::StringRef, hipCounter> CUDA_RUNTIME_TYPE_NAME_MAP {
   // the same - CUstream_st
   {"CUstream_st",                                                      {"ihipStream_t",                                             "", CONV_TYPE, API_RUNTIME, 36}},
   // CUstream
-  {"cudaStream_t",                                                     {"hipStream_t",                                              "miopenAcceleratorQueue_t", CONV_TYPE, API_RUNTIME, 36}},
+  {"cudaStream_t",                                                     {"hipStream_t",                                              "miopenAcceleratorQueue_t", CONV_TYPE, API_RUNTIME, 36, ROC_MIOPEN_ONLY}},
 
   // CUfunction
   {"cudaFunction_t",                                                   {"hipFunction_t",                                            "", CONV_TYPE, API_RUNTIME}},

--- a/src/Statistics.cpp
+++ b/src/Statistics.cpp
@@ -349,7 +349,8 @@ void Statistics::setActive(const std::string &name) {
 }
 
 bool Statistics::isToRoc(const hipCounter &counter) {
-  return TranslateToRoc && (counter.apiType == API_BLAS || counter.apiType == API_DNN || counter.apiType == API_RUNTIME || counter.apiType == API_COMPLEX);
+  return (counter.apiType == API_BLAS || counter.apiType == API_DNN || counter.apiType == API_RUNTIME || counter.apiType == API_COMPLEX) &&
+    ((TranslateToRoc && !TranslateToMIOpen && !isRocMiopenOnly(counter)) || TranslateToMIOpen);
 }
 
 bool Statistics::isHipExperimental(const hipCounter& counter) {
@@ -404,6 +405,10 @@ bool Statistics::isRemoved(const hipCounter &counter) {
 
 bool Statistics::isHipSupportedV2Only(const hipCounter& counter) {
   return HIP_SUPPORTED_V2_ONLY == (counter.supportDegree & HIP_SUPPORTED_V2_ONLY);
+}
+
+bool Statistics::isRocMiopenOnly(const hipCounter& counter) {
+  return ROC_MIOPEN_ONLY == (counter.supportDegree & ROC_MIOPEN_ONLY);
 }
 
 std::string Statistics::getCudaVersion(const cudaVersions& ver) {

--- a/src/Statistics.h
+++ b/src/Statistics.h
@@ -161,7 +161,8 @@ enum SupportDegree {
   HIP_REMOVED = 0x80,
   REMOVED = 0x100,
   HIP_EXPERIMENTAL = 0x200,
-  HIP_SUPPORTED_V2_ONLY = 0x400
+  HIP_SUPPORTED_V2_ONLY = 0x400,
+  ROC_MIOPEN_ONLY = 0x800
 };
 
 enum cudaVersions {
@@ -424,6 +425,8 @@ public:
   static bool isRemoved(const hipCounter& counter);
   // Check whether the counter is HIP_SUPPORTED_V2_ONLY or not.
   static bool isHipSupportedV2Only(const hipCounter& counter);
+  // Check whether the counter is ROC_MIOPEN_ONLY or not.
+  static bool isRocMiopenOnly(const hipCounter& counter);
   // Get string CUDA version.
   static std::string getCudaVersion(const cudaVersions &ver);
   // Get string HIP version.

--- a/tests/run_test.bat
+++ b/tests/run_test.bat
@@ -23,6 +23,10 @@ if %NUM% EQU 3 (
   set HIPIFY_OPTS=%6 %7 %8
   set NUM=%9
 )
+if %NUM% EQU 4 (
+  set HIPIFY_OPTS=%6 %7 %8 %9
+  set NUM=%10
+)
 
 call set clang_args=%%all_args:*%NUM%=%%
 set clang_args=%NUM%%clang_args%

--- a/tests/run_test.sh
+++ b/tests/run_test.sh
@@ -25,6 +25,10 @@ elif [ $NUM -eq 3 ]
 then
 HIPIFY_OPTS="$6 $7 $8"
 shift 8
+elif [ $NUM -eq 4 ]
+then
+HIPIFY_OPTS="$6 $7 $8 $9"
+shift 9
 fi
 
 test_dir=${IN_FILE%/*}

--- a/tests/unit_tests/synthetic/libraries/cublas2rocblas.cu
+++ b/tests/unit_tests/synthetic/libraries/cublas2rocblas.cu
@@ -84,6 +84,98 @@ int main() {
   cublasGemmAlgo_t blasGemmAlgo;
   cublasGemmAlgo_t BLAS_GEMM_DFALT = CUBLAS_GEMM_DFALT;
 
+  // CHECK: rocblas_handle blasHandle;
+  cublasHandle_t blasHandle;
+
+  // CUDA: cublasStatus CUBLASWINAPI cublasInit(void);
+  // ROC: ROCBLAS_EXPORT void rocblas_initialize(void);
+  // CHECK: blasStatus = rocblas_initialize();
+  blasStatus = cublasInit();
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasGetAtomicsMode(cublasHandle_t handle, cublasAtomicsMode_t* mode);
+  // ROC: ROCBLAS_EXPORT rocblas_status rocblas_get_atomics_mode(rocblas_handle handle, rocblas_atomics_mode* atomics_mode);
+  // CHECK: blasStatus = rocblas_get_atomics_mode(blasHandle, &blasAtomicsMode);
+  blasStatus = cublasGetAtomicsMode(blasHandle, &blasAtomicsMode);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasSetAtomicsMode(cublasHandle_t handle, cublasAtomicsMode_t mode);
+  // ROC: ROCBLAS_EXPORT rocblas_status rocblas_set_atomics_mode(rocblas_handle handle, rocblas_atomics_mode atomics_mode);
+  // CHECK: blasStatus = rocblas_set_atomics_mode(blasHandle, blasAtomicsMode);
+  blasStatus = cublasSetAtomicsMode(blasHandle, blasAtomicsMode);
+
+  const char* const_ch = nullptr;
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasCreate_v2(cublasHandle_t* handle);
+  // CUDA: #define cublasCreate cublasCreate_v2
+  // ROC: ROCBLAS_EXPORT rocblas_status rocblas_create_handle(rocblas_handle* handle);
+  // CHECK: blasStatus = rocblas_create_handle(&blasHandle);
+  // CHECK-NEXT: blasStatus = rocblas_create_handle(&blasHandle);
+  blasStatus = cublasCreate(&blasHandle);
+  blasStatus = cublasCreate_v2(&blasHandle);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasDestroy_v2(cublasHandle_t handle);
+  // CUDA: #define cublasDestroy cublasDestroy_v2
+  // ROC: ROCBLAS_EXPORT rocblas_status rocblas_destroy_handle(rocblas_handle handle);
+  // CHECK: blasStatus = rocblas_destroy_handle(blasHandle);
+  // CHECK-NEXT: blasStatus = rocblas_destroy_handle(blasHandle);
+  blasStatus = cublasDestroy(blasHandle);
+  blasStatus = cublasDestroy_v2(blasHandle);
+
+  // CHECK: hipStream_t stream;
+  cudaStream_t stream;
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasSetStream_v2(cublasHandle_t handle, cudaStream_t streamId);
+  // CUDA: #define cublasSetStream cublasSetStream_v2
+  // ROC: ROCBLAS_EXPORT rocblas_status rocblas_set_stream(rocblas_handle handle, hipStream_t stream);
+  // CHECK: blasStatus = rocblas_set_stream(blasHandle, stream);
+  // CHECK-NEXT: blasStatus = rocblas_set_stream(blasHandle, stream);
+  blasStatus = cublasSetStream(blasHandle, stream);
+  blasStatus = cublasSetStream_v2(blasHandle, stream);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasGetStream_v2(cublasHandle_t handle, cudaStream_t* streamId);
+  // CUDA: #define cublasGetStream cublasGetStream_v2
+  // HIP: ROCBLAS_EXPORT rocblas_status rocblas_get_stream(rocblas_handle handle, hipStream_t* stream);
+  // CHECK: blasStatus = rocblas_get_stream(blasHandle, &stream);
+  // CHECK-NEXT: blasStatus = rocblas_get_stream(blasHandle, &stream);
+  blasStatus = cublasGetStream(blasHandle, &stream);
+  blasStatus = cublasGetStream_v2(blasHandle, &stream);
+
+#if CUDA_VERSION >= 8000
+  // CHECK: rocblas_datatype DataType;
+  // CHECK-NEXT: rocblas_datatype_ DataType_t;
+  // CHECK-NEXT: rocblas_datatype blasDataType;
+  // CHECK-NEXT: rocblas_datatype R_16F = rocblas_datatype_f16_r;
+  // CHECK-NEXT: rocblas_datatype C_16F = rocblas_datatype_f16_c;
+  // CHECK-NEXT: rocblas_datatype R_32F = rocblas_datatype_f32_r;
+  // CHECK-NEXT: rocblas_datatype C_32F = rocblas_datatype_f32_c;
+  // CHECK-NEXT: rocblas_datatype R_64F = rocblas_datatype_f64_r;
+  // CHECK-NEXT: rocblas_datatype C_64F = rocblas_datatype_f64_c;
+  // CHECK-NEXT: rocblas_datatype R_8I = rocblas_datatype_i8_r;
+  // CHECK-NEXT: rocblas_datatype C_8I = rocblas_datatype_i8_c;
+  // CHECK-NEXT: rocblas_datatype R_8U = rocblas_datatype_u8_r;
+  // CHECK-NEXT: rocblas_datatype C_8U = rocblas_datatype_u8_c;
+  // CHECK-NEXT: rocblas_datatype R_32I = rocblas_datatype_i32_r;
+  // CHECK-NEXT: rocblas_datatype C_32I = rocblas_datatype_i32_c;
+  // CHECK-NEXT: rocblas_datatype R_32U = rocblas_datatype_u32_r;
+  // CHECK-NEXT: rocblas_datatype C_32U = rocblas_datatype_u32_c;
+  cudaDataType DataType;
+  cudaDataType_t DataType_t;
+  cublasDataType_t blasDataType;
+  cublasDataType_t R_16F = CUDA_R_16F;
+  cublasDataType_t C_16F = CUDA_C_16F;
+  cublasDataType_t R_32F = CUDA_R_32F;
+  cublasDataType_t C_32F = CUDA_C_32F;
+  cublasDataType_t R_64F = CUDA_R_64F;
+  cublasDataType_t C_64F = CUDA_C_64F;
+  cublasDataType_t R_8I = CUDA_R_8I;
+  cublasDataType_t C_8I = CUDA_C_8I;
+  cublasDataType_t R_8U = CUDA_R_8U;
+  cublasDataType_t C_8U = CUDA_C_8U;
+  cublasDataType_t R_32I = CUDA_R_32I;
+  cublasDataType_t C_32I = CUDA_C_32I;
+  cublasDataType_t R_32U = CUDA_R_32U;
+  cublasDataType_t C_32U = CUDA_C_32U;
+#endif
+
 #if CUDA_VERSION >= 9000
   // CHECK: rocblas_gemm_algo BLAS_GEMM_DEFAULT = rocblas_gemm_algo_standard;
   cublasGemmAlgo_t BLAS_GEMM_DEFAULT = CUBLAS_GEMM_DEFAULT;
@@ -95,6 +187,20 @@ int main() {
 
   // CHECK: rocblas_fill BLAS_FILL_MODE_FULL = rocblas_fill_full;
   cublasFillMode_t BLAS_FILL_MODE_FULL = CUBLAS_FILL_MODE_FULL;
+#endif
+
+#if CUDA_VERSION >= 11000
+  // CHECK: rocblas_datatype R_16BF = rocblas_datatype_bf16_r;
+  // CHECK-NEXT: rocblas_datatype C_16BF = rocblas_datatype_bf16_c;
+  cublasDataType_t R_16BF = CUDA_R_16BF;
+  cublasDataType_t C_16BF = CUDA_C_16BF;
+#endif
+
+#if CUDA_VERSION >= 11040
+  // CUDA: CUBLASAPI const char* CUBLASWINAPI cublasGetStatusString(cublasStatus_t status);
+  // ROC: ROCBLAS_EXPORT const char* rocblas_status_to_string(rocblas_status status);
+  // CHECK: const_ch = rocblas_status_to_string(blasStatus);
+  const_ch = cublasGetStatusString(blasStatus);
 #endif
 
   return 0;

--- a/tests/unit_tests/synthetic/libraries/cudnn2miopen.cu
+++ b/tests/unit_tests/synthetic/libraries/cudnn2miopen.cu
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %hipify_args 3 --skip-excluded-preprocessor-conditional-blocks --experimental -roc %clang_args -D__CUDA_API_VERSION_INTERNAL
+// RUN: %run_test hipify "%s" "%t" %hipify_args 4 --skip-excluded-preprocessor-conditional-blocks --experimental --roc --miopen %clang_args -D__CUDA_API_VERSION_INTERNAL
 
 // CHECK: #include <hip/hip_runtime.h>
 #include <cuda_runtime.h>


### PR DESCRIPTION
+ Introduced `--miopen` option for hipification to `MIOpen` (set to `false` by default); previously only `--roc` was used for both `ROC` and `MIOpen`
+ Introduced `ROC_MIOPEN_ONLY` flag for APIs which have to be hipified to `ROC`/`MIOpen` only if `--miopen` is set, otherwise such APIs will be hipified to `HIP`; it means that (at least currently) both options `--miopen` and `--roc` might be specified at once, and `MIOpen` hipification has priority over `ROC` ones
+ Updated run_test scripts to obtain more hipify-specific options
+ Added more synthetic tests for `cublas2rocblas.cu` synthetic tests
+ Add `--miopen` option for `cudnn2miopen.cu` synthetic tests

[ToDo]
+ Revise the ROC/MIOpen hipification logic in case of any conflicts in the future: if there are both ROC and MIOpen API for the same HIP API