### PR TITLE
[HIPIFY][SWDEV-407588][clang][fix] Applied an ugly hack for the LLVM < 13.0

### DIFF
--- a/src/HipifyAction.cpp
+++ b/src/HipifyAction.cpp
@@ -146,6 +146,7 @@ std::string getCastType(hipify::CastTypes c) {
 }
 
 std::map<std::string, std::string> TypeOverloads {
+  {"enum cudaDataType_t", "hipDataType"},
   {"cudaDataType_t", "hipDataType"},
   {"cudaDataType", "hipDataType"},
 };
@@ -1344,6 +1345,8 @@ bool HipifyAction::dataTypeSelection(const mat::MatchFinder::MatchResult& Result
     std::string name = QT.getAsString();
     const auto found = TypeOverloads.find(name);
     if (found == TypeOverloads.end()) return false;
+    if (name.find("enum ") == 0)
+      name.erase(0, 5);
     std::string correct_name = found->second;
     const clang::TypeSourceInfo *si = vardecl->getTypeSourceInfo();
     const clang::TypeLoc tloc = si->getTypeLoc();


### PR DESCRIPTION
**[Synopsis]**
+ MatchFinder in clang < 13.0 incorrectly peels a `CanonicalType` from the `enumType` declared as `typedef`
+ That leads to incorrect hipification of variable declaration for at least `typedef enum cudaDataType_t`
+ clang's MatchFinder for the declaration `cudaDataType_t dataType_t;` gets the canonical type as `enum cudaDataType_t` without peeling the `enum`

**[Solution]**
+ Apply an ugly hack directly in hipify-clang's `dataTypeSelection` matcher just for older versions of clang
+ [Reason] Very rare situation, as the issue is not observed when hipify-clang is built against LLVM >= 13.0