### PR TITLE
[HIPIFY][fix] Fix `joint` documentation generation in the `compact` mode

### DIFF
--- a/src/CUDA2HIP_Doc.cpp
+++ b/src/CUDA2HIP_Doc.cpp
@@ -231,7 +231,8 @@ namespace doc {
                     fMap.insert(f);
                   }
                 } else {
-                  if (format != compact || (format == compact && !Statistics::isHipUnsupported(f.second))) {
+                  if (format != compact || (format == compact && ((!isJoint() && !Statistics::isHipUnsupported(f.second)) ||
+                                                                   (isJoint() && (!Statistics::isHipUnsupported(f.second) || !Statistics::isRocUnsupported(f.second)))))) {
                     fMap.insert(f);
                   }
                 }


### PR DESCRIPTION
[Synopsis]
+ ROC-only supported APIs were being excluded from the table

[Solution]
+ Do not populate `joint` tables in the `compact` mode only with APIs unsupported both by HIP and ROC