### PR TITLE
[HIPIFY][#1046][clang][compatibility][fix] clang 18.0.0git compatibility support

### DIFF
--- a/src/HipifyAction.cpp
+++ b/src/HipifyAction.cpp
@@ -1736,12 +1736,9 @@ void HipifyAction::EndSourceFileAction() {
     // one copy of the hip include into every file.
     bool placeForIncludeCalculated = false;
     clang::SourceLocation sl, controllingMacroLoc;
-    auto &SM = getCompilerInstance().getSourceManager();
-    clang::Preprocessor &PP = getCompilerInstance().getPreprocessor();
-    clang::HeaderSearch &HS = PP.getHeaderSearchInfo();
-    clang::ExternalPreprocessorSource *EPL = HS.getExternalLookup();
-    const clang::FileEntry *FE = SM.getFileEntryForID(SM.getMainFileID());
-    const clang::IdentifierInfo *controllingMacro = HS.getFileInfo(FE).getControllingMacro(EPL);
+    auto &CI = getCompilerInstance();
+    auto &SM = CI.getSourceManager();
+    const clang::IdentifierInfo *controllingMacro = llcompat::getControllingMacro(CI);
     if (controllingMacro) {
       auto found = Ifndefs.find(controllingMacro->getName().str());
       if (found != Ifndefs.end()) {

--- a/src/LLVMCompat.cpp
+++ b/src/LLVMCompat.cpp
@@ -175,4 +175,17 @@ void addTargetIfNeeded(ct::RefactoringTool& Tool) {
 #endif
 }
 
+const clang::IdentifierInfo *getControllingMacro(clang::CompilerInstance &CI) {
+  auto &SM = CI.getSourceManager();
+  clang::Preprocessor &PP = CI.getPreprocessor();
+  clang::HeaderSearch &HS = PP.getHeaderSearchInfo();
+  clang::ExternalPreprocessorSource *EPL = HS.getExternalLookup();
+  const clang::FileEntry *FE = SM.getFileEntryForID(SM.getMainFileID());
+#if LLVM_VERSION_MAJOR >= 18
+  return HS.getFileInfo(FE->getLastRef()).getControllingMacro(EPL);
+#else
+  return HS.getFileInfo(FE).getControllingMacro(EPL);
+#endif
+}
+
 } // namespace llcompat

--- a/src/LLVMCompat.h
+++ b/src/LLVMCompat.h
@@ -101,4 +101,6 @@ Memory_Buffer getMemoryBuffer(const clang::SourceManager &SM);
 
 void addTargetIfNeeded(ct::RefactoringTool& Tool);
 
+const clang::IdentifierInfo *getControllingMacro(clang::CompilerInstance &CI);
+
 } // namespace llcompat


### PR DESCRIPTION
**[Root Cause]**
+ SHA-1: b0abc9dd44271815b3ae1ad5d009a1ca83e0fdca (2023.09.11)
+ [clang] NFCI: Use `FileEntryRef` in `ASTReader::GetHeaderFileInfo()`

**[IMP]**
+ To build hipify-clang correctly with the ToT LLVM 18.0.0git, pull the latest LLVM sources
