### PR TITLE
[HIPIFY][tests][fix] CUDA < 9.0: the test `half2_allocators.cu` is excluded

### DIFF
--- a/tests/lit.cfg
+++ b/tests/lit.cfg
@@ -58,6 +58,7 @@ if config.cuda_version_major < 9:
     config.excludes.append('cuSPARSE_07.cu')
     config.excludes.append('benchmark_curand_kernel.cpp')
     config.excludes.append('reinterpret_cast.cu')
+    config.excludes.append('half2_allocators.cu')
     config.excludes.append('cub_01.cu')
     config.excludes.append('cub_02.cu')
     config.excludes.append('cub_03.cu')


### PR DESCRIPTION
+ [Reason] error: no member named 'x' ('y') in '__half2'
