### PR TITLE
[HIPIFY][hipBLAS][5.4.0] Sync with hipBLAS 5.4.0

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -1891,6 +1891,7 @@ sub simpleSubstitutions {
     subst("cublasCgbmv", "hipblasCgbmv", "library");
     subst("cublasCgbmv_v2", "hipblasCgbmv", "library");
     subst("cublasCgeam", "hipblasCgeam", "library");
+    subst("cublasCgelsBatched", "hipblasCgelsBatched", "library");
     subst("cublasCgemm", "hipblasCgemm", "library");
     subst("cublasCgemmBatched", "hipblasCgemmBatched", "library");
     subst("cublasCgemmStridedBatched", "hipblasCgemmStridedBatched", "library");
@@ -1982,6 +1983,7 @@ sub simpleSubstitutions {
     subst("cublasDgbmv", "hipblasDgbmv", "library");
     subst("cublasDgbmv_v2", "hipblasDgbmv", "library");
     subst("cublasDgeam", "hipblasDgeam", "library");
+    subst("cublasDgelsBatched", "hipblasDgelsBatched", "library");
     subst("cublasDgemm", "hipblasDgemm", "library");
     subst("cublasDgemmBatched", "hipblasDgemmBatched", "library");
     subst("cublasDgemmStridedBatched", "hipblasDgemmStridedBatched", "library");
@@ -2109,6 +2111,7 @@ sub simpleSubstitutions {
     subst("cublasSgbmv", "hipblasSgbmv", "library");
     subst("cublasSgbmv_v2", "hipblasSgbmv", "library");
     subst("cublasSgeam", "hipblasSgeam", "library");
+    subst("cublasSgelsBatched", "hipblasSgelsBatched", "library");
     subst("cublasSgemm", "hipblasSgemm", "library");
     subst("cublasSgemmBatched", "hipblasSgemmBatched", "library");
     subst("cublasSgemmStridedBatched", "hipblasSgemmStridedBatched", "library");
@@ -2187,6 +2190,7 @@ sub simpleSubstitutions {
     subst("cublasZgbmv", "hipblasZgbmv", "library");
     subst("cublasZgbmv_v2", "hipblasZgbmv", "library");
     subst("cublasZgeam", "hipblasZgeam", "library");
+    subst("cublasZgelsBatched", "hipblasZgelsBatched", "library");
     subst("cublasZgemm", "hipblasZgemm", "library");
     subst("cublasZgemmBatched", "hipblasZgemmBatched", "library");
     subst("cublasZgemmStridedBatched", "hipblasZgemmStridedBatched", "library");
@@ -7965,7 +7969,6 @@ sub warnHipOnlyUnsupportedFunctions {
         "cublasZtpttr",
         "cublasZmatinvBatched",
         "cublasZgemm3m",
-        "cublasZgelsBatched",
         "cublasXerbla",
         "cublasUint8gemmBias",
         "cublasSwapEx",
@@ -7976,7 +7979,6 @@ sub warnHipOnlyUnsupportedFunctions {
         "cublasSmatinvBatched",
         "cublasShutdown",
         "cublasSgemmEx",
-        "cublasSgelsBatched",
         "cublasSetSmCountTarget",
         "cublasSetMathMode",
         "cublasSetLoggerCallback",
@@ -8007,7 +8009,6 @@ sub warnHipOnlyUnsupportedFunctions {
         "cublasDtrmm",
         "cublasDtpttr",
         "cublasDmatinvBatched",
-        "cublasDgelsBatched",
         "cublasCtrttp",
         "cublasCtrmm_v2",
         "cublasCtrmm",
@@ -8024,7 +8025,6 @@ sub warnHipOnlyUnsupportedFunctions {
         "cublasCgemm3mEx",
         "cublasCgemm3mBatched",
         "cublasCgemm3m",
-        "cublasCgelsBatched",
         "cublasAsumEx",
         "cublasAlloc",
         "CUDA_R_8F_E5M2",

--- a/doc/markdown/CUBLAS_API_supported_by_HIP.md
+++ b/doc/markdown/CUBLAS_API_supported_by_HIP.md
@@ -554,7 +554,7 @@
 |`cublasAxpyEx`|8.0| | |`hipblasAxpyEx`|4.1.0| | | |
 |`cublasCdgmm`| | | |`hipblasCdgmm`|3.6.0| | | |
 |`cublasCgeam`| | | |`hipblasCgeam`|3.6.0| | | |
-|`cublasCgelsBatched`| | | | | | | | |
+|`cublasCgelsBatched`| | | |`hipblasCgelsBatched`|5.4.0| | | |
 |`cublasCgemmEx`|8.0| | | | | | | |
 |`cublasCgeqrfBatched`| | | |`hipblasCgeqrfBatched`|3.5.0| | | |
 |`cublasCgetrfBatched`| | | |`hipblasCgetrfBatched`|3.5.0| | | |
@@ -571,7 +571,7 @@
 |`cublasCtrttp`| | | | | | | | |
 |`cublasDdgmm`| | | |`hipblasDdgmm`|3.6.0| | | |
 |`cublasDgeam`| | | |`hipblasDgeam`|1.8.2| | | |
-|`cublasDgelsBatched`| | | | | | | | |
+|`cublasDgelsBatched`| | | |`hipblasDgelsBatched`|5.4.0| | | |
 |`cublasDgeqrfBatched`| | | |`hipblasDgeqrfBatched`|3.5.0| | | |
 |`cublasDgetrfBatched`| | | |`hipblasDgetrfBatched`|3.5.0| | | |
 |`cublasDgetriBatched`| | | |`hipblasDgetriBatched`|3.7.0| | | |
@@ -594,7 +594,7 @@
 |`cublasScalEx`|8.0| | |`hipblasScalEx`|4.1.0| | | |
 |`cublasSdgmm`| | | |`hipblasSdgmm`|3.6.0| | | |
 |`cublasSgeam`| | | |`hipblasSgeam`|1.8.2| | | |
-|`cublasSgelsBatched`| | | | | | | | |
+|`cublasSgelsBatched`| | | |`hipblasSgelsBatched`|5.4.0| | | |
 |`cublasSgemmEx`|7.5| | | | | | | |
 |`cublasSgeqrfBatched`| | | |`hipblasSgeqrfBatched`|3.5.0| | | |
 |`cublasSgetrfBatched`| | | |`hipblasSgetrfBatched`|3.5.0| | | |
@@ -608,7 +608,7 @@
 |`cublasUint8gemmBias`|8.0| | | | | | | |
 |`cublasZdgmm`| | | |`hipblasZdgmm`|3.6.0| | | |
 |`cublasZgeam`| | | |`hipblasZgeam`|3.6.0| | | |
-|`cublasZgelsBatched`| | | | | | | | |
+|`cublasZgelsBatched`| | | |`hipblasZgelsBatched`|5.4.0| | | |
 |`cublasZgeqrfBatched`| | | |`hipblasZgeqrfBatched`|3.5.0| | | |
 |`cublasZgetrfBatched`| | | |`hipblasZgetrfBatched`|3.5.0| | | |
 |`cublasZgetriBatched`| | | |`hipblasZgetriBatched`|3.7.0| | | |

--- a/src/CUDA2HIP_BLAS_API_functions.cpp
+++ b/src/CUDA2HIP_BLAS_API_functions.cpp
@@ -383,10 +383,10 @@ const std::map<llvm::StringRef, hipCounter> CUDA_BLAS_FUNCTION_MAP {
   {"cublasZgeqrfBatched",            {"hipblasZgeqrfBatched",            "",                                         CONV_LIB_FUNC, API_BLAS, 8, ROC_UNSUPPORTED}},
 
   // Least Square Min only m >= n and Non-transpose supported
-  {"cublasSgelsBatched",             {"hipblasSgelsBatched",             "",                                         CONV_LIB_FUNC, API_BLAS, 8, UNSUPPORTED}},
-  {"cublasDgelsBatched",             {"hipblasDgelsBatched",             "",                                         CONV_LIB_FUNC, API_BLAS, 8, UNSUPPORTED}},
-  {"cublasCgelsBatched",             {"hipblasCgelsBatched",             "",                                         CONV_LIB_FUNC, API_BLAS, 8, UNSUPPORTED}},
-  {"cublasZgelsBatched",             {"hipblasZgelsBatched",             "",                                         CONV_LIB_FUNC, API_BLAS, 8, UNSUPPORTED}},
+  {"cublasSgelsBatched",             {"hipblasSgelsBatched",             "",                                         CONV_LIB_FUNC, API_BLAS, 8, ROC_UNSUPPORTED}},
+  {"cublasDgelsBatched",             {"hipblasDgelsBatched",             "",                                         CONV_LIB_FUNC, API_BLAS, 8, ROC_UNSUPPORTED}},
+  {"cublasCgelsBatched",             {"hipblasCgelsBatched",             "",                                         CONV_LIB_FUNC, API_BLAS, 8, ROC_UNSUPPORTED}},
+  {"cublasZgelsBatched",             {"hipblasZgelsBatched",             "",                                         CONV_LIB_FUNC, API_BLAS, 8, ROC_UNSUPPORTED}},
 
   // DGMM
   {"cublasSdgmm",                    {"hipblasSdgmm",                    "rocblas_sdgmm",                            CONV_LIB_FUNC, API_BLAS, 8}},
@@ -1166,6 +1166,10 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_BLAS_FUNCTION_VER_MAP {
   {"rocblas_get_vector_async",                   {HIP_3050, HIP_0,    HIP_0   }},
   {"rocblas_set_matrix_async",                   {HIP_3050, HIP_0,    HIP_0   }},
   {"rocblas_get_matrix_async",                   {HIP_3050, HIP_0,    HIP_0   }},
+  {"hipblasSgelsBatched",                        {HIP_5040, HIP_0,    HIP_0   }},
+  {"hipblasDgelsBatched",                        {HIP_5040, HIP_0,    HIP_0   }},
+  {"hipblasCgelsBatched",                        {HIP_5040, HIP_0,    HIP_0   }},
+  {"hipblasZgelsBatched",                        {HIP_5040, HIP_0,    HIP_0   }},
 };
 
 const std::map<unsigned int, llvm::StringRef> CUDA_BLAS_API_SECTION_MAP {

--- a/tests/unit_tests/synthetic/libraries/cublas2hipblas.cu
+++ b/tests/unit_tests/synthetic/libraries/cublas2hipblas.cu
@@ -1529,6 +1529,28 @@ int main() {
   // CHECK: blasStatus = hipblasZdgmm(blasHandle, blasSideMode, m, n, &dcomplexa, lda, &dcomplexx, incx, &dcomplexC, ldc);
   blasStatus = cublasZdgmm(blasHandle, blasSideMode, m, n, &dcomplexa, lda, &dcomplexx, incx, &dcomplexC, ldc);
 
+  int deviceInfo = 0;
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasSgelsBatched(cublasHandle_t handle, cublasOperation_t trans, int m, int n, int nrhs, float* const Aarray[], int lda, float* const Carray[], int ldc, int* info, int* devInfoArray, int batchSize);
+  // HIP: HIPBLAS_EXPORT hipblasStatus_t hipblasSgelsBatched(hipblasHandle_t handle, hipblasOperation_t trans, const int m, const int n, const int nrhs, float* const A[], const int lda, float* const B[], const int ldb, int* info, int* deviceInfo, const int batchCount);
+  // CHECK: blasStatus = hipblasSgelsBatched(blasHandle, blasOperation, m, n, nrhs, fAarray, lda, fCarray, ldc, &info, &deviceInfo, batchCount);
+  blasStatus = cublasSgelsBatched(blasHandle, blasOperation, m, n, nrhs, fAarray, lda, fCarray, ldc, &info, &deviceInfo, batchCount);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasDgelsBatched(cublasHandle_t handle, cublasOperation_t trans, int m, int n, int nrhs, double* const Aarray[], int lda, double* const Carray[], int ldc, int* info, int* devInfoArray, int batchSize);
+  // HIP: HIPBLAS_EXPORT hipblasStatus_t hipblasDgelsBatched(hipblasHandle_t handle, hipblasOperation_t trans, const int m, const int n, const int nrhs, double* const A[], const int lda, double* const B[], const int ldb, int* info, int* deviceInfo, const int batchCount);
+  // CHECK: blasStatus = hipblasDgelsBatched(blasHandle, blasOperation, m, n, nrhs, dAarray, lda, dCarray, ldc, &info, &deviceInfo, batchCount);
+  blasStatus = cublasDgelsBatched(blasHandle, blasOperation, m, n, nrhs, dAarray, lda, dCarray, ldc, &info, &deviceInfo, batchCount);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasCgelsBatched(cublasHandle_t handle, cublasOperation_t trans, int m, int n, int nrhs, cuComplex* const Aarray[], int lda, cuComplex* const Carray[], int ldc, int* info, int* devInfoArray, int batchSize);
+  // HIP: HIPBLAS_EXPORT hipblasStatus_t hipblasCgelsBatched(hipblasHandle_t handle, hipblasOperation_t trans, const int m, const int n, const int nrhs, hipblasComplex* const A[], const int lda, hipblasComplex* const B[], const int ldb, int* info, int* deviceInfo, const int batchCount);
+  // CHECK: blasStatus = hipblasCgelsBatched(blasHandle, blasOperation, m, n, nrhs, complexAarray, lda, complexCarray, ldc, &info, &deviceInfo, batchCount);
+  blasStatus = cublasCgelsBatched(blasHandle, blasOperation, m, n, nrhs, complexAarray, lda, complexCarray, ldc, &info, &deviceInfo, batchCount);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasZgelsBatched(cublasHandle_t handle, cublasOperation_t trans, int m, int n, int nrhs, cuDoubleComplex* const Aarray[], int lda, cuDoubleComplex* const Carray[], int ldc, int* info, int* devInfoArray, int batchSize);
+  // HIP: HIPBLAS_EXPORT hipblasStatus_t hipblasZgelsBatched(hipblasHandle_t handle, hipblasOperation_t trans, const int m, const int n, const int nrhs, hipblasDoubleComplex* const A[], const int lda, hipblasDoubleComplex* const B[], const int ldb, int* info, int* deviceInfo, const int batchCount);
+  // CHECK: blasStatus = hipblasZgelsBatched(blasHandle, blasOperation, m, n, nrhs, dcomplexAarray, lda, dcomplexCarray, ldc, &info, &deviceInfo, batchCount);
+  blasStatus = cublasZgelsBatched(blasHandle, blasOperation, m, n, nrhs, dcomplexAarray, lda, dcomplexCarray, ldc, &info, &deviceInfo, batchCount);
+
   long long int strideA = 0;
   long long int strideB = 0;
   long long int strideC = 0;


### PR DESCRIPTION
+ Update hipify-perl, CUBLAS_API_supported_by_HIP.md, and the corresponding synthetic test cublas2hipblas.cu
