### PR TITLE
[HIPIFY][doc] LLVM 17.0.3 is the latest supported LLVM release

### DIFF
--- a/docs/hipify-clang.md
+++ b/docs/hipify-clang.md
@@ -21,7 +21,7 @@ After applying all the matchers, the output HIP source is produced.
 
 `hipify-clang` requires:
 
-1. [**LLVM+CLANG**](http://releases.llvm.org) of at least version [4.0.0](http://releases.llvm.org/download.html#4.0.0); the latest stable and recommended release: [**17.0.2**](https://github.com/llvm/llvm-project/releases/tag/llvmorg-17.0.2).
+1. [**LLVM+CLANG**](http://releases.llvm.org) of at least version [4.0.0](http://releases.llvm.org/download.html#4.0.0); the latest stable and recommended release: [**17.0.3**](https://github.com/llvm/llvm-project/releases/tag/llvmorg-17.0.3).
 
 2. [**CUDA**](https://developer.nvidia.com/cuda-downloads) of at least version [8.0](https://developer.nvidia.com/cuda-80-ga2-download-archive), the latest supported version is [**12.2.2**](https://developer.nvidia.com/cuda-downloads).
 
@@ -175,7 +175,8 @@ After applying all the matchers, the output HIP source is produced.
     </tr>
     <tr align="center">
       <td bgcolor="eefaeb"><a href="https://github.com/llvm/llvm-project/releases/tag/llvmorg-17.0.1">17.0.1</a>,
-                           <a href="https://github.com/llvm/llvm-project/releases/tag/llvmorg-17.0.2"><b>17.0.2</b></a></td>
+                           <a href="https://github.com/llvm/llvm-project/releases/tag/llvmorg-17.0.2">17.0.2</a>,
+                           <a href="https://github.com/llvm/llvm-project/releases/tag/llvmorg-17.0.3"><b>17.0.3</b></a></td>
       <td bgcolor="eefaeb"><a href="https://developer.nvidia.com/cuda-downloads"><b>12.2.2</b></a></td>
       <td colspan=2 bgcolor="eefaeb"><font color="green"><b>LATEST STABLE CONFIG</b></font></td>
     </tr>
@@ -197,7 +198,7 @@ After applying all the matchers, the output HIP source is produced.
 In most cases, you can get a suitable version of `LLVM+CLANG` with your package manager.
 
 Failing that or having multiple versions of `LLVM`, you can [download a release archive](http://releases.llvm.org/), build or install it, and set
-[CMAKE_PREFIX_PATH](https://cmake.org/cmake/help/v3.5/variable/CMAKE_PREFIX_PATH.html) so `cmake` can find it; for instance: `-DCMAKE_PREFIX_PATH=D:\LLVM\17.0.2\dist`
+[CMAKE_PREFIX_PATH](https://cmake.org/cmake/help/v3.5/variable/CMAKE_PREFIX_PATH.html) so `cmake` can find it; for instance: `-DCMAKE_PREFIX_PATH=D:\LLVM\17.0.3\dist`
 
 ### <a name="hipify-clang-usage"></a>hipify-clang: usage
 
@@ -297,7 +298,7 @@ Run `Visual Studio 16 2019`, open the generated `LLVM.sln`, build all, and build
 
 **LLVM >= 10.0.0:**
 
-1. download [`LLVM project`](https://github.com/llvm/llvm-project/releases/tag/llvmorg-17.0.2) sources;
+1. download [`LLVM project`](https://github.com/llvm/llvm-project/releases/tag/llvmorg-17.0.3) sources;
 2. build [`LLVM project`](http://llvm.org/docs/CMake.html):
 
 ```bash
@@ -364,9 +365,9 @@ Run `Visual Studio 17 2022`, open the generated `LLVM.sln`, build all, build pro
 
     * Install `lit` into `python`:
 
-        - ***Linux***: `python /usr/llvm/17.0.2/llvm-project/llvm/utils/lit/setup.py install`
+        - ***Linux***: `python /usr/llvm/17.0.3/llvm-project/llvm/utils/lit/setup.py install`
 
-        - ***Windows***: `python D:/LLVM/17.0.2/llvm-project/llvm/utils/lit/setup.py install`
+        - ***Windows***: `python D:/LLVM/17.0.3/llvm-project/llvm/utils/lit/setup.py install`
 
        In case of errors, similar to `ModuleNotFoundError: No module named 'setuptools'`, upgrade the `setuptools` package:
 
@@ -374,15 +375,15 @@ Run `Visual Studio 17 2022`, open the generated `LLVM.sln`, build all, build pro
 
     * Starting with LLVM 6.0.1 path to `llvm-lit` python script should be specified by the `LLVM_EXTERNAL_LIT` option:
 
-        - ***Linux***: `-DLLVM_EXTERNAL_LIT=/usr/llvm/17.0.2/build/bin/llvm-lit`
+        - ***Linux***: `-DLLVM_EXTERNAL_LIT=/usr/llvm/17.0.3/build/bin/llvm-lit`
 
-        - ***Windows***: `-DLLVM_EXTERNAL_LIT=D:/LLVM/17.0.2/build/Release/bin/llvm-lit.py`
+        - ***Windows***: `-DLLVM_EXTERNAL_LIT=D:/LLVM/17.0.3/build/Release/bin/llvm-lit.py`
 
     * `FileCheck`:
 
-        - ***Linux***: copy from `/usr/llvm/17.0.2/build/bin/` to `CMAKE_INSTALL_PREFIX/dist/bin`
+        - ***Linux***: copy from `/usr/llvm/17.0.3/build/bin/` to `CMAKE_INSTALL_PREFIX/dist/bin`
 
-        - ***Windows***: copy from `D:/LLVM/17.0.2/build/Release/bin` to `CMAKE_INSTALL_PREFIX/dist/bin`
+        - ***Windows***: copy from `D:/LLVM/17.0.3/build/Release/bin` to `CMAKE_INSTALL_PREFIX/dist/bin`
 
         - Or specify the path to `FileCheck` in `CMAKE_INSTALL_PREFIX` option
 
@@ -404,9 +405,9 @@ Ubuntu 14: LLVM 4.0.0 - 7.1.0, CUDA 7.0 - 9.0, cuDNN 5.0.5 - 7.6.5
 
 Ubuntu 16-18: LLVM 8.0.0 - 14.0.6, CUDA 8.0 - 10.2, cuDNN 5.1.10 - 8.0.5
 
-Ubuntu 20-21: LLVM 9.0.0 - 17.0.2, CUDA 8.0 - 12.2.2, cuDNN 5.1.10 - 8.9.5
+Ubuntu 20-21: LLVM 9.0.0 - 17.0.3, CUDA 8.0 - 12.2.2, cuDNN 5.1.10 - 8.9.5
 
-Ubuntu 22: LLVM 13.0.0 - 17.0.2, CUDA 10.0 - 12.2.2, cuDNN 8.0.5 - 8.9.5
+Ubuntu 22: LLVM 13.0.0 - 17.0.3, CUDA 10.0 - 12.2.2, cuDNN 8.0.5 - 8.9.5
 
 Minimum build system requirements for the above configurations:
 
@@ -423,11 +424,11 @@ cmake
  -DHIPIFY_CLANG_TESTS=ON \
  -DCMAKE_BUILD_TYPE=Release \
  -DCMAKE_INSTALL_PREFIX=../dist \
- -DCMAKE_PREFIX_PATH=/usr/llvm/17.0.2/dist \
+ -DCMAKE_PREFIX_PATH=/usr/llvm/17.0.3/dist \
  -DCUDA_TOOLKIT_ROOT_DIR=/usr/local/cuda \
  -DCUDA_DNN_ROOT_DIR=/usr/local/cuda \
  -DCUDA_CUB_ROOT_DIR=/usr/CUB \
- -DLLVM_EXTERNAL_LIT=/usr/llvm/17.0.2/build/bin/llvm-lit \
+ -DLLVM_EXTERNAL_LIT=/usr/llvm/17.0.3/build/bin/llvm-lit \
  ../hipify
 ```
 
@@ -447,14 +448,14 @@ cmake
 -- Detecting CXX compile features
 -- Detecting CXX compile features - done
 -- Found ZLIB: /usr/lib/x86_64-linux-gnu/libz.so (found version "1.2.11")
--- Found LLVM 17.0.2:
---    - CMake module path: /usr/llvm/17.0.2/dist/lib/cmake/llvm
---    - Include path     : /usr/llvm/17.0.2/dist/include
---    - Binary path      : /usr/llvm/17.0.2/dist/bin
+-- Found LLVM 17.0.3:
+--    - CMake module path: /usr/llvm/17.0.3/dist/lib/cmake/llvm
+--    - Include path     : /usr/llvm/17.0.3/dist/include
+--    - Binary path      : /usr/llvm/17.0.3/dist/bin
 -- Linker detection: GNU ld
 -- Found PythonInterp: /usr/bin/python (found suitable version "3.9.7", minimum required is "2.7")
 -- Found lit: /usr/local/bin/lit
--- Found FileCheck: /usr/llvm/17.0.2/dist/bin/FileCheck
+-- Found FileCheck: /usr/llvm/17.0.3/dist/bin/FileCheck
 -- Looking for pthread.h
 -- Looking for pthread.h - found
 -- Performing Test CMAKE_HAVE_LIBC_PTHREAD
@@ -475,7 +476,7 @@ make test-hipify
 Running HIPify regression tests
 ========================================
 CUDA 12.2 - will be used for testing
-LLVM 17.0.2 - will be used for testing
+LLVM 17.0.3 - will be used for testing
 x86_64 - Platform architecture
 Linux 5.13.0-21-generic - Platform OS
 64 - hipify-clang binary bitness
@@ -594,7 +595,7 @@ Testing Time: 7.90s
 | 14.0.0 - 14.0.6 | 7.0 - 11.7.1 | 8.0.5  - 8.4.1 | 2017.15.9.57*, 2019.16.11.17, 2022.17.2.6 | 3.24.0          | 3.10.6        |
 | 15.0.0 - 15.0.7 | 7.0 - 11.8.0 | 8.0.5  - 8.8.1 | 2019.16.11.25, 2022.17.5.2                | 3.26.0          | 3.11.2        |
 | 16.0.0 - 16.0.6 | 7.0 - 12.2.2 | 8.0.5  - 8.9.5 | 2019.16.11.29, 2022.17.7.1                | 3.27.3          | 3.11.4        |
-| 17.0.1** 17.0.2 | 7.0 - 12.2.2 | 8.0.5  - 8.9.5 | 2019.16.11.30, 2022.17.7.4                | 3.27.6          | 3.12.0        |
+| 17.0.1** 17.0.3 | 7.0 - 12.2.2 | 8.0.5  - 8.9.5 | 2019.16.11.30, 2022.17.7.4                | 3.27.6          | 3.12.0        |
 | 18.0.0git       | 7.0 - 12.2.2 | 8.0.5  - 8.9.5 | 2019.16.11.30, 2022.17.7.4                | 3.27.6          | 3.12.0        |
 
 `*` LLVM 14.x.x is the latest major release supporting Visual Studio 2017.
@@ -613,12 +614,12 @@ cmake
  -DHIPIFY_CLANG_TESTS=ON \
  -DCMAKE_BUILD_TYPE=Release \
  -DCMAKE_INSTALL_PREFIX=../dist \
- -DCMAKE_PREFIX_PATH=D:/LLVM/17.0.2/dist \
+ -DCMAKE_PREFIX_PATH=D:/LLVM/17.0.3/dist \
  -DCUDA_TOOLKIT_ROOT_DIR="C:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v12.2" \
  -DCUDA_SDK_ROOT_DIR="C:/ProgramData/NVIDIA Corporation/CUDA Samples/v12.2" \
  -DCUDA_DNN_ROOT_DIR=D:/CUDA/cuDNN/8.9.5 \
  -DCUDA_CUB_ROOT_DIR=D:/CUDA/CUB/cub-2.1.0 \
- -DLLVM_EXTERNAL_LIT=D:/LLVM/17.0.2/build/Release/bin/llvm-lit.py \
+ -DLLVM_EXTERNAL_LIT=D:/LLVM/17.0.3/build/Release/bin/llvm-lit.py \
  ../hipify
 ```
 *A corresponding successful output:*
@@ -640,21 +641,21 @@ cmake
 --    - Build hipify-clang : ON
 --    - Test  hipify-clang : ON
 --    - Is part of HIP SDK : OFF
--- Found LLVM 17.0.2:
---    - CMake module path  : D:/LLVM/17.0.2/dist/lib/cmake/llvm
---    - Clang include path : D:/LLVM/17.0.2/dist/include
---    - LLVM Include path  : D:/LLVM/17.0.2/dist/include
---    - Binary path        : D:/LLVM/17.0.2/dist/bin
+-- Found LLVM 17.0.3:
+--    - CMake module path  : D:/LLVM/17.0.3/dist/lib/cmake/llvm
+--    - Clang include path : D:/LLVM/17.0.3/dist/include
+--    - LLVM Include path  : D:/LLVM/17.0.3/dist/include
+--    - Binary path        : D:/LLVM/17.0.3/dist/bin
 -- ---- The below configuring for hipify-clang testing only ----
 -- Found Python: C:/Users/TT/AppData/Local/Programs/Python/Python312/python.exe (found version "3.12.0") found components: Interpreter
 -- Found lit: C:/Users/TT/AppData/Local/Programs/Python/Python312/Scripts/lit.exe
--- Found FileCheck: D:/toltec/work/LLVM/trunk-for-submit/llvm-64-release-vs2022-17.7.4/dist/bin/FileCheck.exe
+-- Found FileCheck: D:/LLVM/17.0.3/dist/bin/FileCheck.exe
 -- Initial CUDA to configure:
 --    - CUDA Toolkit path  : C:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v12.2
 --    - CUDA Samples path  : C:/ProgramData/NVIDIA Corporation/CUDA Samples/v12.2
 --    - cuDNN path         : D:/CUDA/cuDNN/8.9.5
 --    - CUB path           : D:/CUDA/CUB/cub-2.1.0
--- Found CUDAToolkit: C:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v11.8/include (found version "12.2.140")
+-- Found CUDAToolkit: C:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v12.2/include (found version "12.2.140")
 -- Found CUDA config:
 --    - CUDA Toolkit path  : C:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v12.2
 --    - CUDA Samples path  : C:/ProgramData/NVIDIA Corporation/CUDA Samples/v12.2


### PR DESCRIPTION
+ No patches are needed
+ Updated README.md accordingly
+ Tested on Windows 11 and Ubuntu 21.10
+ Fixed typos
