### PR TITLE
[HIPIFY][fix] Use `isCudaDeprecated` instead of `isDeprecated` for detecting CUDA-only deprecated APIs

### DIFF
--- a/src/HipifyAction.cpp
+++ b/src/HipifyAction.cpp
@@ -447,7 +447,7 @@ void HipifyAction::FindAndReplace(StringRef name,
   Statistics::current().incrementCounter(found->second, name.str());
   clang::DiagnosticsEngine &DE = getCompilerInstance().getDiagnostics();
   // Warn about the deprecated identifier in CUDA but hipify it.
-  if (Statistics::isDeprecated(found->second)) {
+  if (Statistics::isCudaDeprecated(found->second)) {
     const auto ID = DE.getCustomDiagID(clang::DiagnosticsEngine::Warning, "'%0' is deprecated in CUDA.");
     DE.Report(sl, ID) << found->first;
   }


### PR DESCRIPTION
**[Synopsis]**
+ The function `isDeprecated` was erroneously used for reporting deprecated CUDA APIs
+ As a result, HIP deprecated APIs were also triggered the corresponding warning about using deprecated `CUDA` API