### PR TITLE
[HIPIFY][#722][SWDEV-375013][fix][build][compatibility][clang] Latest LLVM 16.0.0git compatibility support

### DIFF
--- a/src/HipifyAction.cpp
+++ b/src/HipifyAction.cpp
@@ -730,8 +730,10 @@ public:
                           StringRef file_name, bool is_angled, clang::CharSourceRange filename_range,
 #if LLVM_VERSION_MAJOR < 15
                           const clang::FileEntry *file,
-#else
+#elif LLVM_VERSION_MAJOR == 15
                           Optional<clang::FileEntryRef> file,
+#else
+                          clang::OptionalFileEntryRef file,
 #endif
                           StringRef search_path, StringRef relative_path,
                           const clang::Module *imported


### PR DESCRIPTION
+ Fixes #722

**[ToDo]**
+ Add temporary define for supporting build against LLVM older than 854c10f8d185286d941307e1033eb492e085c203 (2022.12.10)
