### PR TITLE
[HIPIFY][#674][rocSPARSE][feature] rocSPARSE support - Step 50 - functions `rocsparse_csrgemm_nnz` and `rocsparse_bsric0_zero_pivot`

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -182,6 +182,7 @@ my %deprecated_funcs = (
     "cusparseXbsrsv2_zeroPivot" => "12.2",
     "cusparseXbsrsm2_zeroPivot" => "12.2",
     "cusparseXbsrilu02_zeroPivot" => "12.2",
+    "cusparseXbsric02_zeroPivot" => "12.2",
     "cusparseSsctr" => "11.0",
     "cusparseSroti" => "11.0",
     "cusparseSpruneDense2csr_bufferSizeExt" => "12.2",
@@ -1894,6 +1895,7 @@ sub rocSubstitutions {
     subst("cusparseSpruneDense2csrNnz", "rocsparse_sprune_dense2csr_nnz", "library");
     subst("cusparseSpruneDense2csrNnzByPercentage", "rocsparse_sprune_dense2csr_nnz_by_percentage", "library");
     subst("cusparseSpruneDense2csr_bufferSizeExt", "rocsparse_sprune_dense2csr_buffer_size", "library");
+    subst("cusparseXbsric02_zeroPivot", "rocsparse_bsric0_zero_pivot", "library");
     subst("cusparseXbsrilu02_zeroPivot", "rocsparse_bsrilu0_zero_pivot", "library");
     subst("cusparseXcoo2csr", "rocsparse_coo2csr", "library");
     subst("cusparseXcoosortByColumn", "rocsparse_coosort_by_column", "library");
@@ -1904,6 +1906,7 @@ sub rocSubstitutions {
     subst("cusparseXcsr2bsrNnz", "rocsparse_csr2bsr_nnz", "library");
     subst("cusparseXcsr2coo", "rocsparse_csr2coo", "library");
     subst("cusparseXcsr2gebsrNnz", "rocsparse_csr2gebsr_nnz", "library");
+    subst("cusparseXcsrgemm2Nnz", "rocsparse_csrgemm_nnz", "library");
     subst("cusparseXcsric02_zeroPivot", "rocsparse_csric0_zero_pivot", "library");
     subst("cusparseXcsrilu02_zeroPivot", "rocsparse_csrilu0_zero_pivot", "library");
     subst("cusparseXcsrsort", "rocsparse_csrsort", "library");
@@ -1957,6 +1960,8 @@ sub rocSubstitutions {
     subst("bsric02Info_t", "rocsparse_mat_info", "type");
     subst("bsrilu02Info", "_rocsparse_mat_info", "type");
     subst("bsrilu02Info_t", "rocsparse_mat_info", "type");
+    subst("csrgemm2Info", "_rocsparse_mat_info", "type");
+    subst("csrgemm2Info_t", "rocsparse_mat_info", "type");
     subst("csric02Info", "_rocsparse_mat_info", "type");
     subst("csric02Info_t", "rocsparse_mat_info", "type");
     subst("csrilu02Info", "_rocsparse_mat_info", "type");
@@ -4241,6 +4246,7 @@ sub simpleSubstitutions {
     subst("bsrsm2Info_t", "bsrsm2Info_t", "type");
     subst("bsrsv2Info", "bsrsv2Info", "type");
     subst("bsrsv2Info_t", "bsrsv2Info_t", "type");
+    subst("csrgemm2Info", "csrgemm2Info", "type");
     subst("csrgemm2Info_t", "csrgemm2Info_t", "type");
     subst("csric02Info", "csric02Info", "type");
     subst("csric02Info_t", "csric02Info_t", "type");
@@ -7874,7 +7880,6 @@ sub warnUnsupportedFunctions {
         "cuArrayGetMemoryRequirements",
         "csrsv2Info",
         "csrsm2Info",
-        "csrgemm2Info",
         "cl_event_flags_enum",
         "cl_event_flags",
         "cl_context_flags_enum",

--- a/docs/tables/CUSPARSE_API_supported_by_HIP.md
+++ b/docs/tables/CUSPARSE_API_supported_by_HIP.md
@@ -116,7 +116,7 @@
 |`bsrsm2Info_t`| |12.2| |`bsrsm2Info_t`|4.5.0| | | |
 |`bsrsv2Info`| |12.2| |`bsrsv2Info`|3.6.0| | | |
 |`bsrsv2Info_t`| |12.2| |`bsrsv2Info_t`|3.6.0| | | |
-|`csrgemm2Info`| | |12.0| | | | | |
+|`csrgemm2Info`| | |12.0|`csrgemm2Info`|2.8.0| | | |
 |`csrgemm2Info_t`| | |12.0|`csrgemm2Info_t`|2.8.0| | | |
 |`csric02Info`| |12.2| |`csric02Info`|3.1.0| | | |
 |`csric02Info_t`| |12.2| |`csric02Info_t`|3.1.0| | | |
@@ -569,7 +569,7 @@
 |`cusparseSgtsvInterleavedBatch_bufferSizeExt`|9.2| | |`hipsparseSgtsvInterleavedBatch_bufferSizeExt`|5.1.0| | | |
 |`cusparseSgtsvStridedBatch`| |10.2|11.0| | | | | |
 |`cusparseSgtsv_nopivot`| |10.2|11.0| | | | | |
-|`cusparseXbsric02_zeroPivot`| | | |`hipsparseXbsric02_zeroPivot`|3.8.0| | | |
+|`cusparseXbsric02_zeroPivot`| |12.2| |`hipsparseXbsric02_zeroPivot`|3.8.0| | | |
 |`cusparseXbsrilu02_zeroPivot`| |12.2| |`hipsparseXbsrilu02_zeroPivot`|3.9.0| | | |
 |`cusparseXcsric02_zeroPivot`| |12.2| |`hipsparseXcsric02_zeroPivot`|3.1.0| | | |
 |`cusparseXcsrilu02_zeroPivot`| |12.2| |`hipsparseXcsrilu02_zeroPivot`|1.9.2| | | |

--- a/docs/tables/CUSPARSE_API_supported_by_HIP_and_ROC.md
+++ b/docs/tables/CUSPARSE_API_supported_by_HIP_and_ROC.md
@@ -116,8 +116,8 @@
 |`bsrsm2Info_t`| |12.2| |`bsrsm2Info_t`|4.5.0| | | | | | | | |
 |`bsrsv2Info`| |12.2| |`bsrsv2Info`|3.6.0| | | | | | | | |
 |`bsrsv2Info_t`| |12.2| |`bsrsv2Info_t`|3.6.0| | | | | | | | |
-|`csrgemm2Info`| | |12.0| | | | | | | | | | |
-|`csrgemm2Info_t`| | |12.0|`csrgemm2Info_t`|2.8.0| | | | | | | | |
+|`csrgemm2Info`| | |12.0|`csrgemm2Info`|2.8.0| | | |`_rocsparse_mat_info`|1.9.0| | | |
+|`csrgemm2Info_t`| | |12.0|`csrgemm2Info_t`|2.8.0| | | |`rocsparse_mat_info`|1.9.0| | | |
 |`csric02Info`| |12.2| |`csric02Info`|3.1.0| | | |`_rocsparse_mat_info`|1.9.0| | | |
 |`csric02Info_t`| |12.2| |`csric02Info_t`|3.1.0| | | |`rocsparse_mat_info`|1.9.0| | | |
 |`csrilu02Info`| |12.2| |`csrilu02Info`|1.9.2| | | |`_rocsparse_mat_info`|1.9.0| | | |
@@ -456,7 +456,7 @@
 |`cusparseScsrgemm2_bufferSizeExt`| |11.0|12.0|`hipsparseScsrgemm2_bufferSizeExt`|2.8.0| | | | | | | | |
 |`cusparseXcsrgeam2Nnz`|10.0| | |`hipsparseXcsrgeam2Nnz`|3.5.0| | | | | | | | |
 |`cusparseXcsrgeamNnz`| |10.2|11.0|`hipsparseXcsrgeamNnz`|3.5.0| | | | | | | | |
-|`cusparseXcsrgemm2Nnz`| |11.0|12.0|`hipsparseXcsrgemm2Nnz`|2.8.0| | | | | | | | |
+|`cusparseXcsrgemm2Nnz`| |11.0|12.0|`hipsparseXcsrgemm2Nnz`|2.8.0| | | |`rocsparse_csrgemm_nnz`|2.8.0| | | |
 |`cusparseXcsrgemmNnz`| |10.2|11.0|`hipsparseXcsrgemmNnz`|2.8.0| | | | | | | | |
 |`cusparseZcsrgeam`| |10.2|11.0|`hipsparseZcsrgeam`|3.5.0| | | | | | | | |
 |`cusparseZcsrgeam2`|10.0| | |`hipsparseZcsrgeam2`|3.5.0| | | | | | | | |
@@ -569,7 +569,7 @@
 |`cusparseSgtsvInterleavedBatch_bufferSizeExt`|9.2| | |`hipsparseSgtsvInterleavedBatch_bufferSizeExt`|5.1.0| | | |`rocsparse_sgtsv_interleaved_batch_buffer_size`|5.1.0| | | |
 |`cusparseSgtsvStridedBatch`| |10.2|11.0| | | | | | | | | | |
 |`cusparseSgtsv_nopivot`| |10.2|11.0| | | | | | | | | | |
-|`cusparseXbsric02_zeroPivot`| | | |`hipsparseXbsric02_zeroPivot`|3.8.0| | | | | | | | |
+|`cusparseXbsric02_zeroPivot`| |12.2| |`hipsparseXbsric02_zeroPivot`|3.8.0| | | |`rocsparse_bsric0_zero_pivot`|3.8.0| | | |
 |`cusparseXbsrilu02_zeroPivot`| |12.2| |`hipsparseXbsrilu02_zeroPivot`|3.9.0| | | |`rocsparse_bsrilu0_zero_pivot`|3.9.0| | | |
 |`cusparseXcsric02_zeroPivot`| |12.2| |`hipsparseXcsric02_zeroPivot`|3.1.0| | | |`rocsparse_csric0_zero_pivot`|3.1.0| | | |
 |`cusparseXcsrilu02_zeroPivot`| |12.2| |`hipsparseXcsrilu02_zeroPivot`|1.9.2| | | |`rocsparse_csrilu0_zero_pivot`|1.9.0| | | |

--- a/docs/tables/CUSPARSE_API_supported_by_ROC.md
+++ b/docs/tables/CUSPARSE_API_supported_by_ROC.md
@@ -116,8 +116,8 @@
 |`bsrsm2Info_t`| |12.2| | | | | | |
 |`bsrsv2Info`| |12.2| | | | | | |
 |`bsrsv2Info_t`| |12.2| | | | | | |
-|`csrgemm2Info`| | |12.0| | | | | |
-|`csrgemm2Info_t`| | |12.0| | | | | |
+|`csrgemm2Info`| | |12.0|`_rocsparse_mat_info`|1.9.0| | | |
+|`csrgemm2Info_t`| | |12.0|`rocsparse_mat_info`|1.9.0| | | |
 |`csric02Info`| |12.2| |`_rocsparse_mat_info`|1.9.0| | | |
 |`csric02Info_t`| |12.2| |`rocsparse_mat_info`|1.9.0| | | |
 |`csrilu02Info`| |12.2| |`_rocsparse_mat_info`|1.9.0| | | |
@@ -456,7 +456,7 @@
 |`cusparseScsrgemm2_bufferSizeExt`| |11.0|12.0| | | | | |
 |`cusparseXcsrgeam2Nnz`|10.0| | | | | | | |
 |`cusparseXcsrgeamNnz`| |10.2|11.0| | | | | |
-|`cusparseXcsrgemm2Nnz`| |11.0|12.0| | | | | |
+|`cusparseXcsrgemm2Nnz`| |11.0|12.0|`rocsparse_csrgemm_nnz`|2.8.0| | | |
 |`cusparseXcsrgemmNnz`| |10.2|11.0| | | | | |
 |`cusparseZcsrgeam`| |10.2|11.0| | | | | |
 |`cusparseZcsrgeam2`|10.0| | | | | | | |
@@ -569,7 +569,7 @@
 |`cusparseSgtsvInterleavedBatch_bufferSizeExt`|9.2| | |`rocsparse_sgtsv_interleaved_batch_buffer_size`|5.1.0| | | |
 |`cusparseSgtsvStridedBatch`| |10.2|11.0| | | | | |
 |`cusparseSgtsv_nopivot`| |10.2|11.0| | | | | |
-|`cusparseXbsric02_zeroPivot`| | | | | | | | |
+|`cusparseXbsric02_zeroPivot`| |12.2| |`rocsparse_bsric0_zero_pivot`|3.8.0| | | |
 |`cusparseXbsrilu02_zeroPivot`| |12.2| |`rocsparse_bsrilu0_zero_pivot`|3.9.0| | | |
 |`cusparseXcsric02_zeroPivot`| |12.2| |`rocsparse_csric0_zero_pivot`|3.1.0| | | |
 |`cusparseXcsrilu02_zeroPivot`| |12.2| |`rocsparse_csrilu0_zero_pivot`|1.9.0| | | |

--- a/src/CUDA2HIP_SPARSE_API_functions.cpp
+++ b/src/CUDA2HIP_SPARSE_API_functions.cpp
@@ -300,17 +300,19 @@ const std::map<llvm::StringRef, hipCounter> CUDA_SPARSE_FUNCTION_MAP {
   {"cusparseCcsrgeam2_bufferSizeExt",                   {"hipsparseCcsrgeam2_bufferSizeExt",                   "",                                                                 CONV_LIB_FUNC, API_SPARSE, 11, ROC_UNSUPPORTED}},
   {"cusparseZcsrgeam2_bufferSizeExt",                   {"hipsparseZcsrgeam2_bufferSizeExt",                   "",                                                                 CONV_LIB_FUNC, API_SPARSE, 11, ROC_UNSUPPORTED}},
 
+  // NOTE: rocsparse_(s|d|c|z)csrgemm have different signatures, thus they are unsupported yet
   {"cusparseScsrgemm",                                  {"hipsparseScsrgemm",                                  "",                                                                 CONV_LIB_FUNC, API_SPARSE, 11, ROC_UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED}},
   {"cusparseDcsrgemm",                                  {"hipsparseDcsrgemm",                                  "",                                                                 CONV_LIB_FUNC, API_SPARSE, 11, ROC_UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED}},
   {"cusparseCcsrgemm",                                  {"hipsparseCcsrgemm",                                  "",                                                                 CONV_LIB_FUNC, API_SPARSE, 11, ROC_UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED}},
   {"cusparseZcsrgemm",                                  {"hipsparseZcsrgemm",                                  "",                                                                 CONV_LIB_FUNC, API_SPARSE, 11, ROC_UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED}},
+  // NOTE: rocsparse_csrgemm_nnz has different signature, thus it is unsupported yet
   {"cusparseXcsrgemmNnz",                               {"hipsparseXcsrgemmNnz",                               "",                                                                 CONV_LIB_FUNC, API_SPARSE, 11, ROC_UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED}},
 
   {"cusparseScsrgemm2",                                 {"hipsparseScsrgemm2",                                 "",                                                                 CONV_LIB_FUNC, API_SPARSE, 11, ROC_UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED}},
   {"cusparseDcsrgemm2",                                 {"hipsparseDcsrgemm2",                                 "",                                                                 CONV_LIB_FUNC, API_SPARSE, 11, ROC_UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED}},
   {"cusparseCcsrgemm2",                                 {"hipsparseCcsrgemm2",                                 "",                                                                 CONV_LIB_FUNC, API_SPARSE, 11, ROC_UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED}},
   {"cusparseZcsrgemm2",                                 {"hipsparseZcsrgemm2",                                 "",                                                                 CONV_LIB_FUNC, API_SPARSE, 11, ROC_UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED}},
-  {"cusparseXcsrgemm2Nnz",                              {"hipsparseXcsrgemm2Nnz",                              "",                                                                 CONV_LIB_FUNC, API_SPARSE, 11, ROC_UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED}},
+  {"cusparseXcsrgemm2Nnz",                              {"hipsparseXcsrgemm2Nnz",                              "rocsparse_csrgemm_nnz",                                            CONV_LIB_FUNC, API_SPARSE, 11, CUDA_DEPRECATED | CUDA_REMOVED}},
 
   {"cusparseScsrgemm2_bufferSizeExt",                   {"hipsparseScsrgemm2_bufferSizeExt",                   "",                                                                 CONV_LIB_FUNC, API_SPARSE, 11, ROC_UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED}},
   {"cusparseDcsrgemm2_bufferSizeExt",                   {"hipsparseDcsrgemm2_bufferSizeExt",                   "",                                                                 CONV_LIB_FUNC, API_SPARSE, 11, ROC_UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED}},
@@ -362,10 +364,11 @@ const std::map<llvm::StringRef, hipCounter> CUDA_SPARSE_FUNCTION_MAP {
   {"cusparseDbsric02",                                  {"hipsparseDbsric02",                                  "rocsparse_dbsric0",                                                CONV_LIB_FUNC, API_SPARSE, 12, CUDA_DEPRECATED}},
   {"cusparseCbsric02",                                  {"hipsparseCbsric02",                                  "rocsparse_cbsric0",                                                CONV_LIB_FUNC, API_SPARSE, 12, CUDA_DEPRECATED}},
   {"cusparseZbsric02",                                  {"hipsparseZbsric02",                                  "rocsparse_zbsric0",                                                CONV_LIB_FUNC, API_SPARSE, 12, CUDA_DEPRECATED}},
-  {"cusparseXbsric02_zeroPivot",                        {"hipsparseXbsric02_zeroPivot",                        "",                                                                 CONV_LIB_FUNC, API_SPARSE, 12, ROC_UNSUPPORTED | CUDA_DEPRECATED}},
+  // TODO: rocsparse_get_stream and hipStreamSynchronize need to be added correspondingly before and after rocsparse_bsric0_zero_pivot call, because cusparseXbsric02_zeroPivot is blocking, and rocsparse_bsric0_zero_pivot is not
+  {"cusparseXbsric02_zeroPivot",                        {"hipsparseXbsric02_zeroPivot",                        "rocsparse_bsric0_zero_pivot",                                      CONV_LIB_FUNC, API_SPARSE, 12, CUDA_DEPRECATED}},
 
   // 12.2. Incomplete LU Factorization: level 0
-  // NOTE: rocsparse_(s|d|c|z)csrilu0 have different signatures
+  // NOTE: rocsparse_(s|d|c|z)csrilu0 have different signatures, thus they are also unsupported yet
   {"cusparseScsrilu0",                                  {"hipsparseScsrilu0",                                  "",                                                                 CONV_LIB_FUNC, API_SPARSE, 12, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED}},
   {"cusparseDcsrilu0",                                  {"hipsparseDcsrilu0",                                  "",                                                                 CONV_LIB_FUNC, API_SPARSE, 12, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED}},
   {"cusparseCcsrilu0",                                  {"hipsparseCcsrilu0",                                  "",                                                                 CONV_LIB_FUNC, API_SPARSE, 12, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED}},
@@ -1441,6 +1444,7 @@ const std::map<llvm::StringRef, cudaAPIversions> CUDA_SPARSE_FUNCTION_VER_MAP {
   {"cusparseDcsr2csru",                                 {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
   {"cusparseCcsr2csru",                                 {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
   {"cusparseZcsr2csru",                                 {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
+  {"cusparseXbsric02_zeroPivot",                        {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
 };
 
 const std::map<llvm::StringRef, hipAPIversions> HIP_SPARSE_FUNCTION_VER_MAP {
@@ -2231,6 +2235,8 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_SPARSE_FUNCTION_VER_MAP {
   {"rocsparse_cbsric0_buffer_size",                      {HIP_3080, HIP_0,    HIP_0   }},
   {"rocsparse_dbsric0_buffer_size",                      {HIP_3080, HIP_0,    HIP_0   }},
   {"rocsparse_sbsric0_buffer_size",                      {HIP_3080, HIP_0,    HIP_0   }},
+  {"rocsparse_bsric0_zero_pivot",                        {HIP_3080, HIP_0,    HIP_0   }},
+  {"rocsparse_csrgemm_nnz",                              {HIP_2080, HIP_0,    HIP_0   }},
 };
 
 const std::map<unsigned int, llvm::StringRef> CUDA_SPARSE_API_SECTION_MAP {

--- a/src/CUDA2HIP_SPARSE_API_types.cpp
+++ b/src/CUDA2HIP_SPARSE_API_types.cpp
@@ -65,8 +65,8 @@ const std::map<llvm::StringRef, hipCounter> CUDA_SPARSE_TYPE_NAME_MAP {
   {"csric02Info",                               {"csric02Info",                                "_rocsparse_mat_info",                                CONV_TYPE, API_SPARSE, 4, CUDA_DEPRECATED}},
   {"csric02Info_t",                             {"csric02Info_t",                              "rocsparse_mat_info",                                 CONV_TYPE, API_SPARSE, 4, CUDA_DEPRECATED}},
 
-  {"csrgemm2Info",                              {"csrgemm2Info",                               "",                                                   CONV_TYPE, API_SPARSE, 4, UNSUPPORTED | CUDA_REMOVED}},
-  {"csrgemm2Info_t",                            {"csrgemm2Info_t",                             "",                                                   CONV_TYPE, API_SPARSE, 4, ROC_UNSUPPORTED | CUDA_REMOVED}},
+  {"csrgemm2Info",                              {"csrgemm2Info",                               "_rocsparse_mat_info",                                CONV_TYPE, API_SPARSE, 4, CUDA_REMOVED}},
+  {"csrgemm2Info_t",                            {"csrgemm2Info_t",                             "rocsparse_mat_info",                                 CONV_TYPE, API_SPARSE, 4, CUDA_REMOVED}},
 
   {"cusparseColorInfo",                         {"hipsparseColorInfo",                         "_rocsparse_color_info",                              CONV_TYPE, API_SPARSE, 4, HIP_UNSUPPORTED | CUDA_DEPRECATED}},
   {"cusparseColorInfo_t",                       {"hipsparseColorInfo_t",                       "rocsparse_color_info",                               CONV_TYPE, API_SPARSE, 4, CUDA_DEPRECATED}},
@@ -433,6 +433,7 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_SPARSE_TYPE_NAME_VER_MAP {
   {"csrilu02Info_t",                             {HIP_1092, HIP_0,    HIP_0   }},
   {"bsrilu02Info",                               {HIP_3090, HIP_0,    HIP_0   }},
   {"bsrilu02Info_t",                             {HIP_3090, HIP_0,    HIP_0   }},
+  {"csrgemm2Info",                               {HIP_2080, HIP_0,    HIP_0   }},
   {"csrgemm2Info_t",                             {HIP_2080, HIP_0,    HIP_0   }},
   {"pruneInfo",                                  {HIP_3090, HIP_0,    HIP_0   }},
   {"pruneInfo_t",                                {HIP_3090, HIP_0,    HIP_0   }},

--- a/tests/unit_tests/synthetic/libraries/cusparse2hipsparse.cu
+++ b/tests/unit_tests/synthetic/libraries/cusparse2hipsparse.cu
@@ -15,8 +15,8 @@ int main() {
   // CHECK: hipsparseHandle_t handle_t;
   cusparseHandle_t handle_t;
 
-  // CHECK: hipsparseMatDescr_t matDescr_t, matDescr_t_2, matDescr_A, matDescr_C;
-  cusparseMatDescr_t matDescr_t, matDescr_t_2, matDescr_A, matDescr_C;
+  // CHECK: hipsparseMatDescr_t matDescr_t, matDescr_t_2, matDescr_A, matDescr_B, matDescr_C, matDescr_D;
+  cusparseMatDescr_t matDescr_t, matDescr_t_2, matDescr_A, matDescr_B, matDescr_C, matDescr_D;
 
   // CHECK: hipsparseColorInfo_t colorInfo_t;
   cusparseColorInfo_t colorInfo_t;
@@ -125,6 +125,7 @@ int main() {
   int nnza = 0;
   int nnzb = 0;
   int nnzc = 0;
+  int nnzd = 0;
   int nnzPerRow = 0;
   int nnzPerCol = 0;
   int innz = 0;
@@ -136,7 +137,11 @@ int main() {
   int cscRowIndA = 0;
   int cscColPtrA = 0;
   int csrRowPtrA = 0;
+  int csrRowPtrB = 0;
+  int csrRowPtrD = 0;
   int csrColIndA = 0;
+  int csrColIndB = 0;
+  int csrColIndD = 0;
   int ncolors = 0;
   int coloring = 0;
   int reordering = 0;
@@ -980,6 +985,11 @@ int main() {
   // HIP: HIPSPARSE_EXPORT hipsparseStatus_t hipsparseSbsric02_bufferSize(hipsparseHandle_t handle, hipsparseDirection_t dirA, int mb, int nnzb, const hipsparseMatDescr_t descrA, float* bsrValA, const int* bsrRowPtrA, const int* bsrColIndA, int blockDim, bsric02Info_t info, int* pBufferSizeInBytes);
   // CHECK: status_t = hipsparseSbsric02_bufferSize(handle_t, direction_t, mb, nnzb, matDescr_A, &fbsrSortedVal, &bsrSortedRowPtr, &bsrSortedColInd, blockDim, bsric02_info, &bufferSizeInBytes);
   status_t = cusparseSbsric02_bufferSize(handle_t, direction_t, mb, nnzb, matDescr_A, &fbsrSortedVal, &bsrSortedRowPtr, &bsrSortedColInd, blockDim, bsric02_info, &bufferSizeInBytes);
+
+  // CUDA: CUSPARSE_DEPRECATED cusparseStatus_t CUSPARSEAPI cusparseXbsric02_zeroPivot(cusparseHandle_t handle, bsric02Info_t info, int* position);
+  // HIP: HIPSPARSE_EXPORT hipsparseStatus_t hipsparseXbsric02_zeroPivot(hipsparseHandle_t handle, bsric02Info_t info, int* position);
+  // CHECK: status_t = hipsparseXbsric02_zeroPivot(handle_t, bsric02_info, &iposition);
+  status_t = cusparseXbsric02_zeroPivot(handle_t, bsric02_info, &iposition);
 
 #if CUDA_VERSION >= 8000
   // CHECK: hipDataType dataType_t;
@@ -1848,6 +1858,8 @@ int main() {
 #endif
 
 #if CUDA_VERSION < 12000
+  csrgemm2Info_t csrgemm2_info;
+
   // CUDA: CUSPARSE_DEPRECATED(cusparseSparseToDense) cusparseStatus_t CUSPARSEAPI cusparseZcsc2dense(cusparseHandle_t handle, int m, int n, const cusparseMatDescr_t descrA, const cuDoubleComplex* cscSortedValA, const int* cscSortedRowIndA, const int* cscSortedColPtrA, cuDoubleComplex* A, int lda);
   // HIP: DEPRECATED_CUDA_11000("The routine will be removed in CUDA 12") HIPSPARSE_EXPORT hipsparseStatus_t hipsparseZcsc2dense(hipsparseHandle_t handle, int m, int n, const hipsparseMatDescr_t descr, const hipDoubleComplex* csc_val, const int* csc_row_ind, const int* csc_col_ptr, hipDoubleComplex* A, int ld);
   // CHECK: status_t = hipsparseZcsc2dense(handle_t, m, n, matDescr_A, &dComplexcscSortedVal, &csrSortedRowPtr, &csrSortedColInd, &dcomplexA, lda);
@@ -1927,6 +1939,11 @@ int main() {
   // HIP: HIPSPARSE_EXPORT hipsparseStatus_t hipsparseSdense2csr(hipsparseHandle_t handle, int m, int n, const hipsparseMatDescr_t descr, const float* A, int ld, const int* nnz_per_rows, float* csr_val, int* csr_row_ptr, int* csr_col_ind);
   // CHECK: status_t = hipsparseSdense2csr(handle_t, m, n, matDescr_A, &fA, lda, &nnzPerRow, &csrSortedValA, &csrRowPtrA, &csrColIndA);
   status_t = cusparseSdense2csr(handle_t, m, n, matDescr_A, &fA, lda, &nnzPerRow, &csrSortedValA, &csrRowPtrA, &csrColIndA);
+
+  // CUDA: CUSPARSE_DEPRECATED(cusparseSpGEMM) cusparseStatus_t CUSPARSEAPI cusparseXcsrgemm2Nnz(cusparseHandle_t handle, int m, int n, int k, const cusparseMatDescr_t descrA, int nnzA, const int* csrSortedRowPtrA, const int* csrSortedColIndA, const cusparseMatDescr_t descrB, int nnzB, const int* csrSortedRowPtrB, const int* csrSortedColIndB, const cusparseMatDescr_t descrD, int nnzD, const int* csrSortedRowPtrD, const int* csrSortedColIndD, const cusparseMatDescr_t descrC, int* csrSortedRowPtrC, int* nnzTotalDevHostPtr, const csrgemm2Info_t info, void* pBuffer);
+  // HIP: DEPRECATED_CUDA_11000("The routine will be removed in CUDA 12") HIPSPARSE_EXPORT hipsparseStatus_t hipsparseXcsrgemm2Nnz(hipsparseHandle_t handle, int m, int n, int k, const hipsparseMatDescr_t descrA, int nnzA, const int* csrRowPtrA, const int* csrColIndA, const hipsparseMatDescr_t descrB, int nnzB, const int* csrRowPtrB, const int* csrColIndB, const hipsparseMatDescr_t descrD, int nnzD, const int* csrRowPtrD, const int* csrColIndD, const hipsparseMatDescr_t descrC, int* csrRowPtrC, int* nnzTotalDevHostPtr, const csrgemm2Info_t info, void* pBuffer);
+  // CHECK: status_t = hipsparseXcsrgemm2Nnz(handle_t, m, n, k, matDescr_A, nnza, &csrRowPtrA, &csrColIndA, matDescr_B, nnzB, &csrRowPtrB, &csrColIndB, matDescr_D, nnzD, &csrRowPtrD, &csrColIndD, matDescr_C, &csrRowPtrC, nnzTotalDevHostPtr, csrgemm2_info, pBuffer);
+  status_t = cusparseXcsrgemm2Nnz(handle_t, m, n, k, matDescr_A, nnza, &csrRowPtrA, &csrColIndA, matDescr_B, nnzB, &csrRowPtrB, &csrColIndB, matDescr_D, nnzD, &csrRowPtrD, &csrColIndD, matDescr_C, &csrRowPtrC, nnzTotalDevHostPtr, csrgemm2_info, pBuffer);
 #endif
 
 #if CUDA_VERSION >= 12000


### PR DESCRIPTION
+ `csrgemm2Info_t` -> `rocsparse_mat_info`
+ [fix] `csrgemm2Info` is supported by HIP since 2.8
+ [fix] Mark `cusparseXbsric02_zeroPivot` as CUDA_DEPRECATED since 12.0
+ Updated synthetic tests and the regenerated hipify-perl and SPARSE docs
