### PR TITLE
[HIPIFY][#801] Introduced the `--no-undocumented-features` option (`false` by default)

### DIFF
--- a/src/ArgParse.cpp
+++ b/src/ArgParse.cpp
@@ -176,6 +176,12 @@ cl::opt<bool> Experimental("experimental",
   cl::value_desc("experimental"),
   cl::cat(ToolTemplateCategory));
 
+cl::opt<bool> NoUndocumented("no-undocumented-features",
+  cl::desc("Do not rely on undocumented features in code transformation"),
+  cl::value_desc("no-undocumented-features"),
+  cl::init(false),
+  cl::cat(ToolTemplateCategory));
+
 cl::opt<bool> CudaKernelExecutionSyntax("cuda-kernel-execution-syntax",
   cl::desc("Keep CUDA kernel launch syntax (default)"),
   cl::value_desc("cuda-kernel-execution-syntax"),
@@ -215,6 +221,7 @@ const std::vector<std::string> hipifyOptions {
   std::string(DocFormat.ArgStr),
   std::string(Experimental.ArgStr),
   std::string(Versions.ArgStr),
+  std::string(NoUndocumented.ArgStr),
 };
 
 const std::vector<std::string> hipifyOptionsWithTwoArgs {

--- a/src/ArgParse.h
+++ b/src/ArgParse.h
@@ -64,3 +64,4 @@ extern cl::opt<bool> HipKernelExecutionSyntax;
 extern const std::vector<std::string> hipifyOptions;
 extern const std::vector<std::string> hipifyOptionsWithTwoArgs;
 extern cl::opt<bool> Versions;
+extern cl::opt<bool> NoUndocumented;


### PR DESCRIPTION
+ `--no-undocumented-features`: Do not rely on undocumented features in code transformation
+ If set, do not use the matchers, relying on undocumented features, like the `half` type of the `half2` struct members
