### PR TITLE
[HIPIFY][SPARSE][test][fix] Take into account `CUSPARSE_VERSION` for cuSPARSE 11.2.x APIs in the corresponding hipSPARSE and rocSPARSE tests

### DIFF
--- a/tests/unit_tests/synthetic/libraries/cusparse2hipsparse.cu
+++ b/tests/unit_tests/synthetic/libraries/cusparse2hipsparse.cu
@@ -763,7 +763,7 @@ int main() {
   status_t = cusparseCscSetPointers(spMatDescr_t, cscColOffsets, cscRowInd, cscValues);
 #endif
 
-#if CUDA_VERSION >= 11020
+#if CUDA_VERSION >= 11020 && CUSPARSE_VERSION >= 11400
   // CHECK: hipsparseFormat_t FORMAT_BLOCKED_ELL = HIPSPARSE_FORMAT_BLOCKED_ELL;
   cusparseFormat_t FORMAT_BLOCKED_ELL = CUSPARSE_FORMAT_BLOCKED_ELL;
 

--- a/tests/unit_tests/synthetic/libraries/cusparse2rocsparse.cu
+++ b/tests/unit_tests/synthetic/libraries/cusparse2rocsparse.cu
@@ -741,7 +741,7 @@ int main() {
   status_t = cusparseCscSetPointers(spMatDescr_t, cscColOffsets, cscRowInd, cscValues);
 #endif
 
-#if CUDA_VERSION >= 11020
+#if CUDA_VERSION >= 11020 && CUSPARSE_VERSION >= 11400
   // CHECK: rocsparse_format FORMAT_BLOCKED_ELL = rocsparse_format_bell;
   cusparseFormat_t FORMAT_BLOCKED_ELL = CUSPARSE_FORMAT_BLOCKED_ELL;
 


### PR DESCRIPTION
+ [Reason] Some data types and functions are appeared in CUDA 11.2.1 (`CUDA_VERSION == 11020` and `CUSPARSE_VERSION == 11400`) and are not presented in CUDA 11.2.0 (`CUDA_VERSION == 11020` and `CUSPARSE_VERSION == 11300`), so we need to distinguish them; otherwise some tests will fail
