### PR TITLE
[HIPIFY][HIP][5.7.0] All 5.6.x APIs are no longer experimental

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -858,19 +858,7 @@ my %removed_funcs = (
 );
 
 my %experimental_funcs = (
-    "cudaHostRegisterReadOnly" => "5.6.0",
-    "cudaGraphInstantiateFlagUseNodePriority" => "5.6.0",
-    "cudaGraphInstantiateFlagUpload" => "5.6.0",
-    "cudaGraphInstantiateFlagDeviceLaunch" => "5.6.0",
-    "cudaArrayGetInfo" => "5.6.0",
-    "cuArrayGetDescriptor_v2" => "5.6.0",
-    "cuArrayGetDescriptor" => "5.6.0",
-    "cuArray3DGetDescriptor_v2" => "5.6.0",
-    "cuArray3DGetDescriptor" => "5.6.0",
-    "CU_MEMHOSTREGISTER_READ_ONLY" => "5.6.0",
-    "CUDA_GRAPH_INSTANTIATE_FLAG_USE_NODE_PRIORITY" => "5.6.0",
-    "CUDA_GRAPH_INSTANTIATE_FLAG_UPLOAD" => "5.6.0",
-    "CUDA_GRAPH_INSTANTIATE_FLAG_DEVICE_LAUNCH" => "5.6.0"
+
 );
 
 $print_stats = 1 if $examine;
