### PR TITLE
[HIPIFY][doc] CUDA 12.2.0 is the latest supported release

### DIFF
--- a/docs/hipify-clang.md
+++ b/docs/hipify-clang.md
@@ -23,7 +23,7 @@ After applying all the matchers, the output HIP source is produced.
 
 1. [**LLVM+CLANG**](http://releases.llvm.org) of at least version [4.0.0](http://releases.llvm.org/download.html#4.0.0); the latest stable and recommended release: [**16.0.6**](https://github.com/llvm/llvm-project/releases/tag/llvmorg-16.0.6).
 
-2. [**CUDA**](https://developer.nvidia.com/cuda-downloads) of at least version [8.0](https://developer.nvidia.com/cuda-80-ga2-download-archive), the latest supported version is [**12.1.1**](https://developer.nvidia.com/cuda-downloads).
+2. [**CUDA**](https://developer.nvidia.com/cuda-downloads) of at least version [8.0](https://developer.nvidia.com/cuda-80-ga2-download-archive), the latest supported version is [**12.2.0**](https://developer.nvidia.com/cuda-downloads).
 
 <table align="center">
   <thead>
@@ -169,12 +169,12 @@ After applying all the matchers, the output HIP source is produced.
                            <a href="https://github.com/llvm/llvm-project/releases/tag/llvmorg-16.0.4">16.0.4</a>,
                            <a href="https://github.com/llvm/llvm-project/releases/tag/llvmorg-16.0.5">16.0.5</a>,<br>
                            <a href="https://github.com/llvm/llvm-project/releases/tag/llvmorg-16.0.6"><b>16.0.6</b></a></td>
-      <td bgcolor="eefaeb"><a href="https://developer.nvidia.com/cuda-downloads"><b>12.1.1</b></a></td>
+      <td bgcolor="eefaeb"><a href="https://developer.nvidia.com/cuda-downloads"><b>12.2.0</b></a></td>
       <td colspan=2 bgcolor="eefaeb"><font color="green"><b>LATEST STABLE CONFIG</b></font></td>
     </tr>
     <tr align="center">
       <td><a href="https://github.com/llvm/llvm-project">17.0.0git</a></td>
-      <td><a href="https://developer.nvidia.com/cuda-downloads">12.1.1</a></td>
+      <td><a href="https://developer.nvidia.com/cuda-downloads">12.2.0</a></td>
       <td>+</td>
       <td>+</td>
     </tr>
@@ -199,14 +199,14 @@ To process a file, `hipify-clang` needs access to the same headers that would be
 For example:
 
 ```shell
-./hipify-clang square.cu --cuda-path=/usr/local/cuda-12.1 -I /usr/local/cuda-12.1/samples/common/inc
+./hipify-clang square.cu --cuda-path=/usr/local/cuda-12.2 -I /usr/local/cuda-12.2/samples/common/inc
 ```
 
 `hipify-clang` arguments are given first, followed by a separator `'--'`, and then the arguments you'd pass to `clang` if you
 were compiling the input file. For example:
 
 ```bash
-./hipify-clang cpp17.cu --cuda-path=/usr/local/cuda-12.1 -- -std=c++17
+./hipify-clang cpp17.cu --cuda-path=/usr/local/cuda-12.2 -- -std=c++17
 ```
 
 The [Clang manual for compiling CUDA](https://llvm.org/docs/CompileCudaWithLLVM.html#compiling-cuda-code) may be useful.
@@ -327,9 +327,9 @@ Run `Visual Studio 17 2022`, open the generated `LLVM.sln`, build all, build pro
 
         - ***Linux***: `-DCUDA_TOOLKIT_ROOT_DIR=/usr/include`
 
-        - ***Windows***: `-DCUDA_TOOLKIT_ROOT_DIR="c:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v12.1"`
+        - ***Windows***: `-DCUDA_TOOLKIT_ROOT_DIR="c:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v12.2"`
 
-          `-DCUDA_SDK_ROOT_DIR="c:/ProgramData/NVIDIA Corporation/CUDA Samples/v12.1"`
+          `-DCUDA_SDK_ROOT_DIR="c:/ProgramData/NVIDIA Corporation/CUDA Samples/v12.2"`
 
 4. Ensure [`cuDNN`](https://developer.nvidia.com/rdp/cudnn-archive) of the version corresponding to CUDA's version is installed.
 
@@ -389,7 +389,7 @@ Ubuntu 14: LLVM 4.0.0 - 7.1.0, CUDA 7.0 - 9.0, cuDNN 5.0.5 - 7.6.5
 
 Ubuntu 16-18: LLVM 8.0.0 - 14.0.6, CUDA 8.0 - 10.2, cuDNN 5.1.10 - 8.0.5
 
-Ubuntu 20-21: LLVM 9.0.0 - 16.0.6, CUDA 8.0 - 12.1.1, cuDNN 5.1.10 - 8.9.2
+Ubuntu 20-21: LLVM 9.0.0 - 16.0.6, CUDA 8.0 - 12.2.0, cuDNN 5.1.10 - 8.9.2
 
 Minimum build system requirements for the above configurations:
 
@@ -443,7 +443,7 @@ cmake
 -- Performing Test CMAKE_HAVE_LIBC_PTHREAD
 -- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Success
 -- Found Threads: TRUE
--- Found CUDA: /usr/local/cuda (found version "12.1")
+-- Found CUDA: /usr/local/cuda (found version "12.2")
 -- Configuring done
 -- Generating done
 -- Build files have been written to: /usr/hipify/build
@@ -457,7 +457,7 @@ make test-hipify
 ```shell
 Running HIPify regression tests
 ========================================
-CUDA 12.1 - will be used for testing
+CUDA 12.2 - will be used for testing
 LLVM 16.0.6 - will be used for testing
 x86_64 - Platform architecture
 Linux 5.13.0-21-generic - Platform OS
@@ -576,8 +576,8 @@ Testing Time: 7.90s
 | 12.0.0 - 13.0.1 | 7.0 - 11.5.1 | 7.6.5  - 8.3.2 | 2017.15.9.43, 2019.16.11.9               | 3.22.2          | 3.10.2        |
 | 14.0.0 - 14.0.6 | 7.0 - 11.7.1 | 8.0.5  - 8.4.1 | 2017.15.9.49, 2019.16.11.17, 2022.17.2.6 | 3.24.0          | 3.10.6        |
 | 15.0.0 - 15.0.7 | 7.0 - 11.8.0 | 8.0.5  - 8.8.1 | 2017.15.9.53, 2019.16.11.25, 2022.17.5.2 | 3.26.0          | 3.11.2        |
-| 16.0.0 - 16.0.6 | 7.0 - 12.1.1 | 8.0.5  - 8.9.2 | 2017.15.9.55, 2019.16.11.27, 2022.17.6.4 | 3.26.4          | 3.11.4        |
-| 17.0.0git       | 7.0 - 12.1.1 | 8.0.5  - 8.9.2 | 2017.15.9.55, 2019.16.11.27, 2022.17.6.4 | 3.26.4          | 3.11.4        |
+| 16.0.0 - 16.0.6 | 7.0 - 12.2.0 | 8.0.5  - 8.9.2 | 2017.15.9.55, 2019.16.11.27, 2022.17.6.4 | 3.26.4          | 3.11.4        |
+| 17.0.0git       | 7.0 - 12.2.0 | 8.0.5  - 8.9.2 | 2017.15.9.55, 2019.16.11.27, 2022.17.6.4 | 3.26.4          | 3.11.4        |
 
 *Building with testing support by `Visual Studio 17 2022` on `Windows 10`:*
 
@@ -590,9 +590,9 @@ cmake
  -DCMAKE_BUILD_TYPE=Release \
  -DCMAKE_INSTALL_PREFIX=../dist \
  -DCMAKE_PREFIX_PATH=d:/LLVM/16.0.6/dist \
- -DCUDA_TOOLKIT_ROOT_DIR="c:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v12.1" \
- -DCUDA_SDK_ROOT_DIR="c:/ProgramData/NVIDIA Corporation/CUDA Samples/v12.1" \
- -DCUDA_DNN_ROOT_DIR=d:/CUDNN/cudnn-12.1-windows-x64-v8.9.2 \
+ -DCUDA_TOOLKIT_ROOT_DIR="c:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v12.2" \
+ -DCUDA_SDK_ROOT_DIR="c:/ProgramData/NVIDIA Corporation/CUDA Samples/v12.2" \
+ -DCUDA_DNN_ROOT_DIR=d:/CUDNN/cudnn-12.2-windows-x64-v8.9.2 \
  -DCUDA_CUB_ROOT_DIR=d:/GIT/cub \
  -DLLVM_EXTERNAL_LIT=d:/LLVM/16.0.6/build/Release/bin/llvm-lit.py \
  ../hipify
@@ -606,7 +606,7 @@ cmake
 -- Found PythonInterp: c:/Program Files/Python311/python.exe (found suitable version "3.11.4", minimum required is "3.6")
 -- Found lit: c:/Program Files/Python311/Scripts/lit.exe
 -- Found FileCheck: d:/LLVM/16.0.6/dist/bin/FileCheck.exe
--- Found CUDA: c:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v12.1 (found version "12.1")
+-- Found CUDA: c:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v12.2 (found version "12.2")
 -- Configuring done
 -- Generating done
 -- Build files have been written to: d:/hipify/build


### PR DESCRIPTION
+ CUDA 12.2 is supported by LLVM >= 16.0.0
+ Updated README.md accordingly
+ Tested on Windows 10 and Ubuntu 21.10
