### PR TITLE
[HIPIFY][SWDEV-429021][build][Linux][fix] Fix for `no template named 'list'` build failure

### DIFF
--- a/src/Statistics.h
+++ b/src/Statistics.h
@@ -27,6 +27,7 @@ THE SOFTWARE.
 #include <fstream>
 #include <map>
 #include <set>
+#include <list>
 #include <llvm/ADT/StringRef.h>
 #include <llvm/Support/raw_ostream.h>
 


### PR DESCRIPTION
+ Added an explicit include for `std::list`
