### PR TITLE
[HIPIFY][#675][#677][RSERP-704][DCGPUBU-141][SOLVER][feature] cuSOLVER support - Step 2 - `cusolverDn(D|S)getrf(_bufferSize)?` and `cusolverDn(D|S)getrs` functions

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -1265,7 +1265,13 @@ sub experimentalSubstitutions {
     subst("cudaGraphExternalSemaphoresWaitNodeSetParams", "hipGraphExternalSemaphoresWaitNodeSetParams", "graph");
     subst("cusolverDnCreate", "hipsolverDnCreate", "library");
     subst("cusolverDnDestroy", "hipsolverDnDestroy", "library");
+    subst("cusolverDnDgetrf", "hipsolverDnDgetrf", "library");
+    subst("cusolverDnDgetrf_bufferSize", "hipsolverDnDgetrf_bufferSize", "library");
+    subst("cusolverDnDgetrs", "hipsolverDnDgetrs", "library");
     subst("cusolverDnHandle_t", "hipsolverHandle_t", "library");
+    subst("cusolverDnSgetrf", "hipsolverDnSgetrf", "library");
+    subst("cusolverDnSgetrf_bufferSize", "hipsolverDnSgetrf_bufferSize", "library");
+    subst("cusolverDnSgetrs", "hipsolverDnSgetrs", "library");
     subst("cusolverStatus_t", "hipsolverStatus_t", "library");
     subst("CUDA_EXT_SEM_SIGNAL_NODE_PARAMS", "hipExternalSemaphoreSignalNodeParams", "type");
     subst("CUDA_EXT_SEM_SIGNAL_NODE_PARAMS_st", "hipExternalSemaphoreSignalNodeParams", "type");

--- a/src/CUDA2HIP_SOLVER_API_functions.cpp
+++ b/src/CUDA2HIP_SOLVER_API_functions.cpp
@@ -26,6 +26,18 @@ THE SOFTWARE.
 const std::map<llvm::StringRef, hipCounter> CUDA_SOLVER_FUNCTION_MAP {
   {"cusolverDnCreate",                                    {"hipsolverDnCreate",                                    "rocblas_create_handle",                                          CONV_LIB_FUNC, API_SOLVER, 2, HIP_EXPERIMENTAL}},
   {"cusolverDnDestroy",                                   {"hipsolverDnDestroy",                                   "rocblas_destroy_handle",                                         CONV_LIB_FUNC, API_SOLVER, 2, HIP_EXPERIMENTAL}},
+  // [HIPIFY feature] TODO: cusolverDnDgetrf -> rocsolver_dgetrf + harness of other API calls
+  {"cusolverDnDgetrf",                                    {"hipsolverDnDgetrf",                                    "rocsolver_dgetrf",                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
+  // [HIPIFY feature] TODO: cusolverDnDgetrf_bufferSize -> rocsolver_dgetrf + harness of other API calls
+  {"cusolverDnDgetrf_bufferSize",                         {"hipsolverDnDgetrf_bufferSize",                         "rocsolver_dgetrf",                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
+  // [HIPIFY feature] TODO: cusolverDnSgetrf -> rocsolver_sgetrf + harness of other API calls
+  {"cusolverDnSgetrf",                                    {"hipsolverDnSgetrf",                                    "rocsolver_sgetrf",                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
+  // [HIPIFY feature] TODO: cusolverDnSgetrf_bufferSize -> rocsolver_sgetrf + harness of other API calls
+  {"cusolverDnSgetrf_bufferSize",                         {"hipsolverDnSgetrf_bufferSize",                         "rocsolver_sgetrf",                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
+  // [HIPIFY feature] TODO: cusolverDnDgetrs -> rocsolver_dgetrs + harness of other API calls
+  {"cusolverDnDgetrs",                                    {"hipsolverDnDgetrs",                                    "rocsolver_dgetrs",                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
+  // [HIPIFY feature] TODO: cusolverDnSgetrs -> rocsolver_sgetrs + harness of other API calls
+  {"cusolverDnSgetrs",                                    {"hipsolverDnSgetrs",                                    "rocsolver_sgetrs",                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
 };
 
 const std::map<llvm::StringRef, cudaAPIversions> CUDA_SOLVER_FUNCTION_VER_MAP {
@@ -34,4 +46,10 @@ const std::map<llvm::StringRef, cudaAPIversions> CUDA_SOLVER_FUNCTION_VER_MAP {
 const std::map<llvm::StringRef, hipAPIversions> HIP_SOLVER_FUNCTION_VER_MAP {
   {"hipsolverDnCreate",                                   {HIP_5010, HIP_0,    HIP_0,  HIP_LATEST}},
   {"hipsolverDnDestroy",                                  {HIP_5010, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipsolverDnDgetrf",                                   {HIP_5010, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipsolverDnDgetrf_bufferSize",                        {HIP_5010, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipsolverDnSgetrf",                                   {HIP_5010, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipsolverDnSgetrf_bufferSize",                        {HIP_5010, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipsolverDnDgetrs",                                   {HIP_5010, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipsolverDnSgetrs",                                   {HIP_5010, HIP_0,    HIP_0,  HIP_LATEST}},
 };

--- a/tests/unit_tests/synthetic/libraries/cusolver2hipsolver.cu
+++ b/tests/unit_tests/synthetic/libraries/cusolver2hipsolver.cu
@@ -9,11 +9,29 @@
 int main() {
   printf("19. cuSOLVER API to hipSOLVER API synthetic test\n");
 
+  int m = 0;
+  int n = 0;
+  int nrhs = 0;
+  int lda = 0;
+  int ldb = 0;
+  int Lwork = 0;
+  int devIpiv = 0;
+  int devInfo = 0;
+  float fA = 0.f;
+  double dA = 0.f;
+  float fB = 0.f;
+  double dB = 0.f;
+  float fWorkspace = 0.f;
+  double dWorkspace = 0.f;
+
   // CHECK: hipsolverHandle_t handle;
   cusolverDnHandle_t handle;
 
   // CHECK: hipsolverStatus_t status;
   cusolverStatus_t status;
+
+  // CHECK: hipblasOperation_t blasOperation;
+  cublasOperation_t blasOperation;
 
   // CUDA: cusolverStatus_t CUSOLVERAPI cusolverDnCreate(cusolverDnHandle_t *handle);
   // HIP: HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDnCreate(hipsolverHandle_t* handle);
@@ -24,6 +42,36 @@ int main() {
   // HIP: HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDnDestroy(hipsolverHandle_t handle);
   // CHECK: status = hipsolverDnDestroy(handle);
   status = cusolverDnDestroy(handle);
+
+  // CUDA: cusolverStatus_t CUSOLVERAPI cusolverDnDgetrf(cusolverDnHandle_t handle, int m, int n, double* A, int lda, double* Workspace, int* devIpiv, int* devInfo);
+  // HIP: HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDnDgetrf(hipsolverHandle_t handle, int m, int n,double* A, int lda, double* work, int* devIpiv, int* devInfo);
+  // CHECK: status = hipsolverDnDgetrf(handle, m, n, &dA, lda, &dWorkspace, &devIpiv, &devInfo);
+  status = cusolverDnDgetrf(handle, m, n, &dA, lda, &dWorkspace, &devIpiv, &devInfo);
+
+  // CUDA: cusolverStatus_t CUSOLVERAPI cusolverDnDgetrf_bufferSize(cusolverDnHandle_t handle, int m, int n, double* A, int lda, int* Lwork);
+  // HIP: HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDnDgetrf_bufferSize(hipsolverHandle_t handle, int m, int n, double* A, int lda, int* lwork);
+  // CHECK: status = hipsolverDnDgetrf_bufferSize(handle, m, n, &dA, lda, &Lwork);
+  status = cusolverDnDgetrf_bufferSize(handle, m, n, &dA, lda, &Lwork);
+
+  // CUDA: cusolverStatus_t CUSOLVERAPI cusolverDnSgetrf(cusolverDnHandle_t handle, int m, int n, float* A, int lda, float* Workspace, int* devIpiv, int* devInfo);
+  // HIP: HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDnSgetrf(hipsolverHandle_t handle, int m, int n, float* A, int lda, float* work, int* devIpiv, int* devInfo);
+  // CHECK: status = hipsolverDnSgetrf(handle, m, n, &fA, lda, &fWorkspace, &devIpiv, &devInfo);
+  status = cusolverDnSgetrf(handle, m, n, &fA, lda, &fWorkspace, &devIpiv, &devInfo);
+
+  // CUDA: cusolverStatus_t CUSOLVERAPI cusolverDnSgetrf_bufferSize(cusolverDnHandle_t handle, int m, int n, float* A, int lda, int* Lwork);
+  // HIP: HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDnSgetrf_bufferSize(hipsolverHandle_t handle, int m, int n, float* A, int lda, int* lwork);
+  // CHECK: status = hipsolverDnSgetrf_bufferSize(handle, m, n, &fA, lda, &Lwork);
+  status = cusolverDnSgetrf_bufferSize(handle, m, n, &fA, lda, &Lwork);
+
+  // CUDA: cusolverStatus_t CUSOLVERAPI cusolverDnDgetrs(cusolverDnHandle_t handle, cublasOperation_t trans, int n, int nrhs,const double* A, int lda, const int* devIpiv, double* B, int ldb, int* devInfo);
+  // HIP: HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDnDgetrs(hipsolverHandle_t handle, hipsolverOperation_t trans, int n, int nrhs, const double* A, int lda, const int* devIpiv, double* B, int ldb, int* devInfo);
+  // CHECK: status = hipsolverDnDgetrs(handle, blasOperation, n, nrhs , &dA, lda, &devIpiv, &dB, ldb, &devInfo);
+  status = cusolverDnDgetrs(handle, blasOperation, n, nrhs , &dA, lda, &devIpiv, &dB, ldb, &devInfo);
+
+  // CUDA: cusolverStatus_t CUSOLVERAPI cusolverDnSgetrs(cusolverDnHandle_t handle, cublasOperation_t  trans, int n, int nrhs, const float* A, int lda, const int* devIpiv, float* B, int ldb, int* devInfo);
+  // HIP: HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDnSgetrs(hipsolverHandle_t handle, hipsolverOperation_t trans, int n, int nrhs, const float* A, int lda, const int* devIpiv, float* B, int ldb, int* devInfo);
+  // CHECK: status = hipsolverDnSgetrs(handle, blasOperation, n, nrhs , &fA, lda, &devIpiv, &fB, ldb, &devInfo);
+  status = cusolverDnSgetrs(handle, blasOperation, n, nrhs , &fA, lda, &devIpiv, &fB, ldb, &devInfo);
 
   return 0;
 }


### PR DESCRIPTION
+ Updated `SOLVER` synthetic test
+ Updated the regenerated hipify-perl
+ [ToDo] `SOLVER` `CUDA2HIP` documentation generation
+ [ToDo][feature][hard][long-term] `cusolverXXX` -> `rocsolver_XXX` + harness of other `SOLVER` and `BLAS` API calls