### PR TITLE
[HIPIFY][RT] Sync with CUDA 12.0 - Part 29 - RT API

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -90,6 +90,8 @@ GetOptions(
 $cuda_kernel_execution_syntax = 1;
 
 my %deprecated_funcs = (
+    "nvrtcGetNVVMSize" => "12.0",
+    "nvrtcGetNVVM" => "12.0",
     "cusparseZsctr" => "11.0",
     "cusparseZhybsv_solve" => "10.2",
     "cusparseZhybsv_analysis" => "10.2",
@@ -5847,9 +5849,13 @@ sub warnUnsupportedFunctions {
     foreach $func (
         "pruneInfo",
         "nvrtcGetSupportedArchs",
+        "nvrtcGetOptiXIRSize",
+        "nvrtcGetOptiXIR",
         "nvrtcGetNumSupportedArchs",
         "nvrtcGetNVVMSize",
         "nvrtcGetNVVM",
+        "nvrtcGetLTOIRSize",
+        "nvrtcGetLTOIR",
         "nv_bfloat162",
         "nv_bfloat16",
         "memoryBarrier",

--- a/doc/markdown/CUDA_RTC_API_supported_by_HIP.md
+++ b/doc/markdown/CUDA_RTC_API_supported_by_HIP.md
@@ -30,10 +30,14 @@
 |`nvrtcGetCUBIN`|11.1| | |`hiprtcGetBitcode`|5.3.0| | | |
 |`nvrtcGetCUBINSize`|11.1| | |`hiprtcGetBitcodeSize`|5.3.0| | | |
 |`nvrtcGetErrorString`| | | |`hiprtcGetErrorString`|2.6.0| | | |
+|`nvrtcGetLTOIR`|12.0| | | | | | | |
+|`nvrtcGetLTOIRSize`|12.0| | | | | | | |
 |`nvrtcGetLoweredName`|8.0| | |`hiprtcGetLoweredName`|2.6.0| | | |
-|`nvrtcGetNVVM`|11.4| | | | | | | |
-|`nvrtcGetNVVMSize`|11.4| | | | | | | |
+|`nvrtcGetNVVM`|11.4|12.0| | | | | | |
+|`nvrtcGetNVVMSize`|11.4|12.0| | | | | | |
 |`nvrtcGetNumSupportedArchs`|11.2| | | | | | | |
+|`nvrtcGetOptiXIR`|12.0| | | | | | | |
+|`nvrtcGetOptiXIRSize`|12.0| | | | | | | |
 |`nvrtcGetPTX`| | | |`hiprtcGetCode`|2.6.0| | | |
 |`nvrtcGetPTXSize`| | | |`hiprtcGetCodeSize`|2.6.0| | | |
 |`nvrtcGetProgramLog`| | | |`hiprtcGetProgramLog`|2.6.0| | | |

--- a/src/CUDA2HIP_RTC_API_functions.cpp
+++ b/src/CUDA2HIP_RTC_API_functions.cpp
@@ -35,12 +35,16 @@ const std::map<llvm::StringRef, hipCounter> CUDA_RTC_FUNCTION_MAP {
   {"nvrtcGetPTX",                                 {"hiprtcGetCode",                                "", CONV_LIB_FUNC, API_RTC, 2}},
   {"nvrtcGetCUBINSize",                           {"hiprtcGetBitcodeSize",                         "", CONV_LIB_FUNC, API_RTC, 2}},
   {"nvrtcGetCUBIN",                               {"hiprtcGetBitcode",                             "", CONV_LIB_FUNC, API_RTC, 2}},
-  {"nvrtcGetNVVMSize",                            {"hiprtcGetNVVMSize",                            "", CONV_LIB_FUNC, API_RTC, 2, HIP_UNSUPPORTED}},
-  {"nvrtcGetNVVM",                                {"hiprtcGetNVVM",                                "", CONV_LIB_FUNC, API_RTC, 2, HIP_UNSUPPORTED}},
+  {"nvrtcGetNVVMSize",                            {"hiprtcGetNVVMSize",                            "", CONV_LIB_FUNC, API_RTC, 2, HIP_UNSUPPORTED | CUDA_DEPRECATED}},
+  {"nvrtcGetNVVM",                                {"hiprtcGetNVVM",                                "", CONV_LIB_FUNC, API_RTC, 2, HIP_UNSUPPORTED | CUDA_DEPRECATED}},
   {"nvrtcGetProgramLogSize",                      {"hiprtcGetProgramLogSize",                      "", CONV_LIB_FUNC, API_RTC, 2}},
   {"nvrtcGetProgramLog",                          {"hiprtcGetProgramLog",                          "", CONV_LIB_FUNC, API_RTC, 2}},
   {"nvrtcAddNameExpression",                      {"hiprtcAddNameExpression",                      "", CONV_LIB_FUNC, API_RTC, 2}},
   {"nvrtcGetLoweredName",                         {"hiprtcGetLoweredName",                         "", CONV_LIB_FUNC, API_RTC, 2}},
+  {"nvrtcGetLTOIRSize",                           {"hiprtcGetLTOIRSize",                           "", CONV_LIB_FUNC, API_RTC, 2, HIP_UNSUPPORTED}},
+  {"nvrtcGetLTOIR",                               {"hiprtcGetLTOIR",                               "", CONV_LIB_FUNC, API_RTC, 2, HIP_UNSUPPORTED}},
+  {"nvrtcGetOptiXIRSize",                         {"hiprtcGetOptiXIRSize",                         "", CONV_LIB_FUNC, API_RTC, 2, HIP_UNSUPPORTED}},
+  {"nvrtcGetOptiXIR",                             {"hiprtcGetOptiXIR",                             "", CONV_LIB_FUNC, API_RTC, 2, HIP_UNSUPPORTED}},
 };
 
 const std::map<llvm::StringRef, cudaAPIversions> CUDA_RTC_FUNCTION_VER_MAP {
@@ -48,10 +52,14 @@ const std::map<llvm::StringRef, cudaAPIversions> CUDA_RTC_FUNCTION_VER_MAP {
   {"nvrtcGetSupportedArchs",                      {CUDA_112, CUDA_0,   CUDA_0  }},
   {"nvrtcGetCUBINSize",                           {CUDA_111, CUDA_0,   CUDA_0  }},
   {"nvrtcGetCUBIN",                               {CUDA_111, CUDA_0,   CUDA_0  }},
-  {"nvrtcGetNVVMSize",                            {CUDA_114, CUDA_0,   CUDA_0  }},
-  {"nvrtcGetNVVM",                                {CUDA_114, CUDA_0,   CUDA_0  }},
+  {"nvrtcGetNVVMSize",                            {CUDA_114, CUDA_120, CUDA_0  }},
+  {"nvrtcGetNVVM",                                {CUDA_114, CUDA_120, CUDA_0  }},
   {"nvrtcAddNameExpression",                      {CUDA_80,  CUDA_0,   CUDA_0  }},
   {"nvrtcGetLoweredName",                         {CUDA_80,  CUDA_0,   CUDA_0  }},
+  {"nvrtcGetLTOIRSize",                           {CUDA_120, CUDA_0,   CUDA_0  }},
+  {"nvrtcGetLTOIR",                               {CUDA_120, CUDA_0,   CUDA_0  }},
+  {"nvrtcGetOptiXIRSize",                         {CUDA_120, CUDA_0,   CUDA_0  }},
+  {"nvrtcGetOptiXIR",                             {CUDA_120, CUDA_0,   CUDA_0  }},
 };
 
 const std::map<llvm::StringRef, hipAPIversions> HIP_RTC_FUNCTION_VER_MAP {


### PR DESCRIPTION
+ Updated the regenerated hipify-perl and CUDA_RTC_API_supported_by_HIP.md accordingly
