### PR TITLE
[HIPIFY][#801][SWDEV-343109] Add an explicit `reinterpret_cast` for every `MemberExpr` of the `half2` struct - Step 3

### DIFF
--- a/src/HipifyAction.cpp
+++ b/src/HipifyAction.cpp
@@ -602,6 +602,9 @@ bool HipifyAction::half2Member(const mat::MatchFinder::MatchResult &Result) {
     ct::Replacement Rep(*Result.SourceManager, sr.getBegin(), exprName.size(), OS.str());
     clang::FullSourceLoc fullSL(sr.getBegin(), *Result.SourceManager);
     insertReplacement(Rep, fullSL);
+    clang::DiagnosticsEngine& DE = getCompilerInstance().getDiagnostics();
+    const auto ID = DE.getCustomDiagID(clang::DiagnosticsEngine::Warning, "Undocumented feature. CUDA API does not explicitly define the 'x' and 'y' members of 'half2' and the access through the dot operator, while in practice, nvcc supports it and treats them as 'half'. AMD HIP does define the 'x' and 'y' members of 'half2' as 'unsigned short'. Thus, without 'reinterpret_cast' to 'half' of the 'half2' members, the resulting values in the hipified code are incorrect and differ from CUDA ones. The '%0' will be transformed to 'reinterpret_cast<half&>(%0)'.");
+    DE.Report(fullSL, ID) << exprName;
     return true;
   }
   return false;


### PR DESCRIPTION
+ Add a corresponding warning message about undocumented feature for every explicit `reinterpret_cast` for accessing the struct `half2` members

**[ToDo]**
+ [optional] Add an option for undocumented feature warning suppress
+ [optional] Add an option for not using undocumented features
