### PR TITLE
[HIPIFY] Introduced the option `--default-preprocessor` synonymous with the '--skip-excluded-preprocessor-conditional-blocks' option

### DIFF
--- a/src/ArgParse.cpp
+++ b/src/ArgParse.cpp
@@ -144,6 +144,11 @@ cl::opt<bool> SkipExcludedPPConditionalBlocks("skip-excluded-preprocessor-condit
   cl::value_desc("skip-excluded-preprocessor-conditional-blocks"),
   cl::cat(ToolTemplateCategory));
 
+cl::opt<bool> DefaultPreprocessor("default-preprocessor",
+  cl::desc("Enable default preprocessor behaviour (synonymous with '--skip-excluded-preprocessor-conditional-blocks')"),
+  cl::value_desc("default-preprocessor"),
+  cl::cat(ToolTemplateCategory));
+
 cl::opt<std::string> CudaGpuArch("cuda-gpu-arch",
   cl::desc("CUDA GPU architecture (e.g. sm_35);\nmay be specified more than once"),
   cl::value_desc("value"),

--- a/src/ArgParse.h
+++ b/src/ArgParse.h
@@ -53,6 +53,7 @@ extern cl::opt<bool> TranslateToRoc;
 extern cl::opt<bool> TranslateToMIOpen;
 extern cl::opt<bool> DashDash;
 extern cl::opt<bool> SkipExcludedPPConditionalBlocks;
+extern cl::opt<bool> DefaultPreprocessor;
 extern cl::opt<std::string> CudaGpuArch;
 extern cl::opt<bool> GenerateMarkdown;
 extern cl::opt<bool> GenerateCSV;

--- a/src/LLVMCompat.cpp
+++ b/src/LLVMCompat.cpp
@@ -130,7 +130,13 @@ bool pragma_once_outside_header() {
 void RetainExcludedConditionalBlocks(clang::CompilerInstance &CI) {
 #if LLVM_VERSION_MAJOR > 9
   clang::PreprocessorOptions &PPOpts = CI.getPreprocessorOpts();
-  PPOpts.RetainExcludedConditionalBlocks = !SkipExcludedPPConditionalBlocks;
+  if (SkipExcludedPPConditionalBlocks) {
+    PPOpts.RetainExcludedConditionalBlocks = !SkipExcludedPPConditionalBlocks;
+  } else if (DefaultPreprocessor) {
+    PPOpts.RetainExcludedConditionalBlocks = !DefaultPreprocessor;
+  } else {
+    PPOpts.RetainExcludedConditionalBlocks = !SkipExcludedPPConditionalBlocks;
+  }
 #endif
 }
 
@@ -138,6 +144,9 @@ bool CheckCompatibility() {
 #if LLVM_VERSION_MAJOR < 10
   if (SkipExcludedPPConditionalBlocks) {
     llvm::errs() << "\n" << sHipify << sWarning << "Option '" << SkipExcludedPPConditionalBlocks.ArgStr.str() << "' is supported starting from LLVM version 10.0\n";
+  }
+  if (DefaultPreprocessor) {
+    llvm::errs() << "\n" << sHipify << sWarning << "Option '" << DefaultPreprocessor.ArgStr.str() << "' is supported starting from LLVM version 10.0\n";
   }
 #endif
   return true;


### PR DESCRIPTION
**[Reason]**
+ '--skip-excluded-preprocessor-conditional-blocks' is wordy and misleading

**[IMP]**
+ Any of the synonymous options or both might be set to enable a default preprocessor behaviour