### PR TITLE
[HIPIFY][#778][BLAS][tests] Sync with CUDA 12.0 - Part 30 - BLAS tests

### DIFF
--- a/tests/lit.cfg
+++ b/tests/lit.cfg
@@ -82,6 +82,18 @@ if config.cuda_version_major > 10:
 if config.cuda_version_major < 11 or (config.cuda_version_major == 11 and config.cuda_version_minor < 1):
     config.excludes.append('runtime_functions_11010.cu')
 
+if config.cuda_version_major < 12:
+    config.excludes.append('headers_test_06_12000.cu')
+    config.excludes.append('headers_test_07_12000.cu')
+    config.excludes.append('headers_test_08_12000.cu')
+    config.excludes.append('headers_test_09_12000.cu')
+
+if config.cuda_version_major >= 12:
+    config.excludes.append('headers_test_06.cu')
+    config.excludes.append('headers_test_07.cu')
+    config.excludes.append('headers_test_08.cu')
+    config.excludes.append('headers_test_09.cu')
+
 # name: The name of this test suite.
 config.name = 'hipify'
 

--- a/tests/unit_tests/headers/headers_test_06_12000.cu
+++ b/tests/unit_tests/headers/headers_test_06_12000.cu
@@ -1,0 +1,8 @@
+// RUN: %run_test hipify "%s" "%t" %hipify_args 1 --skip-excluded-preprocessor-conditional-blocks %clang_args
+
+// CHECK: #include <hip/hip_runtime.h>
+// CHECK: #include <hipblas.h>
+// CHECK: #include <stdio.h>
+#include <cuda.h>
+#include <cublas.h>
+#include <stdio.h>

--- a/tests/unit_tests/headers/headers_test_07_12000.cu
+++ b/tests/unit_tests/headers/headers_test_07_12000.cu
@@ -1,0 +1,10 @@
+// RUN: %run_test hipify "%s" "%t" %hipify_args 1 --skip-excluded-preprocessor-conditional-blocks %clang_args
+
+// CHECK: #include <hip/hip_runtime.h>
+// CHECK: #include "hipblas.h"
+// CHECK-NOT: #include "cublas_v2.h"
+// CHECK: #include <stdio.h>
+#include <cuda.h>
+#include "cublas_v2.h"
+// CHECK-NOT: #include "hipblas.h"
+#include <stdio.h>

--- a/tests/unit_tests/headers/headers_test_08_12000.cu
+++ b/tests/unit_tests/headers/headers_test_08_12000.cu
@@ -1,0 +1,16 @@
+// RUN: %run_test hipify "%s" "%t" %hipify_args %clang_args
+
+// CHECK: #include <hip/hip_runtime.h>
+// CHECK: #include <iostream>
+// CHECK: #include "hipblas.h"
+// CHECK-NOT: #include "cublas.h"
+// CHECK: #include <stdio.h>
+// CHECK-NOT: #include <cuda.h>
+#include <cuda.h>
+// CHECK-NOT: #include <cuda_runtime.h>
+#include <cuda_runtime.h>
+// CHECK-NOT: #include <hip/hip_runtime.h>
+#include <iostream>
+#include "cublas.h"
+// CHECK-NOT: #include "hipblas.h"
+#include <stdio.h>

--- a/tests/unit_tests/headers/headers_test_09_12000.cu
+++ b/tests/unit_tests/headers/headers_test_09_12000.cu
@@ -1,0 +1,103 @@
+// RUN: %run_test hipify "%s" "%t" %hipify_args %clang_args
+
+// CHECK: #include <hip/hip_runtime.h>
+// CHECK: #include <memory>
+
+// CHECK-NOT: #include <cuda_runtime.h>
+// CHECK-NOT: #include <hip/hip_runtime.h>
+
+// CHECK: #include "hip/hip_runtime_api.h"
+// CHECK: #include "hip/channel_descriptor.h"
+// CHECK: #include "hip/device_functions.h"
+// CHECK: #include "hip/driver_types.h"
+// CHECK: #include "hip/hip_complex.h"
+// CHECK: #include "hip/hip_fp16.h"
+// CHECK: #include "hip/hip_texture_types.h"
+// CHECK: #include "hip/hip_vector_types.h"
+
+// CHECK: #include <iostream>
+
+// CHECK: #include "hipblas.h"
+// CHECK-NOT: #include "cublas_v2.h"
+
+// CHECK: #include <stdio.h>
+
+// CHECK: #include "hiprand.h"
+// CHECK: #include "hiprand_kernel.h"
+
+// CHECK: #include <algorithm>
+
+// CHECK-NOT: #include "hiprand.h"
+// CHECK-NOT: #include "hiprand_kernel.h"
+// CHECK-NOT: #include "curand_discrete.h"
+// CHECK-NOT: #include "curand_discrete2.h"
+// CHECK-NOT: #include "curand_globals.h"
+// CHECK-NOT: #include "curand_lognormal.h"
+// CHECK-NOT: #include "curand_mrg32k3a.h"
+// CHECK-NOT: #include "curand_mtgp32.h"
+// CHECK-NOT: #include "curand_mtgp32_host.h"
+// CHECK-NOT: #include "curand_mtgp32_kernel.h"
+// CHECK-NOT: #include "curand_mtgp32dc_p_11213.h"
+// CHECK-NOT: #include "curand_normal.h"
+// CHECK-NOT: #include "curand_normal_static.h"
+// CHECK-NOT: #include "curand_philox4x32_x.h"
+// CHECK-NOT: #include "curand_poisson.h"
+// CHECK-NOT: #include "curand_precalc.h"
+// CHECK-NOT: #include "curand_uniform.h"
+
+// CHECK: #include <string>
+
+// CHECK: #include "hipfft.h"
+// CHECK: #include "hipsparse.h"
+
+#include <cuda.h>
+// CHECK-NOT: #include <hip/hip_runtime.h>
+
+#include <memory>
+
+#include <cuda_runtime.h>
+// CHECK-NOT: #include <hip/hip_runtime.h>
+
+#include "cuda_runtime_api.h"
+#include "channel_descriptor.h"
+#include "device_functions.h"
+#include "driver_types.h"
+#include "cuComplex.h"
+#include "cuda_fp16.h"
+#include "cuda_texture_types.h"
+#include "vector_types.h"
+
+#include <iostream>
+
+#include "cublas_v2.h"
+
+// CHECK-NOT: #include "hipblas.h"
+
+#include <stdio.h>
+
+#include "curand.h"
+#include "curand_kernel.h"
+
+#include <algorithm>
+
+#include "curand_discrete.h"
+#include "curand_discrete2.h"
+#include "curand_globals.h"
+#include "curand_lognormal.h"
+#include "curand_mrg32k3a.h"
+#include "curand_mtgp32.h"
+#include "curand_mtgp32_host.h"
+#include "curand_mtgp32_kernel.h"
+#include "curand_mtgp32dc_p_11213.h"
+#include "curand_normal.h"
+#include "curand_normal_static.h"
+#include "curand_philox4x32_x.h"
+#include "curand_poisson.h"
+#include "curand_precalc.h"
+#include "curand_uniform.h"
+
+#include <string>
+
+#include "cufft.h"
+
+#include "cusparse.h"


### PR DESCRIPTION
+ Split Blas-related header tests into two: (1) pre-CUDA 12.0 tests and (2) CUDA 12.0 and later tests
+ Exclude (1) from running against CUDA 12.0 and (2) from running against pre-CUDA 12.0

**[ToDo]**
+ Fix the rest BLAS-related tests
