### PR TITLE
[HIPIFY][cmake][fix] Search for `CUDAToolkit` instead of `CUDA` for cmake >= 3.27.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -232,7 +232,25 @@ if(HIPIFY_CLANG_TESTS OR HIPIFY_CLANG_TESTS_ONLY)
   require_program(lit)
   require_program(FileCheck)
 
-  find_package(CUDA REQUIRED)
+  set(CUDA_TOOLKIT_ROOT_DIR OFF CACHE PATH "Path to CUDA Toolkit to use in hipify-clang unit testing")
+
+  if(${CMAKE_VERSION} VERSION_LESS "3.27.0")
+    find_package(CUDA REQUIRED)
+  else()
+    if(DEFINED CUDA_TOOLKIT_ROOT_DIR)
+      if(NOT DEFINED CUDAToolkit_ROOT)
+        set(CUDAToolkit_ROOT "${CUDA_TOOLKIT_ROOT_DIR}")
+      endif()
+    endif()
+    find_package(CUDAToolkit REQUIRED)
+    set(CUDA_VERSION_MAJOR "${CUDAToolkit_VERSION_MAJOR}")
+    set(CUDA_VERSION_MINOR "${CUDAToolkit_VERSION_MINOR}")
+    set(CUDA_VERSION "${CUDAToolkit_VERSION_MAJOR}.${CUDAToolkit_VERSION_MINOR}")
+    if(NOT DEFINED CUDA_TOOLKIT_ROOT_DIR)
+      set(CUDA_TOOLKIT_ROOT_DIR "${CUDAToolkit_ROOT}")
+    endif()
+  endif()
+
   if((CUDA_VERSION VERSION_LESS "7.0") OR (LLVM_PACKAGE_VERSION VERSION_LESS "3.8") OR
      (CUDA_VERSION VERSION_GREATER "7.5" AND LLVM_PACKAGE_VERSION VERSION_LESS "4.0") OR
      (CUDA_VERSION VERSION_GREATER "8.0" AND LLVM_PACKAGE_VERSION VERSION_LESS "6.0") OR


### PR DESCRIPTION
**[Reason]** Since cmake 3.27.0, `FindCUDA` is available only if policy CMP0146 is not set to NEW, otherwise, cmake warns that the policy is not set

+ Overridden `CUDA_VERSION` (set by former `FindCUDA`) with `CUDAToolkit_VERSION` (set by `FindCUDAToolkit`)
+ Overridden `CUDA_TOOLKIT_ROOT_DIR` (specified as cmake's command line define) with `CUDAToolkit_ROOT` (set by `FindCUDAToolkit`)
+ Introduced `CUDA_TOOLKIT_ROOT_DIR` as an internal cmake variable to make the previous override work
+ If `CUDAToolkit_ROOT` is not specified use `CUDA_TOOLKIT_ROOT_DIR` (backward compatibility) for searching CUDA

**[ToDo]** Introduce the rest of CUDA-related stuff as internal variables