### PR TITLE
[HIPIFY][SPARSE] Sync with CUDA 12.2.1 - Part 1 - cuSPARSE API - data types

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -90,6 +90,8 @@ GetOptions(
 $cuda_kernel_execution_syntax = 1;
 
 my %deprecated_funcs = (
+    "pruneInfo_t" => "12.2",
+    "pruneInfo" => "12.2",
     "nvrtcGetNVVMSize" => "12.0",
     "nvrtcGetNVVM" => "12.0",
     "cusparseZsctr" => "11.0",
@@ -144,6 +146,7 @@ my %deprecated_funcs = (
     "cusparseXcsrgeamNnz" => "10.2",
     "cusparseSsctr" => "11.0",
     "cusparseSroti" => "11.0",
+    "cusparseSolvePolicy_t" => "12.2",
     "cusparseSolveAnalysisInfo_t" => "10.2",
     "cusparseSolveAnalysisInfo" => "10.2",
     "cusparseShybsv_solve" => "10.2",
@@ -258,6 +261,9 @@ my %deprecated_funcs = (
     "cusparseCooAoSGet" => "11.2",
     "cusparseConstrainedGeMM_bufferSize" => "11.2",
     "cusparseConstrainedGeMM" => "11.2",
+    "cusparseColorInfo_t" => "12.2",
+    "cusparseColorInfo" => "12.2",
+    "cusparseColorAlg_t" => "12.2",
     "cusparseChybsv_solve" => "10.2",
     "cusparseChybsv_analysis" => "10.2",
     "cusparseChybmv" => "10.2",
@@ -501,6 +507,18 @@ my %deprecated_funcs = (
     "cuD3D10GetDirect3DDevice" => "9.2",
     "cuD3D10CtxCreateOnDevice" => "9.2",
     "cuD3D10CtxCreate" => "9.2",
+    "csru2csrInfo_t" => "12.2",
+    "csru2csrInfo" => "12.2",
+    "csrilu02Info_t" => "12.2",
+    "csrilu02Info" => "12.2",
+    "csric02Info_t" => "12.2",
+    "csric02Info" => "12.2",
+    "bsrsv2Info_t" => "12.2",
+    "bsrsv2Info" => "12.2",
+    "bsrsm2Info_t" => "12.2",
+    "bsrsm2Info" => "12.2",
+    "bsrilu02Info_t" => "12.2",
+    "bsrilu02Info" => "12.2",
     "CU_JIT_REFERENCED_VARIABLE_NAMES" => "12.0",
     "CU_JIT_REFERENCED_VARIABLE_COUNT" => "12.0",
     "CU_JIT_REFERENCED_KERNEL_NAMES" => "12.0",
@@ -524,6 +542,8 @@ my %deprecated_funcs = (
     "CU_DEVICE_ATTRIBUTE_GPU_OVERLAP" => "5.0",
     "CU_DEVICE_ATTRIBUTE_CAN_TEX2D_GATHER" => "5.0",
     "CU_CTX_BLOCKING_SYNC" => "4.0",
+    "CUSPARSE_SOLVE_POLICY_USE_LEVEL" => "12.2",
+    "CUSPARSE_SOLVE_POLICY_NO_LEVEL" => "12.2",
     "CUSPARSE_MV_ALG_DEFAULT" => "11.3",
     "CUSPARSE_MM_ALG_DEFAULT" => "11.0",
     "CUSPARSE_HYB_PARTITION_USER" => "10.2",
@@ -536,6 +556,8 @@ my %deprecated_funcs = (
     "CUSPARSE_COOMM_ALG3" => "11.0",
     "CUSPARSE_COOMM_ALG2" => "11.0",
     "CUSPARSE_COOMM_ALG1" => "11.0",
+    "CUSPARSE_COLOR_ALG1" => "12.2",
+    "CUSPARSE_COLOR_ALG0" => "12.2",
     "CUDNN_CONVOLUTION_FWD_SPECIFY_WORKSPACE_LIMIT" => "7.6.5",
     "CUDNN_CONVOLUTION_FWD_PREFER_FASTEST" => "7.6.5",
     "CUDNN_CONVOLUTION_FWD_NO_WORKSPACE" => "7.6.5",
@@ -3870,12 +3892,18 @@ sub simpleSubstitutions {
     subst("CUuuid_st", "hipUUID_t", "type");
     subst("GLenum", "GLenum", "type");
     subst("GLuint", "GLuint", "type");
+    subst("bsric02Info", "bsric02Info", "type");
     subst("bsric02Info_t", "bsric02Info_t", "type");
+    subst("bsrilu02Info", "bsrilu02Info", "type");
     subst("bsrilu02Info_t", "bsrilu02Info_t", "type");
     subst("bsrsm2Info", "bsrsm2Info", "type");
     subst("bsrsm2Info_t", "bsrsm2Info_t", "type");
+    subst("bsrsv2Info", "bsrsv2Info", "type");
     subst("bsrsv2Info_t", "bsrsv2Info_t", "type");
     subst("csrgemm2Info_t", "csrgemm2Info_t", "type");
+    subst("csric02Info", "csric02Info", "type");
+    subst("csric02Info_t", "csric02Info_t", "type");
+    subst("csrilu02Info", "csrilu02Info", "type");
     subst("csrilu02Info_t", "csrilu02Info_t", "type");
     subst("csrsm2Info_t", "csrsm2Info_t", "type");
     subst("csrsv2Info_t", "csrsv2Info_t", "type");
@@ -6444,6 +6472,7 @@ sub warnUnsupportedFunctions {
         "cusparseConstCooGet",
         "cusparseConstBlockedEllGet",
         "cusparseColorInfo",
+        "cusparseColorAlg_t",
         "cusparseChybsv_solve",
         "cusparseChybsv_analysis",
         "cusparseChyb2dense",
@@ -7504,15 +7533,11 @@ sub warnUnsupportedFunctions {
         "cuArrayGetMemoryRequirements",
         "csrsv2Info",
         "csrsm2Info",
-        "csrilu02Info",
         "csrgemm2Info",
         "cl_event_flags_enum",
         "cl_event_flags",
         "cl_context_flags_enum",
         "cl_context_flags",
-        "bsrsv2Info",
-        "bsrilu02Info",
-        "bsric02Info",
         "__nv_saturation_t",
         "__nv_fp8x4_storage_t",
         "__nv_fp8x4_e5m2",
@@ -8105,6 +8130,8 @@ sub warnUnsupportedFunctions {
         "CUSPARSE_SIDE_LEFT",
         "CUSPARSE_FORMAT_SLICED_ELLPACK",
         "CUSPARSE_FORMAT_BSR",
+        "CUSPARSE_COLOR_ALG1",
+        "CUSPARSE_COLOR_ALG0",
         "CUSPARSE_ALG_NAIVE",
         "CUSPARSE_ALG_MERGE_PATH",
         "CUSPARSE_ALG1",

--- a/docs/tables/CUSPARSE_API_supported_by_HIP.md
+++ b/docs/tables/CUSPARSE_API_supported_by_HIP.md
@@ -10,6 +10,8 @@
 |`CUSPARSE_ALG1`|8.0| |11.0| | | | | |
 |`CUSPARSE_ALG_MERGE_PATH`|9.2| |12.0| | | | | |
 |`CUSPARSE_ALG_NAIVE`|9.2| |11.0| | | | | |
+|`CUSPARSE_COLOR_ALG0`|8.0|12.2| | | | | | |
+|`CUSPARSE_COLOR_ALG1`|8.0|12.2| | | | | | |
 |`CUSPARSE_COOMM_ALG1`|10.1|11.0|12.0|`HIPSPARSE_COOMM_ALG1`|4.2.0| | | |
 |`CUSPARSE_COOMM_ALG2`|10.1|11.0|12.0|`HIPSPARSE_COOMM_ALG2`|4.2.0| | | |
 |`CUSPARSE_COOMM_ALG3`|10.1|11.0|12.0|`HIPSPARSE_COOMM_ALG3`|4.2.0| | | |
@@ -58,8 +60,8 @@
 |`CUSPARSE_SDDMM_ALG_DEFAULT`|11.2| | |`HIPSPARSE_SDDMM_ALG_DEFAULT`|4.3.0| | | |
 |`CUSPARSE_SIDE_LEFT`| | |11.5| | | | | |
 |`CUSPARSE_SIDE_RIGHT`| | |11.5| | | | | |
-|`CUSPARSE_SOLVE_POLICY_NO_LEVEL`| | | |`HIPSPARSE_SOLVE_POLICY_NO_LEVEL`|1.9.2| | | |
-|`CUSPARSE_SOLVE_POLICY_USE_LEVEL`| | | |`HIPSPARSE_SOLVE_POLICY_USE_LEVEL`|1.9.2| | | |
+|`CUSPARSE_SOLVE_POLICY_NO_LEVEL`| |12.2| |`HIPSPARSE_SOLVE_POLICY_NO_LEVEL`|1.9.2| | | |
+|`CUSPARSE_SOLVE_POLICY_USE_LEVEL`| |12.2| |`HIPSPARSE_SOLVE_POLICY_USE_LEVEL`|1.9.2| | | |
 |`CUSPARSE_SPARSETODENSE_ALG_DEFAULT`|11.1| | |`HIPSPARSE_SPARSETODENSE_ALG_DEFAULT`|4.2.0| | | |
 |`CUSPARSE_SPGEMM_ALG1`|12.0| | |`HIPSPARSE_SPGEMM_ALG1`|5.6.0| | | |
 |`CUSPARSE_SPGEMM_ALG2`|12.0| | |`HIPSPARSE_SPGEMM_ALG2`|5.6.0| | | |
@@ -106,28 +108,31 @@
 |`CUSPARSE_STATUS_NOT_SUPPORTED`|10.2| | |`HIPSPARSE_STATUS_NOT_SUPPORTED`|4.1.0| | | |
 |`CUSPARSE_STATUS_SUCCESS`| | | |`HIPSPARSE_STATUS_SUCCESS`|1.9.2| | | |
 |`CUSPARSE_STATUS_ZERO_PIVOT`| | | |`HIPSPARSE_STATUS_ZERO_PIVOT`|1.9.2| | | |
-|`bsric02Info`| | | | | | | | |
+|`bsric02Info`| | | |`bsric02Info`|3.8.0| | | |
 |`bsric02Info_t`| | | |`bsric02Info_t`|3.8.0| | | |
-|`bsrilu02Info`| | | | | | | | |
-|`bsrilu02Info_t`| | | |`bsrilu02Info_t`|3.9.0| | | |
-|`bsrsm2Info`| | | |`bsrsm2Info`|4.5.0| | | |
-|`bsrsm2Info_t`| | | |`bsrsm2Info_t`|4.5.0| | | |
-|`bsrsv2Info`| | | | | | | | |
-|`bsrsv2Info_t`| | | |`bsrsv2Info_t`|3.6.0| | | |
+|`bsrilu02Info`| |12.2| |`bsrilu02Info`|3.9.0| | | |
+|`bsrilu02Info_t`| |12.2| |`bsrilu02Info_t`|3.9.0| | | |
+|`bsrsm2Info`| |12.2| |`bsrsm2Info`|4.5.0| | | |
+|`bsrsm2Info_t`| |12.2| |`bsrsm2Info_t`|4.5.0| | | |
+|`bsrsv2Info`| |12.2| |`bsrsv2Info`|3.6.0| | | |
+|`bsrsv2Info_t`| |12.2| |`bsrsv2Info_t`|3.6.0| | | |
 |`csrgemm2Info`| | |12.0| | | | | |
 |`csrgemm2Info_t`| | |12.0|`csrgemm2Info_t`|2.8.0| | | |
-|`csrilu02Info`| | | | | | | | |
-|`csrilu02Info_t`| | | |`csrilu02Info_t`|1.9.2| | | |
+|`csric02Info`| |12.2| |`csric02Info`|3.1.0| | | |
+|`csric02Info_t`| |12.2| |`csric02Info_t`|3.1.0| | | |
+|`csrilu02Info`| |12.2| |`csrilu02Info`|1.9.2| | | |
+|`csrilu02Info_t`| |12.2| |`csrilu02Info_t`|1.9.2| | | |
 |`csrsm2Info`|9.2| |12.0| | | | | |
 |`csrsm2Info_t`|9.2| |12.0|`csrsm2Info_t`|3.1.0| | | |
 |`csrsv2Info`| | |12.0| | | | | |
 |`csrsv2Info_t`| | |12.0|`csrsv2Info_t`|1.9.2| | | |
-|`csru2csrInfo`| | | |`csru2csrInfo`|4.2.0| | | |
-|`csru2csrInfo_t`| | | |`csru2csrInfo_t`|4.2.0| | | |
+|`csru2csrInfo`| |12.2| |`csru2csrInfo`|4.2.0| | | |
+|`csru2csrInfo_t`| |12.2| |`csru2csrInfo_t`|4.2.0| | | |
 |`cusparseAction_t`| | | |`hipsparseAction_t`|1.9.2| | | |
 |`cusparseAlgMode_t`|8.0| |12.0| | | | | |
-|`cusparseColorInfo`| | | | | | | | |
-|`cusparseColorInfo_t`| | | |`hipsparseColorInfo_t`|4.5.0| | | |
+|`cusparseColorAlg_t`|8.0|12.2| | | | | | |
+|`cusparseColorInfo`| |12.2| | | | | | |
+|`cusparseColorInfo_t`| |12.2| |`hipsparseColorInfo_t`|4.5.0| | | |
 |`cusparseConstDnMatDescr_t`|12.0| | | | | | | |
 |`cusparseConstDnVecDescr_t`|12.0| | | | | | | |
 |`cusparseConstSpMatDescr_t`|12.0| | | | | | | |
@@ -160,7 +165,7 @@
 |`cusparseSideMode_t`| | |11.5| | | | | |
 |`cusparseSolveAnalysisInfo`| |10.2|11.0| | | | | |
 |`cusparseSolveAnalysisInfo_t`| |10.2|11.0| | | | | |
-|`cusparseSolvePolicy_t`| | | |`hipsparseSolvePolicy_t`|1.9.2| | | |
+|`cusparseSolvePolicy_t`| |12.2| |`hipsparseSolvePolicy_t`|1.9.2| | | |
 |`cusparseSpGEMMAlg_t`|11.0| | |`hipsparseSpGEMMAlg_t`|4.1.0| | | |
 |`cusparseSpGEMMDescr`|11.0| | |`hipsparseSpGEMMDescr`|4.1.0| | | |
 |`cusparseSpGEMMDescr_t`|11.0| | |`hipsparseSpGEMMDescr_t`|4.1.0| | | |
@@ -183,8 +188,8 @@
 |`cusparseSpVecDescr_t`|10.2| | |`hipsparseSpVecDescr_t`|4.1.0| | | |
 |`cusparseSparseToDenseAlg_t`|11.1| | |`hipsparseSparseToDenseAlg_t`|4.2.0| | | |
 |`cusparseStatus_t`| | | |`hipsparseStatus_t`|1.9.2| | | |
-|`pruneInfo`|9.0| | |`pruneInfo`|3.9.0| | | |
-|`pruneInfo_t`|9.0| | |`pruneInfo_t`|3.9.0| | | |
+|`pruneInfo`|9.0|12.2| |`pruneInfo`|3.9.0| | | |
+|`pruneInfo_t`|9.0|12.2| |`pruneInfo_t`|3.9.0| | | |
 
 ## **5. CUSPARSE Management Function Reference**
 

--- a/docs/tables/CUSPARSE_API_supported_by_HIP_and_ROC.md
+++ b/docs/tables/CUSPARSE_API_supported_by_HIP_and_ROC.md
@@ -10,6 +10,8 @@
 |`CUSPARSE_ALG1`|8.0| |11.0| | | | | | | | | | |
 |`CUSPARSE_ALG_MERGE_PATH`|9.2| |12.0| | | | | | | | | | |
 |`CUSPARSE_ALG_NAIVE`|9.2| |11.0| | | | | | | | | | |
+|`CUSPARSE_COLOR_ALG0`|8.0|12.2| | | | | | | | | | | |
+|`CUSPARSE_COLOR_ALG1`|8.0|12.2| | | | | | | | | | | |
 |`CUSPARSE_COOMM_ALG1`|10.1|11.0|12.0|`HIPSPARSE_COOMM_ALG1`|4.2.0| | | | | | | | |
 |`CUSPARSE_COOMM_ALG2`|10.1|11.0|12.0|`HIPSPARSE_COOMM_ALG2`|4.2.0| | | | | | | | |
 |`CUSPARSE_COOMM_ALG3`|10.1|11.0|12.0|`HIPSPARSE_COOMM_ALG3`|4.2.0| | | | | | | | |
@@ -58,8 +60,8 @@
 |`CUSPARSE_SDDMM_ALG_DEFAULT`|11.2| | |`HIPSPARSE_SDDMM_ALG_DEFAULT`|4.3.0| | | |`rocsparse_sddmm_alg_default`|4.3.0| | | |
 |`CUSPARSE_SIDE_LEFT`| | |11.5| | | | | | | | | | |
 |`CUSPARSE_SIDE_RIGHT`| | |11.5| | | | | | | | | | |
-|`CUSPARSE_SOLVE_POLICY_NO_LEVEL`| | | |`HIPSPARSE_SOLVE_POLICY_NO_LEVEL`|1.9.2| | | |`rocsparse_solve_policy_auto`|1.9.0| | | |
-|`CUSPARSE_SOLVE_POLICY_USE_LEVEL`| | | |`HIPSPARSE_SOLVE_POLICY_USE_LEVEL`|1.9.2| | | |`rocsparse_solve_policy_auto`|1.9.0| | | |
+|`CUSPARSE_SOLVE_POLICY_NO_LEVEL`| |12.2| |`HIPSPARSE_SOLVE_POLICY_NO_LEVEL`|1.9.2| | | |`rocsparse_solve_policy_auto`|1.9.0| | | |
+|`CUSPARSE_SOLVE_POLICY_USE_LEVEL`| |12.2| |`HIPSPARSE_SOLVE_POLICY_USE_LEVEL`|1.9.2| | | |`rocsparse_solve_policy_auto`|1.9.0| | | |
 |`CUSPARSE_SPARSETODENSE_ALG_DEFAULT`|11.1| | |`HIPSPARSE_SPARSETODENSE_ALG_DEFAULT`|4.2.0| | | |`rocsparse_sparse_to_dense_alg_default`|4.1.0| | | |
 |`CUSPARSE_SPGEMM_ALG1`|12.0| | |`HIPSPARSE_SPGEMM_ALG1`|5.6.0| | | | | | | | |
 |`CUSPARSE_SPGEMM_ALG2`|12.0| | |`HIPSPARSE_SPGEMM_ALG2`|5.6.0| | | | | | | | |
@@ -106,28 +108,31 @@
 |`CUSPARSE_STATUS_NOT_SUPPORTED`|10.2| | |`HIPSPARSE_STATUS_NOT_SUPPORTED`|4.1.0| | | |`rocsparse_status_not_implemented`|1.9.0| | | |
 |`CUSPARSE_STATUS_SUCCESS`| | | |`HIPSPARSE_STATUS_SUCCESS`|1.9.2| | | |`rocsparse_status_success`|1.9.0| | | |
 |`CUSPARSE_STATUS_ZERO_PIVOT`| | | |`HIPSPARSE_STATUS_ZERO_PIVOT`|1.9.2| | | |`rocsparse_status_zero_pivot`|1.9.0| | | |
-|`bsric02Info`| | | | | | | | | | | | | |
+|`bsric02Info`| | | |`bsric02Info`|3.8.0| | | | | | | | |
 |`bsric02Info_t`| | | |`bsric02Info_t`|3.8.0| | | | | | | | |
-|`bsrilu02Info`| | | | | | | | | | | | | |
-|`bsrilu02Info_t`| | | |`bsrilu02Info_t`|3.9.0| | | | | | | | |
-|`bsrsm2Info`| | | |`bsrsm2Info`|4.5.0| | | | | | | | |
-|`bsrsm2Info_t`| | | |`bsrsm2Info_t`|4.5.0| | | | | | | | |
-|`bsrsv2Info`| | | | | | | | | | | | | |
-|`bsrsv2Info_t`| | | |`bsrsv2Info_t`|3.6.0| | | | | | | | |
+|`bsrilu02Info`| |12.2| |`bsrilu02Info`|3.9.0| | | | | | | | |
+|`bsrilu02Info_t`| |12.2| |`bsrilu02Info_t`|3.9.0| | | | | | | | |
+|`bsrsm2Info`| |12.2| |`bsrsm2Info`|4.5.0| | | | | | | | |
+|`bsrsm2Info_t`| |12.2| |`bsrsm2Info_t`|4.5.0| | | | | | | | |
+|`bsrsv2Info`| |12.2| |`bsrsv2Info`|3.6.0| | | | | | | | |
+|`bsrsv2Info_t`| |12.2| |`bsrsv2Info_t`|3.6.0| | | | | | | | |
 |`csrgemm2Info`| | |12.0| | | | | | | | | | |
 |`csrgemm2Info_t`| | |12.0|`csrgemm2Info_t`|2.8.0| | | | | | | | |
-|`csrilu02Info`| | | | | | | | | | | | | |
-|`csrilu02Info_t`| | | |`csrilu02Info_t`|1.9.2| | | | | | | | |
+|`csric02Info`| |12.2| |`csric02Info`|3.1.0| | | | | | | | |
+|`csric02Info_t`| |12.2| |`csric02Info_t`|3.1.0| | | | | | | | |
+|`csrilu02Info`| |12.2| |`csrilu02Info`|1.9.2| | | | | | | | |
+|`csrilu02Info_t`| |12.2| |`csrilu02Info_t`|1.9.2| | | | | | | | |
 |`csrsm2Info`|9.2| |12.0| | | | | | | | | | |
 |`csrsm2Info_t`|9.2| |12.0|`csrsm2Info_t`|3.1.0| | | | | | | | |
 |`csrsv2Info`| | |12.0| | | | | | | | | | |
 |`csrsv2Info_t`| | |12.0|`csrsv2Info_t`|1.9.2| | | | | | | | |
-|`csru2csrInfo`| | | |`csru2csrInfo`|4.2.0| | | | | | | | |
-|`csru2csrInfo_t`| | | |`csru2csrInfo_t`|4.2.0| | | | | | | | |
+|`csru2csrInfo`| |12.2| |`csru2csrInfo`|4.2.0| | | | | | | | |
+|`csru2csrInfo_t`| |12.2| |`csru2csrInfo_t`|4.2.0| | | | | | | | |
 |`cusparseAction_t`| | | |`hipsparseAction_t`|1.9.2| | | |`rocsparse_action`|1.9.0| | | |
 |`cusparseAlgMode_t`|8.0| |12.0| | | | | | | | | | |
-|`cusparseColorInfo`| | | | | | | | |`_rocsparse_color_info`|4.5.0| | | |
-|`cusparseColorInfo_t`| | | |`hipsparseColorInfo_t`|4.5.0| | | |`rocsparse_color_info`|4.5.0| | | |
+|`cusparseColorAlg_t`|8.0|12.2| | | | | | | | | | | |
+|`cusparseColorInfo`| |12.2| | | | | | |`_rocsparse_color_info`|4.5.0| | | |
+|`cusparseColorInfo_t`| |12.2| |`hipsparseColorInfo_t`|4.5.0| | | |`rocsparse_color_info`|4.5.0| | | |
 |`cusparseConstDnMatDescr_t`|12.0| | | | | | | | | | | | |
 |`cusparseConstDnVecDescr_t`|12.0| | | | | | | | | | | | |
 |`cusparseConstSpMatDescr_t`|12.0| | | | | | | | | | | | |
@@ -160,7 +165,7 @@
 |`cusparseSideMode_t`| | |11.5| | | | | | | | | | |
 |`cusparseSolveAnalysisInfo`| |10.2|11.0| | | | | | | | | | |
 |`cusparseSolveAnalysisInfo_t`| |10.2|11.0| | | | | | | | | | |
-|`cusparseSolvePolicy_t`| | | |`hipsparseSolvePolicy_t`|1.9.2| | | |`rocsparse_solve_policy`|1.9.0| | | |
+|`cusparseSolvePolicy_t`| |12.2| |`hipsparseSolvePolicy_t`|1.9.2| | | |`rocsparse_solve_policy`|1.9.0| | | |
 |`cusparseSpGEMMAlg_t`|11.0| | |`hipsparseSpGEMMAlg_t`|4.1.0| | | |`rocsparse_spgemm_alg`|4.1.0| | | |
 |`cusparseSpGEMMDescr`|11.0| | |`hipsparseSpGEMMDescr`|4.1.0| | | | | | | | |
 |`cusparseSpGEMMDescr_t`|11.0| | |`hipsparseSpGEMMDescr_t`|4.1.0| | | | | | | | |
@@ -183,8 +188,8 @@
 |`cusparseSpVecDescr_t`|10.2| | |`hipsparseSpVecDescr_t`|4.1.0| | | |`rocsparse_spvec_descr`|4.1.0| | | |
 |`cusparseSparseToDenseAlg_t`|11.1| | |`hipsparseSparseToDenseAlg_t`|4.2.0| | | |`rocsparse_sparse_to_dense_alg`|4.1.0| | | |
 |`cusparseStatus_t`| | | |`hipsparseStatus_t`|1.9.2| | | |`rocsparse_status`|1.9.0| | | |
-|`pruneInfo`|9.0| | |`pruneInfo`|3.9.0| | | |`_rocsparse_mat_info`|1.9.0| | | |
-|`pruneInfo_t`|9.0| | |`pruneInfo_t`|3.9.0| | | |`rocsparse_mat_info`|1.9.0| | | |
+|`pruneInfo`|9.0|12.2| |`pruneInfo`|3.9.0| | | |`_rocsparse_mat_info`|1.9.0| | | |
+|`pruneInfo_t`|9.0|12.2| |`pruneInfo_t`|3.9.0| | | |`rocsparse_mat_info`|1.9.0| | | |
 
 ## **5. CUSPARSE Management Function Reference**
 

--- a/docs/tables/CUSPARSE_API_supported_by_ROC.md
+++ b/docs/tables/CUSPARSE_API_supported_by_ROC.md
@@ -10,6 +10,8 @@
 |`CUSPARSE_ALG1`|8.0| |11.0| | | | | |
 |`CUSPARSE_ALG_MERGE_PATH`|9.2| |12.0| | | | | |
 |`CUSPARSE_ALG_NAIVE`|9.2| |11.0| | | | | |
+|`CUSPARSE_COLOR_ALG0`|8.0|12.2| | | | | | |
+|`CUSPARSE_COLOR_ALG1`|8.0|12.2| | | | | | |
 |`CUSPARSE_COOMM_ALG1`|10.1|11.0|12.0| | | | | |
 |`CUSPARSE_COOMM_ALG2`|10.1|11.0|12.0| | | | | |
 |`CUSPARSE_COOMM_ALG3`|10.1|11.0|12.0| | | | | |
@@ -58,8 +60,8 @@
 |`CUSPARSE_SDDMM_ALG_DEFAULT`|11.2| | |`rocsparse_sddmm_alg_default`|4.3.0| | | |
 |`CUSPARSE_SIDE_LEFT`| | |11.5| | | | | |
 |`CUSPARSE_SIDE_RIGHT`| | |11.5| | | | | |
-|`CUSPARSE_SOLVE_POLICY_NO_LEVEL`| | | |`rocsparse_solve_policy_auto`|1.9.0| | | |
-|`CUSPARSE_SOLVE_POLICY_USE_LEVEL`| | | |`rocsparse_solve_policy_auto`|1.9.0| | | |
+|`CUSPARSE_SOLVE_POLICY_NO_LEVEL`| |12.2| |`rocsparse_solve_policy_auto`|1.9.0| | | |
+|`CUSPARSE_SOLVE_POLICY_USE_LEVEL`| |12.2| |`rocsparse_solve_policy_auto`|1.9.0| | | |
 |`CUSPARSE_SPARSETODENSE_ALG_DEFAULT`|11.1| | |`rocsparse_sparse_to_dense_alg_default`|4.1.0| | | |
 |`CUSPARSE_SPGEMM_ALG1`|12.0| | | | | | | |
 |`CUSPARSE_SPGEMM_ALG2`|12.0| | | | | | | |
@@ -108,26 +110,29 @@
 |`CUSPARSE_STATUS_ZERO_PIVOT`| | | |`rocsparse_status_zero_pivot`|1.9.0| | | |
 |`bsric02Info`| | | | | | | | |
 |`bsric02Info_t`| | | | | | | | |
-|`bsrilu02Info`| | | | | | | | |
-|`bsrilu02Info_t`| | | | | | | | |
-|`bsrsm2Info`| | | | | | | | |
-|`bsrsm2Info_t`| | | | | | | | |
-|`bsrsv2Info`| | | | | | | | |
-|`bsrsv2Info_t`| | | | | | | | |
+|`bsrilu02Info`| |12.2| | | | | | |
+|`bsrilu02Info_t`| |12.2| | | | | | |
+|`bsrsm2Info`| |12.2| | | | | | |
+|`bsrsm2Info_t`| |12.2| | | | | | |
+|`bsrsv2Info`| |12.2| | | | | | |
+|`bsrsv2Info_t`| |12.2| | | | | | |
 |`csrgemm2Info`| | |12.0| | | | | |
 |`csrgemm2Info_t`| | |12.0| | | | | |
-|`csrilu02Info`| | | | | | | | |
-|`csrilu02Info_t`| | | | | | | | |
+|`csric02Info`| |12.2| | | | | | |
+|`csric02Info_t`| |12.2| | | | | | |
+|`csrilu02Info`| |12.2| | | | | | |
+|`csrilu02Info_t`| |12.2| | | | | | |
 |`csrsm2Info`|9.2| |12.0| | | | | |
 |`csrsm2Info_t`|9.2| |12.0| | | | | |
 |`csrsv2Info`| | |12.0| | | | | |
 |`csrsv2Info_t`| | |12.0| | | | | |
-|`csru2csrInfo`| | | | | | | | |
-|`csru2csrInfo_t`| | | | | | | | |
+|`csru2csrInfo`| |12.2| | | | | | |
+|`csru2csrInfo_t`| |12.2| | | | | | |
 |`cusparseAction_t`| | | |`rocsparse_action`|1.9.0| | | |
 |`cusparseAlgMode_t`|8.0| |12.0| | | | | |
-|`cusparseColorInfo`| | | |`_rocsparse_color_info`|4.5.0| | | |
-|`cusparseColorInfo_t`| | | |`rocsparse_color_info`|4.5.0| | | |
+|`cusparseColorAlg_t`|8.0|12.2| | | | | | |
+|`cusparseColorInfo`| |12.2| |`_rocsparse_color_info`|4.5.0| | | |
+|`cusparseColorInfo_t`| |12.2| |`rocsparse_color_info`|4.5.0| | | |
 |`cusparseConstDnMatDescr_t`|12.0| | | | | | | |
 |`cusparseConstDnVecDescr_t`|12.0| | | | | | | |
 |`cusparseConstSpMatDescr_t`|12.0| | | | | | | |
@@ -160,7 +165,7 @@
 |`cusparseSideMode_t`| | |11.5| | | | | |
 |`cusparseSolveAnalysisInfo`| |10.2|11.0| | | | | |
 |`cusparseSolveAnalysisInfo_t`| |10.2|11.0| | | | | |
-|`cusparseSolvePolicy_t`| | | |`rocsparse_solve_policy`|1.9.0| | | |
+|`cusparseSolvePolicy_t`| |12.2| |`rocsparse_solve_policy`|1.9.0| | | |
 |`cusparseSpGEMMAlg_t`|11.0| | |`rocsparse_spgemm_alg`|4.1.0| | | |
 |`cusparseSpGEMMDescr`|11.0| | | | | | | |
 |`cusparseSpGEMMDescr_t`|11.0| | | | | | | |
@@ -183,8 +188,8 @@
 |`cusparseSpVecDescr_t`|10.2| | |`rocsparse_spvec_descr`|4.1.0| | | |
 |`cusparseSparseToDenseAlg_t`|11.1| | |`rocsparse_sparse_to_dense_alg`|4.1.0| | | |
 |`cusparseStatus_t`| | | |`rocsparse_status`|1.9.0| | | |
-|`pruneInfo`|9.0| | |`_rocsparse_mat_info`|1.9.0| | | |
-|`pruneInfo_t`|9.0| | |`rocsparse_mat_info`|1.9.0| | | |
+|`pruneInfo`|9.0|12.2| |`_rocsparse_mat_info`|1.9.0| | | |
+|`pruneInfo_t`|9.0|12.2| |`rocsparse_mat_info`|1.9.0| | | |
 
 ## **5. CUSPARSE Management Function Reference**
 

--- a/src/CUDA2HIP_SPARSE_API_types.cpp
+++ b/src/CUDA2HIP_SPARSE_API_types.cpp
@@ -44,32 +44,35 @@ const std::map<llvm::StringRef, hipCounter> CUDA_SPARSE_TYPE_NAME_MAP {
   {"csrsm2Info",                                {"csrsm2Info",                                 "",                                                   CONV_TYPE, API_SPARSE, 4, UNSUPPORTED | CUDA_REMOVED}},
   {"csrsm2Info_t",                              {"csrsm2Info_t",                               "",                                                   CONV_TYPE, API_SPARSE, 4, ROC_UNSUPPORTED | CUDA_REMOVED}},
 
-  {"bsrsv2Info",                                {"bsrsv2Info",                                 "",                                                   CONV_TYPE, API_SPARSE, 4, UNSUPPORTED}},
-  {"bsrsv2Info_t",                              {"bsrsv2Info_t",                               "",                                                   CONV_TYPE, API_SPARSE, 4, ROC_UNSUPPORTED}},
+  {"bsrsv2Info",                                {"bsrsv2Info",                                 "",                                                   CONV_TYPE, API_SPARSE, 4, ROC_UNSUPPORTED | CUDA_DEPRECATED}},
+  {"bsrsv2Info_t",                              {"bsrsv2Info_t",                               "",                                                   CONV_TYPE, API_SPARSE, 4, ROC_UNSUPPORTED | CUDA_DEPRECATED}},
 
-  {"bsrsm2Info",                                {"bsrsm2Info",                                 "",                                                   CONV_TYPE, API_SPARSE, 4, ROC_UNSUPPORTED}},
-  {"bsrsm2Info_t",                              {"bsrsm2Info_t",                               "",                                                   CONV_TYPE, API_SPARSE, 4, ROC_UNSUPPORTED}},
+  {"bsrsm2Info",                                {"bsrsm2Info",                                 "",                                                   CONV_TYPE, API_SPARSE, 4, ROC_UNSUPPORTED | CUDA_DEPRECATED}},
+  {"bsrsm2Info_t",                              {"bsrsm2Info_t",                               "",                                                   CONV_TYPE, API_SPARSE, 4, ROC_UNSUPPORTED | CUDA_DEPRECATED}},
 
-  {"bsric02Info",                               {"bsric02Info",                                "",                                                   CONV_TYPE, API_SPARSE, 4, UNSUPPORTED}},
-  {"bsric02Info_t",                             {"bsric02Info_t",                              "",                                                   CONV_TYPE, API_SPARSE, 4, ROC_UNSUPPORTED}},
+  {"bsric02Info",                               {"bsric02Info",                                "",                                                   CONV_TYPE, API_SPARSE, 4, ROC_UNSUPPORTED | CUDA_DEPRECATED}},
+  {"bsric02Info_t",                             {"bsric02Info_t",                              "",                                                   CONV_TYPE, API_SPARSE, 4, ROC_UNSUPPORTED | CUDA_DEPRECATED}},
 
-  {"csrilu02Info",                              {"csrilu02Info",                               "",                                                   CONV_TYPE, API_SPARSE, 4, UNSUPPORTED}},
-  {"csrilu02Info_t",                            {"csrilu02Info_t",                             "",                                                   CONV_TYPE, API_SPARSE, 4, ROC_UNSUPPORTED}},
+  {"csrilu02Info",                              {"csrilu02Info",                               "",                                                   CONV_TYPE, API_SPARSE, 4, ROC_UNSUPPORTED | CUDA_DEPRECATED}},
+  {"csrilu02Info_t",                            {"csrilu02Info_t",                             "",                                                   CONV_TYPE, API_SPARSE, 4, ROC_UNSUPPORTED | CUDA_DEPRECATED}},
 
-  {"bsrilu02Info",                              {"bsrilu02Info",                               "",                                                   CONV_TYPE, API_SPARSE, 4, UNSUPPORTED}},
-  {"bsrilu02Info_t",                            {"bsrilu02Info_t",                             "",                                                   CONV_TYPE, API_SPARSE, 4, ROC_UNSUPPORTED}},
+  {"bsrilu02Info",                              {"bsrilu02Info",                               "",                                                   CONV_TYPE, API_SPARSE, 4, ROC_UNSUPPORTED | CUDA_DEPRECATED}},
+  {"bsrilu02Info_t",                            {"bsrilu02Info_t",                             "",                                                   CONV_TYPE, API_SPARSE, 4, ROC_UNSUPPORTED | CUDA_DEPRECATED}},
 
-  {"csru2csrInfo",                              {"csru2csrInfo",                               "",                                                   CONV_TYPE, API_SPARSE, 4, ROC_UNSUPPORTED}},
-  {"csru2csrInfo_t",                            {"csru2csrInfo_t",                             "",                                                   CONV_TYPE, API_SPARSE, 4, ROC_UNSUPPORTED}},
+  {"csru2csrInfo",                              {"csru2csrInfo",                               "",                                                   CONV_TYPE, API_SPARSE, 4, ROC_UNSUPPORTED | CUDA_DEPRECATED}},
+  {"csru2csrInfo_t",                            {"csru2csrInfo_t",                             "",                                                   CONV_TYPE, API_SPARSE, 4, ROC_UNSUPPORTED | CUDA_DEPRECATED}},
+
+  {"csric02Info",                               {"csric02Info",                                "",                                                   CONV_TYPE, API_SPARSE, 4, ROC_UNSUPPORTED | CUDA_DEPRECATED}},
+  {"csric02Info_t",                             {"csric02Info_t",                              "",                                                   CONV_TYPE, API_SPARSE, 4, ROC_UNSUPPORTED | CUDA_DEPRECATED}},
 
   {"csrgemm2Info",                              {"csrgemm2Info",                               "",                                                   CONV_TYPE, API_SPARSE, 4, UNSUPPORTED | CUDA_REMOVED}},
   {"csrgemm2Info_t",                            {"csrgemm2Info_t",                             "",                                                   CONV_TYPE, API_SPARSE, 4, ROC_UNSUPPORTED | CUDA_REMOVED}},
 
-  {"cusparseColorInfo",                         {"hipsparseColorInfo",                         "_rocsparse_color_info",                              CONV_TYPE, API_SPARSE, 4, HIP_UNSUPPORTED}},
-  {"cusparseColorInfo_t",                       {"hipsparseColorInfo_t",                       "rocsparse_color_info",                               CONV_TYPE, API_SPARSE, 4}},
+  {"cusparseColorInfo",                         {"hipsparseColorInfo",                         "_rocsparse_color_info",                              CONV_TYPE, API_SPARSE, 4, HIP_UNSUPPORTED | CUDA_DEPRECATED}},
+  {"cusparseColorInfo_t",                       {"hipsparseColorInfo_t",                       "rocsparse_color_info",                               CONV_TYPE, API_SPARSE, 4, CUDA_DEPRECATED}},
 
-  {"pruneInfo",                                 {"pruneInfo",                                  "_rocsparse_mat_info",                                CONV_TYPE, API_SPARSE, 4}},
-  {"pruneInfo_t",                               {"pruneInfo_t",                                "rocsparse_mat_info",                                 CONV_TYPE, API_SPARSE, 4}},
+  {"pruneInfo",                                 {"pruneInfo",                                  "_rocsparse_mat_info",                                CONV_TYPE, API_SPARSE, 4, CUDA_DEPRECATED}},
+  {"pruneInfo_t",                               {"pruneInfo_t",                                "rocsparse_mat_info",                                 CONV_TYPE, API_SPARSE, 4, CUDA_DEPRECATED}},
 
   {"cusparseSpMatDescr",                        {"hipsparseSpMatDescr",                        "_rocsparse_spmat_descr",                             CONV_TYPE, API_SPARSE, 4, HIP_UNSUPPORTED}},
   {"cusparseSpMatDescr_t",                      {"hipsparseSpMatDescr_t",                      "rocsparse_spmat_descr",                              CONV_TYPE, API_SPARSE, 4}},
@@ -143,9 +146,9 @@ const std::map<llvm::StringRef, hipCounter> CUDA_SPARSE_TYPE_NAME_MAP {
   {"CUSPARSE_ALG_MERGE_PATH",                   {"CUSPARSE_ALG_MERGE_PATH",                    "",                                                   CONV_NUMERIC_LITERAL, API_SPARSE, 4, UNSUPPORTED | CUDA_REMOVED}},
 
   // TODO [HIPIFY] Warn about hipification to rocsparse_solve_policy_auto (automatically decide on level information)
-  {"cusparseSolvePolicy_t",                     {"hipsparseSolvePolicy_t",                     "rocsparse_solve_policy",                             CONV_TYPE, API_SPARSE, 4}},
-  {"CUSPARSE_SOLVE_POLICY_NO_LEVEL",            {"HIPSPARSE_SOLVE_POLICY_NO_LEVEL",            "rocsparse_solve_policy_auto",                        CONV_NUMERIC_LITERAL, API_SPARSE, 4}},
-  {"CUSPARSE_SOLVE_POLICY_USE_LEVEL",           {"HIPSPARSE_SOLVE_POLICY_USE_LEVEL",           "rocsparse_solve_policy_auto",                        CONV_NUMERIC_LITERAL, API_SPARSE, 4}},
+  {"cusparseSolvePolicy_t",                     {"hipsparseSolvePolicy_t",                     "rocsparse_solve_policy",                             CONV_TYPE, API_SPARSE, 4, CUDA_DEPRECATED}},
+  {"CUSPARSE_SOLVE_POLICY_NO_LEVEL",            {"HIPSPARSE_SOLVE_POLICY_NO_LEVEL",            "rocsparse_solve_policy_auto",                        CONV_NUMERIC_LITERAL, API_SPARSE, 4, CUDA_DEPRECATED}},
+  {"CUSPARSE_SOLVE_POLICY_USE_LEVEL",           {"HIPSPARSE_SOLVE_POLICY_USE_LEVEL",           "rocsparse_solve_policy_auto",                        CONV_NUMERIC_LITERAL, API_SPARSE, 4, CUDA_DEPRECATED}},
 
   {"cusparseStatus_t",                          {"hipsparseStatus_t",                          "rocsparse_status",                                   CONV_TYPE, API_SPARSE, 4}},
   {"CUSPARSE_STATUS_SUCCESS",                   {"HIPSPARSE_STATUS_SUCCESS",                   "rocsparse_status_success",                           CONV_NUMERIC_LITERAL, API_SPARSE, 4}},
@@ -255,6 +258,10 @@ const std::map<llvm::StringRef, hipCounter> CUDA_SPARSE_TYPE_NAME_MAP {
   {"CUSPARSE_SPSV_UPDATE_GENERAL",              {"HIPSPARSE_SPSV_UPDATE_GENERAL",              "",                                                   CONV_NUMERIC_LITERAL, API_SPARSE, 4, UNSUPPORTED}},
   {"CUSPARSE_SPSV_UPDATE_DIAGONAL",             {"HIPSPARSE_SPSV_UPDATE_DIAGONAL",             "",                                                   CONV_NUMERIC_LITERAL, API_SPARSE, 4, UNSUPPORTED}},
 
+  {"cusparseColorAlg_t",                        {"hipsparseColorAlg_t",                        "",                                                   CONV_TYPE, API_SPARSE, 4, UNSUPPORTED | CUDA_DEPRECATED}},
+  {"CUSPARSE_COLOR_ALG0",                       {"HIPSPARSE_COLOR_ALG0",                       "",                                                   CONV_NUMERIC_LITERAL, API_SPARSE, 4, UNSUPPORTED | CUDA_DEPRECATED}},
+  {"CUSPARSE_COLOR_ALG1",                       {"HIPSPARSE_COLOR_ALG1",                       "",                                                   CONV_NUMERIC_LITERAL, API_SPARSE, 4, UNSUPPORTED | CUDA_DEPRECATED}},
+
   // 3. Defines
 
   // 4. Typedefs
@@ -272,8 +279,8 @@ const std::map<llvm::StringRef, cudaAPIversions> CUDA_SPARSE_TYPE_NAME_VER_MAP {
   {"cusparseSolveAnalysisInfo_t",               {CUDA_0,   CUDA_102, CUDA_110}},
   {"csrsm2Info",                                {CUDA_92,  CUDA_0,   CUDA_120}},
   {"csrsm2Info_t",                              {CUDA_92,  CUDA_0,   CUDA_120}},
-  {"pruneInfo",                                 {CUDA_90,  CUDA_0,   CUDA_0  }},
-  {"pruneInfo_t",                               {CUDA_90,  CUDA_0,   CUDA_0  }},
+  {"pruneInfo",                                 {CUDA_90,  CUDA_122, CUDA_0  }},
+  {"pruneInfo_t",                               {CUDA_90,  CUDA_122, CUDA_0  }},
   {"cusparseSpMatDescr",                        {CUDA_101, CUDA_0,   CUDA_0  }},
   {"cusparseSpMatDescr_t",                      {CUDA_101, CUDA_0,   CUDA_0  }},
   {"cusparseDnMatDescr",                        {CUDA_101, CUDA_0,   CUDA_0  }},
@@ -388,6 +395,28 @@ const std::map<llvm::StringRef, cudaAPIversions> CUDA_SPARSE_TYPE_NAME_VER_MAP {
   {"cusparseSpSVUpdate_t",                      {CUDA_121, CUDA_0,   CUDA_0  }}, // CUSPARSE_VERSION 12100
   {"CUSPARSE_SPSV_UPDATE_GENERAL",              {CUDA_121, CUDA_0,   CUDA_0  }}, // CUSPARSE_VERSION 12100
   {"CUSPARSE_SPSV_UPDATE_DIAGONAL",             {CUDA_121, CUDA_0,   CUDA_0  }}, // CUSPARSE_VERSION 12100
+  {"bsrsv2Info",                                {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12200
+  {"bsrsv2Info_t",                              {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12200
+  {"bsrsm2Info",                                {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12200
+  {"bsrsm2Info_t",                              {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12200
+  {"csric02Info",                               {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12200
+  {"csric02Info_t",                             {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12200
+  {"csrilu02Info",                              {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12200
+  {"csrilu02Info_t",                            {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12200
+  {"bsrilu02Info",                              {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12200
+  {"bsrilu02Info_t",                            {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12200
+  {"csru2csrInfo",                              {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12200
+  {"csru2csrInfo_t",                            {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12200
+  {"cusparseColorInfo",                         {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12200
+  {"cusparseColorInfo_t",                       {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12200
+  {"pruneInfo",                                 {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12200
+  {"pruneInfo_t",                               {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12200
+  {"cusparseSolvePolicy_t",                     {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12200
+  {"CUSPARSE_SOLVE_POLICY_NO_LEVEL",            {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12200
+  {"CUSPARSE_SOLVE_POLICY_USE_LEVEL",           {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12200
+  {"cusparseColorAlg_t",                        {CUDA_80,  CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12200
+  {"CUSPARSE_COLOR_ALG0",                       {CUDA_80,  CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12200
+  {"CUSPARSE_COLOR_ALG1",                       {CUDA_80,  CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12200
 };
 
 const std::map<llvm::StringRef, hipAPIversions> HIP_SPARSE_TYPE_NAME_VER_MAP {
@@ -396,9 +425,13 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_SPARSE_TYPE_NAME_VER_MAP {
   {"hipsparseMatDescr_t",                        {HIP_1092, HIP_0,    HIP_0   }},
   {"csrsv2Info_t",                               {HIP_1092, HIP_0,    HIP_0   }},
   {"csrsm2Info_t",                               {HIP_3010, HIP_0,    HIP_0   }},
+  {"bsrsv2Info",                                 {HIP_3060, HIP_0,    HIP_0   }},
   {"bsrsv2Info_t",                               {HIP_3060, HIP_0,    HIP_0   }},
+  {"bsric02Info",                                {HIP_3080, HIP_0,    HIP_0   }},
   {"bsric02Info_t",                              {HIP_3080, HIP_0,    HIP_0   }},
+  {"csrilu02Info",                               {HIP_1092, HIP_0,    HIP_0   }},
   {"csrilu02Info_t",                             {HIP_1092, HIP_0,    HIP_0   }},
+  {"bsrilu02Info",                               {HIP_3090, HIP_0,    HIP_0   }},
   {"bsrilu02Info_t",                             {HIP_3090, HIP_0,    HIP_0   }},
   {"csrgemm2Info_t",                             {HIP_2080, HIP_0,    HIP_0   }},
   {"pruneInfo",                                  {HIP_3090, HIP_0,    HIP_0   }},
@@ -528,6 +561,8 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_SPARSE_TYPE_NAME_VER_MAP {
   {"HIPSPARSE_SPGEMM_ALG1",                      {HIP_5060, HIP_0,    HIP_0   }},
   {"HIPSPARSE_SPGEMM_ALG2",                      {HIP_5060, HIP_0,    HIP_0   }},
   {"HIPSPARSE_SPGEMM_ALG3",                      {HIP_5060, HIP_0,    HIP_0   }},
+  {"csric02Info_t",                              {HIP_3010, HIP_0,    HIP_0   }},
+  {"csric02Info",                                {HIP_3010, HIP_0,    HIP_0   }},
   {"_rocsparse_handle",                          {HIP_1090, HIP_0,    HIP_0   }},
   {"rocsparse_handle",                           {HIP_1090, HIP_0,    HIP_0   }},
   {"_rocsparse_hyb_mat",                         {HIP_1090, HIP_0,    HIP_0   }},


### PR DESCRIPTION
+ Marked deprecated data types
+ Updated the regenerated hipify-perl and docs accordingly
+ [fix] Added missing data types `csric02Info_t` and `cusparseColorAlg_t`
