### PR TITLE
[HIPIFY][#674][rocSPARSE][feature] rocSPARSE support - Step 62 - functions `rocsparse_(s|d|c|z)gemvi_bufferSize`

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -1796,6 +1796,7 @@ sub rocSubstitutions {
     subst("cusparseCgebsr2gebsr", "rocsparse_cgebsr2gebsr", "library");
     subst("cusparseCgebsr2gebsr_bufferSize", "rocsparse_cgebsr2gebsr_buffer_size", "library");
     subst("cusparseCgemvi", "rocsparse_cgemvi", "library");
+    subst("cusparseCgemvi_bufferSize", "rocsparse_cgemvi_buffer_size", "library");
     subst("cusparseCgpsvInterleavedBatch", "rocsparse_cgpsv_interleaved_batch", "library");
     subst("cusparseCgpsvInterleavedBatch_bufferSizeExt", "rocsparse_cgpsv_interleaved_batch_buffer_size", "library");
     subst("cusparseCgtsv2", "rocsparse_cgtsv", "library");
@@ -1879,6 +1880,7 @@ sub rocSubstitutions {
     subst("cusparseDgebsr2gebsr", "rocsparse_dgebsr2gebsr", "library");
     subst("cusparseDgebsr2gebsr_bufferSize", "rocsparse_dgebsr2gebsr_buffer_size", "library");
     subst("cusparseDgemvi", "rocsparse_dgemvi", "library");
+    subst("cusparseDgemvi_bufferSize", "rocsparse_dgemvi_buffer_size", "library");
     subst("cusparseDgpsvInterleavedBatch", "rocsparse_dgpsv_interleaved_batch", "library");
     subst("cusparseDgpsvInterleavedBatch_bufferSizeExt", "rocsparse_dgpsv_interleaved_batch_buffer_size", "library");
     subst("cusparseDgtsv2", "rocsparse_dgtsv", "library");
@@ -1971,6 +1973,7 @@ sub rocSubstitutions {
     subst("cusparseSgebsr2gebsr", "rocsparse_sgebsr2gebsr", "library");
     subst("cusparseSgebsr2gebsr_bufferSize", "rocsparse_sgebsr2gebsr_buffer_size", "library");
     subst("cusparseSgemvi", "rocsparse_sgemvi", "library");
+    subst("cusparseSgemvi_bufferSize", "rocsparse_sgemvi_buffer_size", "library");
     subst("cusparseSgpsvInterleavedBatch", "rocsparse_sgpsv_interleaved_batch", "library");
     subst("cusparseSgpsvInterleavedBatch_bufferSizeExt", "rocsparse_sgpsv_interleaved_batch_buffer_size", "library");
     subst("cusparseSgtsv2", "rocsparse_sgtsv", "library");
@@ -2070,6 +2073,7 @@ sub rocSubstitutions {
     subst("cusparseZgebsr2gebsr", "rocsparse_zgebsr2gebsr", "library");
     subst("cusparseZgebsr2gebsr_bufferSize", "rocsparse_zgebsr2gebsr_buffer_size", "library");
     subst("cusparseZgemvi", "rocsparse_zgemvi", "library");
+    subst("cusparseZgemvi_bufferSize", "rocsparse_zgemvi_buffer_size", "library");
     subst("cusparseZgpsvInterleavedBatch", "rocsparse_zgpsv_interleaved_batch", "library");
     subst("cusparseZgpsvInterleavedBatch_bufferSizeExt", "rocsparse_zgpsv_interleaved_batch_buffer_size", "library");
     subst("cusparseZgtsv2", "rocsparse_zgtsv", "library");

--- a/docs/tables/CUSPARSE_API_supported_by_HIP_and_ROC.md
+++ b/docs/tables/CUSPARSE_API_supported_by_HIP_and_ROC.md
@@ -307,7 +307,7 @@
 |`cusparseCcsrsv_analysis`| |10.2| |11.0| | | | | | | | | | | | |
 |`cusparseCcsrsv_solve`| |10.2| |11.0| | | | | | | | | | | | |
 |`cusparseCgemvi`|7.5| | | |`hipsparseCgemvi`|4.3.0| | | | |`rocsparse_cgemvi`|4.3.0| | | | |
-|`cusparseCgemvi_bufferSize`|7.5| | | |`hipsparseCgemvi_bufferSize`|4.3.0| | | | | | | | | | |
+|`cusparseCgemvi_bufferSize`|7.5| | | |`hipsparseCgemvi_bufferSize`|4.3.0| | | | |`rocsparse_cgemvi_buffer_size`|4.3.0| | | | |
 |`cusparseChybmv`| |10.2| |11.0|`hipsparseChybmv`|3.1.0| | | | | | | | | | |
 |`cusparseChybsv_analysis`| |10.2| |11.0| | | | | | | | | | | | |
 |`cusparseChybsv_solve`| |10.2| |11.0| | | | | | | | | | | | |
@@ -330,7 +330,7 @@
 |`cusparseDcsrsv_analysis`| |10.2| |11.0| | | | | | | | | | | | |
 |`cusparseDcsrsv_solve`| |10.2| |11.0| | | | | | | | | | | | |
 |`cusparseDgemvi`|7.5| | | |`hipsparseDgemvi`|4.3.0| | | | |`rocsparse_dgemvi`|4.3.0| | | | |
-|`cusparseDgemvi_bufferSize`|7.5| | | |`hipsparseDgemvi_bufferSize`|4.3.0| | | | | | | | | | |
+|`cusparseDgemvi_bufferSize`|7.5| | | |`hipsparseDgemvi_bufferSize`|4.3.0| | | | |`rocsparse_dgemvi_buffer_size`|4.3.0| | | | |
 |`cusparseDhybmv`| |10.2| |11.0|`hipsparseDhybmv`|1.9.2| | | | | | | | | | |
 |`cusparseDhybsv_analysis`| |10.2| |11.0| | | | | | | | | | | | |
 |`cusparseDhybsv_solve`| |10.2| |11.0| | | | | | | | | | | | |
@@ -349,7 +349,7 @@
 |`cusparseScsrsv_analysis`| |10.2| |11.0| | | | | | | | | | | | |
 |`cusparseScsrsv_solve`| |10.2| |11.0| | | | | | | | | | | | |
 |`cusparseSgemvi`|7.5| | | |`hipsparseSgemvi`|4.3.0| | | | |`rocsparse_sgemvi`|4.3.0| | | | |
-|`cusparseSgemvi_bufferSize`|7.5| | | |`hipsparseSgemvi_bufferSize`|4.3.0| | | | | | | | | | |
+|`cusparseSgemvi_bufferSize`|7.5| | | |`hipsparseSgemvi_bufferSize`|4.3.0| | | | |`rocsparse_sgemvi_buffer_size`|4.3.0| | | | |
 |`cusparseShybmv`| |10.2| |11.0|`hipsparseShybmv`|1.9.2| | | | | | | | | | |
 |`cusparseShybsv_analysis`| |10.2| |11.0| | | | | | | | | | | | |
 |`cusparseShybsv_solve`| |10.2| |11.0| | | | | | | | | | | | |
@@ -370,7 +370,7 @@
 |`cusparseZcsrsv_analysis`| |10.2| |11.0| | | | | | | | | | | | |
 |`cusparseZcsrsv_solve`| |10.2| |11.0| | | | | | | | | | | | |
 |`cusparseZgemvi`|7.5| | | |`hipsparseZgemvi`|4.3.0| | | | |`rocsparse_zgemvi`|4.3.0| | | | |
-|`cusparseZgemvi_bufferSize`|7.5| | | |`hipsparseZgemvi_bufferSize`|4.3.0| | | | | | | | | | |
+|`cusparseZgemvi_bufferSize`|7.5| | | |`hipsparseZgemvi_bufferSize`|4.3.0| | | | |`rocsparse_zgemvi_buffer_size`|4.3.0| | | | |
 |`cusparseZhybmv`| |10.2| |11.0|`hipsparseZhybmv`|3.1.0| | | | | | | | | | |
 |`cusparseZhybsv_analysis`| |10.2| |11.0| | | | | | | | | | | | |
 |`cusparseZhybsv_solve`| |10.2| |11.0| | | | | | | | | | | | |

--- a/docs/tables/CUSPARSE_API_supported_by_ROC.md
+++ b/docs/tables/CUSPARSE_API_supported_by_ROC.md
@@ -307,7 +307,7 @@
 |`cusparseCcsrsv_analysis`| |10.2| |11.0| | | | | | |
 |`cusparseCcsrsv_solve`| |10.2| |11.0| | | | | | |
 |`cusparseCgemvi`|7.5| | | |`rocsparse_cgemvi`|4.3.0| | | | |
-|`cusparseCgemvi_bufferSize`|7.5| | | | | | | | | |
+|`cusparseCgemvi_bufferSize`|7.5| | | |`rocsparse_cgemvi_buffer_size`|4.3.0| | | | |
 |`cusparseChybmv`| |10.2| |11.0| | | | | | |
 |`cusparseChybsv_analysis`| |10.2| |11.0| | | | | | |
 |`cusparseChybsv_solve`| |10.2| |11.0| | | | | | |
@@ -330,7 +330,7 @@
 |`cusparseDcsrsv_analysis`| |10.2| |11.0| | | | | | |
 |`cusparseDcsrsv_solve`| |10.2| |11.0| | | | | | |
 |`cusparseDgemvi`|7.5| | | |`rocsparse_dgemvi`|4.3.0| | | | |
-|`cusparseDgemvi_bufferSize`|7.5| | | | | | | | | |
+|`cusparseDgemvi_bufferSize`|7.5| | | |`rocsparse_dgemvi_buffer_size`|4.3.0| | | | |
 |`cusparseDhybmv`| |10.2| |11.0| | | | | | |
 |`cusparseDhybsv_analysis`| |10.2| |11.0| | | | | | |
 |`cusparseDhybsv_solve`| |10.2| |11.0| | | | | | |
@@ -349,7 +349,7 @@
 |`cusparseScsrsv_analysis`| |10.2| |11.0| | | | | | |
 |`cusparseScsrsv_solve`| |10.2| |11.0| | | | | | |
 |`cusparseSgemvi`|7.5| | | |`rocsparse_sgemvi`|4.3.0| | | | |
-|`cusparseSgemvi_bufferSize`|7.5| | | | | | | | | |
+|`cusparseSgemvi_bufferSize`|7.5| | | |`rocsparse_sgemvi_buffer_size`|4.3.0| | | | |
 |`cusparseShybmv`| |10.2| |11.0| | | | | | |
 |`cusparseShybsv_analysis`| |10.2| |11.0| | | | | | |
 |`cusparseShybsv_solve`| |10.2| |11.0| | | | | | |
@@ -370,7 +370,7 @@
 |`cusparseZcsrsv_analysis`| |10.2| |11.0| | | | | | |
 |`cusparseZcsrsv_solve`| |10.2| |11.0| | | | | | |
 |`cusparseZgemvi`|7.5| | | |`rocsparse_zgemvi`|4.3.0| | | | |
-|`cusparseZgemvi_bufferSize`|7.5| | | | | | | | | |
+|`cusparseZgemvi_bufferSize`|7.5| | | |`rocsparse_zgemvi_buffer_size`|4.3.0| | | | |
 |`cusparseZhybmv`| |10.2| |11.0| | | | | | |
 |`cusparseZhybsv_analysis`| |10.2| |11.0| | | | | | |
 |`cusparseZhybsv_solve`| |10.2| |11.0| | | | | | |

--- a/src/CUDA2HIP_SPARSE_API_functions.cpp
+++ b/src/CUDA2HIP_SPARSE_API_functions.cpp
@@ -144,10 +144,10 @@ const std::map<llvm::StringRef, hipCounter> CUDA_SPARSE_FUNCTION_MAP {
   {"cusparseCgemvi",                                    {"hipsparseCgemvi",                                    "rocsparse_cgemvi",                                                 CONV_LIB_FUNC, API_SPARSE, 9}},
   {"cusparseZgemvi",                                    {"hipsparseZgemvi",                                    "rocsparse_zgemvi",                                                 CONV_LIB_FUNC, API_SPARSE, 9}},
 
-  {"cusparseSgemvi_bufferSize",                         {"hipsparseSgemvi_bufferSize",                         "",                                                                 CONV_LIB_FUNC, API_SPARSE, 9, ROC_UNSUPPORTED}},
-  {"cusparseDgemvi_bufferSize",                         {"hipsparseDgemvi_bufferSize",                         "",                                                                 CONV_LIB_FUNC, API_SPARSE, 9, ROC_UNSUPPORTED}},
-  {"cusparseCgemvi_bufferSize",                         {"hipsparseCgemvi_bufferSize",                         "",                                                                 CONV_LIB_FUNC, API_SPARSE, 9, ROC_UNSUPPORTED}},
-  {"cusparseZgemvi_bufferSize",                         {"hipsparseZgemvi_bufferSize",                         "",                                                                 CONV_LIB_FUNC, API_SPARSE, 9, ROC_UNSUPPORTED}},
+  {"cusparseSgemvi_bufferSize",                         {"hipsparseSgemvi_bufferSize",                         "rocsparse_sgemvi_buffer_size",                                     CONV_LIB_FUNC, API_SPARSE, 9}},
+  {"cusparseDgemvi_bufferSize",                         {"hipsparseDgemvi_bufferSize",                         "rocsparse_dgemvi_buffer_size",                                     CONV_LIB_FUNC, API_SPARSE, 9}},
+  {"cusparseCgemvi_bufferSize",                         {"hipsparseCgemvi_bufferSize",                         "rocsparse_cgemvi_buffer_size",                                     CONV_LIB_FUNC, API_SPARSE, 9}},
+  {"cusparseZgemvi_bufferSize",                         {"hipsparseZgemvi_bufferSize",                         "rocsparse_zgemvi_buffer_size",                                     CONV_LIB_FUNC, API_SPARSE, 9}},
 
   {"cusparseSbsrsv2_bufferSize",                        {"hipsparseSbsrsv2_bufferSize",                        "",                                                                 CONV_LIB_FUNC, API_SPARSE, 9, ROC_UNSUPPORTED | CUDA_DEPRECATED}},
   {"cusparseSbsrsv2_bufferSizeExt",                     {"hipsparseSbsrsv2_bufferSizeExt",                     "",                                                                 CONV_LIB_FUNC, API_SPARSE, 9, ROC_UNSUPPORTED | CUDA_DEPRECATED}},
@@ -2315,6 +2315,10 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_SPARSE_FUNCTION_VER_MAP {
   {"rocsparse_dgemvi",                                   {HIP_4030, HIP_0,    HIP_0   }},
   {"rocsparse_cgemvi",                                   {HIP_4030, HIP_0,    HIP_0   }},
   {"rocsparse_zgemvi",                                   {HIP_4030, HIP_0,    HIP_0   }},
+  {"rocsparse_sgemvi_buffer_size",                       {HIP_4030, HIP_0,    HIP_0   }},
+  {"rocsparse_dgemvi_buffer_size",                       {HIP_4030, HIP_0,    HIP_0   }},
+  {"rocsparse_cgemvi_buffer_size",                       {HIP_4030, HIP_0,    HIP_0   }},
+  {"rocsparse_zgemvi_buffer_size",                       {HIP_4030, HIP_0,    HIP_0   }},
 };
 
 const std::map<llvm::StringRef, cudaAPIChangedVersions> CUDA_SPARSE_FUNCTION_CHANGED_VER_MAP {

--- a/src/HipifyAction.cpp
+++ b/src/HipifyAction.cpp
@@ -151,6 +151,10 @@ const std::string sCusparseScsrsm2_bufferSizeExt = "cusparseScsrsm2_bufferSizeEx
 const std::string sCusparseDcsrsm2_bufferSizeExt = "cusparseDcsrsm2_bufferSizeExt";
 const std::string sCusparseCcsrsm2_bufferSizeExt = "cusparseCcsrsm2_bufferSizeExt";
 const std::string sCusparseZcsrsm2_bufferSizeExt = "cusparseZcsrsm2_bufferSizeExt";
+const std::string sCusparseZgemvi_bufferSize = "cusparseZgemvi_bufferSize";
+const std::string sCusparseCgemvi_bufferSize = "cusparseCgemvi_bufferSize";
+const std::string sCusparseDgemvi_bufferSize = "cusparseDgemvi_bufferSize";
+const std::string sCusparseSgemvi_bufferSize = "cusparseSgemvi_bufferSize";
 
 // CUDA_OVERLOADED
 const std::string sCudaEventCreate = "cudaEventCreate";
@@ -1087,6 +1091,42 @@ std::map<std::string, ArgCastStruct> FuncArgCasts {
       false
     }
   },
+  {sCusparseZgemvi_bufferSize,
+    {
+      {
+        {5, {e_reinterpret_cast_size_t, cw_None}}
+      },
+      true,
+      false
+    }
+  },
+  {sCusparseCgemvi_bufferSize,
+    {
+      {
+        {5, {e_reinterpret_cast_size_t, cw_None}}
+      },
+      true,
+      false
+    }
+  },
+  {sCusparseDgemvi_bufferSize,
+    {
+      {
+        {5, {e_reinterpret_cast_size_t, cw_None}}
+      },
+      true,
+      false
+    }
+  },
+  {sCusparseSgemvi_bufferSize,
+    {
+      {
+        {5, {e_reinterpret_cast_size_t, cw_None}}
+      },
+      true,
+      false
+    }
+  },
 };
 
 void HipifyAction::RewriteString(StringRef s, clang::SourceLocation start) {
@@ -1866,7 +1906,11 @@ std::unique_ptr<clang::ASTConsumer> HipifyAction::CreateASTConsumer(clang::Compi
             sCusparseScsrsm2_bufferSizeExt,
             sCusparseDcsrsm2_bufferSizeExt,
             sCusparseCcsrsm2_bufferSizeExt,
-            sCusparseZcsrsm2_bufferSizeExt
+            sCusparseZcsrsm2_bufferSizeExt,
+            sCusparseZgemvi_bufferSize,
+            sCusparseCgemvi_bufferSize,
+            sCusparseDgemvi_bufferSize,
+            sCusparseSgemvi_bufferSize
           )
         )
       )

--- a/tests/unit_tests/synthetic/libraries/cusparse2hipsparse.cu
+++ b/tests/unit_tests/synthetic/libraries/cusparse2hipsparse.cu
@@ -1097,6 +1097,26 @@ int main() {
   // HIP: HIPSPARSE_EXPORT hipsparseStatus_t hipsparseSgemvi(hipsparseHandle_t handle, hipsparseOperation_t transA, int m, int n, const float* alpha, const float* A, int lda, int nnz, const float* x, const int* xInd, const float* beta, float* y, hipsparseIndexBase_t idxBase, void* pBuffer);
   // CHECK: status_t = hipsparseSgemvi(handle_t, opA, m, n, &fAlpha, &fA, lda, innz, &fX, &xInd, &fBeta, &fY, indexBase_t, pBuffer);
   status_t = cusparseSgemvi(handle_t, opA, m, n, &fAlpha, &fA, lda, innz, &fX, &xInd, &fBeta, &fY, indexBase_t, pBuffer);
+
+  // CUDA: cusparseStatus_t CUSPARSEAPI cusparseZgemvi_bufferSize(cusparseHandle_t handle, cusparseOperation_t transA, int m, int n, int nnz, int* pBufferSize);
+  // HIP: HIPSPARSE_EXPORT hipsparseStatus_t hipsparseZgemvi_bufferSize(hipsparseHandle_t handle, hipsparseOperation_t transA, int m, int n, int nnz, int* pBufferSize);
+  // CHECK: status_t = hipsparseZgemvi_bufferSize(handle_t, opA, m, n, innz, &bufferSizeInBytes);
+  status_t = cusparseZgemvi_bufferSize(handle_t, opA, m, n, innz, &bufferSizeInBytes);
+
+  // CUDA: cusparseStatus_t CUSPARSEAPI cusparseCgemvi_bufferSize(cusparseHandle_t handle, cusparseOperation_t transA, int m, int n, int nnz, int* pBufferSize);
+  // HIP: HIPSPARSE_EXPORT hipsparseStatus_t hipsparseCgemvi_bufferSize(hipsparseHandle_t handle, hipsparseOperation_t transA, int m, int n, int nnz, int* pBufferSize);
+  // CHECK: status_t = hipsparseCgemvi_bufferSize(handle_t, opA, m, n, innz, &bufferSizeInBytes);
+  status_t = cusparseCgemvi_bufferSize(handle_t, opA, m, n, innz, &bufferSizeInBytes);
+
+  // CUDA: cusparseStatus_t CUSPARSEAPI cusparseDgemvi_bufferSize(cusparseHandle_t handle, cusparseOperation_t transA, int m, int n, int nnz, int* pBufferSize);
+  // HIP: HIPSPARSE_EXPORT hipsparseStatus_t hipsparseDgemvi_bufferSize(hipsparseHandle_t handle, hipsparseOperation_t transA, int m, int n, int nnz, int* pBufferSize);
+  // CHECK: status_t = hipsparseDgemvi_bufferSize(handle_t, opA, m, n, innz, &bufferSizeInBytes);
+  status_t = cusparseDgemvi_bufferSize(handle_t, opA, m, n, innz, &bufferSizeInBytes);
+
+  // CUDA: cusparseStatus_t CUSPARSEAPI cusparseSgemvi_bufferSize(cusparseHandle_t handle, cusparseOperation_t transA, int m, int n, int nnz, int* pBufferSize);
+  // HIP: HIPSPARSE_EXPORT hipsparseStatus_t hipsparseSgemvi_bufferSize(hipsparseHandle_t handle, hipsparseOperation_t transA, int m, int n, int nnz, int* pBufferSize);
+  // CHECK: status_t = hipsparseSgemvi_bufferSize(handle_t, opA, m, n, innz, &bufferSizeInBytes);
+  status_t = cusparseSgemvi_bufferSize(handle_t, opA, m, n, innz, &bufferSizeInBytes);
 #endif
 
 #if CUDA_VERSION >= 8000

--- a/tests/unit_tests/synthetic/libraries/cusparse2rocsparse.cu
+++ b/tests/unit_tests/synthetic/libraries/cusparse2rocsparse.cu
@@ -1090,6 +1090,26 @@ int main() {
   // ROC: ROCSPARSE_EXPORT rocsparse_status rocsparse_sgemvi(rocsparse_handle handle, rocsparse_operation trans, rocsparse_int m, rocsparse_int n, const float* alpha, const float* A, rocsparse_int lda, rocsparse_int nnz, const float* x_val, const rocsparse_int* x_ind, const float* beta, float* y, rocsparse_index_base idx_base, void* temp_buffer);
   // CHECK: status_t = rocsparse_sgemvi(handle_t, opA, m, n, &fAlpha, &fA, lda, innz, &fX, &xInd, &fBeta, &fY, indexBase_t, pBuffer);
   status_t = cusparseSgemvi(handle_t, opA, m, n, &fAlpha, &fA, lda, innz, &fX, &xInd, &fBeta, &fY, indexBase_t, pBuffer);
+
+  // CUDA: cusparseStatus_t CUSPARSEAPI cusparseZgemvi_bufferSize(cusparseHandle_t handle, cusparseOperation_t transA, int m, int n, int nnz, int* pBufferSize);
+  // ROC: ROCSPARSE_EXPORT rocsparse_status rocsparse_zgemvi_buffer_size(rocsparse_handle handle, rocsparse_operation trans, rocsparse_int m, rocsparse_int n, rocsparse_int nnz, size_t* buffer_size);
+  // CHECK: status_t = rocsparse_zgemvi_buffer_size(handle_t, opA, m, n, innz, reinterpret_cast<size_t*>(&bufferSizeInBytes));
+  status_t = cusparseZgemvi_bufferSize(handle_t, opA, m, n, innz, &bufferSizeInBytes);
+
+  // CUDA: cusparseStatus_t CUSPARSEAPI cusparseCgemvi_bufferSize(cusparseHandle_t handle, cusparseOperation_t transA, int m, int n, int nnz, int* pBufferSize);
+  // ROC: ROCSPARSE_EXPORT rocsparse_status rocsparse_cgemvi_buffer_size(rocsparse_handle handle, rocsparse_operation trans, rocsparse_int m, rocsparse_int n, rocsparse_int nnz, size_t* buffer_size);
+  // CHECK: status_t = rocsparse_cgemvi_buffer_size(handle_t, opA, m, n, innz, reinterpret_cast<size_t*>(&bufferSizeInBytes));
+  status_t = cusparseCgemvi_bufferSize(handle_t, opA, m, n, innz, &bufferSizeInBytes);
+
+  // CUDA: cusparseStatus_t CUSPARSEAPI cusparseDgemvi_bufferSize(cusparseHandle_t handle, cusparseOperation_t transA, int m, int n, int nnz, int* pBufferSize);
+  // ROC: ROCSPARSE_EXPORT rocsparse_status rocsparse_dgemvi_buffer_size(rocsparse_handle handle, rocsparse_operation trans, rocsparse_int m, rocsparse_int n, rocsparse_int nnz, size_t* buffer_size);
+  // CHECK: status_t = rocsparse_dgemvi_buffer_size(handle_t, opA, m, n, innz, reinterpret_cast<size_t*>(&bufferSizeInBytes));
+  status_t = cusparseDgemvi_bufferSize(handle_t, opA, m, n, innz, &bufferSizeInBytes);
+
+  // CUDA: cusparseStatus_t CUSPARSEAPI cusparseSgemvi_bufferSize(cusparseHandle_t handle, cusparseOperation_t transA, int m, int n, int nnz, int* pBufferSize);
+  // ROC: ROCSPARSE_EXPORT rocsparse_status rocsparse_sgemvi_buffer_size(rocsparse_handle handle, rocsparse_operation trans, rocsparse_int m, rocsparse_int n, rocsparse_int nnz, size_t* buffer_size);
+  // CHECK: status_t = rocsparse_sgemvi_buffer_size(handle_t, opA, m, n, innz, reinterpret_cast<size_t*>(&bufferSizeInBytes));
+  status_t = cusparseSgemvi_bufferSize(handle_t, opA, m, n, innz, &bufferSizeInBytes);
 #endif
 
 #if CUDA_VERSION >= 8000


### PR DESCRIPTION
+ Updated synthetic tests, the regenerated hipify-perl, and `SPARSE` `CUDA2HIP` documentation
