### PR TITLE
[HIPIFY][6.0.0][hipSPARSE] Support for ROCm HIP 6.0.0 - Step 22 - hipSPARSE

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -3597,6 +3597,8 @@ sub simpleSubstitutions {
     subst("cusparseChybmv", "hipsparseChybmv", "library");
     subst("cusparseCnnz", "hipsparseCnnz", "library");
     subst("cusparseCnnz_compress", "hipsparseCnnz_compress", "library");
+    subst("cusparseConstSpVecGet", "hipsparseConstSpVecGet", "library");
+    subst("cusparseConstSpVecGetValues", "hipsparseConstSpVecGetValues", "library");
     subst("cusparseCooAoSGet", "hipsparseCooAoSGet", "library");
     subst("cusparseCooGet", "hipsparseCooGet", "library");
     subst("cusparseCooSetPointers", "hipsparseCooSetPointers", "library");
@@ -3609,6 +3611,7 @@ sub simpleSubstitutions {
     subst("cusparseCreateBsrsm2Info", "hipsparseCreateBsrsm2Info", "library");
     subst("cusparseCreateBsrsv2Info", "hipsparseCreateBsrsv2Info", "library");
     subst("cusparseCreateColorInfo", "hipsparseCreateColorInfo", "library");
+    subst("cusparseCreateConstSpVec", "hipsparseCreateConstSpVec", "library");
     subst("cusparseCreateCoo", "hipsparseCreateCoo", "library");
     subst("cusparseCreateCooAoS", "hipsparseCreateCooAoS", "library");
     subst("cusparseCreateCsc", "hipsparseCreateCsc", "library");
@@ -3761,6 +3764,8 @@ sub simpleSubstitutions {
     subst("cusparseDroti", "hipsparseDroti", "library");
     subst("cusparseDsctr", "hipsparseDsctr", "library");
     subst("cusparseGather", "hipsparseGather", "library");
+    subst("cusparseGetErrorName", "hipsparseGetErrorName", "library");
+    subst("cusparseGetErrorString", "hipsparseGetErrorString", "library");
     subst("cusparseGetMatDiagType", "hipsparseGetMatDiagType", "library");
     subst("cusparseGetMatFillMode", "hipsparseGetMatFillMode", "library");
     subst("cusparseGetMatIndexBase", "hipsparseGetMatIndexBase", "library");
@@ -4543,6 +4548,7 @@ sub simpleSubstitutions {
     subst("curandStatus_t", "hiprandStatus_t", "type");
     subst("cusparseAction_t", "hipsparseAction_t", "type");
     subst("cusparseColorInfo_t", "hipsparseColorInfo_t", "type");
+    subst("cusparseConstSpVecDescr_t", "hipsparseConstSpVecDescr_t", "type");
     subst("cusparseCsr2CscAlg_t", "hipsparseCsr2CscAlg_t", "type");
     subst("cusparseDenseToSparseAlg_t", "hipsparseDenseToSparseAlg_t", "type");
     subst("cusparseDiagType_t", "hipsparseDiagType_t", "type");
@@ -6893,7 +6899,6 @@ sub warnUnsupportedFunctions {
         "cusparseCscGet",
         "cusparseCreateSolveAnalysisInfo",
         "cusparseCreateSlicedEll",
-        "cusparseCreateConstSpVec",
         "cusparseCreateConstSlicedEll",
         "cusparseCreateConstDnVec",
         "cusparseCreateConstDnMat",
@@ -6906,9 +6911,6 @@ sub warnUnsupportedFunctions {
         "cusparseContext",
         "cusparseConstrainedGeMM_bufferSize",
         "cusparseConstrainedGeMM",
-        "cusparseConstSpVecGetValues",
-        "cusparseConstSpVecGet",
-        "cusparseConstSpVecDescr_t",
         "cusparseConstSpMatGetValues",
         "cusparseConstSpMatDescr_t",
         "cusparseConstDnVecGetValues",

--- a/docs/tables/CUSPARSE_API_supported_by_HIP.md
+++ b/docs/tables/CUSPARSE_API_supported_by_HIP.md
@@ -136,7 +136,7 @@
 |`cusparseConstDnMatDescr_t`|12.0| | | | | | | | |
 |`cusparseConstDnVecDescr_t`|12.0| | | | | | | | |
 |`cusparseConstSpMatDescr_t`|12.0| | | | | | | | |
-|`cusparseConstSpVecDescr_t`|12.0| | | | | | | | |
+|`cusparseConstSpVecDescr_t`|12.0| | |`hipsparseConstSpVecDescr_t`|6.0.0| | | |6.0.0|
 |`cusparseContext`| | | | | | | | | |
 |`cusparseCsr2CscAlg_t`|10.1| | |`hipsparseCsr2CscAlg_t`|5.4.0| | | | |
 |`cusparseDenseToSparseAlg_t`|11.1| | |`hipsparseDenseToSparseAlg_t`|4.2.0| | | | |
@@ -197,6 +197,8 @@
 |:--|:-:|:-:|:-:|:-:|:--|:-:|:-:|:-:|:-:|
 |`cusparseCreate`| | | |`hipsparseCreate`|1.9.2| | | | |
 |`cusparseDestroy`| | | |`hipsparseDestroy`|1.9.2| | | | |
+|`cusparseGetErrorName`|10.2| | |`hipsparseGetErrorName`|6.0.0| | | |6.0.0|
+|`cusparseGetErrorString`|10.2| | |`hipsparseGetErrorString`|6.0.0| | | |6.0.0|
 |`cusparseGetPointerMode`| | | |`hipsparseGetPointerMode`|1.9.2| | | | |
 |`cusparseGetStream`| | | |`hipsparseGetStream`|1.9.2| | | | |
 |`cusparseGetVersion`| | | |`hipsparseGetVersion`|1.9.2| | | | |
@@ -808,8 +810,8 @@
 |`cusparseConstDnVecGet`|12.0| | | | | | | | |
 |`cusparseConstDnVecGetValues`|12.0| | | | | | | | |
 |`cusparseConstSpMatGetValues`|12.0| | | | | | | | |
-|`cusparseConstSpVecGet`|12.0| | | | | | | | |
-|`cusparseConstSpVecGetValues`|12.0| | | | | | | | |
+|`cusparseConstSpVecGet`|12.0| | |`hipsparseConstSpVecGet`|6.0.0| | | |6.0.0|
+|`cusparseConstSpVecGetValues`|12.0| | |`hipsparseConstSpVecGetValues`|6.0.0| | | |6.0.0|
 |`cusparseConstrainedGeMM`|10.2|11.2|12.0| | | | | | |
 |`cusparseConstrainedGeMM_bufferSize`|10.2|11.2|12.0| | | | | | |
 |`cusparseCooAoSGet`|10.2|11.2|12.0|`hipsparseCooAoSGet`|4.1.0| | | | |
@@ -826,7 +828,7 @@
 |`cusparseCreateConstDnMat`|12.0| | | | | | | | |
 |`cusparseCreateConstDnVec`|12.0| | | | | | | | |
 |`cusparseCreateConstSlicedEll`|12.1| | | | | | | | |
-|`cusparseCreateConstSpVec`|12.0| | | | | | | | |
+|`cusparseCreateConstSpVec`|12.0| | |`hipsparseCreateConstSpVec`|6.0.0| | | |6.0.0|
 |`cusparseCreateCoo`|10.1| | |`hipsparseCreateCoo`|4.1.0| | | | |
 |`cusparseCreateCooAoS`|10.2|11.2|12.0|`hipsparseCreateCooAoS`|4.1.0| | | | |
 |`cusparseCreateCsc`|11.1| | |`hipsparseCreateCsc`|4.2.0| | | | |

--- a/docs/tables/CUSPARSE_API_supported_by_HIP_and_ROC.md
+++ b/docs/tables/CUSPARSE_API_supported_by_HIP_and_ROC.md
@@ -136,7 +136,7 @@
 |`cusparseConstDnMatDescr_t`|12.0| | | | | | | | | | | | | | |
 |`cusparseConstDnVecDescr_t`|12.0| | | | | | | | | | | | | | |
 |`cusparseConstSpMatDescr_t`|12.0| | | | | | | | | | | | | | |
-|`cusparseConstSpVecDescr_t`|12.0| | | | | | | | | | | | | | |
+|`cusparseConstSpVecDescr_t`|12.0| | |`hipsparseConstSpVecDescr_t`|6.0.0| | | |6.0.0| | | | | | |
 |`cusparseContext`| | | | | | | | | |`_rocsparse_handle`|1.9.0| | | | |
 |`cusparseCsr2CscAlg_t`|10.1| | |`hipsparseCsr2CscAlg_t`|5.4.0| | | | | | | | | | |
 |`cusparseDenseToSparseAlg_t`|11.1| | |`hipsparseDenseToSparseAlg_t`|4.2.0| | | | |`rocsparse_dense_to_sparse_alg`|4.1.0| | | | |
@@ -197,6 +197,8 @@
 |:--|:-:|:-:|:-:|:-:|:--|:-:|:-:|:-:|:-:|:--|:-:|:-:|:-:|:-:|:-:|
 |`cusparseCreate`| | | |`hipsparseCreate`|1.9.2| | | | |`rocsparse_create_handle`|1.9.0| | | | |
 |`cusparseDestroy`| | | |`hipsparseDestroy`|1.9.2| | | | |`rocsparse_destroy_handle`|1.9.0| | | | |
+|`cusparseGetErrorName`|10.2| | |`hipsparseGetErrorName`|6.0.0| | | |6.0.0| | | | | | |
+|`cusparseGetErrorString`|10.2| | |`hipsparseGetErrorString`|6.0.0| | | |6.0.0| | | | | | |
 |`cusparseGetPointerMode`| | | |`hipsparseGetPointerMode`|1.9.2| | | | |`rocsparse_get_pointer_mode`|1.9.0| | | | |
 |`cusparseGetStream`| | | |`hipsparseGetStream`|1.9.2| | | | |`rocsparse_get_stream`|1.9.0| | | | |
 |`cusparseGetVersion`| | | |`hipsparseGetVersion`|1.9.2| | | | |`rocsparse_get_version`|1.9.0| | | | |
@@ -808,8 +810,8 @@
 |`cusparseConstDnVecGet`|12.0| | | | | | | | | | | | | | |
 |`cusparseConstDnVecGetValues`|12.0| | | | | | | | | | | | | | |
 |`cusparseConstSpMatGetValues`|12.0| | | | | | | | | | | | | | |
-|`cusparseConstSpVecGet`|12.0| | | | | | | | | | | | | | |
-|`cusparseConstSpVecGetValues`|12.0| | | | | | | | | | | | | | |
+|`cusparseConstSpVecGet`|12.0| | |`hipsparseConstSpVecGet`|6.0.0| | | |6.0.0| | | | | | |
+|`cusparseConstSpVecGetValues`|12.0| | |`hipsparseConstSpVecGetValues`|6.0.0| | | |6.0.0| | | | | | |
 |`cusparseConstrainedGeMM`|10.2|11.2|12.0| | | | | | | | | | | | |
 |`cusparseConstrainedGeMM_bufferSize`|10.2|11.2|12.0| | | | | | | | | | | | |
 |`cusparseCooAoSGet`|10.2|11.2|12.0|`hipsparseCooAoSGet`|4.1.0| | | | |`rocsparse_coo_aos_get`|4.1.0| | | | |
@@ -826,7 +828,7 @@
 |`cusparseCreateConstDnMat`|12.0| | | | | | | | | | | | | | |
 |`cusparseCreateConstDnVec`|12.0| | | | | | | | | | | | | | |
 |`cusparseCreateConstSlicedEll`|12.1| | | | | | | | | | | | | | |
-|`cusparseCreateConstSpVec`|12.0| | | | | | | | | | | | | | |
+|`cusparseCreateConstSpVec`|12.0| | |`hipsparseCreateConstSpVec`|6.0.0| | | |6.0.0| | | | | | |
 |`cusparseCreateCoo`|10.1| | |`hipsparseCreateCoo`|4.1.0| | | | |`rocsparse_create_coo_descr`|4.1.0| | | | |
 |`cusparseCreateCooAoS`|10.2|11.2|12.0|`hipsparseCreateCooAoS`|4.1.0| | | | |`rocsparse_create_coo_aos_descr`|4.1.0| | | | |
 |`cusparseCreateCsc`|11.1| | |`hipsparseCreateCsc`|4.2.0| | | | |`rocsparse_create_csc_descr`|4.1.0| | | | |

--- a/docs/tables/CUSPARSE_API_supported_by_ROC.md
+++ b/docs/tables/CUSPARSE_API_supported_by_ROC.md
@@ -197,6 +197,8 @@
 |:--|:-:|:-:|:-:|:-:|:--|:-:|:-:|:-:|:-:|
 |`cusparseCreate`| | | |`rocsparse_create_handle`|1.9.0| | | | |
 |`cusparseDestroy`| | | |`rocsparse_destroy_handle`|1.9.0| | | | |
+|`cusparseGetErrorName`|10.2| | | | | | | | |
+|`cusparseGetErrorString`|10.2| | | | | | | | |
 |`cusparseGetPointerMode`| | | |`rocsparse_get_pointer_mode`|1.9.0| | | | |
 |`cusparseGetStream`| | | |`rocsparse_get_stream`|1.9.0| | | | |
 |`cusparseGetVersion`| | | |`rocsparse_get_version`|1.9.0| | | | |

--- a/src/CUDA2HIP_SPARSE_API_functions.cpp
+++ b/src/CUDA2HIP_SPARSE_API_functions.cpp
@@ -32,6 +32,8 @@ const std::map<llvm::StringRef, hipCounter> CUDA_SPARSE_FUNCTION_MAP {
   {"cusparseSetPointerMode",                            {"hipsparseSetPointerMode",                            "rocsparse_set_pointer_mode",                                       CONV_LIB_FUNC, API_SPARSE, 5}},
   {"cusparseSetStream",                                 {"hipsparseSetStream",                                 "rocsparse_set_stream",                                             CONV_LIB_FUNC, API_SPARSE, 5}},
   {"cusparseGetStream",                                 {"hipsparseGetStream",                                 "rocsparse_get_stream",                                             CONV_LIB_FUNC, API_SPARSE, 5}},
+  {"cusparseGetErrorName",                              {"hipsparseGetErrorName",                              "",                                                                 CONV_LIB_FUNC, API_SPARSE, 5, ROC_UNSUPPORTED}},
+  {"cusparseGetErrorString",                            {"hipsparseGetErrorString",                            "",                                                                 CONV_LIB_FUNC, API_SPARSE, 5, ROC_UNSUPPORTED}},
 
   // 6. cuSPARSE Logging
   {"cusparseLoggerSetCallback",                         {"hipsparseLoggerSetCallback",                         "",                                                                 CONV_LIB_FUNC, API_SPARSE, 6, UNSUPPORTED}},
@@ -771,13 +773,13 @@ const std::map<llvm::StringRef, hipCounter> CUDA_SPARSE_FUNCTION_MAP {
   {"cusparseCreateConstSlicedEll",                      {"hipsparseCreateConstSlicedEll",                      "",                                                                 CONV_LIB_FUNC, API_SPARSE, 15, UNSUPPORTED}},
   // Sparse Vector descriptor
   {"cusparseCreateSpVec",                               {"hipsparseCreateSpVec",                               "rocsparse_create_spvec_descr",                                     CONV_LIB_FUNC, API_SPARSE, 15}},
-  {"cusparseCreateConstSpVec",                          {"hipsparseCreateConstSpVec",                          "",                                                                 CONV_LIB_FUNC, API_SPARSE, 15, UNSUPPORTED}},
+  {"cusparseCreateConstSpVec",                          {"hipsparseCreateConstSpVec",                          "",                                                                 CONV_LIB_FUNC, API_SPARSE, 15, ROC_UNSUPPORTED}},
   {"cusparseDestroySpVec",                              {"hipsparseDestroySpVec",                              "rocsparse_destroy_spvec_descr",                                    CONV_LIB_FUNC, API_SPARSE, 15}},
   {"cusparseSpVecGet",                                  {"hipsparseSpVecGet",                                  "rocsparse_spvec_get",                                              CONV_LIB_FUNC, API_SPARSE, 15}},
-  {"cusparseConstSpVecGet",                             {"hipsparseConstSpVecGet",                             "",                                                                 CONV_LIB_FUNC, API_SPARSE, 15, UNSUPPORTED}},
+  {"cusparseConstSpVecGet",                             {"hipsparseConstSpVecGet",                             "",                                                                 CONV_LIB_FUNC, API_SPARSE, 15, ROC_UNSUPPORTED}},
   {"cusparseSpVecGetIndexBase",                         {"hipsparseSpVecGetIndexBase",                         "rocsparse_spvec_get_index_base",                                   CONV_LIB_FUNC, API_SPARSE, 15}},
   {"cusparseSpVecGetValues",                            {"hipsparseSpVecGetValues",                            "rocsparse_spvec_get_values",                                       CONV_LIB_FUNC, API_SPARSE, 15}},
-  {"cusparseConstSpVecGetValues",                       {"hipsparseConstSpVecGetValues",                       "",                                                                 CONV_LIB_FUNC, API_SPARSE, 15, UNSUPPORTED}},
+  {"cusparseConstSpVecGetValues",                       {"hipsparseConstSpVecGetValues",                       "",                                                                 CONV_LIB_FUNC, API_SPARSE, 15, ROC_UNSUPPORTED}},
   {"cusparseSpVecSetValues",                            {"hipsparseSpVecSetValues",                            "rocsparse_spvec_set_values",                                       CONV_LIB_FUNC, API_SPARSE, 15}},
 
   // Generic Dense API helper functions
@@ -1445,6 +1447,8 @@ const std::map<llvm::StringRef, cudaAPIversions> CUDA_SPARSE_FUNCTION_VER_MAP {
   {"cusparseCcsr2csru",                                 {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
   {"cusparseZcsr2csru",                                 {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
   {"cusparseXbsric02_zeroPivot",                        {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
+  {"cusparseGetErrorName",                              {CUDA_102, CUDA_0,   CUDA_0  }}, // CUSPARSE_VERSION 10301
+  {"cusparseGetErrorString",                            {CUDA_102, CUDA_0,   CUDA_0  }}, // CUSPARSE_VERSION 10301
 };
 
 const std::map<llvm::StringRef, hipAPIversions> HIP_SPARSE_FUNCTION_VER_MAP {
@@ -1959,6 +1963,11 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_SPARSE_FUNCTION_VER_MAP {
   {"hipsparseCsr2cscEx2_bufferSize",                     {HIP_5040, HIP_0,    HIP_0   }},
   {"hipsparseCsr2cscEx2",                                {HIP_5040, HIP_0,    HIP_0   }},
   {"hipsparseCopyMatDescr",                              {HIP_1092, HIP_0,    HIP_0   }},
+  {"hipsparseGetErrorName",                              {HIP_6000, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipsparseGetErrorString",                            {HIP_6000, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipsparseCreateConstSpVec",                          {HIP_6000, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipsparseConstSpVecGet",                             {HIP_6000, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipsparseConstSpVecGetValues",                       {HIP_6000, HIP_0,    HIP_0,  HIP_LATEST}},
   {"rocsparse_create_handle",                            {HIP_1090, HIP_0,    HIP_0   }},
   {"rocsparse_destroy_handle",                           {HIP_1090, HIP_0,    HIP_0   }},
   {"rocsparse_set_stream",                               {HIP_1090, HIP_0,    HIP_0   }},

--- a/src/CUDA2HIP_SPARSE_API_types.cpp
+++ b/src/CUDA2HIP_SPARSE_API_types.cpp
@@ -266,7 +266,7 @@ const std::map<llvm::StringRef, hipCounter> CUDA_SPARSE_TYPE_NAME_MAP {
 
   // 4. Typedefs
   {"cusparseLoggerCallback_t",                  {"hipsparseLoggerCallback_t",                  "",                                                   CONV_TYPE, API_SPARSE, 4, UNSUPPORTED}},
-  {"cusparseConstSpVecDescr_t",                 {"hipsparseConstSpVecDescr_t",                 "",                                                   CONV_TYPE, API_SPARSE, 4, UNSUPPORTED}},
+  {"cusparseConstSpVecDescr_t",                 {"hipsparseConstSpVecDescr_t",                 "",                                                   CONV_TYPE, API_SPARSE, 4, ROC_UNSUPPORTED}},
   {"cusparseConstDnVecDescr_t",                 {"hipsparseConstDnVecDescr_t",                 "",                                                   CONV_TYPE, API_SPARSE, 4, UNSUPPORTED}},
   {"cusparseConstSpMatDescr_t",                 {"hipsparseConstSpMatDescr_t",                 "",                                                   CONV_TYPE, API_SPARSE, 4, UNSUPPORTED}},
   {"cusparseConstDnMatDescr_t",                 {"hipsparseConstDnMatDescr_t",                 "",                                                   CONV_TYPE, API_SPARSE, 4, UNSUPPORTED}},
@@ -562,6 +562,7 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_SPARSE_TYPE_NAME_VER_MAP {
   {"HIPSPARSE_SPGEMM_ALG1",                      {HIP_5060, HIP_0,    HIP_0   }},
   {"HIPSPARSE_SPGEMM_ALG2",                      {HIP_5060, HIP_0,    HIP_0   }},
   {"HIPSPARSE_SPGEMM_ALG3",                      {HIP_5060, HIP_0,    HIP_0   }},
+  {"hipsparseConstSpVecDescr_t",                 {HIP_6000, HIP_0,    HIP_0,  HIP_LATEST}},
   {"csric02Info_t",                              {HIP_3010, HIP_0,    HIP_0   }},
   {"csric02Info",                                {HIP_3010, HIP_0,    HIP_0   }},
   {"_rocsparse_handle",                          {HIP_1090, HIP_0,    HIP_0   }},


### PR DESCRIPTION
+ Updated synthetic tests and the regenerated hipify-perl and SPARSE docs

**[TODO]**
+ `C-Changed` marker for CUDA APIs as well
+ Mark as `C` `cusparseDestroySpVec` and `cusparseSpVecGetIndexBase`
