### PR TITLE
[HIPIFY][tests][BLAS][fix] Move `__nv_bfloat16`-related APIs under `#if CUDA_VERSION >= 11000`

### DIFF
--- a/tests/unit_tests/synthetic/libraries/cublas2hipblas.cu
+++ b/tests/unit_tests/synthetic/libraries/cublas2hipblas.cu
@@ -246,17 +246,6 @@ int main() {
   // CHECK: __half** hyarray = 0;
   __half** hyarray = 0;
 
-  // CHECK: hip_bfloat16** bf16Aarray = 0;
-  __nv_bfloat16** bf16Aarray = 0;
-  // CHECK: const hip_bfloat16** const bf16Aarray_const = const_cast<const hip_bfloat16**>(bf16Aarray);
-  const __nv_bfloat16** const bf16Aarray_const = const_cast<const __nv_bfloat16**>(bf16Aarray);
-  // CHECK: hip_bfloat16** bf16xarray = 0;
-  __nv_bfloat16** bf16xarray = 0;
-  // CHECK: const hip_bfloat16** const bf16xarray_const = const_cast<const hip_bfloat16**>(bf16xarray_const);
-  const __nv_bfloat16** const bf16xarray_const = const_cast<const __nv_bfloat16**>(bf16xarray_const);
-  // CHECK: hip_bfloat16** bf16yarray = 0;
-  __nv_bfloat16** bf16yarray = 0;
-
   double da = 0;
   double dA = 0;
   double db = 0;
@@ -1657,6 +1646,17 @@ int main() {
   // CHECK-NEXT: hipDataType C_16BF = HIP_C_16BF;
   cublasDataType_t R_16BF = CUDA_R_16BF;
   cublasDataType_t C_16BF = CUDA_C_16BF;
+
+  // CHECK: hip_bfloat16** bf16Aarray = 0;
+  __nv_bfloat16** bf16Aarray = 0;
+  // CHECK: const hip_bfloat16** const bf16Aarray_const = const_cast<const hip_bfloat16**>(bf16Aarray);
+  const __nv_bfloat16** const bf16Aarray_const = const_cast<const __nv_bfloat16**>(bf16Aarray);
+  // CHECK: hip_bfloat16** bf16xarray = 0;
+  __nv_bfloat16** bf16xarray = 0;
+  // CHECK: const hip_bfloat16** const bf16xarray_const = const_cast<const hip_bfloat16**>(bf16xarray_const);
+  const __nv_bfloat16** const bf16xarray_const = const_cast<const __nv_bfloat16**>(bf16xarray_const);
+  // CHECK: hip_bfloat16** bf16yarray = 0;
+  __nv_bfloat16** bf16yarray = 0;
 
   // CHECK: hipblasComputeType_t blasComputeType;
   cublasComputeType_t blasComputeType;

--- a/tests/unit_tests/synthetic/libraries/cublas2hipblas_v2.cu
+++ b/tests/unit_tests/synthetic/libraries/cublas2hipblas_v2.cu
@@ -257,17 +257,6 @@ int main() {
   // CHECK: __half** hyarray = 0;
   __half** hyarray = 0;
 
-  // CHECK: hip_bfloat16** bf16Aarray = 0;
-  __nv_bfloat16** bf16Aarray = 0;
-  // CHECK: const hip_bfloat16** const bf16Aarray_const = const_cast<const hip_bfloat16**>(bf16Aarray);
-  const __nv_bfloat16** const bf16Aarray_const = const_cast<const __nv_bfloat16**>(bf16Aarray);
-  // CHECK: hip_bfloat16** bf16xarray = 0;
-  __nv_bfloat16** bf16xarray = 0;
-  // CHECK: const hip_bfloat16** const bf16xarray_const = const_cast<const hip_bfloat16**>(bf16xarray_const);
-  const __nv_bfloat16** const bf16xarray_const = const_cast<const __nv_bfloat16**>(bf16xarray_const);
-  // CHECK: hip_bfloat16** bf16yarray = 0;
-  __nv_bfloat16** bf16yarray = 0;
-
   double da = 0;
   double dA = 0;
   double db = 0;
@@ -1812,6 +1801,17 @@ int main() {
   // CHECK-NEXT: hipDataType C_16BF = HIP_C_16BF;
   cublasDataType_t R_16BF = CUDA_R_16BF;
   cublasDataType_t C_16BF = CUDA_C_16BF;
+
+  // CHECK: hip_bfloat16** bf16Aarray = 0;
+  __nv_bfloat16** bf16Aarray = 0;
+  // CHECK: const hip_bfloat16** const bf16Aarray_const = const_cast<const hip_bfloat16**>(bf16Aarray);
+  const __nv_bfloat16** const bf16Aarray_const = const_cast<const __nv_bfloat16**>(bf16Aarray);
+  // CHECK: hip_bfloat16** bf16xarray = 0;
+  __nv_bfloat16** bf16xarray = 0;
+  // CHECK: const hip_bfloat16** const bf16xarray_const = const_cast<const hip_bfloat16**>(bf16xarray_const);
+  const __nv_bfloat16** const bf16xarray_const = const_cast<const __nv_bfloat16**>(bf16xarray_const);
+  // CHECK: hip_bfloat16** bf16yarray = 0;
+  __nv_bfloat16** bf16yarray = 0;
 
   // CHECK: hipblasComputeType_t blasComputeType;
   cublasComputeType_t blasComputeType;

--- a/tests/unit_tests/synthetic/libraries/cublas2rocblas.cu
+++ b/tests/unit_tests/synthetic/libraries/cublas2rocblas.cu
@@ -278,24 +278,6 @@ int main() {
   // CHECK: rocblas_half** hyarray = 0;
   __half** hyarray = 0;
 
-  // CHECK: rocblas_bfloat16* bf16A = 0;
-  __nv_bfloat16* bf16A = 0;
-  // CHECK: rocblas_bfloat16* bf16x = 0;
-  __nv_bfloat16* bf16x = 0;
-  // CHECK: rocblas_bfloat16* bf16y = 0;
-  __nv_bfloat16* bf16y = 0;
-
-  // CHECK: rocblas_bfloat16** bf16Aarray = 0;
-  __nv_bfloat16** bf16Aarray = 0;
-  // CHECK: const rocblas_bfloat16** const bf16Aarray_const = const_cast<const rocblas_bfloat16**>(bf16Aarray);
-  const __nv_bfloat16** const bf16Aarray_const = const_cast<const __nv_bfloat16**>(bf16Aarray);
-  // CHECK: rocblas_bfloat16** bf16xarray = 0;
-  __nv_bfloat16** bf16xarray = 0;
-  // CHECK: const rocblas_bfloat16** const bf16xarray_const = const_cast<const rocblas_bfloat16**>(bf16xarray_const);
-  const __nv_bfloat16** const bf16xarray_const = const_cast<const __nv_bfloat16**>(bf16xarray_const);
-  // CHECK: rocblas_bfloat16** bf16yarray = 0;
-  __nv_bfloat16** bf16yarray = 0;
-
   double da = 0;
   double dA = 0;
   double db = 0;
@@ -1792,6 +1774,24 @@ int main() {
   // CHECK-NEXT: rocblas_datatype C_16BF = rocblas_datatype_bf16_c;
   cublasDataType_t R_16BF = CUDA_R_16BF;
   cublasDataType_t C_16BF = CUDA_C_16BF;
+
+  // CHECK: rocblas_bfloat16* bf16A = 0;
+  __nv_bfloat16* bf16A = 0;
+  // CHECK: rocblas_bfloat16* bf16x = 0;
+  __nv_bfloat16* bf16x = 0;
+  // CHECK: rocblas_bfloat16* bf16y = 0;
+  __nv_bfloat16* bf16y = 0;
+
+  // CHECK: rocblas_bfloat16** bf16Aarray = 0;
+  __nv_bfloat16** bf16Aarray = 0;
+  // CHECK: const rocblas_bfloat16** const bf16Aarray_const = const_cast<const rocblas_bfloat16**>(bf16Aarray);
+  const __nv_bfloat16** const bf16Aarray_const = const_cast<const __nv_bfloat16**>(bf16Aarray);
+  // CHECK: rocblas_bfloat16** bf16xarray = 0;
+  __nv_bfloat16** bf16xarray = 0;
+  // CHECK: const rocblas_bfloat16** const bf16xarray_const = const_cast<const rocblas_bfloat16**>(bf16xarray_const);
+  const __nv_bfloat16** const bf16xarray_const = const_cast<const __nv_bfloat16**>(bf16xarray_const);
+  // CHECK: rocblas_bfloat16** bf16yarray = 0;
+  __nv_bfloat16** bf16yarray = 0;
 
   // CHECK: rocblas_computetype blasComputeType;
   // CHECK-NEXT: rocblas_computetype BLAS_COMPUTE_32F = rocblas_compute_type_f32;


### PR DESCRIPTION
**[Synopsis]**
+ `cublas2hipblas.cu`, `cublas2hipblas_v2.cu`, and `cublas2rocblas.cu` synthetic tests fail against CUDA < 11.0

**[Reason]**
+ `__nv_bfloat16` type appeared in CUDA 11.0 only