### PR TITLE
[HIPIFY][#675][#677][SOLVER][feature] `cuSOLVER` support - Step 12 - Functions (DN)

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -2398,6 +2398,7 @@ sub rocSubstitutions {
     subst("CUSPARSE_STATUS_NOT_SUPPORTED", "rocsparse_status_not_implemented", "numeric_literal");
     subst("CUSPARSE_STATUS_SUCCESS", "rocsparse_status_success", "numeric_literal");
     subst("CUSPARSE_STATUS_ZERO_PIVOT", "rocsparse_status_zero_pivot", "numeric_literal");
+    subst("cusolver_int_t", "rocblas_int", "numeric_literal");
 }
 
 sub simpleSubstitutions {
@@ -3608,6 +3609,7 @@ sub simpleSubstitutions {
     subst("curandSetPseudoRandomGeneratorSeed", "hiprandSetPseudoRandomGeneratorSeed", "library");
     subst("curandSetQuasiRandomGeneratorDimensions", "hiprandSetQuasiRandomGeneratorDimensions", "library");
     subst("curandSetStream", "hiprandSetStream", "library");
+    subst("cusolverDnZZgesv", "hipsolverDnZZgesv", "library");
     subst("cusparseAxpby", "hipsparseAxpby", "library");
     subst("cusparseBlockedEllGet", "hipsparseBlockedEllGet", "library");
     subst("cusparseCaxpyi", "hipsparseCaxpyi", "library");
@@ -5841,6 +5843,7 @@ sub simpleSubstitutions {
     subst("cudaStreamSetCaptureDependencies", "hipStreamSetCaptureDependencies", "numeric_literal");
     subst("cudaSuccess", "hipSuccess", "numeric_literal");
     subst("cudaUserObjectNoDestructorSync", "hipUserObjectNoDestructorSync", "numeric_literal");
+    subst("cusolver_int_t", "int", "numeric_literal");
     subst("CUB_MAX", "CUB_MAX", "define");
     subst("CUB_MIN", "CUB_MIN", "define");
     subst("CUB_NAMESPACE_BEGIN", "BEGIN_HIPCUB_NAMESPACE", "define");
@@ -7107,6 +7110,13 @@ sub warnUnsupportedFunctions {
         "cusolverDnIRSParamsCreate",
         "cusolverDnIRSParams",
         "cusolverDnIRSInfos_t",
+        "cusolverDnIRSInfosRequestResidual",
+        "cusolverDnIRSInfosGetResidualHistory",
+        "cusolverDnIRSInfosGetOuterNiters",
+        "cusolverDnIRSInfosGetNiters",
+        "cusolverDnIRSInfosGetMaxIters",
+        "cusolverDnIRSInfosDestroy",
+        "cusolverDnIRSInfosCreate",
         "cusolverDnIRSInfos",
         "cusolverDnGetDeterministicMode",
         "cusolverDnFunction_t",

--- a/docs/tables/CUSOLVER_API_supported_by_HIP.md
+++ b/docs/tables/CUSOLVER_API_supported_by_HIP.md
@@ -98,6 +98,7 @@
 |`cusolverPrecType_t`|11.0| | | | | | | | | |
 |`cusolverStatus_t`| | | | |`hipsolverStatus_t`|4.5.0| | | |6.1.0|
 |`cusolverStorevMode_t`|11.0| | | | | | | | | |
+|`cusolver_int_t`|10.1| | | |`int`| | | | | |
 |`gesvdjInfo`|9.0| | | | | | | | | |
 |`gesvdjInfo_t`|9.0| | | |`hipsolverGesvdjInfo_t`|5.1.0| | | |6.1.0|
 |`syevjInfo`|9.0| | | | | | | | | |
@@ -115,6 +116,13 @@
 |`cusolverDnDgetrs`| | | | |`hipsolverDnDgetrs`|5.1.0| | | |6.1.0|
 |`cusolverDnGetDeterministicMode`|12.2| | | | | | | | | |
 |`cusolverDnGetStream`| | | | |`hipsolverGetStream`|4.5.0| | | |6.1.0|
+|`cusolverDnIRSInfosCreate`|10.2| | | | | | | | | |
+|`cusolverDnIRSInfosDestroy`|10.2| | | | | | | | | |
+|`cusolverDnIRSInfosGetMaxIters`|10.2| | | | | | | | | |
+|`cusolverDnIRSInfosGetNiters`|10.2| | | | | | | | | |
+|`cusolverDnIRSInfosGetOuterNiters`|10.2| | | | | | | | | |
+|`cusolverDnIRSInfosGetResidualHistory`|10.2| | | | | | | | | |
+|`cusolverDnIRSInfosRequestResidual`|10.2| | | | | | | | | |
 |`cusolverDnIRSParamsCreate`|10.2| | | | | | | | | |
 |`cusolverDnIRSParamsDestroy`|10.2| | | | | | | | | |
 |`cusolverDnIRSParamsDisableFallback`|11.0| | | | | | | | | |
@@ -137,6 +145,7 @@
 |`cusolverDnXgetrf`|11.1| | | | | | | | | |
 |`cusolverDnXgetrf_bufferSize`|11.1| | | | | | | | | |
 |`cusolverDnXgetrs`|11.1| | | | | | | | | |
+|`cusolverDnZZgesv`|10.2| | | |`hipsolverDnZZgesv`|5.1.0| | | |6.1.0|
 
 
 \*A - Added; D - Deprecated; C - Changed; R - Removed; E - Experimental

--- a/docs/tables/CUSOLVER_API_supported_by_HIP_and_ROC.md
+++ b/docs/tables/CUSOLVER_API_supported_by_HIP_and_ROC.md
@@ -98,6 +98,7 @@
 |`cusolverPrecType_t`|11.0| | | | | | | | | | | | | | | |
 |`cusolverStatus_t`| | | | |`hipsolverStatus_t`|4.5.0| | | |6.1.0|`rocblas_status`|3.0.0| | | |6.1.0|
 |`cusolverStorevMode_t`|11.0| | | | | | | | | | | | | | | |
+|`cusolver_int_t`|10.1| | | |`int`| | | | | |`rocblas_int`|3.0.0| | | |6.1.0|
 |`gesvdjInfo`|9.0| | | | | | | | | | | | | | | |
 |`gesvdjInfo_t`|9.0| | | |`hipsolverGesvdjInfo_t`|5.1.0| | | |6.1.0| | | | | | |
 |`syevjInfo`|9.0| | | | | | | | | | | | | | | |
@@ -115,6 +116,13 @@
 |`cusolverDnDgetrs`| | | | |`hipsolverDnDgetrs`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnGetDeterministicMode`|12.2| | | | | | | | | | | | | | | |
 |`cusolverDnGetStream`| | | | |`hipsolverGetStream`|4.5.0| | | |6.1.0|`rocblas_get_stream`| | | | | |
+|`cusolverDnIRSInfosCreate`|10.2| | | | | | | | | | | | | | | |
+|`cusolverDnIRSInfosDestroy`|10.2| | | | | | | | | | | | | | | |
+|`cusolverDnIRSInfosGetMaxIters`|10.2| | | | | | | | | | | | | | | |
+|`cusolverDnIRSInfosGetNiters`|10.2| | | | | | | | | | | | | | | |
+|`cusolverDnIRSInfosGetOuterNiters`|10.2| | | | | | | | | | | | | | | |
+|`cusolverDnIRSInfosGetResidualHistory`|10.2| | | | | | | | | | | | | | | |
+|`cusolverDnIRSInfosRequestResidual`|10.2| | | | | | | | | | | | | | | |
 |`cusolverDnIRSParamsCreate`|10.2| | | | | | | | | | | | | | | |
 |`cusolverDnIRSParamsDestroy`|10.2| | | | | | | | | | | | | | | |
 |`cusolverDnIRSParamsDisableFallback`|11.0| | | | | | | | | | | | | | | |
@@ -137,6 +145,7 @@
 |`cusolverDnXgetrf`|11.1| | | | | | | | | | | | | | | |
 |`cusolverDnXgetrf_bufferSize`|11.1| | | | | | | | | | | | | | | |
 |`cusolverDnXgetrs`|11.1| | | | | | | | | | | | | | | |
+|`cusolverDnZZgesv`|10.2| | | |`hipsolverDnZZgesv`|5.1.0| | | |6.1.0| | | | | | |
 
 
 \*A - Added; D - Deprecated; C - Changed; R - Removed; E - Experimental

--- a/docs/tables/CUSOLVER_API_supported_by_ROC.md
+++ b/docs/tables/CUSOLVER_API_supported_by_ROC.md
@@ -98,6 +98,7 @@
 |`cusolverPrecType_t`|11.0| | | | | | | | | |
 |`cusolverStatus_t`| | | | |`rocblas_status`|3.0.0| | | |6.1.0|
 |`cusolverStorevMode_t`|11.0| | | | | | | | | |
+|`cusolver_int_t`|10.1| | | |`rocblas_int`|3.0.0| | | |6.1.0|
 |`gesvdjInfo`|9.0| | | | | | | | | |
 |`gesvdjInfo_t`|9.0| | | | | | | | | |
 |`syevjInfo`|9.0| | | | | | | | | |
@@ -115,6 +116,13 @@
 |`cusolverDnDgetrs`| | | | | | | | | | |
 |`cusolverDnGetDeterministicMode`|12.2| | | | | | | | | |
 |`cusolverDnGetStream`| | | | |`rocblas_get_stream`| | | | | |
+|`cusolverDnIRSInfosCreate`|10.2| | | | | | | | | |
+|`cusolverDnIRSInfosDestroy`|10.2| | | | | | | | | |
+|`cusolverDnIRSInfosGetMaxIters`|10.2| | | | | | | | | |
+|`cusolverDnIRSInfosGetNiters`|10.2| | | | | | | | | |
+|`cusolverDnIRSInfosGetOuterNiters`|10.2| | | | | | | | | |
+|`cusolverDnIRSInfosGetResidualHistory`|10.2| | | | | | | | | |
+|`cusolverDnIRSInfosRequestResidual`|10.2| | | | | | | | | |
 |`cusolverDnIRSParamsCreate`|10.2| | | | | | | | | |
 |`cusolverDnIRSParamsDestroy`|10.2| | | | | | | | | |
 |`cusolverDnIRSParamsDisableFallback`|11.0| | | | | | | | | |
@@ -137,6 +145,7 @@
 |`cusolverDnXgetrf`|11.1| | | | | | | | | |
 |`cusolverDnXgetrf_bufferSize`|11.1| | | | | | | | | |
 |`cusolverDnXgetrs`|11.1| | | | | | | | | |
+|`cusolverDnZZgesv`|10.2| | | | | | | | | |
 
 
 \*A - Added; D - Deprecated; C - Changed; R - Removed; E - Experimental

--- a/src/CUDA2HIP_SOLVER_API_functions.cpp
+++ b/src/CUDA2HIP_SOLVER_API_functions.cpp
@@ -60,6 +60,15 @@ const std::map<llvm::StringRef, hipCounter> CUDA_SOLVER_FUNCTION_MAP {
   {"cusolverDnIRSParamsGetMaxIters",                      {"hipsolverDnIRSParamsGetMaxIters",                      "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
   {"cusolverDnIRSParamsEnableFallback",                   {"hipsolverDnIRSParamsEnableFallback",                   "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
   {"cusolverDnIRSParamsDisableFallback",                  {"hipsolverDnIRSParamsDisableFallback",                  "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
+  {"cusolverDnIRSInfosCreate",                            {"hipsolverDnIRSInfosCreate",                            "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
+  {"cusolverDnIRSInfosDestroy",                           {"hipsolverDnIRSInfosDestroy",                           "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
+  {"cusolverDnIRSInfosGetNiters",                         {"hipsolverDnIRSInfosGetNiters",                         "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
+  {"cusolverDnIRSInfosGetOuterNiters",                    {"hipsolverDnIRSInfosGetOuterNiters",                    "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
+  {"cusolverDnIRSInfosRequestResidual",                   {"hipsolverDnIRSInfosRequestResidual",                   "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
+  {"cusolverDnIRSInfosGetResidualHistory",                {"hipsolverDnIRSInfosGetResidualHistory",                "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
+  {"cusolverDnIRSInfosGetMaxIters",                       {"hipsolverDnIRSInfosGetMaxIters",                       "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
+  // NOTE: rocsolver_zgesv has a harness of rocblas_set_workspace, hipsolverZZgesv_bufferSize, and rocsolver_zgesv_outofplace
+  {"cusolverDnZZgesv",                                    {"hipsolverDnZZgesv",                                    "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
 };
 
 const std::map<llvm::StringRef, cudaAPIversions> CUDA_SOLVER_FUNCTION_VER_MAP {
@@ -83,6 +92,14 @@ const std::map<llvm::StringRef, cudaAPIversions> CUDA_SOLVER_FUNCTION_VER_MAP {
   {"cusolverDnIRSParamsGetMaxIters",                      {CUDA_102,  CUDA_0, CUDA_0}},
   {"cusolverDnIRSParamsEnableFallback",                   {CUDA_110,  CUDA_0, CUDA_0}},
   {"cusolverDnIRSParamsDisableFallback",                  {CUDA_110,  CUDA_0, CUDA_0}},
+  {"cusolverDnIRSInfosCreate",                            {CUDA_102,  CUDA_0, CUDA_0}},
+  {"cusolverDnIRSInfosDestroy",                           {CUDA_102,  CUDA_0, CUDA_0}},
+  {"cusolverDnIRSInfosGetNiters",                         {CUDA_102,  CUDA_0, CUDA_0}},
+  {"cusolverDnIRSInfosGetOuterNiters",                    {CUDA_102,  CUDA_0, CUDA_0}},
+  {"cusolverDnIRSInfosRequestResidual",                   {CUDA_102,  CUDA_0, CUDA_0}},
+  {"cusolverDnIRSInfosGetResidualHistory",                {CUDA_102,  CUDA_0, CUDA_0}},
+  {"cusolverDnIRSInfosGetMaxIters",                       {CUDA_102,  CUDA_0, CUDA_0}},
+  {"cusolverDnZZgesv",                                    {CUDA_102,  CUDA_0, CUDA_0}},
 };
 
 const std::map<llvm::StringRef, hipAPIversions> HIP_SOLVER_FUNCTION_VER_MAP {
@@ -96,6 +113,7 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_SOLVER_FUNCTION_VER_MAP {
   {"hipsolverDnSgetrs",                                   {HIP_5010, HIP_0,    HIP_0,  HIP_LATEST}},
   {"hipsolverSetStream",                                  {HIP_4050, HIP_0,    HIP_0,  HIP_LATEST}},
   {"hipsolverGetStream",                                  {HIP_4050, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipsolverDnZZgesv",                                   {HIP_5010, HIP_0,    HIP_0,  HIP_LATEST}},
 };
 
 const std::map<unsigned int, llvm::StringRef> CUDA_SOLVER_API_SECTION_MAP {

--- a/src/CUDA2HIP_SOLVER_API_types.cpp
+++ b/src/CUDA2HIP_SOLVER_API_types.cpp
@@ -122,9 +122,11 @@ const std::map<llvm::StringRef, hipCounter> CUDA_SOLVER_TYPE_NAME_MAP {
   {"cusolverDeterministicMode_t",                              {"hipsolverDeterministicMode_t",                              "",                                                                 CONV_TYPE, API_SOLVER, 1, UNSUPPORTED}},
   {"CUSOLVER_DETERMINISTIC_RESULTS",                           {"HIPSOLVER_DETERMINISTIC_RESULTS",                           "",                                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1, UNSUPPORTED}},
   {"CUSOLVER_ALLOW_NON_DETERMINISTIC_RESULTS",                 {"HIPSOLVER_ALLOW_NON_DETERMINISTIC_RESULTS",                 "",                                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1, UNSUPPORTED}},
+  {"cusolver_int_t",                                           {"int",                                                       "rocblas_int",                                                      CONV_NUMERIC_LITERAL, API_SOLVER, 1}},
 };
 
 const std::map<llvm::StringRef, cudaAPIversions> CUDA_SOLVER_TYPE_NAME_VER_MAP {
+  {"cusolver_int_t",                                           {CUDA_101, CUDA_0, CUDA_0}},
   {"CUSOLVER_STATUS_IRS_PARAMS_NOT_INITIALIZED",               {CUDA_102, CUDA_0, CUDA_0}},
   {"CUSOLVER_STATUS_IRS_PARAMS_INVALID",                       {CUDA_102, CUDA_0, CUDA_0}},
   {"CUSOLVER_STATUS_IRS_PARAMS_INVALID_PREC",                  {CUDA_110, CUDA_0, CUDA_0}},
@@ -237,6 +239,7 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_SOLVER_TYPE_NAME_VER_MAP {
   {"hipsolverSyevjInfo_t",                                     {HIP_5010, HIP_0,    HIP_0,  HIP_LATEST}},
   {"hipsolverGesvdjInfo_t",                                    {HIP_5010, HIP_0,    HIP_0,  HIP_LATEST}},
 
+  {"rocblas_int",                                              {HIP_3000, HIP_0,    HIP_0,  HIP_LATEST}},
   {"rocblas_status",                                           {HIP_3000, HIP_0,    HIP_0,  HIP_LATEST}},
   {"rocblas_status_success",                                   {HIP_3000, HIP_0,    HIP_0,  HIP_LATEST}},
   {"rocblas_status_invalid_handle",                            {HIP_5060, HIP_0,    HIP_0,  HIP_LATEST}},

--- a/tests/unit_tests/synthetic/libraries/cusolver2hipsolver.cu
+++ b/tests/unit_tests/synthetic/libraries/cusolver2hipsolver.cu
@@ -23,6 +23,11 @@ int main() {
   double dB = 0.f;
   float fWorkspace = 0.f;
   double dWorkspace = 0.f;
+  void *Workspace = nullptr;
+  size_t lwork_bytes = 0;
+
+  // CHECK: hipDoubleComplex dComplexA, dComplexB, dComplexX;
+  cuDoubleComplex dComplexA, dComplexB, dComplexX;
 
   // CHECK: hipsolverHandle_t handle;
   cusolverDnHandle_t handle;
@@ -133,6 +138,23 @@ int main() {
 #endif
 
 #if CUDA_VERSION >= 10010
+  // CHECK: int solver_int = 0;
+  // CHECK: int ln = 0;
+  // CHECK: int ldda = 0;
+  // CHECK: int lddb = 0;
+  // CHECK: int lddx = 0;
+  // CHECK: int dipiv = 0;
+  // CHECK: int iter = 0;
+  // CHECK: int d_info = 0;
+  cusolver_int_t solver_int = 0;
+  cusolver_int_t ln = 0;
+  cusolver_int_t ldda = 0;
+  cusolver_int_t lddb = 0;
+  cusolver_int_t lddx = 0;
+  cusolver_int_t dipiv = 0;
+  cusolver_int_t iter = 0;
+  cusolver_int_t d_info = 0;
+
   // CHECK: hipsolverEigRange_t eigRange;
   // CHECK-NEXT: hipsolverEigRange_t EIG_RANGE_ALL = HIPSOLVER_EIG_RANGE_ALL;
   // CHECK-NEXT: hipsolverEigRange_t EIG_RANGE_I = HIPSOLVER_EIG_RANGE_I;
@@ -150,6 +172,11 @@ int main() {
   cusolverStatus_t STATUS_IRS_PARAMS_INVALID = CUSOLVER_STATUS_IRS_PARAMS_INVALID;
   cusolverStatus_t STATUS_IRS_INTERNAL_ERROR = CUSOLVER_STATUS_IRS_INTERNAL_ERROR;
   cusolverStatus_t STATUS_IRS_NOT_SUPPORTED = CUSOLVER_STATUS_IRS_NOT_SUPPORTED;
+
+  // CUDA: cusolverStatus_t CUSOLVERAPI cusolverDnZZgesv(cusolverDnHandle_t handle, cusolver_int_t n, cusolver_int_t nrhs, cuDoubleComplex * dA, cusolver_int_t ldda, cusolver_int_t * dipiv, cuDoubleComplex * dB, cusolver_int_t lddb, cuDoubleComplex * dX, cusolver_int_t lddx, void * dWorkspace, size_t lwork_bytes, cusolver_int_t * iter, cusolver_int_t * d_info);
+  // HIP: HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDnZZgesv(hipsolverHandle_t handle, int n, int nrhs, hipDoubleComplex* A, int lda, int* devIpiv, hipDoubleComplex* B, int ldb, hipDoubleComplex* X, int ldx, void* work, size_t lwork, int* niters, int* devInfo);
+  // CHECK: status = hipsolverDnZZgesv(handle, ln, nrhs, &dComplexA, ldda, &dipiv, &dComplexB, lddb, &dComplexX, lddx, &Workspace, lwork_bytes, &iter, &d_info);
+  status = cusolverDnZZgesv(handle, ln, nrhs, &dComplexA, ldda, &dipiv, &dComplexB, lddb, &dComplexX, lddx, &Workspace, lwork_bytes, &iter, &d_info);
 #endif
 
   return 0;


### PR DESCRIPTION
+ `cusolverDnIRSInfos*` are `UNSUPPORTED`
+ `cusolver_int_t` -> `int` -> `rocblas_int`
+ `cusolverDnZZgesv` -> `hipsolverDnZZgesv`
+ [NOTE] rocsolver_zgesv has a harness of `rocblas_set_workspace`, `hipsolverZZgesv_bufferSize`, and `rocsolver_zgesv_outofplace`
+ Updated `SOLVER` synthetic tests, the regenerated hipify-perl, and `SOLVER` `CUDA2HIP` documentation
