### PR TITLE
[HIPIFY][SWDEV-409236][perl] - Get the absolute path of the script directory

### DIFF
--- a/bin/hipconvertinplace-perl.sh
+++ b/bin/hipconvertinplace-perl.sh
@@ -11,8 +11,7 @@
 #   - If ".prehip" file exists, this is used as input to hipify.
 # (this is useful for testing improvements to the hipify-perl toolset).
 
-
-SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+SCRIPT_DIR="$(dirname "$(realpath "$0")")"
 PRIV_SCRIPT_DIR="$SCRIPT_DIR/../libexec/hipify"
 SEARCH_DIR=$1
 shift

--- a/bin/hipconvertinplace-perl.sh
+++ b/bin/hipconvertinplace-perl.sh
@@ -12,7 +12,7 @@
 # (this is useful for testing improvements to the hipify-perl toolset).
 
 
-SCRIPT_DIR=`dirname $0`
+SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
 PRIV_SCRIPT_DIR="$SCRIPT_DIR/../libexec/hipify"
 SEARCH_DIR=$1
 shift

--- a/bin/hipconvertinplace.sh
+++ b/bin/hipconvertinplace.sh
@@ -6,7 +6,7 @@
 # This can be quite handy when dealing with an existing CUDA code base since the script
 # preserves the existing directory structure.
 
-SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+SCRIPT_DIR="$(dirname "$(realpath "$0")")"
 PRIV_SCRIPT_DIR="$SCRIPT_DIR/../libexec/hipify"
 SEARCH_DIR=$1
 

--- a/bin/hipconvertinplace.sh
+++ b/bin/hipconvertinplace.sh
@@ -6,7 +6,7 @@
 # This can be quite handy when dealing with an existing CUDA code base since the script
 # preserves the existing directory structure.
 
-SCRIPT_DIR=`dirname $0`
+SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
 PRIV_SCRIPT_DIR="$SCRIPT_DIR/../libexec/hipify"
 SEARCH_DIR=$1
 

--- a/bin/hipexamine-perl.sh
+++ b/bin/hipexamine-perl.sh
@@ -6,7 +6,7 @@
 # in the specified directory.
 
 
-SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+SCRIPT_DIR="$(dirname "$(realpath "$0")")"
 PRIV_SCRIPT_DIR="$SCRIPT_DIR/../libexec/hipify"
 SEARCH_DIR=$1
 shift

--- a/bin/hipexamine-perl.sh
+++ b/bin/hipexamine-perl.sh
@@ -6,7 +6,7 @@
 # in the specified directory.
 
 
-SCRIPT_DIR=`dirname $0`
+SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
 PRIV_SCRIPT_DIR="$SCRIPT_DIR/../libexec/hipify"
 SEARCH_DIR=$1
 shift

--- a/bin/hipexamine.sh
+++ b/bin/hipexamine.sh
@@ -4,7 +4,7 @@
 
 # Generate CUDA->HIP conversion statistics for all the code files in the specified directory.
 
-SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+SCRIPT_DIR="$(dirname "$(realpath "$0")")"
 PRIV_SCRIPT_DIR="$SCRIPT_DIR/../libexec/hipify"
 SEARCH_DIR=$1
 

--- a/bin/hipexamine.sh
+++ b/bin/hipexamine.sh
@@ -4,7 +4,7 @@
 
 # Generate CUDA->HIP conversion statistics for all the code files in the specified directory.
 
-SCRIPT_DIR=`dirname $0`
+SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
 PRIV_SCRIPT_DIR="$SCRIPT_DIR/../libexec/hipify"
 SEARCH_DIR=$1
 


### PR DESCRIPTION
Softlinks of the hipify scripts will be there in /usr/bin directory due to update-alternatives execution. Invoking scripts from softlinks results in failure, since the script directory path was incorrect. Use realpath to get the absolute paths