### PR TITLE
[HIPIFY][tests][doc] Python 3.12.0 is supported

### DIFF
--- a/docs/hipify-clang.md
+++ b/docs/hipify-clang.md
@@ -368,6 +368,10 @@ Run `Visual Studio 17 2022`, open the generated `LLVM.sln`, build all, build pro
 
         - ***Windows***: `python d:/LLVM/17.0.2/llvm-project/llvm/utils/lit/setup.py install`
 
+       In case of errors, similar to `ModuleNotFoundError: No module named 'setuptools'`, upgrade the `setuptools` package:
+
+       `python -m pip install --upgrade pip setuptools`
+
     * Starting with LLVM 6.0.1 path to `llvm-lit` python script should be specified by the `LLVM_EXTERNAL_LIT` option:
 
         - ***Linux***: `-DLLVM_EXTERNAL_LIT=/usr/llvm/17.0.2/build/bin/llvm-lit`
@@ -590,8 +594,8 @@ Testing Time: 7.90s
 | 14.0.0 - 14.0.6 | 7.0 - 11.7.1 | 8.0.5  - 8.4.1 | 2017.15.9.57*, 2019.16.11.17, 2022.17.2.6 | 3.24.0          | 3.10.6        |
 | 15.0.0 - 15.0.7 | 7.0 - 11.8.0 | 8.0.5  - 8.8.1 | 2019.16.11.25, 2022.17.5.2                | 3.26.0          | 3.11.2        |
 | 16.0.0 - 16.0.6 | 7.0 - 12.2.2 | 8.0.5  - 8.9.5 | 2019.16.11.29, 2022.17.7.1                | 3.27.3          | 3.11.4        |
-| 17.0.1** 17.0.2 | 7.0 - 12.2.2 | 8.0.5  - 8.9.5 | 2019.16.11.30, 2022.17.7.4                | 3.27.6          | 3.11.5        |
-| 18.0.0git       | 7.0 - 12.2.2 | 8.0.5  - 8.9.5 | 2019.16.11.30, 2022.17.7.4                | 3.27.6          | 3.11.5        |
+| 17.0.1** 17.0.2 | 7.0 - 12.2.2 | 8.0.5  - 8.9.5 | 2019.16.11.30, 2022.17.7.4                | 3.27.6          | 3.12.0        |
+| 18.0.0git       | 7.0 - 12.2.2 | 8.0.5  - 8.9.5 | 2019.16.11.30, 2022.17.7.4                | 3.27.6          | 3.12.0        |
 
 `*` LLVM 14.x.x is the latest major release supporting Visual Studio 2017.
 To build LLVM 14.x.x correctly by Visual Studio 2017, `-DLLVM_FORCE_USE_OLD_TOOLCHAIN=ON` should be added to a corresponding cmake command line.
@@ -623,8 +627,8 @@ cmake
 --    - CMake module path: d:/LLVM/17.0.2/dist/lib/cmake/llvm
 --    - Include path     : d:/LLVM/17.0.2/dist/include
 --    - Binary path      : d:/LLVM/17.0.2/dist/bin
--- Found PythonInterp: c:/Program Files/Python311/python.exe (found suitable version "3.11.5", minimum required is "3.6")
--- Found lit: c:/Program Files/Python311/Scripts/lit.exe
+-- Found PythonInterp: c:/Program Files/Python312/python.exe (found suitable version "3.12.0", minimum required is "3.6")
+-- Found lit: c:/Program Files/Python312/Scripts/lit.exe
 -- Found FileCheck: d:/LLVM/17.0.2/dist/bin/FileCheck.exe
 -- Found CUDA: c:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v12.2 (found version "12.2")
 -- Configuring done


### PR DESCRIPTION
+ [IMP] In case of errors, similar to `ModuleNotFoundError: No module named 'setuptools'`, upgrade the `setuptools` package: `python -m pip install --upgrade pip setuptools`
