### PR TITLE
[HIPIFY][#1050][clang][compatibility][fix] clang 18.0.0git compatibility support

### DIFF
--- a/src/LLVMCompat.cpp
+++ b/src/LLVMCompat.cpp
@@ -180,10 +180,11 @@ const clang::IdentifierInfo *getControllingMacro(clang::CompilerInstance &CI) {
   clang::Preprocessor &PP = CI.getPreprocessor();
   clang::HeaderSearch &HS = PP.getHeaderSearchInfo();
   clang::ExternalPreprocessorSource *EPL = HS.getExternalLookup();
-  const clang::FileEntry *FE = SM.getFileEntryForID(SM.getMainFileID());
 #if LLVM_VERSION_MAJOR >= 18
-  return HS.getFileInfo(FE->getLastRef()).getControllingMacro(EPL);
+  const clang::OptionalFileEntryRef OFE = SM.getFileEntryRefForID(SM.getMainFileID());
+  return HS.getFileInfo(*OFE.getPointer()).getControllingMacro(EPL);
 #else
+  const clang::FileEntry *FE = SM.getFileEntryForID(SM.getMainFileID());
   return HS.getFileInfo(FE).getControllingMacro(EPL);
 #endif
 }


### PR DESCRIPTION
**[Root Cause]**
+ SHA-1: 25a6b891cbcd9aacee404cc0ccceed3248d93dd3 (2023.10.03)
+ [clang] NFC: Remove unused `FileEntry::getLastRef()` (#68156)

**[IMP]**
+ To build hipify-clang correctly with the ToT LLVM 18.0.0git, pull the latest LLVM sources
