### PR TITLE
[HIPIFY][#674][rocSPARSE][feature] rocSPARSE support - Step 63 - functions `rocsparse_(s|d|c|z)hybmv`

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -1823,6 +1823,7 @@ sub rocSubstitutions {
     subst("cusparseCgtsv2_nopivot_bufferSizeExt", "rocsparse_cgtsv_no_pivot_buffer_size", "library");
     subst("cusparseCgtsvInterleavedBatch", "rocsparse_cgtsv_interleaved_batch", "library");
     subst("cusparseCgtsvInterleavedBatch_bufferSizeExt", "rocsparse_cgtsv_interleaved_batch_buffer_size", "library");
+    subst("cusparseChybmv", "rocsparse_chybmv", "library");
     subst("cusparseCnnz", "rocsparse_cnnz", "library");
     subst("cusparseCnnz_compress", "rocsparse_cnnz_compress", "library");
     subst("cusparseCooAoSGet", "rocsparse_coo_aos_get", "library");
@@ -1907,6 +1908,7 @@ sub rocSubstitutions {
     subst("cusparseDgtsv2_nopivot_bufferSizeExt", "rocsparse_dgtsv_no_pivot_buffer_size", "library");
     subst("cusparseDgtsvInterleavedBatch", "rocsparse_dgtsv_interleaved_batch", "library");
     subst("cusparseDgtsvInterleavedBatch_bufferSizeExt", "rocsparse_dgtsv_interleaved_batch_buffer_size", "library");
+    subst("cusparseDhybmv", "rocsparse_dhybmv", "library");
     subst("cusparseDnMatGet", "rocsparse_dnmat_get", "library");
     subst("cusparseDnMatGetStridedBatch", "rocsparse_dnmat_get_strided_batch", "library");
     subst("cusparseDnMatGetValues", "rocsparse_dnmat_get_values", "library");
@@ -2000,6 +2002,7 @@ sub rocSubstitutions {
     subst("cusparseSgtsv2_nopivot_bufferSizeExt", "rocsparse_sgtsv_no_pivot_buffer_size", "library");
     subst("cusparseSgtsvInterleavedBatch", "rocsparse_sgtsv_interleaved_batch", "library");
     subst("cusparseSgtsvInterleavedBatch_bufferSizeExt", "rocsparse_sgtsv_interleaved_batch_buffer_size", "library");
+    subst("cusparseShybmv", "rocsparse_shybmv", "library");
     subst("cusparseSnnz", "rocsparse_snnz", "library");
     subst("cusparseSnnz_compress", "rocsparse_snnz_compress", "library");
     subst("cusparseSpMV", "rocsparse_spmv", "library");
@@ -2100,6 +2103,7 @@ sub rocSubstitutions {
     subst("cusparseZgtsv2_nopivot_bufferSizeExt", "rocsparse_zgtsv_no_pivot_buffer_size", "library");
     subst("cusparseZgtsvInterleavedBatch", "rocsparse_zgtsv_interleaved_batch", "library");
     subst("cusparseZgtsvInterleavedBatch_bufferSizeExt", "rocsparse_zgtsv_interleaved_batch_buffer_size", "library");
+    subst("cusparseZhybmv", "rocsparse_zhybmv", "library");
     subst("cusparseZnnz", "rocsparse_znnz", "library");
     subst("cusparseZnnz_compress", "rocsparse_znnz_compress", "library");
     subst("__half", "rocblas_half", "device_type");

--- a/docs/tables/CUSPARSE_API_supported_by_HIP_and_ROC.md
+++ b/docs/tables/CUSPARSE_API_supported_by_HIP_and_ROC.md
@@ -308,7 +308,7 @@
 |`cusparseCcsrsv_solve`| |10.2| |11.0| | | | | | | | | | | | |
 |`cusparseCgemvi`|7.5| | | |`hipsparseCgemvi`|4.3.0| | | | |`rocsparse_cgemvi`|4.3.0| | | | |
 |`cusparseCgemvi_bufferSize`|7.5| | | |`hipsparseCgemvi_bufferSize`|4.3.0| | | | |`rocsparse_cgemvi_buffer_size`|4.3.0| | | | |
-|`cusparseChybmv`| |10.2| |11.0|`hipsparseChybmv`|3.1.0| | | | | | | | | | |
+|`cusparseChybmv`| |10.2| |11.0|`hipsparseChybmv`|3.1.0| | | | |`rocsparse_chybmv`|2.10.0| | | | |
 |`cusparseChybsv_analysis`| |10.2| |11.0| | | | | | | | | | | | |
 |`cusparseChybsv_solve`| |10.2| |11.0| | | | | | | | | | | | |
 |`cusparseCsrmvEx`|8.0|11.2| |12.0| | | | | | | | | | | | |
@@ -331,7 +331,7 @@
 |`cusparseDcsrsv_solve`| |10.2| |11.0| | | | | | | | | | | | |
 |`cusparseDgemvi`|7.5| | | |`hipsparseDgemvi`|4.3.0| | | | |`rocsparse_dgemvi`|4.3.0| | | | |
 |`cusparseDgemvi_bufferSize`|7.5| | | |`hipsparseDgemvi_bufferSize`|4.3.0| | | | |`rocsparse_dgemvi_buffer_size`|4.3.0| | | | |
-|`cusparseDhybmv`| |10.2| |11.0|`hipsparseDhybmv`|1.9.2| | | | | | | | | | |
+|`cusparseDhybmv`| |10.2| |11.0|`hipsparseDhybmv`|1.9.2| | | | |`rocsparse_dhybmv`|1.9.0| | | | |
 |`cusparseDhybsv_analysis`| |10.2| |11.0| | | | | | | | | | | | |
 |`cusparseDhybsv_solve`| |10.2| |11.0| | | | | | | | | | | | |
 |`cusparseSbsrmv`| | | | |`hipsparseSbsrmv`|3.5.0| | | | | | | | | | |
@@ -350,7 +350,7 @@
 |`cusparseScsrsv_solve`| |10.2| |11.0| | | | | | | | | | | | |
 |`cusparseSgemvi`|7.5| | | |`hipsparseSgemvi`|4.3.0| | | | |`rocsparse_sgemvi`|4.3.0| | | | |
 |`cusparseSgemvi_bufferSize`|7.5| | | |`hipsparseSgemvi_bufferSize`|4.3.0| | | | |`rocsparse_sgemvi_buffer_size`|4.3.0| | | | |
-|`cusparseShybmv`| |10.2| |11.0|`hipsparseShybmv`|1.9.2| | | | | | | | | | |
+|`cusparseShybmv`| |10.2| |11.0|`hipsparseShybmv`|1.9.2| | | | |`rocsparse_shybmv`|1.9.0| | | | |
 |`cusparseShybsv_analysis`| |10.2| |11.0| | | | | | | | | | | | |
 |`cusparseShybsv_solve`| |10.2| |11.0| | | | | | | | | | | | |
 |`cusparseXbsrsv2_zeroPivot`| |12.2| | |`hipsparseXbsrsv2_zeroPivot`|3.6.0| | | | | | | | | | |
@@ -371,7 +371,7 @@
 |`cusparseZcsrsv_solve`| |10.2| |11.0| | | | | | | | | | | | |
 |`cusparseZgemvi`|7.5| | | |`hipsparseZgemvi`|4.3.0| | | | |`rocsparse_zgemvi`|4.3.0| | | | |
 |`cusparseZgemvi_bufferSize`|7.5| | | |`hipsparseZgemvi_bufferSize`|4.3.0| | | | |`rocsparse_zgemvi_buffer_size`|4.3.0| | | | |
-|`cusparseZhybmv`| |10.2| |11.0|`hipsparseZhybmv`|3.1.0| | | | | | | | | | |
+|`cusparseZhybmv`| |10.2| |11.0|`hipsparseZhybmv`|3.1.0| | | | |`rocsparse_zhybmv`|2.10.0| | | | |
 |`cusparseZhybsv_analysis`| |10.2| |11.0| | | | | | | | | | | | |
 |`cusparseZhybsv_solve`| |10.2| |11.0| | | | | | | | | | | | |
 

--- a/docs/tables/CUSPARSE_API_supported_by_ROC.md
+++ b/docs/tables/CUSPARSE_API_supported_by_ROC.md
@@ -308,7 +308,7 @@
 |`cusparseCcsrsv_solve`| |10.2| |11.0| | | | | | |
 |`cusparseCgemvi`|7.5| | | |`rocsparse_cgemvi`|4.3.0| | | | |
 |`cusparseCgemvi_bufferSize`|7.5| | | |`rocsparse_cgemvi_buffer_size`|4.3.0| | | | |
-|`cusparseChybmv`| |10.2| |11.0| | | | | | |
+|`cusparseChybmv`| |10.2| |11.0|`rocsparse_chybmv`|2.10.0| | | | |
 |`cusparseChybsv_analysis`| |10.2| |11.0| | | | | | |
 |`cusparseChybsv_solve`| |10.2| |11.0| | | | | | |
 |`cusparseCsrmvEx`|8.0|11.2| |12.0| | | | | | |
@@ -331,7 +331,7 @@
 |`cusparseDcsrsv_solve`| |10.2| |11.0| | | | | | |
 |`cusparseDgemvi`|7.5| | | |`rocsparse_dgemvi`|4.3.0| | | | |
 |`cusparseDgemvi_bufferSize`|7.5| | | |`rocsparse_dgemvi_buffer_size`|4.3.0| | | | |
-|`cusparseDhybmv`| |10.2| |11.0| | | | | | |
+|`cusparseDhybmv`| |10.2| |11.0|`rocsparse_dhybmv`|1.9.0| | | | |
 |`cusparseDhybsv_analysis`| |10.2| |11.0| | | | | | |
 |`cusparseDhybsv_solve`| |10.2| |11.0| | | | | | |
 |`cusparseSbsrmv`| | | | | | | | | | |
@@ -350,7 +350,7 @@
 |`cusparseScsrsv_solve`| |10.2| |11.0| | | | | | |
 |`cusparseSgemvi`|7.5| | | |`rocsparse_sgemvi`|4.3.0| | | | |
 |`cusparseSgemvi_bufferSize`|7.5| | | |`rocsparse_sgemvi_buffer_size`|4.3.0| | | | |
-|`cusparseShybmv`| |10.2| |11.0| | | | | | |
+|`cusparseShybmv`| |10.2| |11.0|`rocsparse_shybmv`|1.9.0| | | | |
 |`cusparseShybsv_analysis`| |10.2| |11.0| | | | | | |
 |`cusparseShybsv_solve`| |10.2| |11.0| | | | | | |
 |`cusparseXbsrsv2_zeroPivot`| |12.2| | | | | | | | |
@@ -371,7 +371,7 @@
 |`cusparseZcsrsv_solve`| |10.2| |11.0| | | | | | |
 |`cusparseZgemvi`|7.5| | | |`rocsparse_zgemvi`|4.3.0| | | | |
 |`cusparseZgemvi_bufferSize`|7.5| | | |`rocsparse_zgemvi_buffer_size`|4.3.0| | | | |
-|`cusparseZhybmv`| |10.2| |11.0| | | | | | |
+|`cusparseZhybmv`| |10.2| |11.0|`rocsparse_zhybmv`|2.10.0| | | | |
 |`cusparseZhybsv_analysis`| |10.2| |11.0| | | | | | |
 |`cusparseZhybsv_solve`| |10.2| |11.0| | | | | | |
 

--- a/src/CUDA2HIP_SPARSE_API_functions.cpp
+++ b/src/CUDA2HIP_SPARSE_API_functions.cpp
@@ -202,10 +202,10 @@ const std::map<llvm::StringRef, hipCounter> CUDA_SPARSE_FUNCTION_MAP {
   {"cusparseZcsrsv2_solve",                             {"hipsparseZcsrsv2_solve",                             "",                                                                 CONV_LIB_FUNC, API_SPARSE, 9, ROC_UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED}},
   {"cusparseXcsrsv2_zeroPivot",                         {"hipsparseXcsrsv2_zeroPivot",                         "",                                                                 CONV_LIB_FUNC, API_SPARSE, 9, ROC_UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED}},
 
-  {"cusparseShybmv",                                    {"hipsparseShybmv",                                    "",                                                                 CONV_LIB_FUNC, API_SPARSE, 9, ROC_UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED}},
-  {"cusparseDhybmv",                                    {"hipsparseDhybmv",                                    "",                                                                 CONV_LIB_FUNC, API_SPARSE, 9, ROC_UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED}},
-  {"cusparseChybmv",                                    {"hipsparseChybmv",                                    "",                                                                 CONV_LIB_FUNC, API_SPARSE, 9, ROC_UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED}},
-  {"cusparseZhybmv",                                    {"hipsparseZhybmv",                                    "",                                                                 CONV_LIB_FUNC, API_SPARSE, 9, ROC_UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED}},
+  {"cusparseShybmv",                                    {"hipsparseShybmv",                                    "rocsparse_shybmv",                                                 CONV_LIB_FUNC, API_SPARSE, 9, CUDA_DEPRECATED | CUDA_REMOVED}},
+  {"cusparseDhybmv",                                    {"hipsparseDhybmv",                                    "rocsparse_dhybmv",                                                 CONV_LIB_FUNC, API_SPARSE, 9, CUDA_DEPRECATED | CUDA_REMOVED}},
+  {"cusparseChybmv",                                    {"hipsparseChybmv",                                    "rocsparse_chybmv",                                                 CONV_LIB_FUNC, API_SPARSE, 9, CUDA_DEPRECATED | CUDA_REMOVED}},
+  {"cusparseZhybmv",                                    {"hipsparseZhybmv",                                    "rocsparse_zhybmv",                                                 CONV_LIB_FUNC, API_SPARSE, 9, CUDA_DEPRECATED | CUDA_REMOVED}},
 
   {"cusparseShybsv_analysis",                           {"hipsparseShybsv_analysis",                           "",                                                                 CONV_LIB_FUNC, API_SPARSE, 9, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED}},
   {"cusparseDhybsv_analysis",                           {"hipsparseDhybsv_analysis",                           "",                                                                 CONV_LIB_FUNC, API_SPARSE, 9, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED}},
@@ -2319,6 +2319,10 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_SPARSE_FUNCTION_VER_MAP {
   {"rocsparse_dgemvi_buffer_size",                       {HIP_4030, HIP_0,    HIP_0   }},
   {"rocsparse_cgemvi_buffer_size",                       {HIP_4030, HIP_0,    HIP_0   }},
   {"rocsparse_zgemvi_buffer_size",                       {HIP_4030, HIP_0,    HIP_0   }},
+  {"rocsparse_zhybmv",                                   {HIP_2100, HIP_0,    HIP_0   }},
+  {"rocsparse_chybmv",                                   {HIP_2100, HIP_0,    HIP_0   }},
+  {"rocsparse_dhybmv",                                   {HIP_1090, HIP_0,    HIP_0   }},
+  {"rocsparse_shybmv",                                   {HIP_1090, HIP_0,    HIP_0   }},
 };
 
 const std::map<llvm::StringRef, cudaAPIChangedVersions> CUDA_SPARSE_FUNCTION_CHANGED_VER_MAP {

--- a/tests/unit_tests/synthetic/libraries/cusparse2hipsparse.cu
+++ b/tests/unit_tests/synthetic/libraries/cusparse2hipsparse.cu
@@ -2019,6 +2019,26 @@ int main() {
   // HIP: DEPRECATED_CUDA_10000("The routine will be removed in CUDA 11") HIPSPARSE_EXPORT hipsparseStatus_t hipsparseScsrmm(hipsparseHandle_t handle, hipsparseOperation_t transA, int m, int n, int k, int nnz, const float* alpha, const hipsparseMatDescr_t descrA, const float* csrSortedValA, const int* csrSortedRowPtrA, const int* csrSortedColIndA, const float* B, int ldb, const float* beta, float* C, int ldc);
   // CHECK: status_t = hipsparseScsrmm(handle_t, opA, m, n, k, innz, &fA, matDescr_A, &csrSortedValA, &csrRowPtrA, &csrColIndA, &fB, ldb, &fBeta, &fC, ldc);
   status_t = cusparseScsrmm(handle_t, opA, m, n, k, innz, &fA, matDescr_A, &csrSortedValA, &csrRowPtrA, &csrColIndA, &fB, ldb, &fBeta, &fC, ldc);
+
+  // CUDA: CUSPARSE_DEPRECATED cusparseStatus_t CUSPARSEAPI cusparseZhybmv(cusparseHandle_t handle, cusparseOperation_t transA, const cuDoubleComplex* alpha, const cusparseMatDescr_t descrA, const cusparseHybMat_t hybA, const cuDoubleComplex* x, const cuDoubleComplex* beta, cuDoubleComplex* y);
+  // HIP: DEPRECATED_CUDA_10000("The routine will be removed in CUDA 11") HIPSPARSE_EXPORT hipsparseStatus_t hipsparseZhybmv(hipsparseHandle_t handle, hipsparseOperation_t transA, const hipDoubleComplex* alpha, const hipsparseMatDescr_t descrA, const hipsparseHybMat_t hybA, const hipDoubleComplex* x, const hipDoubleComplex* beta, hipDoubleComplex* y);
+  // CHECK: status_t = hipsparseZhybmv(handle_t, opA, &dcomplexAlpha, matDescr_A, hybMat_t, &dcomplexX, &dcomplexBeta, &dcomplexY);
+  status_t = cusparseZhybmv(handle_t, opA, &dcomplexAlpha, matDescr_A, hybMat_t, &dcomplexX, &dcomplexBeta, &dcomplexY);
+
+  // CUDA: CUSPARSE_DEPRECATED cusparseStatus_t CUSPARSEAPI cusparseChybmv(cusparseHandle_t handle, cusparseOperation_t transA, const cuComplex* alpha, const cusparseMatDescr_t descrA, const cusparseHybMat_t hybA, const cuComplex* x, const cuComplex* beta, cuComplex* y);
+  // HIP: DEPRECATED_CUDA_10000("The routine will be removed in CUDA 11") HIPSPARSE_EXPORT hipsparseStatus_t hipsparseChybmv(hipsparseHandle_t handle, hipsparseOperation_t transA, const hipComplex* alpha, const hipsparseMatDescr_t descrA, const hipsparseHybMat_t hybA, const hipComplex* x, const hipComplex* beta, hipComplex* y);
+  // CHECK: status_t = hipsparseChybmv(handle_t, opA, &complexAlpha, matDescr_A, hybMat_t, &complexX, &complexBeta, &complexY);
+  status_t = cusparseChybmv(handle_t, opA, &complexAlpha, matDescr_A, hybMat_t, &complexX, &complexBeta, &complexY);
+
+  // CUDA: CUSPARSE_DEPRECATED cusparseStatus_t CUSPARSEAPI cusparseDhybmv(cusparseHandle_t handle, cusparseOperation_t transA, const double* alpha, const cusparseMatDescr_t descrA, const cusparseHybMat_t hybA, const double* x, const double* beta, double* y);
+  // HIP: DEPRECATED_CUDA_10000("The routine will be removed in CUDA 11") HIPSPARSE_EXPORT hipsparseStatus_t hipsparseDhybmv(hipsparseHandle_t handle, hipsparseOperation_t transA, const double* alpha, const hipsparseMatDescr_t descrA, const hipsparseHybMat_t hybA, const double* x, const double* beta, double* y);
+  // CHECK: status_t = hipsparseDhybmv(handle_t, opA, &dAlpha, matDescr_A, hybMat_t, &dX, &dBeta, &dY);
+  status_t = cusparseDhybmv(handle_t, opA, &dAlpha, matDescr_A, hybMat_t, &dX, &dBeta, &dY);
+
+  // CUDA: CUSPARSE_DEPRECATED cusparseStatus_t CUSPARSEAPI cusparseShybmv(cusparseHandle_t handle, cusparseOperation_t transA, const float* alpha, const cusparseMatDescr_t descrA, const cusparseHybMat_t hybA, const float* x, const float* beta, float* y);
+  // HIP: DEPRECATED_CUDA_10000("The routine will be removed in CUDA 11") HIPSPARSE_EXPORT hipsparseStatus_t hipsparseShybmv(hipsparseHandle_t handle, hipsparseOperation_t transA, const float* alpha, const hipsparseMatDescr_t descrA, const hipsparseHybMat_t hybA, const float* x, const float* beta, float* y);
+  // CHECK: status_t = hipsparseShybmv(handle_t, opA, &fAlpha, matDescr_A, hybMat_t, &fX, &fBeta, &fY);
+  status_t = cusparseShybmv(handle_t, opA, &fAlpha, matDescr_A, hybMat_t, &fX, &fBeta, &fY);
 #endif
 
 #if CUDA_VERSION >= 11000

--- a/tests/unit_tests/synthetic/libraries/cusparse2rocsparse.cu
+++ b/tests/unit_tests/synthetic/libraries/cusparse2rocsparse.cu
@@ -1739,6 +1739,26 @@ int main() {
   // ROC: ROCSPARSE_EXPORT rocsparse_status rocsparse_scsrmm(rocsparse_handle handle, rocsparse_operation trans_A, rocsparse_operation trans_B, rocsparse_int m, rocsparse_int n, rocsparse_int k, rocsparse_int nnz, const float* alpha, const rocsparse_mat_descr descr, const float* csr_val, const rocsparse_int* csr_row_ptr, const rocsparse_int* csr_col_ind, const float* B, rocsparse_int ldb, const float* beta, float* C, rocsparse_int ldc);
   // CHECK: status_t = rocsparse_scsrmm(handle_t, opA, m, n, k, innz, &fA, matDescr_A, &csrSortedValA, &csrRowPtrA, &csrColIndA, &fB, ldb, &fBeta, &fC, ldc);
   status_t = cusparseScsrmm(handle_t, opA, m, n, k, innz, &fA, matDescr_A, &csrSortedValA, &csrRowPtrA, &csrColIndA, &fB, ldb, &fBeta, &fC, ldc);
+
+  // CUDA: CUSPARSE_DEPRECATED cusparseStatus_t CUSPARSEAPI cusparseZhybmv(cusparseHandle_t handle, cusparseOperation_t transA, const cuDoubleComplex* alpha, const cusparseMatDescr_t descrA, const cusparseHybMat_t hybA, const cuDoubleComplex* x, const cuDoubleComplex* beta, cuDoubleComplex* y);
+  // ROC: ROCSPARSE_EXPORT rocsparse_status rocsparse_zhybmv(rocsparse_handle handle, rocsparse_operation trans, const rocsparse_double_complex* alpha, const rocsparse_mat_descr descr, const rocsparse_hyb_mat hyb, const rocsparse_double_complex* x, const rocsparse_double_complex* beta, rocsparse_double_complex* y);
+  // CHECK: status_t = rocsparse_zhybmv(handle_t, opA, &dcomplexAlpha, matDescr_A, hybMat_t, &dcomplexX, &dcomplexBeta, &dcomplexY);
+  status_t = cusparseZhybmv(handle_t, opA, &dcomplexAlpha, matDescr_A, hybMat_t, &dcomplexX, &dcomplexBeta, &dcomplexY);
+
+  // CUDA: CUSPARSE_DEPRECATED cusparseStatus_t CUSPARSEAPI cusparseChybmv(cusparseHandle_t handle, cusparseOperation_t transA, const cuComplex* alpha, const cusparseMatDescr_t descrA, const cusparseHybMat_t hybA, const cuComplex* x, const cuComplex* beta, cuComplex* y);
+  // ROC: ROCSPARSE_EXPORT rocsparse_status rocsparse_chybmv(rocsparse_handle handle, rocsparse_operation trans, const rocsparse_float_complex* alpha, const rocsparse_mat_descr descr, const rocsparse_hyb_mat hyb, const rocsparse_float_complex* x, const rocsparse_float_complex* beta, rocsparse_float_complex* y);
+  // CHECK: status_t = rocsparse_chybmv(handle_t, opA, &complexAlpha, matDescr_A, hybMat_t, &complexX, &complexBeta, &complexY);
+  status_t = cusparseChybmv(handle_t, opA, &complexAlpha, matDescr_A, hybMat_t, &complexX, &complexBeta, &complexY);
+
+  // CUDA: CUSPARSE_DEPRECATED cusparseStatus_t CUSPARSEAPI cusparseDhybmv(cusparseHandle_t handle, cusparseOperation_t transA, const double* alpha, const cusparseMatDescr_t descrA, const cusparseHybMat_t hybA, const double* x, const double* beta, double* y);
+  // ROC: ROCSPARSE_EXPORT rocsparse_status rocsparse_dhybmv(rocsparse_handle handle, rocsparse_operation trans, const double* alpha, const rocsparse_mat_descr descr, const rocsparse_hyb_mat hyb, const double* x, const double* beta, double* y);
+  // CHECK: status_t = rocsparse_dhybmv(handle_t, opA, &dAlpha, matDescr_A, hybMat_t, &dX, &dBeta, &dY);
+  status_t = cusparseDhybmv(handle_t, opA, &dAlpha, matDescr_A, hybMat_t, &dX, &dBeta, &dY);
+
+  // CUDA: CUSPARSE_DEPRECATED cusparseStatus_t CUSPARSEAPI cusparseShybmv(cusparseHandle_t handle, cusparseOperation_t transA, const float* alpha, const cusparseMatDescr_t descrA, const cusparseHybMat_t hybA, const float* x, const float* beta, float* y);
+  // ROC: ROCSPARSE_EXPORT rocsparse_status rocsparse_shybmv(rocsparse_handle handle, rocsparse_operation trans, const float* alpha, const rocsparse_mat_descr descr, const rocsparse_hyb_mat hyb, const float* x, const float* beta, float* y);
+  // CHECK: status_t = rocsparse_shybmv(handle_t, opA, &fAlpha, matDescr_A, hybMat_t, &fX, &fBeta, &fY);
+  status_t = cusparseShybmv(handle_t, opA, &fAlpha, matDescr_A, hybMat_t, &fX, &fBeta, &fY);
 #endif
 
 #if CUDA_VERSION >= 11000


### PR DESCRIPTION
+ Updated synthetic tests, the regenerated hipify-perl, and `SPARSE` `CUDA2HIP` documentation
