### PR TITLE
[HIPIFY] Introduced the `--versions` option for 3rd-party software

### DIFF
--- a/src/ArgParse.cpp
+++ b/src/ArgParse.cpp
@@ -187,6 +187,11 @@ cl::opt<bool> HipKernelExecutionSyntax("hip-kernel-execution-syntax",
   cl::value_desc("hip-kernel-execution-syntax"),
   cl::cat(ToolTemplateCategory));
 
+cl::opt<bool> Versions("versions",
+  cl::desc("Display the versions of the supported 3rd-party software"),
+  cl::value_desc("versions"),
+  cl::cat(ToolTemplateCategory));
+
 cl::extrahelp CommonHelp(ct::CommonOptionsParser::HelpMessage);
 
 const std::vector<std::string> hipifyOptions {
@@ -209,6 +214,7 @@ const std::vector<std::string> hipifyOptions {
   std::string(SaveTemps.ArgStr),
   std::string(DocFormat.ArgStr),
   std::string(Experimental.ArgStr),
+  std::string(Versions.ArgStr),
 };
 
 const std::vector<std::string> hipifyOptionsWithTwoArgs {

--- a/src/ArgParse.h
+++ b/src/ArgParse.h
@@ -63,3 +63,4 @@ extern cl::opt<bool> CudaKernelExecutionSyntax;
 extern cl::opt<bool> HipKernelExecutionSyntax;
 extern const std::vector<std::string> hipifyOptions;
 extern const std::vector<std::string> hipifyOptionsWithTwoArgs;
+extern cl::opt<bool> Versions;

--- a/src/Statistics.h
+++ b/src/Statistics.h
@@ -234,6 +234,7 @@ enum cudaVersions {
   CUDA_118 = 11080,
   CUDA_120 = 12000,
   CUDA_121 = 12010,
+  CUDA_LATEST = CUDA_121,
   CUDNN_10 = 100,
   CUDNN_20 = 200,
   CUDNN_30 = 300,
@@ -273,6 +274,7 @@ enum cudaVersions {
   CUDNN_860 = 860,
   CUDNN_870 = 870,
   CUDNN_880 = 880,
+  CUDNN_LATEST = CUDNN_880,
 };
 
 enum hipVersions {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -177,6 +177,12 @@ bool generatePython() {
   return bToPython;
 }
 
+void printVersions() {
+  llvm::errs() << "\n" << sHipify << "Supports ROCm HIP from " << Statistics::getHipVersion(hipVersions::HIP_5000) << " up to " << Statistics::getHipVersion(hipVersions::HIP_LATEST);
+  llvm::errs() << "\n" << sHipify << "Supports CUDA Toolkit from " << Statistics::getCudaVersion(cudaVersions::CUDA_70) << " up to " << Statistics::getCudaVersion(cudaVersions::CUDA_LATEST);
+  llvm::errs() << "\n" << sHipify << "Supports cuDNN from " << Statistics::getCudaVersion(cudaVersions::CUDNN_705) << " up to " << Statistics::getCudaVersion(cudaVersions::CUDNN_LATEST) << " \n";
+}
+
 int main(int argc, const char **argv) {
   std::vector<const char*> new_argv(argv, argv + argc);
   std::string sCompilationDatabaseDir;
@@ -236,10 +242,11 @@ int main(int argc, const char **argv) {
   } else {
     fileSources = OptionsParser.getSourcePathList();
   }
-  if (fileSources.empty() && !GeneratePerl && !GeneratePython && !GenerateMarkdown && !GenerateCSV) {
+  if (fileSources.empty() && !GeneratePerl && !GeneratePython && !GenerateMarkdown && !GenerateCSV && !Versions) {
     llvm::errs() << "\n" << sHipify << sError << "Must specify at least 1 positional argument for source file" << "\n";
     return 1;
   }
+  if (Versions) printVersions();
   if (!GenerateMarkdown && !GenerateCSV && !DocFormat.empty()) {
     llvm::errs() << "\n" << sHipify << sError << "Must specify a document type to generate: \"md\" and | or \"csv\"" << "\n";
     return 1;


### PR DESCRIPTION
Currently, it prints the following:

```
[HIPIFY] Supports ROCm HIP from 5.0.0 up to 5.5.0
[HIPIFY] Supports CUDA Toolkit from 7.0 up to 12.1
[HIPIFY] Supports cuDNN from 7.0.5 up to 8.8.0
```

Further, the `up to` version will be calculated based on the latest supported version, the `from` version might be changed explicitly.