### PR TITLE
[HIPIFY][HIP][5.7.0] Mark the deprecated HIP functions

### DIFF
--- a/docs/tables/CUDA_Driver_API_functions_supported_by_HIP.md
+++ b/docs/tables/CUDA_Driver_API_functions_supported_by_HIP.md
@@ -1590,9 +1590,9 @@
 |`cuMemsetD8`| | | |`hipMemsetD8`|1.6.0| | | |
 |`cuMemsetD8Async`| | | |`hipMemsetD8Async`|3.0.0| | | |
 |`cuMemsetD8_v2`| | | |`hipMemsetD8`|1.6.0| | | |
-|`cuMipmappedArrayCreate`| | | |`hipMipmappedArrayCreate`|3.5.0| | | |
-|`cuMipmappedArrayDestroy`| | | |`hipMipmappedArrayDestroy`|3.5.0| | | |
-|`cuMipmappedArrayGetLevel`| | | |`hipMipmappedArrayGetLevel`|3.5.0| | | |
+|`cuMipmappedArrayCreate`| | | |`hipMipmappedArrayCreate`|3.5.0|5.7.0| | |
+|`cuMipmappedArrayDestroy`| | | |`hipMipmappedArrayDestroy`|3.5.0|5.7.0| | |
+|`cuMipmappedArrayGetLevel`| | | |`hipMipmappedArrayGetLevel`|3.5.0|5.7.0| | |
 |`cuMipmappedArrayGetMemoryRequirements`|11.6| | | | | | | |
 
 ## **14. Virtual Memory Management**

--- a/docs/tables/CUDA_Runtime_API_functions_supported_by_HIP.md
+++ b/docs/tables/CUDA_Runtime_API_functions_supported_by_HIP.md
@@ -1448,7 +1448,7 @@
 |`cudaBindTexture`| |11.0|12.0|`hipBindTexture`|1.6.0|3.8.0| | |
 |`cudaBindTexture2D`| |11.0|12.0|`hipBindTexture2D`|1.7.0|3.8.0| | |
 |`cudaBindTextureToArray`| |11.0|12.0|`hipBindTextureToArray`|1.6.0|3.8.0| | |
-|`cudaBindTextureToMipmappedArray`| |11.0|12.0|`hipBindTextureToMipmappedArray`|1.7.0| | | |
+|`cudaBindTextureToMipmappedArray`| |11.0|12.0|`hipBindTextureToMipmappedArray`|1.7.0|5.7.0| | |
 |`cudaGetTextureAlignmentOffset`| |11.0|12.0|`hipGetTextureAlignmentOffset`|1.9.0|3.8.0| | |
 |`cudaGetTextureReference`| |11.0|12.0|`hipGetTextureReference`|1.7.0|5.3.0| | |
 |`cudaUnbindTexture`| |11.0|12.0|`hipUnbindTexture`|1.6.0|3.8.0| | |

