### PR TITLE
[HIPIFY][SPARSE][test][fix] Take into account `CUSPARSE_VERSION` for cuSPARSE 11.1.x APIs in the corresponding hipSPARSE and rocSPARSE tests

### DIFF
--- a/tests/unit_tests/synthetic/libraries/cusparse2hipsparse.cu
+++ b/tests/unit_tests/synthetic/libraries/cusparse2hipsparse.cu
@@ -736,7 +736,7 @@ int main() {
   status_t = cusparseDestroyHybMat(hybMat_t);
 #endif
 
-#if CUDA_VERSION >= 11010
+#if CUDA_VERSION >= 11010 && CUSPARSE_VERSION >= 11300
   // CHECK: hipsparseSparseToDenseAlg_t sparseToDenseAlg_t;
   // CHECK-NEXT: hipsparseSparseToDenseAlg_t SPARSETODENSE_ALG_DEFAULT = HIPSPARSE_SPARSETODENSE_ALG_DEFAULT;
   cusparseSparseToDenseAlg_t sparseToDenseAlg_t;

--- a/tests/unit_tests/synthetic/libraries/cusparse2rocsparse.cu
+++ b/tests/unit_tests/synthetic/libraries/cusparse2rocsparse.cu
@@ -714,7 +714,7 @@ int main() {
   status_t = cusparseAxpby(handle_t, alpha, spVecDescr_t, beta, vecY);
 #endif
 
-#if CUDA_VERSION >= 11010
+#if CUDA_VERSION >= 11010 && CUSPARSE_VERSION >= 11300
   // CHECK: rocsparse_sparse_to_dense_alg sparseToDenseAlg_t;
   // CHECK-NEXT: rocsparse_sparse_to_dense_alg SPARSETODENSE_ALG_DEFAULT = rocsparse_sparse_to_dense_alg_default;
   cusparseSparseToDenseAlg_t sparseToDenseAlg_t;


### PR DESCRIPTION
+ [Reason] Some data types and functions are appeared in CUDA 11.1.1 (`CUDA_VERSION == 11010` and `CUSPARSE_VERSION == 11300`) and are not presented in CUDA 11.1.0 (`CUDA_VERSION == 11010` and `CUSPARSE_VERSION == 11200`), so we need to distinguish them; otherwise, some tests will fail
