### PR TITLE
[HIPIFY][5.5] Initial support of ROCm HIP 5.5.0

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -743,8 +743,7 @@ my %removed_funcs = (
 );
 
 my %experimental_funcs = (
-    "cuGetErrorString" => "5.4.0",
-    "cuGetErrorName" => "5.4.0"
+
 );
 
 $print_stats = 1 if $examine;
@@ -882,8 +881,6 @@ sub subst {
 }
 
 sub experimentalSubstitutions {
-    subst("cuGetErrorName", "hipDrvGetErrorName", "error");
-    subst("cuGetErrorString", "hipDrvGetErrorString", "error");
 }
 
 sub rocSubstitutions {
@@ -1322,6 +1319,8 @@ sub rocSubstitutions {
 }
 
 sub simpleSubstitutions {
+    subst("cuGetErrorName", "hipDrvGetErrorName", "error");
+    subst("cuGetErrorString", "hipDrvGetErrorString", "error");
     subst("cudaGetErrorName", "hipGetErrorName", "error");
     subst("cudaGetErrorString", "hipGetErrorString", "error");
     subst("cudaGetLastError", "hipGetLastError", "error");
@@ -8501,7 +8500,7 @@ if ($help) {
     print STDERR "$USAGE\n";
 }
 if ($version) {
-    print STDERR "HIP version 5.4.0\n";
+    print STDERR "HIP version 5.5.0\n";
 }
 while (@ARGV) {
     $fileName=shift (@ARGV);

--- a/doc/markdown/CUDA_Driver_API_functions_supported_by_HIP.md
+++ b/doc/markdown/CUDA_Driver_API_functions_supported_by_HIP.md
@@ -1279,8 +1279,8 @@
 
 |**CUDA**|**A**|**D**|**R**|**HIP**|**A**|**D**|**R**|**E**|
 |:--|:-:|:-:|:-:|:--|:-:|:-:|:-:|:-:|
-|`cuGetErrorName`| | | |`hipDrvGetErrorName`|5.4.0| | |5.4.0|
-|`cuGetErrorString`| | | |`hipDrvGetErrorString`|5.4.0| | |5.4.0|
+|`cuGetErrorName`| | | |`hipDrvGetErrorName`|5.4.0| | | |
+|`cuGetErrorString`| | | |`hipDrvGetErrorString`|5.4.0| | | |
 
 ## **3. Initialization**
 

--- a/src/CUDA2HIP_Driver_API_functions.cpp
+++ b/src/CUDA2HIP_Driver_API_functions.cpp
@@ -27,10 +27,10 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_FUNCTION_MAP {
   // 2. Error Handling
   // no analogue
   // NOTE: cudaGetErrorName and cuGetErrorName have different signatures
-  {"cuGetErrorName",                                       {"hipDrvGetErrorName",                                      "", CONV_ERROR, API_DRIVER, 2, HIP_EXPERIMENTAL}},
+  {"cuGetErrorName",                                       {"hipDrvGetErrorName",                                      "", CONV_ERROR, API_DRIVER, 2}},
   // no analogue
   // NOTE: cudaGetErrorString and cuGetErrorString have different signatures
-  {"cuGetErrorString",                                     {"hipDrvGetErrorString",                                    "", CONV_ERROR, API_DRIVER, 2, HIP_EXPERIMENTAL}},
+  {"cuGetErrorString",                                     {"hipDrvGetErrorString",                                    "", CONV_ERROR, API_DRIVER, 2}},
 
   // 3. Initialization
   // no analogue
@@ -1479,8 +1479,8 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_DRIVER_FUNCTION_VER_MAP {
   {"hiprtcLinkAddData",                                    {HIP_5030, HIP_0,    HIP_0   }},
   {"hiprtcLinkComplete",                                   {HIP_5030, HIP_0,    HIP_0   }},
   {"hiprtcLinkDestroy",                                    {HIP_5030, HIP_0,    HIP_0   }},
-  {"hipDrvGetErrorName",                                   {HIP_5040, HIP_0,    HIP_0,  HIP_LATEST}},
-  {"hipDrvGetErrorString",                                 {HIP_5040, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipDrvGetErrorName",                                   {HIP_5040, HIP_0,    HIP_0   }},
+  {"hipDrvGetErrorString",                                 {HIP_5040, HIP_0,    HIP_0   }},
 };
 
 const std::map<unsigned int, llvm::StringRef> CUDA_DRIVER_API_SECTION_MAP {

--- a/src/Statistics.cpp
+++ b/src/Statistics.cpp
@@ -555,6 +555,7 @@ std::string Statistics::getHipVersion(const hipVersions& ver) {
     case HIP_5020: return "5.2.0";
     case HIP_5030: return "5.3.0";
     case HIP_5040: return "5.4.0";
+    case HIP_5050: return "5.5.0";
   }
   return "";
 }

--- a/src/Statistics.h
+++ b/src/Statistics.h
@@ -335,7 +335,8 @@ enum hipVersions {
   HIP_5020 = 5020,
   HIP_5030 = 5030,
   HIP_5040 = 5040,
-  HIP_LATEST = HIP_5040,
+  HIP_5050 = 5050,
+  HIP_LATEST = HIP_5050,
 };
 
 struct cudaAPIversions {


### PR DESCRIPTION
+ Updated versions
+ Unmarked all experimental APIs
+ Regenerated hipify-perl and CUDA2HIP markdown documentation