### PR TITLE
[HIPIFY][fix] Sync with CUDA 12.1 - Part 4 - Runtime API

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -982,7 +982,7 @@ push(@exclude_filelist, split(',', $exclude_files));
 %exclude_dirhash = map { $_ => 1 } @exclude_dirlist;
 %exclude_filehash = map { $_ => 1 } @exclude_filelist;
 
-@statNames = ("error", "init", "version", "device", "context", "module", "library", "memory", "virtual_memory", "ordered_memory", "multicast", "unified", "stream", "event", "external_resource", "stream_memory", "execution", "graph", "occupancy", "texture", "surface", "tensor", "peer", "graphics", "driver_entry_point", "coredump", "driver_interact", "profiler", "openGL", "D3D9", "D3D10", "D3D11", "VDPAU", "EGL", "thread", "complex", "library", "device_library", "device_function", "device_type", "include", "include_cuda_main_header", "include_cuda_main_header_v2", "type", "literal", "numeric_literal", "define", "extern_shared", "kernel_launch");
+@statNames = ("error", "init", "version", "device", "context", "module", "library", "memory", "virtual_memory", "ordered_memory", "multicast", "unified", "stream", "event", "external_resource", "stream_memory", "execution", "graph", "occupancy", "texture", "surface", "tensor", "peer", "graphics", "driver_entry_point", "cpp", "coredump", "driver_interact", "profiler", "openGL", "D3D9", "D3D10", "D3D11", "VDPAU", "EGL", "thread", "complex", "library", "device_library", "device_function", "device_type", "include", "include_cuda_main_header", "include_cuda_main_header_v2", "type", "literal", "numeric_literal", "define", "extern_shared", "kernel_launch");
 
 sub totalStats {
     my %count = %{shift()};
@@ -6428,6 +6428,7 @@ sub warnUnsupportedFunctions {
         "cudaLaunchAttributeAccessPolicyWindow",
         "cudaLaunchAttribute",
         "cudaKeyValuePair",
+        "cudaKernel_t",
         "cudaKernelNodeAttributePriority",
         "cudaKernelNodeAttributeMemSyncDomainMap",
         "cudaKernelNodeAttributeMemSyncDomain",
@@ -6485,6 +6486,7 @@ sub warnUnsupportedFunctions {
         "cudaGetSurfaceObjectResourceDesc",
         "cudaGetParameterBufferV2",
         "cudaGetParameterBuffer",
+        "cudaGetKernel",
         "cudaGetFuncBySymbol",
         "cudaGetDriverEntryPointFlags",
         "cudaGetDriverEntryPoint",
@@ -6541,6 +6543,7 @@ sub warnUnsupportedFunctions {
         "cudaEventCreateFromEGLSync",
         "cudaErrorUnsupportedPtxVersion",
         "cudaErrorUnsupportedExecAffinity",
+        "cudaErrorUnsupportedDevSideSync",
         "cudaErrorTooManyPeers",
         "cudaErrorTimeout",
         "cudaErrorTextureNotBound",
@@ -6696,6 +6699,7 @@ sub warnUnsupportedFunctions {
         "cudaDriverEntryPointSymbolNotFound",
         "cudaDriverEntryPointSuccess",
         "cudaDriverEntryPointQueryResult",
+        "cudaDeviceSyncMemops",
         "cudaDevicePropDontCare",
         "cudaDeviceMask",
         "cudaDeviceGetTexture1DLinearMaxWidth",
@@ -6706,6 +6710,10 @@ sub warnUnsupportedFunctions {
         "cudaDevAttrReservedSharedMemoryPerBlock",
         "cudaDevAttrReserved93",
         "cudaDevAttrReserved92",
+        "cudaDevAttrReserved132",
+        "cudaDevAttrReserved129",
+        "cudaDevAttrReserved128",
+        "cudaDevAttrReserved127",
         "cudaDevAttrReserved124",
         "cudaDevAttrReserved123",
         "cudaDevAttrReserved122",
@@ -9672,7 +9680,7 @@ while (@ARGV) {
             transformHostFunctions();
             # TODO: would like to move this code outside loop but it uses $_ which contains the whole file
             unless ($no_output) {
-                my $apiCalls   = $ft{'error'} + $ft{'init'} + $ft{'version'} + $ft{'device'} + $ft{'context'} + $ft{'module'} + $ft{'library'} + $ft{'memory'} + $ft{'virtual_memory'} + $ft{'ordered_memory'} + $ft{'multicast'} + $ft{'unified'} + $ft{'stream'} + $ft{'event'} + $ft{'external_resource'} + $ft{'stream_memory'} + $ft{'execution'} + $ft{'graph'} + $ft{'occupancy'} + $ft{'texture'} + $ft{'surface'} + $ft{'tensor'} + $ft{'peer'} + $ft{'graphics'} + $ft{'driver_entry_point'} + $ft{'coredump'} + $ft{'driver_interact'} + $ft{'profiler'} + $ft{'openGL'} + $ft{'D3D9'} + $ft{'D3D10'} + $ft{'D3D11'} + $ft{'VDPAU'} + $ft{'EGL'} + $ft{'thread'} + $ft{'complex'} + $ft{'library'} + $ft{'device_library'} + $ft{'device_type'} + $ft{'include'} + $ft{'include_cuda_main_header'} + $ft{'include_cuda_main_header_v2'} + $ft{'type'} + $ft{'literal'} + $ft{'numeric_literal'} + $ft{'define'};
+                my $apiCalls   = $ft{'error'} + $ft{'init'} + $ft{'version'} + $ft{'device'} + $ft{'context'} + $ft{'module'} + $ft{'library'} + $ft{'memory'} + $ft{'virtual_memory'} + $ft{'ordered_memory'} + $ft{'multicast'} + $ft{'unified'} + $ft{'stream'} + $ft{'event'} + $ft{'external_resource'} + $ft{'stream_memory'} + $ft{'execution'} + $ft{'graph'} + $ft{'occupancy'} + $ft{'texture'} + $ft{'surface'} + $ft{'tensor'} + $ft{'peer'} + $ft{'graphics'} + $ft{'driver_entry_point'} + $ft{'cpp'} + $ft{'coredump'} + $ft{'driver_interact'} + $ft{'profiler'} + $ft{'openGL'} + $ft{'D3D9'} + $ft{'D3D10'} + $ft{'D3D11'} + $ft{'VDPAU'} + $ft{'EGL'} + $ft{'thread'} + $ft{'complex'} + $ft{'library'} + $ft{'device_library'} + $ft{'device_type'} + $ft{'include'} + $ft{'include_cuda_main_header'} + $ft{'include_cuda_main_header_v2'} + $ft{'type'} + $ft{'literal'} + $ft{'numeric_literal'} + $ft{'define'};
                 my $kernStuff  = $hasDeviceCode + $ft{'kernel_launch'} + $ft{'device_function'};
                 my $totalCalls = $apiCalls + $kernStuff;
                 $is_dos = m/\r\n$/;

--- a/doc/markdown/CUDA_Runtime_API_functions_supported_by_HIP.md
+++ b/doc/markdown/CUDA_Runtime_API_functions_supported_by_HIP.md
@@ -498,7 +498,9 @@
 
 ## **30. C++ API Routines**
 
-Unsupported
+|**CUDA**|**A**|**D**|**R**|**HIP**|**A**|**D**|**R**|**E**|
+|:--|:-:|:-:|:-:|:--|:-:|:-:|:-:|:-:|
+|`cudaGetKernel`|12.1| | | | | | | |
 
 ## **31. Interactions with the CUDA Driver API**
 
@@ -526,6 +528,7 @@ Unsupported
 |`CUgraphExec_st`|10.0| | |`hipGraphExec`|4.3.0| | | |
 |`CUgraphNode_st`|10.0| | |`hipGraphNode`|4.3.0| | | |
 |`CUgraph_st`|10.0| | |`ihipGraph`|4.3.0| | | |
+|`CUkern_st`|12.1| | | | | | | |
 |`CUstream_st`| | | |`ihipStream_t`|1.5.0| | | |
 |`CUuuid_st`| | | |`hipUUID_t`|5.2.0| | | |
 |`MAJOR_VERSION`|8.0| | | | | | | |
@@ -739,6 +742,10 @@ Unsupported
 |`cudaDevAttrReserved122`|12.0| | | | | | | |
 |`cudaDevAttrReserved123`|12.0| | | | | | | |
 |`cudaDevAttrReserved124`|12.0| | | | | | | |
+|`cudaDevAttrReserved127`|12.1| | | | | | | |
+|`cudaDevAttrReserved128`|12.1| | | | | | | |
+|`cudaDevAttrReserved129`|12.1| | | | | | | |
+|`cudaDevAttrReserved132`|12.1| | | | | | | |
 |`cudaDevAttrReserved92`|9.0| | | | | | | |
 |`cudaDevAttrReserved93`|9.0| | | | | | | |
 |`cudaDevAttrReserved94`|9.0| | |`hipDeviceAttributeCanUseStreamWaitValue`|4.3.0| | | |
@@ -771,6 +778,7 @@ Unsupported
 |`cudaDeviceScheduleMask`| | | |`hipDeviceScheduleMask`|1.6.0| | | |
 |`cudaDeviceScheduleSpin`| | | |`hipDeviceScheduleSpin`|1.6.0| | | |
 |`cudaDeviceScheduleYield`| | | |`hipDeviceScheduleYield`|1.6.0| | | |
+|`cudaDeviceSyncMemops`|12.1| | | | | | | |
 |`cudaDriverEntryPointQueryResult`|12.0| | | | | | | |
 |`cudaDriverEntryPointSuccess`|12.0| | | | | | | |
 |`cudaDriverEntryPointSymbolNotFound`|12.0| | | | | | | |
@@ -986,6 +994,7 @@ Unsupported
 |`cudaErrorTooManyPeers`| | | | | | | | |
 |`cudaErrorUnknown`| | | |`hipErrorUnknown`|1.6.0| | | |
 |`cudaErrorUnmapBufferObjectFailed`| | | |`hipErrorUnmapFailed`|1.6.0| | | |
+|`cudaErrorUnsupportedDevSideSync`|12.1| | | | | | | |
 |`cudaErrorUnsupportedExecAffinity`|11.4| | | | | | | |
 |`cudaErrorUnsupportedLimit`| | | |`hipErrorUnsupportedLimit`|1.6.0| | | |
 |`cudaErrorUnsupportedPtxVersion`|11.1| | | | | | | |
@@ -1183,6 +1192,7 @@ Unsupported
 |`cudaKernelNodeAttributeMemSyncDomainMap`|12.0| | | | | | | |
 |`cudaKernelNodeAttributePriority`|11.7| | | | | | | |
 |`cudaKernelNodeParams`|10.0| | |`hipKernelNodeParams`|4.3.0| | | |
+|`cudaKernel_t`|12.1| | | | | | | |
 |`cudaKeyValuePair`| | |12.0| | | | | |
 |`cudaLaunchAttribute`|11.8| | | | | | | |
 |`cudaLaunchAttributeAccessPolicyWindow`|11.8| | | | | | | |

--- a/src/CUDA2HIP_Driver_API_types.cpp
+++ b/src/CUDA2HIP_Driver_API_types.cpp
@@ -331,9 +331,9 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_TYPE_NAME_MAP {
   //
   {"CUlibrary",                                                        {"hipLibraty",                                               "", CONV_TYPE, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
 
-  //
+  // the same CUkern_st
   {"CUkern_st",                                                        {"hipKernel",                                                "", CONV_TYPE, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
-  //
+  // cudaKernel_t
   {"CUkernel",                                                         {"hipKernel",                                                "", CONV_TYPE, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
 
   // cudaGraphInstantiateParams_st
@@ -504,7 +504,7 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_TYPE_NAME_MAP {
   {"CU_CTX_COREDUMP_ENABLE",                                           {"hipDeviceCoreDumpEnable",                                  "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED}}, // 0x20
   //
   {"CU_CTX_USER_COREDUMP_ENABLE",                                      {"hipDeviceUserCoreDumpEnable",                              "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED}}, // 0x40
-  //
+  // cudaDeviceSyncMemops
   {"CU_CTX_SYNC_MEMOPS",                                               {"hipDeviceSyncMemOps",                                      "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED}}, // 0x80
   // cudaDeviceMask
   {"CU_CTX_FLAGS_MASK",                                                {"hipDeviceMask",                                            "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED}}, // 0xff
@@ -1613,8 +1613,8 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_TYPE_NAME_MAP {
   {"CUDA_ERROR_JIT_COMPILATION_DISABLED",                              {"hipErrorJitCompilationDisabled",                           "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED}}, // 223
   // cudaErrorUnsupportedExecAffinity
   {"CUDA_ERROR_UNSUPPORTED_EXEC_AFFINITY",                             {"hipErrorUnsupportedExecAffinity",                          "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED}}, // 224
-  //
-  {"CUDA_ERROR_UNSUPPORTED_DEVSIDE_SYNC",                              {"hipErrorUnsupportedDevsideSync",                           "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED}}, // 225
+  // cudaErrorUnsupportedDevSideSync
+  {"CUDA_ERROR_UNSUPPORTED_DEVSIDE_SYNC",                              {"hipErrorUnsupportedDevSideSync",                           "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED}}, // 225
   // cudaErrorInvalidSource
   {"CUDA_ERROR_INVALID_SOURCE",                                        {"hipErrorInvalidSource",                                    "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES}}, // 300
   // cudaErrorFileNotFound

--- a/src/CUDA2HIP_Runtime_API_functions.cpp
+++ b/src/CUDA2HIP_Runtime_API_functions.cpp
@@ -842,7 +842,7 @@ const std::map<llvm::StringRef, hipCounter> CUDA_RUNTIME_FUNCTION_MAP {
   {"cudaGetDriverEntryPoint",                                 {"hipGetProcAddress",                                      "", CONV_DRIVER_ENTRY_POINT, API_RUNTIME, SEC::DRIVER_ENTRY_POINT, HIP_UNSUPPORTED}},
 
   // 30. C++ API Routines
-  // TODO
+  {"cudaGetKernel",                                           {"hipGetKernel",                                           "", CONV_CPP, API_RUNTIME, SEC::CPP, HIP_UNSUPPORTED}},
 
   // 31. Interactions with the CUDA Driver API
   {"cudaGetFuncBySymbol",                                     {"hipGetFuncBySymbol",                                     "", CONV_DRIVER_INTERACT, API_RUNTIME, SEC::DRIVER_INTERACT, HIP_UNSUPPORTED}},
@@ -1109,6 +1109,7 @@ const std::map<llvm::StringRef, cudaAPIversions> CUDA_RUNTIME_FUNCTION_VER_MAP {
   {"cudaStreamGetId",                                         {CUDA_120, CUDA_0,   CUDA_0  }},
   {"cudaGraphInstantiateWithParams",                          {CUDA_120, CUDA_0,   CUDA_0  }},
   {"cudaGraphExecGetFlags",                                   {CUDA_120, CUDA_0,   CUDA_0  }},
+  {"cudaGetKernel",                                           {CUDA_121, CUDA_0,   CUDA_0  }},
 };
 
 const std::map<llvm::StringRef, hipAPIversions> HIP_RUNTIME_FUNCTION_VER_MAP {

--- a/src/CUDA2HIP_Runtime_API_types.cpp
+++ b/src/CUDA2HIP_Runtime_API_types.cpp
@@ -225,6 +225,11 @@ const std::map<llvm::StringRef, hipCounter> CUDA_RUNTIME_TYPE_NAME_MAP {
   // CUlaunchMemSyncDomainMap
   {"cudaLaunchMemSyncDomainMap",                                       {"hipLaunchMemSyncDomainMap",                                "", CONV_TYPE, API_RUNTIME, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
 
+  // the same CUkern_st
+  {"CUkern_st",                                                        {"hipKernel",                                                "", CONV_TYPE, API_RUNTIME, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
+  // CUkernel
+  {"cudaKernel_t",                                                     {"hipKernel",                                                "", CONV_TYPE, API_RUNTIME, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
+
   // 2. Unions
 
   // CUstreamAttrValue
@@ -591,6 +596,14 @@ const std::map<llvm::StringRef, hipCounter> CUDA_RUNTIME_TYPE_NAME_MAP {
   {"cudaDevAttrIpcEventSupport",                                       {"hipDevAttrIpcEventSupport",                                "", CONV_NUMERIC_LITERAL, API_RUNTIME, SEC::DATA_TYPES, HIP_UNSUPPORTED}}, // 125
   // CU_DEVICE_ATTRIBUTE_MEM_SYNC_DOMAIN_COUNT
   {"cudaDevAttrMemSyncDomainCount",                                    {"hipDevAttrMemSyncDomainCount",                             "", CONV_NUMERIC_LITERAL, API_RUNTIME, SEC::DATA_TYPES, HIP_UNSUPPORTED}}, // 126
+  // CU_DEVICE_ATTRIBUTE_TENSOR_MAP_ACCESS_SUPPORTED
+  {"cudaDevAttrReserved127",                                           {"hipDeviceAttributeTensorMapAccessSupported",               "", CONV_NUMERIC_LITERAL, API_RUNTIME, SEC::DATA_TYPES, HIP_UNSUPPORTED}}, // 127
+  //
+  {"cudaDevAttrReserved128",                                           {"hipDevAttrReserved128",                                    "", CONV_NUMERIC_LITERAL, API_RUNTIME, SEC::DATA_TYPES, HIP_UNSUPPORTED}}, // 128
+  // CU_DEVICE_ATTRIBUTE_UNIFIED_FUNCTION_POINTERS
+  {"cudaDevAttrReserved129",                                           {"hipDeviceAttributeUnifiedFunctionPointers",                "", CONV_NUMERIC_LITERAL, API_RUNTIME, SEC::DATA_TYPES, HIP_UNSUPPORTED}}, // 129
+  // CU_DEVICE_ATTRIBUTE_MULTICAST_SUPPORTED
+  {"cudaDevAttrReserved132",                                           {"hipDeviceAttributeMulticastSupported",                     "", CONV_NUMERIC_LITERAL, API_RUNTIME, SEC::DATA_TYPES, HIP_UNSUPPORTED}}, // 132
   // CU_DEVICE_ATTRIBUTE_MAX
   {"cudaDevAttrMax",                                                   {"hipDeviceAttributeMax",                                    "", CONV_NUMERIC_LITERAL, API_RUNTIME, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
 
@@ -930,6 +943,8 @@ const std::map<llvm::StringRef, hipCounter> CUDA_RUNTIME_TYPE_NAME_MAP {
   {"cudaErrorJitCompilationDisabled",                                  {"hipErrorJitCompilationDisabled",                           "", CONV_NUMERIC_LITERAL, API_RUNTIME, SEC::DATA_TYPES, HIP_UNSUPPORTED}}, // 223
   // CUDA_ERROR_UNSUPPORTED_EXEC_AFFINITY
   {"cudaErrorUnsupportedExecAffinity",                                 {"hipErrorUnsupportedExecAffinity",                          "", CONV_NUMERIC_LITERAL, API_RUNTIME, SEC::DATA_TYPES, HIP_UNSUPPORTED}}, // 224
+  // CUDA_ERROR_UNSUPPORTED_DEVSIDE_SYNC
+  {"cudaErrorUnsupportedDevSideSync",                                  {"hipErrorUnsupportedDevSideSync",                           "", CONV_NUMERIC_LITERAL, API_RUNTIME, SEC::DATA_TYPES, HIP_UNSUPPORTED}}, // 225
   // CUDA_ERROR_INVALID_SOURCE
   {"cudaErrorInvalidSource",                                           {"hipErrorInvalidSource",                                    "", CONV_NUMERIC_LITERAL, API_RUNTIME, SEC::DATA_TYPES}}, // 300
   // CUDA_ERROR_FILE_NOT_FOUND
@@ -1869,6 +1884,8 @@ const std::map<llvm::StringRef, hipCounter> CUDA_RUNTIME_TYPE_NAME_MAP {
   // CU_CTX_LMEM_RESIZE_TO_MAX
   // NOTE: hipDeviceLmemResizeToMax = 0x16
   {"cudaDeviceLmemResizeToMax",                                        {"hipDeviceLmemResizeToMax",                                 "", CONV_DEFINE, API_RUNTIME, SEC::DATA_TYPES}}, // 0x10
+  // CU_CTX_SYNC_MEMOPS
+  {"cudaDeviceSyncMemops",                                             {"hipDeviceSyncMemops",                                      "", CONV_DEFINE, API_RUNTIME, SEC::DATA_TYPES, HIP_UNSUPPORTED}}, // 0x80
   // CU_CTX_MAP_HOST
   {"cudaDeviceMapHost",                                                {"hipDeviceMapHost",                                         "", CONV_DEFINE, API_RUNTIME, SEC::DATA_TYPES}}, // 0x08
   // CU_CTX_FLAGS_MASK
@@ -2492,6 +2509,14 @@ const std::map<llvm::StringRef, cudaAPIversions> CUDA_RUNTIME_TYPE_NAME_VER_MAP 
   {"cudaKernelNodeAttributeMemSyncDomain",                             {CUDA_120, CUDA_0,   CUDA_0  }},
   {"texture",                                                          {CUDA_0,   CUDA_0,   CUDA_120}},
   {"surfaceReference",                                                 {CUDA_0,   CUDA_0,   CUDA_120}},
+  {"cudaDeviceSyncMemops",                                             {CUDA_121, CUDA_0,   CUDA_0  }},
+  {"cudaErrorUnsupportedDevSideSync",                                  {CUDA_121, CUDA_0,   CUDA_0  }},
+  {"cudaDevAttrReserved127",                                           {CUDA_121, CUDA_0,   CUDA_0  }},
+  {"cudaDevAttrReserved128",                                           {CUDA_121, CUDA_0,   CUDA_0  }},
+  {"cudaDevAttrReserved129",                                           {CUDA_121, CUDA_0,   CUDA_0  }},
+  {"cudaDevAttrReserved132",                                           {CUDA_121, CUDA_0,   CUDA_0  }},
+  {"CUkern_st",                                                        {CUDA_121, CUDA_0,   CUDA_0  }},
+  {"cudaKernel_t",                                                     {CUDA_121, CUDA_0,   CUDA_0  }},
 };
 
 const std::map<llvm::StringRef, hipAPIversions> HIP_RUNTIME_TYPE_NAME_VER_MAP {

--- a/src/Statistics.cpp
+++ b/src/Statistics.cpp
@@ -53,6 +53,7 @@ const char *counterNames[NUM_CONV_TYPES] = {
   "peer", // CONV_PEER
   "graphics", // CONV_GRAPHICS
   "driver_entry_point", // CONV_DRIVER_ENTRY_POINT
+  "cpp", // CONV_CPP
   "coredump", // CONV_COREDUMP
   "driver_interact", // CONV_DRIVER_INTERACT
   "profiler", // CONV_PROFILER
@@ -105,6 +106,7 @@ const char *counterTypes[NUM_CONV_TYPES] = {
   "CONV_PEER",
   "CONV_GRAPHICS",
   "CONV_DRIVER_ENTRY_POINT",
+  "CONV_CPP",
   "CONV_COREDUMP",
   "CONV_DRIVER_INTERACT",
   "CONV_PROFILER",

--- a/src/Statistics.h
+++ b/src/Statistics.h
@@ -111,6 +111,8 @@ enum ConvTypes {
   //  driver::DRIVER_ENTRY_POINT
   // runtime::DRIVER_ENTRY_POINT
   CONV_DRIVER_ENTRY_POINT,
+  // runtime::CPP
+  CONV_CPP,
   //  driver::COREDUMP
   CONV_COREDUMP,
   // runtime::DRIVER_INTERACT


### PR DESCRIPTION
+ Sync with the analogous Driver API ones
+ Introduced `C++ API Routines` section
+ Updated the regenerated `hipify-perl` and `CUDA_Runtime_API_functions_supported_by_HIP.md` accordingly
