### PR TITLE
[HIPIFY][#690][SWDEV-310152][package][build][revert] Remove rpath from binary files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -152,6 +152,8 @@ if(UNIX)
 
     #get rid of any RPATH definations already
     set_target_properties(hipify-clang PROPERTIES INSTALL_RPATH "")
+    #set RPATH for the binary
+    set_target_properties(hipify-clang PROPERTIES LINK_FLAGS "-Wl,--disable-new-dtags -Wl,--rpath,$ORIGIN/../lib" )
 
     if(FILE_REORG_BACKWARD_COMPATIBILITY)
         include(hipify-backward-compat.cmake)


### PR DESCRIPTION
**[Reason]**
+ Reverting the removal of `rpath` from binary files due to deferring it to 5.6
