### PR TITLE
[HIPIFY][RTC][SWDEV-430220][doc][fix] Reflect the functions `nvrtcCompileProgram` and `nvrtcCreateProgram` signatures changes

### DIFF
--- a/docs/tables/CUDA_RTC_API_supported_by_HIP.md
+++ b/docs/tables/CUDA_RTC_API_supported_by_HIP.md
@@ -25,8 +25,8 @@
 |**CUDA**|**A**|**D**|**C**|**R**|**HIP**|**A**|**D**|**C**|**R**|**E**|
 |:--|:-:|:-:|:-:|:-:|:--|:-:|:-:|:-:|:-:|:-:|
 |`nvrtcAddNameExpression`|8.0| | | |`hiprtcAddNameExpression`|2.6.0| | | | |
-|`nvrtcCompileProgram`| | | | |`hiprtcCompileProgram`|2.6.0| | | | |
-|`nvrtcCreateProgram`| | | | |`hiprtcCreateProgram`|2.6.0| | | | |
+|`nvrtcCompileProgram`| | |8.0| |`hiprtcCompileProgram`|2.6.0| | | | |
+|`nvrtcCreateProgram`| | |8.0| |`hiprtcCreateProgram`|2.6.0| | | | |
 |`nvrtcDestroyProgram`| | | | |`hiprtcDestroyProgram`|2.6.0| | | | |
 |`nvrtcGetCUBIN`|11.1| | | |`hiprtcGetBitcode`|5.3.0| | | | |
 |`nvrtcGetCUBINSize`|11.1| | | |`hiprtcGetBitcodeSize`|5.3.0| | | | |

--- a/src/CUDA2HIP.h
+++ b/src/CUDA2HIP.h
@@ -156,6 +156,7 @@ extern const std::map<llvm::StringRef, hipAPIversions> HIP_CUB_TYPE_NAME_VER_MAP
 extern const std::map<llvm::StringRef, hipAPIversions> HIP_CUB_FUNCTION_VER_MAP;
 extern const std::map<llvm::StringRef, hipAPIversions> HIP_RTC_TYPE_NAME_VER_MAP;
 extern const std::map<llvm::StringRef, hipAPIversions> HIP_RTC_FUNCTION_VER_MAP;
+extern const std::map<llvm::StringRef, cudaAPIChangedVersions> CUDA_RTC_FUNCTION_CHANGED_VER_MAP;
 extern const std::map<llvm::StringRef, hipAPIversions> HIP_SOLVER_TYPE_NAME_VER_MAP;
 extern const std::map<llvm::StringRef, hipAPIversions> HIP_SOLVER_FUNCTION_VER_MAP;
 

--- a/src/CUDA2HIP_Doc.cpp
+++ b/src/CUDA2HIP_Doc.cpp
@@ -794,6 +794,7 @@ namespace doc {
       const typeMap &getTypes() const override { return CUDA_RTC_TYPE_NAME_MAP; }
       const versionMap &getFunctionVersions() const override { return CUDA_RTC_FUNCTION_VER_MAP; }
       const hipVersionMap &getHipFunctionVersions() const override { return HIP_RTC_FUNCTION_VER_MAP; }
+      const cudaChangedVersionMap& getCudaChangedFunctionVersions() const override { return CUDA_RTC_FUNCTION_CHANGED_VER_MAP; }
       const versionMap &getTypeVersions() const override { return CUDA_RTC_TYPE_NAME_VER_MAP; }
       const hipVersionMap &getHipTypeVersions() const override { return HIP_RTC_TYPE_NAME_VER_MAP; }
       const string &getName() const override { return sCURTC; }

--- a/src/CUDA2HIP_RTC_API_functions.cpp
+++ b/src/CUDA2HIP_RTC_API_functions.cpp
@@ -78,6 +78,11 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_RTC_FUNCTION_VER_MAP {
   {"hiprtcGetBitcodeSize",                        {HIP_5030, HIP_0,    HIP_0   }},
 };
 
+const std::map<llvm::StringRef, cudaAPIChangedVersions> CUDA_RTC_FUNCTION_CHANGED_VER_MAP {
+  {"nvrtcCreateProgram",                          {CUDA_80}},
+  {"nvrtcCompileProgram",                         {CUDA_80}},
+};
+
 const std::map<unsigned int, llvm::StringRef> CUDA_RTC_API_SECTION_MAP {
   {1, "RTC Data types"},
   {2, "RTC API functions"},


### PR DESCRIPTION
+ [Reason] The types of the last arguments of the above mentioned functions are changed in CUDA 8.0
+ [Solution] Reflect it in the documentation
+ [TODO]
  + [HIPIFY] Implement const_cast transformation for the affected arguments
  + [HIP RT] Plan an ABI change in hiprtcCreateProgram for some of the upcomming HIP releases