--- a/src/CUDA2HIP_Driver_API_functions.cpp
+++ b/src/CUDA2HIP_Driver_API_functions.cpp
@@ -353,13 +353,13 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_FUNCTION_MAP {
   {"cuMemsetD8Async",                                      {"hipMemsetD8Async",                                        "", CONV_MEMORY, API_DRIVER, SEC::MEMORY}},
   // no analogue
   // NOTE: Not equal to cudaMallocMipmappedArray due to different signatures
-  {"cuMipmappedArrayCreate",                               {"hipMipmappedArrayCreate",                                 "", CONV_MEMORY, API_DRIVER, SEC::MEMORY}},
+  {"cuMipmappedArrayCreate",                               {"hipMipmappedArrayCreate",                                 "", CONV_MEMORY, API_DRIVER, SEC::MEMORY, HIP_DEPRECATED}},
   // no analogue
   // NOTE: Not equal to cudaFreeMipmappedArray due to different signatures
-  {"cuMipmappedArrayDestroy",                              {"hipMipmappedArrayDestroy",                                "", CONV_MEMORY, API_DRIVER, SEC::MEMORY}},
+  {"cuMipmappedArrayDestroy",                              {"hipMipmappedArrayDestroy",                                "", CONV_MEMORY, API_DRIVER, SEC::MEMORY, HIP_DEPRECATED}},
   // no analogue
   // NOTE: Not equal to cudaGetMipmappedArrayLevel due to different signatures
-  {"cuMipmappedArrayGetLevel",                             {"hipMipmappedArrayGetLevel",                               "", CONV_MEMORY, API_DRIVER, SEC::MEMORY}},
+  {"cuMipmappedArrayGetLevel",                             {"hipMipmappedArrayGetLevel",                               "", CONV_MEMORY, API_DRIVER, SEC::MEMORY, HIP_DEPRECATED}},
   // cudaArrayGetSparseProperties
   {"cuArrayGetSparseProperties",                           {"hipArrayGetSparseProperties",                             "", CONV_MEMORY, API_DRIVER, SEC::MEMORY, HIP_UNSUPPORTED}},
   // cudaArrayGetPlane
@@ -1458,9 +1458,9 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_DRIVER_FUNCTION_VER_MAP {
   {"hipMemsetD32Async",                                    {HIP_2030, HIP_0,    HIP_0   }},
   {"hipMemsetD8",                                          {HIP_1060, HIP_0,    HIP_0   }},
   {"hipMemsetD8Async",                                     {HIP_3000, HIP_0,    HIP_0   }},
-  {"hipMipmappedArrayCreate",                              {HIP_3050, HIP_0,    HIP_0   }},
-  {"hipMipmappedArrayDestroy",                             {HIP_3050, HIP_0,    HIP_0   }},
-  {"hipMipmappedArrayGetLevel",                            {HIP_3050, HIP_0,    HIP_0   }},
+  {"hipMipmappedArrayCreate",                              {HIP_3050, HIP_5070, HIP_0   }},
+  {"hipMipmappedArrayDestroy",                             {HIP_3050, HIP_5070, HIP_0   }},
+  {"hipMipmappedArrayGetLevel",                            {HIP_3050, HIP_5070, HIP_0   }},
   {"hipFuncGetAttribute",                                  {HIP_2080, HIP_0,    HIP_0   }},
   {"hipModuleLaunchKernel",                                {HIP_1060, HIP_0,    HIP_0   }},
   {"hipModuleOccupancyMaxActiveBlocksPerMultiprocessor",   {HIP_3050, HIP_0,    HIP_0   }},

--- a/src/CUDA2HIP_Runtime_API_functions.cpp
+++ b/src/CUDA2HIP_Runtime_API_functions.cpp
@@ -885,7 +885,7 @@ const std::map<llvm::StringRef, hipCounter> CUDA_RUNTIME_FUNCTION_MAP {
   // no analogue
   {"cudaBindTextureToArray",                                  {"hipBindTextureToArray",                                  "", CONV_TEXTURE, API_RUNTIME, SEC::TEXTURE_REMOVED, HIP_DEPRECATED | CUDA_REMOVED}},
   // no analogue
-  {"cudaBindTextureToMipmappedArray",                         {"hipBindTextureToMipmappedArray",                         "", CONV_TEXTURE, API_RUNTIME, SEC::TEXTURE_REMOVED, CUDA_REMOVED}},
+  {"cudaBindTextureToMipmappedArray",                         {"hipBindTextureToMipmappedArray",                         "", CONV_TEXTURE, API_RUNTIME, SEC::TEXTURE_REMOVED, HIP_DEPRECATED | CUDA_REMOVED}},
   // no analogue
   {"cudaGetTextureAlignmentOffset",                           {"hipGetTextureAlignmentOffset",                           "", CONV_TEXTURE, API_RUNTIME, SEC::TEXTURE_REMOVED, HIP_DEPRECATED | CUDA_REMOVED}},
   // no analogue
@@ -1245,7 +1245,7 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_RUNTIME_FUNCTION_VER_MAP {
   {"hipBindTexture",                                          {HIP_1060, HIP_3080, HIP_0   }},
   {"hipBindTexture2D",                                        {HIP_1070, HIP_3080, HIP_0   }},
   {"hipBindTextureToArray",                                   {HIP_1060, HIP_3080, HIP_0   }},
-  {"hipBindTextureToMipmappedArray",                          {HIP_1070, HIP_0,    HIP_0   }},
+  {"hipBindTextureToMipmappedArray",                          {HIP_1070, HIP_5070, HIP_0   }},
   {"hipCreateChannelDesc",                                    {HIP_1060, HIP_0,    HIP_0   }},
   {"hipGetChannelDesc",                                       {HIP_1070, HIP_0,    HIP_0   }},
   {"hipGetTextureAlignmentOffset",                            {HIP_1090, HIP_3080, HIP_0   }},


### PR DESCRIPTION
+ Updated the generated docs accordingly