### PR TITLE
[HIPIFY][tests] Sync with CUDA 12.0 - Part 34 (final) - temporary excluding of some tests

### DIFF
--- a/tests/lit.cfg
+++ b/tests/lit.cfg
@@ -91,6 +91,13 @@ if config.cuda_version_major >= 12:
     config.excludes.append('headers_test_09.cu')
     config.excludes.append('tex2dKernel.cpp')
     config.excludes.append('cuSPARSE_11.cu')
+    config.excludes.append('cublas_0_based_indexing.cu')
+    config.excludes.append('cublas_0_based_indexing_rocblas.cu')
+    config.excludes.append('cublas2hipblas.cu')
+    config.excludes.append('cublas2rocblas.cu')
+    config.excludes.append('cub_01.cu')
+    config.excludes.append('cub_02.cu')
+    config.excludes.append('cub_03.cu')
 
 if config.llvm_version_major < 8:
     config.excludes.append('cd_intro.cu')


### PR DESCRIPTION
**[ToDo]**
+ #782
+ Get rid of the error `CUDA device code does not support variadic functions` in CUB tests
