### PR TITLE
[HIPIFY][#584][DNN][MIOpen] cuDNN -> MIOpen - Part 11 - cuDNN Pooling functions

### DIFF
--- a/src/CUDA2HIP_DNN_API_functions.cpp
+++ b/src/CUDA2HIP_DNN_API_functions.cpp
@@ -139,13 +139,13 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DNN_FUNCTION_MAP {
 
   // cuDNN Pooling functions
   {"cudnnCreatePoolingDescriptor",                        {"hipdnnCreatePoolingDescriptor",                        "miopenCreatePoolingDescriptor",                        CONV_LIB_FUNC, API_DNN, 2}},
-  {"cudnnSetPooling2dDescriptor",                         {"hipdnnSetPooling2dDescriptor",                         "", CONV_LIB_FUNC, API_DNN, 2}},
-  {"cudnnGetPooling2dDescriptor",                         {"hipdnnGetPooling2dDescriptor",                         "", CONV_LIB_FUNC, API_DNN, 2}},
-  {"cudnnSetPoolingNdDescriptor",                         {"hipdnnSetPoolingNdDescriptor",                         "", CONV_LIB_FUNC, API_DNN, 2}},
-  {"cudnnGetPoolingNdDescriptor",                         {"hipdnnGetPoolingNdDescriptor",                         "", CONV_LIB_FUNC, API_DNN, 2, HIP_UNSUPPORTED}},
-  {"cudnnGetPoolingNdForwardOutputDim",                   {"hipdnnGetPoolingNdForwardOutputDim",                   "", CONV_LIB_FUNC, API_DNN, 2, HIP_UNSUPPORTED}},
-  {"cudnnGetPooling2dForwardOutputDim",                   {"hipdnnGetPooling2dForwardOutputDim",                   "", CONV_LIB_FUNC, API_DNN, 2}},
-  {"cudnnDestroyPoolingDescriptor",                       {"hipdnnDestroyPoolingDescriptor",                       "", CONV_LIB_FUNC, API_DNN, 2}},
+  {"cudnnSetPooling2dDescriptor",                         {"hipdnnSetPooling2dDescriptor",                         "miopenSet2dPoolingDescriptor",                         CONV_LIB_FUNC, API_DNN, 2}},
+  {"cudnnGetPooling2dDescriptor",                         {"hipdnnGetPooling2dDescriptor",                         "miopenGet2dPoolingDescriptor",                         CONV_LIB_FUNC, API_DNN, 2}},
+  {"cudnnSetPoolingNdDescriptor",                         {"hipdnnSetPoolingNdDescriptor",                         "miopenSetNdPoolingDescriptor",                         CONV_LIB_FUNC, API_DNN, 2}},
+  {"cudnnGetPoolingNdDescriptor",                         {"hipdnnGetPoolingNdDescriptor",                         "miopenGetNdPoolingDescriptor",                         CONV_LIB_FUNC, API_DNN, 2, HIP_UNSUPPORTED}},
+  {"cudnnGetPoolingNdForwardOutputDim",                   {"hipdnnGetPoolingNdForwardOutputDim",                   "miopenGetPoolingNdForwardOutputDim",                   CONV_LIB_FUNC, API_DNN, 2, HIP_UNSUPPORTED}},
+  {"cudnnGetPooling2dForwardOutputDim",                   {"hipdnnGetPooling2dForwardOutputDim",                   "miopenGetPoolingForwardOutputDim",                     CONV_LIB_FUNC, API_DNN, 2}},
+  {"cudnnDestroyPoolingDescriptor",                       {"hipdnnDestroyPoolingDescriptor",                       "miopenDestroyPoolingDescriptor",                       CONV_LIB_FUNC, API_DNN, 2}},
   {"cudnnPoolingForward",                                 {"hipdnnPoolingForward",                                 "", CONV_LIB_FUNC, API_DNN, 2}},
   {"cudnnPoolingBackward",                                {"hipdnnPoolingBackward",                                "", CONV_LIB_FUNC, API_DNN, 2}},
 

--- a/src/HipifyAction.cpp
+++ b/src/HipifyAction.cpp
@@ -70,6 +70,10 @@ const std::string sCudaGetTextureReference = "cudaGetTextureReference";
 const std::string sCudnnGetConvolutionForwardWorkspaceSize = "cudnnGetConvolutionForwardWorkspaceSize";
 const std::string sCudnnGetConvolutionBackwardDataWorkspaceSize = "cudnnGetConvolutionBackwardDataWorkspaceSize";
 const std::string sCudnnFindConvolutionForwardAlgorithmEx = "cudnnFindConvolutionForwardAlgorithmEx";
+const std::string sCudnnSetPooling2dDescriptor = "cudnnSetPooling2dDescriptor";
+const std::string sCudnnGetPooling2dDescriptor = "cudnnGetPooling2dDescriptor";
+const std::string sCudnnSetPoolingNdDescriptor = "cudnnSetPoolingNdDescriptor";
+const std::string sCudnnGetPoolingNdDescriptor = "cudnnGetPoolingNdDescriptor";
 // Matchers' names
 const StringRef sCudaLaunchKernel = "cudaLaunchKernel";
 const StringRef sCudaHostFuncCall = "cudaHostFuncCall";
@@ -219,6 +223,42 @@ std::map<std::string, ArgCastStruct> FuncArgCasts {
     {
       {
         {13, {e_add_const_argument, cw_None, "true"}}
+      },
+      true,
+      true
+    }
+  },
+  {sCudnnSetPooling2dDescriptor,
+    {
+      {
+        {2, {e_remove_argument, cw_None}}
+      },
+      true,
+      true
+    }
+  },
+  {sCudnnGetPooling2dDescriptor,
+    {
+      {
+        {2, {e_remove_argument, cw_None}}
+      },
+      true,
+      true
+    }
+  },
+  {sCudnnSetPoolingNdDescriptor,
+    {
+      {
+        {2, {e_remove_argument, cw_None}}
+      },
+      true,
+      true
+    }
+  },
+  {sCudnnGetPoolingNdDescriptor,
+    {
+      {
+        {3, {e_remove_argument, cw_None}}
       },
       true,
       true
@@ -802,7 +842,11 @@ std::unique_ptr<clang::ASTConsumer> HipifyAction::CreateASTConsumer(clang::Compi
             sCudaGetTextureReference,
             sCudnnGetConvolutionForwardWorkspaceSize,
             sCudnnGetConvolutionBackwardDataWorkspaceSize,
-            sCudnnFindConvolutionForwardAlgorithmEx
+            sCudnnFindConvolutionForwardAlgorithmEx,
+            sCudnnSetPooling2dDescriptor,
+            sCudnnGetPooling2dDescriptor,
+            sCudnnSetPoolingNdDescriptor,
+            sCudnnGetPoolingNdDescriptor
           )
         )
       )

--- a/tests/unit_tests/synthetic/libraries/cudnn2miopen.cu
+++ b/tests/unit_tests/synthetic/libraries/cudnn2miopen.cu
@@ -386,5 +386,55 @@ int main() {
   // CHECK: status = miopenCreatePoolingDescriptor(&poolingDescriptor);
   status = cudnnCreatePoolingDescriptor(&poolingDescriptor);
 
+  cudnnNanPropagation_t maxpoolingNanOpt;
+  int wH = 0;
+  int wW = 0;
+  int pad_h = 0;
+  int pad_w = 0;
+  int stride_h = 0;
+  int stride_w = 0;
+
+  // CUDA: cudnnStatus_t CUDNNWINAPI cudnnSetPooling2dDescriptor(cudnnPoolingDescriptor_t poolingDesc, cudnnPoolingMode_t mode, cudnnNanPropagation_t maxpoolingNanOpt, int windowHeight, int windowWidth, int verticalPadding, int horizontalPadding, int verticalStride, int horizontalStride);
+  // MIOPEN: MIOPEN_EXPORT miopenStatus_t miopenSet2dPoolingDescriptor(miopenPoolingDescriptor_t poolDesc, miopenPoolingMode_t mode, int windowHeight, int windowWidth, int pad_h, int pad_w, int stride_h, int stride_w);
+  // CHECK: status = miopenSet2dPoolingDescriptor(poolingDescriptor, poolingMode,  wH, wW, pad_h, pad_w, stride_h, stride_w);
+  status = cudnnSetPooling2dDescriptor(poolingDescriptor, poolingMode, maxpoolingNanOpt, wH, wW, pad_h, pad_w, stride_h, stride_w);
+
+  // CUDA: cudnnStatus_t CUDNNWINAPI cudnnGetPooling2dDescriptor(const cudnnPoolingDescriptor_t poolingDesc, cudnnPoolingMode_t* mode, cudnnNanPropagation_t* maxpoolingNanOpt, int* windowHeight, int* windowWidth, int* verticalPadding, int* horizontalPadding, int* verticalStride, int* horizontalStride);
+  // MIOPEN: MIOPEN_EXPORT miopenStatus_t miopenGet2dPoolingDescriptor(const miopenPoolingDescriptor_t poolDesc, miopenPoolingMode_t* mode, int* windowHeight, int* windowWidth, int* pad_h, int* pad_w, int* stride_h, int* stride_w);
+  // CHECK: status = miopenGet2dPoolingDescriptor(poolingDescriptor, &poolingMode,  &wH, &wW, &pad_h, &pad_w, &stride_h, &stride_w);
+  status = cudnnGetPooling2dDescriptor(poolingDescriptor, &poolingMode, &maxpoolingNanOpt, &wH, &wW, &pad_h, &pad_w, &stride_h, &stride_w);
+
+  int nbDims = 0;
+  int nbDimsRequested = 0;
+  int* windowDimA = nullptr;
+  int* padA = nullptr;
+  int* stridesA = nullptr;
+  int* tensorDimArr = nullptr;
+
+  // CUDA: cudnnStatus_t CUDNNWINAPI cudnnGetPooling2dForwardOutputDim(const cudnnPoolingDescriptor_t poolingDesc, const cudnnTensorDescriptor_t inputTensorDesc, int* n, int* c, int* h, int* w);
+  // MIOPEN: MIOPEN_EXPORT miopenStatus_t miopenGetPoolingForwardOutputDim(const miopenPoolingDescriptor_t poolDesc, const miopenTensorDescriptor_t tensorDesc, int* n, int* c, int* h, int* w);
+  // CHECK: status = miopenGetPoolingForwardOutputDim(poolingDescriptor, tensorDescriptor, &n, &c, &h, &w);
+  status = cudnnGetPooling2dForwardOutputDim(poolingDescriptor, tensorDescriptor, &n, &c, &h, &w);
+
+  // CUDA: cudnnStatus_t CUDNNWINAPI cudnnGetPoolingNdForwardOutputDim(const cudnnPoolingDescriptor_t poolingDesc, const cudnnTensorDescriptor_t inputTensorDesc, int nbDims, int outputTensorDimA[]);
+  // MIOPEN: MIOPEN_EXPORT miopenStatus_t miopenGetPoolingNdForwardOutputDim(const miopenPoolingDescriptor_t poolDesc, const miopenTensorDescriptor_t tensorDesc, int dims, int* tensorDimArr);
+  // CHECK: status = miopenGetPoolingNdForwardOutputDim(poolingDescriptor, tensorDescriptor, nbDims, tensorDimArr);
+  status = cudnnGetPoolingNdForwardOutputDim(poolingDescriptor, tensorDescriptor, nbDims, tensorDimArr);
+
+  // CUDA: cudnnStatus_t CUDNNWINAPI cudnnSetPoolingNdDescriptor(cudnnPoolingDescriptor_t poolingDesc, const cudnnPoolingMode_t mode, const cudnnNanPropagation_t maxpoolingNanOpt, int nbDims, const int windowDimA[], const int paddingA[], const int strideA[]);
+  // MIOPEN: MIOPEN_EXPORT miopenStatus_t miopenSetNdPoolingDescriptor(miopenPoolingDescriptor_t poolDesc, const miopenPoolingMode_t mode, int nbDims, int* windowDimA, int* padA, int* stridesA);
+  // CHECK: status = miopenSetNdPoolingDescriptor(poolingDescriptor, poolingMode, nbDims, windowDimA, padA, stridesA);
+  status = cudnnSetPoolingNdDescriptor(poolingDescriptor, poolingMode, maxpoolingNanOpt, nbDims, windowDimA, padA, stridesA);
+
+  // CUDA: cudnnStatus_t CUDNNWINAPI cudnnGetPoolingNdDescriptor(const cudnnPoolingDescriptor_t poolingDesc, int nbDimsRequested, cudnnPoolingMode_t* mode, cudnnNanPropagation_t* maxpoolingNanOpt, int* nbDims, int windowDimA[], int paddingA[], int strideA[]);
+  // MIOPEN: MIOPEN_EXPORT miopenStatus_t miopenGetNdPoolingDescriptor(const miopenPoolingDescriptor_t poolDesc, int nbDimsRequested, miopenPoolingMode_t* mode, int* nbDims, int* windowDimA, int* padA, int* stridesA);
+  // CHECK: status = miopenGetNdPoolingDescriptor(poolingDescriptor, nbDimsRequested, &poolingMode,  &nbDims, windowDimA, padA, stridesA);
+  status = cudnnGetPoolingNdDescriptor(poolingDescriptor, nbDimsRequested, &poolingMode, &maxpoolingNanOpt, &nbDims, windowDimA, padA, stridesA);
+
+  // CUDA: cudnnStatus_t CUDNNWINAPI cudnnDestroyPoolingDescriptor(cudnnPoolingDescriptor_t poolingDesc);
+  // MIOPEN: MIOPEN_EXPORT miopenStatus_t miopenDestroyPoolingDescriptor(miopenPoolingDescriptor_t poolDesc);
+  // CHECK: status = miopenDestroyPoolingDescriptor(poolingDescriptor);
+  status = cudnnDestroyPoolingDescriptor(poolingDescriptor);
+
   return 0;
 }


### PR DESCRIPTION
+ Continued supporting hipification to MIOpen based on `miopen.h`
+ Updated the synthetic test `cudnn2miopen.cu` accordingly
+ [IMP] `cudnnPoolingForward` and `cudnnPoolingBackward` do not have a correspondence to `miopenPoolingForward` and `miopenPoolingBackward` - to discuss with the team
