### PR TITLE
[HIPIFY][#801][SWDEV-343109] Add an explicit `reinterpret_cast` for every `MemberExpr` of the `half2` struct - Step 2

### DIFF
--- a/src/HipifyAction.cpp
+++ b/src/HipifyAction.cpp
@@ -622,7 +622,16 @@ std::unique_ptr<clang::ASTConsumer> HipifyAction::CreateASTConsumer(clang::Compi
   Finder->addMatcher(mat::cudaKernelCallExpr(mat::isExpansionInMainFile()).bind(sCudaLaunchKernel), this);
   Finder->addMatcher(
     mat::memberExpr(
-      mat::isExpansionInMainFile()
+      mat::isExpansionInMainFile(),
+      mat::unless(
+        mat::hasParent(
+          mat::cxxReinterpretCastExpr(
+            mat::hasDestinationType(
+              mat::referenceType()
+            )
+          )
+        )
+      )
     ).bind(sHalf2Member),
     this
   );

--- a/tests/unit_tests/samples/half2_allocators.cu
+++ b/tests/unit_tests/samples/half2_allocators.cu
@@ -25,8 +25,10 @@ __global__ void add(int n, T *x, T *y) {
   half2 tmp = __float2half2_rn(0.0f);
   // CHECK: float max_val = fmax((float)reinterpret_cast<half&>(tmp.x), (float)reinterpret_cast<half&>(tmp.y));
   float max_val = fmax((float)tmp.x, (float)tmp.y);
+  // CHECK: float min_val = fmin((float)reinterpret_cast<half&>(tmp.x), (float)reinterpret_cast<half&>(tmp.y));
+  float min_val = fmin((float)reinterpret_cast<half&>(tmp.x), (float)reinterpret_cast<half&>(tmp.y));
   for (int i = index; i < n; i += stride)
-      y[i] = x[i] + y[i];
+      y[i] = max_val - min_val + x[i] + y[i];
 }
 
 int main(int argc, char* argv[]) {


### PR DESCRIPTION
+ Took into account cases where the corresponding `reinterpret_cast<half&>` already takes place
+ Updated the test `half2_allocators.cu` accordingly
