### PR TITLE
[HIPIFY][rocSPARSE][test][fix] Take into account `CUSPARSE_VERSION` for cuSPARSE 12.1.x APIs in the corresponding rocSPARSE tests

### DIFF
--- a/tests/unit_tests/synthetic/libraries/cusparse2rocsparse.cu
+++ b/tests/unit_tests/synthetic/libraries/cusparse2rocsparse.cu
@@ -821,16 +821,14 @@ int main() {
   status_t = cusparseSpMatSetAttribute(spMatDescr_t, spMatAttribute_t, &data, dataSize);
 #endif
 
-#if CUDA_VERSION >= 12010
+#if CUDA_VERSION >= 12010 && CUSPARSE_VERSION >= 12100
+  // CHECK: rocsparse_spmv_alg SPMV_SELL_ALG1 = rocsparse_spmv_alg_ell;
+  cusparseSpMVAlg_t SPMV_SELL_ALG1 = CUSPARSE_SPMV_SELL_ALG1;
+
   // CHECK: rocsparse_format FORMAT_BSR = rocsparse_format_bsr;
   // CHECK-NEXT: rocsparse_format FORMAT_SLICED_ELLPACK = rocsparse_format_ell;
   cusparseFormat_t FORMAT_BSR = CUSPARSE_FORMAT_BSR;
   cusparseFormat_t FORMAT_SLICED_ELLPACK = CUSPARSE_FORMAT_SLICED_ELLPACK;
-#endif
-
-#if CUDA_VERSION >= 12010 && CUSPARSE_VERSION >= 12100
-  // CHECK: rocsparse_spmv_alg SPMV_SELL_ALG1 = rocsparse_spmv_alg_ell;
-  cusparseSpMVAlg_t SPMV_SELL_ALG1 = CUSPARSE_SPMV_SELL_ALG1;
 #endif
 
   return 0;


### PR DESCRIPTION
+ [Reason] Some `cusparseFormat_t` values are appeared in CUDA 12.1.1 (`CUDA_VERSION == 12010` and `CUSPARSE_VERSION == 12100`) and are not presented in CUDA 12.1.0 (`CUDA_VERSION == 12010` and `CUSPARSE_VERSION == 12000`), so we need to distinguish them; otherwise some tests will fail
+ [TODO] Add CUDA patch version distinguishing to test-harness and, probably, to hipify-clang
