### PR TITLE
[HIPIFY][#674][hipBLAS-#366][workaround] Introduce an option-driven matcher for Data Types substitution

### DIFF
--- a/src/ArgParse.cpp
+++ b/src/ArgParse.cpp
@@ -209,6 +209,13 @@ cl::opt<bool> Versions("versions",
   cl::value_desc("versions"),
   cl::cat(ToolTemplateCategory));
 
+// NOTE: A temporary solution; to remove after fixing https://github.com/ROCmSoftwarePlatform/hipBLAS/issues/366
+cl::opt<bool> UseHipDataType("use-hip-data-types",
+  cl::desc("Use 'hipDataType' instead of 'hipblasDatatype_t' or 'rocblas_datatype'"),
+  cl::value_desc("use-hip-data-types"),
+  cl::init(false),
+  cl::cat(ToolTemplateCategory));
+
 cl::extrahelp CommonHelp(ct::CommonOptionsParser::HelpMessage);
 
 const std::vector<std::string> hipifyOptions {

--- a/src/ArgParse.h
+++ b/src/ArgParse.h
@@ -67,3 +67,4 @@ extern const std::vector<std::string> hipifyOptionsWithTwoArgs;
 extern cl::opt<bool> Versions;
 extern cl::opt<bool> NoUndocumented;
 extern cl::opt<bool> NoWarningsUndocumented;
+extern cl::opt<bool> UseHipDataType;

--- a/src/CUDA2HIP_SPARSE_API_functions.cpp
+++ b/src/CUDA2HIP_SPARSE_API_functions.cpp
@@ -758,7 +758,7 @@ const std::map<llvm::StringRef, hipCounter> CUDA_SPARSE_FUNCTION_MAP {
   {"cusparseCreateSlicedEll",                           {"hipsparseCreateSlicedEll",                           "",                                                                 CONV_LIB_FUNC, API_SPARSE, 15, UNSUPPORTED}},
   {"cusparseCreateConstSlicedEll",                      {"hipsparseCreateConstSlicedEll",                      "",                                                                 CONV_LIB_FUNC, API_SPARSE, 15, UNSUPPORTED}},
   // Sparse Vector descriptor
-  {"cusparseCreateSpVec",                               {"hipsparseCreateSpVec",                               "",                                                                 CONV_LIB_FUNC, API_SPARSE, 15, ROC_UNSUPPORTED}},
+  {"cusparseCreateSpVec",                               {"hipsparseCreateSpVec",                               "rocsparse_create_spvec_descr",                                     CONV_LIB_FUNC, API_SPARSE, 15}},
   {"cusparseCreateConstSpVec",                          {"hipsparseCreateConstSpVec",                          "",                                                                 CONV_LIB_FUNC, API_SPARSE, 15, UNSUPPORTED}},
   {"cusparseDestroySpVec",                              {"hipsparseDestroySpVec",                              "",                                                                 CONV_LIB_FUNC, API_SPARSE, 15, ROC_UNSUPPORTED}},
   {"cusparseSpVecGet",                                  {"hipsparseSpVecGet",                                  "",                                                                 CONV_LIB_FUNC, API_SPARSE, 15, ROC_UNSUPPORTED}},
@@ -1821,6 +1821,7 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_SPARSE_FUNCTION_VER_MAP {
   {"rocsparse_destroy_hyb_mat",                          {HIP_1090, HIP_0,    HIP_0   }},
   {"rocsparse_create_color_info",                        {HIP_4050, HIP_0,    HIP_0   }},
   {"rocsparse_destroy_color_info",                       {HIP_4050, HIP_0,    HIP_0   }},
+  {"rocsparse_create_spvec_descr",                       {HIP_4010, HIP_0,    HIP_0   }},
 };
 
 const std::map<unsigned int, llvm::StringRef> CUDA_SPARSE_API_SECTION_MAP {

--- a/src/CUDA2HIP_Scripting.h
+++ b/src/CUDA2HIP_Scripting.h
@@ -83,6 +83,8 @@ extern std::map<std::string, hipify::ArgCastStruct> FuncArgCasts;
 
 extern std::map<std::string, hipify::FuncOverloadsStruct> FuncOverloads;
 
+extern std::map<std::string, std::string> TypeOverloads;
+
 namespace perl {
 
   bool generate(bool Generate = true);

--- a/src/HipifyAction.h
+++ b/src/HipifyAction.h
@@ -80,6 +80,7 @@ public:
   bool cubFunctionTemplateDecl(const mat::MatchFinder::MatchResult &Result);
   bool cubUsingNamespaceDecl(const mat::MatchFinder::MatchResult &Result);
   bool half2Member(const mat::MatchFinder::MatchResult &Result);
+  bool dataTypeSelection(const mat::MatchFinder::MatchResult &Result);
 
   // Called by the preprocessor for each include directive during the non-raw lexing pass.
   void InclusionDirective(clang::SourceLocation hash_loc,

--- a/tests/unit_tests/synthetic/libraries/cusparse2hipsparse.cu
+++ b/tests/unit_tests/synthetic/libraries/cusparse2hipsparse.cu
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %hipify_args 2 --skip-excluded-preprocessor-conditional-blocks --experimental %clang_args -ferror-limit=500
+// RUN: %run_test hipify "%s" "%t" %hipify_args 3 --skip-excluded-preprocessor-conditional-blocks --experimental --use-hip-data-types %clang_args -ferror-limit=500
 
 // CHECK: #include <hip/hip_runtime.h>
 #include <cuda_runtime.h>
@@ -211,6 +211,13 @@ int main() {
   // CHECK: status_t = hipsparseDestroyColorInfo(colorInfo_t);
   status_t = cusparseDestroyColorInfo(colorInfo_t);
 
+#if CUDA_VERSION >= 8000
+  // CHECK: hipDataType dataType_t;
+  // CHECK-NEXT: hipDataType dataType;
+  cudaDataType_t dataType_t;
+  cudaDataType dataType;
+#endif
+
 #if CUDA_VERSION >= 8000 && CUDA_VERSION < 12000
   // CUDA: cusparseStatus_t CUSPARSEAPI cusparseCopyMatDescr(cusparseMatDescr_t dest, const cusparseMatDescr_t src);
   // HIP: HIPSPARSE_EXPORT hipsparseStatus_t hipsparseCopyMatDescr(hipsparseMatDescr_t dest, const hipsparseMatDescr_t src);
@@ -275,6 +282,16 @@ int main() {
 
   // CHECK: hipsparseSpMVAlg_t spMVAlg_t;
   cusparseSpMVAlg_t spMVAlg_t;
+
+  int64_t size = 0;
+  int64_t nnz = 0;
+  void *indices = nullptr;
+  void *values = nullptr;
+
+  // CUDA: cusparseStatus_t CUSPARSEAPI cusparseCreateSpVec(cusparseSpVecDescr_t* spVecDescr, int64_t size, int64_t nnz, void* indices, void* values, cusparseIndexType_t idxType, cusparseIndexBase_t idxBase, cudaDataType valueType);
+  // HIP: HIPSPARSE_EXPORT hipsparseStatus_t hipsparseCreateSpVec(hipsparseSpVecDescr_t* spVecDescr, int64_t size, int64_t nnz, void* indices, void* values, hipsparseIndexType_t idxType, hipsparseIndexBase_t idxBase, hipDataType valueType);
+  // CHECK: status_t = hipsparseCreateSpVec(&spVecDescr_t, size, nnz, indices, values, indexType_t, indexBase_t, dataType);
+  status_t = cusparseCreateSpVec(&spVecDescr_t, size, nnz, indices, values, indexType_t, indexBase_t, dataType);
 #endif
 
 #if CUDA_VERSION >= 10020 && CUDA_VERSION < 12000


### PR DESCRIPTION
**[Synopsis]**
+ `hipSPARSE` already uses the common HIP library type `hipDataType`, whereas `hipBLAS`, `rocBLAS`, and `rocSPARSE` don't
+ So, it is needed to hipify `cudaDataType` to `hipDataType` in some cases (like for SPARSE-related sources), and to `hipblasDatatype_t`, `rocblas_datatype`, or `rocsparse_datatype` in other cases

**[Solution]**
+ There is no single solid solution for sources where `cudaDataType_t` is used for both SPARSE and BLAS
+ [temporary][partial] Introduce the `--use-hip-data-types` option for use `hipDataType` instead of `hipblasDatatype_t` or `rocblas_datatype`; switched off by default
+ Introduced option-driven matcher `DataTypeSelection` for Data Types substitution
+ Check the solution on `cusparseCreateSpVec` to `hipsparseCreateSpVec` hipification, where `hipDataType` is used (the synthetic test `cusparse2hipsparse.cu`)

**[ToDo]**
+ File tickets to `rocBLAS` and `rocSPARSE` similar to https://github.com/ROCmSoftwarePlatform/hipBLAS/issues/366
+ Take into account all of the supported `cudaDataType_t` enum members and update the tests
+ Remove the workaround after all the HIP libs start to use the single `hipDataType`