### PR TITLE
[HIPIFY][#722][#723][SWDEV-375013][build][compatibility][clang][temporary][workaround] Add a workaround for the `SWDEV-375013` blocker

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,6 +85,12 @@ else()
     endif()
 endif()
 
+# [ToDo] Remove SWDEV_375013 related guards from CMakeLists.txt and HipifyAction.cpp along with the LLVM 16.0.0 official release
+option (SWDEV_375013 "Enables SWDEV-375013 blocker workaround for the clang's change https://reviews.llvm.org/D140332" OFF)
+if(SWDEV_375013)
+    add_definitions(-DSWDEV_375013)
+endif()
+
 if(MSVC)
     target_link_libraries(hipify-clang PRIVATE version)
     target_compile_options(hipify-clang PRIVATE ${STD} /Od /GR- /EHs- /EHc-)

--- a/src/HipifyAction.cpp
+++ b/src/HipifyAction.cpp
@@ -725,12 +725,12 @@ class PPCallbackProxy : public clang::PPCallbacks {
 
 public:
   explicit PPCallbackProxy(HipifyAction &action): hipifyAction(action) {}
-
+  // [ToDo] Remove SWDEV_375013 related guards from CMakeLists.txt and HipifyAction.cpp along with the LLVM 16.0.0 official release
   void InclusionDirective(clang::SourceLocation hash_loc, const clang::Token &include_token,
                           StringRef file_name, bool is_angled, clang::CharSourceRange filename_range,
 #if LLVM_VERSION_MAJOR < 15
                           const clang::FileEntry *file,
-#elif LLVM_VERSION_MAJOR == 15
+#elif (LLVM_VERSION_MAJOR == 15) || (LLVM_VERSION_MAJOR == 16 && SWDEV_375013)
                           Optional<clang::FileEntryRef> file,
 #else
                           clang::OptionalFileEntryRef file,


### PR DESCRIPTION
**[IMP]**
+ To build hipify-clang against `trunk LLVM (16.0.0git)` nothing to do else
+ To build hipify-clang against `trunk LLVM (16.0.0git)` older than `854c10f8d185286d941307e1033eb492e085c203` (2022.12.20, DR: https://reviews.llvm.org/D140332) `-DSWDEV-375013` should be added to hipify-clang's cmake command line

**[ToDo]**
+ Remove `SWDEV_375013` related guards from CMakeLists.txt and HipifyAction.cpp along with the LLVM 16.0.0 official release