### PR TITLE
[HIPIFY][#675][#677][SOLVER][feature] `cuSOLVER` support - Step 13 - Functions (DN)

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -3613,6 +3613,9 @@ sub simpleSubstitutions {
     subst("curandSetPseudoRandomGeneratorSeed", "hiprandSetPseudoRandomGeneratorSeed", "library");
     subst("curandSetQuasiRandomGeneratorDimensions", "hiprandSetQuasiRandomGeneratorDimensions", "library");
     subst("curandSetStream", "hiprandSetStream", "library");
+    subst("cusolverDnCCgesv", "hipsolverDnCCgesv", "library");
+    subst("cusolverDnDDgesv", "hipsolverDnDDgesv", "library");
+    subst("cusolverDnSSgesv", "hipsolverDnSSgesv", "library");
     subst("cusolverDnZZgesv", "hipsolverDnZZgesv", "library");
     subst("cusparseAxpby", "hipsparseAxpby", "library");
     subst("cusparseBlockedEllGet", "hipsparseBlockedEllGet", "library");
@@ -7091,11 +7094,18 @@ sub warnUnsupportedFunctions {
         "cusolverPrecType_t",
         "cusolverNorm_t",
         "cusolverIRSRefinement_t",
+        "cusolverDnZYgesv",
+        "cusolverDnZKgesv",
+        "cusolverDnZEgesv",
+        "cusolverDnZCgesv",
         "cusolverDnXgetrs",
         "cusolverDnXgetrf_bufferSize",
         "cusolverDnXgetrf",
         "cusolverDnSetDeterministicMode",
         "cusolverDnSetAdvOptions",
+        "cusolverDnSXgesv",
+        "cusolverDnSHgesv",
+        "cusolverDnSBgesv",
         "cusolverDnParams_t",
         "cusolverDnParams",
         "cusolverDnIRSParams_t",
@@ -7124,8 +7134,15 @@ sub warnUnsupportedFunctions {
         "cusolverDnIRSInfos",
         "cusolverDnGetDeterministicMode",
         "cusolverDnFunction_t",
+        "cusolverDnDXgesv",
+        "cusolverDnDSgesv",
+        "cusolverDnDHgesv",
+        "cusolverDnDBgesv",
         "cusolverDnCreateParams",
         "cusolverDnContext",
+        "cusolverDnCYgesv",
+        "cusolverDnCKgesv",
+        "cusolverDnCEgesv",
         "cusolverDirectMode_t",
         "cusolverDeterministicMode_t",
         "cusolverAlgMode_t",

--- a/docs/tables/CUSOLVER_API_supported_by_HIP.md
+++ b/docs/tables/CUSOLVER_API_supported_by_HIP.md
@@ -108,8 +108,17 @@
 
 |**CUDA**|**A**|**D**|**C**|**R**|**HIP**|**A**|**D**|**C**|**R**|**E**|
 |:--|:-:|:-:|:-:|:-:|:--|:-:|:-:|:-:|:-:|:-:|
+|`cusolverDnCCgesv`|10.2| | | |`hipsolverDnCCgesv`|5.1.0| | | |6.1.0|
+|`cusolverDnCEgesv`|11.0| | | | | | | | | |
+|`cusolverDnCKgesv`|10.2| | | | | | | | | |
+|`cusolverDnCYgesv`|11.0| | | | | | | | | |
 |`cusolverDnCreate`| | | | |`hipsolverDnCreate`|5.1.0| | | |6.1.0|
 |`cusolverDnCreateParams`|11.0| | | | | | | | | |
+|`cusolverDnDBgesv`|11.0| | | | | | | | | |
+|`cusolverDnDDgesv`|10.2| | | |`hipsolverDnDDgesv`|5.1.0| | | |6.1.0|
+|`cusolverDnDHgesv`|10.2| | | | | | | | | |
+|`cusolverDnDSgesv`|10.2| | | | | | | | | |
+|`cusolverDnDXgesv`|11.0| | | | | | | | | |
 |`cusolverDnDestroy`| | | | |`hipsolverDnDestroy`|5.1.0| | | |6.1.0|
 |`cusolverDnDgetrf`| | | | |`hipsolverDnDgetrf`|5.1.0| | | |6.1.0|
 |`cusolverDnDgetrf_bufferSize`| | | | |`hipsolverDnDgetrf_bufferSize`|5.1.0| | | |6.1.0|
@@ -136,6 +145,10 @@
 |`cusolverDnIRSParamsSetSolverPrecisions`|10.2| | | | | | | | | |
 |`cusolverDnIRSParamsSetTol`|10.2| | | | | | | | | |
 |`cusolverDnIRSParamsSetTolInner`|10.2| | | | | | | | | |
+|`cusolverDnSBgesv`|11.0| | | | | | | | | |
+|`cusolverDnSHgesv`|10.2| | | | | | | | | |
+|`cusolverDnSSgesv`|10.2| | | |`hipsolverDnSSgesv`|5.1.0| | | |6.1.0|
+|`cusolverDnSXgesv`|11.0| | | | | | | | | |
 |`cusolverDnSetAdvOptions`|11.0| | | | | | | | | |
 |`cusolverDnSetDeterministicMode`|12.2| | | | | | | | | |
 |`cusolverDnSetStream`| | | | |`hipsolverSetStream`|4.5.0| | | |6.1.0|
@@ -145,6 +158,10 @@
 |`cusolverDnXgetrf`|11.1| | | | | | | | | |
 |`cusolverDnXgetrf_bufferSize`|11.1| | | | | | | | | |
 |`cusolverDnXgetrs`|11.1| | | | | | | | | |
+|`cusolverDnZCgesv`|10.2| | | | | | | | | |
+|`cusolverDnZEgesv`|11.0| | | | | | | | | |
+|`cusolverDnZKgesv`|10.2| | | | | | | | | |
+|`cusolverDnZYgesv`|11.0| | | | | | | | | |
 |`cusolverDnZZgesv`|10.2| | | |`hipsolverDnZZgesv`|5.1.0| | | |6.1.0|
 
 

--- a/docs/tables/CUSOLVER_API_supported_by_HIP_and_ROC.md
+++ b/docs/tables/CUSOLVER_API_supported_by_HIP_and_ROC.md
@@ -108,8 +108,17 @@
 
 |**CUDA**|**A**|**D**|**C**|**R**|**HIP**|**A**|**D**|**C**|**R**|**E**|**ROC**|**A**|**D**|**C**|**R**|**E**|
 |:--|:-:|:-:|:-:|:-:|:--|:-:|:-:|:-:|:-:|:-:|:--|:-:|:-:|:-:|:-:|:-:|
+|`cusolverDnCCgesv`|10.2| | | |`hipsolverDnCCgesv`|5.1.0| | | |6.1.0| | | | | | |
+|`cusolverDnCEgesv`|11.0| | | | | | | | | | | | | | | |
+|`cusolverDnCKgesv`|10.2| | | | | | | | | | | | | | | |
+|`cusolverDnCYgesv`|11.0| | | | | | | | | | | | | | | |
 |`cusolverDnCreate`| | | | |`hipsolverDnCreate`|5.1.0| | | |6.1.0|`rocblas_create_handle`| | | | | |
 |`cusolverDnCreateParams`|11.0| | | | | | | | | | | | | | | |
+|`cusolverDnDBgesv`|11.0| | | | | | | | | | | | | | | |
+|`cusolverDnDDgesv`|10.2| | | |`hipsolverDnDDgesv`|5.1.0| | | |6.1.0| | | | | | |
+|`cusolverDnDHgesv`|10.2| | | | | | | | | | | | | | | |
+|`cusolverDnDSgesv`|10.2| | | | | | | | | | | | | | | |
+|`cusolverDnDXgesv`|11.0| | | | | | | | | | | | | | | |
 |`cusolverDnDestroy`| | | | |`hipsolverDnDestroy`|5.1.0| | | |6.1.0|`rocblas_destroy_handle`| | | | | |
 |`cusolverDnDgetrf`| | | | |`hipsolverDnDgetrf`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnDgetrf_bufferSize`| | | | |`hipsolverDnDgetrf_bufferSize`|5.1.0| | | |6.1.0| | | | | | |
@@ -136,6 +145,10 @@
 |`cusolverDnIRSParamsSetSolverPrecisions`|10.2| | | | | | | | | | | | | | | |
 |`cusolverDnIRSParamsSetTol`|10.2| | | | | | | | | | | | | | | |
 |`cusolverDnIRSParamsSetTolInner`|10.2| | | | | | | | | | | | | | | |
+|`cusolverDnSBgesv`|11.0| | | | | | | | | | | | | | | |
+|`cusolverDnSHgesv`|10.2| | | | | | | | | | | | | | | |
+|`cusolverDnSSgesv`|10.2| | | |`hipsolverDnSSgesv`|5.1.0| | | |6.1.0| | | | | | |
+|`cusolverDnSXgesv`|11.0| | | | | | | | | | | | | | | |
 |`cusolverDnSetAdvOptions`|11.0| | | | | | | | | | | | | | | |
 |`cusolverDnSetDeterministicMode`|12.2| | | | | | | | | | | | | | | |
 |`cusolverDnSetStream`| | | | |`hipsolverSetStream`|4.5.0| | | |6.1.0|`rocblas_set_stream`| | | | | |
@@ -145,6 +158,10 @@
 |`cusolverDnXgetrf`|11.1| | | | | | | | | | | | | | | |
 |`cusolverDnXgetrf_bufferSize`|11.1| | | | | | | | | | | | | | | |
 |`cusolverDnXgetrs`|11.1| | | | | | | | | | | | | | | |
+|`cusolverDnZCgesv`|10.2| | | | | | | | | | | | | | | |
+|`cusolverDnZEgesv`|11.0| | | | | | | | | | | | | | | |
+|`cusolverDnZKgesv`|10.2| | | | | | | | | | | | | | | |
+|`cusolverDnZYgesv`|11.0| | | | | | | | | | | | | | | |
 |`cusolverDnZZgesv`|10.2| | | |`hipsolverDnZZgesv`|5.1.0| | | |6.1.0| | | | | | |
 
 

--- a/docs/tables/CUSOLVER_API_supported_by_ROC.md
+++ b/docs/tables/CUSOLVER_API_supported_by_ROC.md
@@ -108,8 +108,17 @@
 
 |**CUDA**|**A**|**D**|**C**|**R**|**ROC**|**A**|**D**|**C**|**R**|**E**|
 |:--|:-:|:-:|:-:|:-:|:--|:-:|:-:|:-:|:-:|:-:|
+|`cusolverDnCCgesv`|10.2| | | | | | | | | |
+|`cusolverDnCEgesv`|11.0| | | | | | | | | |
+|`cusolverDnCKgesv`|10.2| | | | | | | | | |
+|`cusolverDnCYgesv`|11.0| | | | | | | | | |
 |`cusolverDnCreate`| | | | |`rocblas_create_handle`| | | | | |
 |`cusolverDnCreateParams`|11.0| | | | | | | | | |
+|`cusolverDnDBgesv`|11.0| | | | | | | | | |
+|`cusolverDnDDgesv`|10.2| | | | | | | | | |
+|`cusolverDnDHgesv`|10.2| | | | | | | | | |
+|`cusolverDnDSgesv`|10.2| | | | | | | | | |
+|`cusolverDnDXgesv`|11.0| | | | | | | | | |
 |`cusolverDnDestroy`| | | | |`rocblas_destroy_handle`| | | | | |
 |`cusolverDnDgetrf`| | | | | | | | | | |
 |`cusolverDnDgetrf_bufferSize`| | | | | | | | | | |
@@ -136,6 +145,10 @@
 |`cusolverDnIRSParamsSetSolverPrecisions`|10.2| | | | | | | | | |
 |`cusolverDnIRSParamsSetTol`|10.2| | | | | | | | | |
 |`cusolverDnIRSParamsSetTolInner`|10.2| | | | | | | | | |
+|`cusolverDnSBgesv`|11.0| | | | | | | | | |
+|`cusolverDnSHgesv`|10.2| | | | | | | | | |
+|`cusolverDnSSgesv`|10.2| | | | | | | | | |
+|`cusolverDnSXgesv`|11.0| | | | | | | | | |
 |`cusolverDnSetAdvOptions`|11.0| | | | | | | | | |
 |`cusolverDnSetDeterministicMode`|12.2| | | | | | | | | |
 |`cusolverDnSetStream`| | | | |`rocblas_set_stream`| | | | | |
@@ -145,6 +158,10 @@
 |`cusolverDnXgetrf`|11.1| | | | | | | | | |
 |`cusolverDnXgetrf_bufferSize`|11.1| | | | | | | | | |
 |`cusolverDnXgetrs`|11.1| | | | | | | | | |
+|`cusolverDnZCgesv`|10.2| | | | | | | | | |
+|`cusolverDnZEgesv`|11.0| | | | | | | | | |
+|`cusolverDnZKgesv`|10.2| | | | | | | | | |
+|`cusolverDnZYgesv`|11.0| | | | | | | | | |
 |`cusolverDnZZgesv`|10.2| | | | | | | | | |
 
 

--- a/src/CUDA2HIP_SOLVER_API_functions.cpp
+++ b/src/CUDA2HIP_SOLVER_API_functions.cpp
@@ -69,6 +69,26 @@ const std::map<llvm::StringRef, hipCounter> CUDA_SOLVER_FUNCTION_MAP {
   {"cusolverDnIRSInfosGetMaxIters",                       {"hipsolverDnIRSInfosGetMaxIters",                       "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
   // NOTE: rocsolver_zgesv has a harness of rocblas_set_workspace, hipsolverZZgesv_bufferSize, and rocsolver_zgesv_outofplace
   {"cusolverDnZZgesv",                                    {"hipsolverDnZZgesv",                                    "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
+  {"cusolverDnZCgesv",                                    {"hipsolverDnZCgesv",                                    "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
+  {"cusolverDnZKgesv",                                    {"hipsolverDnZKgesv",                                    "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
+  {"cusolverDnZEgesv",                                    {"hipsolverDnZEgesv",                                    "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
+  {"cusolverDnZYgesv",                                    {"hipsolverDnZYgesv",                                    "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
+  // NOTE: rocsolver_cgesv has a harness of rocblas_set_workspace, hipsolverCCgesv_bufferSize, and rocsolver_cgesv_outofplace
+  {"cusolverDnCCgesv",                                    {"hipsolverDnCCgesv",                                    "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
+  {"cusolverDnCEgesv",                                    {"hipsolverDnCEgesv",                                    "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
+  {"cusolverDnCKgesv",                                    {"hipsolverDnCKgesv",                                    "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
+  {"cusolverDnCYgesv",                                    {"hipsolverDnCYgesv",                                    "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
+  // NOTE: rocsolver_dgesv has a harness of rocblas_set_workspace, hipsolverDDgesv_bufferSize, and rocsolver_dgesv_outofplace
+  {"cusolverDnDDgesv",                                    {"hipsolverDnDDgesv",                                    "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
+  {"cusolverDnDSgesv",                                    {"hipsolverDnDSgesv",                                    "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
+  {"cusolverDnDHgesv",                                    {"hipsolverDnDHgesv",                                    "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
+  {"cusolverDnDBgesv",                                    {"hipsolverDnDBgesv",                                    "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
+  {"cusolverDnDXgesv",                                    {"hipsolverDnDXgesv",                                    "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
+  // NOTE: rocsolver_sgesv has a harness of rocblas_set_workspace, hipsolverSSgesv_bufferSize, and rocsolver_sgesv_outofplace
+  {"cusolverDnSSgesv",                                    {"hipsolverDnSSgesv",                                    "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
+  {"cusolverDnSHgesv",                                    {"hipsolverDnSHgesv",                                    "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
+  {"cusolverDnSBgesv",                                    {"hipsolverDnSBgesv",                                    "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
+  {"cusolverDnSXgesv",                                    {"hipsolverDnSXgesv",                                    "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
 };
 
 const std::map<llvm::StringRef, cudaAPIversions> CUDA_SOLVER_FUNCTION_VER_MAP {
@@ -100,6 +120,23 @@ const std::map<llvm::StringRef, cudaAPIversions> CUDA_SOLVER_FUNCTION_VER_MAP {
   {"cusolverDnIRSInfosGetResidualHistory",                {CUDA_102,  CUDA_0, CUDA_0}},
   {"cusolverDnIRSInfosGetMaxIters",                       {CUDA_102,  CUDA_0, CUDA_0}},
   {"cusolverDnZZgesv",                                    {CUDA_102,  CUDA_0, CUDA_0}},
+  {"cusolverDnZCgesv",                                    {CUDA_102,  CUDA_0, CUDA_0}},
+  {"cusolverDnZKgesv",                                    {CUDA_102,  CUDA_0, CUDA_0}},
+  {"cusolverDnZEgesv",                                    {CUDA_110,  CUDA_0, CUDA_0}},
+  {"cusolverDnZYgesv",                                    {CUDA_110,  CUDA_0, CUDA_0}},
+  {"cusolverDnCCgesv",                                    {CUDA_102,  CUDA_0, CUDA_0}},
+  {"cusolverDnCEgesv",                                    {CUDA_110,  CUDA_0, CUDA_0}},
+  {"cusolverDnCKgesv",                                    {CUDA_102,  CUDA_0, CUDA_0}},
+  {"cusolverDnCYgesv",                                    {CUDA_110,  CUDA_0, CUDA_0}},
+  {"cusolverDnDDgesv",                                    {CUDA_102,  CUDA_0, CUDA_0}},
+  {"cusolverDnDSgesv",                                    {CUDA_102,  CUDA_0, CUDA_0}},
+  {"cusolverDnDHgesv",                                    {CUDA_102,  CUDA_0, CUDA_0}},
+  {"cusolverDnDBgesv",                                    {CUDA_110,  CUDA_0, CUDA_0}},
+  {"cusolverDnDXgesv",                                    {CUDA_110,  CUDA_0, CUDA_0}},
+  {"cusolverDnSSgesv",                                    {CUDA_102,  CUDA_0, CUDA_0}},
+  {"cusolverDnSHgesv",                                    {CUDA_102,  CUDA_0, CUDA_0}},
+  {"cusolverDnSBgesv",                                    {CUDA_110,  CUDA_0, CUDA_0}},
+  {"cusolverDnSXgesv",                                    {CUDA_110,  CUDA_0, CUDA_0}},
 };
 
 const std::map<llvm::StringRef, hipAPIversions> HIP_SOLVER_FUNCTION_VER_MAP {
@@ -114,6 +151,9 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_SOLVER_FUNCTION_VER_MAP {
   {"hipsolverSetStream",                                  {HIP_4050, HIP_0,    HIP_0,  HIP_LATEST}},
   {"hipsolverGetStream",                                  {HIP_4050, HIP_0,    HIP_0,  HIP_LATEST}},
   {"hipsolverDnZZgesv",                                   {HIP_5010, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipsolverDnCCgesv",                                   {HIP_5010, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipsolverDnDDgesv",                                   {HIP_5010, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipsolverDnSSgesv",                                   {HIP_5010, HIP_0,    HIP_0,  HIP_LATEST}},
 };
 
 const std::map<unsigned int, llvm::StringRef> CUDA_SOLVER_API_SECTION_MAP {

--- a/tests/unit_tests/synthetic/libraries/cusolver2hipsolver.cu
+++ b/tests/unit_tests/synthetic/libraries/cusolver2hipsolver.cu
@@ -18,9 +18,11 @@ int main() {
   int devIpiv = 0;
   int devInfo = 0;
   float fA = 0.f;
-  double dA = 0.f;
   float fB = 0.f;
+  float fX = 0.f;
+  double dA = 0.f;
   double dB = 0.f;
+  double dX = 0.f;
   float fWorkspace = 0.f;
   double dWorkspace = 0.f;
   void *Workspace = nullptr;
@@ -28,6 +30,9 @@ int main() {
 
   // CHECK: hipDoubleComplex dComplexA, dComplexB, dComplexX;
   cuDoubleComplex dComplexA, dComplexB, dComplexX;
+
+  // CHECK: hipComplex complexA, complexB, complexX;
+  cuComplex complexA, complexB, complexX;
 
   // CHECK: hipsolverHandle_t handle;
   cusolverDnHandle_t handle;
@@ -140,6 +145,7 @@ int main() {
 #if CUDA_VERSION >= 10010
   // CHECK: int solver_int = 0;
   // CHECK: int ln = 0;
+  // CHECK: int lnrhs = 0;
   // CHECK: int ldda = 0;
   // CHECK: int lddb = 0;
   // CHECK: int lddx = 0;
@@ -148,6 +154,7 @@ int main() {
   // CHECK: int d_info = 0;
   cusolver_int_t solver_int = 0;
   cusolver_int_t ln = 0;
+  cusolver_int_t lnrhs = 0;
   cusolver_int_t ldda = 0;
   cusolver_int_t lddb = 0;
   cusolver_int_t lddx = 0;
@@ -175,8 +182,23 @@ int main() {
 
   // CUDA: cusolverStatus_t CUSOLVERAPI cusolverDnZZgesv(cusolverDnHandle_t handle, cusolver_int_t n, cusolver_int_t nrhs, cuDoubleComplex * dA, cusolver_int_t ldda, cusolver_int_t * dipiv, cuDoubleComplex * dB, cusolver_int_t lddb, cuDoubleComplex * dX, cusolver_int_t lddx, void * dWorkspace, size_t lwork_bytes, cusolver_int_t * iter, cusolver_int_t * d_info);
   // HIP: HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDnZZgesv(hipsolverHandle_t handle, int n, int nrhs, hipDoubleComplex* A, int lda, int* devIpiv, hipDoubleComplex* B, int ldb, hipDoubleComplex* X, int ldx, void* work, size_t lwork, int* niters, int* devInfo);
-  // CHECK: status = hipsolverDnZZgesv(handle, ln, nrhs, &dComplexA, ldda, &dipiv, &dComplexB, lddb, &dComplexX, lddx, &Workspace, lwork_bytes, &iter, &d_info);
-  status = cusolverDnZZgesv(handle, ln, nrhs, &dComplexA, ldda, &dipiv, &dComplexB, lddb, &dComplexX, lddx, &Workspace, lwork_bytes, &iter, &d_info);
+  // CHECK: status = hipsolverDnZZgesv(handle, ln, lnrhs, &dComplexA, ldda, &dipiv, &dComplexB, lddb, &dComplexX, lddx, &Workspace, lwork_bytes, &iter, &d_info);
+  status = cusolverDnZZgesv(handle, ln, lnrhs, &dComplexA, ldda, &dipiv, &dComplexB, lddb, &dComplexX, lddx, &Workspace, lwork_bytes, &iter, &d_info);
+
+  // CUDA: cusolverStatus_t CUSOLVERAPI cusolverDnCCgesv(cusolverDnHandle_t handle, cusolver_int_t n, cusolver_int_t nrhs, cuComplex * dA, cusolver_int_t ldda, cusolver_int_t * dipiv, cuComplex * dB, cusolver_int_t lddb, cuComplex * dX, cusolver_int_t lddx, void * dWorkspace, size_t lwork_bytes, cusolver_int_t * iter, cusolver_int_t * d_info);
+  // HIP: HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDnCCgesv(hipsolverHandle_t handle, int n, int nrhs, hipFloatComplex* A, int lda, int* devIpiv, hipFloatComplex* B, int ldb, hipFloatComplex* X, int ldx, void* work, size_t lwork, int* niters, int* devInfo);
+  // CHECK: status = hipsolverDnCCgesv(handle, ln, lnrhs, &complexA, ldda, &dipiv, &complexB, lddb, &complexX, lddx, &Workspace, lwork_bytes, &iter, &d_info);
+  status = cusolverDnCCgesv(handle, ln, lnrhs, &complexA, ldda, &dipiv, &complexB, lddb, &complexX, lddx, &Workspace, lwork_bytes, &iter, &d_info);
+
+  // CUDA: cusolverStatus_t CUSOLVERAPI cusolverDnDDgesv(cusolverDnHandle_t handle, cusolver_int_t n, cusolver_int_t nrhs, double * dA, cusolver_int_t ldda, cusolver_int_t * dipiv, double * dB, cusolver_int_t lddb, double * dX, cusolver_int_t lddx, void * dWorkspace, size_t lwork_bytes, cusolver_int_t * iter, cusolver_int_t * d_info);
+  // HIP: HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDnDDgesv(hipsolverHandle_t handle, int n, int nrhs, double* A, int lda, int* devIpiv, double* B, int ldb, double* X, int ldx, void* work, size_t lwork, int* niters, int* devInfo);
+  // CHECK: status = hipsolverDnDDgesv(handle, ln, lnrhs, &dA, ldda, &dipiv, &dB, lddb, &dX, lddx, &Workspace, lwork_bytes, &iter, &d_info);
+  status = cusolverDnDDgesv(handle, ln, lnrhs, &dA, ldda, &dipiv, &dB, lddb, &dX, lddx, &Workspace, lwork_bytes, &iter, &d_info);
+
+  // CUDA: cusolverStatus_t CUSOLVERAPI cusolverDnSSgesv(cusolverDnHandle_t handle, cusolver_int_t n, cusolver_int_t nrhs, float * dA, cusolver_int_t ldda, cusolver_int_t * dipiv, float * dB, cusolver_int_t lddb, float * dX, cusolver_int_t lddx, void * dWorkspace, size_t lwork_bytes, cusolver_int_t * iter, cusolver_int_t * d_info);
+  // HIP: HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDnSSgesv(hipsolverHandle_t handle, int n, int nrhs, float* A, int lda, int* devIpiv, float* B, int ldb, float* X, int ldx, void* work, size_t lwork, int* niters, int* devInfo);
+  // CHECK: status = hipsolverDnSSgesv(handle, ln, lnrhs, &fA, ldda, &dipiv, &fB, lddb, &fX, lddx, &Workspace, lwork_bytes, &iter, &d_info);
+  status = cusolverDnSSgesv(handle, ln, lnrhs, &fA, ldda, &dipiv, &fB, lddb, &fX, lddx, &Workspace, lwork_bytes, &iter, &d_info);
 #endif
 
   return 0;


### PR DESCRIPTION
+ `hipsolverDn(CC|DD|SS)gesv` are `SUPPORTED`
+ `cusolverDnZ(C|K|E|Y)gesv`, `cusolverDnC(E|K|Y)gesv`, `cusolverDnD(S|H|B|X)gesv`, and `cusolverDnS(H|B|X)gesv` are `UNSUPPORTED`
+ [NOTE] `rocsolver_(c|d|s)gesv` has a harness of `rocblas_set_workspace`, `hipsolver(CC|DD|SS)gesv_bufferSize`, and `rocsolver_(c|d|s)gesv_outofplace`, thus `UNSUPPORTED`
+ Updated `SOLVER` synthetic tests, the regenerated hipify-perl, and `SOLVER` `CUDA2HIP` documentation
