### PR TITLE
[HIPIFY][#674][rocSPARSE][feature] rocSPARSE support - Step 1 - initial

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -3214,9 +3214,9 @@ sub simpleSubstitutions {
     subst("cufft.h", "hipfft.h", "include_cuda_main_header");
     subst("curand.h", "hiprand.h", "include_cuda_main_header");
     subst("cusparse.h", "hipsparse.h", "include_cuda_main_header");
-    subst("cusparse_v2.h", "hipsparse.h", "include_cuda_main_header");
     subst("nvrtc.h", "hiprtc.h", "include_cuda_main_header");
     subst("cublas_v2.h", "hipblas.h", "include_cuda_main_header_v2");
+    subst("cusparse_v2.h", "hipsparse.h", "include_cuda_main_header_v2");
     subst("CUDAContext", "HIPContext", "type");
     subst("CUDA_ARRAY3D_DESCRIPTOR", "HIP_ARRAY3D_DESCRIPTOR", "type");
     subst("CUDA_ARRAY3D_DESCRIPTOR_st", "HIP_ARRAY3D_DESCRIPTOR", "type");
@@ -3648,7 +3648,6 @@ sub simpleSubstitutions {
     subst("cusparseCsr2CscAlg_t", "hipsparseCsr2CscAlg_t", "type");
     subst("cusparseDiagType_t", "hipsparseDiagType_t", "type");
     subst("cusparseDirection_t", "hipsparseDirection_t", "type");
-    subst("cusparseDnMatDescr", "hipsparseDnMatDescr", "type");
     subst("cusparseDnMatDescr_t", "hipsparseDnMatDescr_t", "type");
     subst("cusparseDnVecDescr_t", "hipsparseDnVecDescr_t", "type");
     subst("cusparseFillMode_t", "hipsparseFillMode_t", "type");
@@ -5932,6 +5931,7 @@ sub warnUnsupportedFunctions {
         "cusparseHpruneCsr2csr",
         "cusparseGetLevelInfo",
         "cusparseDnVecDescr",
+        "cusparseDnMatDescr",
         "cusparseDhybsv_solve",
         "cusparseDhybsv_analysis",
         "cusparseDhyb2dense",

--- a/docs/tables/CUSPARSE_API_supported_by_HIP.md
+++ b/docs/tables/CUSPARSE_API_supported_by_HIP.md
@@ -141,7 +141,7 @@
 |`cusparseDenseToSparseAlg_t`|11.1| | | | | | | |
 |`cusparseDiagType_t`| | | |`hipsparseDiagType_t`|1.9.2| | | |
 |`cusparseDirection_t`| | | |`hipsparseDirection_t`|3.2.0| | | |
-|`cusparseDnMatDescr`|10.1| | |`hipsparseDnMatDescr`|4.2.0| | | |
+|`cusparseDnMatDescr`|10.1| | | | | | | |
 |`cusparseDnMatDescr_t`|10.1| | |`hipsparseDnMatDescr_t`|4.2.0| | | |
 |`cusparseDnVecDescr`|10.2| | | | | | | |
 |`cusparseDnVecDescr_t`|10.2| | |`hipsparseDnVecDescr_t`|4.1.0| | | |

--- a/src/CUDA2HIP.cpp
+++ b/src/CUDA2HIP.cpp
@@ -67,8 +67,8 @@ const std::map <llvm::StringRef, hipCounter> CUDA_INCLUDE_MAP {
   {"cufft.h",                                               {"hipfft.h",                                              "", CONV_INCLUDE_CUDA_MAIN_H,    API_FFT, 0}},
   {"cufftXt.h",                                             {"hipfftXt.h",                                            "", CONV_INCLUDE,                API_FFT, 0}},
   // cuSPARSE includes
-  {"cusparse.h",                                            {"hipsparse.h",                                           "", CONV_INCLUDE_CUDA_MAIN_H,    API_SPARSE, 0}},
-  {"cusparse_v2.h",                                         {"hipsparse.h",                                           "", CONV_INCLUDE_CUDA_MAIN_H,    API_SPARSE, 0}},
+  {"cusparse.h",                                            {"hipsparse.h",                                "rocsparse.h", CONV_INCLUDE_CUDA_MAIN_H,    API_SPARSE, 0}},
+  {"cusparse_v2.h",                                         {"hipsparse.h",                                "rocsparse.h", CONV_INCLUDE_CUDA_MAIN_V2_H, API_SPARSE, 0}},
   // CUB includes
   {"cub/cub.cuh",                                           {"hipcub/hipcub.hpp",                                     "", CONV_INCLUDE_CUDA_MAIN_H,    API_CUB, 0}},
   // CAFFE2 includes

--- a/src/CUDA2HIP_SPARSE_API_types.cpp
+++ b/src/CUDA2HIP_SPARSE_API_types.cpp
@@ -26,14 +26,14 @@ THE SOFTWARE.
 const std::map<llvm::StringRef, hipCounter> CUDA_SPARSE_TYPE_NAME_MAP {
 
   // 1. Structs
-  {"cusparseContext",                           {"hipsparseContext",                           "", CONV_TYPE, API_SPARSE, 4, HIP_UNSUPPORTED}},
-  {"cusparseHandle_t",                          {"hipsparseHandle_t",                          "", CONV_TYPE, API_SPARSE, 4}},
+  {"cusparseContext",                           {"hipsparseContext",                           "_rocsparse_handle",                                  CONV_TYPE, API_SPARSE, 4, HIP_UNSUPPORTED}},
+  {"cusparseHandle_t",                          {"hipsparseHandle_t",                          "rocsparse_handle",                                   CONV_TYPE, API_SPARSE, 4}},
 
-  {"cusparseHybMat",                            {"hipsparseHybMat",                            "", CONV_TYPE, API_SPARSE, 4, HIP_UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED}},
-  {"cusparseHybMat_t",                          {"hipsparseHybMat_t",                          "", CONV_TYPE, API_SPARSE, 4, CUDA_DEPRECATED | CUDA_REMOVED}},
+  {"cusparseHybMat",                            {"hipsparseHybMat",                            "_rocsparse_hyb_mat",                                 CONV_TYPE, API_SPARSE, 4, HIP_UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED}},
+  {"cusparseHybMat_t",                          {"hipsparseHybMat_t",                          "rocsparse_hyb_mat",                                  CONV_TYPE, API_SPARSE, 4, CUDA_DEPRECATED | CUDA_REMOVED}},
 
-  {"cusparseMatDescr",                          {"hipsparseMatDescr",                          "", CONV_TYPE, API_SPARSE, 4, HIP_UNSUPPORTED}},
-  {"cusparseMatDescr_t",                        {"hipsparseMatDescr_t",                        "", CONV_TYPE, API_SPARSE, 4}},
+  {"cusparseMatDescr",                          {"hipsparseMatDescr",                          "_rocsparse_mat_descr",                               CONV_TYPE, API_SPARSE, 4, HIP_UNSUPPORTED}},
+  {"cusparseMatDescr_t",                        {"hipsparseMatDescr_t",                        "rocsparse_mat_descr",                                CONV_TYPE, API_SPARSE, 4}},
 
   {"cusparseSolveAnalysisInfo",                 {"hipsparseSolveAnalysisInfo",                 "", CONV_TYPE, API_SPARSE, 4, HIP_UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED}},
   {"cusparseSolveAnalysisInfo_t",               {"hipsparseSolveAnalysisInfo_t",               "", CONV_TYPE, API_SPARSE, 4, HIP_UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED}},
@@ -71,17 +71,17 @@ const std::map<llvm::StringRef, hipCounter> CUDA_SPARSE_TYPE_NAME_MAP {
   {"pruneInfo",                                 {"pruneInfo",                                  "", CONV_TYPE, API_SPARSE, 4, HIP_UNSUPPORTED}},
   {"pruneInfo_t",                               {"pruneInfo_t",                                "", CONV_TYPE, API_SPARSE, 4}},
 
-  {"cusparseSpMatDescr",                        {"hipsparseSpMatDescr",                        "", CONV_TYPE, API_SPARSE, 4, HIP_UNSUPPORTED}},
-  {"cusparseSpMatDescr_t",                      {"hipsparseSpMatDescr_t",                      "", CONV_TYPE, API_SPARSE, 4}},
+  {"cusparseSpMatDescr",                        {"hipsparseSpMatDescr",                        "_rocsparse_spmat_descr",                             CONV_TYPE, API_SPARSE, 4, HIP_UNSUPPORTED}},
+  {"cusparseSpMatDescr_t",                      {"hipsparseSpMatDescr_t",                      "rocsparse_spmat_descr",                              CONV_TYPE, API_SPARSE, 4}},
 
-  {"cusparseDnMatDescr",                        {"hipsparseDnMatDescr",                        "", CONV_TYPE, API_SPARSE, 4}},
-  {"cusparseDnMatDescr_t",                      {"hipsparseDnMatDescr_t",                      "", CONV_TYPE, API_SPARSE, 4}},
+  {"cusparseDnMatDescr",                        {"hipsparseDnMatDescr",                        "_rocsparse_dnmat_descr",                             CONV_TYPE, API_SPARSE, 4, HIP_UNSUPPORTED}},
+  {"cusparseDnMatDescr_t",                      {"hipsparseDnMatDescr_t",                      "rocsparse_dnmat_descr",                              CONV_TYPE, API_SPARSE, 4}},
 
-  {"cusparseSpVecDescr",                        {"hipsparseSpVecDescr",                        "", CONV_TYPE, API_SPARSE, 4, HIP_UNSUPPORTED}},
-  {"cusparseSpVecDescr_t",                      {"hipsparseSpVecDescr_t",                      "", CONV_TYPE, API_SPARSE, 4}},
+  {"cusparseSpVecDescr",                        {"hipsparseSpVecDescr",                        "_rocsparse_spvec_descr",                             CONV_TYPE, API_SPARSE, 4, HIP_UNSUPPORTED}},
+  {"cusparseSpVecDescr_t",                      {"hipsparseSpVecDescr_t",                      "rocsparse_spvec_descr",                              CONV_TYPE, API_SPARSE, 4}},
 
-  {"cusparseDnVecDescr",                        {"hipsparseDnVecDescr",                        "", CONV_TYPE, API_SPARSE, 4, HIP_UNSUPPORTED}},
-  {"cusparseDnVecDescr_t",                      {"hipsparseDnVecDescr_t",                      "", CONV_TYPE, API_SPARSE, 4}},
+  {"cusparseDnVecDescr",                        {"hipsparseDnVecDescr",                        "_rocsparse_dnvec_descr",                             CONV_TYPE, API_SPARSE, 4, HIP_UNSUPPORTED}},
+  {"cusparseDnVecDescr_t",                      {"hipsparseDnVecDescr_t",                      "rocsparse_dnvec_descr",                              CONV_TYPE, API_SPARSE, 4}},
 
   {"cusparseSpGEMMDescr",                       {"hipsparseSpGEMMDescr",                       "", CONV_TYPE, API_SPARSE, 4}},
   {"cusparseSpGEMMDescr_t",                     {"hipsparseSpGEMMDescr_t",                     "", CONV_TYPE, API_SPARSE, 4}},
@@ -478,7 +478,6 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_SPARSE_TYPE_NAME_VER_MAP {
   {"HIPSPARSE_SPGEMM_DEFAULT",                   {HIP_4010, HIP_0,    HIP_0   }},
   {"csru2csrInfo",                               {HIP_4020, HIP_0,    HIP_0   }},
   {"csru2csrInfo_t",                             {HIP_4020, HIP_0,    HIP_0   }},
-  {"hipsparseDnMatDescr",                        {HIP_4020, HIP_0,    HIP_0   }},
   {"hipsparseDnMatDescr_t",                      {HIP_4020, HIP_0,    HIP_0   }},
   {"hipsparseOrder_t",                           {HIP_4020, HIP_0,    HIP_0   }},
   {"HIPSPARSE_ORDER_COL",                        {HIP_5040, HIP_0,    HIP_0   }},
@@ -526,4 +525,18 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_SPARSE_TYPE_NAME_VER_MAP {
   {"HIPSPARSE_CSR2CSC_ALG1",                     {HIP_5040, HIP_0,    HIP_0   }},
   {"HIPSPARSE_CSR2CSC_ALG2",                     {HIP_5040, HIP_0,    HIP_0   }},
   {"HIPSPARSE_ORDER_COLUMN",                     {HIP_4020, HIP_5040, HIP_0   }},
+  {"_rocsparse_handle",                          {HIP_1090, HIP_0,    HIP_0   }},
+  {"rocsparse_handle",                           {HIP_1090, HIP_0,    HIP_0   }},
+  {"_rocsparse_hyb_mat",                         {HIP_1090, HIP_0,    HIP_0   }},
+  {"rocsparse_hyb_mat",                          {HIP_1090, HIP_0,    HIP_0   }},
+  {"_rocsparse_mat_descr",                       {HIP_1090, HIP_0,    HIP_0   }},
+  {"rocsparse_mat_descr",                        {HIP_1090, HIP_0,    HIP_0   }},
+  {"_rocsparse_spvec_descr",                     {HIP_4010, HIP_0,    HIP_0   }},
+  {"rocsparse_spvec_descr",                      {HIP_4010, HIP_0,    HIP_0   }},
+  {"_rocsparse_spmat_descr",                     {HIP_4010, HIP_0,    HIP_0   }},
+  {"rocsparse_spmat_descr",                      {HIP_4010, HIP_0,    HIP_0   }},
+  {"_rocsparse_dnvec_descr",                     {HIP_4010, HIP_0,    HIP_0   }},
+  {"rocsparse_dnvec_descr",                      {HIP_4010, HIP_0,    HIP_0   }},
+  {"_rocsparse_dnmat_descr",                     {HIP_4010, HIP_0,    HIP_0   }},
+  {"rocsparse_dnmat_descr",                      {HIP_4010, HIP_0,    HIP_0   }},
 };

--- a/src/HipifyAction.cpp
+++ b/src/HipifyAction.cpp
@@ -580,6 +580,11 @@ bool HipifyAction::Exclude(const hipCounter &hipToken) {
           insertedBLASHeader_V2 = true;
           if (insertedBLASHeader) return true;
           return false;
+        case API_SPARSE:
+          if (insertedSPARSEHeader_V2) return true;
+          insertedSPARSEHeader_V2 = true;
+          if (insertedSPARSEHeader) return true;
+          return false;
         default:
           return false;
       }

--- a/src/HipifyAction.h
+++ b/src/HipifyAction.h
@@ -55,6 +55,7 @@ private:
   bool insertedDNNHeader = false;
   bool insertedFFTHeader = false;
   bool insertedSPARSEHeader = false;
+  bool insertedSPARSEHeader_V2 = false;
   bool insertedComplexHeader = false;
   bool firstHeader = false;
   bool pragmaOnce = false;

--- a/src/Statistics.cpp
+++ b/src/Statistics.cpp
@@ -363,7 +363,7 @@ void Statistics::setActive(const std::string &name) {
 }
 
 bool Statistics::isToRoc(const hipCounter &counter) {
-  return (counter.apiType == API_BLAS || counter.apiType == API_DNN || counter.apiType == API_RUNTIME || counter.apiType == API_COMPLEX) &&
+  return (counter.apiType == API_BLAS || counter.apiType == API_DNN || counter.apiType == API_SPARSE || counter.apiType == API_RUNTIME || counter.apiType == API_COMPLEX) &&
     ((TranslateToRoc && !TranslateToMIOpen && !isRocMiopenOnly(counter)) || TranslateToMIOpen);
 }
 

--- a/tests/unit_tests/synthetic/libraries/cusparse2hipsparse.cu
+++ b/tests/unit_tests/synthetic/libraries/cusparse2hipsparse.cu
@@ -1,0 +1,41 @@
+// RUN: %run_test hipify "%s" "%t" %hipify_args 2 --skip-excluded-preprocessor-conditional-blocks --experimental %clang_args -ferror-limit=500
+
+// CHECK: #include <hip/hip_runtime.h>
+#include <cuda_runtime.h>
+#include <stdio.h>
+// CHECK: #include "hipsparse.h"
+#include "cusparse.h"
+// CHECK-NOT: #include "hipsparse.h"
+
+int main() {
+  printf("17. cuSPARSE API to hipSPARSE API synthetic test\n");
+
+  // CHECK: hipsparseHandle_t handle_t;
+  cusparseHandle_t handle_t;
+
+  // CHECK: hipsparseMatDescr_t matDescr_t;
+  cusparseMatDescr_t matDescr_t;
+
+#if CUDA_VERSION >= 10010
+  // CHECK: hipsparseSpMatDescr_t spMatDescr_t;
+  cusparseSpMatDescr_t spMatDescr_t;
+
+  // CHECK: hipsparseDnMatDescr_t dnMatDescr_t;
+  cusparseDnMatDescr_t dnMatDescr_t;
+#endif
+
+#if CUDA_VERSION >= 10020
+  // CHECK: hipsparseSpVecDescr_t spVecDescr_t;
+  cusparseSpVecDescr_t spVecDescr_t;
+
+  // CHECK: hipsparseDnVecDescr_t dnVecDescr_t;
+  cusparseDnVecDescr_t dnVecDescr_t;
+#endif
+
+#if CUDA_VERSION < 11000
+  // CHECK: hipsparseHybMat_t hybMat_t;
+  cusparseHybMat_t hybMat_t;
+#endif
+
+  return 0;
+}

--- a/tests/unit_tests/synthetic/libraries/cusparse2rocsparse.cu
+++ b/tests/unit_tests/synthetic/libraries/cusparse2rocsparse.cu
@@ -1,0 +1,55 @@
+// RUN: %run_test hipify "%s" "%t" %hipify_args 3 --skip-excluded-preprocessor-conditional-blocks --experimental --roc %clang_args -ferror-limit=500
+
+// CHECK: #include <hip/hip_runtime.h>
+#include <cuda_runtime.h>
+#include <stdio.h>
+// CHECK: #include "rocsparse.h"
+#include "cusparse.h"
+// CHECK-NOT: #include "rocsparse.h"
+
+int main() {
+  printf("18. cuSPARSE API to rocSPARSE API synthetic test\n");
+
+  // CHECK: _rocsparse_handle *handle = nullptr;
+  // CHECK-NEXT: rocsparse_handle handle_t;
+  cusparseContext *handle = nullptr;
+  cusparseHandle_t handle_t;
+
+  // CHECK: _rocsparse_mat_descr *matDescr = nullptr;
+  // CHECK-NEXT: rocsparse_mat_descr matDescr_t;
+  cusparseMatDescr *matDescr = nullptr;
+  cusparseMatDescr_t matDescr_t;
+
+#if CUDA_VERSION >= 10010
+  // CHECK: _rocsparse_spmat_descr *spMatDescr = nullptr;
+  // CHECK-NEXT: rocsparse_spmat_descr spMatDescr_t;
+  cusparseSpMatDescr *spMatDescr = nullptr;
+  cusparseSpMatDescr_t spMatDescr_t;
+
+  // CHECK: _rocsparse_dnmat_descr *dnMatDescr = nullptr;
+  // CHECK-NEXT: rocsparse_dnmat_descr dnMatDescr_t;
+  cusparseDnMatDescr *dnMatDescr = nullptr;
+  cusparseDnMatDescr_t dnMatDescr_t;
+#endif
+
+#if CUDA_VERSION >= 10020
+  // CHECK: _rocsparse_spvec_descr *spVecDescr = nullptr;
+  // CHECK-NEXT: rocsparse_spvec_descr spVecDescr_t;
+  cusparseSpVecDescr *spVecDescr = nullptr;
+  cusparseSpVecDescr_t spVecDescr_t;
+
+  // CHECK: _rocsparse_dnvec_descr *dnVecDescr = nullptr;
+  // CHECK-NEXT: rocsparse_dnvec_descr dnVecDescr_t;
+  cusparseDnVecDescr *dnVecDescr = nullptr;
+  cusparseDnVecDescr_t dnVecDescr_t;
+#endif
+
+#if CUDA_VERSION < 11000
+  // CHECK: _rocsparse_hyb_mat *hybMat = nullptr;
+  // CHECK-NEXT: rocsparse_hyb_mat hybMat_t;
+  cusparseHybMat *hybMat = nullptr;
+  cusparseHybMat_t hybMat_t;
+#endif
+
+  return 0;
+}


### PR DESCRIPTION
+ Started to introduce `rocSPARSE` API in sync with `cuSPARSE` and `hipSPARSE`
+ Started to create full-coverage synthetic tests for both `hipSPARSE` and `rocSPARSE`
+ [fix] `cusparseDnMatDescr` is not supported by `hipSPARSE`, only by `rocSPARSE`
+ Updated the regenerated `hipify-perl` and corresponding SPARSE doc

**[ToDo]**
+ [fix][perl] `rocSPARSE` and `MIOpen` APIs are not presented in `hipify-perl`
+ [doc] Start to generate `SPARSE` documentation in `joint` and `separate` formats