### PR TITLE
[HIPIFY][#674][rocSPARSE][feature] rocSPARSE support - Step 7 - functions

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -2715,6 +2715,7 @@ sub simpleSubstitutions {
     subst("cusparseCooGet", "hipsparseCooGet", "library");
     subst("cusparseCooSetPointers", "hipsparseCooSetPointers", "library");
     subst("cusparseCooSetStridedBatch", "hipsparseCooSetStridedBatch", "library");
+    subst("cusparseCopyMatDescr", "hipsparseCopyMatDescr", "library");
     subst("cusparseCreate", "hipsparseCreate", "library");
     subst("cusparseCreateBlockedEll", "hipsparseCreateBlockedEll", "library");
     subst("cusparseCreateBsric02Info", "hipsparseCreateBsric02Info", "library");
@@ -5976,7 +5977,6 @@ sub warnUnsupportedFunctions {
         "cusparseCreateConstBsr",
         "cusparseCreateConstBlockedEll",
         "cusparseCreateBsr",
-        "cusparseCopyMatDescr",
         "cusparseContext",
         "cusparseConstrainedGeMM_bufferSize",
         "cusparseConstrainedGeMM",

--- a/docs/tables/CUSPARSE_API_supported_by_HIP.md
+++ b/docs/tables/CUSPARSE_API_supported_by_HIP.md
@@ -217,7 +217,7 @@
 
 |**CUDA**|**A**|**D**|**R**|**HIP**|**A**|**D**|**R**|**E**|
 |:--|:-:|:-:|:-:|:--|:-:|:-:|:-:|:-:|
-|`cusparseCopyMatDescr`|8.0| |12.0| | | | | |
+|`cusparseCopyMatDescr`|8.0| |12.0|`hipsparseCopyMatDescr`|1.9.2| | | |
 |`cusparseCreateBsric02Info`| | | |`hipsparseCreateBsric02Info`|3.8.0| | | |
 |`cusparseCreateBsrilu02Info`| | | |`hipsparseCreateBsrilu02Info`|3.9.0| | | |
 |`cusparseCreateBsrsm2Info`| | | |`hipsparseCreateBsrsm2Info`|4.5.0| | | |

--- a/docs/tables/CUSPARSE_API_supported_by_HIP_and_ROC.md
+++ b/docs/tables/CUSPARSE_API_supported_by_HIP_and_ROC.md
@@ -194,13 +194,13 @@
 
 |**CUDA**|**A**|**D**|**R**|**HIP**|**A**|**D**|**R**|**E**|**ROC**|**A**|**D**|**R**|**E**|
 |:--|:-:|:-:|:-:|:--|:-:|:-:|:-:|:-:|:--|:-:|:-:|:-:|:-:|
-|`cusparseCreate`| | | |`hipsparseCreate`|1.9.2| | | | | | | | |
-|`cusparseDestroy`| | | |`hipsparseDestroy`|1.9.2| | | | | | | | |
-|`cusparseGetPointerMode`| | | |`hipsparseGetPointerMode`|1.9.2| | | | | | | | |
-|`cusparseGetStream`| | | |`hipsparseGetStream`|1.9.2| | | | | | | | |
-|`cusparseGetVersion`| | | |`hipsparseGetVersion`|1.9.2| | | | | | | | |
-|`cusparseSetPointerMode`| | | |`hipsparseSetPointerMode`|1.9.2| | | | | | | | |
-|`cusparseSetStream`| | | |`hipsparseSetStream`|1.9.2| | | | | | | | |
+|`cusparseCreate`| | | |`hipsparseCreate`|1.9.2| | | |`rocsparse_create_handle`|1.9.0| | | |
+|`cusparseDestroy`| | | |`hipsparseDestroy`|1.9.2| | | |`rocsparse_destroy_handle`|1.9.0| | | |
+|`cusparseGetPointerMode`| | | |`hipsparseGetPointerMode`|1.9.2| | | |`rocsparse_get_pointer_mode`|1.9.0| | | |
+|`cusparseGetStream`| | | |`hipsparseGetStream`|1.9.2| | | |`rocsparse_get_stream`|1.9.0| | | |
+|`cusparseGetVersion`| | | |`hipsparseGetVersion`|1.9.2| | | |`rocsparse_get_version`|1.9.0| | | |
+|`cusparseSetPointerMode`| | | |`hipsparseSetPointerMode`|1.9.2| | | |`rocsparse_set_pointer_mode`|1.9.0| | | |
+|`cusparseSetStream`| | | |`hipsparseSetStream`|1.9.2| | | |`rocsparse_set_stream`|1.9.0| | | |
 
 ## **6. CUSPARSE Logging**
 
@@ -217,7 +217,7 @@
 
 |**CUDA**|**A**|**D**|**R**|**HIP**|**A**|**D**|**R**|**E**|**ROC**|**A**|**D**|**R**|**E**|
 |:--|:-:|:-:|:-:|:--|:-:|:-:|:-:|:-:|:--|:-:|:-:|:-:|:-:|
-|`cusparseCopyMatDescr`|8.0| |12.0| | | | | | | | | | |
+|`cusparseCopyMatDescr`|8.0| |12.0|`hipsparseCopyMatDescr`|1.9.2| | | |`rocsparse_copy_mat_descr`|1.9.0| | | |
 |`cusparseCreateBsric02Info`| | | |`hipsparseCreateBsric02Info`|3.8.0| | | | | | | | |
 |`cusparseCreateBsrilu02Info`| | | |`hipsparseCreateBsrilu02Info`|3.9.0| | | | | | | | |
 |`cusparseCreateBsrsm2Info`| | | |`hipsparseCreateBsrsm2Info`|4.5.0| | | | | | | | |
@@ -229,7 +229,7 @@
 |`cusparseCreateCsrsm2Info`|10.0|11.3|12.0|`hipsparseCreateCsrsm2Info`|3.1.0| | | | | | | | |
 |`cusparseCreateCsrsv2Info`| |11.3|12.0|`hipsparseCreateCsrsv2Info`|1.9.2| | | | | | | | |
 |`cusparseCreateHybMat`| |10.2|11.0|`hipsparseCreateHybMat`|1.9.2| | | | | | | | |
-|`cusparseCreateMatDescr`| | | |`hipsparseCreateMatDescr`|1.9.2| | | | | | | | |
+|`cusparseCreateMatDescr`| | | |`hipsparseCreateMatDescr`|1.9.2| | | |`rocsparse_create_mat_descr`|1.9.0| | | |
 |`cusparseCreatePruneInfo`|9.0| | |`hipsparseCreatePruneInfo`|3.9.0| | | | | | | | |
 |`cusparseCreateSolveAnalysisInfo`| |10.2|11.0| | | | | | | | | | |
 |`cusparseDestroyBsric02Info`| | | |`hipsparseDestroyBsric02Info`|3.8.0| | | | | | | | |
@@ -243,7 +243,7 @@
 |`cusparseDestroyCsrsm2Info`|10.0|11.3|12.0|`hipsparseDestroyCsrsm2Info`|3.1.0| | | | | | | | |
 |`cusparseDestroyCsrsv2Info`| |11.3|12.0|`hipsparseDestroyCsrsv2Info`|1.9.2| | | | | | | | |
 |`cusparseDestroyHybMat`| |10.2|11.0|`hipsparseDestroyHybMat`|1.9.2| | | | | | | | |
-|`cusparseDestroyMatDescr`| | | |`hipsparseDestroyMatDescr`|1.9.2| | | | | | | | |
+|`cusparseDestroyMatDescr`| | | |`hipsparseDestroyMatDescr`|1.9.2| | | |`rocsparse_destroy_mat_descr`|1.9.0| | | |
 |`cusparseDestroyPruneInfo`|9.0| | |`hipsparseDestroyPruneInfo`|3.9.0| | | | | | | | |
 |`cusparseDestroySolveAnalysisInfo`| |10.2|11.0| | | | | | | | | | |
 |`cusparseGetLevelInfo`| | |11.0| | | | | | | | | | |

--- a/docs/tables/CUSPARSE_API_supported_by_ROC.md
+++ b/docs/tables/CUSPARSE_API_supported_by_ROC.md
@@ -194,13 +194,13 @@
 
 |**CUDA**|**A**|**D**|**R**|**ROC**|**A**|**D**|**R**|**E**|
 |:--|:-:|:-:|:-:|:--|:-:|:-:|:-:|:-:|
-|`cusparseCreate`| | | | | | | | |
-|`cusparseDestroy`| | | | | | | | |
-|`cusparseGetPointerMode`| | | | | | | | |
-|`cusparseGetStream`| | | | | | | | |
-|`cusparseGetVersion`| | | | | | | | |
-|`cusparseSetPointerMode`| | | | | | | | |
-|`cusparseSetStream`| | | | | | | | |
+|`cusparseCreate`| | | |`rocsparse_create_handle`|1.9.0| | | |
+|`cusparseDestroy`| | | |`rocsparse_destroy_handle`|1.9.0| | | |
+|`cusparseGetPointerMode`| | | |`rocsparse_get_pointer_mode`|1.9.0| | | |
+|`cusparseGetStream`| | | |`rocsparse_get_stream`|1.9.0| | | |
+|`cusparseGetVersion`| | | |`rocsparse_get_version`|1.9.0| | | |
+|`cusparseSetPointerMode`| | | |`rocsparse_set_pointer_mode`|1.9.0| | | |
+|`cusparseSetStream`| | | |`rocsparse_set_stream`|1.9.0| | | |
 
 ## **6. CUSPARSE Logging**
 
@@ -217,7 +217,7 @@
 
 |**CUDA**|**A**|**D**|**R**|**ROC**|**A**|**D**|**R**|**E**|
 |:--|:-:|:-:|:-:|:--|:-:|:-:|:-:|:-:|
-|`cusparseCopyMatDescr`|8.0| |12.0| | | | | |
+|`cusparseCopyMatDescr`|8.0| |12.0|`rocsparse_copy_mat_descr`|1.9.0| | | |
 |`cusparseCreateBsric02Info`| | | | | | | | |
 |`cusparseCreateBsrilu02Info`| | | | | | | | |
 |`cusparseCreateBsrsm2Info`| | | | | | | | |
@@ -229,7 +229,7 @@
 |`cusparseCreateCsrsm2Info`|10.0|11.3|12.0| | | | | |
 |`cusparseCreateCsrsv2Info`| |11.3|12.0| | | | | |
 |`cusparseCreateHybMat`| |10.2|11.0| | | | | |
-|`cusparseCreateMatDescr`| | | | | | | | |
+|`cusparseCreateMatDescr`| | | |`rocsparse_create_mat_descr`|1.9.0| | | |
 |`cusparseCreatePruneInfo`|9.0| | | | | | | |
 |`cusparseCreateSolveAnalysisInfo`| |10.2|11.0| | | | | |
 |`cusparseDestroyBsric02Info`| | | | | | | | |
@@ -243,7 +243,7 @@
 |`cusparseDestroyCsrsm2Info`|10.0|11.3|12.0| | | | | |
 |`cusparseDestroyCsrsv2Info`| |11.3|12.0| | | | | |
 |`cusparseDestroyHybMat`| |10.2|11.0| | | | | |
-|`cusparseDestroyMatDescr`| | | | | | | | |
+|`cusparseDestroyMatDescr`| | | |`rocsparse_destroy_mat_descr`|1.9.0| | | |
 |`cusparseDestroyPruneInfo`|9.0| | | | | | | |
 |`cusparseDestroySolveAnalysisInfo`| |10.2|11.0| | | | | |
 |`cusparseGetLevelInfo`| | |11.0| | | | | |

--- a/src/CUDA2HIP_SPARSE_API_functions.cpp
+++ b/src/CUDA2HIP_SPARSE_API_functions.cpp
@@ -25,13 +25,13 @@ THE SOFTWARE.
 // Maps the names of CUDA SPARSE API functions to the corresponding HIP functions
 const std::map<llvm::StringRef, hipCounter> CUDA_SPARSE_FUNCTION_MAP {
   // 5. cuSPARSE Management Function Reference
-  {"cusparseCreate",                                    {"hipsparseCreate",                                    "",                                                                 CONV_LIB_FUNC, API_SPARSE, 5, ROC_UNSUPPORTED}},
-  {"cusparseDestroy",                                   {"hipsparseDestroy",                                   "",                                                                 CONV_LIB_FUNC, API_SPARSE, 5, ROC_UNSUPPORTED}},
-  {"cusparseGetPointerMode",                            {"hipsparseGetPointerMode",                            "",                                                                 CONV_LIB_FUNC, API_SPARSE, 5, ROC_UNSUPPORTED}},
-  {"cusparseGetVersion",                                {"hipsparseGetVersion",                                "",                                                                 CONV_LIB_FUNC, API_SPARSE, 5, ROC_UNSUPPORTED}},
-  {"cusparseSetPointerMode",                            {"hipsparseSetPointerMode",                            "",                                                                 CONV_LIB_FUNC, API_SPARSE, 5, ROC_UNSUPPORTED}},
-  {"cusparseSetStream",                                 {"hipsparseSetStream",                                 "",                                                                 CONV_LIB_FUNC, API_SPARSE, 5, ROC_UNSUPPORTED}},
-  {"cusparseGetStream",                                 {"hipsparseGetStream",                                 "",                                                                 CONV_LIB_FUNC, API_SPARSE, 5, ROC_UNSUPPORTED}},
+  {"cusparseCreate",                                    {"hipsparseCreate",                                    "rocsparse_create_handle",                                          CONV_LIB_FUNC, API_SPARSE, 5}},
+  {"cusparseDestroy",                                   {"hipsparseDestroy",                                   "rocsparse_destroy_handle",                                         CONV_LIB_FUNC, API_SPARSE, 5}},
+  {"cusparseGetPointerMode",                            {"hipsparseGetPointerMode",                            "rocsparse_get_pointer_mode",                                       CONV_LIB_FUNC, API_SPARSE, 5}},
+  {"cusparseGetVersion",                                {"hipsparseGetVersion",                                "rocsparse_get_version",                                            CONV_LIB_FUNC, API_SPARSE, 5}},
+  {"cusparseSetPointerMode",                            {"hipsparseSetPointerMode",                            "rocsparse_set_pointer_mode",                                       CONV_LIB_FUNC, API_SPARSE, 5}},
+  {"cusparseSetStream",                                 {"hipsparseSetStream",                                 "rocsparse_set_stream",                                             CONV_LIB_FUNC, API_SPARSE, 5}},
+  {"cusparseGetStream",                                 {"hipsparseGetStream",                                 "rocsparse_get_stream",                                             CONV_LIB_FUNC, API_SPARSE, 5}},
 
   // 6. cuSPARSE Logging
   {"cusparseLoggerSetCallback",                         {"hipsparseLoggerSetCallback",                         "",                                                                 CONV_LIB_FUNC, API_SPARSE, 6, UNSUPPORTED}},
@@ -44,11 +44,11 @@ const std::map<llvm::StringRef, hipCounter> CUDA_SPARSE_FUNCTION_MAP {
   // 7. cuSPARSE Helper Function Reference
   {"cusparseCreateSolveAnalysisInfo",                   {"hipsparseCreateSolveAnalysisInfo",                   "",                                                                 CONV_LIB_FUNC, API_SPARSE, 7, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED}},
   {"cusparseCreateHybMat",                              {"hipsparseCreateHybMat",                              "",                                                                 CONV_LIB_FUNC, API_SPARSE, 7, ROC_UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED}},
-  {"cusparseCreateMatDescr",                            {"hipsparseCreateMatDescr",                            "",                                                                 CONV_LIB_FUNC, API_SPARSE, 7, ROC_UNSUPPORTED}},
+  {"cusparseCreateMatDescr",                            {"hipsparseCreateMatDescr",                            "rocsparse_create_mat_descr",                                       CONV_LIB_FUNC, API_SPARSE, 7}},
   {"cusparseDestroySolveAnalysisInfo",                  {"hipsparseDestroySolveAnalysisInfo",                  "",                                                                 CONV_LIB_FUNC, API_SPARSE, 7, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED}},
   {"cusparseDestroyHybMat",                             {"hipsparseDestroyHybMat",                             "",                                                                 CONV_LIB_FUNC, API_SPARSE, 7, ROC_UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED}},
-  {"cusparseDestroyMatDescr",                           {"hipsparseDestroyMatDescr",                           "",                                                                 CONV_LIB_FUNC, API_SPARSE, 7, ROC_UNSUPPORTED}},
-  {"cusparseCopyMatDescr",                              {"hipsparseCopyMatDescr",                              "",                                                                 CONV_LIB_FUNC, API_SPARSE, 7, UNSUPPORTED | CUDA_REMOVED}},
+  {"cusparseDestroyMatDescr",                           {"hipsparseDestroyMatDescr",                           "rocsparse_destroy_mat_descr",                                      CONV_LIB_FUNC, API_SPARSE, 7}},
+  {"cusparseCopyMatDescr",                              {"hipsparseCopyMatDescr",                              "rocsparse_copy_mat_descr",                                         CONV_LIB_FUNC, API_SPARSE, 7, CUDA_REMOVED}},
   {"cusparseGetLevelInfo",                              {"hipsparseGetLevelInfo",                              "",                                                                 CONV_LIB_FUNC, API_SPARSE, 7, UNSUPPORTED | CUDA_REMOVED}},
   {"cusparseGetMatDiagType",                            {"hipsparseGetMatDiagType",                            "",                                                                 CONV_LIB_FUNC, API_SPARSE, 7, ROC_UNSUPPORTED}},
   {"cusparseGetMatFillMode",                            {"hipsparseGetMatFillMode",                            "",                                                                 CONV_LIB_FUNC, API_SPARSE, 7, ROC_UNSUPPORTED}},
@@ -1798,6 +1798,17 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_SPARSE_FUNCTION_VER_MAP {
   {"hipsparseDnMatSetStridedBatch",                      {HIP_5020, HIP_0,    HIP_0   }},
   {"hipsparseCsr2cscEx2_bufferSize",                     {HIP_5040, HIP_0,    HIP_0   }},
   {"hipsparseCsr2cscEx2",                                {HIP_5040, HIP_0,    HIP_0   }},
+  {"hipsparseCopyMatDescr",                              {HIP_1092, HIP_0,    HIP_0   }},
+  {"rocsparse_create_handle",                            {HIP_1090, HIP_0,    HIP_0   }},
+  {"rocsparse_destroy_handle",                           {HIP_1090, HIP_0,    HIP_0   }},
+  {"rocsparse_set_stream",                               {HIP_1090, HIP_0,    HIP_0   }},
+  {"rocsparse_get_stream",                               {HIP_1090, HIP_0,    HIP_0   }},
+  {"rocsparse_set_pointer_mode",                         {HIP_1090, HIP_0,    HIP_0   }},
+  {"rocsparse_get_pointer_mode",                         {HIP_1090, HIP_0,    HIP_0   }},
+  {"rocsparse_get_version",                              {HIP_1090, HIP_0,    HIP_0   }},
+  {"rocsparse_create_mat_descr",                         {HIP_1090, HIP_0,    HIP_0   }},
+  {"rocsparse_copy_mat_descr",                           {HIP_1090, HIP_0,    HIP_0   }},
+  {"rocsparse_destroy_mat_descr",                        {HIP_1090, HIP_0,    HIP_0   }},
 };
 
 const std::map<unsigned int, llvm::StringRef> CUDA_SPARSE_API_SECTION_MAP {

--- a/tests/unit_tests/synthetic/libraries/cusparse2hipsparse.cu
+++ b/tests/unit_tests/synthetic/libraries/cusparse2hipsparse.cu
@@ -13,8 +13,8 @@ int main() {
   // CHECK: hipsparseHandle_t handle_t;
   cusparseHandle_t handle_t;
 
-  // CHECK: hipsparseMatDescr_t matDescr_t;
-  cusparseMatDescr_t matDescr_t;
+  // CHECK: hipsparseMatDescr_t matDescr_t, matDescr_t_2;
+  cusparseMatDescr_t matDescr_t, matDescr_t_2;
 
   // CHECK: hipsparseColorInfo_t colorInfo_t;
   cusparseColorInfo_t colorInfo_t;
@@ -110,6 +110,63 @@ int main() {
   cusparseStatus_t STATUS_INTERNAL_ERROR = CUSPARSE_STATUS_INTERNAL_ERROR;
   cusparseStatus_t STATUS_MATRIX_TYPE_NOT_SUPPORTED = CUSPARSE_STATUS_MATRIX_TYPE_NOT_SUPPORTED;
   cusparseStatus_t STATUS_ZERO_PIVOT = CUSPARSE_STATUS_ZERO_PIVOT;
+
+  // CHECK: hipStream_t stream_t;
+  cudaStream_t stream_t;
+
+  int iVal = 0;
+
+  // CUDA: cusparseStatus_t CUSPARSEAPI cusparseCreate(cusparseHandle_t* handle);
+  // HIP: HIPSPARSE_EXPORT hipsparseStatus_t hipsparseCreate(hipsparseHandle_t* handle);
+  // CHECK: status_t = hipsparseCreate(&handle_t);
+  status_t = cusparseCreate(&handle_t);
+
+  // CUDA: cusparseStatus_t CUSPARSEAPI cusparseDestroy(cusparseHandle_t handle);
+  // HIP: HIPSPARSE_EXPORT hipsparseStatus_t hipsparseDestroy(hipsparseHandle_t handle);
+  // CHECK: status_t = hipsparseDestroy(handle_t);
+  status_t = cusparseDestroy(handle_t);
+
+  // CUDA: cusparseStatus_t CUSPARSEAPI cusparseSetStream(cusparseHandle_t handle, cudaStream_t streamId);
+  // HIP: HIPSPARSE_EXPORT hipsparseStatus_t hipsparseSetStream(hipsparseHandle_t handle, hipStream_t streamId);
+  // CHECK: status_t = hipsparseSetStream(handle_t, stream_t);
+  status_t = cusparseSetStream(handle_t, stream_t);
+
+  // CUDA: cusparseStatus_t CUSPARSEAPI cusparseGetStream(cusparseHandle_t handle, cudaStream_t* streamId);
+  // HIP: HIPSPARSE_EXPORT hipsparseStatus_t hipsparseGetStream(hipsparseHandle_t handle, hipStream_t* streamId);
+  // CHECK: status_t = hipsparseGetStream(handle_t, &stream_t);
+  status_t = cusparseGetStream(handle_t, &stream_t);
+
+  // CUDA: cusparseStatus_t CUSPARSEAPI cusparseSetPointerMode(cusparseHandle_t handle, cusparsePointerMode_t mode);
+  // HIP: HIPSPARSE_EXPORT hipsparseStatus_t hipsparseSetPointerMode(hipsparseHandle_t handle, hipsparsePointerMode_t mode);
+  // CHECK: status_t = hipsparseSetPointerMode(handle_t, pointerMode_t);
+  status_t = cusparseSetPointerMode(handle_t, pointerMode_t);
+
+  // CUDA: cusparseStatus_t CUSPARSEAPI cusparseGetPointerMode(cusparseHandle_t handle, cusparsePointerMode_t* mode);
+  // HIP: HIPSPARSE_EXPORT hipsparseStatus_t hipsparseGetPointerMode(hipsparseHandle_t handle, hipsparsePointerMode_t* mode);
+  // CHECK: status_t = hipsparseGetPointerMode(handle_t, &pointerMode_t);
+  status_t = cusparseGetPointerMode(handle_t, &pointerMode_t);
+
+  // CUDA: cusparseStatus_t CUSPARSEAPI cusparseGetVersion(cusparseHandle_t handle, int* version);
+  // HIP: HIPSPARSE_EXPORT hipsparseStatus_t hipsparseGetVersion(hipsparseHandle_t handle, int* version);
+  // CHECK: status_t = hipsparseGetVersion(handle_t, &iVal);
+  status_t = cusparseGetVersion(handle_t, &iVal);
+
+  // CUDA: cusparseStatus_t CUSPARSEAPI cusparseCreateMatDescr(cusparseMatDescr_t* descrA);
+  // HIP: HIPSPARSE_EXPORT hipsparseStatus_t hipsparseCreateMatDescr(hipsparseMatDescr_t* descrA);
+  // CHECK: status_t = hipsparseCreateMatDescr(&matDescr_t);
+  status_t = cusparseCreateMatDescr(&matDescr_t);
+
+  // CUDA: cusparseStatus_t CUSPARSEAPI cusparseDestroyMatDescr(cusparseMatDescr_t descrA);
+  // HIP: HIPSPARSE_EXPORT hipsparseStatus_t hipsparseDestroyMatDescr(hipsparseMatDescr_t descrA);
+  // CHECK: status_t = hipsparseDestroyMatDescr(matDescr_t);
+  status_t = cusparseDestroyMatDescr(matDescr_t);
+
+#if CUDA_VERSION >= 8000 && CUDA_VERSION < 12000
+  // CUDA: cusparseStatus_t CUSPARSEAPI cusparseCopyMatDescr(cusparseMatDescr_t dest, const cusparseMatDescr_t src);
+  // HIP: HIPSPARSE_EXPORT hipsparseStatus_t hipsparseCopyMatDescr(hipsparseMatDescr_t dest, const hipsparseMatDescr_t src);
+  // CHECK: status_t = hipsparseCopyMatDescr(matDescr_t, matDescr_t_2);
+  status_t = cusparseCopyMatDescr(matDescr_t, matDescr_t_2);
+#endif
 
 #if CUDA_VERSION >= 10010
   // CHECK: hipsparseSpMatDescr_t spMatDescr_t;

--- a/tests/unit_tests/synthetic/libraries/cusparse2rocsparse.cu
+++ b/tests/unit_tests/synthetic/libraries/cusparse2rocsparse.cu
@@ -16,9 +16,9 @@ int main() {
   cusparseHandle_t handle_t;
 
   // CHECK: _rocsparse_mat_descr *matDescr = nullptr;
-  // CHECK-NEXT: rocsparse_mat_descr matDescr_t;
+  // CHECK-NEXT: rocsparse_mat_descr matDescr_t, matDescr_t_2;
   cusparseMatDescr *matDescr = nullptr;
-  cusparseMatDescr_t matDescr_t;
+  cusparseMatDescr_t matDescr_t, matDescr_t_2;
 
   // CHECK: _rocsparse_color_info *colorInfo = nullptr;
   // CHECK-NEXT: rocsparse_color_info colorInfo_t;
@@ -110,6 +110,63 @@ int main() {
   cusparseStatus_t STATUS_ARCH_MISMATCH = CUSPARSE_STATUS_ARCH_MISMATCH;
   cusparseStatus_t STATUS_INTERNAL_ERROR = CUSPARSE_STATUS_INTERNAL_ERROR;
   cusparseStatus_t STATUS_ZERO_PIVOT = CUSPARSE_STATUS_ZERO_PIVOT;
+
+  // CHECK: hipStream_t stream_t;
+  cudaStream_t stream_t;
+
+  int iVal = 0;
+
+  // CUDA: cusparseStatus_t CUSPARSEAPI cusparseCreate(cusparseHandle_t* handle);
+  // ROC: ROCSPARSE_EXPORT rocsparse_status rocsparse_create_handle(rocsparse_handle* handle);
+  // CHECK: status_t = rocsparse_create_handle(&handle_t);
+  status_t = cusparseCreate(&handle_t);
+
+  // CUDA: cusparseStatus_t CUSPARSEAPI cusparseDestroy(cusparseHandle_t handle);
+  // ROC: ROCSPARSE_EXPORT rocsparse_status rocsparse_destroy_handle(rocsparse_handle handle);
+  // CHECK: status_t = rocsparse_destroy_handle(handle_t);
+  status_t = cusparseDestroy(handle_t);
+
+  // CUDA: cusparseStatus_t CUSPARSEAPI cusparseSetStream(cusparseHandle_t handle, cudaStream_t streamId);
+  // ROC: ROCSPARSE_EXPORT rocsparse_status rocsparse_set_stream(rocsparse_handle handle, hipStream_t stream);
+  // CHECK: status_t = rocsparse_set_stream(handle_t, stream_t);
+  status_t = cusparseSetStream(handle_t, stream_t);
+
+  // CUDA: cusparseStatus_t CUSPARSEAPI cusparseGetStream(cusparseHandle_t handle, cudaStream_t* streamId);
+  // ROC: ROCSPARSE_EXPORT rocsparse_status rocsparse_get_stream(rocsparse_handle handle, hipStream_t* stream);
+  // CHECK: status_t = rocsparse_get_stream(handle_t, &stream_t);
+  status_t = cusparseGetStream(handle_t, &stream_t);
+
+  // CUDA: cusparseStatus_t CUSPARSEAPI cusparseSetPointerMode(cusparseHandle_t handle, cusparsePointerMode_t mode);
+  // ROC: ROCSPARSE_EXPORT rocsparse_status rocsparse_set_pointer_mode(rocsparse_handle handle, rocsparse_pointer_mode pointer_mode);
+  // CHECK: status_t = rocsparse_set_pointer_mode(handle_t, pointerMode_t);
+  status_t = cusparseSetPointerMode(handle_t, pointerMode_t);
+
+  // CUDA: cusparseStatus_t CUSPARSEAPI cusparseGetPointerMode(cusparseHandle_t handle, cusparsePointerMode_t* mode);
+  // ROC: ROCSPARSE_EXPORT rocsparse_status rocsparse_get_pointer_mode(rocsparse_handle handle, rocsparse_pointer_mode* pointer_mode);
+  // CHECK: status_t = rocsparse_get_pointer_mode(handle_t, &pointerMode_t);
+  status_t = cusparseGetPointerMode(handle_t, &pointerMode_t);
+
+  // CUDA: cusparseStatus_t CUSPARSEAPI cusparseGetVersion(cusparseHandle_t handle, int* version);
+  // ROC: ROCSPARSE_EXPORT rocsparse_status rocsparse_get_version(rocsparse_handle handle, int* version);
+  // CHECK: status_t = rocsparse_get_version(handle_t, &iVal);
+  status_t = cusparseGetVersion(handle_t, &iVal);
+
+  // CUDA: cusparseStatus_t CUSPARSEAPI cusparseCreateMatDescr(cusparseMatDescr_t* descrA);
+  // ROC: ROCSPARSE_EXPORT rocsparse_status rocsparse_create_mat_descr(rocsparse_mat_descr* descr);
+  // CHECK: status_t = rocsparse_create_mat_descr(&matDescr_t);
+  status_t = cusparseCreateMatDescr(&matDescr_t);
+
+  // CUDA: cusparseStatus_t CUSPARSEAPI cusparseDestroyMatDescr(cusparseMatDescr_t descrA);
+  // ROC: ROCSPARSE_EXPORT rocsparse_status rocsparse_destroy_mat_descr(rocsparse_mat_descr descr);
+  // CHECK: status_t = rocsparse_destroy_mat_descr(matDescr_t);
+  status_t = cusparseDestroyMatDescr(matDescr_t);
+
+#if CUDA_VERSION >= 8000 && CUDA_VERSION < 12000
+  // CUDA: cusparseStatus_t CUSPARSEAPI cusparseCopyMatDescr(cusparseMatDescr_t dest, const cusparseMatDescr_t src);
+  // ROC: ROCSPARSE_EXPORT rocsparse_status rocsparse_copy_mat_descr(rocsparse_mat_descr dest, const rocsparse_mat_descr src);
+  // CHECK: status_t = rocsparse_copy_mat_descr(matDescr_t, matDescr_t_2);
+  status_t = cusparseCopyMatDescr(matDescr_t, matDescr_t_2);
+#endif
 
 #if CUDA_VERSION >= 10010
   // CHECK: _rocsparse_spmat_descr *spMatDescr = nullptr;


### PR DESCRIPTION
+ Updated synthetic tests and the regenerated hipify-perl and SPARSE docs
+ [fix] Added the missing `cusparseCopyMatDescr` -> `hipsparseCopyMatDescr` support
