### PR TITLE
[HIPIFY] Sync with CUDA 12.0 - Part 8 - Runtime API - types only

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -3343,6 +3343,8 @@ sub simpleSubstitutions {
     subst("cudaKernelNodeAttrID", "hipKernelNodeAttrID", "type");
     subst("cudaKernelNodeAttrValue", "hipKernelNodeAttrValue", "type");
     subst("cudaKernelNodeParams", "hipKernelNodeParams", "type");
+    subst("cudaLaunchMemSyncDomainMap", "hipLaunchMemSyncDomainMap", "type");
+    subst("cudaLaunchMemSyncDomainMap_st", "hipLaunchMemSyncDomainMap", "type");
     subst("cudaLaunchParams", "hipLaunchParams", "type");
     subst("cudaLimit", "hipLimit_t", "type");
     subst("cudaMemAccessDesc", "hipMemAccessDesc", "type");
@@ -6131,6 +6133,9 @@ sub warnUnsupportedFunctions {
         "cudaLimitMaxL2FetchGranularity",
         "cudaLimitDevRuntimeSyncDepth",
         "cudaLimitDevRuntimePendingLaunchCount",
+        "cudaLaunchMemSyncDomainRemote",
+        "cudaLaunchMemSyncDomainDefault",
+        "cudaLaunchMemSyncDomain",
         "cudaLaunchKernelExC",
         "cudaLaunchConfig_t",
         "cudaLaunchConfig_st",
@@ -6140,6 +6145,8 @@ sub warnUnsupportedFunctions {
         "cudaLaunchAttributeProgrammaticStreamSerialization",
         "cudaLaunchAttributeProgrammaticEvent",
         "cudaLaunchAttributePriority",
+        "cudaLaunchAttributeMemSyncDomainMap",
+        "cudaLaunchAttributeMemSyncDomain",
         "cudaLaunchAttributeIgnore",
         "cudaLaunchAttributeID",
         "cudaLaunchAttributeCooperative",
@@ -6181,15 +6188,21 @@ sub warnUnsupportedFunctions {
         "cudaGraphKernelNodeCopyAttributes",
         "cudaGraphInstantiateSuccess",
         "cudaGraphInstantiateResult",
+        "cudaGraphInstantiateParams_st",
+        "cudaGraphInstantiateParams",
         "cudaGraphInstantiateNodeOperationNotSupported",
         "cudaGraphInstantiateMultipleDevicesNotSupported",
         "cudaGraphInstantiateInvalidStructure",
         "cudaGraphInstantiateFlagUseNodePriority",
+        "cudaGraphInstantiateFlagUpload",
+        "cudaGraphInstantiateFlagDeviceLaunch",
         "cudaGraphInstantiateError",
         "cudaGraphExternalSemaphoresWaitNodeSetParams",
         "cudaGraphExternalSemaphoresWaitNodeGetParams",
         "cudaGraphExternalSemaphoresSignalNodeSetParams",
         "cudaGraphExternalSemaphoresSignalNodeGetParams",
+        "cudaGraphExecUpdateResultInfo_st",
+        "cudaGraphExecUpdateResultInfo",
         "cudaGraphExecUpdateErrorAttributesChanged",
         "cudaGraphExecExternalSemaphoresWaitNodeSetParams",
         "cudaGraphExecExternalSemaphoresSignalNodeSetParams",
@@ -6422,6 +6435,10 @@ sub warnUnsupportedFunctions {
         "cudaEGLStreamConsumerConnectWithFlags",
         "cudaEGLStreamConsumerConnect",
         "cudaEGLStreamConsumerAcquireFrame",
+        "cudaDriverEntryPointVersionNotSufficent",
+        "cudaDriverEntryPointSymbolNotFound",
+        "cudaDriverEntryPointSuccess",
+        "cudaDriverEntryPointQueryResult",
         "cudaDevicePropDontCare",
         "cudaDeviceMask",
         "cudaDeviceGetTexture1DLinearMaxWidth",

--- a/doc/markdown/CUDA_Runtime_API_functions_supported_by_HIP.md
+++ b/doc/markdown/CUDA_Runtime_API_functions_supported_by_HIP.md
@@ -791,6 +791,10 @@ Unsupported
 |`cudaDeviceScheduleMask`| | | |`hipDeviceScheduleMask`|1.6.0| | | |
 |`cudaDeviceScheduleSpin`| | | |`hipDeviceScheduleSpin`|1.6.0| | | |
 |`cudaDeviceScheduleYield`| | | |`hipDeviceScheduleYield`|1.6.0| | | |
+|`cudaDriverEntryPointQueryResult`|12.0| | | | | | | |
+|`cudaDriverEntryPointSuccess`|12.0| | | | | | | |
+|`cudaDriverEntryPointSymbolNotFound`|12.0| | | | | | | |
+|`cudaDriverEntryPointVersionNotSufficent`|12.0| | | | | | | |
 |`cudaEglColorFormat`|9.1| | | | | | | |
 |`cudaEglColorFormatA`|9.1| | | | | | | |
 |`cudaEglColorFormatABGR`|9.1| | | | | | | |
@@ -1112,15 +1116,21 @@ Unsupported
 |`cudaGraphExecUpdateErrorTopologyChanged`|10.2| | |`hipGraphExecUpdateErrorTopologyChanged`|4.3.0| | | |
 |`cudaGraphExecUpdateErrorUnsupportedFunctionChange`|11.2| | |`hipGraphExecUpdateErrorUnsupportedFunctionChange`|4.3.0| | | |
 |`cudaGraphExecUpdateResult`|10.2| | |`hipGraphExecUpdateResult`|4.3.0| | | |
+|`cudaGraphExecUpdateResultInfo`|12.0| | | | | | | |
+|`cudaGraphExecUpdateResultInfo_st`|12.0| | | | | | | |
 |`cudaGraphExecUpdateSuccess`|10.2| | |`hipGraphExecUpdateSuccess`|4.3.0| | | |
 |`cudaGraphExec_t`|10.0| | |`hipGraphExec_t`|4.3.0| | | |
 |`cudaGraphInstantiateError`|12.0| | | | | | | |
 |`cudaGraphInstantiateFlagAutoFreeOnLaunch`|11.4| | |`hipGraphInstantiateFlagAutoFreeOnLaunch`|5.2.0| | | |
+|`cudaGraphInstantiateFlagDeviceLaunch`|12.0| | | | | | | |
+|`cudaGraphInstantiateFlagUpload`|12.0| | | | | | | |
 |`cudaGraphInstantiateFlagUseNodePriority`|11.7| | | | | | | |
 |`cudaGraphInstantiateFlags`|11.4| | |`hipGraphInstantiateFlags`|5.2.0| | | |
 |`cudaGraphInstantiateInvalidStructure`|12.0| | | | | | | |
 |`cudaGraphInstantiateMultipleDevicesNotSupported`|12.0| | | | | | | |
 |`cudaGraphInstantiateNodeOperationNotSupported`|12.0| | | | | | | |
+|`cudaGraphInstantiateParams`|12.0| | | | | | | |
+|`cudaGraphInstantiateParams_st`|12.0| | | | | | | |
 |`cudaGraphInstantiateResult`|12.0| | | | | | | |
 |`cudaGraphInstantiateSuccess`|12.0| | | | | | | |
 |`cudaGraphMemAttrReservedMemCurrent`|11.4| | |`hipGraphMemAttrReservedMemCurrent`|5.3.0| | | |
@@ -1198,6 +1208,8 @@ Unsupported
 |`cudaLaunchAttributeCooperative`|11.8| | | | | | | |
 |`cudaLaunchAttributeID`|11.8| | | | | | | |
 |`cudaLaunchAttributeIgnore`|11.8| | | | | | | |
+|`cudaLaunchAttributeMemSyncDomain`|12.0| | | | | | | |
+|`cudaLaunchAttributeMemSyncDomainMap`|12.0| | | | | | | |
 |`cudaLaunchAttributePriority`|11.8| | | | | | | |
 |`cudaLaunchAttributeProgrammaticEvent`|11.8| | | | | | | |
 |`cudaLaunchAttributeProgrammaticStreamSerialization`|11.8| | | | | | | |
@@ -1206,6 +1218,11 @@ Unsupported
 |`cudaLaunchAttribute_st`|11.8| | | | | | | |
 |`cudaLaunchConfig_st`|11.8| | | | | | | |
 |`cudaLaunchConfig_t`|11.8| | | | | | | |
+|`cudaLaunchMemSyncDomain`|12.0| | | | | | | |
+|`cudaLaunchMemSyncDomainDefault`|12.0| | | | | | | |
+|`cudaLaunchMemSyncDomainMap`|12.0| | |`hipLaunchMemSyncDomainMap`| | | | |
+|`cudaLaunchMemSyncDomainMap_st`|12.0| | |`hipLaunchMemSyncDomainMap`| | | | |
+|`cudaLaunchMemSyncDomainRemote`|12.0| | | | | | | |
 |`cudaLaunchParams`|9.0| | |`hipLaunchParams`|2.6.0| | | |
 |`cudaLimit`| | | |`hipLimit_t`|1.6.0| | | |
 |`cudaLimitDevRuntimePendingLaunchCount`| | | | | | | | |

--- a/src/CUDA2HIP_Driver_API_types.cpp
+++ b/src/CUDA2HIP_Driver_API_types.cpp
@@ -334,14 +334,14 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_TYPE_NAME_MAP {
   //
   {"CUkernel",                                                         {"hipKernel",                                                "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
 
-  //
+  // cudaGraphInstantiateParams_st
   {"CUDA_GRAPH_INSTANTIATE_PARAMS_st",                                 {"HIP_GRAPH_INSTANTIATE_PARAMS",                             "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
-  //
+  // cudaGraphInstantiateParams
   {"CUDA_GRAPH_INSTANTIATE_PARAMS",                                    {"HIP_GRAPH_INSTANTIATE_PARAMS",                             "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
 
-  //
+  // cudaLaunchMemSyncDomainMap_st
   {"CUlaunchMemSyncDomainMap_st",                                      {"hipLaunchMemSyncDomainMap",                                "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
-  //
+  // cudaLaunchMemSyncDomainMap
   {"CUlaunchMemSyncDomainMap",                                         {"hipLaunchMemSyncDomainMap",                                "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
 
   //
@@ -354,9 +354,11 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_TYPE_NAME_MAP {
   //
   {"CUtensorMap",                                                      {"hipTensorMap",                                             "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
 
-  //
+  // cudaGraphExecUpdateResultInfo_st
   {"CUgraphExecUpdateResultInfo_st",                                   {"hipGraphExecUpdateResultInfo",                             "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
+  // cudaGraphExecUpdateResultInfo
   {"CUgraphExecUpdateResultInfo_v1",                                   {"hipGraphExecUpdateResultInfo",                             "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
+  // cudaGraphExecUpdateResultInfo
   {"CUgraphExecUpdateResultInfo",                                      {"hipGraphExecUpdateResultInfo",                             "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
 
   // 2. Unions
@@ -2191,9 +2193,9 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_TYPE_NAME_MAP {
   // CUgraphInstantiate_flags enum values
   // cudaGraphInstantiateFlagAutoFreeOnLaunch
   {"CUDA_GRAPH_INSTANTIATE_FLAG_AUTO_FREE_ON_LAUNCH",                  {"hipGraphInstantiateFlagAutoFreeOnLaunch",                  "", CONV_NUMERIC_LITERAL, API_DRIVER, 1}},
-  //
+  // cudaGraphInstantiateFlagUpload
   {"CUDA_GRAPH_INSTANTIATE_FLAG_UPLOAD",                               {"hipGraphInstantiateFlagUpload",                            "", CONV_NUMERIC_LITERAL, API_DRIVER, 1, HIP_UNSUPPORTED}},
-  //
+  // cudaGraphInstantiateFlagDeviceLaunch
   {"CUDA_GRAPH_INSTANTIATE_FLAG_DEVICE_LAUNCH",                        {"hipGraphInstantiateFlagDeviceLaunch",                      "", CONV_NUMERIC_LITERAL, API_DRIVER, 1, HIP_UNSUPPORTED}},
   // cudaGraphInstantiateFlagUseNodePriority
   {"CUDA_GRAPH_INSTANTIATE_FLAG_USE_NODE_PRIORITY",                    {"hipGraphInstantiateFlagUseNodePriority",                   "", CONV_NUMERIC_LITERAL, API_DRIVER, 1, HIP_UNSUPPORTED}},
@@ -2291,9 +2293,9 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_TYPE_NAME_MAP {
   {"CU_LAUNCH_ATTRIBUTE_PROGRAMMATIC_EVENT",                           {"hipLaunchAttributeProgrammaticEvent",                      "", CONV_NUMERIC_LITERAL, API_DRIVER, 1, HIP_UNSUPPORTED}},
   // cudaLaunchAttributePriority
   {"CU_LAUNCH_ATTRIBUTE_PRIORITY",                                     {"hipLaunchAttributePriority",                               "", CONV_NUMERIC_LITERAL, API_DRIVER, 1, HIP_UNSUPPORTED}},
-  //
+  // cudaLaunchAttributeMemSyncDomainMap
   {"CU_LAUNCH_ATTRIBUTE_MEM_SYNC_DOMAIN_MAP",                          {"hipLaunchAttributeMemSyncDomainMap",                       "", CONV_NUMERIC_LITERAL, API_DRIVER, 1, HIP_UNSUPPORTED}},
-  //
+  // cudaLaunchAttributeMemSyncDomain
   {"CU_LAUNCH_ATTRIBUTE_MEM_SYNC_DOMAIN",                              {"hipLaunchAttributeMemSyncDomain",                          "", CONV_NUMERIC_LITERAL, API_DRIVER, 1, HIP_UNSUPPORTED}},
 
   // cudaGraphInstantiateResult
@@ -2311,14 +2313,14 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_TYPE_NAME_MAP {
   // cudaGraphInstantiateMultipleDevicesNotSupported
   {"CUDA_GRAPH_INSTANTIATE_MULTIPLE_CTXS_NOT_SUPPORTED",               {"hipGraphInstantiateMultipleDevicesNotSupported",           "", CONV_NUMERIC_LITERAL, API_DRIVER, 1, HIP_UNSUPPORTED}},
 
-  //
+  // cudaLaunchMemSyncDomain
   {"CUlaunchMemSyncDomain",                                            {"hipLaunchMemSyncDomain",                                   "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
   {"CUlaunchMemSyncDomain_enum",                                       {"hipLaunchMemSyncDomain",                                   "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},
   // CUlaunchMemSyncDomain enum values
-  //
-  {"CU_LAUNCH_MEM_SYNC_DOMAIN_DEFAULT",                                {"HIP_LAUNCH_MEM_SYNC_DOMAIN_DEFAULT",                       "", CONV_NUMERIC_LITERAL, API_DRIVER, 1, HIP_UNSUPPORTED}},
-  //
-  {"CU_LAUNCH_MEM_SYNC_DOMAIN_REMOTE",                                 {"HIP_LAUNCH_MEM_SYNC_DOMAIN_REMOTE",                        "", CONV_NUMERIC_LITERAL, API_DRIVER, 1, HIP_UNSUPPORTED}},
+  // cudaLaunchMemSyncDomainDefault
+  {"CU_LAUNCH_MEM_SYNC_DOMAIN_DEFAULT",                                {"hipLaunchMemSyncDomainDefault",                            "", CONV_NUMERIC_LITERAL, API_DRIVER, 1, HIP_UNSUPPORTED}},
+  // cudaLaunchMemSyncDomainRemote
+  {"CU_LAUNCH_MEM_SYNC_DOMAIN_REMOTE",                                 {"hipLaunchMemSyncDomainRemote",                             "", CONV_NUMERIC_LITERAL, API_DRIVER, 1, HIP_UNSUPPORTED}},
 
   //
   {"CUdriverProcAddressQueryResult",                                   {"hipDriverProcAddressQueryResult",                          "", CONV_TYPE, API_DRIVER, 1, HIP_UNSUPPORTED}},

--- a/src/CUDA2HIP_Runtime_API_types.cpp
+++ b/src/CUDA2HIP_Runtime_API_types.cpp
@@ -217,6 +217,11 @@ const std::map<llvm::StringRef, hipCounter> CUDA_RUNTIME_TYPE_NAME_MAP {
   // CUDA_ARRAY_MEMORY_REQUIREMENTS_st
   {"cudaArrayMemoryRequirements",                                      {"hipArrayMemoryRequirements",                               "", CONV_TYPE, API_RUNTIME, 36, HIP_UNSUPPORTED}},
 
+  // CUlaunchMemSyncDomainMap_st
+  {"cudaLaunchMemSyncDomainMap_st",                                    {"hipLaunchMemSyncDomainMap",                                "", CONV_TYPE, API_RUNTIME, 36}},
+  // CUlaunchMemSyncDomainMap
+  {"cudaLaunchMemSyncDomainMap",                                       {"hipLaunchMemSyncDomainMap",                                "", CONV_TYPE, API_RUNTIME, 36}},
+
   // 2. Unions
 
   // CUstreamAttrValue
@@ -236,7 +241,17 @@ const std::map<llvm::StringRef, hipCounter> CUDA_RUNTIME_TYPE_NAME_MAP {
   // CUlaunchConfig_st
   {"cudaLaunchConfig_st",                                              {"hipLaunchConfig",                                          "", CONV_TYPE, API_RUNTIME, 36, HIP_UNSUPPORTED}},
   // CUlaunchConfig
-  {"cudaLaunchConfig_t",                                              {"hipLaunchConfig",                                       "", CONV_TYPE, API_RUNTIME, 36, HIP_UNSUPPORTED}},
+  {"cudaLaunchConfig_t",                                               {"hipLaunchConfig",                                          "", CONV_TYPE, API_RUNTIME, 36, HIP_UNSUPPORTED}},
+
+  // CUDA_GRAPH_INSTANTIATE_PARAMS_st
+  {"cudaGraphInstantiateParams_st",                                    {"hipGraphInstantiateParams",                                "", CONV_TYPE, API_RUNTIME, 36, HIP_UNSUPPORTED}},
+  // CUDA_GRAPH_INSTANTIATE_PARAMS
+  {"cudaGraphInstantiateParams",                                       {"hipGraphInstantiateParams",                                "", CONV_TYPE, API_RUNTIME, 36, HIP_UNSUPPORTED}},
+
+  // CUgraphExecUpdateResultInfo_st
+  {"cudaGraphExecUpdateResultInfo_st",                                 {"hipGraphExecUpdateResultInfo",                             "", CONV_TYPE, API_RUNTIME, 36, HIP_UNSUPPORTED}},
+  // CUgraphExecUpdateResultInfo
+  {"cudaGraphExecUpdateResultInfo",                                    {"hipGraphExecUpdateResultInfo",                             "", CONV_TYPE, API_RUNTIME, 36, HIP_UNSUPPORTED}},
 
   // 3. Enums
 
@@ -1727,6 +1742,10 @@ const std::map<llvm::StringRef, hipCounter> CUDA_RUNTIME_TYPE_NAME_MAP {
   // cudaGraphInstantiateFlags enum values
   // CUDA_GRAPH_INSTANTIATE_FLAG_AUTO_FREE_ON_LAUNCH
   {"cudaGraphInstantiateFlagAutoFreeOnLaunch",                         {"hipGraphInstantiateFlagAutoFreeOnLaunch",                  "", CONV_NUMERIC_LITERAL, API_RUNTIME, 36}},
+  // CUDA_GRAPH_INSTANTIATE_FLAG_UPLOAD
+  {"cudaGraphInstantiateFlagUpload",                                   {"hipGraphInstantiateFlagUpload",                            "", CONV_NUMERIC_LITERAL, API_RUNTIME, 36, HIP_UNSUPPORTED}},
+  // CUDA_GRAPH_INSTANTIATE_FLAG_DEVICE_LAUNCH
+  {"cudaGraphInstantiateFlagDeviceLaunch",                             {"hipGraphInstantiateFlagDeviceLaunch",                      "", CONV_NUMERIC_LITERAL, API_RUNTIME, 36, HIP_UNSUPPORTED}},
   // CUDA_GRAPH_INSTANTIATE_FLAG_USE_NODE_PRIORITY
   {"cudaGraphInstantiateFlagUseNodePriority",                          {"hipGraphInstantiateFlagUseNodePriority",                   "", CONV_NUMERIC_LITERAL, API_RUNTIME, 36, HIP_UNSUPPORTED}},
 
@@ -1761,6 +1780,10 @@ const std::map<llvm::StringRef, hipCounter> CUDA_RUNTIME_TYPE_NAME_MAP {
   {"cudaLaunchAttributeProgrammaticEvent",                             {"hipLaunchAttributeProgrammaticEvent",                      "", CONV_NUMERIC_LITERAL, API_RUNTIME, 36, HIP_UNSUPPORTED}},
   // CU_LAUNCH_ATTRIBUTE_PRIORITY
   {"cudaLaunchAttributePriority",                                      {"hipLaunchAttributePriority",                               "", CONV_NUMERIC_LITERAL, API_RUNTIME, 36, HIP_UNSUPPORTED}},
+  // CU_LAUNCH_ATTRIBUTE_MEM_SYNC_DOMAIN_MAP
+  {"cudaLaunchAttributeMemSyncDomainMap",                              {"hipLaunchAttributeMemSyncDomainMap",                       "", CONV_NUMERIC_LITERAL, API_RUNTIME, 36, HIP_UNSUPPORTED}},
+  // CU_LAUNCH_ATTRIBUTE_MEM_SYNC_DOMAIN
+  {"cudaLaunchAttributeMemSyncDomain",                                 {"hipLaunchAttributeMemSyncDomain",                          "", CONV_NUMERIC_LITERAL, API_RUNTIME, 36, HIP_UNSUPPORTED}},
 
   // CUgraphInstantiateResult
   {"cudaGraphInstantiateResult",                                       {"hipGraphInstantiateResult",                                "", CONV_TYPE, API_RUNTIME, 36, HIP_UNSUPPORTED}},
@@ -1776,6 +1799,20 @@ const std::map<llvm::StringRef, hipCounter> CUDA_RUNTIME_TYPE_NAME_MAP {
   // CUDA_GRAPH_INSTANTIATE_MULTIPLE_CTXS_NOT_SUPPORTED
   {"cudaGraphInstantiateMultipleDevicesNotSupported",                  {"hipGraphInstantiateMultipleDevicesNotSupported",           "", CONV_NUMERIC_LITERAL, API_RUNTIME, 36, HIP_UNSUPPORTED}},
 
+  // no analogues
+  {"cudaDriverEntryPointQueryResult",                                  {"hipDriverEntryPointQueryResult",                           "", CONV_TYPE, API_RUNTIME, 36, HIP_UNSUPPORTED}},
+  // cudaDriverEntryPointQueryResult enum values
+  {"cudaDriverEntryPointSuccess",                                      {"cudaDriverEntryPointSuccess",                              "", CONV_NUMERIC_LITERAL, API_RUNTIME, 36, HIP_UNSUPPORTED}},
+  {"cudaDriverEntryPointSymbolNotFound",                               {"hipDriverEntryPointSymbolNotFound",                        "", CONV_NUMERIC_LITERAL, API_RUNTIME, 36, HIP_UNSUPPORTED}},
+  {"cudaDriverEntryPointVersionNotSufficent",                          {"hipDriverEntryPointVersionNotSufficent",                   "", CONV_NUMERIC_LITERAL, API_RUNTIME, 36, HIP_UNSUPPORTED}},
+
+  // CUlaunchMemSyncDomain
+  {"cudaLaunchMemSyncDomain",                                          {"hipLaunchMemSyncDomain",                                   "", CONV_TYPE, API_RUNTIME, 36, HIP_UNSUPPORTED}},
+  // cudaLaunchMemSyncDomain enum values
+  // CU_LAUNCH_MEM_SYNC_DOMAIN_DEFAULT
+  {"cudaLaunchMemSyncDomainDefault",                                   {"hipLaunchMemSyncDomainDefault",                            "", CONV_NUMERIC_LITERAL, API_RUNTIME, 36, HIP_UNSUPPORTED}},
+  // CU_LAUNCH_MEM_SYNC_DOMAIN_REMOTE
+  {"cudaLaunchMemSyncDomainRemote",                                    {"hipLaunchMemSyncDomainRemote",                             "", CONV_NUMERIC_LITERAL, API_RUNTIME, 36, HIP_UNSUPPORTED}},
 
   // 4. Typedefs
 
@@ -2419,6 +2456,23 @@ const std::map<llvm::StringRef, cudaAPIversions> CUDA_RUNTIME_TYPE_NAME_VER_MAP 
   {"cudaGraphInstantiateInvalidStructure",                             {CUDA_120, CUDA_0,   CUDA_0  }},
   {"cudaGraphInstantiateNodeOperationNotSupported",                    {CUDA_120, CUDA_0,   CUDA_0  }},
   {"cudaGraphInstantiateMultipleDevicesNotSupported",                  {CUDA_120, CUDA_0,   CUDA_0  }},
+  {"cudaGraphInstantiateParams_st",                                    {CUDA_120, CUDA_0,   CUDA_0  }},
+  {"cudaGraphInstantiateParams",                                       {CUDA_120, CUDA_0,   CUDA_0  }},
+  {"cudaGraphExecUpdateResultInfo_st",                                 {CUDA_120, CUDA_0,   CUDA_0  }},
+  {"cudaGraphExecUpdateResultInfo",                                    {CUDA_120, CUDA_0,   CUDA_0  }},
+  {"cudaDriverEntryPointQueryResult",                                  {CUDA_120, CUDA_0,   CUDA_0  }},
+  {"cudaDriverEntryPointSuccess",                                      {CUDA_120, CUDA_0,   CUDA_0  }},
+  {"cudaDriverEntryPointSymbolNotFound",                               {CUDA_120, CUDA_0,   CUDA_0  }},
+  {"cudaDriverEntryPointVersionNotSufficent",                          {CUDA_120, CUDA_0,   CUDA_0  }},
+  {"cudaGraphInstantiateFlagUpload",                                   {CUDA_120, CUDA_0,   CUDA_0  }},
+  {"cudaGraphInstantiateFlagDeviceLaunch",                             {CUDA_120, CUDA_0,   CUDA_0  }},
+  {"cudaLaunchMemSyncDomain",                                          {CUDA_120, CUDA_0,   CUDA_0  }},
+  {"cudaLaunchMemSyncDomainDefault",                                   {CUDA_120, CUDA_0,   CUDA_0  }},
+  {"cudaLaunchMemSyncDomainRemote",                                    {CUDA_120, CUDA_0,   CUDA_0  }},
+  {"cudaLaunchMemSyncDomainMap_st",                                    {CUDA_120, CUDA_0,   CUDA_0  }},
+  {"cudaLaunchMemSyncDomainMap",                                       {CUDA_120, CUDA_0,   CUDA_0  }},
+  {"cudaLaunchAttributeMemSyncDomainMap",                              {CUDA_120, CUDA_0,   CUDA_0  }},
+  {"cudaLaunchAttributeMemSyncDomain",                                 {CUDA_120, CUDA_0,   CUDA_0  }},
 };
 
 const std::map<llvm::StringRef, hipAPIversions> HIP_RUNTIME_TYPE_NAME_VER_MAP {


### PR DESCRIPTION
+ Sync with CUDA 12.0 Driver types
+ Update regenerated hipify-perl CUDA_Runtime_API_functions_supported_by_HIP.md accordingly
