### PR TITLE
[HIPIFY][SWDEV-405584][#713][install][fix] Make install clang version-independent

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -136,7 +136,7 @@ install(
     PATTERN "*.sh")
 # install all folders under clang/version/ in CMAKE_INSTALL_PREFIX path
 install(
-    DIRECTORY ${LLVM_DIR}/../../clang/${LLVM_VERSION_MAJOR}.${LLVM_VERSION_MINOR}.${LLVM_VERSION_PATCH}/
+    DIRECTORY ${LLVM_DIR}/../../clang/${LIB_CLANG_RES}/
     DESTINATION .
     COMPONENT clang-resource-headers
     FILES_MATCHING


### PR DESCRIPTION
+ That had to be done in #713
+ The regression is uncovered by LLVM commits: `e1b88c8a09be25b86b13f98755a9bd744b4dbf14` (https://reviews.llvm.org/D125860; 2022.11.10) + `0beffb854209a41f31beb18f9631258349a99299` (2023.06.03)
+ [IMP] The opportunity to build and install against previous clang versions, where dist header files are located in the `LLVM_VERSION_MAJOR.LLVM_VERSION_MINOR.LLVM_VERSION_PATCH` subfolder, is still possible under the hipify-clang Cmake command line option `-D125860`