### PR TITLE
[HIPIFY][SWDEV-374523][BLAS][test][fix] Fix `cublas2rocblas.cu` test failure on CUDA 11.4.0 and 11.4.1

### DIFF
--- a/tests/unit_tests/synthetic/libraries/cublas2rocblas.cu
+++ b/tests/unit_tests/synthetic/libraries/cublas2rocblas.cu
@@ -1864,7 +1864,7 @@ int main() {
   cublasDataType_t C_16BF = CUDA_C_16BF;
 #endif
 
-#if CUDA_VERSION >= 11040
+#if CUDA_VERSION >= 11040 && CUBLAS_VERSION >= 11600
   // CUDA: CUBLASAPI const char* CUBLASWINAPI cublasGetStatusString(cublasStatus_t status);
   // ROC: ROCBLAS_EXPORT const char* rocblas_status_to_string(rocblas_status status);
   // CHECK: const_ch = rocblas_status_to_string(blasStatus);


### PR DESCRIPTION
**[Synopsis]**
+ As a rule, CUDA doesn't introduce new APIs with its minor updates (aka 11.4.2, where 2 is the second update of 11.4)
+ But in `CUDA 11.4.2` two new APIs were introduced in cuBLAS: `cublasGetStatusName` and `cublasGetStatusString`; the second has an analogue: `rocblas_status_to_string` in `rocBLAS`
+ Unfortunately, there is no `Update` or `Patch` version in `CUDA_VERSION`: for instance, all 11.4.x are 11040

**[Solution]**
+ To take into account `CUBLAS_VERSION` besides `CUDA_VERSION`: for instance, `cuBLAS` shipped with CUDA 11.4.1 has `CUBLAS_VERSION` equal 11508, and `cuBLAS` shipped with CUDA 11.4.2 has `CUBLAS_VERSION` equal 11601