### PR TITLE
[HIPIFY][#782][#783][feature] Initial hipification support for overloaded CUDA functions

### DIFF
--- a/src/CUDA2HIP_Runtime_API_functions.cpp
+++ b/src/CUDA2HIP_Runtime_API_functions.cpp
@@ -170,7 +170,7 @@ const std::map<llvm::StringRef, hipCounter> CUDA_RUNTIME_FUNCTION_MAP {
   // 5. Event Management
   // no analogue
   // NOTE: Not equal to cuEventCreate due to different signatures
-  {"cudaEventCreate",                                         {"hipEventCreate",                                         "", CONV_EVENT, API_RUNTIME, SEC::EVENT}},
+  {"cudaEventCreate",                                         {"hipEventCreate",                                         "", CONV_EVENT, API_RUNTIME, SEC::EVENT, CUDA_OVERLOADED}},
   // cuEventCreate
   {"cudaEventCreateWithFlags",                                {"hipEventCreateWithFlags",                                "", CONV_EVENT, API_RUNTIME, SEC::EVENT}},
   // cuEventDestroy

--- a/src/CUDA2HIP_Scripting.h
+++ b/src/CUDA2HIP_Scripting.h
@@ -34,9 +34,17 @@ namespace hipify {
     e_move_argument,
   };
 
+  enum OverloadTypes {
+    ot_arguments_number,
+  };
+
   enum CastWarning {
     cw_None,
     cw_DataLoss,
+  };
+
+  enum OverloadWarning {
+    ow_None,
   };
 
   struct CastInfo {
@@ -54,10 +62,26 @@ namespace hipify {
     bool isToRoc = false;
     bool isToMIOpen = false;
   };
+
+  struct OverloadInfo {
+    hipCounter counter;
+    OverloadTypes overloadType;
+    OverloadWarning overloadWarn;
+  };
+
+  typedef std::map<unsigned, OverloadInfo> OverloadMap;
+
+  struct FuncOverloadsStruct {
+    OverloadMap overloadMap;
+    bool isToRoc = false;
+    bool isToMIOpen = false;
+  };
 }
 
 extern std::string getCastType(hipify::CastTypes c);
 extern std::map<std::string, hipify::ArgCastStruct> FuncArgCasts;
+
+extern std::map<std::string, hipify::FuncOverloadsStruct> FuncOverloads;
 
 namespace perl {
 

--- a/src/HipifyAction.h
+++ b/src/HipifyAction.h
@@ -74,6 +74,7 @@ public:
   bool cudaLaunchKernel(const mat::MatchFinder::MatchResult &Result);
   bool cudaDeviceFuncCall(const mat::MatchFinder::MatchResult &Result);
   bool cudaHostFuncCall(const mat::MatchFinder::MatchResult &Result);
+  bool cudaOverloadedHostFuncCall(const mat::MatchFinder::MatchResult &Result);
   bool cubNamespacePrefix(const mat::MatchFinder::MatchResult &Result);
   bool cubFunctionTemplateDecl(const mat::MatchFinder::MatchResult &Result);
   bool cubUsingNamespaceDecl(const mat::MatchFinder::MatchResult &Result);

--- a/src/Statistics.cpp
+++ b/src/Statistics.cpp
@@ -425,6 +425,10 @@ bool Statistics::isRocMiopenOnly(const hipCounter& counter) {
   return ROC_MIOPEN_ONLY == (counter.supportDegree & ROC_MIOPEN_ONLY);
 }
 
+bool Statistics::isCudaOverloaded(const hipCounter& counter) {
+  return CUDA_OVERLOADED == (counter.supportDegree & CUDA_OVERLOADED);
+}
+
 std::string Statistics::getCudaVersion(const cudaVersions& ver) {
   switch (ver) {
     case CUDA_0:

--- a/src/Statistics.h
+++ b/src/Statistics.h
@@ -193,7 +193,8 @@ enum SupportDegree {
   REMOVED = 0x100,
   HIP_EXPERIMENTAL = 0x200,
   HIP_SUPPORTED_V2_ONLY = 0x400,
-  ROC_MIOPEN_ONLY = 0x800
+  ROC_MIOPEN_ONLY = 0x800,
+  CUDA_OVERLOADED = 0x1000
 };
 
 enum cudaVersions {
@@ -468,6 +469,8 @@ public:
   static bool isHipSupportedV2Only(const hipCounter& counter);
   // Check whether the counter is ROC_MIOPEN_ONLY or not.
   static bool isRocMiopenOnly(const hipCounter& counter);
+  // Check whether the counter is CUDA_OVERLOADED or not.
+  static bool isCudaOverloaded(const hipCounter& counter);
   // Get string CUDA version.
   static std::string getCudaVersion(const cudaVersions &ver);
   // Get string HIP version.

--- a/tests/unit_tests/synthetic/runtime_functions.cu
+++ b/tests/unit_tests/synthetic/runtime_functions.cu
@@ -1049,6 +1049,11 @@ int main() {
   // CHECK: result = hipEventCreate(&Event_t);
   result = cudaEventCreate(&Event_t);
 
+  // CUDA: static __inline__ __host__ cudaError_t cudaEventCreate(cudaEvent_t* event, unsigned int flags);
+  // HIP: hipError_t hipEventCreateWithFlags(hipEvent_t* event, unsigned flags);
+  // CHECK: result = hipEventCreateWithFlags(&Event_t, flags);
+  result = cudaEventCreate(&Event_t, flags);
+
   // CUDA: extern __host__ __cudart_builtin__ cudaError_t CUDARTAPI cudaEventCreateWithFlags(cudaEvent_t *event, unsigned int flags);
   // HIP: hipError_t hipEventCreateWithFlags(hipEvent_t* event, unsigned flags);
   // CHECK: result = hipEventCreateWithFlags(&Event_t, flags);


### PR DESCRIPTION
**[IMP]**
+ Introduced 1-to-N hipification for overloaded APIs with different number of arguments (see the `cudaEventCreate` example in #783)
+ Introduced a new marker `CUDA_OVERLOADED` and the corresponding Matcher `cudaOverloadedHostFuncCall`
+ Currently, `CUDA_OVERLOADED` APIs are hipified twice: first, by rewriting string blindly, and second, by overload matcher (correcting)
+ Added a synthetic test for cudaEventCreate to `hipEventCreateWithFlags` hipification in `runtime_functions.cu`

**[ToDo]**
+ Take into account other markers, firstly `HIP_UNSUPPORTED`, in overloaded hipification
+ Take into account `CUDA_VERSION` for overloaded APIs: currently, versioning is provided only for a single instance of the overloaded API
+ Find all the existing overloaded CUDA APIs, update HIPIFY correspondingly for those APIs, and provide tests
+ [sub-task] Implement overloading with the same number of arguments and different argument types
+ [optionally] Think about implementing the same in hipify-perl