### PR TITLE
[HIPIFY][#703][#713][build][cleanup] Remove the workaround with a temporary technical option `-D125860=ON`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -156,12 +156,7 @@ if (NOT HIPIFY_CLANG_TESTS_ONLY)
   endif()
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${EXTRA_CFLAGS} ${addr_var}")
 
-  # [ToDo] Remove D125860 related guards from CMakeLists.txt with the LLVM 16.0.0 official release.
-  option (D125860 "Enables treating clang's resource dir as lib/clang/X.Y.Z, as it was before clang's change D125860, merged as e1b88c8a09be25b86b13f98755a9bd744b4dbf14" OFF)
-  if(D125860)
-    add_definitions(-D125860)
-  endif()
-  if((LLVM_PACKAGE_VERSION VERSION_EQUAL "16.0.0" OR LLVM_PACKAGE_VERSION VERSION_GREATER "16.0.0") AND (NOT D125860))
+  if(LLVM_PACKAGE_VERSION VERSION_EQUAL "16.0.0" OR LLVM_PACKAGE_VERSION VERSION_GREATER "16.0.0")
     set(LIB_CLANG_RES ${LLVM_VERSION_MAJOR})
   else()
     set(LIB_CLANG_RES ${LLVM_VERSION_MAJOR}.${LLVM_VERSION_MINOR}.${LLVM_VERSION_PATCH})


### PR DESCRIPTION
**[Reason]**
+ LLVM 16 and 17 are released, and there is no need for building hipify-clang against intermediate 15.x < LLVM < 16.0
