### PR TITLE
[HIPIFY][SWDEV-429021][warning][fix] Fix for the warning `'function' overrides a member function but is not marked 'override'`

### DIFF
--- a/src/CUDA2HIP_Doc.cpp
+++ b/src/CUDA2HIP_Doc.cpp
@@ -538,8 +538,8 @@ namespace doc {
       const versionMap &getTypeVersions() const override { return CUDA_BLAS_TYPE_NAME_VER_MAP; }
       const hipVersionMap &getHipTypeVersions() const override { return HIP_BLAS_TYPE_NAME_VER_MAP; }
       const string &getName() const override { return sCUBLAS; }
-      const string &getSecondAPI() const { return sROC; }
-      const string &getJointAPI() const { return sHIPandROC; }
+      const string &getSecondAPI() const override { return sROC; }
+      const string &getJointAPI() const override { return sHIPandROC; }
       const string &getFileName(docType format) const override {
         switch (format) {
           case none:
@@ -555,7 +555,7 @@ namespace doc {
       ROCBLAS(const string &outDir): BLAS(outDir) { hasROC = false; isROC = true; }
       virtual ~ROCBLAS() {}
     protected:
-      const string &getAPI() const { return sROC; }
+      const string &getAPI() const override { return sROC; }
       const string &getFileName(docType format) const override {
         switch (format) {
           case none:
@@ -602,8 +602,8 @@ namespace doc {
       const versionMap &getTypeVersions() const override { return CUDA_DNN_TYPE_NAME_VER_MAP; }
       const hipVersionMap &getHipTypeVersions() const override { return HIP_DNN_TYPE_NAME_VER_MAP; }
       const string &getName() const override { return sCUDNN; }
-      const string &getSecondAPI() const { return sMIOPEN; }
-      const string &getJointAPI() const { return sHIPandMIOPEN; }
+      const string &getSecondAPI() const override { return sMIOPEN; }
+      const string &getJointAPI() const override { return sHIPandMIOPEN; }
       const string &getFileName(docType format) const override {
         switch (format) {
           case none:
@@ -619,7 +619,7 @@ namespace doc {
       MIOPEN(const string &outDir): DNN(outDir) { hasROC = false; isROC = true; }
       virtual ~MIOPEN() {}
     protected:
-      const string &getAPI() const { return sMIOPEN; }
+      const string &getAPI() const override { return sMIOPEN; }
       const string &getFileName(docType format) const override {
         switch (format) {
           case none:
@@ -666,8 +666,8 @@ namespace doc {
       const versionMap &getTypeVersions() const override { return CUDA_SPARSE_TYPE_NAME_VER_MAP; }
       const hipVersionMap &getHipTypeVersions() const override { return HIP_SPARSE_TYPE_NAME_VER_MAP; }
       const string &getName() const override { return sCUSPARSE; }
-      const string &getSecondAPI() const { return sROC; }
-      const string &getJointAPI() const { return sHIPandROC; }
+      const string &getSecondAPI() const override { return sROC; }
+      const string &getJointAPI() const override { return sHIPandROC; }
       const string &getFileName(docType format) const override {
         switch (format) {
           case none:
@@ -683,7 +683,7 @@ namespace doc {
     ROCSPARSE(const string &outDir) : SPARSE(outDir) { hasROC = false; isROC = true; }
     virtual ~ROCSPARSE() {}
   protected:
-    const string &getAPI() const { return sROC; }
+    const string &getAPI() const override { return sROC; }
     const string &getFileName(docType format) const override {
       switch (format) {
       case none:


### PR DESCRIPTION
+ Added the missing `override` keyword for virtual functions' `getAPI`, `getSecondAPI`, and `getJointAPI` overrides
