### PR TITLE
[HIPIFY][6.0.0][hipBLAS#529][fix] Support for ROCm HIP 6.0.0 - Step 5 - `hipblasDatatype_t` -> `hipblasComputeType_t`

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -4334,7 +4334,7 @@ sub simpleSubstitutions {
     subst("cuDoubleComplex", "hipDoubleComplex", "type");
     subst("cuFloatComplex", "hipFloatComplex", "type");
     subst("cublasAtomicsMode_t", "hipblasAtomicsMode_t", "type");
-    subst("cublasComputeType_t", "hipblasDatatype_t", "type");
+    subst("cublasComputeType_t", "hipblasComputeType_t", "type");
     subst("cublasDataType_t", "hipDataType", "type");
     subst("cublasDiagType_t", "hipblasDiagType_t", "type");
     subst("cublasFillMode_t", "hipblasFillMode_t", "type");
@@ -4569,6 +4569,17 @@ sub simpleSubstitutions {
     subst("textureReference", "textureReference", "type");
     subst("CUBLAS_ATOMICS_ALLOWED", "HIPBLAS_ATOMICS_ALLOWED", "numeric_literal");
     subst("CUBLAS_ATOMICS_NOT_ALLOWED", "HIPBLAS_ATOMICS_NOT_ALLOWED", "numeric_literal");
+    subst("CUBLAS_COMPUTE_16F", "HIPBLAS_COMPUTE_16F", "numeric_literal");
+    subst("CUBLAS_COMPUTE_16F_PEDANTIC", "HIPBLAS_COMPUTE_16F_PEDANTIC", "numeric_literal");
+    subst("CUBLAS_COMPUTE_32F", "HIPBLAS_COMPUTE_32F", "numeric_literal");
+    subst("CUBLAS_COMPUTE_32F_FAST_16BF", "HIPBLAS_COMPUTE_32F_FAST_16BF", "numeric_literal");
+    subst("CUBLAS_COMPUTE_32F_FAST_16F", "HIPBLAS_COMPUTE_32F_FAST_16F", "numeric_literal");
+    subst("CUBLAS_COMPUTE_32F_FAST_TF32", "HIPBLAS_COMPUTE_32F_FAST_TF32", "numeric_literal");
+    subst("CUBLAS_COMPUTE_32F_PEDANTIC", "HIPBLAS_COMPUTE_32F_PEDANTIC", "numeric_literal");
+    subst("CUBLAS_COMPUTE_32I", "HIPBLAS_COMPUTE_32I", "numeric_literal");
+    subst("CUBLAS_COMPUTE_32I_PEDANTIC", "HIPBLAS_COMPUTE_32I_PEDANTIC", "numeric_literal");
+    subst("CUBLAS_COMPUTE_64F", "HIPBLAS_COMPUTE_64F", "numeric_literal");
+    subst("CUBLAS_COMPUTE_64F_PEDANTIC", "HIPBLAS_COMPUTE_64F_PEDANTIC", "numeric_literal");
     subst("CUBLAS_DIAG_NON_UNIT", "HIPBLAS_DIAG_NON_UNIT", "numeric_literal");
     subst("CUBLAS_DIAG_UNIT", "HIPBLAS_DIAG_UNIT", "numeric_literal");
     subst("CUBLAS_FILL_MODE_FULL", "HIPBLAS_FILL_MODE_FULL", "numeric_literal");
@@ -9827,18 +9838,7 @@ sub warnHipOnlyUnsupportedFunctions {
         "CUBLAS_GEMM_ALGO1",
         "CUBLAS_GEMM_ALGO0_TENSOR_OP",
         "CUBLAS_GEMM_ALGO0",
-        "CUBLAS_DEFAULT_MATH",
-        "CUBLAS_COMPUTE_64F_PEDANTIC",
-        "CUBLAS_COMPUTE_64F",
-        "CUBLAS_COMPUTE_32I_PEDANTIC",
-        "CUBLAS_COMPUTE_32I",
-        "CUBLAS_COMPUTE_32F_PEDANTIC",
-        "CUBLAS_COMPUTE_32F_FAST_TF32",
-        "CUBLAS_COMPUTE_32F_FAST_16F",
-        "CUBLAS_COMPUTE_32F_FAST_16BF",
-        "CUBLAS_COMPUTE_32F",
-        "CUBLAS_COMPUTE_16F_PEDANTIC",
-        "CUBLAS_COMPUTE_16F"
+        "CUBLAS_DEFAULT_MATH"
     )
     {
         my $mt = m/($func)/g;

--- a/docs/tables/CUBLAS_API_supported_by_HIP.md
+++ b/docs/tables/CUBLAS_API_supported_by_HIP.md
@@ -6,17 +6,17 @@
 |:--|:-:|:-:|:-:|:--|:-:|:-:|:-:|:-:|
 |`CUBLAS_ATOMICS_ALLOWED`| | | |`HIPBLAS_ATOMICS_ALLOWED`|3.10.0| | | |
 |`CUBLAS_ATOMICS_NOT_ALLOWED`| | | |`HIPBLAS_ATOMICS_NOT_ALLOWED`|3.10.0| | | |
-|`CUBLAS_COMPUTE_16F`|11.0| | | | | | | |
-|`CUBLAS_COMPUTE_16F_PEDANTIC`|11.0| | | | | | | |
-|`CUBLAS_COMPUTE_32F`|11.0| | | | | | | |
-|`CUBLAS_COMPUTE_32F_FAST_16BF`|11.0| | | | | | | |
-|`CUBLAS_COMPUTE_32F_FAST_16F`|11.0| | | | | | | |
-|`CUBLAS_COMPUTE_32F_FAST_TF32`|11.0| | | | | | | |
-|`CUBLAS_COMPUTE_32F_PEDANTIC`|11.0| | | | | | | |
-|`CUBLAS_COMPUTE_32I`|11.0| | | | | | | |
-|`CUBLAS_COMPUTE_32I_PEDANTIC`|11.0| | | | | | | |
-|`CUBLAS_COMPUTE_64F`|11.0| | | | | | | |
-|`CUBLAS_COMPUTE_64F_PEDANTIC`|11.0| | | | | | | |
+|`CUBLAS_COMPUTE_16F`|11.0| | |`HIPBLAS_COMPUTE_16F`|6.0.0| | |6.0.0|
+|`CUBLAS_COMPUTE_16F_PEDANTIC`|11.0| | |`HIPBLAS_COMPUTE_16F_PEDANTIC`|6.0.0| | |6.0.0|
+|`CUBLAS_COMPUTE_32F`|11.0| | |`HIPBLAS_COMPUTE_32F`|6.0.0| | |6.0.0|
+|`CUBLAS_COMPUTE_32F_FAST_16BF`|11.0| | |`HIPBLAS_COMPUTE_32F_FAST_16BF`|6.0.0| | |6.0.0|
+|`CUBLAS_COMPUTE_32F_FAST_16F`|11.0| | |`HIPBLAS_COMPUTE_32F_FAST_16F`|6.0.0| | |6.0.0|
+|`CUBLAS_COMPUTE_32F_FAST_TF32`|11.0| | |`HIPBLAS_COMPUTE_32F_FAST_TF32`|6.0.0| | |6.0.0|
+|`CUBLAS_COMPUTE_32F_PEDANTIC`|11.0| | |`HIPBLAS_COMPUTE_32F_PEDANTIC`|6.0.0| | |6.0.0|
+|`CUBLAS_COMPUTE_32I`|11.0| | |`HIPBLAS_COMPUTE_32I`|6.0.0| | |6.0.0|
+|`CUBLAS_COMPUTE_32I_PEDANTIC`|11.0| | |`HIPBLAS_COMPUTE_32I_PEDANTIC`|6.0.0| | |6.0.0|
+|`CUBLAS_COMPUTE_64F`|11.0| | |`HIPBLAS_COMPUTE_64F`|6.0.0| | |6.0.0|
+|`CUBLAS_COMPUTE_64F_PEDANTIC`|11.0| | |`HIPBLAS_COMPUTE_64F_PEDANTIC`|6.0.0| | |6.0.0|
 |`CUBLAS_DEFAULT_MATH`|9.0| | | | | | | |
 |`CUBLAS_DIAG_NON_UNIT`| | | |`HIPBLAS_DIAG_NON_UNIT`|1.8.2| | | |
 |`CUBLAS_DIAG_UNIT`| | | |`HIPBLAS_DIAG_UNIT`|1.8.2| | | |
@@ -91,7 +91,7 @@
 |`CUBLAS_TENSOR_OP_MATH`|9.0|11.0| | | | | | |
 |`CUBLAS_TF32_TENSOR_OP_MATH`|11.0| | | | | | | |
 |`cublasAtomicsMode_t`| | | |`hipblasAtomicsMode_t`|3.10.0| | | |
-|`cublasComputeType_t`|11.0| | |`hipblasDatatype_t`|1.8.2| | | |
+|`cublasComputeType_t`|11.0| | |`hipblasComputeType_t`|6.0.0| | |6.0.0|
 |`cublasContext`| | | | | | | | |
 |`cublasDiagType_t`| | | |`hipblasDiagType_t`|1.8.2| | | |
 |`cublasFillMode_t`| | | |`hipblasFillMode_t`|1.8.2| | | |

--- a/docs/tables/CUBLAS_API_supported_by_HIP_and_ROC.md
+++ b/docs/tables/CUBLAS_API_supported_by_HIP_and_ROC.md
@@ -6,17 +6,17 @@
 |:--|:-:|:-:|:-:|:--|:-:|:-:|:-:|:-:|:--|:-:|:-:|:-:|:-:|
 |`CUBLAS_ATOMICS_ALLOWED`| | | |`HIPBLAS_ATOMICS_ALLOWED`|3.10.0| | | |`rocblas_atomics_allowed`|3.8.0| | | |
 |`CUBLAS_ATOMICS_NOT_ALLOWED`| | | |`HIPBLAS_ATOMICS_NOT_ALLOWED`|3.10.0| | | |`rocblas_atomics_not_allowed`|3.8.0| | | |
-|`CUBLAS_COMPUTE_16F`|11.0| | | | | | | | | | | | |
-|`CUBLAS_COMPUTE_16F_PEDANTIC`|11.0| | | | | | | | | | | | |
-|`CUBLAS_COMPUTE_32F`|11.0| | | | | | | |`rocblas_compute_type_f32`|5.7.0| | | |
-|`CUBLAS_COMPUTE_32F_FAST_16BF`|11.0| | | | | | | | | | | | |
-|`CUBLAS_COMPUTE_32F_FAST_16F`|11.0| | | | | | | | | | | | |
-|`CUBLAS_COMPUTE_32F_FAST_TF32`|11.0| | | | | | | | | | | | |
-|`CUBLAS_COMPUTE_32F_PEDANTIC`|11.0| | | | | | | | | | | | |
-|`CUBLAS_COMPUTE_32I`|11.0| | | | | | | | | | | | |
-|`CUBLAS_COMPUTE_32I_PEDANTIC`|11.0| | | | | | | | | | | | |
-|`CUBLAS_COMPUTE_64F`|11.0| | | | | | | | | | | | |
-|`CUBLAS_COMPUTE_64F_PEDANTIC`|11.0| | | | | | | | | | | | |
+|`CUBLAS_COMPUTE_16F`|11.0| | |`HIPBLAS_COMPUTE_16F`|6.0.0| | |6.0.0| | | | | |
+|`CUBLAS_COMPUTE_16F_PEDANTIC`|11.0| | |`HIPBLAS_COMPUTE_16F_PEDANTIC`|6.0.0| | |6.0.0| | | | | |
+|`CUBLAS_COMPUTE_32F`|11.0| | |`HIPBLAS_COMPUTE_32F`|6.0.0| | |6.0.0|`rocblas_compute_type_f32`|5.7.0| | | |
+|`CUBLAS_COMPUTE_32F_FAST_16BF`|11.0| | |`HIPBLAS_COMPUTE_32F_FAST_16BF`|6.0.0| | |6.0.0| | | | | |
+|`CUBLAS_COMPUTE_32F_FAST_16F`|11.0| | |`HIPBLAS_COMPUTE_32F_FAST_16F`|6.0.0| | |6.0.0| | | | | |
+|`CUBLAS_COMPUTE_32F_FAST_TF32`|11.0| | |`HIPBLAS_COMPUTE_32F_FAST_TF32`|6.0.0| | |6.0.0| | | | | |
+|`CUBLAS_COMPUTE_32F_PEDANTIC`|11.0| | |`HIPBLAS_COMPUTE_32F_PEDANTIC`|6.0.0| | |6.0.0| | | | | |
+|`CUBLAS_COMPUTE_32I`|11.0| | |`HIPBLAS_COMPUTE_32I`|6.0.0| | |6.0.0| | | | | |
+|`CUBLAS_COMPUTE_32I_PEDANTIC`|11.0| | |`HIPBLAS_COMPUTE_32I_PEDANTIC`|6.0.0| | |6.0.0| | | | | |
+|`CUBLAS_COMPUTE_64F`|11.0| | |`HIPBLAS_COMPUTE_64F`|6.0.0| | |6.0.0| | | | | |
+|`CUBLAS_COMPUTE_64F_PEDANTIC`|11.0| | |`HIPBLAS_COMPUTE_64F_PEDANTIC`|6.0.0| | |6.0.0| | | | | |
 |`CUBLAS_DEFAULT_MATH`|9.0| | | | | | | |`rocblas_default_math`|5.7.0| | | |
 |`CUBLAS_DIAG_NON_UNIT`| | | |`HIPBLAS_DIAG_NON_UNIT`|1.8.2| | | |`rocblas_diagonal_non_unit`|1.5.0| | | |
 |`CUBLAS_DIAG_UNIT`| | | |`HIPBLAS_DIAG_UNIT`|1.8.2| | | |`rocblas_diagonal_unit`|1.5.0| | | |
@@ -91,7 +91,7 @@
 |`CUBLAS_TENSOR_OP_MATH`|9.0|11.0| | | | | | | | | | | |
 |`CUBLAS_TF32_TENSOR_OP_MATH`|11.0| | | | | | | |`rocblas_xf32_xdl_math_op`|5.7.0| | | |
 |`cublasAtomicsMode_t`| | | |`hipblasAtomicsMode_t`|3.10.0| | | |`rocblas_atomics_mode`|3.8.0| | | |
-|`cublasComputeType_t`|11.0| | |`hipblasDatatype_t`|1.8.2| | | |`rocblas_computetype`|5.7.0| | | |
+|`cublasComputeType_t`|11.0| | |`hipblasComputeType_t`|6.0.0| | |6.0.0|`rocblas_computetype`|5.7.0| | | |
 |`cublasContext`| | | | | | | | |`_rocblas_handle`|1.5.0| | | |
 |`cublasDiagType_t`| | | |`hipblasDiagType_t`|1.8.2| | | |`rocblas_diagonal`|1.5.0| | | |
 |`cublasFillMode_t`| | | |`hipblasFillMode_t`|1.8.2| | | |`rocblas_fill`|1.5.0| | | |

--- a/src/CUDA2HIP_BLAS_API_types.cpp
+++ b/src/CUDA2HIP_BLAS_API_types.cpp
@@ -169,20 +169,18 @@ const std::map<llvm::StringRef, hipCounter> CUDA_BLAS_TYPE_NAME_MAP {
   // TODO: dereferencing: typedef struct cublasContext *cublasHandle_t;
   {"cublasContext",                  {"hipblasContext",                  "_rocblas_handle",                       CONV_TYPE, API_BLAS, 2, HIP_UNSUPPORTED}},
 
-  // NOTE: renamed UNSUPPORTED hipblasComputeType_t to the HIP supported hipblasDatatype_t (workaround)
-  // TODO: change the type to the correct one after fixing https://github.com/ROCmSoftwarePlatform/hipBLAS/issues/529
-  {"cublasComputeType_t",            {"hipblasDatatype_t",               "rocblas_computetype",                   CONV_TYPE, API_BLAS, 2}},
-  {"CUBLAS_COMPUTE_16F",             {"HIPBLAS_COMPUTE_16F",             "",                                      CONV_NUMERIC_LITERAL, API_BLAS, 2, UNSUPPORTED}}, // 64
-  {"CUBLAS_COMPUTE_16F_PEDANTIC",    {"HIPBLAS_COMPUTE_16F_PEDANTIC",    "",                                      CONV_NUMERIC_LITERAL, API_BLAS, 2, UNSUPPORTED}}, // 65
-  {"CUBLAS_COMPUTE_32F",             {"HIPBLAS_COMPUTE_32F",             "rocblas_compute_type_f32",              CONV_NUMERIC_LITERAL, API_BLAS, 2, HIP_UNSUPPORTED}}, // 68
-  {"CUBLAS_COMPUTE_32F_PEDANTIC",    {"HIPBLAS_COMPUTE_32F_PEDANTIC",    "",                                      CONV_NUMERIC_LITERAL, API_BLAS, 2, UNSUPPORTED}}, // 69
-  {"CUBLAS_COMPUTE_32F_FAST_16F",    {"HIPBLAS_COMPUTE_32F_FAST_16F",    "",                                      CONV_NUMERIC_LITERAL, API_BLAS, 2, UNSUPPORTED}}, // 74
-  {"CUBLAS_COMPUTE_32F_FAST_16BF",   {"HIPBLAS_COMPUTE_32F_FAST_16BF",   "",                                      CONV_NUMERIC_LITERAL, API_BLAS, 2, UNSUPPORTED}}, // 75
-  {"CUBLAS_COMPUTE_32F_FAST_TF32",   {"HIPBLAS_COMPUTE_32F_FAST_TF32",   "",                                      CONV_NUMERIC_LITERAL, API_BLAS, 2, UNSUPPORTED}}, // 77
-  {"CUBLAS_COMPUTE_64F",             {"HIPBLAS_COMPUTE_64F",             "",                                      CONV_NUMERIC_LITERAL, API_BLAS, 2, UNSUPPORTED}}, // 70
-  {"CUBLAS_COMPUTE_64F_PEDANTIC",    {"HIPBLAS_COMPUTE_64F_PEDANTIC",    "",                                      CONV_NUMERIC_LITERAL, API_BLAS, 2, UNSUPPORTED}}, // 71
-  {"CUBLAS_COMPUTE_32I",             {"HIPBLAS_COMPUTE_32I",             "",                                      CONV_NUMERIC_LITERAL, API_BLAS, 2, UNSUPPORTED}}, // 72
-  {"CUBLAS_COMPUTE_32I_PEDANTIC",    {"HIPBLAS_COMPUTE_32I_PEDANTIC",    "",                                      CONV_NUMERIC_LITERAL, API_BLAS, 2, UNSUPPORTED}}, // 73
+  {"cublasComputeType_t",            {"hipblasComputeType_t",            "rocblas_computetype",                   CONV_TYPE, API_BLAS, 2}},
+  {"CUBLAS_COMPUTE_16F",             {"HIPBLAS_COMPUTE_16F",             "",                                      CONV_NUMERIC_LITERAL, API_BLAS, 2, ROC_UNSUPPORTED}}, // 64
+  {"CUBLAS_COMPUTE_16F_PEDANTIC",    {"HIPBLAS_COMPUTE_16F_PEDANTIC",    "",                                      CONV_NUMERIC_LITERAL, API_BLAS, 2, ROC_UNSUPPORTED}}, // 65
+  {"CUBLAS_COMPUTE_32F",             {"HIPBLAS_COMPUTE_32F",             "rocblas_compute_type_f32",              CONV_NUMERIC_LITERAL, API_BLAS, 2}}, // 68
+  {"CUBLAS_COMPUTE_32F_PEDANTIC",    {"HIPBLAS_COMPUTE_32F_PEDANTIC",    "",                                      CONV_NUMERIC_LITERAL, API_BLAS, 2, ROC_UNSUPPORTED}}, // 69
+  {"CUBLAS_COMPUTE_32F_FAST_16F",    {"HIPBLAS_COMPUTE_32F_FAST_16F",    "",                                      CONV_NUMERIC_LITERAL, API_BLAS, 2, ROC_UNSUPPORTED}}, // 74
+  {"CUBLAS_COMPUTE_32F_FAST_16BF",   {"HIPBLAS_COMPUTE_32F_FAST_16BF",   "",                                      CONV_NUMERIC_LITERAL, API_BLAS, 2, ROC_UNSUPPORTED}}, // 75
+  {"CUBLAS_COMPUTE_32F_FAST_TF32",   {"HIPBLAS_COMPUTE_32F_FAST_TF32",   "",                                      CONV_NUMERIC_LITERAL, API_BLAS, 2, ROC_UNSUPPORTED}}, // 77
+  {"CUBLAS_COMPUTE_64F",             {"HIPBLAS_COMPUTE_64F",             "",                                      CONV_NUMERIC_LITERAL, API_BLAS, 2, ROC_UNSUPPORTED}}, // 70
+  {"CUBLAS_COMPUTE_64F_PEDANTIC",    {"HIPBLAS_COMPUTE_64F_PEDANTIC",    "",                                      CONV_NUMERIC_LITERAL, API_BLAS, 2, ROC_UNSUPPORTED}}, // 71
+  {"CUBLAS_COMPUTE_32I",             {"HIPBLAS_COMPUTE_32I",             "",                                      CONV_NUMERIC_LITERAL, API_BLAS, 2, ROC_UNSUPPORTED}}, // 72
+  {"CUBLAS_COMPUTE_32I_PEDANTIC",    {"HIPBLAS_COMPUTE_32I_PEDANTIC",    "",                                      CONV_NUMERIC_LITERAL, API_BLAS, 2, ROC_UNSUPPORTED}}, // 73
 };
 
 const std::map<llvm::StringRef, cudaAPIversions> CUDA_BLAS_TYPE_NAME_VER_MAP {
@@ -353,6 +351,18 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_BLAS_TYPE_NAME_VER_MAP {
   {"HIP_C_32U",                                        {HIP_5070, HIP_0,    HIP_0   }},
   {"HIP_R_16BF",                                       {HIP_5070, HIP_0,    HIP_0   }},
   {"HIP_C_16BF",                                       {HIP_5070, HIP_0,    HIP_0   }},
+  {"hipblasComputeType_t",                             {HIP_6000, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"HIPBLAS_COMPUTE_16F",                              {HIP_6000, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"HIPBLAS_COMPUTE_16F_PEDANTIC",                     {HIP_6000, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"HIPBLAS_COMPUTE_32F",                              {HIP_6000, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"HIPBLAS_COMPUTE_32F_PEDANTIC",                     {HIP_6000, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"HIPBLAS_COMPUTE_32F_FAST_16F",                     {HIP_6000, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"HIPBLAS_COMPUTE_32F_FAST_16BF",                    {HIP_6000, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"HIPBLAS_COMPUTE_32F_FAST_TF32",                    {HIP_6000, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"HIPBLAS_COMPUTE_64F",                              {HIP_6000, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"HIPBLAS_COMPUTE_64F_PEDANTIC",                     {HIP_6000, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"HIPBLAS_COMPUTE_32I",                              {HIP_6000, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"HIPBLAS_COMPUTE_32I_PEDANTIC",                     {HIP_6000, HIP_0,    HIP_0,  HIP_LATEST}},
   {"rocblas_handle",                                   {HIP_1050, HIP_0,    HIP_0   }},
   {"_rocblas_handle",                                  {HIP_1050, HIP_0,    HIP_0   }},
   {"rocblas_operation",                                {HIP_1050, HIP_0,    HIP_0   }},

--- a/tests/unit_tests/synthetic/libraries/cublas2hipblas.cu
+++ b/tests/unit_tests/synthetic/libraries/cublas2hipblas.cu
@@ -1570,9 +1570,7 @@ int main() {
   cublasDataType_t R_16BF = CUDA_R_16BF;
   cublasDataType_t C_16BF = CUDA_C_16BF;
 
-  // NOTE: WORKAROUND: cublasComputeType_t is not actually supported by hipBLAS
-  // TODO: Fix it after fixing https://github.com/ROCmSoftwarePlatform/hipBLAS/issues/529
-  // CHECK: hipblasDatatype_t blasComputeType;
+  // CHECK: hipblasComputeType_t blasComputeType;
   cublasComputeType_t blasComputeType;
 
   // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasGemmEx(cublasHandle_t handle, cublasOperation_t transa, cublasOperation_t transb, int m, int n, int k, const void* alpha, const void* A, cudaDataType Atype, int lda, const void* B, cudaDataType Btype, int ldb, const void* beta, void* C, cudaDataType Ctype, int ldc, cublasComputeType_t computeType, cublasGemmAlgo_t algo);

--- a/tests/unit_tests/synthetic/libraries/cublas2hipblas_v2.cu
+++ b/tests/unit_tests/synthetic/libraries/cublas2hipblas_v2.cu
@@ -1739,9 +1739,7 @@ int main() {
   cublasDataType_t R_16BF = CUDA_R_16BF;
   cublasDataType_t C_16BF = CUDA_C_16BF;
 
-  // NOTE: WORKAROUND: cublasComputeType_t is not actually supported by hipBLAS
-  // TODO: Fix it after fixing https://github.com/ROCmSoftwarePlatform/hipBLAS/issues/529
-  // CHECK: hipblasDatatype_t blasComputeType;
+  // CHECK: hipblasComputeType_t blasComputeType;
   cublasComputeType_t blasComputeType;
 
   // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasGemmEx(cublasHandle_t handle, cublasOperation_t transa, cublasOperation_t transb, int m, int n, int k, const void* alpha, const void* A, cudaDataType Atype, int lda, const void* B, cudaDataType Btype, int ldb, const void* beta, void* C, cudaDataType Ctype, int ldc, cublasComputeType_t computeType, cublasGemmAlgo_t algo);


### PR DESCRIPTION
**[IMP]**
+ In hipBLAS 6.0.0, https://github.com/ROCmSoftwarePlatform/hipBLAS/issues/529 is finally fixed, thus HIPIFY can use `hipblasComputeType_t` instead of `hipblasDatatype_t`, where `cublasComputeType_t` is implied

**[TODO]**
+ Revise all the hipBLAS functions which use `hipblasDatatype_t` instead of `hipblasComputeType_t`
+ Close ROCmSoftwarePlatform/hipBLAS/issues/529 as implemented with the releasing of hipBLAS 6.0.0