### PR TITLE
[HIPIFY][SWDEV-427658][build][compatibility][fix] Added an explicit include for `HeaderSearch.h` for LLVM < 13

### DIFF
--- a/src/LLVMCompat.cpp
+++ b/src/LLVMCompat.cpp
@@ -23,6 +23,9 @@ THE SOFTWARE.
 #include "ArgParse.h"
 #include "LLVMCompat.h"
 #include "llvm/Support/Path.h"
+#if LLVM_VERSION_MAJOR < 13
+#include "clang/Lex/HeaderSearch.h"
+#endif
 #include "clang/Lex/PreprocessorOptions.h"
 #include "clang/Frontend/CompilerInstance.h"
 


### PR DESCRIPTION
+ This fixes the compilation error that occurred when building against LLVM < 13:

```cpp
/hipify/src/LLVMCompat.cpp:182:46: error: member access into incomplete type 'clang::HeaderSearch'
  clang::ExternalPreprocessorSource *EPL = HS.getExternalLookup();
                                             ^
/root/llvm-project-llvmorg-12.0.1/dist/include/clang/Lex/ModuleMap.h:42:7: note: forward declaration of 'clang::HeaderSearch'
class HeaderSearch;
      ^
/hipify/src/LLVMCompat.cpp:187:12: error: member access into incomplete type 'clang::HeaderSearch'
  return HS.getFileInfo(FE).getControllingMacro(EPL);
           ^
/root/llvm-project-llvmorg-12.0.1/dist/include/clang/Lex/ModuleMap.h:42:7: note: forward declaration of 'clang::HeaderSearch'
class HeaderSearch;
      ^
2 errors generated.
```