@@ -1008,19 +996,6 @@ sub subst {
 }
 
 sub experimentalSubstitutions {
-    subst("cuArray3DGetDescriptor", "hipArray3DGetDescriptor", "memory");
-    subst("cuArray3DGetDescriptor_v2", "hipArray3DGetDescriptor", "memory");
-    subst("cuArrayGetDescriptor", "hipArrayGetDescriptor", "memory");
-    subst("cuArrayGetDescriptor_v2", "hipArrayGetDescriptor", "memory");
-    subst("cudaArrayGetInfo", "hipArrayGetInfo", "memory");
-    subst("CUDA_GRAPH_INSTANTIATE_FLAG_DEVICE_LAUNCH", "hipGraphInstantiateFlagDeviceLaunch", "numeric_literal");
-    subst("CUDA_GRAPH_INSTANTIATE_FLAG_UPLOAD", "hipGraphInstantiateFlagUpload", "numeric_literal");
-    subst("CUDA_GRAPH_INSTANTIATE_FLAG_USE_NODE_PRIORITY", "hipGraphInstantiateFlagUseNodePriority", "numeric_literal");
-    subst("cudaGraphInstantiateFlagDeviceLaunch", "hipGraphInstantiateFlagDeviceLaunch", "numeric_literal");
-    subst("cudaGraphInstantiateFlagUpload", "hipGraphInstantiateFlagUpload", "numeric_literal");
-    subst("cudaGraphInstantiateFlagUseNodePriority", "hipGraphInstantiateFlagUseNodePriority", "numeric_literal");
-    subst("CU_MEMHOSTREGISTER_READ_ONLY", "hipHostRegisterReadOnly", "define");
-    subst("cudaHostRegisterReadOnly", "hipHostRegisterReadOnly", "define");
 }
 
 sub rocSubstitutions {
@@ -1940,9 +1915,13 @@ sub simpleSubstitutions {
     subst("cuModuleUnload", "hipModuleUnload", "module");
     subst("cuArray3DCreate", "hipArray3DCreate", "memory");
     subst("cuArray3DCreate_v2", "hipArray3DCreate", "memory");
+    subst("cuArray3DGetDescriptor", "hipArray3DGetDescriptor", "memory");
+    subst("cuArray3DGetDescriptor_v2", "hipArray3DGetDescriptor", "memory");
     subst("cuArrayCreate", "hipArrayCreate", "memory");
     subst("cuArrayCreate_v2", "hipArrayCreate", "memory");
     subst("cuArrayDestroy", "hipArrayDestroy", "memory");
+    subst("cuArrayGetDescriptor", "hipArrayGetDescriptor", "memory");
+    subst("cuArrayGetDescriptor_v2", "hipArrayGetDescriptor", "memory");
     subst("cuDeviceGetByPCIBusId", "hipDeviceGetByPCIBusId", "memory");
     subst("cuDeviceGetPCIBusId", "hipDeviceGetPCIBusId", "memory");
     subst("cuIpcCloseMemHandle", "hipIpcCloseMemHandle", "memory");
@@ -2009,6 +1988,7 @@ sub simpleSubstitutions {
     subst("cuMipmappedArrayCreate", "hipMipmappedArrayCreate", "memory");
     subst("cuMipmappedArrayDestroy", "hipMipmappedArrayDestroy", "memory");
     subst("cuMipmappedArrayGetLevel", "hipMipmappedArrayGetLevel", "memory");
+    subst("cudaArrayGetInfo", "hipArrayGetInfo", "memory");
     subst("cudaFree", "hipFree", "memory");
     subst("cudaFreeArray", "hipFreeArray", "memory");
     subst("cudaFreeAsync", "hipFreeAsync", "memory");
@@ -4170,6 +4150,9 @@ sub simpleSubstitutions {
     subst("CUDA_ERROR_UNMAP_FAILED", "hipErrorUnmapFailed", "numeric_literal");
     subst("CUDA_ERROR_UNSUPPORTED_LIMIT", "hipErrorUnsupportedLimit", "numeric_literal");
     subst("CUDA_GRAPH_INSTANTIATE_FLAG_AUTO_FREE_ON_LAUNCH", "hipGraphInstantiateFlagAutoFreeOnLaunch", "numeric_literal");
+    subst("CUDA_GRAPH_INSTANTIATE_FLAG_DEVICE_LAUNCH", "hipGraphInstantiateFlagDeviceLaunch", "numeric_literal");
+    subst("CUDA_GRAPH_INSTANTIATE_FLAG_UPLOAD", "hipGraphInstantiateFlagUpload", "numeric_literal");
+    subst("CUDA_GRAPH_INSTANTIATE_FLAG_USE_NODE_PRIORITY", "hipGraphInstantiateFlagUseNodePriority", "numeric_literal");
     subst("CUDA_R_16BF", "HIPBLAS_R_16B", "numeric_literal");
     subst("CUDA_R_16F", "HIPBLAS_R_16F", "numeric_literal");
     subst("CUDA_R_32F", "HIPBLAS_R_32F", "numeric_literal");
@@ -5035,6 +5018,9 @@ sub simpleSubstitutions {
     subst("cudaGraphExecUpdateErrorUnsupportedFunctionChange", "hipGraphExecUpdateErrorUnsupportedFunctionChange", "numeric_literal");
     subst("cudaGraphExecUpdateSuccess", "hipGraphExecUpdateSuccess", "numeric_literal");
     subst("cudaGraphInstantiateFlagAutoFreeOnLaunch", "hipGraphInstantiateFlagAutoFreeOnLaunch", "numeric_literal");
+    subst("cudaGraphInstantiateFlagDeviceLaunch", "hipGraphInstantiateFlagDeviceLaunch", "numeric_literal");
+    subst("cudaGraphInstantiateFlagUpload", "hipGraphInstantiateFlagUpload", "numeric_literal");
+    subst("cudaGraphInstantiateFlagUseNodePriority", "hipGraphInstantiateFlagUseNodePriority", "numeric_literal");
     subst("cudaGraphMemAttrReservedMemCurrent", "hipGraphMemAttrReservedMemCurrent", "numeric_literal");
     subst("cudaGraphMemAttrReservedMemHigh", "hipGraphMemAttrReservedMemHigh", "numeric_literal");
     subst("cudaGraphMemAttrUsedMemCurrent", "hipGraphMemAttrUsedMemCurrent", "numeric_literal");
@@ -5183,6 +5169,7 @@ sub simpleSubstitutions {
     subst("CU_MEMHOSTREGISTER_DEVICEMAP", "hipHostRegisterMapped", "define");
     subst("CU_MEMHOSTREGISTER_IOMEMORY", "hipHostRegisterIoMemory", "define");
     subst("CU_MEMHOSTREGISTER_PORTABLE", "hipHostRegisterPortable", "define");
+    subst("CU_MEMHOSTREGISTER_READ_ONLY", "hipHostRegisterReadOnly", "define");
     subst("CU_STREAM_PER_THREAD", "hipStreamPerThread", "define");
     subst("CU_TRSA_OVERRIDE_FORMAT", "HIP_TRSA_OVERRIDE_FORMAT", "define");
     subst("CU_TRSF_NORMALIZED_COORDINATES", "HIP_TRSF_NORMALIZED_COORDINATES", "define");
@@ -5223,6 +5210,7 @@ sub simpleSubstitutions {
     subst("cudaHostRegisterIoMemory", "hipHostRegisterIoMemory", "define");
     subst("cudaHostRegisterMapped", "hipHostRegisterMapped", "define");
     subst("cudaHostRegisterPortable", "hipHostRegisterPortable", "define");
+    subst("cudaHostRegisterReadOnly", "hipHostRegisterReadOnly", "define");
     subst("cudaInvalidDeviceId", "hipInvalidDeviceId", "define");
     subst("cudaIpcMemLazyEnablePeerAccess", "hipIpcMemLazyEnablePeerAccess", "define");
     subst("cudaMemAttachGlobal", "hipMemAttachGlobal", "define");
@@ -9862,7 +9850,7 @@ if ($help) {
     print STDERR "$USAGE\n";
 }
 if ($version) {
-    print STDERR "HIP version 5.6.0\n";
+    print STDERR "HIP version 5.7.0\n";
 }
 while (@ARGV) {
     $fileName=shift (@ARGV);

--- a/docs/tables/CUDA_Driver_API_functions_supported_by_HIP.md
+++ b/docs/tables/CUDA_Driver_API_functions_supported_by_HIP.md
@@ -153,9 +153,9 @@
 |`CUDA_EXT_SEM_WAIT_NODE_PARAMS_v1`|11.3| | | | | | | |
 |`CUDA_GRAPH_INSTANTIATE_ERROR`|12.0| | | | | | | |
 |`CUDA_GRAPH_INSTANTIATE_FLAG_AUTO_FREE_ON_LAUNCH`|11.4| | |`hipGraphInstantiateFlagAutoFreeOnLaunch`|5.2.0| | | |
-|`CUDA_GRAPH_INSTANTIATE_FLAG_DEVICE_LAUNCH`|12.0| | |`hipGraphInstantiateFlagDeviceLaunch`|5.6.0| | |5.6.0|
-|`CUDA_GRAPH_INSTANTIATE_FLAG_UPLOAD`|12.0| | |`hipGraphInstantiateFlagUpload`|5.6.0| | |5.6.0|
-|`CUDA_GRAPH_INSTANTIATE_FLAG_USE_NODE_PRIORITY`|11.7| | |`hipGraphInstantiateFlagUseNodePriority`|5.6.0| | |5.6.0|
+|`CUDA_GRAPH_INSTANTIATE_FLAG_DEVICE_LAUNCH`|12.0| | |`hipGraphInstantiateFlagDeviceLaunch`|5.6.0| | | |
+|`CUDA_GRAPH_INSTANTIATE_FLAG_UPLOAD`|12.0| | |`hipGraphInstantiateFlagUpload`|5.6.0| | | |
+|`CUDA_GRAPH_INSTANTIATE_FLAG_USE_NODE_PRIORITY`|11.7| | |`hipGraphInstantiateFlagUseNodePriority`|5.6.0| | | |
 |`CUDA_GRAPH_INSTANTIATE_INVALID_STRUCTURE`|12.0| | | | | | | |
 |`CUDA_GRAPH_INSTANTIATE_MULTIPLE_CTXS_NOT_SUPPORTED`|12.0| | | | | | | |
 |`CUDA_GRAPH_INSTANTIATE_NODE_OPERATION_NOT_SUPPORTED`|12.0| | | | | | | |
@@ -743,7 +743,7 @@
 |`CU_MEMHOSTREGISTER_DEVICEMAP`| | | |`hipHostRegisterMapped`|1.6.0| | | |
 |`CU_MEMHOSTREGISTER_IOMEMORY`|7.5| | |`hipHostRegisterIoMemory`|1.6.0| | | |
 |`CU_MEMHOSTREGISTER_PORTABLE`| | | |`hipHostRegisterPortable`|1.6.0| | | |
-|`CU_MEMHOSTREGISTER_READ_ONLY`|11.1| | |`hipHostRegisterReadOnly`|5.6.0| | |5.6.0|
+|`CU_MEMHOSTREGISTER_READ_ONLY`|11.1| | |`hipHostRegisterReadOnly`|5.6.0| | | |
 |`CU_MEMORYTYPE_ARRAY`| | | |`hipMemoryTypeArray`|1.7.0| | | |
 |`CU_MEMORYTYPE_DEVICE`| | | |`hipMemoryTypeDevice`|1.6.0| | | |
 |`CU_MEMORYTYPE_HOST`| | | |`hipMemoryTypeHost`|1.6.0| | | |
@@ -1447,13 +1447,13 @@
 |:--|:-:|:-:|:-:|:--|:-:|:-:|:-:|:-:|
 |`cuArray3DCreate`| | | |`hipArray3DCreate`|1.7.1| | | |
 |`cuArray3DCreate_v2`| | | |`hipArray3DCreate`|1.7.1| | | |
-|`cuArray3DGetDescriptor`| | | |`hipArray3DGetDescriptor`|5.6.0| | |5.6.0|
-|`cuArray3DGetDescriptor_v2`| | | |`hipArray3DGetDescriptor`|5.6.0| | |5.6.0|
+|`cuArray3DGetDescriptor`| | | |`hipArray3DGetDescriptor`|5.6.0| | | |
+|`cuArray3DGetDescriptor_v2`| | | |`hipArray3DGetDescriptor`|5.6.0| | | |
 |`cuArrayCreate`| | | |`hipArrayCreate`|1.9.0| | | |
 |`cuArrayCreate_v2`| | | |`hipArrayCreate`|1.9.0| | | |
 |`cuArrayDestroy`| | | |`hipArrayDestroy`|4.2.0| | | |
-|`cuArrayGetDescriptor`| | | |`hipArrayGetDescriptor`|5.6.0| | |5.6.0|
-|`cuArrayGetDescriptor_v2`| | | |`hipArrayGetDescriptor`|5.6.0| | |5.6.0|
+|`cuArrayGetDescriptor`| | | |`hipArrayGetDescriptor`|5.6.0| | | |
+|`cuArrayGetDescriptor_v2`| | | |`hipArrayGetDescriptor`|5.6.0| | | |
 |`cuArrayGetMemoryRequirements`|11.6| | | | | | | |
 |`cuArrayGetPlane`|11.2| | | | | | | |
 |`cuArrayGetSparseProperties`|11.1| | | | | | | |

--- a/docs/tables/CUDA_Runtime_API_functions_supported_by_HIP.md
+++ b/docs/tables/CUDA_Runtime_API_functions_supported_by_HIP.md
@@ -146,7 +146,7 @@
 
 |**CUDA**|**A**|**D**|**R**|**HIP**|**A**|**D**|**R**|**E**|
 |:--|:-:|:-:|:-:|:--|:-:|:-:|:-:|:-:|
-|`cudaArrayGetInfo`| | | |`hipArrayGetInfo`|5.6.0| | |5.6.0|
+|`cudaArrayGetInfo`| | | |`hipArrayGetInfo`|5.6.0| | | |
 |`cudaArrayGetMemoryRequirements`|11.6| | | | | | | |
 |`cudaArrayGetPlane`|11.2| | | | | | | |
 |`cudaArrayGetSparseProperties`|11.1| | | | | | | |
@@ -1109,9 +1109,9 @@
 |`cudaGraphExec_t`|10.0| | |`hipGraphExec_t`|4.3.0| | | |
 |`cudaGraphInstantiateError`|12.0| | | | | | | |
 |`cudaGraphInstantiateFlagAutoFreeOnLaunch`|11.4| | |`hipGraphInstantiateFlagAutoFreeOnLaunch`|5.2.0| | | |
-|`cudaGraphInstantiateFlagDeviceLaunch`|12.0| | |`hipGraphInstantiateFlagDeviceLaunch`|5.6.0| | |5.6.0|
-|`cudaGraphInstantiateFlagUpload`|12.0| | |`hipGraphInstantiateFlagUpload`|5.6.0| | |5.6.0|
-|`cudaGraphInstantiateFlagUseNodePriority`|11.7| | |`hipGraphInstantiateFlagUseNodePriority`|5.6.0| | |5.6.0|
+|`cudaGraphInstantiateFlagDeviceLaunch`|12.0| | |`hipGraphInstantiateFlagDeviceLaunch`|5.6.0| | | |
+|`cudaGraphInstantiateFlagUpload`|12.0| | |`hipGraphInstantiateFlagUpload`|5.6.0| | | |
+|`cudaGraphInstantiateFlagUseNodePriority`|11.7| | |`hipGraphInstantiateFlagUseNodePriority`|5.6.0| | | |
 |`cudaGraphInstantiateFlags`|11.4| | |`hipGraphInstantiateFlags`|5.2.0| | | |
 |`cudaGraphInstantiateInvalidStructure`|12.0| | | | | | | |
 |`cudaGraphInstantiateMultipleDevicesNotSupported`|12.0| | | | | | | |
@@ -1171,7 +1171,7 @@
 |`cudaHostRegisterIoMemory`|7.5| | |`hipHostRegisterIoMemory`|1.6.0| | | |
 |`cudaHostRegisterMapped`| | | |`hipHostRegisterMapped`|1.6.0| | | |
 |`cudaHostRegisterPortable`| | | |`hipHostRegisterPortable`|1.6.0| | | |
-|`cudaHostRegisterReadOnly`|11.1| | |`hipHostRegisterReadOnly`|5.6.0| | |5.6.0|
+|`cudaHostRegisterReadOnly`|11.1| | |`hipHostRegisterReadOnly`|5.6.0| | | |
 |`cudaInitDeviceFlagsAreValid`|12.0| | | | | | | |
 |`cudaInvalidDeviceId`|8.0| | |`hipInvalidDeviceId`|3.7.0| | | |
 |`cudaIpcEventHandle_st`| | | |`hipIpcEventHandle_st`|3.5.0| | | |

--- a/src/CUDA2HIP_Driver_API_functions.cpp
+++ b/src/CUDA2HIP_Driver_API_functions.cpp
@@ -184,13 +184,13 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_FUNCTION_MAP {
   // no analogue
   {"cuArray3DCreate",                                      {"hipArray3DCreate",                                        "", CONV_MEMORY, API_DRIVER, SEC::MEMORY}},
   {"cuArray3DCreate_v2",                                   {"hipArray3DCreate",                                        "", CONV_MEMORY, API_DRIVER, SEC::MEMORY}},
-  {"cuArray3DGetDescriptor",                               {"hipArray3DGetDescriptor",                                 "", CONV_MEMORY, API_DRIVER, SEC::MEMORY, HIP_EXPERIMENTAL}},
-  {"cuArray3DGetDescriptor_v2",                            {"hipArray3DGetDescriptor",                                 "", CONV_MEMORY, API_DRIVER, SEC::MEMORY, HIP_EXPERIMENTAL}},
+  {"cuArray3DGetDescriptor",                               {"hipArray3DGetDescriptor",                                 "", CONV_MEMORY, API_DRIVER, SEC::MEMORY}},
+  {"cuArray3DGetDescriptor_v2",                            {"hipArray3DGetDescriptor",                                 "", CONV_MEMORY, API_DRIVER, SEC::MEMORY}},
   {"cuArrayCreate",                                        {"hipArrayCreate",                                          "", CONV_MEMORY, API_DRIVER, SEC::MEMORY}},
   {"cuArrayCreate_v2",                                     {"hipArrayCreate",                                          "", CONV_MEMORY, API_DRIVER, SEC::MEMORY}},
   {"cuArrayDestroy",                                       {"hipArrayDestroy",                                         "", CONV_MEMORY, API_DRIVER, SEC::MEMORY}},
-  {"cuArrayGetDescriptor",                                 {"hipArrayGetDescriptor",                                   "", CONV_MEMORY, API_DRIVER, SEC::MEMORY, HIP_EXPERIMENTAL}},
-  {"cuArrayGetDescriptor_v2",                              {"hipArrayGetDescriptor",                                   "", CONV_MEMORY, API_DRIVER, SEC::MEMORY, HIP_EXPERIMENTAL}},
+  {"cuArrayGetDescriptor",                                 {"hipArrayGetDescriptor",                                   "", CONV_MEMORY, API_DRIVER, SEC::MEMORY}},
+  {"cuArrayGetDescriptor_v2",                              {"hipArrayGetDescriptor",                                   "", CONV_MEMORY, API_DRIVER, SEC::MEMORY}},
   //
   {"cuMipmappedArrayGetMemoryRequirements",                {"hipMipmappedArrayGetMemoryRequirements",                  "", CONV_MEMORY, API_DRIVER, SEC::MEMORY, HIP_UNSUPPORTED}},
   // cudaArrayGetMemoryRequirements
@@ -1530,8 +1530,8 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_DRIVER_FUNCTION_VER_MAP {
   {"hipGraphKernelNodeCopyAttributes",                     {HIP_5050, HIP_0,    HIP_0   }},
   {"hipGraphNodeSetEnabled",                               {HIP_5050, HIP_0,    HIP_0   }},
   {"hipGraphNodeGetEnabled",                               {HIP_5050, HIP_0,    HIP_0   }},
-  {"hipArrayGetDescriptor",                                {HIP_5060, HIP_0,    HIP_0,  HIP_LATEST}},
-  {"hipArray3DGetDescriptor",                              {HIP_5060, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipArrayGetDescriptor",                                {HIP_5060, HIP_0,    HIP_0   }},
+  {"hipArray3DGetDescriptor",                              {HIP_5060, HIP_0,    HIP_0   }},
 };
 
 const std::map<unsigned int, llvm::StringRef> CUDA_DRIVER_API_SECTION_MAP {

--- a/src/CUDA2HIP_Driver_API_types.cpp
+++ b/src/CUDA2HIP_Driver_API_types.cpp
@@ -2213,11 +2213,11 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_TYPE_NAME_MAP {
   // cudaGraphInstantiateFlagAutoFreeOnLaunch
   {"CUDA_GRAPH_INSTANTIATE_FLAG_AUTO_FREE_ON_LAUNCH",                  {"hipGraphInstantiateFlagAutoFreeOnLaunch",                  "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES}},
   // cudaGraphInstantiateFlagUpload
-  {"CUDA_GRAPH_INSTANTIATE_FLAG_UPLOAD",                               {"hipGraphInstantiateFlagUpload",                            "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES, HIP_EXPERIMENTAL}},
+  {"CUDA_GRAPH_INSTANTIATE_FLAG_UPLOAD",                               {"hipGraphInstantiateFlagUpload",                            "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES}},
   // cudaGraphInstantiateFlagDeviceLaunch
-  {"CUDA_GRAPH_INSTANTIATE_FLAG_DEVICE_LAUNCH",                        {"hipGraphInstantiateFlagDeviceLaunch",                      "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES, HIP_EXPERIMENTAL}},
+  {"CUDA_GRAPH_INSTANTIATE_FLAG_DEVICE_LAUNCH",                        {"hipGraphInstantiateFlagDeviceLaunch",                      "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES}},
   // cudaGraphInstantiateFlagUseNodePriority
-  {"CUDA_GRAPH_INSTANTIATE_FLAG_USE_NODE_PRIORITY",                    {"hipGraphInstantiateFlagUseNodePriority",                   "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES, HIP_EXPERIMENTAL}},
+  {"CUDA_GRAPH_INSTANTIATE_FLAG_USE_NODE_PRIORITY",                    {"hipGraphInstantiateFlagUseNodePriority",                   "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES}},
 
   // no analogue
   {"CUstreamMemoryBarrier_flags",                                      {"hipGraphInstantiateFlags",                                 "", CONV_TYPE, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
@@ -2531,7 +2531,7 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_TYPE_NAME_MAP {
   // cudaHostRegisterIoMemory
   {"CU_MEMHOSTREGISTER_IOMEMORY",                                      {"hipHostRegisterIoMemory",                                  "", CONV_DEFINE, API_DRIVER, SEC::DATA_TYPES}}, // 0x04
   // cudaHostRegisterReadOnly
-  {"CU_MEMHOSTREGISTER_READ_ONLY",                                     {"hipHostRegisterReadOnly",                                  "", CONV_DEFINE, API_DRIVER, SEC::DATA_TYPES, HIP_EXPERIMENTAL}}, // 0x08
+  {"CU_MEMHOSTREGISTER_READ_ONLY",                                     {"hipHostRegisterReadOnly",                                  "", CONV_DEFINE, API_DRIVER, SEC::DATA_TYPES}}, // 0x08
   //
   {"CU_PARAM_TR_DEFAULT",                                              {"HIP_PARAM_TR_DEFAULT",                                     "", CONV_DEFINE, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED}}, // -1
   // cudaStreamLegacy ((cudaStream_t)0x1)

--- a/src/CUDA2HIP_Runtime_API_functions.cpp
+++ b/src/CUDA2HIP_Runtime_API_functions.cpp
@@ -261,7 +261,7 @@ const std::map<llvm::StringRef, hipCounter> CUDA_RUNTIME_FUNCTION_MAP {
 
   // 9. Memory Management
   // no analogue
-  {"cudaArrayGetInfo",                                        {"hipArrayGetInfo",                                        "", CONV_MEMORY, API_RUNTIME, SEC::MEMORY, HIP_EXPERIMENTAL}},
+  {"cudaArrayGetInfo",                                        {"hipArrayGetInfo",                                        "", CONV_MEMORY, API_RUNTIME, SEC::MEMORY}},
   // cuMemFree
   {"cudaFree",                                                {"hipFree",                                                "", CONV_MEMORY, API_RUNTIME, SEC::MEMORY}},
   // no analogue
@@ -1354,7 +1354,7 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_RUNTIME_FUNCTION_VER_MAP {
   {"hipGraphReleaseUserObject",                               {HIP_5030, HIP_0,    HIP_0   }},
   {"hipOccupancyMaxPotentialBlockSizeVariableSMem",           {HIP_5050, HIP_0,    HIP_0   }},
   {"hipOccupancyMaxPotentialBlockSizeVariableSMemWithFlags",  {HIP_5050, HIP_0,    HIP_0   }},
-  {"hipArrayGetInfo",                                         {HIP_5060, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipArrayGetInfo",                                         {HIP_5060, HIP_0,    HIP_0   }},
 };
 
 const std::map<unsigned int, llvm::StringRef> CUDA_RUNTIME_API_SECTION_MAP {

--- a/src/CUDA2HIP_Runtime_API_types.cpp
+++ b/src/CUDA2HIP_Runtime_API_types.cpp
@@ -1748,11 +1748,11 @@ const std::map<llvm::StringRef, hipCounter> CUDA_RUNTIME_TYPE_NAME_MAP {
   // CUDA_GRAPH_INSTANTIATE_FLAG_AUTO_FREE_ON_LAUNCH
   {"cudaGraphInstantiateFlagAutoFreeOnLaunch",                         {"hipGraphInstantiateFlagAutoFreeOnLaunch",                  "", CONV_NUMERIC_LITERAL, API_RUNTIME, SEC::DATA_TYPES}},
   // CUDA_GRAPH_INSTANTIATE_FLAG_UPLOAD
-  {"cudaGraphInstantiateFlagUpload",                                   {"hipGraphInstantiateFlagUpload",                            "", CONV_NUMERIC_LITERAL, API_RUNTIME, SEC::DATA_TYPES, HIP_EXPERIMENTAL}},
+  {"cudaGraphInstantiateFlagUpload",                                   {"hipGraphInstantiateFlagUpload",                            "", CONV_NUMERIC_LITERAL, API_RUNTIME, SEC::DATA_TYPES}},
   // CUDA_GRAPH_INSTANTIATE_FLAG_DEVICE_LAUNCH
-  {"cudaGraphInstantiateFlagDeviceLaunch",                             {"hipGraphInstantiateFlagDeviceLaunch",                      "", CONV_NUMERIC_LITERAL, API_RUNTIME, SEC::DATA_TYPES, HIP_EXPERIMENTAL}},
+  {"cudaGraphInstantiateFlagDeviceLaunch",                             {"hipGraphInstantiateFlagDeviceLaunch",                      "", CONV_NUMERIC_LITERAL, API_RUNTIME, SEC::DATA_TYPES}},
   // CUDA_GRAPH_INSTANTIATE_FLAG_USE_NODE_PRIORITY
-  {"cudaGraphInstantiateFlagUseNodePriority",                          {"hipGraphInstantiateFlagUseNodePriority",                   "", CONV_NUMERIC_LITERAL, API_RUNTIME, SEC::DATA_TYPES, HIP_EXPERIMENTAL}},
+  {"cudaGraphInstantiateFlagUseNodePriority",                          {"hipGraphInstantiateFlagUseNodePriority",                   "", CONV_NUMERIC_LITERAL, API_RUNTIME, SEC::DATA_TYPES}},
 
   // CUclusterSchedulingPolicy
   {"cudaClusterSchedulingPolicy",                                      {"hipClusterSchedulingPolicy",                               "", CONV_TYPE, API_RUNTIME, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
@@ -1939,7 +1939,7 @@ const std::map<llvm::StringRef, hipCounter> CUDA_RUNTIME_TYPE_NAME_MAP {
   // CU_MEMHOSTREGISTER_IOMEMORY
   {"cudaHostRegisterIoMemory",                                         {"hipHostRegisterIoMemory",                                  "", CONV_DEFINE, API_RUNTIME, SEC::DATA_TYPES}}, // 0x04
   // CU_MEMHOSTREGISTER_READ_ONLY
-  {"cudaHostRegisterReadOnly",                                         {"hipHostRegisterReadOnly",                                  "", CONV_DEFINE, API_RUNTIME, SEC::DATA_TYPES, HIP_EXPERIMENTAL}}, // 0x08
+  {"cudaHostRegisterReadOnly",                                         {"hipHostRegisterReadOnly",                                  "", CONV_DEFINE, API_RUNTIME, SEC::DATA_TYPES}}, // 0x08
   // CU_IPC_MEM_LAZY_ENABLE_PEER_ACCESS
   {"cudaIpcMemLazyEnablePeerAccess",                                   {"hipIpcMemLazyEnablePeerAccess",                            "", CONV_DEFINE, API_RUNTIME, SEC::DATA_TYPES}}, // 0x01
   // CU_MEM_ATTACH_GLOBAL
@@ -2742,8 +2742,8 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_RUNTIME_TYPE_NAME_VER_MAP {
   {"hipGraphDebugDotFlagsExtSemasWaitNodeParams",                      {HIP_5050, HIP_0,    HIP_0   }},
   {"hipGraphDebugDotFlagsKernelNodeAttributes",                        {HIP_5050, HIP_0,    HIP_0   }},
   {"hipGraphDebugDotFlagsHandles",                                     {HIP_5050, HIP_0,    HIP_0   }},
-  {"hipGraphInstantiateFlagUpload",                                    {HIP_5060, HIP_0,    HIP_0,  HIP_LATEST}},
-  {"hipGraphInstantiateFlagDeviceLaunch",                              {HIP_5060, HIP_0,    HIP_0,  HIP_LATEST}},
-  {"hipGraphInstantiateFlagUseNodePriority",                           {HIP_5060, HIP_0,    HIP_0,  HIP_LATEST}},
-  {"hipHostRegisterReadOnly",                                          {HIP_5060, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipGraphInstantiateFlagUpload",                                    {HIP_5060, HIP_0,    HIP_0   }},
+  {"hipGraphInstantiateFlagDeviceLaunch",                              {HIP_5060, HIP_0,    HIP_0   }},
+  {"hipGraphInstantiateFlagUseNodePriority",                           {HIP_5060, HIP_0,    HIP_0   }},
+  {"hipHostRegisterReadOnly",                                          {HIP_5060, HIP_0,    HIP_0   }},
 };

--- a/src/Statistics.cpp
+++ b/src/Statistics.cpp
@@ -593,6 +593,7 @@ std::string Statistics::getHipVersion(const hipVersions& ver) {
     case HIP_5040: return "5.4.0";
     case HIP_5050: return "5.5.0";
     case HIP_5060: return "5.6.0";
+    case HIP_5070: return "5.7.0";
   }
   return "";
 }

--- a/src/Statistics.h
+++ b/src/Statistics.h
@@ -345,7 +345,8 @@ enum hipVersions {
   HIP_5040 = 5040,
   HIP_5050 = 5050,
   HIP_5060 = 5060,
-  HIP_LATEST = HIP_5060,
+  HIP_5070 = 5070,
+  HIP_LATEST = HIP_5070,
 };
 
 struct cudaAPIversions {


### PR DESCRIPTION
+ 5.7.0 is the latest HIP version now
+ Updated the regenerated hipify-perl and docs
