### PR TITLE
[HIPIFY][tests] Sync with CUDA 12.0 - Part 31 - tests with removed APIs

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -554,6 +554,8 @@ my %deprecated_funcs = (
 );
 
 my %removed_funcs = (
+    "texture" => "12.0",
+    "surfaceReference" => "12.0",
     "cusparseZsctr" => "12.0",
     "cusparseZhybsv_solve" => "11.0",
     "cusparseZhybsv_analysis" => "11.0",
@@ -3734,6 +3736,7 @@ sub simpleSubstitutions {
     subst("nvrtcResult", "hiprtcResult", "type");
     subst("pruneInfo_t", "pruneInfo_t", "type");
     subst("surfaceReference", "surfaceReference", "type");
+    subst("texture", "texture", "type");
     subst("textureReference", "textureReference", "type");
     subst("CUBLAS_ATOMICS_ALLOWED", "HIPBLAS_ATOMICS_ALLOWED", "numeric_literal");
     subst("CUBLAS_ATOMICS_NOT_ALLOWED", "HIPBLAS_ATOMICS_NOT_ALLOWED", "numeric_literal");

--- a/doc/markdown/CUDA_Runtime_API_functions_supported_by_HIP.md
+++ b/doc/markdown/CUDA_Runtime_API_functions_supported_by_HIP.md
@@ -1416,7 +1416,8 @@ Unsupported
 |`cudaUserObject_t`|11.3| | |`hipUserObject_t`|5.3.0| | | |
 |`libraryPropertyType`|8.0| | | | | | | |
 |`libraryPropertyType_t`|8.0| | | | | | | |
-|`surfaceReference`| | | |`surfaceReference`|1.9.0| | | |
+|`surfaceReference`| | |12.0|`surfaceReference`|1.9.0| | | |
+|`texture`| | |12.0|`texture`| | | | |
 |`textureReference`| | | |`textureReference`|1.6.0| | | |
 
 ## **37. Execution Control [REMOVED]**

--- a/src/CUDA2HIP_Runtime_API_types.cpp
+++ b/src/CUDA2HIP_Runtime_API_types.cpp
@@ -120,10 +120,11 @@ const std::map<llvm::StringRef, hipCounter> CUDA_RUNTIME_TYPE_NAME_MAP {
   {"CUuuid_st",                                                        {"hipUUID_t",                                                "", CONV_TYPE, API_RUNTIME, 36}},
 
   // NOTE: possibly CUsurfref is analogue
-  {"surfaceReference",                                                 {"surfaceReference",                                         "", CONV_TYPE, API_RUNTIME, 36}},
+  {"surfaceReference",                                                 {"surfaceReference",                                         "", CONV_TYPE, API_RUNTIME, 36, CUDA_REMOVED}},
 
   // NOTE: possibly CUtexref_st is analogue
   {"textureReference",                                                 {"textureReference",                                         "", CONV_TYPE, API_RUNTIME, 36}},
+  {"texture",                                                          {"texture",                                                  "", CONV_TYPE, API_RUNTIME, 36, CUDA_REMOVED}},
 
   // the same - CUevent_st
   {"CUevent_st",                                                       {"ihipEvent_t",                                              "", CONV_TYPE, API_RUNTIME, 36}},
@@ -2487,6 +2488,8 @@ const std::map<llvm::StringRef, cudaAPIversions> CUDA_RUNTIME_TYPE_NAME_VER_MAP 
   {"cudaStreamAttributeMemSyncDomain",                                 {CUDA_120, CUDA_0,   CUDA_0  }},
   {"cudaKernelNodeAttributeMemSyncDomainMap",                          {CUDA_120, CUDA_0,   CUDA_0  }},
   {"cudaKernelNodeAttributeMemSyncDomain",                             {CUDA_120, CUDA_0,   CUDA_0  }},
+  {"texture",                                                          {CUDA_0,   CUDA_0,   CUDA_120}},
+  {"surfaceReference",                                                 {CUDA_0,   CUDA_0,   CUDA_120}},
 };
 
 const std::map<llvm::StringRef, hipAPIversions> HIP_RUNTIME_TYPE_NAME_VER_MAP {

--- a/tests/lit.cfg
+++ b/tests/lit.cfg
@@ -93,6 +93,7 @@ if config.cuda_version_major >= 12:
     config.excludes.append('headers_test_07.cu')
     config.excludes.append('headers_test_08.cu')
     config.excludes.append('headers_test_09.cu')
+    config.excludes.append('tex2dKernel.cpp')
 
 # name: The name of this test suite.
 config.name = 'hipify'

--- a/tests/unit_tests/samples/2_Cookbook/11_texture_driver/texture2dDrv.cpp
+++ b/tests/unit_tests/samples/2_Cookbook/11_texture_driver/texture2dDrv.cpp
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %hipify_args %clang_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args 1 --skip-excluded-preprocessor-conditional-blocks %clang_args
 /*
 Copyright (c) 2015-present Advanced Micro Devices, Inc. All rights reserved.
 
@@ -28,8 +28,10 @@ THE SOFTWARE.
 #include <vector>
 
 #define fileName "tex2dKernel.code"
+#if CUDA_VERSION < 12000
 // CHECK: texture<float, 2, hipReadModeElementType> tex;
 texture<float, 2, cudaReadModeElementType> tex;
+#endif
 bool testResult = false;
 
 // CHECK: hipError_t status = cmd;

--- a/tests/unit_tests/synthetic/driver_functions.cu
+++ b/tests/unit_tests/synthetic/driver_functions.cu
@@ -306,11 +306,6 @@ int main() {
   // CHECK: result = hipGraphGetRootNodes(graph, &graphNode, &bytes);
   result = cuGraphGetRootNodes(graph, &graphNode, &bytes);
 
-  // CUDA: CUresult CUDAAPI cuGraphInstantiate(CUgraphExec *phGraphExec, CUgraph hGraph, CUgraphNode *phErrorNode, char *logBuffer, size_t bufferSize);
-  // HIP: hipError_t hipGraphInstantiate(hipGraphExec_t* pGraphExec, hipGraph_t graph, hipGraphNode_t* pErrorNode, char* pLogBuffer, size_t bufferSize);
-  // CHECK: result = hipGraphInstantiate(&graphExec, graph, &graphNode, nullptr, bytes);
-  result = cuGraphInstantiate(&graphExec, graph, &graphNode, nullptr, bytes);
-
   // CUDA: CUresult CUDAAPI cuGraphKernelNodeGetParams(CUgraphNode hNode, CUDA_KERNEL_NODE_PARAMS *nodeParams);
   // HIP: hipError_t hipGraphKernelNodeGetParams(hipGraphNode_t node, hipKernelNodeParams* pNodeParams);
   // CHECK: result = hipGraphKernelNodeGetParams(graphNode, &KERNEL_NODE_PARAMS);
@@ -415,6 +410,13 @@ int main() {
   // HIP: hipError_t hipGraphClone(hipGraph_t* pGraphClone, hipGraph_t originalGraph);
   // CHECK: result = hipGraphClone(&graph, graph2);
   result = cuGraphClone(&graph, graph2);
+#endif
+
+#if CUDA_VERSION >= 10000 && CUDA_VERSION < 12000
+  // CUDA: CUresult CUDAAPI cuGraphInstantiate(CUgraphExec *phGraphExec, CUgraph hGraph, CUgraphNode *phErrorNode, char *logBuffer, size_t bufferSize);
+  // HIP: hipError_t hipGraphInstantiate(hipGraphExec_t* pGraphExec, hipGraph_t graph, hipGraphNode_t* pErrorNode, char* pLogBuffer, size_t bufferSize);
+  // CHECK: result = hipGraphInstantiate(&graphExec, graph, &graphNode, nullptr, bytes);
+  result = cuGraphInstantiate(&graphExec, graph, &graphNode, nullptr, bytes);
 #endif
 
 #if CUDA_VERSION >= 10010

--- a/tests/unit_tests/synthetic/runtime_functions.cu
+++ b/tests/unit_tests/synthetic/runtime_functions.cu
@@ -74,6 +74,23 @@ int main() {
   // CHECK: hipMemcpyKind MemcpyKind;
   cudaMemcpyKind MemcpyKind;
 
+  // CHECK: hipChannelFormatDesc ChannelFormatDesc;
+  cudaChannelFormatDesc ChannelFormatDesc;
+
+  // CHECK: hipMipmappedArray* MipmappedArray;
+  // CHECK-NEXT: hipMipmappedArray_t MipmappedArray_t;
+  // CHECK-NEXT: hipMipmappedArray_const_t MipmappedArray_const_t;
+  cudaMipmappedArray* MipmappedArray;
+  cudaMipmappedArray_t MipmappedArray_t;
+  cudaMipmappedArray_const_t MipmappedArray_const_t;
+
+  // CHECK: hipArray* Array;
+  // CHECK-NEXT: hipArray_t Array_t;
+  // CHECK-NEXT: hipArray_const_t Array_const_t;
+  cudaArray* Array;
+  cudaArray_t Array_t;
+  cudaArray_const_t Array_const_t;
+
 #if CUDA_VERSION >= 8000
   // CHECK: hipDeviceP2PAttr DeviceP2PAttr;
   cudaDeviceP2PAttr DeviceP2PAttr;
@@ -756,6 +773,43 @@ int main() {
   result = cudaGraphNodeGetEnabled(GraphExec_t, graphNode, &flags);
 #endif
 
+#if CUDA_VERSION < 12000
+  // CUDA: extern __CUDA_DEPRECATED __host__ cudaError_t CUDARTAPI cudaBindTexture(size_t *offset, const struct textureReference *texref, const void *devPtr, const struct cudaChannelFormatDesc *desc, size_t size __dv(UINT_MAX));
+  // HIP: DEPRECATED(DEPRECATED_MSG) hipError_t hipBindTexture(size_t* offset, const textureReference* tex, const void* devPtr, const hipChannelFormatDesc* desc, size_t size __dparm(UINT_MAX));
+  // CHECK: result = hipBindTexture(&wOffset, texref, deviceptr, &ChannelFormatDesc, bytes);
+  result = cudaBindTexture(&wOffset, texref, deviceptr, &ChannelFormatDesc, bytes);
+
+  // CUDA: extern __CUDA_DEPRECATED __host__ cudaError_t CUDARTAPI cudaBindTexture2D(size_t *offset, const struct textureReference *texref, const void *devPtr, const struct cudaChannelFormatDesc *desc, size_t width, size_t height, size_t pitch);
+  // HIP: DEPRECATED(DEPRECATED_MSG) hipError_t hipBindTexture2D(size_t* offset, const textureReference* tex, const void* devPtr, const hipChannelFormatDesc* desc, size_t width, size_t height, size_t pitch);
+  // CHECK: result = hipBindTexture2D(&wOffset, texref, deviceptr, &ChannelFormatDesc, width, height, pitch);
+  result = cudaBindTexture2D(&wOffset, texref, deviceptr, &ChannelFormatDesc, width, height, pitch);
+
+  // CUDA: extern __CUDA_DEPRECATED __host__ cudaError_t CUDARTAPI cudaBindTextureToArray(const struct textureReference *texref, cudaArray_const_t array, const struct cudaChannelFormatDesc *desc);
+  // HIP: DEPRECATED(DEPRECATED_MSG) hipError_t hipBindTextureToArray(const textureReference* tex, hipArray_const_t array, const hipChannelFormatDesc* desc);
+  // CHECK: result = hipBindTextureToArray(texref, Array_const_t, &ChannelFormatDesc);
+  result = cudaBindTextureToArray(texref, Array_const_t, &ChannelFormatDesc);
+
+  // CUDA: extern __CUDA_DEPRECATED __host__ cudaError_t CUDARTAPI cudaBindTextureToMipmappedArray(const struct textureReference *texref, cudaMipmappedArray_const_t mipmappedArray, const struct cudaChannelFormatDesc *desc);
+  // HIP: hipError_t hipBindTextureToMipmappedArray(const textureReference* tex, hipMipmappedArray_const_t mipmappedArray, const hipChannelFormatDesc* desc);
+  // CHECK: result = hipBindTextureToMipmappedArray(texref, MipmappedArray_const_t, &ChannelFormatDesc);
+  result = cudaBindTextureToMipmappedArray(texref, MipmappedArray_const_t, &ChannelFormatDesc);
+
+  // CUDA: extern __CUDA_DEPRECATED __host__ cudaError_t CUDARTAPI cudaGetTextureAlignmentOffset(size_t *offset, const struct textureReference *texref);
+  // HIP: hipError_t hipGetTextureAlignmentOffset(size_t* offset, const textureReference* texref);
+  // CHECK: result = hipGetTextureAlignmentOffset(&wOffset, texref);
+  result = cudaGetTextureAlignmentOffset(&wOffset, texref);
+
+  // CUDA: extern __CUDA_DEPRECATED __host__ cudaError_t CUDARTAPI cudaGetTextureReference(const struct textureReference **texref, const void *symbol);
+  // HIP:  hipError_t hipGetTextureReference(const textureReference** texref, const void* symbol);
+  // CHECK: result = hipGetTextureReference(const_cast<const textureReference**>(&texref), {{(HIP_SYMBOL\()?}}image{{(\))?}});
+  result = cudaGetTextureReference(const_cast<const textureReference**>(&texref), image);
+
+  // CUDA: extern __CUDA_DEPRECATED __host__ cudaError_t CUDARTAPI cudaUnbindTexture(const struct textureReference *texref);
+  // HIP:  DEPRECATED(DEPRECATED_MSG) hipError_t hipUnbindTexture(const textureReference* tex);
+  // CHECK: result = hipUnbindTexture(texref);
+  result = cudaUnbindTexture(texref);
+#endif
+
   // CHECK: hipDeviceProp_t DeviceProp;
   cudaDeviceProp DeviceProp;
 
@@ -1073,13 +1127,6 @@ int main() {
   // CHECK: result = hipFree(deviceptr);
   result = cudaFree(deviceptr);
 
-  // CHECK: hipArray* Array;
-  // CHECK-NEXT: hipArray_t Array_t;
-  // CHECK-NEXT: hipArray_const_t Array_const_t;
-  cudaArray* Array;
-  cudaArray_t Array_t;
-  cudaArray_const_t Array_const_t;
-
   // CUDA: extern __host__ cudaError_t CUDARTAPI cudaFreeArray(cudaArray_t array);
   // HIP: hipError_t hipFreeArray(hipArray* array);
   // CHECK: result = hipFreeArray(Array_t);
@@ -1089,13 +1136,6 @@ int main() {
   // HIP: hipError_t hipHostFree(void* ptr);
   // CHECK: result = hipHostFree(deviceptr);
   result = cudaFreeHost(deviceptr);
-
-  // CHECK: hipMipmappedArray* MipmappedArray;
-  // CHECK-NEXT: hipMipmappedArray_t MipmappedArray_t;
-  // CHECK-NEXT: hipMipmappedArray_const_t MipmappedArray_const_t;
-  cudaMipmappedArray* MipmappedArray;
-  cudaMipmappedArray_t MipmappedArray_t;
-  cudaMipmappedArray_const_t MipmappedArray_const_t;
 
   // CUDA: extern __host__ cudaError_t CUDARTAPI cudaFreeMipmappedArray(cudaMipmappedArray_t mipmappedArray);
   // HIP: hipError_t hipFreeMipmappedArray(hipMipmappedArray_t mipmappedArray);
@@ -1157,9 +1197,6 @@ int main() {
   // HIP: hipError_t hipMalloc3D(hipPitchedPtr* pitchedDevPtr, hipExtent extent);
   // CHECK: result = hipMalloc3D(&PitchedPtr, Extent);
   result = cudaMalloc3D(&PitchedPtr, Extent);
-
-  // CHECK: hipChannelFormatDesc ChannelFormatDesc;
-  cudaChannelFormatDesc ChannelFormatDesc;
 
   // CUDA: extern __host__ cudaError_t CUDARTAPI cudaMalloc3DArray(cudaArray_t *array, const struct cudaChannelFormatDesc* desc, struct cudaExtent extent, unsigned int flags __dv(0));
   // HIP: hipError_t hipMalloc3DArray(hipArray** array, const struct hipChannelFormatDesc* desc, struct hipExtent extent, unsigned int flags);
@@ -1400,26 +1437,6 @@ int main() {
   // CHECK: result = hipGraphicsUnregisterResource(GraphicsResource);
   result = cudaGraphicsUnregisterResource(GraphicsResource);
 
-  // CUDA: extern __CUDA_DEPRECATED __host__ cudaError_t CUDARTAPI cudaBindTexture(size_t *offset, const struct textureReference *texref, const void *devPtr, const struct cudaChannelFormatDesc *desc, size_t size __dv(UINT_MAX));
-  // HIP: DEPRECATED(DEPRECATED_MSG) hipError_t hipBindTexture(size_t* offset, const textureReference* tex, const void* devPtr, const hipChannelFormatDesc* desc, size_t size __dparm(UINT_MAX));
-  // CHECK: result = hipBindTexture(&wOffset, texref, deviceptr, &ChannelFormatDesc, bytes);
-  result = cudaBindTexture(&wOffset, texref, deviceptr, &ChannelFormatDesc, bytes);
-
-  // CUDA: extern __CUDA_DEPRECATED __host__ cudaError_t CUDARTAPI cudaBindTexture2D(size_t *offset, const struct textureReference *texref, const void *devPtr, const struct cudaChannelFormatDesc *desc, size_t width, size_t height, size_t pitch);
-  // HIP: DEPRECATED(DEPRECATED_MSG) hipError_t hipBindTexture2D(size_t* offset, const textureReference* tex, const void* devPtr, const hipChannelFormatDesc* desc, size_t width, size_t height, size_t pitch);
-  // CHECK: result = hipBindTexture2D(&wOffset, texref, deviceptr, &ChannelFormatDesc, width, height, pitch);
-  result = cudaBindTexture2D(&wOffset, texref, deviceptr, &ChannelFormatDesc, width, height, pitch);
-
-  // CUDA: extern __CUDA_DEPRECATED __host__ cudaError_t CUDARTAPI cudaBindTextureToArray(const struct textureReference *texref, cudaArray_const_t array, const struct cudaChannelFormatDesc *desc);
-  // HIP: DEPRECATED(DEPRECATED_MSG) hipError_t hipBindTextureToArray(const textureReference* tex, hipArray_const_t array, const hipChannelFormatDesc* desc);
-  // CHECK: result = hipBindTextureToArray(texref, Array_const_t, &ChannelFormatDesc);
-  result = cudaBindTextureToArray(texref, Array_const_t, &ChannelFormatDesc);
-
-  // CUDA: extern __CUDA_DEPRECATED __host__ cudaError_t CUDARTAPI cudaBindTextureToMipmappedArray(const struct textureReference *texref, cudaMipmappedArray_const_t mipmappedArray, const struct cudaChannelFormatDesc *desc);
-  // HIP: hipError_t hipBindTextureToMipmappedArray(const textureReference* tex, hipMipmappedArray_const_t mipmappedArray, const hipChannelFormatDesc* desc);
-  // CHECK: result = hipBindTextureToMipmappedArray(texref, MipmappedArray_const_t, &ChannelFormatDesc);
-  result = cudaBindTextureToMipmappedArray(texref, MipmappedArray_const_t, &ChannelFormatDesc);
-
   // CHECK: hipChannelFormatKind ChannelFormatKind;
   cudaChannelFormatKind ChannelFormatKind;
 
@@ -1432,21 +1449,6 @@ int main() {
   // HIP: hipError_t hipGetChannelDesc(hipChannelFormatDesc* desc, hipArray_const_t array);
   // CHECK: result = hipGetChannelDesc(&ChannelFormatDesc, Array_const_t);
   result = cudaGetChannelDesc(&ChannelFormatDesc, Array_const_t);
-
-  // CUDA: extern __CUDA_DEPRECATED __host__ cudaError_t CUDARTAPI cudaGetTextureAlignmentOffset(size_t *offset, const struct textureReference *texref);
-  // HIP: hipError_t hipGetTextureAlignmentOffset(size_t* offset, const textureReference* texref);
-  // CHECK: result = hipGetTextureAlignmentOffset(&wOffset, texref);
-  result = cudaGetTextureAlignmentOffset(&wOffset, texref);
-
-  // CUDA: extern __CUDA_DEPRECATED __host__ cudaError_t CUDARTAPI cudaGetTextureReference(const struct textureReference **texref, const void *symbol);
-  // HIP:  hipError_t hipGetTextureReference(const textureReference** texref, const void* symbol);
-  // CHECK: result = hipGetTextureReference(const_cast<const textureReference**>(&texref), HIP_SYMBOL(image));
-  result = cudaGetTextureReference(const_cast<const textureReference**>(&texref), image);
-
-  // CUDA: extern __CUDA_DEPRECATED __host__ cudaError_t CUDARTAPI cudaUnbindTexture(const struct textureReference *texref);
-  // HIP:  DEPRECATED(DEPRECATED_MSG) hipError_t hipUnbindTexture(const textureReference* tex);
-  // CHECK: result = hipUnbindTexture(texref);
-  result = cudaUnbindTexture(texref);
 
   // CHECK: hipTextureObject_t TextureObject_t;
   cudaTextureObject_t TextureObject_t;

--- a/tests/unit_tests/synthetic/runtime_structs.cu
+++ b/tests/unit_tests/synthetic/runtime_structs.cu
@@ -50,9 +50,6 @@ int main() {
   // CHECK: hipTextureDesc TextureDesc;
   cudaTextureDesc TextureDesc;
 
-  // CHECK: surfaceReference surfaceRef;
-  surfaceReference surfaceRef;
-
   // CHECK: ihipEvent_t* event_st;
   // CHECK-NEXT: hipEvent_t Event_t;
   CUevent_st* event_st;
@@ -179,6 +176,11 @@ int main() {
 #if CUDA_VERSION >= 11040
   // CHECK: hipMemallocNodeParams MemAllocNodeParams;
   cudaMemAllocNodeParams MemAllocNodeParams;
+#endif
+
+#if CUDA_VERSION < 12000
+  // CHECK: surfaceReference surfaceRef;
+  surfaceReference surfaceRef;
 #endif
 
   return 0;


### PR DESCRIPTION
+ Added APIs that are deleted since CUDA 12.0
+ Updated the affected tests
+ Updated the regenerated hipify-perl and docs
