### PR TITLE
[HIPIFY][SPARSE][tests][fix] CUDA < 8.0 test fixes

### DIFF
--- a/docs/tables/CUSPARSE_API_supported_by_HIP.md
+++ b/docs/tables/CUSPARSE_API_supported_by_HIP.md
@@ -200,7 +200,7 @@
 |`cusparseGetErrorName`|10.2| | | |`hipsparseGetErrorName`|6.0.0| | | | |
 |`cusparseGetErrorString`|10.2| | | |`hipsparseGetErrorString`|6.0.0| | | | |
 |`cusparseGetPointerMode`| | | | |`hipsparseGetPointerMode`|1.9.2| | | | |
-|`cusparseGetStream`| | | | |`hipsparseGetStream`|1.9.2| | | | |
+|`cusparseGetStream`|8.0| | | |`hipsparseGetStream`|1.9.2| | | | |
 |`cusparseGetVersion`| | | | |`hipsparseGetVersion`|1.9.2| | | | |
 |`cusparseSetPointerMode`| | | | |`hipsparseSetPointerMode`|1.9.2| | | | |
 |`cusparseSetStream`| | | | |`hipsparseSetStream`|1.9.2| | | | |

--- a/docs/tables/CUSPARSE_API_supported_by_HIP_and_ROC.md
+++ b/docs/tables/CUSPARSE_API_supported_by_HIP_and_ROC.md
@@ -200,7 +200,7 @@
 |`cusparseGetErrorName`|10.2| | | |`hipsparseGetErrorName`|6.0.0| | | | | | | | | | |
 |`cusparseGetErrorString`|10.2| | | |`hipsparseGetErrorString`|6.0.0| | | | | | | | | | |
 |`cusparseGetPointerMode`| | | | |`hipsparseGetPointerMode`|1.9.2| | | | |`rocsparse_get_pointer_mode`|1.9.0| | | | |
-|`cusparseGetStream`| | | | |`hipsparseGetStream`|1.9.2| | | | |`rocsparse_get_stream`|1.9.0| | | | |
+|`cusparseGetStream`|8.0| | | |`hipsparseGetStream`|1.9.2| | | | |`rocsparse_get_stream`|1.9.0| | | | |
 |`cusparseGetVersion`| | | | |`hipsparseGetVersion`|1.9.2| | | | |`rocsparse_get_version`|1.9.0| | | | |
 |`cusparseSetPointerMode`| | | | |`hipsparseSetPointerMode`|1.9.2| | | | |`rocsparse_set_pointer_mode`|1.9.0| | | | |
 |`cusparseSetStream`| | | | |`hipsparseSetStream`|1.9.2| | | | |`rocsparse_set_stream`|1.9.0| | | | |

--- a/docs/tables/CUSPARSE_API_supported_by_ROC.md
+++ b/docs/tables/CUSPARSE_API_supported_by_ROC.md
@@ -200,7 +200,7 @@
 |`cusparseGetErrorName`|10.2| | | | | | | | | |
 |`cusparseGetErrorString`|10.2| | | | | | | | | |
 |`cusparseGetPointerMode`| | | | |`rocsparse_get_pointer_mode`|1.9.0| | | | |
-|`cusparseGetStream`| | | | |`rocsparse_get_stream`|1.9.0| | | | |
+|`cusparseGetStream`|8.0| | | |`rocsparse_get_stream`|1.9.0| | | | |
 |`cusparseGetVersion`| | | | |`rocsparse_get_version`|1.9.0| | | | |
 |`cusparseSetPointerMode`| | | | |`rocsparse_set_pointer_mode`|1.9.0| | | | |
 |`cusparseSetStream`| | | | |`rocsparse_set_stream`|1.9.0| | | | |

