### PR TITLE
[HIPIFY][#1024][doc] Do not need to build any LLVM targets for LLVM >= 10.0.0 anymore

### DIFF
--- a/docs/hipify-clang.md
+++ b/docs/hipify-clang.md
@@ -303,7 +303,7 @@ Run `Visual Studio 16 2019`, open the generated `LLVM.sln`, build all, and build
    ```bash
         cmake \
          -DCMAKE_INSTALL_PREFIX=../dist \
-         -DLLVM_TARGETS_TO_BUILD="X86;NVPTX" \
+         -DLLVM_TARGETS_TO_BUILD="" \
          -DLLVM_ENABLE_PROJECTS="clang" \
          -DLLVM_INCLUDE_TESTS=OFF \
          -DCMAKE_BUILD_TYPE=Release \
@@ -317,7 +317,7 @@ Run `Visual Studio 16 2019`, open the generated `LLVM.sln`, build all, and build
          -A x64 \
          -Thost=x64 \
          -DCMAKE_INSTALL_PREFIX=../dist \
-         -DLLVM_TARGETS_TO_BUILD="NVPTX" \
+         -DLLVM_TARGETS_TO_BUILD="" \
          -DLLVM_ENABLE_PROJECTS="clang" \
          -DLLVM_INCLUDE_TESTS=OFF \
          -DCMAKE_BUILD_TYPE=Release \


### PR DESCRIPTION
**[Reasons]**
+ With excluding tests from LLVM building (#1024), it turned out that building of any of the LLVM targets (`X86` or `NVPTX`) are not needed for hipify-clang as well:
  - Actually, there were some minor dependencies (probably erroneous) between some tests and targets in some LLVM versions, which were entirely gone with tests' exclusion
+ It was needed to check `-DLLVM_TARGETS_TO_BUILD=""`, because hipify-clang is also can be built under `HIPIFY_INCLUDE_IN_HIP_SDK` against ROCm's LLVM, which build is not targeting `NVPTX`
+ Reduction of LLVM compilation time up to two times

**[Testing]**
+ Building and testing of hipify-clang were checked against all LLVM versions >= 10.0.0 built with `-DLLVM_TARGETS_TO_BUILD=""`

**[ToDo]**
+ [Not IMP] Check `-DLLVM_TARGETS_TO_BUILD=""` for LLVM < 10.0.0