### PR TITLE
[HIPIFY][#693][Win][MSVS][fix] Explicitly set `--target=x86_64-pc-windows-msvc` for LLVM >= 16

### DIFF
--- a/README.md
+++ b/README.md
@@ -574,9 +574,7 @@ Testing Time: 6.94s
 | 12.0.0 - 13.0.1 | 7.0 - 11.5.1 | 7.6.5  - 8.3.2 | 2017.15.9.43, 2019.16.11.9               | 3.22.2         | 3.10.2       |
 | 14.0.0 - 14.0.6 | 7.0 - 11.7.1 | 8.0.5  - 8.4.1 | 2017.15.9.49, 2019.16.11.17, 2022.17.2.6 | 3.24.0         | 3.10.6       |
 | 15.0.0 - 15.0.6 | 7.0 - 11.8.0 | 8.0.5  - 8.6.0 | 2017.15.9.51, 2019.16.11.21, 2022.17.4.2 | 3.25.1         | 3.11.1       |
-| 16.0.0git*      | 7.0 - 11.8.0 | 8.0.5  - 8.6.0 | 2017.15.9.51, 2019.16.11.21, 2022.17.4.2 | 3.25.1         | 3.11.1       |
-
-`*` There is an issue with the trunk LLVM ([#693](https://github.com/ROCm-Developer-Tools/HIPIFY/issues/693)) which is under investigation, so it is strongly recommended to use the latest stable LLVM release 15.0.6.
+| 16.0.0git       | 7.0 - 11.8.0 | 8.0.5  - 8.6.0 | 2017.15.9.51, 2019.16.11.21, 2022.17.4.2 | 3.25.1         | 3.11.1       |
 
 *Building with testing support by `Visual Studio 17 2022` on `Windows 10`:*
 

--- a/src/LLVMCompat.cpp
+++ b/src/LLVMCompat.cpp
@@ -159,4 +159,11 @@ Memory_Buffer getMemoryBuffer(const clang::SourceManager &SM) {
 #endif
 }
 
+void addTargetIfNeeded(ct::RefactoringTool& Tool) {
+#if defined(_WIN32) && LLVM_VERSION_MAJOR >= 16
+  std::string sTarget = "--target=x86_64-pc-windows-msvc";
+  Tool.appendArgumentsAdjuster(ct::getInsertArgumentAdjuster(sTarget.c_str(), ct::ArgumentInsertPosition::BEGIN));
+#endif
+}
+
 } // namespace llcompat

--- a/src/LLVMCompat.h
+++ b/src/LLVMCompat.h
@@ -99,4 +99,6 @@ clang::SourceLocation getEndOfExpansionRangeForLoc(const clang::SourceManager &S
 
 Memory_Buffer getMemoryBuffer(const clang::SourceManager &SM);
 
+void addTargetIfNeeded(ct::RefactoringTool& Tool);
+
 } // namespace llcompat

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -160,6 +160,7 @@ void appendArgumentsAdjusters(ct::RefactoringTool &Tool, const std::string &sSou
     std::string sCudaPath = "--cuda-path=" + CudaPath;
     Tool.appendArgumentsAdjuster(ct::getInsertArgumentAdjuster(sCudaPath.c_str(), ct::ArgumentInsertPosition::BEGIN));
   }
+  llcompat::addTargetIfNeeded(Tool);
   Tool.appendArgumentsAdjuster(ct::getInsertArgumentAdjuster("cuda", ct::ArgumentInsertPosition::BEGIN));
   Tool.appendArgumentsAdjuster(ct::getInsertArgumentAdjuster("-x", ct::ArgumentInsertPosition::BEGIN));
   if (Verbose) {


### PR DESCRIPTION
+ Linux is unaffected
+ Update README.md accordingly
+ Hipification on Windows now works correctly, and all unit tests are passed

**[ToDo]**
+ Triage the affection LLVM change(s)
+ File an issue to LLVM
+ Fix it in LLVM