### PR TITLE
[HIPIFY][hipSPARSE][5.4.0] Sync with hipSPARSE 5.4.0

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -2548,6 +2548,8 @@ sub simpleSubstitutions {
     subst("cusparseCreateSpVec", "hipsparseCreateSpVec", "library");
     subst("cusparseCscSetPointers", "hipsparseCscSetPointers", "library");
     subst("cusparseCsctr", "hipsparseCsctr", "library");
+    subst("cusparseCsr2cscEx2", "hipsparseCsr2cscEx2", "library");
+    subst("cusparseCsr2cscEx2_bufferSize", "hipsparseCsr2cscEx2_bufferSize", "library");
     subst("cusparseCsrGet", "hipsparseCsrGet", "library");
     subst("cusparseCsrSetPointers", "hipsparseCsrSetPointers", "library");
     subst("cusparseCsrSetStridedBatch", "hipsparseCsrSetStridedBatch", "library");
@@ -3441,6 +3443,7 @@ sub simpleSubstitutions {
     subst("curandStatus_t", "hiprandStatus_t", "type");
     subst("cusparseAction_t", "hipsparseAction_t", "type");
     subst("cusparseColorInfo_t", "hipsparseColorInfo_t", "type");
+    subst("cusparseCsr2CscAlg_t", "hipsparseCsr2CscAlg_t", "type");
     subst("cusparseDiagType_t", "hipsparseDiagType_t", "type");
     subst("cusparseDirection_t", "hipsparseDirection_t", "type");
     subst("cusparseDnMatDescr", "hipsparseDnMatDescr", "type");
@@ -3769,6 +3772,8 @@ sub simpleSubstitutions {
     subst("CUSPARSE_COOMM_ALG2", "HIPSPARSE_COOMM_ALG2", "numeric_literal");
     subst("CUSPARSE_COOMM_ALG3", "HIPSPARSE_COOMM_ALG3", "numeric_literal");
     subst("CUSPARSE_COOMV_ALG", "HIPSPARSE_COOMV_ALG", "numeric_literal");
+    subst("CUSPARSE_CSR2CSC_ALG1", "HIPSPARSE_CSR2CSC_ALG1", "numeric_literal");
+    subst("CUSPARSE_CSR2CSC_ALG2", "HIPSPARSE_CSR2CSC_ALG2", "numeric_literal");
     subst("CUSPARSE_CSRMM_ALG1", "HIPSPARSE_CSRMM_ALG1", "numeric_literal");
     subst("CUSPARSE_CSRMV_ALG1", "HIPSPARSE_CSRMV_ALG1", "numeric_literal");
     subst("CUSPARSE_CSRMV_ALG2", "HIPSPARSE_CSRMV_ALG2", "numeric_literal");
@@ -5702,10 +5707,7 @@ sub warnUnsupportedFunctions {
         "cusparseCsrmvEx_bufferSize",
         "cusparseCsrmvEx",
         "cusparseCsrilu0Ex",
-        "cusparseCsr2cscEx2_bufferSize",
-        "cusparseCsr2cscEx2",
         "cusparseCsr2cscEx",
-        "cusparseCsr2CscAlg_t",
         "cusparseCscGet",
         "cusparseCreateSolveAnalysisInfo",
         "cusparseContext",
@@ -7205,8 +7207,6 @@ sub warnUnsupportedFunctions {
         "CUSPARSE_SIDE_RIGHT",
         "CUSPARSE_SIDE_LEFT",
         "CUSPARSE_DENSETOSPARSE_ALG_DEFAULT",
-        "CUSPARSE_CSR2CSC_ALG2",
-        "CUSPARSE_CSR2CSC_ALG1",
         "CUSPARSE_ALG_NAIVE",
         "CUSPARSE_ALG_MERGE_PATH",
         "CUSPARSE_ALG1",

--- a/doc/markdown/CUSPARSE_API_supported_by_HIP.md
+++ b/doc/markdown/CUSPARSE_API_supported_by_HIP.md
@@ -14,8 +14,8 @@
 |`CUSPARSE_COOMM_ALG2`|10.1|11.0| |`HIPSPARSE_COOMM_ALG2`|4.2.0| | | |
 |`CUSPARSE_COOMM_ALG3`|10.1|11.0| |`HIPSPARSE_COOMM_ALG3`|4.2.0| | | |
 |`CUSPARSE_COOMV_ALG`|10.2|11.2| |`HIPSPARSE_COOMV_ALG`|4.1.0| | | |
-|`CUSPARSE_CSR2CSC_ALG1`|10.1| | | | | | | |
-|`CUSPARSE_CSR2CSC_ALG2`|10.1| | | | | | | |
+|`CUSPARSE_CSR2CSC_ALG1`|10.1| | |`HIPSPARSE_CSR2CSC_ALG1`|5.4.0| | | |
+|`CUSPARSE_CSR2CSC_ALG2`|10.1| | |`HIPSPARSE_CSR2CSC_ALG2`|5.4.0| | | |
 |`CUSPARSE_CSRMM_ALG1`|10.2|11.0| |`HIPSPARSE_CSRMM_ALG1`|4.2.0| | | |
 |`CUSPARSE_CSRMV_ALG1`|10.2|11.2| |`HIPSPARSE_CSRMV_ALG1`|4.1.0| | | |
 |`CUSPARSE_CSRMV_ALG2`|10.2|11.2| |`HIPSPARSE_CSRMV_ALG2`|4.1.0| | | |
@@ -48,7 +48,7 @@
 |`CUSPARSE_OPERATION_CONJUGATE_TRANSPOSE`| | | |`HIPSPARSE_OPERATION_CONJUGATE_TRANSPOSE`|1.9.2| | | |
 |`CUSPARSE_OPERATION_NON_TRANSPOSE`| | | |`HIPSPARSE_OPERATION_NON_TRANSPOSE`|1.9.2| | | |
 |`CUSPARSE_OPERATION_TRANSPOSE`| | | |`HIPSPARSE_OPERATION_TRANSPOSE`|1.9.2| | | |
-|`CUSPARSE_ORDER_COL`|10.1| | |`HIPSPARSE_ORDER_COL`|4.2.0| | | |
+|`CUSPARSE_ORDER_COL`|10.1| | |`HIPSPARSE_ORDER_COL`|5.4.0| | | |
 |`CUSPARSE_ORDER_ROW`|10.1| | |`HIPSPARSE_ORDER_ROW`|4.2.0| | | |
 |`CUSPARSE_POINTER_MODE_DEVICE`| | | |`HIPSPARSE_POINTER_MODE_DEVICE`|1.9.2| | | |
 |`CUSPARSE_POINTER_MODE_HOST`| | | |`HIPSPARSE_POINTER_MODE_HOST`|1.9.2| | | |
@@ -125,7 +125,7 @@
 |`cusparseColorInfo`| | | | | | | | |
 |`cusparseColorInfo_t`| | | |`hipsparseColorInfo_t`|4.5.0| | | |
 |`cusparseContext`| | | | | | | | |
-|`cusparseCsr2CscAlg_t`|10.1| | | | | | | |
+|`cusparseCsr2CscAlg_t`|10.1| | |`hipsparseCsr2CscAlg_t`|5.4.0| | | |
 |`cusparseDenseToSparseAlg_t`|11.1| | | | | | | |
 |`cusparseDiagType_t`| | | |`hipsparseDiagType_t`|1.9.2| | | |
 |`cusparseDirection_t`| | | |`hipsparseDirection_t`|3.2.0| | | |
@@ -637,8 +637,8 @@
 |`cusparseCreateCsru2csrInfo`| | | |`hipsparseCreateCsru2csrInfo`|4.2.0| | | |
 |`cusparseCreateIdentityPermutation`| | | |`hipsparseCreateIdentityPermutation`|1.9.2| | | |
 |`cusparseCsr2cscEx`|8.0|10.2|11.0| | | | | |
-|`cusparseCsr2cscEx2`|10.1| | | | | | | |
-|`cusparseCsr2cscEx2_bufferSize`|10.1| | | | | | | |
+|`cusparseCsr2cscEx2`|10.1| | |`hipsparseCsr2cscEx2`|5.4.0| | | |
+|`cusparseCsr2cscEx2_bufferSize`|10.1| | |`hipsparseCsr2cscEx2_bufferSize`|5.4.0| | | |
 |`cusparseDbsr2csr`| | | |`hipsparseDbsr2csr`|3.5.0| | | |
 |`cusparseDcsc2dense`| |11.1| |`hipsparseDcsc2dense`|3.5.0| | | |
 |`cusparseDcsc2hyb`| |10.2|11.0| | | | | |

--- a/src/CUDA2HIP_SPARSE_API_functions.cpp
+++ b/src/CUDA2HIP_SPARSE_API_functions.cpp
@@ -576,8 +576,8 @@ const std::map<llvm::StringRef, hipCounter> CUDA_SPARSE_FUNCTION_MAP {
   {"cusparseZcsr2csc",                                  {"hipsparseZcsr2csc",                                  "", CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED | CUDA_REMOVED}},
 
   {"cusparseCsr2cscEx",                                 {"hipsparseCsr2cscEx",                                 "", CONV_LIB_FUNC, API_SPARSE, 14, HIP_UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED}},
-  {"cusparseCsr2cscEx2",                                {"hipsparseCsr2cscEx2",                                "", CONV_LIB_FUNC, API_SPARSE, 14, HIP_UNSUPPORTED}},
-  {"cusparseCsr2cscEx2_bufferSize",                     {"hipsparseCsr2cscEx2_bufferSize",                     "", CONV_LIB_FUNC, API_SPARSE, 14, HIP_UNSUPPORTED}},
+  {"cusparseCsr2cscEx2",                                {"hipsparseCsr2cscEx2",                                "", CONV_LIB_FUNC, API_SPARSE, 14}},
+  {"cusparseCsr2cscEx2_bufferSize",                     {"hipsparseCsr2cscEx2_bufferSize",                     "", CONV_LIB_FUNC, API_SPARSE, 14}},
 
   {"cusparseScsr2dense",                                {"hipsparseScsr2dense",                                "", CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED}},
   {"cusparseDcsr2dense",                                {"hipsparseDcsr2dense",                                "", CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED}},
@@ -1741,6 +1741,8 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_SPARSE_FUNCTION_VER_MAP {
   {"hipsparseCsrSetStridedBatch",                        {HIP_5020, HIP_0,    HIP_0   }},
   {"hipsparseDnMatGetStridedBatch",                      {HIP_5020, HIP_0,    HIP_0   }},
   {"hipsparseDnMatSetStridedBatch",                      {HIP_5020, HIP_0,    HIP_0   }},
+  {"hipsparseCsr2cscEx2_bufferSize",                     {HIP_5040, HIP_0,    HIP_0   }},
+  {"hipsparseCsr2cscEx2",                                {HIP_5040, HIP_0,    HIP_0   }},
 };
 
 const std::map<unsigned int, llvm::StringRef> CUDA_SPARSE_API_SECTION_MAP {

--- a/src/CUDA2HIP_SPARSE_API_types.cpp
+++ b/src/CUDA2HIP_SPARSE_API_types.cpp
@@ -160,9 +160,9 @@ const std::map<llvm::StringRef, hipCounter> CUDA_SPARSE_TYPE_NAME_MAP {
   {"CUSPARSE_STATUS_NOT_SUPPORTED",             {"HIPSPARSE_STATUS_NOT_SUPPORTED",             "", CONV_NUMERIC_LITERAL, API_SPARSE, 4}},
   {"CUSPARSE_STATUS_INSUFFICIENT_RESOURCES",    {"HIPSPARSE_STATUS_INSUFFICIENT_RESOURCES",    "", CONV_NUMERIC_LITERAL, API_SPARSE, 4}},
 
-  {"cusparseCsr2CscAlg_t",                      {"hipsparseCsr2CscAlg_t",                      "", CONV_TYPE, API_SPARSE, 4, HIP_UNSUPPORTED}},
-  {"CUSPARSE_CSR2CSC_ALG1",                     {"HIPSPARSE_CSR2CSC_ALG1",                     "", CONV_NUMERIC_LITERAL, API_SPARSE, 4, HIP_UNSUPPORTED}},
-  {"CUSPARSE_CSR2CSC_ALG2",                     {"HIPSPARSE_CSR2CSC_ALG2",                     "", CONV_NUMERIC_LITERAL, API_SPARSE, 4, HIP_UNSUPPORTED}},
+  {"cusparseCsr2CscAlg_t",                      {"hipsparseCsr2CscAlg_t",                      "", CONV_TYPE, API_SPARSE, 4}},
+  {"CUSPARSE_CSR2CSC_ALG1",                     {"HIPSPARSE_CSR2CSC_ALG1",                     "", CONV_NUMERIC_LITERAL, API_SPARSE, 4}},
+  {"CUSPARSE_CSR2CSC_ALG2",                     {"HIPSPARSE_CSR2CSC_ALG2",                     "", CONV_NUMERIC_LITERAL, API_SPARSE, 4}},
 
   {"cusparseFormat_t",                          {"hipsparseFormat_t",                          "", CONV_TYPE, API_SPARSE, 4}},
   {"CUSPARSE_FORMAT_CSR",                       {"HIPSPARSE_FORMAT_CSR",                       "", CONV_NUMERIC_LITERAL, API_SPARSE, 4}},
@@ -450,7 +450,7 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_SPARSE_TYPE_NAME_VER_MAP {
   {"hipsparseDnMatDescr",                        {HIP_4020, HIP_0,    HIP_0   }},
   {"hipsparseDnMatDescr_t",                      {HIP_4020, HIP_0,    HIP_0   }},
   {"hipsparseOrder_t",                           {HIP_4020, HIP_0,    HIP_0   }},
-  {"HIPSPARSE_ORDER_COL",                        {HIP_4020, HIP_0,    HIP_0   }},
+  {"HIPSPARSE_ORDER_COL",                        {HIP_5040, HIP_0,    HIP_0   }},
   {"HIPSPARSE_ORDER_ROW",                        {HIP_4020, HIP_0,    HIP_0   }},
   {"hipsparseSpMMAlg_t",                         {HIP_4020, HIP_0,    HIP_0   }},
   {"HIPSPARSE_MM_ALG_DEFAULT",                   {HIP_4020, HIP_0,    HIP_0   }},
@@ -491,4 +491,8 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_SPARSE_TYPE_NAME_VER_MAP {
   {"hipsparseSpMatAttribute_t",                  {HIP_4050, HIP_0,    HIP_0   }},
   {"HIPSPARSE_SPMAT_FILL_MODE",                  {HIP_4050, HIP_0,    HIP_0   }},
   {"HIPSPARSE_SPMAT_DIAG_TYPE",                  {HIP_4050, HIP_0,    HIP_0   }},
+  {"hipsparseCsr2CscAlg_t",                      {HIP_5040, HIP_0,    HIP_0   }},
+  {"HIPSPARSE_CSR2CSC_ALG1",                     {HIP_5040, HIP_0,    HIP_0   }},
+  {"HIPSPARSE_CSR2CSC_ALG2",                     {HIP_5040, HIP_0,    HIP_0   }},
+  {"HIPSPARSE_ORDER_COLUMN",                     {HIP_4020, HIP_5040, HIP_0   }},
 };


### PR DESCRIPTION
+ Updated hipify-perl and CUSPARSE_API_supported_by_HIP.md
