### PR TITLE
[HIPIFY][build][#724][SWDEV_375013][cleanup] Remove `SWDEV_375013` related guards from `CMakeLists.txt` and `HipifyAction.cpp`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,12 +119,6 @@ else()
     endif()
 endif()
 
-# [ToDo] Remove SWDEV_375013 related guards from CMakeLists.txt and HipifyAction.cpp along with the LLVM 16.0.0 official release
-option (SWDEV_375013 "Enables SWDEV-375013 blocker workaround for the clang's change https://reviews.llvm.org/D140332" OFF)
-if(SWDEV_375013)
-    add_definitions(-DSWDEV_375013)
-endif()
-
 if(MSVC)
     target_link_libraries(hipify-clang PRIVATE version)
     target_compile_options(hipify-clang PRIVATE ${STD} /Od /GR- /EHs- /EHc-)

--- a/src/HipifyAction.cpp
+++ b/src/HipifyAction.cpp
@@ -1199,12 +1199,11 @@ class PPCallbackProxy : public clang::PPCallbacks {
 
 public:
   explicit PPCallbackProxy(HipifyAction &action): hipifyAction(action) {}
-  // [ToDo] Remove SWDEV_375013 related guards from CMakeLists.txt and HipifyAction.cpp along with the LLVM 16.0.0 official release
   void InclusionDirective(clang::SourceLocation hash_loc, const clang::Token &include_token,
                           StringRef file_name, bool is_angled, clang::CharSourceRange filename_range,
 #if LLVM_VERSION_MAJOR < 15
                           const clang::FileEntry *file,
-#elif (LLVM_VERSION_MAJOR == 15) || (LLVM_VERSION_MAJOR == 16 && SWDEV_375013)
+#elif LLVM_VERSION_MAJOR == 15
                           Optional<clang::FileEntryRef> file,
 #else
                           clang::OptionalFileEntryRef file,


### PR DESCRIPTION
[Reason] LLVM 16.0.0 was released a long ago, so the guard is not used anymore
