### PR TITLE
[HIPIFY][#584][DNN][MIOpen][refactor] cuDNN -> MIOpen - Part 8

### DIFF
--- a/src/CUDA2HIP_Perl.cpp
+++ b/src/CUDA2HIP_Perl.cpp
@@ -487,8 +487,8 @@ namespace perl {
     set<string> ReinterpretFunctions1;
     set<string> RemoveArgFunctions3;
     for (auto f : FuncArgCasts) {
-      auto casts = f.second;
-      for (auto c : casts) {
+      auto castStruct = f.second;
+      for (auto c : castStruct.castMap) {
         switch (c.first) {
           case 0:
             switch (c.second.castType) {

--- a/src/CUDA2HIP_Scripting.h
+++ b/src/CUDA2HIP_Scripting.h
@@ -43,10 +43,16 @@ namespace hipify {
   };
 
   typedef std::map<unsigned, CastInfo> ArgCastMap;
+
+  struct ArgCastStruct {
+    ArgCastMap castMap;
+    bool isToRoc = false;
+    bool isToMIOpen = false;
+  };
 }
 
 extern std::string getCastType(hipify::CastTypes c);
-extern std::map<std::string, hipify::ArgCastMap> FuncArgCasts;
+extern std::map<std::string, hipify::ArgCastStruct> FuncArgCasts;
 
 namespace perl {
 

--- a/tests/unit_tests/synthetic/libraries/cudnn2miopen.cu
+++ b/tests/unit_tests/synthetic/libraries/cudnn2miopen.cu
@@ -335,12 +335,11 @@ int main() {
   // CHECK: status = miopenFindConvolutionForwardAlgorithm(handle, xD, x, filterDescriptor, W, convolutionDescriptor, yD, y, requestedAlgoCount, &returnedAlgoCount, &ConvolutionFwdAlgoPerf_t, workSpace, workSpaceSizeInBytes);
   status = cudnnFindConvolutionForwardAlgorithmEx(handle, xD, x, filterDescriptor, W, convolutionDescriptor, yD, y, requestedAlgoCount, &returnedAlgoCount, &ConvolutionFwdAlgoPerf_t, workSpace, workSpaceSizeInBytes);
 
-  // TODO: remove the penultimate arg (cudnnConvolutionFwdAlgo_t algo)
   // TODO: swap 2 and 3 arguments (const miopenTensorDescriptor_t wDesc and const miopenTensorDescriptor_t xDesc)
   // CUDA: cudnnStatus_t CUDNNWINAPI cudnnGetConvolutionForwardWorkspaceSize(cudnnHandle_t handle, const cudnnTensorDescriptor_t xDesc, const cudnnFilterDescriptor_t wDesc, const cudnnConvolutionDescriptor_t convDesc, const cudnnTensorDescriptor_t yDesc, cudnnConvolutionFwdAlgo_t algo, size_t* sizeInBytes);
   // MIOPEN: MIOPEN_EXPORT miopenStatus_t miopenConvolutionForwardGetWorkSpaceSize(miopenHandle_t handle, const miopenTensorDescriptor_t wDesc, const miopenTensorDescriptor_t xDesc, const miopenConvolutionDescriptor_t convDesc, const miopenTensorDescriptor_t yDesc, size_t* workSpaceSize);
-  // CHECK: status = miopenConvolutionForwardGetWorkSpaceSize(handle, xD, filterDescriptor, convolutionDescriptor, yD, convolutionFwdAlgo , &workSpaceSizeInBytes);
-  status = cudnnGetConvolutionForwardWorkspaceSize(handle, xD, filterDescriptor, convolutionDescriptor, yD, convolutionFwdAlgo , &workSpaceSizeInBytes);
+  // CHECK: status = miopenConvolutionForwardGetWorkSpaceSize(handle, xD, filterDescriptor, convolutionDescriptor, yD,  &workSpaceSizeInBytes);
+  status = cudnnGetConvolutionForwardWorkspaceSize(handle, xD, filterDescriptor, convolutionDescriptor, yD, convolutionFwdAlgo, &workSpaceSizeInBytes);
 
   // TODO: swap correstly last 5 arguments
   // CUDA: cudnnStatus_t CUDNNWINAPI cudnnConvolutionForward(cudnnHandle_t handle, const void* alpha, const cudnnTensorDescriptor_t xDesc, const void* x, const cudnnFilterDescriptor_t wDesc, const void* w, const cudnnConvolutionDescriptor_t convDesc, cudnnConvolutionFwdAlgo_t algo, void* workSpace, size_t workSpaceSizeInBytes, const void* beta, const cudnnTensorDescriptor_t yDesc, void* y);


### PR DESCRIPTION
+ [refactor] Introduced `ArgCastStruct` with additional fields `isToRoc` and `isToMIOpen` (both are `false` by default) for the correct argument casting in `roc*` and `miopen*` functions
+ Removed the penultimate (5th) arg `cudnnConvolutionFwdAlgo_t algo` from the `miopenConvolutionForwardGetWorkSpaceSize` function call after hipification of `cudnnGetConvolutionForwardWorkspaceSize` due to the absence of that argument in `miopenConvolutionForwardGetWorkSpaceSize`; no warning is emitted
+ Updated the synthetic test `cudnn2miopen.cu` accordingly