### PR TITLE
[HIPIFY][#1029][tests] Updated the `tex2dKernel` test

### DIFF
--- a/tests/unit_tests/samples/2_Cookbook/11_texture_driver/tex2dKernel.cpp
+++ b/tests/unit_tests/samples/2_Cookbook/11_texture_driver/tex2dKernel.cpp
@@ -34,3 +34,10 @@ extern "C" __global__ void tex2dKernel(float* outputData, int width, int height)
   int y = blockDim.y * blockIdx.y + threadIdx.y;
   outputData[y * width + x] = tex2D(tex, x, y);
 }
+
+int main(int argc, char** argv) {
+  float out = 0.f;
+  // CHECK: tex2dKernel<<<512, 512>>>(&out, 128, 128);
+  tex2dKernel<<<512, 512>>>(&out, 128, 128);
+  return 0;
+}


### PR DESCRIPTION
+ Added an entry point to the test source
+ [Reason] hipify-clang outer users are trying to compile hipify-clang unit tests
+ [ToDo][long-term]
  - Segregate compilable tests
  - Start to compile the segregated tests (after hipification) on a regular basis
  - Mark explicitly the rest of the non-compilable tests as synthetic (dedicated for hipification testing only)
+ [ToDo][very-long-term]
  - Run the successfully hipified and compiled tests on:
     + AMD GPU
     + NVIDIA GPU