### PR TITLE
[HIPIFY][SWDEV-400555][tests][fix] Move some CUDA 12+ specific tests in a separate test

### DIFF
--- a/tests/lit.cfg
+++ b/tests/lit.cfg
@@ -83,6 +83,7 @@ if config.cuda_version_major < 12:
     config.excludes.append('headers_test_07_12000.cu')
     config.excludes.append('headers_test_08_12000.cu')
     config.excludes.append('headers_test_09_12000.cu')
+    config.excludes.append('runtime_functions_12000.cu')
 
 if config.cuda_version_major >= 12:
     config.excludes.append('headers_test_06.cu')

--- a/tests/unit_tests/synthetic/runtime_functions.cu
+++ b/tests/unit_tests/synthetic/runtime_functions.cu
@@ -773,13 +773,6 @@ int main() {
   result = cudaGraphNodeGetEnabled(GraphExec_t, graphNode, &flags);
 #endif
 
-#if CUDA_VERSION >= 12000
-  // CUDA: extern __host__ cudaError_t CUDARTAPI cudaGraphInstantiate(cudaGraphExec_t *pGraphExec, cudaGraph_t graph, unsigned long long flags __dv(0));
-  // HIP: hipError_t hipGraphInstantiateWithFlags(hipGraphExec_t* pGraphExec, hipGraph_t graph, unsigned long long flags);
-  // CHECK: result = hipGraphInstantiateWithFlags(&GraphExec_t, Graph_t, ull);
-  result = cudaGraphInstantiate(&GraphExec_t, Graph_t, ull);
-#endif
-
 #if CUDA_VERSION < 12000
   // CUDA: extern __CUDA_DEPRECATED __host__ cudaError_t CUDARTAPI cudaBindTexture(size_t *offset, const struct textureReference *texref, const void *devPtr, const struct cudaChannelFormatDesc *desc, size_t size __dv(UINT_MAX));
   // HIP: DEPRECATED(DEPRECATED_MSG) hipError_t hipBindTexture(size_t* offset, const textureReference* tex, const void* devPtr, const hipChannelFormatDesc* desc, size_t size __dparm(UINT_MAX));

--- a/tests/unit_tests/synthetic/runtime_functions_12000.cu
+++ b/tests/unit_tests/synthetic/runtime_functions_12000.cu
@@ -1,0 +1,34 @@
+// RUN: %run_test hipify "%s" "%t" %hipify_args 2 --skip-excluded-preprocessor-conditional-blocks --experimental %clang_args
+
+// CHECK: #include <hip/hip_runtime.h>
+#include <cuda_runtime.h>
+#include <string>
+#include <stdio.h>
+
+int main() {
+  printf("12.12000. CUDA Runtime API Functions synthetic test for CUDA >= 12000\n");
+
+  // CHECK: hipError_t result = hipSuccess;
+  cudaError result = cudaSuccess;
+
+  // CHECK: hipGraphExec_t GraphExec_t;
+  cudaGraphExec_t GraphExec_t;
+
+  // CHECK: hipGraph_t Graph_t;
+  cudaGraph_t Graph_t;
+
+#if defined(_WIN32)
+  unsigned long long ull = 0;
+#else
+  unsigned long ull = 0;
+#endif
+
+#if CUDA_VERSION >= 12000
+  // CUDA: extern __host__ cudaError_t CUDARTAPI cudaGraphInstantiate(cudaGraphExec_t *pGraphExec, cudaGraph_t graph, unsigned long long flags __dv(0));
+  // HIP: hipError_t hipGraphInstantiateWithFlags(hipGraphExec_t* pGraphExec, hipGraph_t graph, unsigned long long flags);
+  // CHECK: result = hipGraphInstantiateWithFlags(&GraphExec_t, Graph_t, ull);
+  result = cudaGraphInstantiate(&GraphExec_t, Graph_t, ull);
+#endif
+
+  return 0;
+}


### PR DESCRIPTION
**[Synopsis]**
+ llvm-lit `CHECK` constructions work on plain text and don't care about C++ preprocessor
+ As a result, in a macro-guarded code, where all the needed hipifications weren't performed, `CHECKs were failed

**[Solution]**
+ Move some CUDA 12+ specific tests in a separate synthetic test `runtime_functions_12000.cu` for `CUDA_VERSION >= 12.0`