### PR TITLE
[HIPIFY][#801] Introduced the `--no-warnings-on-undocumented-features` option (`false` by default)

### DIFF
--- a/src/ArgParse.cpp
+++ b/src/ArgParse.cpp
@@ -182,6 +182,12 @@ cl::opt<bool> NoUndocumented("no-undocumented-features",
   cl::init(false),
   cl::cat(ToolTemplateCategory));
 
+cl::opt<bool> NoWarningsUndocumented("no-warnings-on-undocumented-features",
+  cl::desc("Suppress warnings on undocumented features in code transformation"),
+  cl::value_desc("no-warnings-on-undocumented-features"),
+  cl::init(false),
+  cl::cat(ToolTemplateCategory));
+
 cl::opt<bool> CudaKernelExecutionSyntax("cuda-kernel-execution-syntax",
   cl::desc("Keep CUDA kernel launch syntax (default)"),
   cl::value_desc("cuda-kernel-execution-syntax"),
@@ -222,6 +228,7 @@ const std::vector<std::string> hipifyOptions {
   std::string(Experimental.ArgStr),
   std::string(Versions.ArgStr),
   std::string(NoUndocumented.ArgStr),
+  std::string(NoWarningsUndocumented.ArgStr),
 };
 
 const std::vector<std::string> hipifyOptionsWithTwoArgs {

--- a/src/ArgParse.h
+++ b/src/ArgParse.h
@@ -65,3 +65,4 @@ extern const std::vector<std::string> hipifyOptions;
 extern const std::vector<std::string> hipifyOptionsWithTwoArgs;
 extern cl::opt<bool> Versions;
 extern cl::opt<bool> NoUndocumented;
+extern cl::opt<bool> NoWarningsUndocumented;

--- a/src/HipifyAction.cpp
+++ b/src/HipifyAction.cpp
@@ -602,9 +602,11 @@ bool HipifyAction::half2Member(const mat::MatchFinder::MatchResult &Result) {
     ct::Replacement Rep(*Result.SourceManager, sr.getBegin(), exprName.size(), OS.str());
     clang::FullSourceLoc fullSL(sr.getBegin(), *Result.SourceManager);
     insertReplacement(Rep, fullSL);
-    clang::DiagnosticsEngine& DE = getCompilerInstance().getDiagnostics();
-    const auto ID = DE.getCustomDiagID(clang::DiagnosticsEngine::Warning, "Undocumented feature. CUDA API does not explicitly define the 'x' and 'y' members of 'half2' and the access through the dot operator, while in practice, nvcc supports it and treats them as 'half'. AMD HIP does define the 'x' and 'y' members of 'half2' as 'unsigned short'. Thus, without 'reinterpret_cast' to 'half' of the 'half2' members, the resulting values in the hipified code are incorrect and differ from CUDA ones. The '%0' will be transformed to 'reinterpret_cast<half&>(%0)'.");
-    DE.Report(fullSL, ID) << exprName;
+    if (!NoWarningsUndocumented) {
+      clang::DiagnosticsEngine& DE = getCompilerInstance().getDiagnostics();
+      const auto ID = DE.getCustomDiagID(clang::DiagnosticsEngine::Warning, "Undocumented feature. CUDA API does not explicitly define the 'x' and 'y' members of 'half2' and the access through the dot operator, while in practice, nvcc supports it and treats them as 'half'. AMD HIP does define the 'x' and 'y' members of 'half2' as 'unsigned short'. Thus, without 'reinterpret_cast' to 'half' of the 'half2' members, the resulting values in the hipified code are incorrect and differ from CUDA ones. The '%0' will be transformed to 'reinterpret_cast<half&>(%0)'.");
+      DE.Report(fullSL, ID) << exprName;
+    }
     return true;
   }
   return false;


### PR DESCRIPTION
+ `--no-warnings-on-undocumented-features`: Suppress warnings on undocumented features in code transformation