--- a/src/CUDA2HIP_SPARSE_API_functions.cpp
+++ b/src/CUDA2HIP_SPARSE_API_functions.cpp
@@ -1124,6 +1124,7 @@ const std::map<llvm::StringRef, cudaAPIversions> CUDA_SPARSE_FUNCTION_VER_MAP {
   {"cusparseDnnz_compress",                             {CUDA_80,  CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
   {"cusparseCnnz_compress",                             {CUDA_80,  CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
   {"cusparseZnnz_compress",                             {CUDA_80,  CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
+  {"cusparseGetStream",                                 {CUDA_80,  CUDA_0,   CUDA_0  }},
   {"cusparseCreateCoo",                                 {CUDA_101, CUDA_0,   CUDA_0  }},
   {"cusparseCreateCooAoS",                              {CUDA_102, CUDA_112, CUDA_120}},
   {"cusparseCreateCsr",                                 {CUDA_102, CUDA_0,   CUDA_0  }},

--- a/tests/unit_tests/synthetic/libraries/cusparse2hipsparse.cu
+++ b/tests/unit_tests/synthetic/libraries/cusparse2hipsparse.cu
@@ -319,11 +319,6 @@ int main() {
   // CHECK: status_t = hipsparseSetStream(handle_t, stream_t);
   status_t = cusparseSetStream(handle_t, stream_t);
 
-  // CUDA: cusparseStatus_t CUSPARSEAPI cusparseGetStream(cusparseHandle_t handle, cudaStream_t* streamId);
-  // HIP: HIPSPARSE_EXPORT hipsparseStatus_t hipsparseGetStream(hipsparseHandle_t handle, hipStream_t* streamId);
-  // CHECK: status_t = hipsparseGetStream(handle_t, &stream_t);
-  status_t = cusparseGetStream(handle_t, &stream_t);
-
   // CUDA: cusparseStatus_t CUSPARSEAPI cusparseSetPointerMode(cusparseHandle_t handle, cusparsePointerMode_t mode);
   // HIP: HIPSPARSE_EXPORT hipsparseStatus_t hipsparseSetPointerMode(hipsparseHandle_t handle, hipsparsePointerMode_t mode);
   // CHECK: status_t = hipsparseSetPointerMode(handle_t, pointerMode_t);
@@ -1094,6 +1089,11 @@ int main() {
   // HIP: HIPSPARSE_EXPORT hipsparseStatus_t hipsparseSnnz_compress(hipsparseHandle_t handle, int m, const hipsparseMatDescr_t descrA, const float* csrValA, const int* csrRowPtrA, int* nnzPerRow, int* nnzC, float tol);
   // CHECK: status_t = hipsparseSnnz_compress(handle_t, m, matDescr_A, &csrSortedValA, &csrRowPtrA, &nnzPerRow, &nnzc, ftol);
  status_t = cusparseSnnz_compress(handle_t, m, matDescr_A, &csrSortedValA, &csrRowPtrA, &nnzPerRow, &nnzc, ftol);
+
+  // CUDA: cusparseStatus_t CUSPARSEAPI cusparseGetStream(cusparseHandle_t handle, cudaStream_t* streamId);
+  // HIP: HIPSPARSE_EXPORT hipsparseStatus_t hipsparseGetStream(hipsparseHandle_t handle, hipStream_t* streamId);
+  // CHECK: status_t = hipsparseGetStream(handle_t, &stream_t);
+  status_t = cusparseGetStream(handle_t, &stream_t);
 #endif
 
 #if CUDA_VERSION >= 8000 && CUDA_VERSION < 12000

--- a/tests/unit_tests/synthetic/libraries/cusparse2rocsparse.cu
+++ b/tests/unit_tests/synthetic/libraries/cusparse2rocsparse.cu
@@ -311,11 +311,6 @@ int main() {
   // CHECK: status_t = rocsparse_set_stream(handle_t, stream_t);
   status_t = cusparseSetStream(handle_t, stream_t);
 
-  // CUDA: cusparseStatus_t CUSPARSEAPI cusparseGetStream(cusparseHandle_t handle, cudaStream_t* streamId);
-  // ROC: ROCSPARSE_EXPORT rocsparse_status rocsparse_get_stream(rocsparse_handle handle, hipStream_t* stream);
-  // CHECK: status_t = rocsparse_get_stream(handle_t, &stream_t);
-  status_t = cusparseGetStream(handle_t, &stream_t);
-
   // CUDA: cusparseStatus_t CUSPARSEAPI cusparseSetPointerMode(cusparseHandle_t handle, cusparsePointerMode_t mode);
   // ROC: ROCSPARSE_EXPORT rocsparse_status rocsparse_set_pointer_mode(rocsparse_handle handle, rocsparse_pointer_mode pointer_mode);
   // CHECK: status_t = rocsparse_set_pointer_mode(handle_t, pointerMode_t);
@@ -1043,9 +1038,7 @@ int main() {
   status_t = cusparseXbsrsm2_zeroPivot(handle_t, bsrsm2_info, &iposition);
 
 #if CUDA_VERSION >= 8000
-  // CHECK: hipDataType dataType_t;
-  // TODO: [#899] There should be rocsparse_datatype
-  // CHECK-NEXT: hipDataType dataType;
+  // TODO: [#899] There should be rocsparse_datatype instead of hipDataType
   cudaDataType_t dataType_t;
   cudaDataType dataType;
 
@@ -1088,6 +1081,11 @@ int main() {
   // ROC: ROCSPARSE_EXPORT rocsparse_status rocsparse_snnz_compress(rocsparse_handle handle, rocsparse_int m, const rocsparse_mat_descr descr_A, const float* csr_val_A, const rocsparse_int* csr_row_ptr_A, rocsparse_int* nnz_per_row, rocsparse_int* nnz_C, float tol);
   // CHECK: status_t = rocsparse_snnz_compress(handle_t, m, matDescr_A, &csrSortedValA, &csrRowPtrA, &nnzPerRow, &nnzc, ftol);
   status_t = cusparseSnnz_compress(handle_t, m, matDescr_A, &csrSortedValA, &csrRowPtrA, &nnzPerRow, &nnzc, ftol);
+
+  // CUDA: cusparseStatus_t CUSPARSEAPI cusparseGetStream(cusparseHandle_t handle, cudaStream_t* streamId);
+  // ROC: ROCSPARSE_EXPORT rocsparse_status rocsparse_get_stream(rocsparse_handle handle, hipStream_t* stream);
+  // CHECK: status_t = rocsparse_get_stream(handle_t, &stream_t);
+  status_t = cusparseGetStream(handle_t, &stream_t);
 #endif
 
 #if CUDA_VERSION >= 8000 && CUDA_VERSION < 12000


### PR DESCRIPTION
+ [Reason] `cusparseGetStream` appeared in CUDA 8.0
+ [fix] Set the missing A-version for `cusparseGetStream`
+ Updated synthetic `SPARSE` tests and the regenerated `SPARSE` documentation
+ [TODO][#899][temporary] Always convert `cudaDataType_t` to `hipDataType` under the `--use-hip-data-types` option
