### PR TITLE
[HIPIFY][tests][fix] CUDA < 9.0 fix for `int64_t` and `uint64_t`

### DIFF
--- a/tests/unit_tests/synthetic/libraries/cusparse2hipsparse.cu
+++ b/tests/unit_tests/synthetic/libraries/cusparse2hipsparse.cu
@@ -9,6 +9,11 @@
 #include "cusparse.h"
 // CHECK-NOT: #include "hipsparse.h"
 
+#if defined(_WIN32) && CUDDA_VERSION < 9000
+  typedef signed   __int64 int64_t;
+  typedef unsigned __int64 uint64_t;
+#endif
+
 int main() {
   printf("17. cuSPARSE API to hipSPARSE API synthetic test\n");
 

--- a/tests/unit_tests/synthetic/libraries/cusparse2rocsparse.cu
+++ b/tests/unit_tests/synthetic/libraries/cusparse2rocsparse.cu
@@ -9,6 +9,11 @@
 #include "cusparse.h"
 // CHECK-NOT: #include "rocsparse.h"
 
+#if defined(_WIN32) && CUDDA_VERSION < 9000
+  typedef signed   __int64 int64_t;
+  typedef unsigned __int64 uint64_t;
+#endif
+
 int main() {
   printf("18. cuSPARSE API to rocSPARSE API synthetic test\n");
 


### PR DESCRIPTION
+ [Reason] `int64_t` and `uint64_t` types are not declared for MSVS in main headers of CUDA < 9.0
