### PR TITLE
[HIPIFY][#675][#677][SOLVER][feature] `cuSOLVER` support - Step 14 - Functions (DN)

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -1080,17 +1080,25 @@ my %experimental_funcs = (
     "cusolverEigType_t" => "6.1.0",
     "cusolverEigRange_t" => "6.1.0",
     "cusolverEigMode_t" => "6.1.0",
+    "cusolverDnZZgesv_bufferSize" => "6.1.0",
+    "cusolverDnZZgesv" => "6.1.0",
     "cusolverDnSgetrs" => "6.1.0",
     "cusolverDnSgetrf_bufferSize" => "6.1.0",
     "cusolverDnSgetrf" => "6.1.0",
     "cusolverDnSetStream" => "6.1.0",
+    "cusolverDnSSgesv_bufferSize" => "6.1.0",
+    "cusolverDnSSgesv" => "6.1.0",
     "cusolverDnHandle_t" => "6.1.0",
     "cusolverDnGetStream" => "6.1.0",
     "cusolverDnDgetrs" => "6.1.0",
     "cusolverDnDgetrf_bufferSize" => "6.1.0",
     "cusolverDnDgetrf" => "6.1.0",
     "cusolverDnDestroy" => "6.1.0",
+    "cusolverDnDDgesv_bufferSize" => "6.1.0",
+    "cusolverDnDDgesv" => "6.1.0",
     "cusolverDnCreate" => "6.1.0",
+    "cusolverDnCCgesv_bufferSize" => "6.1.0",
+    "cusolverDnCCgesv" => "6.1.0",
     "CUSOLVER_STATUS_ZERO_PIVOT" => "6.1.0",
     "CUSOLVER_STATUS_SUCCESS" => "6.1.0",
     "CUSOLVER_STATUS_NOT_SUPPORTED" => "6.1.0",
@@ -1246,16 +1254,24 @@ sub subst {
 }
 
 sub experimentalSubstitutions {
+    subst("cusolverDnCCgesv", "hipsolverDnCCgesv", "library");
+    subst("cusolverDnCCgesv_bufferSize", "hipsolverDnCCgesv_bufferSize", "library");
     subst("cusolverDnCreate", "hipsolverDnCreate", "library");
+    subst("cusolverDnDDgesv", "hipsolverDnDDgesv", "library");
+    subst("cusolverDnDDgesv_bufferSize", "hipsolverDnDDgesv_bufferSize", "library");
     subst("cusolverDnDestroy", "hipsolverDnDestroy", "library");
     subst("cusolverDnDgetrf", "hipsolverDnDgetrf", "library");
     subst("cusolverDnDgetrf_bufferSize", "hipsolverDnDgetrf_bufferSize", "library");
     subst("cusolverDnDgetrs", "hipsolverDnDgetrs", "library");
     subst("cusolverDnGetStream", "hipsolverGetStream", "library");
+    subst("cusolverDnSSgesv", "hipsolverDnSSgesv", "library");
+    subst("cusolverDnSSgesv_bufferSize", "hipsolverDnSSgesv_bufferSize", "library");
     subst("cusolverDnSetStream", "hipsolverSetStream", "library");
     subst("cusolverDnSgetrf", "hipsolverDnSgetrf", "library");
     subst("cusolverDnSgetrf_bufferSize", "hipsolverDnSgetrf_bufferSize", "library");
     subst("cusolverDnSgetrs", "hipsolverDnSgetrs", "library");
+    subst("cusolverDnZZgesv", "hipsolverDnZZgesv", "library");
+    subst("cusolverDnZZgesv_bufferSize", "hipsolverDnZZgesv_bufferSize", "library");
     subst("cusolverDnHandle_t", "hipsolverHandle_t", "type");
     subst("cusolverEigMode_t", "hipsolverEigMode_t", "type");
     subst("cusolverEigRange_t", "hipsolverEigRange_t", "type");
@@ -3617,10 +3633,6 @@ sub simpleSubstitutions {
     subst("curandSetPseudoRandomGeneratorSeed", "hiprandSetPseudoRandomGeneratorSeed", "library");
     subst("curandSetQuasiRandomGeneratorDimensions", "hiprandSetQuasiRandomGeneratorDimensions", "library");
     subst("curandSetStream", "hiprandSetStream", "library");
-    subst("cusolverDnCCgesv", "hipsolverDnCCgesv", "library");
-    subst("cusolverDnDDgesv", "hipsolverDnDDgesv", "library");
-    subst("cusolverDnSSgesv", "hipsolverDnSSgesv", "library");
-    subst("cusolverDnZZgesv", "hipsolverDnZZgesv", "library");
     subst("cusparseAxpby", "hipsparseAxpby", "library");
     subst("cusparseBlockedEllGet", "hipsparseBlockedEllGet", "library");
     subst("cusparseCaxpyi", "hipsparseCaxpyi", "library");
@@ -7098,17 +7110,24 @@ sub warnUnsupportedFunctions {
         "cusolverPrecType_t",
         "cusolverNorm_t",
         "cusolverIRSRefinement_t",
+        "cusolverDnZYgesv_bufferSize",
         "cusolverDnZYgesv",
+        "cusolverDnZKgesv_bufferSize",
         "cusolverDnZKgesv",
+        "cusolverDnZEgesv_bufferSize",
         "cusolverDnZEgesv",
+        "cusolverDnZCgesv_bufferSize",
         "cusolverDnZCgesv",
         "cusolverDnXgetrs",
         "cusolverDnXgetrf_bufferSize",
         "cusolverDnXgetrf",
         "cusolverDnSetDeterministicMode",
         "cusolverDnSetAdvOptions",
+        "cusolverDnSXgesv_bufferSize",
         "cusolverDnSXgesv",
+        "cusolverDnSHgesv_bufferSize",
         "cusolverDnSHgesv",
+        "cusolverDnSBgesv_bufferSize",
         "cusolverDnSBgesv",
         "cusolverDnParams_t",
         "cusolverDnParams",
@@ -7138,14 +7157,21 @@ sub warnUnsupportedFunctions {
         "cusolverDnIRSInfos",
         "cusolverDnGetDeterministicMode",
         "cusolverDnFunction_t",
+        "cusolverDnDXgesv_bufferSize",
         "cusolverDnDXgesv",
+        "cusolverDnDSgesv_bufferSize",
         "cusolverDnDSgesv",
+        "cusolverDnDHgesv_bufferSize",
         "cusolverDnDHgesv",
+        "cusolverDnDBgesv_bufferSize",
         "cusolverDnDBgesv",
         "cusolverDnCreateParams",
         "cusolverDnContext",
+        "cusolverDnCYgesv_bufferSize",
         "cusolverDnCYgesv",
+        "cusolverDnCKgesv_bufferSize",
         "cusolverDnCKgesv",
+        "cusolverDnCEgesv_bufferSize",
         "cusolverDnCEgesv",
         "cusolverDirectMode_t",
         "cusolverDeterministicMode_t",

--- a/docs/tables/CUSOLVER_API_supported_by_HIP.md
+++ b/docs/tables/CUSOLVER_API_supported_by_HIP.md
@@ -109,16 +109,25 @@
 |**CUDA**|**A**|**D**|**C**|**R**|**HIP**|**A**|**D**|**C**|**R**|**E**|
 |:--|:-:|:-:|:-:|:-:|:--|:-:|:-:|:-:|:-:|:-:|
 |`cusolverDnCCgesv`|10.2| | | |`hipsolverDnCCgesv`|5.1.0| | | |6.1.0|
+|`cusolverDnCCgesv_bufferSize`|10.2| | | |`hipsolverDnCCgesv_bufferSize`|5.1.0| | | |6.1.0|
 |`cusolverDnCEgesv`|11.0| | | | | | | | | |
+|`cusolverDnCEgesv_bufferSize`|11.0| | | | | | | | | |
 |`cusolverDnCKgesv`|10.2| | | | | | | | | |
+|`cusolverDnCKgesv_bufferSize`|10.2| | | | | | | | | |
 |`cusolverDnCYgesv`|11.0| | | | | | | | | |
+|`cusolverDnCYgesv_bufferSize`|11.0| | | | | | | | | |
 |`cusolverDnCreate`| | | | |`hipsolverDnCreate`|5.1.0| | | |6.1.0|
 |`cusolverDnCreateParams`|11.0| | | | | | | | | |
 |`cusolverDnDBgesv`|11.0| | | | | | | | | |
+|`cusolverDnDBgesv_bufferSize`|11.0| | | | | | | | | |
 |`cusolverDnDDgesv`|10.2| | | |`hipsolverDnDDgesv`|5.1.0| | | |6.1.0|
+|`cusolverDnDDgesv_bufferSize`|10.2| | | |`hipsolverDnDDgesv_bufferSize`|5.1.0| | | |6.1.0|
 |`cusolverDnDHgesv`|10.2| | | | | | | | | |
+|`cusolverDnDHgesv_bufferSize`|10.2| | | | | | | | | |
 |`cusolverDnDSgesv`|10.2| | | | | | | | | |
+|`cusolverDnDSgesv_bufferSize`|10.2| | | | | | | | | |
 |`cusolverDnDXgesv`|11.0| | | | | | | | | |
+|`cusolverDnDXgesv_bufferSize`|11.0| | | | | | | | | |
 |`cusolverDnDestroy`| | | | |`hipsolverDnDestroy`|5.1.0| | | |6.1.0|
 |`cusolverDnDgetrf`| | | | |`hipsolverDnDgetrf`|5.1.0| | | |6.1.0|
 |`cusolverDnDgetrf_bufferSize`| | | | |`hipsolverDnDgetrf_bufferSize`|5.1.0| | | |6.1.0|
@@ -146,9 +155,13 @@
 |`cusolverDnIRSParamsSetTol`|10.2| | | | | | | | | |
 |`cusolverDnIRSParamsSetTolInner`|10.2| | | | | | | | | |
 |`cusolverDnSBgesv`|11.0| | | | | | | | | |
+|`cusolverDnSBgesv_bufferSize`|11.0| | | | | | | | | |
 |`cusolverDnSHgesv`|10.2| | | | | | | | | |
+|`cusolverDnSHgesv_bufferSize`|10.2| | | | | | | | | |
 |`cusolverDnSSgesv`|10.2| | | |`hipsolverDnSSgesv`|5.1.0| | | |6.1.0|
+|`cusolverDnSSgesv_bufferSize`|10.2| | | |`hipsolverDnSSgesv_bufferSize`|5.1.0| | | |6.1.0|
 |`cusolverDnSXgesv`|11.0| | | | | | | | | |
+|`cusolverDnSXgesv_bufferSize`|11.0| | | | | | | | | |
 |`cusolverDnSetAdvOptions`|11.0| | | | | | | | | |
 |`cusolverDnSetDeterministicMode`|12.2| | | | | | | | | |
 |`cusolverDnSetStream`| | | | |`hipsolverSetStream`|4.5.0| | | |6.1.0|
@@ -159,10 +172,15 @@
 |`cusolverDnXgetrf_bufferSize`|11.1| | | | | | | | | |
 |`cusolverDnXgetrs`|11.1| | | | | | | | | |
 |`cusolverDnZCgesv`|10.2| | | | | | | | | |
+|`cusolverDnZCgesv_bufferSize`|10.2| | | | | | | | | |
 |`cusolverDnZEgesv`|11.0| | | | | | | | | |
+|`cusolverDnZEgesv_bufferSize`|11.0| | | | | | | | | |
 |`cusolverDnZKgesv`|10.2| | | | | | | | | |
+|`cusolverDnZKgesv_bufferSize`|10.2| | | | | | | | | |
 |`cusolverDnZYgesv`|11.0| | | | | | | | | |
+|`cusolverDnZYgesv_bufferSize`|11.0| | | | | | | | | |
 |`cusolverDnZZgesv`|10.2| | | |`hipsolverDnZZgesv`|5.1.0| | | |6.1.0|
+|`cusolverDnZZgesv_bufferSize`|10.2| | | |`hipsolverDnZZgesv_bufferSize`|5.1.0| | | |6.1.0|
 
 
 \*A - Added; D - Deprecated; C - Changed; R - Removed; E - Experimental

--- a/docs/tables/CUSOLVER_API_supported_by_HIP_and_ROC.md
+++ b/docs/tables/CUSOLVER_API_supported_by_HIP_and_ROC.md
@@ -109,16 +109,25 @@
 |**CUDA**|**A**|**D**|**C**|**R**|**HIP**|**A**|**D**|**C**|**R**|**E**|**ROC**|**A**|**D**|**C**|**R**|**E**|
 |:--|:-:|:-:|:-:|:-:|:--|:-:|:-:|:-:|:-:|:-:|:--|:-:|:-:|:-:|:-:|:-:|
 |`cusolverDnCCgesv`|10.2| | | |`hipsolverDnCCgesv`|5.1.0| | | |6.1.0| | | | | | |
+|`cusolverDnCCgesv_bufferSize`|10.2| | | |`hipsolverDnCCgesv_bufferSize`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnCEgesv`|11.0| | | | | | | | | | | | | | | |
+|`cusolverDnCEgesv_bufferSize`|11.0| | | | | | | | | | | | | | | |
 |`cusolverDnCKgesv`|10.2| | | | | | | | | | | | | | | |
+|`cusolverDnCKgesv_bufferSize`|10.2| | | | | | | | | | | | | | | |
 |`cusolverDnCYgesv`|11.0| | | | | | | | | | | | | | | |
+|`cusolverDnCYgesv_bufferSize`|11.0| | | | | | | | | | | | | | | |
 |`cusolverDnCreate`| | | | |`hipsolverDnCreate`|5.1.0| | | |6.1.0|`rocblas_create_handle`| | | | | |
 |`cusolverDnCreateParams`|11.0| | | | | | | | | | | | | | | |
 |`cusolverDnDBgesv`|11.0| | | | | | | | | | | | | | | |
+|`cusolverDnDBgesv_bufferSize`|11.0| | | | | | | | | | | | | | | |
 |`cusolverDnDDgesv`|10.2| | | |`hipsolverDnDDgesv`|5.1.0| | | |6.1.0| | | | | | |
+|`cusolverDnDDgesv_bufferSize`|10.2| | | |`hipsolverDnDDgesv_bufferSize`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnDHgesv`|10.2| | | | | | | | | | | | | | | |
+|`cusolverDnDHgesv_bufferSize`|10.2| | | | | | | | | | | | | | | |
 |`cusolverDnDSgesv`|10.2| | | | | | | | | | | | | | | |
+|`cusolverDnDSgesv_bufferSize`|10.2| | | | | | | | | | | | | | | |
 |`cusolverDnDXgesv`|11.0| | | | | | | | | | | | | | | |
+|`cusolverDnDXgesv_bufferSize`|11.0| | | | | | | | | | | | | | | |
 |`cusolverDnDestroy`| | | | |`hipsolverDnDestroy`|5.1.0| | | |6.1.0|`rocblas_destroy_handle`| | | | | |
 |`cusolverDnDgetrf`| | | | |`hipsolverDnDgetrf`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnDgetrf_bufferSize`| | | | |`hipsolverDnDgetrf_bufferSize`|5.1.0| | | |6.1.0| | | | | | |
@@ -146,9 +155,13 @@
 |`cusolverDnIRSParamsSetTol`|10.2| | | | | | | | | | | | | | | |
 |`cusolverDnIRSParamsSetTolInner`|10.2| | | | | | | | | | | | | | | |
 |`cusolverDnSBgesv`|11.0| | | | | | | | | | | | | | | |
+|`cusolverDnSBgesv_bufferSize`|11.0| | | | | | | | | | | | | | | |
 |`cusolverDnSHgesv`|10.2| | | | | | | | | | | | | | | |
+|`cusolverDnSHgesv_bufferSize`|10.2| | | | | | | | | | | | | | | |
 |`cusolverDnSSgesv`|10.2| | | |`hipsolverDnSSgesv`|5.1.0| | | |6.1.0| | | | | | |
+|`cusolverDnSSgesv_bufferSize`|10.2| | | |`hipsolverDnSSgesv_bufferSize`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnSXgesv`|11.0| | | | | | | | | | | | | | | |
+|`cusolverDnSXgesv_bufferSize`|11.0| | | | | | | | | | | | | | | |
 |`cusolverDnSetAdvOptions`|11.0| | | | | | | | | | | | | | | |
 |`cusolverDnSetDeterministicMode`|12.2| | | | | | | | | | | | | | | |
 |`cusolverDnSetStream`| | | | |`hipsolverSetStream`|4.5.0| | | |6.1.0|`rocblas_set_stream`| | | | | |
@@ -159,10 +172,15 @@
 |`cusolverDnXgetrf_bufferSize`|11.1| | | | | | | | | | | | | | | |
 |`cusolverDnXgetrs`|11.1| | | | | | | | | | | | | | | |
 |`cusolverDnZCgesv`|10.2| | | | | | | | | | | | | | | |
+|`cusolverDnZCgesv_bufferSize`|10.2| | | | | | | | | | | | | | | |
 |`cusolverDnZEgesv`|11.0| | | | | | | | | | | | | | | |
+|`cusolverDnZEgesv_bufferSize`|11.0| | | | | | | | | | | | | | | |
 |`cusolverDnZKgesv`|10.2| | | | | | | | | | | | | | | |
+|`cusolverDnZKgesv_bufferSize`|10.2| | | | | | | | | | | | | | | |
 |`cusolverDnZYgesv`|11.0| | | | | | | | | | | | | | | |
+|`cusolverDnZYgesv_bufferSize`|11.0| | | | | | | | | | | | | | | |
 |`cusolverDnZZgesv`|10.2| | | |`hipsolverDnZZgesv`|5.1.0| | | |6.1.0| | | | | | |
+|`cusolverDnZZgesv_bufferSize`|10.2| | | |`hipsolverDnZZgesv_bufferSize`|5.1.0| | | |6.1.0| | | | | | |
 
 
 \*A - Added; D - Deprecated; C - Changed; R - Removed; E - Experimental

--- a/docs/tables/CUSOLVER_API_supported_by_ROC.md
+++ b/docs/tables/CUSOLVER_API_supported_by_ROC.md
@@ -109,16 +109,25 @@
 |**CUDA**|**A**|**D**|**C**|**R**|**ROC**|**A**|**D**|**C**|**R**|**E**|
 |:--|:-:|:-:|:-:|:-:|:--|:-:|:-:|:-:|:-:|:-:|
 |`cusolverDnCCgesv`|10.2| | | | | | | | | |
+|`cusolverDnCCgesv_bufferSize`|10.2| | | | | | | | | |
 |`cusolverDnCEgesv`|11.0| | | | | | | | | |
+|`cusolverDnCEgesv_bufferSize`|11.0| | | | | | | | | |
 |`cusolverDnCKgesv`|10.2| | | | | | | | | |
+|`cusolverDnCKgesv_bufferSize`|10.2| | | | | | | | | |
 |`cusolverDnCYgesv`|11.0| | | | | | | | | |
+|`cusolverDnCYgesv_bufferSize`|11.0| | | | | | | | | |
 |`cusolverDnCreate`| | | | |`rocblas_create_handle`| | | | | |
 |`cusolverDnCreateParams`|11.0| | | | | | | | | |
 |`cusolverDnDBgesv`|11.0| | | | | | | | | |
+|`cusolverDnDBgesv_bufferSize`|11.0| | | | | | | | | |
 |`cusolverDnDDgesv`|10.2| | | | | | | | | |
+|`cusolverDnDDgesv_bufferSize`|10.2| | | | | | | | | |
 |`cusolverDnDHgesv`|10.2| | | | | | | | | |
+|`cusolverDnDHgesv_bufferSize`|10.2| | | | | | | | | |
 |`cusolverDnDSgesv`|10.2| | | | | | | | | |
+|`cusolverDnDSgesv_bufferSize`|10.2| | | | | | | | | |
 |`cusolverDnDXgesv`|11.0| | | | | | | | | |
+|`cusolverDnDXgesv_bufferSize`|11.0| | | | | | | | | |
 |`cusolverDnDestroy`| | | | |`rocblas_destroy_handle`| | | | | |
 |`cusolverDnDgetrf`| | | | | | | | | | |
 |`cusolverDnDgetrf_bufferSize`| | | | | | | | | | |
@@ -146,9 +155,13 @@
 |`cusolverDnIRSParamsSetTol`|10.2| | | | | | | | | |
 |`cusolverDnIRSParamsSetTolInner`|10.2| | | | | | | | | |
 |`cusolverDnSBgesv`|11.0| | | | | | | | | |
+|`cusolverDnSBgesv_bufferSize`|11.0| | | | | | | | | |
 |`cusolverDnSHgesv`|10.2| | | | | | | | | |
+|`cusolverDnSHgesv_bufferSize`|10.2| | | | | | | | | |
 |`cusolverDnSSgesv`|10.2| | | | | | | | | |
+|`cusolverDnSSgesv_bufferSize`|10.2| | | | | | | | | |
 |`cusolverDnSXgesv`|11.0| | | | | | | | | |
+|`cusolverDnSXgesv_bufferSize`|11.0| | | | | | | | | |
 |`cusolverDnSetAdvOptions`|11.0| | | | | | | | | |
 |`cusolverDnSetDeterministicMode`|12.2| | | | | | | | | |
 |`cusolverDnSetStream`| | | | |`rocblas_set_stream`| | | | | |
@@ -159,10 +172,15 @@
 |`cusolverDnXgetrf_bufferSize`|11.1| | | | | | | | | |
 |`cusolverDnXgetrs`|11.1| | | | | | | | | |
 |`cusolverDnZCgesv`|10.2| | | | | | | | | |
+|`cusolverDnZCgesv_bufferSize`|10.2| | | | | | | | | |
 |`cusolverDnZEgesv`|11.0| | | | | | | | | |
+|`cusolverDnZEgesv_bufferSize`|11.0| | | | | | | | | |
 |`cusolverDnZKgesv`|10.2| | | | | | | | | |
+|`cusolverDnZKgesv_bufferSize`|10.2| | | | | | | | | |
 |`cusolverDnZYgesv`|11.0| | | | | | | | | |
+|`cusolverDnZYgesv_bufferSize`|11.0| | | | | | | | | |
 |`cusolverDnZZgesv`|10.2| | | | | | | | | |
+|`cusolverDnZZgesv_bufferSize`|10.2| | | | | | | | | |
 
 
 \*A - Added; D - Deprecated; C - Changed; R - Removed; E - Experimental

--- a/src/CUDA2HIP_SOLVER_API_functions.cpp
+++ b/src/CUDA2HIP_SOLVER_API_functions.cpp
@@ -68,27 +68,49 @@ const std::map<llvm::StringRef, hipCounter> CUDA_SOLVER_FUNCTION_MAP {
   {"cusolverDnIRSInfosGetResidualHistory",                {"hipsolverDnIRSInfosGetResidualHistory",                "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
   {"cusolverDnIRSInfosGetMaxIters",                       {"hipsolverDnIRSInfosGetMaxIters",                       "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
   // NOTE: rocsolver_zgesv has a harness of rocblas_set_workspace, hipsolverZZgesv_bufferSize, and rocsolver_zgesv_outofplace
-  {"cusolverDnZZgesv",                                    {"hipsolverDnZZgesv",                                    "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
+  {"cusolverDnZZgesv",                                    {"hipsolverDnZZgesv",                                    "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
   {"cusolverDnZCgesv",                                    {"hipsolverDnZCgesv",                                    "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
   {"cusolverDnZKgesv",                                    {"hipsolverDnZKgesv",                                    "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
   {"cusolverDnZEgesv",                                    {"hipsolverDnZEgesv",                                    "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
   {"cusolverDnZYgesv",                                    {"hipsolverDnZYgesv",                                    "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
   // NOTE: rocsolver_cgesv has a harness of rocblas_set_workspace, hipsolverCCgesv_bufferSize, and rocsolver_cgesv_outofplace
-  {"cusolverDnCCgesv",                                    {"hipsolverDnCCgesv",                                    "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
+  {"cusolverDnCCgesv",                                    {"hipsolverDnCCgesv",                                    "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
   {"cusolverDnCEgesv",                                    {"hipsolverDnCEgesv",                                    "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
   {"cusolverDnCKgesv",                                    {"hipsolverDnCKgesv",                                    "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
   {"cusolverDnCYgesv",                                    {"hipsolverDnCYgesv",                                    "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
   // NOTE: rocsolver_dgesv has a harness of rocblas_set_workspace, hipsolverDDgesv_bufferSize, and rocsolver_dgesv_outofplace
-  {"cusolverDnDDgesv",                                    {"hipsolverDnDDgesv",                                    "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
+  {"cusolverDnDDgesv",                                    {"hipsolverDnDDgesv",                                    "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
   {"cusolverDnDSgesv",                                    {"hipsolverDnDSgesv",                                    "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
   {"cusolverDnDHgesv",                                    {"hipsolverDnDHgesv",                                    "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
   {"cusolverDnDBgesv",                                    {"hipsolverDnDBgesv",                                    "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
   {"cusolverDnDXgesv",                                    {"hipsolverDnDXgesv",                                    "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
   // NOTE: rocsolver_sgesv has a harness of rocblas_set_workspace, hipsolverSSgesv_bufferSize, and rocsolver_sgesv_outofplace
-  {"cusolverDnSSgesv",                                    {"hipsolverDnSSgesv",                                    "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
+  {"cusolverDnSSgesv",                                    {"hipsolverDnSSgesv",                                    "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
   {"cusolverDnSHgesv",                                    {"hipsolverDnSHgesv",                                    "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
   {"cusolverDnSBgesv",                                    {"hipsolverDnSBgesv",                                    "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
   {"cusolverDnSXgesv",                                    {"hipsolverDnSXgesv",                                    "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
+  // NOTE: rocsolver_zgesv has a harness of rocblas_start_device_memory_size_query, rocsolver_zgesv_outofplace, and rocblas_stop_device_memory_size_query
+  {"cusolverDnZZgesv_bufferSize",                         {"hipsolverDnZZgesv_bufferSize",                         "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
+  {"cusolverDnZCgesv_bufferSize",                         {"hipsolverDnZCgesv_bufferSize",                         "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
+  {"cusolverDnZKgesv_bufferSize",                         {"hipsolverDnZKgesv_bufferSize",                         "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
+  {"cusolverDnZEgesv_bufferSize",                         {"hipsolverDnZEgesv_bufferSize",                         "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
+  {"cusolverDnZYgesv_bufferSize",                         {"hipsolverDnZYgesv_bufferSize",                         "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
+  // NOTE: rocsolver_cgesv has a harness of rocblas_start_device_memory_size_query, rocsolver_cgesv_outofplace, and rocblas_stop_device_memory_size_query
+  {"cusolverDnCCgesv_bufferSize",                         {"hipsolverDnCCgesv_bufferSize",                         "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
+  {"cusolverDnCKgesv_bufferSize",                         {"hipsolverDnCKgesv_bufferSize",                         "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
+  {"cusolverDnCEgesv_bufferSize",                         {"hipsolverDnCEgesv_bufferSize",                         "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
+  {"cusolverDnCYgesv_bufferSize",                         {"hipsolverDnCYgesv_bufferSize",                         "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
+  // NOTE: rocsolver_dgesv has a harness of rocblas_start_device_memory_size_query, rocsolver_dgesv_outofplace, and rocblas_stop_device_memory_size_query
+  {"cusolverDnDDgesv_bufferSize",                         {"hipsolverDnDDgesv_bufferSize",                         "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
+  {"cusolverDnDSgesv_bufferSize",                         {"hipsolverDnDSgesv_bufferSize",                         "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
+  {"cusolverDnDHgesv_bufferSize",                         {"hipsolverDnDHgesv_bufferSize",                         "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
+  {"cusolverDnDBgesv_bufferSize",                         {"hipsolverDnDBgesv_bufferSize",                         "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
+  {"cusolverDnDXgesv_bufferSize",                         {"hipsolverDnDXgesv_bufferSize",                         "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
+  // NOTE: rocsolver_sgesv has a harness of rocblas_start_device_memory_size_query, rocsolver_sgesv_outofplace, and rocblas_stop_device_memory_size_query
+  {"cusolverDnSSgesv_bufferSize",                         {"hipsolverDnSSgesv_bufferSize",                         "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
+  {"cusolverDnSHgesv_bufferSize",                         {"hipsolverDnSHgesv_bufferSize",                         "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
+  {"cusolverDnSBgesv_bufferSize",                         {"hipsolverDnSBgesv_bufferSize",                         "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
+  {"cusolverDnSXgesv_bufferSize",                         {"hipsolverDnSXgesv_bufferSize",                         "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
 };
 
 const std::map<llvm::StringRef, cudaAPIversions> CUDA_SOLVER_FUNCTION_VER_MAP {
@@ -137,6 +159,24 @@ const std::map<llvm::StringRef, cudaAPIversions> CUDA_SOLVER_FUNCTION_VER_MAP {
   {"cusolverDnSHgesv",                                    {CUDA_102,  CUDA_0, CUDA_0}},
   {"cusolverDnSBgesv",                                    {CUDA_110,  CUDA_0, CUDA_0}},
   {"cusolverDnSXgesv",                                    {CUDA_110,  CUDA_0, CUDA_0}},
+  {"cusolverDnZZgesv_bufferSize",                         {CUDA_102,  CUDA_0, CUDA_0}},
+  {"cusolverDnZCgesv_bufferSize",                         {CUDA_102,  CUDA_0, CUDA_0}},
+  {"cusolverDnZKgesv_bufferSize",                         {CUDA_102,  CUDA_0, CUDA_0}},
+  {"cusolverDnZEgesv_bufferSize",                         {CUDA_110,  CUDA_0, CUDA_0}},
+  {"cusolverDnZYgesv_bufferSize",                         {CUDA_110,  CUDA_0, CUDA_0}},
+  {"cusolverDnCCgesv_bufferSize",                         {CUDA_102,  CUDA_0, CUDA_0}},
+  {"cusolverDnCKgesv_bufferSize",                         {CUDA_102,  CUDA_0, CUDA_0}},
+  {"cusolverDnCEgesv_bufferSize",                         {CUDA_110,  CUDA_0, CUDA_0}},
+  {"cusolverDnCYgesv_bufferSize",                         {CUDA_110,  CUDA_0, CUDA_0}},
+  {"cusolverDnDDgesv_bufferSize",                         {CUDA_102,  CUDA_0, CUDA_0}},
+  {"cusolverDnDSgesv_bufferSize",                         {CUDA_102,  CUDA_0, CUDA_0}},
+  {"cusolverDnDHgesv_bufferSize",                         {CUDA_102,  CUDA_0, CUDA_0}},
+  {"cusolverDnDBgesv_bufferSize",                         {CUDA_110,  CUDA_0, CUDA_0}},
+  {"cusolverDnDXgesv_bufferSize",                         {CUDA_110,  CUDA_0, CUDA_0}},
+  {"cusolverDnSSgesv_bufferSize",                         {CUDA_102,  CUDA_0, CUDA_0}},
+  {"cusolverDnSHgesv_bufferSize",                         {CUDA_102,  CUDA_0, CUDA_0}},
+  {"cusolverDnSBgesv_bufferSize",                         {CUDA_110,  CUDA_0, CUDA_0}},
+  {"cusolverDnSXgesv_bufferSize",                         {CUDA_110,  CUDA_0, CUDA_0}},
 };
 
 const std::map<llvm::StringRef, hipAPIversions> HIP_SOLVER_FUNCTION_VER_MAP {
@@ -154,6 +194,10 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_SOLVER_FUNCTION_VER_MAP {
   {"hipsolverDnCCgesv",                                   {HIP_5010, HIP_0,    HIP_0,  HIP_LATEST}},
   {"hipsolverDnDDgesv",                                   {HIP_5010, HIP_0,    HIP_0,  HIP_LATEST}},
   {"hipsolverDnSSgesv",                                   {HIP_5010, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipsolverDnZZgesv_bufferSize",                        {HIP_5010, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipsolverDnCCgesv_bufferSize",                        {HIP_5010, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipsolverDnDDgesv_bufferSize",                        {HIP_5010, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipsolverDnSSgesv_bufferSize",                        {HIP_5010, HIP_0,    HIP_0,  HIP_LATEST}},
 };
 
 const std::map<unsigned int, llvm::StringRef> CUDA_SOLVER_API_SECTION_MAP {

--- a/tests/unit_tests/synthetic/libraries/cusolver2hipsolver.cu
+++ b/tests/unit_tests/synthetic/libraries/cusolver2hipsolver.cu
@@ -199,6 +199,26 @@ int main() {
   // HIP: HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDnSSgesv(hipsolverHandle_t handle, int n, int nrhs, float* A, int lda, int* devIpiv, float* B, int ldb, float* X, int ldx, void* work, size_t lwork, int* niters, int* devInfo);
   // CHECK: status = hipsolverDnSSgesv(handle, ln, lnrhs, &fA, ldda, &dipiv, &fB, lddb, &fX, lddx, &Workspace, lwork_bytes, &iter, &d_info);
   status = cusolverDnSSgesv(handle, ln, lnrhs, &fA, ldda, &dipiv, &fB, lddb, &fX, lddx, &Workspace, lwork_bytes, &iter, &d_info);
+
+  // CUDA: cusolverStatus_t CUSOLVERAPI cusolverDnZZgesv_bufferSize(cusolverDnHandle_t handle, cusolver_int_t n, cusolver_int_t nrhs, cuDoubleComplex * dA, cusolver_int_t ldda, cusolver_int_t * dipiv, cuDoubleComplex * dB, cusolver_int_t lddb, cuDoubleComplex * dX, cusolver_int_t lddx, void * dWorkspace, size_t * lwork_bytes);
+  // HIP: HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDnZZgesv_bufferSize(hipsolverHandle_t handle, int n, int nrhs, hipDoubleComplex* A, int lda, int* devIpiv, hipDoubleComplex* B, int ldb, hipDoubleComplex* X, int ldx, void* work, size_t* lwork);
+  // CHECK: status = hipsolverDnZZgesv_bufferSize(handle, ln, lnrhs, &dComplexA, ldda, &dipiv, &dComplexB, lddb, &dComplexX, lddx, &Workspace, &lwork_bytes);
+  status = cusolverDnZZgesv_bufferSize(handle, ln, lnrhs, &dComplexA, ldda, &dipiv, &dComplexB, lddb, &dComplexX, lddx, &Workspace, &lwork_bytes);
+
+  // CUDA: cusolverStatus_t CUSOLVERAPI cusolverDnCCgesv_bufferSize(cusolverDnHandle_t handle, cusolver_int_t n, cusolver_int_t nrhs, cuComplex * dA, cusolver_int_t ldda, cusolver_int_t * dipiv, cuComplex * dB, cusolver_int_t lddb, cuComplex * dX, cusolver_int_t lddx, void * dWorkspace, size_t * lwork_bytes);
+  // HIP: HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDnCCgesv_bufferSize(hipsolverHandle_t handle, int n, int nrhs, hipFloatComplex* A, int lda, int* devIpiv, hipFloatComplex* B, int ldb, hipFloatComplex* X, int ldx, void* work, size_t* lwork);
+  // CHECK: status = hipsolverDnCCgesv_bufferSize(handle, ln, lnrhs, &complexA, ldda, &dipiv, &complexB, lddb, &complexX, lddx, &Workspace, &lwork_bytes);
+  status = cusolverDnCCgesv_bufferSize(handle, ln, lnrhs, &complexA, ldda, &dipiv, &complexB, lddb, &complexX, lddx, &Workspace, &lwork_bytes);
+
+  // CUDA: cusolverStatus_t CUSOLVERAPI cusolverDnDDgesv_bufferSize(cusolverDnHandle_t handle, cusolver_int_t n, cusolver_int_t nrhs, double * dA, cusolver_int_t ldda, cusolver_int_t * dipiv, double * dB, cusolver_int_t lddb, double * dX, cusolver_int_t lddx, void * dWorkspace, size_t * lwork_bytes);
+  // HIP: HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDnDDgesv_bufferSize(hipsolverHandle_t handle, int n, int nrhs, double* A, int lda, int* devIpiv, double* B, int ldb, double* X, int ldx, void* work, size_t* lwork);
+  // CHECK: status = hipsolverDnDDgesv_bufferSize(handle, ln, lnrhs, &dA, ldda, &dipiv, &dB, lddb, &dX, lddx, &Workspace, &lwork_bytes);
+  status = cusolverDnDDgesv_bufferSize(handle, ln, lnrhs, &dA, ldda, &dipiv, &dB, lddb, &dX, lddx, &Workspace, &lwork_bytes);
+
+  // CUDA: cusolverStatus_t CUSOLVERAPI cusolverDnSSgesv_bufferSize(cusolverDnHandle_t handle, cusolver_int_t n, cusolver_int_t nrhs, float * dA, cusolver_int_t ldda, cusolver_int_t * dipiv, float * dB, cusolver_int_t lddb, float * dX, cusolver_int_t lddx, void * dWorkspace, size_t * lwork_bytes);
+  // HIP: HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDnSSgesv_bufferSize(hipsolverHandle_t handle, int n, int nrhs, float* A, int lda, int* devIpiv, float* B, int ldb, float* X, int ldx, void* work, size_t* lwork);
+  // CHECK: status = hipsolverDnSSgesv_bufferSize(handle, ln, lnrhs, &fA, ldda, &dipiv, &fB, lddb, &fX, lddx, &Workspace, &lwork_bytes);
+  status = cusolverDnSSgesv_bufferSize(handle, ln, lnrhs, &fA, ldda, &dipiv, &fB, lddb, &fX, lddx, &Workspace, &lwork_bytes);
 #endif
 
   return 0;


### PR DESCRIPTION
+ `hipsolverDn(ZZ|CC|DD|SS)gesv_bufferSize` are `SUPPORTED`
+ `cusolverDnZ(C|K|E|Y)gesv_bufferSize`, `cusolverDnC(E|K|Y)gesv_bufferSize`, `cusolverDnD(S|H|B|X)gesv_bufferSize`, and `cusolverDnS(H|B|X)gesv_bufferSize` are `UNSUPPORTED`
+ [NOTE] `rocsolver_(z|c|d|s)gesv` have a harness of `rocblas_start_device_memory_size_query`, `rocsolver_(z|c|d|s)gesv_outofplace`, and `rocblas_stop_device_memory_size_query` thus `UNSUPPORTED`
+ Updated `SOLVER` synthetic tests, the regenerated hipify-perl, and `SOLVER` `CUDA2HIP` documentation