### PR TITLE
[HIPIFY][#674][rocSPARSE][feature] rocSPARSE support - Step 49 - functions `rocsparse_(s|d|c|z)bsric0_buffer_size`

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -1676,6 +1676,7 @@ sub rocSubstitutions {
     subst("cusparseCbsr2csr", "rocsparse_cbsr2csr", "library");
     subst("cusparseCbsric02", "rocsparse_cbsric0", "library");
     subst("cusparseCbsric02_analysis", "rocsparse_cbsric0_analysis", "library");
+    subst("cusparseCbsric02_bufferSize", "rocsparse_cbsric0_buffer_size", "library");
     subst("cusparseCbsrilu02", "rocsparse_cbsrilu0", "library");
     subst("cusparseCbsrilu02_analysis", "rocsparse_cbsrilu0_analysis", "library");
     subst("cusparseCbsrilu02_numericBoost", "rocsparse_dcbsrilu0_numeric_boost", "library");
@@ -1739,6 +1740,7 @@ sub rocSubstitutions {
     subst("cusparseDbsr2csr", "rocsparse_dbsr2csr", "library");
     subst("cusparseDbsric02", "rocsparse_dbsric0", "library");
     subst("cusparseDbsric02_analysis", "rocsparse_dbsric0_analysis", "library");
+    subst("cusparseDbsric02_bufferSize", "rocsparse_dbsric0_buffer_size", "library");
     subst("cusparseDbsrilu02", "rocsparse_dbsrilu0", "library");
     subst("cusparseDbsrilu02_analysis", "rocsparse_dbsrilu0_analysis", "library");
     subst("cusparseDbsrilu02_numericBoost", "rocsparse_dbsrilu0_numeric_boost", "library");
@@ -1820,6 +1822,7 @@ sub rocSubstitutions {
     subst("cusparseSbsr2csr", "rocsparse_sbsr2csr", "library");
     subst("cusparseSbsric02", "rocsparse_sbsric0", "library");
     subst("cusparseSbsric02_analysis", "rocsparse_sbsric0_analysis", "library");
+    subst("cusparseSbsric02_bufferSize", "rocsparse_sbsric0_buffer_size", "library");
     subst("cusparseSbsrilu02", "rocsparse_sbsrilu0", "library");
     subst("cusparseSbsrilu02_analysis", "rocsparse_sbsrilu0_analysis", "library");
     subst("cusparseSbsrilu02_numericBoost", "rocsparse_dsbsrilu0_numeric_boost", "library");
@@ -1909,6 +1912,7 @@ sub rocSubstitutions {
     subst("cusparseZbsr2csr", "rocsparse_zbsr2csr", "library");
     subst("cusparseZbsric02", "rocsparse_zbsric0", "library");
     subst("cusparseZbsric02_analysis", "rocsparse_zbsric0_analysis", "library");
+    subst("cusparseZbsric02_bufferSize", "rocsparse_zbsric0_buffer_size", "library");
     subst("cusparseZbsrilu02", "rocsparse_zbsrilu0", "library");
     subst("cusparseZbsrilu02_analysis", "rocsparse_zbsrilu0_analysis", "library");
     subst("cusparseZbsrilu02_numericBoost", "rocsparse_zbsrilu0_numeric_boost", "library");

--- a/docs/tables/CUSPARSE_API_supported_by_HIP_and_ROC.md
+++ b/docs/tables/CUSPARSE_API_supported_by_HIP_and_ROC.md
@@ -471,7 +471,7 @@
 |:--|:-:|:-:|:-:|:--|:-:|:-:|:-:|:-:|:--|:-:|:-:|:-:|:-:|
 |`cusparseCbsric02`| |12.2| |`hipsparseCbsric02`|3.8.0| | | |`rocsparse_cbsric0`|3.8.0| | | |
 |`cusparseCbsric02_analysis`| |12.2| |`hipsparseCbsric02_analysis`|3.8.0| | | |`rocsparse_cbsric0_analysis`|3.6.0| | | |
-|`cusparseCbsric02_bufferSize`| |12.2| |`hipsparseCbsric02_bufferSize`|3.8.0| | | | | | | | |
+|`cusparseCbsric02_bufferSize`| |12.2| |`hipsparseCbsric02_bufferSize`|3.8.0| | | |`rocsparse_cbsric0_buffer_size`|3.8.0| | | |
 |`cusparseCbsric02_bufferSizeExt`| |12.2| | | | | | | | | | | |
 |`cusparseCbsrilu02`| |12.2| |`hipsparseCbsrilu02`|3.9.0| | | |`rocsparse_cbsrilu0`|3.9.0| | | |
 |`cusparseCbsrilu02_analysis`| |12.2| |`hipsparseCbsrilu02_analysis`|3.9.0| | | |`rocsparse_cbsrilu0_analysis`|3.6.0| | | |
@@ -505,7 +505,7 @@
 |`cusparseCsrilu0Ex`|8.0|10.2|11.0| | | | | | | | | | |
 |`cusparseDbsric02`| |12.2| |`hipsparseDbsric02`|3.8.0| | | |`rocsparse_dbsric0`|3.8.0| | | |
 |`cusparseDbsric02_analysis`| |12.2| |`hipsparseDbsric02_analysis`|3.8.0| | | |`rocsparse_dbsric0_analysis`|3.6.0| | | |
-|`cusparseDbsric02_bufferSize`| |12.2| |`hipsparseDbsric02_bufferSize`|3.8.0| | | | | | | | |
+|`cusparseDbsric02_bufferSize`| |12.2| |`hipsparseDbsric02_bufferSize`|3.8.0| | | |`rocsparse_dbsric0_buffer_size`|3.8.0| | | |
 |`cusparseDbsric02_bufferSizeExt`| |12.2| | | | | | | | | | | |
 |`cusparseDbsrilu02`| |12.2| |`hipsparseDbsrilu02`|3.9.0| | | |`rocsparse_dbsrilu0`|3.9.0| | | |
 |`cusparseDbsrilu02_analysis`| |12.2| |`hipsparseDbsrilu02_analysis`|3.9.0| | | |`rocsparse_dbsrilu0_analysis`|3.6.0| | | |
@@ -538,7 +538,7 @@
 |`cusparseDgtsv_nopivot`| |10.2|11.0| | | | | | | | | | |
 |`cusparseSbsric02`| |12.2| |`hipsparseSbsric02`|3.8.0| | | |`rocsparse_sbsric0`|3.8.0| | | |
 |`cusparseSbsric02_analysis`| |12.2| |`hipsparseSbsric02_analysis`|3.8.0| | | |`rocsparse_sbsric0_analysis`|3.6.0| | | |
-|`cusparseSbsric02_bufferSize`| |12.2| |`hipsparseSbsric02_bufferSize`|3.8.0| | | | | | | | |
+|`cusparseSbsric02_bufferSize`| |12.2| |`hipsparseSbsric02_bufferSize`|3.8.0| | | |`rocsparse_sbsric0_buffer_size`|3.8.0| | | |
 |`cusparseSbsric02_bufferSizeExt`| |12.2| | | | | | | | | | | |
 |`cusparseSbsrilu02`| |12.2| |`hipsparseSbsrilu02`|3.9.0| | | |`rocsparse_sbsrilu0`|3.9.0| | | |
 |`cusparseSbsrilu02_analysis`| |12.2| |`hipsparseSbsrilu02_analysis`|3.9.0| | | |`rocsparse_sbsrilu0_analysis`|3.6.0| | | |
@@ -575,7 +575,7 @@
 |`cusparseXcsrilu02_zeroPivot`| |12.2| |`hipsparseXcsrilu02_zeroPivot`|1.9.2| | | |`rocsparse_csrilu0_zero_pivot`|1.9.0| | | |
 |`cusparseZbsric02`| |12.2| |`hipsparseZbsric02`|3.8.0| | | |`rocsparse_zbsric0`|3.8.0| | | |
 |`cusparseZbsric02_analysis`| |12.2| |`hipsparseZbsric02_analysis`|3.8.0| | | |`rocsparse_zbsric0_analysis`|3.6.0| | | |
-|`cusparseZbsric02_bufferSize`| |12.2| |`hipsparseZbsric02_bufferSize`|3.8.0| | | | | | | | |
+|`cusparseZbsric02_bufferSize`| |12.2| |`hipsparseZbsric02_bufferSize`|3.8.0| | | |`rocsparse_zbsric0_buffer_size`|3.8.0| | | |
 |`cusparseZbsric02_bufferSizeExt`| |12.2| | | | | | | | | | | |
 |`cusparseZbsrilu02`| |12.2| |`hipsparseZbsrilu02`|3.9.0| | | |`rocsparse_zbsrilu0`|3.9.0| | | |
 |`cusparseZbsrilu02_analysis`| |12.2| |`hipsparseZbsrilu02_analysis`|3.9.0| | | |`rocsparse_zbsrilu0_analysis`|3.6.0| | | |

--- a/docs/tables/CUSPARSE_API_supported_by_ROC.md
+++ b/docs/tables/CUSPARSE_API_supported_by_ROC.md
@@ -471,7 +471,7 @@
 |:--|:-:|:-:|:-:|:--|:-:|:-:|:-:|:-:|
 |`cusparseCbsric02`| |12.2| |`rocsparse_cbsric0`|3.8.0| | | |
 |`cusparseCbsric02_analysis`| |12.2| |`rocsparse_cbsric0_analysis`|3.6.0| | | |
-|`cusparseCbsric02_bufferSize`| |12.2| | | | | | |
+|`cusparseCbsric02_bufferSize`| |12.2| |`rocsparse_cbsric0_buffer_size`|3.8.0| | | |
 |`cusparseCbsric02_bufferSizeExt`| |12.2| | | | | | |
 |`cusparseCbsrilu02`| |12.2| |`rocsparse_cbsrilu0`|3.9.0| | | |
 |`cusparseCbsrilu02_analysis`| |12.2| |`rocsparse_cbsrilu0_analysis`|3.6.0| | | |
@@ -505,7 +505,7 @@
 |`cusparseCsrilu0Ex`|8.0|10.2|11.0| | | | | |
 |`cusparseDbsric02`| |12.2| |`rocsparse_dbsric0`|3.8.0| | | |
 |`cusparseDbsric02_analysis`| |12.2| |`rocsparse_dbsric0_analysis`|3.6.0| | | |
-|`cusparseDbsric02_bufferSize`| |12.2| | | | | | |
+|`cusparseDbsric02_bufferSize`| |12.2| |`rocsparse_dbsric0_buffer_size`|3.8.0| | | |
 |`cusparseDbsric02_bufferSizeExt`| |12.2| | | | | | |
 |`cusparseDbsrilu02`| |12.2| |`rocsparse_dbsrilu0`|3.9.0| | | |
 |`cusparseDbsrilu02_analysis`| |12.2| |`rocsparse_dbsrilu0_analysis`|3.6.0| | | |
@@ -538,7 +538,7 @@
 |`cusparseDgtsv_nopivot`| |10.2|11.0| | | | | |
 |`cusparseSbsric02`| |12.2| |`rocsparse_sbsric0`|3.8.0| | | |
 |`cusparseSbsric02_analysis`| |12.2| |`rocsparse_sbsric0_analysis`|3.6.0| | | |
-|`cusparseSbsric02_bufferSize`| |12.2| | | | | | |
+|`cusparseSbsric02_bufferSize`| |12.2| |`rocsparse_sbsric0_buffer_size`|3.8.0| | | |
 |`cusparseSbsric02_bufferSizeExt`| |12.2| | | | | | |
 |`cusparseSbsrilu02`| |12.2| |`rocsparse_sbsrilu0`|3.9.0| | | |
 |`cusparseSbsrilu02_analysis`| |12.2| |`rocsparse_sbsrilu0_analysis`|3.6.0| | | |
@@ -575,7 +575,7 @@
 |`cusparseXcsrilu02_zeroPivot`| |12.2| |`rocsparse_csrilu0_zero_pivot`|1.9.0| | | |
 |`cusparseZbsric02`| |12.2| |`rocsparse_zbsric0`|3.8.0| | | |
 |`cusparseZbsric02_analysis`| |12.2| |`rocsparse_zbsric0_analysis`|3.6.0| | | |
-|`cusparseZbsric02_bufferSize`| |12.2| | | | | | |
+|`cusparseZbsric02_bufferSize`| |12.2| |`rocsparse_zbsric0_buffer_size`|3.8.0| | | |
 |`cusparseZbsric02_bufferSizeExt`| |12.2| | | | | | |
 |`cusparseZbsrilu02`| |12.2| |`rocsparse_zbsrilu0`|3.9.0| | | |
 |`cusparseZbsrilu02_analysis`| |12.2| |`rocsparse_zbsrilu0_analysis`|3.6.0| | | |

--- a/src/CUDA2HIP_SPARSE_API_functions.cpp
+++ b/src/CUDA2HIP_SPARSE_API_functions.cpp
@@ -344,13 +344,13 @@ const std::map<llvm::StringRef, hipCounter> CUDA_SPARSE_FUNCTION_MAP {
   {"cusparseZcsric02",                                  {"hipsparseZcsric02",                                  "rocsparse_zcsric0",                                                CONV_LIB_FUNC, API_SPARSE, 12, CUDA_DEPRECATED}},
 
   {"cusparseXcsric02_zeroPivot",                        {"hipsparseXcsric02_zeroPivot",                        "rocsparse_csric0_zero_pivot",                                      CONV_LIB_FUNC, API_SPARSE, 12, CUDA_DEPRECATED}},
-  {"cusparseSbsric02_bufferSize",                       {"hipsparseSbsric02_bufferSize",                       "",                                                                 CONV_LIB_FUNC, API_SPARSE, 12, ROC_UNSUPPORTED | CUDA_DEPRECATED}},
+  {"cusparseSbsric02_bufferSize",                       {"hipsparseSbsric02_bufferSize",                       "rocsparse_sbsric0_buffer_size",                                    CONV_LIB_FUNC, API_SPARSE, 12, CUDA_DEPRECATED}},
   {"cusparseSbsric02_bufferSizeExt",                    {"hipsparseSbsric02_bufferSizeExt",                    "",                                                                 CONV_LIB_FUNC, API_SPARSE, 12, UNSUPPORTED | CUDA_DEPRECATED}},
-  {"cusparseDbsric02_bufferSize",                       {"hipsparseDbsric02_bufferSize",                       "",                                                                 CONV_LIB_FUNC, API_SPARSE, 12, ROC_UNSUPPORTED | CUDA_DEPRECATED}},
+  {"cusparseDbsric02_bufferSize",                       {"hipsparseDbsric02_bufferSize",                       "rocsparse_dbsric0_buffer_size",                                    CONV_LIB_FUNC, API_SPARSE, 12, CUDA_DEPRECATED}},
   {"cusparseDbsric02_bufferSizeExt",                    {"hipsparseDbsric02_bufferSizeExt",                    "",                                                                 CONV_LIB_FUNC, API_SPARSE, 12, UNSUPPORTED | CUDA_DEPRECATED}},
-  {"cusparseCbsric02_bufferSize",                       {"hipsparseCbsric02_bufferSize",                       "",                                                                 CONV_LIB_FUNC, API_SPARSE, 12, ROC_UNSUPPORTED | CUDA_DEPRECATED}},
+  {"cusparseCbsric02_bufferSize",                       {"hipsparseCbsric02_bufferSize",                       "rocsparse_cbsric0_buffer_size",                                    CONV_LIB_FUNC, API_SPARSE, 12, CUDA_DEPRECATED}},
   {"cusparseCbsric02_bufferSizeExt",                    {"hipsparseCbsric02_bufferSizeExt",                    "",                                                                 CONV_LIB_FUNC, API_SPARSE, 12, UNSUPPORTED | CUDA_DEPRECATED}},
-  {"cusparseZbsric02_bufferSize",                       {"hipsparseZbsric02_bufferSize",                       "",                                                                 CONV_LIB_FUNC, API_SPARSE, 12, ROC_UNSUPPORTED | CUDA_DEPRECATED}},
+  {"cusparseZbsric02_bufferSize",                       {"hipsparseZbsric02_bufferSize",                       "rocsparse_zbsric0_buffer_size",                                    CONV_LIB_FUNC, API_SPARSE, 12, CUDA_DEPRECATED}},
   {"cusparseZbsric02_bufferSizeExt",                    {"hipsparseZbsric02_bufferSizeExt",                    "",                                                                 CONV_LIB_FUNC, API_SPARSE, 12, UNSUPPORTED | CUDA_DEPRECATED}},
 
   {"cusparseSbsric02_analysis",                         {"hipsparseSbsric02_analysis",                         "rocsparse_sbsric0_analysis",                                       CONV_LIB_FUNC, API_SPARSE, 12, CUDA_DEPRECATED}},
@@ -2227,6 +2227,10 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_SPARSE_FUNCTION_VER_MAP {
   {"rocsparse_cbsric0_analysis",                         {HIP_3060, HIP_0,    HIP_0   }},
   {"rocsparse_dbsric0_analysis",                         {HIP_3060, HIP_0,    HIP_0   }},
   {"rocsparse_sbsric0_analysis",                         {HIP_3060, HIP_0,    HIP_0   }},
+  {"rocsparse_zbsric0_buffer_size",                      {HIP_3080, HIP_0,    HIP_0   }},
+  {"rocsparse_cbsric0_buffer_size",                      {HIP_3080, HIP_0,    HIP_0   }},
+  {"rocsparse_dbsric0_buffer_size",                      {HIP_3080, HIP_0,    HIP_0   }},
+  {"rocsparse_sbsric0_buffer_size",                      {HIP_3080, HIP_0,    HIP_0   }},
 };
 
 const std::map<unsigned int, llvm::StringRef> CUDA_SPARSE_API_SECTION_MAP {

--- a/src/HipifyAction.cpp
+++ b/src/HipifyAction.cpp
@@ -131,6 +131,10 @@ const std::string sCusparseZbsric02_analysis = "cusparseZbsric02_analysis";
 const std::string sCusparseCbsric02_analysis = "cusparseCbsric02_analysis";
 const std::string sCusparseDbsric02_analysis = "cusparseDbsric02_analysis";
 const std::string sCusparseSbsric02_analysis = "cusparseSbsric02_analysis";
+const std::string sCusparseZbsric02_bufferSize = "cusparseZbsric02_bufferSize";
+const std::string sCusparseCbsric02_bufferSize = "cusparseCbsric02_bufferSize";
+const std::string sCusparseDbsric02_bufferSize = "cusparseDbsric02_bufferSize";
+const std::string sCusparseSbsric02_bufferSize = "cusparseSbsric02_bufferSize";
 // CUDA_OVERLOADED
 const std::string sCudaEventCreate = "cudaEventCreate";
 const std::string sCudaGraphInstantiate = "cudaGraphInstantiate";
@@ -877,6 +881,42 @@ std::map<std::string, ArgCastStruct> FuncArgCasts {
       {
         {10, {e_replace_argument_with_const, cw_None, "rocsparse_analysis_policy_force"}},
         {11, {e_add_const_argument, cw_None, "rocsparse_solve_policy_auto"}}
+      },
+      true,
+      false
+    }
+  },
+  {sCusparseZbsric02_bufferSize,
+    {
+      {
+        {10, {e_reinterpret_cast_size_t, cw_None}}
+      },
+      true,
+      false
+    }
+  },
+  {sCusparseCbsric02_bufferSize,
+    {
+      {
+        {10, {e_reinterpret_cast_size_t, cw_None}}
+      },
+      true,
+      false
+    }
+  },
+  {sCusparseDbsric02_bufferSize,
+    {
+      {
+        {10, {e_reinterpret_cast_size_t, cw_None}}
+      },
+      true,
+      false
+    }
+  },
+  {sCusparseSbsric02_bufferSize,
+    {
+      {
+        {10, {e_reinterpret_cast_size_t, cw_None}}
       },
       true,
       false
@@ -1641,7 +1681,11 @@ std::unique_ptr<clang::ASTConsumer> HipifyAction::CreateASTConsumer(clang::Compi
             sCusparseZbsric02_analysis,
             sCusparseCbsric02_analysis,
             sCusparseDbsric02_analysis,
-            sCusparseSbsric02_analysis
+            sCusparseSbsric02_analysis,
+            sCusparseZbsric02_bufferSize,
+            sCusparseCbsric02_bufferSize,
+            sCusparseDbsric02_bufferSize,
+            sCusparseSbsric02_bufferSize
           )
         )
       )

--- a/tests/unit_tests/synthetic/libraries/cusparse2hipsparse.cu
+++ b/tests/unit_tests/synthetic/libraries/cusparse2hipsparse.cu
@@ -961,6 +961,26 @@ int main() {
   // CHECK: status_t = hipsparseSbsric02_analysis(handle_t, direction_t, mb, nnzb, matDescr_A, &fbsrSortedVal, &bsrSortedRowPtr, &bsrSortedColInd, blockDim, bsric02_info, solvePolicy_t, pBuffer);
   status_t = cusparseSbsric02_analysis(handle_t, direction_t, mb, nnzb, matDescr_A, &fbsrSortedVal, &bsrSortedRowPtr, &bsrSortedColInd, blockDim, bsric02_info, solvePolicy_t, pBuffer);
 
+  // CUDA: CUSPARSE_DEPRECATED cusparseStatus_t CUSPARSEAPI cusparseZbsric02_bufferSize(cusparseHandle_t handle, cusparseDirection_t dirA, int mb, int nnzb, const cusparseMatDescr_t descrA, cuDoubleComplex* bsrSortedVal, const int* bsrSortedRowPtr, const int* bsrSortedColInd, int blockDim, bsric02Info_t info, int* pBufferSizeInBytes);
+  // HIP: HIPSPARSE_EXPORT hipsparseStatus_t hipsparseZbsric02_bufferSize(hipsparseHandle_t handle, hipsparseDirection_t dirA, int mb, int nnzb, const hipsparseMatDescr_t descrA, hipDoubleComplex* bsrValA, const int* bsrRowPtrA, const int* bsrColIndA, int blockDim, bsric02Info_t info, int* pBufferSizeInBytes);
+  // CHECK: status_t = hipsparseZbsric02_bufferSize(handle_t, direction_t, mb, nnzb, matDescr_A, &dComplexbsrSortedVal, &bsrSortedRowPtr, &bsrSortedColInd, blockDim, bsric02_info, &bufferSizeInBytes);
+  status_t = cusparseZbsric02_bufferSize(handle_t, direction_t, mb, nnzb, matDescr_A, &dComplexbsrSortedVal, &bsrSortedRowPtr, &bsrSortedColInd, blockDim, bsric02_info, &bufferSizeInBytes);
+
+  // CUDA: CUSPARSE_DEPRECATED cusparseStatus_t CUSPARSEAPI cusparseCbsric02_bufferSize(cusparseHandle_t handle, cusparseDirection_t dirA, int mb, int nnzb, const cusparseMatDescr_t descrA, cuComplex* bsrSortedVal, const int* bsrSortedRowPtr, const int* bsrSortedColInd, int blockDim, bsric02Info_t info, int* pBufferSizeInBytes);
+  // HIP: HIPSPARSE_EXPORT hipsparseStatus_t hipsparseCbsric02_bufferSize(hipsparseHandle_t handle, hipsparseDirection_t dirA, int mb, int nnzb, const hipsparseMatDescr_t descrA, hipComplex* bsrValA, const int* bsrRowPtrA, const int* bsrColIndA, int blockDim, bsric02Info_t info, int* pBufferSizeInBytes);
+  // CHECK: status_t = hipsparseCbsric02_bufferSize(handle_t, direction_t, mb, nnzb, matDescr_A, &complexbsrSortedVal, &bsrSortedRowPtr, &bsrSortedColInd, blockDim, bsric02_info, &bufferSizeInBytes);
+  status_t = cusparseCbsric02_bufferSize(handle_t, direction_t, mb, nnzb, matDescr_A, &complexbsrSortedVal, &bsrSortedRowPtr, &bsrSortedColInd, blockDim, bsric02_info, &bufferSizeInBytes);
+
+  // CUDA: CUSPARSE_DEPRECATED cusparseStatus_t CUSPARSEAPI cusparseDbsric02_bufferSize(cusparseHandle_t handle, cusparseDirection_t dirA, int mb, int nnzb, const cusparseMatDescr_t descrA, double* bsrSortedVal, const int* bsrSortedRowPtr, const int* bsrSortedColInd, int blockDim, bsric02Info_t info, int* pBufferSizeInBytes);
+  // HIP: HIPSPARSE_EXPORT hipsparseStatus_t hipsparseDbsric02_bufferSize(hipsparseHandle_t handle, hipsparseDirection_t dirA, int mb, int nnzb, const hipsparseMatDescr_t descrA, double* bsrValA, const int* bsrRowPtrA, const int* bsrColIndA, int blockDim, bsric02Info_t info, int* pBufferSizeInBytes);
+  // CHECK: status_t = hipsparseDbsric02_bufferSize(handle_t, direction_t, mb, nnzb, matDescr_A, &dbsrSortedVal, &bsrSortedRowPtr, &bsrSortedColInd, blockDim, bsric02_info, &bufferSizeInBytes);
+  status_t = cusparseDbsric02_bufferSize(handle_t, direction_t, mb, nnzb, matDescr_A, &dbsrSortedVal, &bsrSortedRowPtr, &bsrSortedColInd, blockDim, bsric02_info, &bufferSizeInBytes);
+
+  // CUDA: CUSPARSE_DEPRECATED cusparseStatus_t CUSPARSEAPI cusparseSbsric02_bufferSize(cusparseHandle_t handle, cusparseDirection_t dirA, int mb, int nnzb, const cusparseMatDescr_t descrA, float* bsrSortedVal, const int* bsrSortedRowPtr, const int* bsrSortedColInd, int blockDim, bsric02Info_t info, int* pBufferSizeInBytes);
+  // HIP: HIPSPARSE_EXPORT hipsparseStatus_t hipsparseSbsric02_bufferSize(hipsparseHandle_t handle, hipsparseDirection_t dirA, int mb, int nnzb, const hipsparseMatDescr_t descrA, float* bsrValA, const int* bsrRowPtrA, const int* bsrColIndA, int blockDim, bsric02Info_t info, int* pBufferSizeInBytes);
+  // CHECK: status_t = hipsparseSbsric02_bufferSize(handle_t, direction_t, mb, nnzb, matDescr_A, &fbsrSortedVal, &bsrSortedRowPtr, &bsrSortedColInd, blockDim, bsric02_info, &bufferSizeInBytes);
+  status_t = cusparseSbsric02_bufferSize(handle_t, direction_t, mb, nnzb, matDescr_A, &fbsrSortedVal, &bsrSortedRowPtr, &bsrSortedColInd, blockDim, bsric02_info, &bufferSizeInBytes);
+
 #if CUDA_VERSION >= 8000
   // CHECK: hipDataType dataType_t;
   // CHECK-NEXT: hipDataType dataType;

--- a/tests/unit_tests/synthetic/libraries/cusparse2rocsparse.cu
+++ b/tests/unit_tests/synthetic/libraries/cusparse2rocsparse.cu
@@ -975,6 +975,26 @@ int main() {
   // CHECK: status_t = rocsparse_sbsric0_analysis(handle_t, direction_t, mb, nnzb, matDescr_A, &fbsrSortedVal, &bsrSortedRowPtr, &bsrSortedColInd, blockDim, bsric02_info, rocsparse_analysis_policy_force, rocsparse_solve_policy_auto, pBuffer);
   status_t = cusparseSbsric02_analysis(handle_t, direction_t, mb, nnzb, matDescr_A, &fbsrSortedVal, &bsrSortedRowPtr, &bsrSortedColInd, blockDim, bsric02_info, solvePolicy_t, pBuffer);
 
+  // CUDA: CUSPARSE_DEPRECATED cusparseStatus_t CUSPARSEAPI cusparseZbsric02_bufferSize(cusparseHandle_t handle, cusparseDirection_t dirA, int mb, int nnzb, const cusparseMatDescr_t descrA, cuDoubleComplex* bsrSortedVal, const int* bsrSortedRowPtr, const int* bsrSortedColInd, int blockDim, bsric02Info_t info, int* pBufferSizeInBytes);
+  // ROC: ROCSPARSE_EXPORT rocsparse_status rocsparse_zbsric0_buffer_size(rocsparse_handle handle, rocsparse_direction dir, rocsparse_int mb, rocsparse_int nnzb, const rocsparse_mat_descr descr, const rocsparse_double_complex* bsr_val, const rocsparse_int* bsr_row_ptr, const rocsparse_int* bsr_col_ind, rocsparse_int block_dim, rocsparse_mat_info info, size_t* buffer_size);
+  // CHECK: status_t = rocsparse_zbsric0_buffer_size(handle_t, direction_t, mb, nnzb, matDescr_A, &dComplexbsrSortedVal, &bsrSortedRowPtr, &bsrSortedColInd, blockDim, bsric02_info, reinterpret_cast<size_t*>(&bufferSizeInBytes));
+  status_t = cusparseZbsric02_bufferSize(handle_t, direction_t, mb, nnzb, matDescr_A, &dComplexbsrSortedVal, &bsrSortedRowPtr, &bsrSortedColInd, blockDim, bsric02_info, &bufferSizeInBytes);
+
+  // CUDA: CUSPARSE_DEPRECATED cusparseStatus_t CUSPARSEAPI cusparseCbsric02_bufferSize(cusparseHandle_t handle, cusparseDirection_t dirA, int mb, int nnzb, const cusparseMatDescr_t descrA, cuComplex* bsrSortedVal, const int* bsrSortedRowPtr, const int* bsrSortedColInd, int blockDim, bsric02Info_t info, int* pBufferSizeInBytes);
+  // ROC: ROCSPARSE_EXPORT rocsparse_status rocsparse_cbsric0_buffer_size(rocsparse_handle handle, rocsparse_direction dir, rocsparse_int mb, rocsparse_int nnzb, const rocsparse_mat_descr descr, const rocsparse_float_complex* bsr_val, const rocsparse_int* bsr_row_ptr, const rocsparse_int* bsr_col_ind, rocsparse_int block_dim, rocsparse_mat_info info, size_t* buffer_size);
+  // CHECK: status_t = rocsparse_cbsric0_buffer_size(handle_t, direction_t, mb, nnzb, matDescr_A, &complexbsrSortedVal, &bsrSortedRowPtr, &bsrSortedColInd, blockDim, bsric02_info, reinterpret_cast<size_t*>(&bufferSizeInBytes));
+  status_t = cusparseCbsric02_bufferSize(handle_t, direction_t, mb, nnzb, matDescr_A, &complexbsrSortedVal, &bsrSortedRowPtr, &bsrSortedColInd, blockDim, bsric02_info, &bufferSizeInBytes);
+
+  // CUDA: CUSPARSE_DEPRECATED cusparseStatus_t CUSPARSEAPI cusparseDbsric02_bufferSize(cusparseHandle_t handle, cusparseDirection_t dirA, int mb, int nnzb, const cusparseMatDescr_t descrA, double* bsrSortedVal, const int* bsrSortedRowPtr, const int* bsrSortedColInd, int blockDim, bsric02Info_t info, int* pBufferSizeInBytes);
+  // ROC: ROCSPARSE_EXPORT rocsparse_status rocsparse_dbsric0_buffer_size(rocsparse_handle handle, rocsparse_direction dir, rocsparse_int mb, rocsparse_int nnzb, const rocsparse_mat_descr descr, const double* bsr_val, const rocsparse_int* bsr_row_ptr, const rocsparse_int* bsr_col_ind, rocsparse_int block_dim, rocsparse_mat_info info, size_t* buffer_size);
+  // CHECK: status_t = rocsparse_dbsric0_buffer_size(handle_t, direction_t, mb, nnzb, matDescr_A, &dbsrSortedVal, &bsrSortedRowPtr, &bsrSortedColInd, blockDim, bsric02_info, reinterpret_cast<size_t*>(&bufferSizeInBytes));
+  status_t = cusparseDbsric02_bufferSize(handle_t, direction_t, mb, nnzb, matDescr_A, &dbsrSortedVal, &bsrSortedRowPtr, &bsrSortedColInd, blockDim, bsric02_info, &bufferSizeInBytes);
+
+  // CUDA: CUSPARSE_DEPRECATED cusparseStatus_t CUSPARSEAPI cusparseSbsric02_bufferSize(cusparseHandle_t handle, cusparseDirection_t dirA, int mb, int nnzb, const cusparseMatDescr_t descrA, float* bsrSortedVal, const int* bsrSortedRowPtr, const int* bsrSortedColInd, int blockDim, bsric02Info_t info, int* pBufferSizeInBytes);
+  // ROC: ROCSPARSE_EXPORT rocsparse_status rocsparse_sbsric0_buffer_size(rocsparse_handle handle, rocsparse_direction dir, rocsparse_int mb, rocsparse_int nnzb, const rocsparse_mat_descr descr, const float* bsr_val, const rocsparse_int* bsr_row_ptr, const rocsparse_int* bsr_col_ind, rocsparse_int block_dim, rocsparse_mat_info info, size_t* buffer_size);
+  // CHECK: status_t = rocsparse_sbsric0_buffer_size(handle_t, direction_t, mb, nnzb, matDescr_A, &fbsrSortedVal, &bsrSortedRowPtr, &bsrSortedColInd, blockDim, bsric02_info, reinterpret_cast<size_t*>(&bufferSizeInBytes));
+  status_t = cusparseSbsric02_bufferSize(handle_t, direction_t, mb, nnzb, matDescr_A, &fbsrSortedVal, &bsrSortedRowPtr, &bsrSortedColInd, blockDim, bsric02_info, &bufferSizeInBytes);
+
 #if CUDA_VERSION >= 8000
   // CHECK: hipDataType dataType_t;
   // TODO: [#899] There should be rocsparse_datatype


### PR DESCRIPTION
+ Updated synthetic tests and the regenerated hipify-perl and SPARSE docs
