### PR TITLE
[HIPIFY][#675][#677][RSERP-704][DCGPUBU-141][SOLVER][feature] cuSOLVER support - Step 1

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -1263,6 +1263,10 @@ sub experimentalSubstitutions {
     subst("cudaGraphExternalSemaphoresSignalNodeSetParams", "hipGraphExternalSemaphoresSignalNodeSetParams", "graph");
     subst("cudaGraphExternalSemaphoresWaitNodeGetParams", "hipGraphExternalSemaphoresWaitNodeGetParams", "graph");
     subst("cudaGraphExternalSemaphoresWaitNodeSetParams", "hipGraphExternalSemaphoresWaitNodeSetParams", "graph");
+    subst("cusolverDnCreate", "hipsolverDnCreate", "library");
+    subst("cusolverDnDestroy", "hipsolverDnDestroy", "library");
+    subst("cusolverDnHandle_t", "hipsolverHandle_t", "library");
+    subst("cusolverStatus_t", "hipsolverStatus_t", "library");
     subst("CUDA_EXT_SEM_SIGNAL_NODE_PARAMS", "hipExternalSemaphoreSignalNodeParams", "type");
     subst("CUDA_EXT_SEM_SIGNAL_NODE_PARAMS_st", "hipExternalSemaphoreSignalNodeParams", "type");
     subst("CUDA_EXT_SEM_SIGNAL_NODE_PARAMS_v1", "hipExternalSemaphoreSignalNodeParams", "type");
@@ -1749,6 +1753,10 @@ sub rocSubstitutions {
     subst("cudnnSoftmaxBackward", "miopenSoftmaxBackward_V2", "library");
     subst("cudnnSoftmaxForward", "miopenSoftmaxForward_V2", "library");
     subst("cudnnTransformTensor", "miopenTransformTensor", "library");
+    subst("cusolverDnCreate", "rocblas_create_handle", "library");
+    subst("cusolverDnDestroy", "rocblas_destroy_handle", "library");
+    subst("cusolverDnHandle_t", "rocblas_handle", "library");
+    subst("cusolverStatus_t", "rocblas_status", "library");
     subst("cusparseAxpby", "rocsparse_axpby", "library");
     subst("cusparseBlockedEllGet", "rocsparse_bell_get", "library");
     subst("cusparseCbsr2csr", "rocsparse_cbsr2csr", "library");
@@ -4138,6 +4146,11 @@ sub simpleSubstitutions {
     subst("curand_poisson.h", "hiprand_kernel.h", "include");
     subst("curand_precalc.h", "hiprand_kernel.h", "include");
     subst("curand_uniform.h", "hiprand_kernel.h", "include");
+    subst("cusolverDn.h", "hipsolver.h", "include");
+    subst("cusolverMg.h", "hipsolver.h", "include");
+    subst("cusolverRf.h", "hipsolver.h", "include");
+    subst("cusolverSp.h", "hipsolver.h", "include");
+    subst("cusolver_common.h", "hipsolver.h", "include");
     subst("device_functions.h", "hip\/device_functions.h", "include");
     subst("driver_types.h", "hip\/driver_types.h", "include");
     subst("library_types.h", "hip\/library_types.h", "include");

--- a/src/CUDA2HIP.cpp
+++ b/src/CUDA2HIP.cpp
@@ -70,6 +70,12 @@ const std::map <llvm::StringRef, hipCounter> CUDA_INCLUDE_MAP {
   // cuSPARSE includes
   {"cusparse.h",                                            {"hipsparse.h",                                "rocsparse.h", CONV_INCLUDE_CUDA_MAIN_H,    API_SPARSE, 0}},
   {"cusparse_v2.h",                                         {"hipsparse.h",                                "rocsparse.h", CONV_INCLUDE_CUDA_MAIN_V2_H, API_SPARSE, 0}},
+  // cuSOLVER includes
+  {"cusolverDn.h",                                          {"hipsolver.h",                                "rocsolver.h", CONV_INCLUDE,                API_SOLVER, 0}},
+  {"cusolverMg.h",                                          {"hipsolver.h",                                "rocsolver.h", CONV_INCLUDE,                API_SOLVER, 0}},
+  {"cusolverRf.h",                                          {"hipsolver.h",                                "rocsolver.h", CONV_INCLUDE,                API_SOLVER, 0}},
+  {"cusolverSp.h",                                          {"hipsolver.h",                                "rocsolver.h", CONV_INCLUDE,                API_SOLVER, 0}},
+  {"cusolver_common.h",                                     {"hipsolver.h",                                "rocsolver.h", CONV_INCLUDE,                API_SOLVER, 0}},
   // CUB includes
   {"cub/cub.cuh",                                           {"hipcub/hipcub.hpp",                                     "", CONV_INCLUDE_CUDA_MAIN_H,    API_CUB, 0}},
   // CAFFE2 includes
@@ -115,6 +121,8 @@ const std::map<llvm::StringRef, hipCounter> &CUDA_RENAMES_MAP() {
   ret.insert(CUDA_RTC_TYPE_NAME_MAP.begin(), CUDA_RTC_TYPE_NAME_MAP.end());
   ret.insert(CUDA_RTC_FUNCTION_MAP.begin(), CUDA_RTC_FUNCTION_MAP.end());
   ret.insert(CUDA_DEVICE_TYPE_NAME_MAP.begin(), CUDA_DEVICE_TYPE_NAME_MAP.end());
+  ret.insert(CUDA_SOLVER_TYPE_NAME_MAP.begin(), CUDA_SOLVER_TYPE_NAME_MAP.end());
+  ret.insert(CUDA_SOLVER_FUNCTION_MAP.begin(), CUDA_SOLVER_FUNCTION_MAP.end());
   return ret;
 };
 

--- a/src/CUDA2HIP.h
+++ b/src/CUDA2HIP.h
@@ -81,6 +81,10 @@ extern const std::map<llvm::StringRef, hipCounter> CUDA_CUB_NAMESPACE_MAP;
 extern const std::map<llvm::StringRef, hipCounter> CUDA_RTC_TYPE_NAME_MAP;
 // Maps the names of CUDA RTC API functions to the corresponding HIP functions
 extern const std::map<llvm::StringRef, hipCounter> CUDA_RTC_FUNCTION_MAP;
+// Maps the names of CUDA SOLVER API types to the corresponding HIP types
+extern const std::map<llvm::StringRef, hipCounter> CUDA_SOLVER_TYPE_NAME_MAP;
+// Maps the names of CUDA SOLVER API functions to the corresponding HIP functions
+extern const std::map<llvm::StringRef, hipCounter> CUDA_SOLVER_FUNCTION_MAP;
 
 /**
   * The union of all the above maps, except includes.

--- a/src/CUDA2HIP_SOLVER_API_functions.cpp
+++ b/src/CUDA2HIP_SOLVER_API_functions.cpp
@@ -1,0 +1,37 @@
+/*
+Copyright (c) 2015 - present Advanced Micro Devices, Inc. All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+#include "CUDA2HIP.h"
+
+// Map of all functions
+const std::map<llvm::StringRef, hipCounter> CUDA_SOLVER_FUNCTION_MAP {
+  {"cusolverDnCreate",                                    {"hipsolverDnCreate",                                    "rocblas_create_handle",                                          CONV_LIB_FUNC, API_SOLVER, 2, HIP_EXPERIMENTAL}},
+  {"cusolverDnDestroy",                                   {"hipsolverDnDestroy",                                   "rocblas_destroy_handle",                                         CONV_LIB_FUNC, API_SOLVER, 2, HIP_EXPERIMENTAL}},
+};
+
+const std::map<llvm::StringRef, cudaAPIversions> CUDA_SOLVER_FUNCTION_VER_MAP {
+};
+
+const std::map<llvm::StringRef, hipAPIversions> HIP_SOLVER_FUNCTION_VER_MAP {
+  {"hipsolverDnCreate",                                   {HIP_5010, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipsolverDnDestroy",                                  {HIP_5010, HIP_0,    HIP_0,  HIP_LATEST}},
+};

--- a/src/CUDA2HIP_SOLVER_API_types.cpp
+++ b/src/CUDA2HIP_SOLVER_API_types.cpp
@@ -1,0 +1,37 @@
+/*
+Copyright (c) 2015 - present Advanced Micro Devices, Inc. All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+#include "CUDA2HIP.h"
+
+// Map of all functions
+const std::map<llvm::StringRef, hipCounter> CUDA_SOLVER_TYPE_NAME_MAP {
+  {"cusolverStatus_t",                                      {"hipsolverStatus_t",                                    "rocblas_status",                                                CONV_LIB_FUNC, API_SOLVER, 1, HIP_EXPERIMENTAL}},
+  {"cusolverDnHandle_t",                                    {"hipsolverHandle_t",                                    "rocblas_handle",                                                CONV_LIB_FUNC, API_SOLVER, 1, HIP_EXPERIMENTAL}},
+};
+
+const std::map<llvm::StringRef, cudaAPIversions> CUDA_SOLVER_TYPE_NAME_VER_MAP {
+};
+
+const std::map<llvm::StringRef, hipAPIversions> HIP_SOLVER_TYPE_NAME_VER_MAP {
+  {"hipsolverStatus_t",                                     {HIP_4050, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipsolverHandle_t",                                     {HIP_4050, HIP_0,    HIP_0,  HIP_LATEST}},
+};

--- a/src/Statistics.cpp
+++ b/src/Statistics.cpp
@@ -142,6 +142,7 @@ const char *apiNames[NUM_API_TYPES] = {
   "cuDNN API",
   "cuFFT API",
   "cuSPARSE API",
+  "cuSOLVER API",
   "CUB API",
   "CAFFE2 API",
   "RTC API"
@@ -157,6 +158,7 @@ const char *apiTypes[NUM_API_TYPES] = {
   "API_FFT",
   "API_CUB",
   "API_SPARSE",
+  "API_SOLVER",
   "API_CAFFE2",
   "API_RTC"
 };
@@ -363,8 +365,9 @@ void Statistics::setActive(const std::string &name) {
 }
 
 bool Statistics::isToRoc(const hipCounter &counter) {
-  return (counter.apiType == API_BLAS || counter.apiType == API_DNN || counter.apiType == API_SPARSE || counter.apiType == API_RUNTIME || counter.apiType == API_COMPLEX) &&
-    ((TranslateToRoc && !TranslateToMIOpen && !isRocMiopenOnly(counter)) || TranslateToMIOpen);
+  return (counter.apiType == API_BLAS || counter.apiType == API_DNN || counter.apiType == API_SPARSE || counter.apiType == API_SOLVER ||
+          counter.apiType == API_RUNTIME || counter.apiType == API_COMPLEX) &&
+          ((TranslateToRoc && !TranslateToMIOpen && !isRocMiopenOnly(counter)) || TranslateToMIOpen);
 }
 
 bool Statistics::isHipExperimental(const hipCounter& counter) {

--- a/src/Statistics.h
+++ b/src/Statistics.h
@@ -174,6 +174,7 @@ enum ApiTypes {
   API_DNN,
   API_FFT,
   API_SPARSE,
+  API_SOLVER,
   API_CUB,
   API_CAFFE2,
   API_RTC,

--- a/tests/unit_tests/synthetic/libraries/cusolver2hipsolver.cu
+++ b/tests/unit_tests/synthetic/libraries/cusolver2hipsolver.cu
@@ -1,0 +1,29 @@
+// RUN: %run_test hipify "%s" "%t" %hipify_args 2 --skip-excluded-preprocessor-conditional-blocks --experimental %clang_args -D__CUDA_API_VERSION_INTERNAL -ferror-limit=500
+
+// CHECK: #include <hip/hip_runtime.h>
+#include <cuda_runtime.h>
+#include <stdio.h>
+// CHECK: #include "hipsolver.h"
+#include "cusolverDn.h"
+
+int main() {
+  printf("19. cuSOLVER API to hipSOLVER API synthetic test\n");
+
+  // CHECK: hipsolverHandle_t handle;
+  cusolverDnHandle_t handle;
+
+  // CHECK: hipsolverStatus_t status;
+  cusolverStatus_t status;
+
+  // CUDA: cusolverStatus_t CUSOLVERAPI cusolverDnCreate(cusolverDnHandle_t *handle);
+  // HIP: HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDnCreate(hipsolverHandle_t* handle);
+  // CHECK: status = hipsolverDnCreate(&handle);
+  status = cusolverDnCreate(&handle);
+
+  // CUDA: cusolverStatus_t CUSOLVERAPI cusolverDnDestroy(cusolverDnHandle_t handle);
+  // HIP: HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDnDestroy(hipsolverHandle_t handle);
+  // CHECK: status = hipsolverDnDestroy(handle);
+  status = cusolverDnDestroy(handle);
+
+  return 0;
+}

--- a/tests/unit_tests/synthetic/libraries/cusolver2rocsolver.cu
+++ b/tests/unit_tests/synthetic/libraries/cusolver2rocsolver.cu
@@ -1,0 +1,29 @@
+// RUN: %run_test hipify "%s" "%t" %hipify_args 3 --skip-excluded-preprocessor-conditional-blocks --experimental --roc %clang_args -D__CUDA_API_VERSION_INTERNAL -ferror-limit=500
+
+// CHECK: #include <hip/hip_runtime.h>
+#include <cuda_runtime.h>
+#include <stdio.h>
+// CHECK: #include "rocsolver.h"
+#include "cusolverDn.h"
+
+int main() {
+  printf("20. cuSOLVER API to rocSOLVER API synthetic test\n");
+
+  // CHECK: rocblas_handle handle;
+  cusolverDnHandle_t handle;
+
+  // CHECK: rocblas_status status;
+  cusolverStatus_t status;
+
+  // CUDA: cusolverStatus_t CUSOLVERAPI cusolverDnCreate(cusolverDnHandle_t *handle);
+  // ROC: ROCBLAS_EXPORT rocblas_status rocblas_create_handle(rocblas_handle* handle);
+  // CHECK: status = rocblas_create_handle(&handle);
+  status = cusolverDnCreate(&handle);
+
+  // CUDA: cusolverStatus_t CUSOLVERAPI cusolverDnDestroy(cusolverDnHandle_t handle);
+  // ROC: ROCBLAS_EXPORT rocblas_status rocblas_destroy_handle(rocblas_handle handle);
+  // CHECK: status = rocblas_destroy_handle(handle);
+  status = cusolverDnDestroy(handle);
+
+  return 0;
+}


### PR DESCRIPTION
+ [IMP] Everything is experimental
+ Both implementation are taken into account: `hipSOLVER` and `rocSOLVER`
+ Added new synthetic tests `cusolver2hipsolver.cu` and `cusolver2rocsolver.cu`
+ Updated the regenerated hipify-perl
+ [ToDo] `SOLVER` `CUDA2HIP` documentation generation