### PR TITLE
[HIPIFY][#675][#677][SOLVER][feature] `cuSOLVER` support - Step 15 - Functions (DN)

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -1082,12 +1082,14 @@ my %experimental_funcs = (
     "cusolverEigMode_t" => "6.1.0",
     "cusolverDnZZgesv_bufferSize" => "6.1.0",
     "cusolverDnZZgesv" => "6.1.0",
+    "cusolverDnZZgels" => "6.1.0",
     "cusolverDnSgetrs" => "6.1.0",
     "cusolverDnSgetrf_bufferSize" => "6.1.0",
     "cusolverDnSgetrf" => "6.1.0",
     "cusolverDnSetStream" => "6.1.0",
     "cusolverDnSSgesv_bufferSize" => "6.1.0",
     "cusolverDnSSgesv" => "6.1.0",
+    "cusolverDnSSgels" => "6.1.0",
     "cusolverDnHandle_t" => "6.1.0",
     "cusolverDnGetStream" => "6.1.0",
     "cusolverDnDgetrs" => "6.1.0",
@@ -1096,9 +1098,11 @@ my %experimental_funcs = (
     "cusolverDnDestroy" => "6.1.0",
     "cusolverDnDDgesv_bufferSize" => "6.1.0",
     "cusolverDnDDgesv" => "6.1.0",
+    "cusolverDnDDgels" => "6.1.0",
     "cusolverDnCreate" => "6.1.0",
     "cusolverDnCCgesv_bufferSize" => "6.1.0",
     "cusolverDnCCgesv" => "6.1.0",
+    "cusolverDnCCgels" => "6.1.0",
     "CUSOLVER_STATUS_ZERO_PIVOT" => "6.1.0",
     "CUSOLVER_STATUS_SUCCESS" => "6.1.0",
     "CUSOLVER_STATUS_NOT_SUPPORTED" => "6.1.0",
@@ -1254,9 +1258,11 @@ sub subst {
 }
 
 sub experimentalSubstitutions {
+    subst("cusolverDnCCgels", "hipsolverDnCCgels", "library");
     subst("cusolverDnCCgesv", "hipsolverDnCCgesv", "library");
     subst("cusolverDnCCgesv_bufferSize", "hipsolverDnCCgesv_bufferSize", "library");
     subst("cusolverDnCreate", "hipsolverDnCreate", "library");
+    subst("cusolverDnDDgels", "hipsolverDnDDgels", "library");
     subst("cusolverDnDDgesv", "hipsolverDnDDgesv", "library");
     subst("cusolverDnDDgesv_bufferSize", "hipsolverDnDDgesv_bufferSize", "library");
     subst("cusolverDnDestroy", "hipsolverDnDestroy", "library");
@@ -1264,12 +1270,14 @@ sub experimentalSubstitutions {
     subst("cusolverDnDgetrf_bufferSize", "hipsolverDnDgetrf_bufferSize", "library");
     subst("cusolverDnDgetrs", "hipsolverDnDgetrs", "library");
     subst("cusolverDnGetStream", "hipsolverGetStream", "library");
+    subst("cusolverDnSSgels", "hipsolverDnSSgels", "library");
     subst("cusolverDnSSgesv", "hipsolverDnSSgesv", "library");
     subst("cusolverDnSSgesv_bufferSize", "hipsolverDnSSgesv_bufferSize", "library");
     subst("cusolverDnSetStream", "hipsolverSetStream", "library");
     subst("cusolverDnSgetrf", "hipsolverDnSgetrf", "library");
     subst("cusolverDnSgetrf_bufferSize", "hipsolverDnSgetrf_bufferSize", "library");
     subst("cusolverDnSgetrs", "hipsolverDnSgetrs", "library");
+    subst("cusolverDnZZgels", "hipsolverDnZZgels", "library");
     subst("cusolverDnZZgesv", "hipsolverDnZZgesv", "library");
     subst("cusolverDnZZgesv_bufferSize", "hipsolverDnZZgesv_bufferSize", "library");
     subst("cusolverDnHandle_t", "hipsolverHandle_t", "type");
@@ -7116,12 +7124,16 @@ sub warnUnsupportedFunctions {
         "cusolverIRSRefinement_t",
         "cusolverDnZYgesv_bufferSize",
         "cusolverDnZYgesv",
+        "cusolverDnZYgels",
         "cusolverDnZKgesv_bufferSize",
         "cusolverDnZKgesv",
+        "cusolverDnZKgels",
         "cusolverDnZEgesv_bufferSize",
         "cusolverDnZEgesv",
+        "cusolverDnZEgels",
         "cusolverDnZCgesv_bufferSize",
         "cusolverDnZCgesv",
+        "cusolverDnZCgels",
         "cusolverDnXgetrs",
         "cusolverDnXgetrf_bufferSize",
         "cusolverDnXgetrf",
@@ -7129,10 +7141,13 @@ sub warnUnsupportedFunctions {
         "cusolverDnSetAdvOptions",
         "cusolverDnSXgesv_bufferSize",
         "cusolverDnSXgesv",
+        "cusolverDnSXgels",
         "cusolverDnSHgesv_bufferSize",
         "cusolverDnSHgesv",
+        "cusolverDnSHgels",
         "cusolverDnSBgesv_bufferSize",
         "cusolverDnSBgesv",
+        "cusolverDnSBgels",
         "cusolverDnParams_t",
         "cusolverDnParams",
         "cusolverDnIRSParams_t",
@@ -7163,20 +7178,27 @@ sub warnUnsupportedFunctions {
         "cusolverDnFunction_t",
         "cusolverDnDXgesv_bufferSize",
         "cusolverDnDXgesv",
+        "cusolverDnDXgels",
         "cusolverDnDSgesv_bufferSize",
         "cusolverDnDSgesv",
+        "cusolverDnDSgels",
         "cusolverDnDHgesv_bufferSize",
         "cusolverDnDHgesv",
+        "cusolverDnDHgels",
         "cusolverDnDBgesv_bufferSize",
         "cusolverDnDBgesv",
+        "cusolverDnDBgels",
         "cusolverDnCreateParams",
         "cusolverDnContext",
         "cusolverDnCYgesv_bufferSize",
         "cusolverDnCYgesv",
+        "cusolverDnCYgels",
         "cusolverDnCKgesv_bufferSize",
         "cusolverDnCKgesv",
+        "cusolverDnCKgels",
         "cusolverDnCEgesv_bufferSize",
         "cusolverDnCEgesv",
+        "cusolverDnCEgels",
         "cusolverDirectMode_t",
         "cusolverDeterministicMode_t",
         "cusolverAlgMode_t",

--- a/docs/tables/CUSOLVER_API_supported_by_HIP.md
+++ b/docs/tables/CUSOLVER_API_supported_by_HIP.md
@@ -108,24 +108,33 @@
 
 |**CUDA**|**A**|**D**|**C**|**R**|**HIP**|**A**|**D**|**C**|**R**|**E**|
 |:--|:-:|:-:|:-:|:-:|:--|:-:|:-:|:-:|:-:|:-:|
+|`cusolverDnCCgels`|11.0| | | |`hipsolverDnCCgels`|5.1.0| | | |6.1.0|
 |`cusolverDnCCgesv`|10.2| | | |`hipsolverDnCCgesv`|5.1.0| | | |6.1.0|
 |`cusolverDnCCgesv_bufferSize`|10.2| | | |`hipsolverDnCCgesv_bufferSize`|5.1.0| | | |6.1.0|
+|`cusolverDnCEgels`|11.0| | | | | | | | | |
 |`cusolverDnCEgesv`|11.0| | | | | | | | | |
 |`cusolverDnCEgesv_bufferSize`|11.0| | | | | | | | | |
+|`cusolverDnCKgels`|11.0| | | | | | | | | |
 |`cusolverDnCKgesv`|10.2| | | | | | | | | |
 |`cusolverDnCKgesv_bufferSize`|10.2| | | | | | | | | |
+|`cusolverDnCYgels`|11.0| | | | | | | | | |
 |`cusolverDnCYgesv`|11.0| | | | | | | | | |
 |`cusolverDnCYgesv_bufferSize`|11.0| | | | | | | | | |
 |`cusolverDnCreate`| | | | |`hipsolverDnCreate`|5.1.0| | | |6.1.0|
 |`cusolverDnCreateParams`|11.0| | | | | | | | | |
+|`cusolverDnDBgels`|11.0| | | | | | | | | |
 |`cusolverDnDBgesv`|11.0| | | | | | | | | |
 |`cusolverDnDBgesv_bufferSize`|11.0| | | | | | | | | |
+|`cusolverDnDDgels`|11.0| | | |`hipsolverDnDDgels`|5.1.0| | | |6.1.0|
 |`cusolverDnDDgesv`|10.2| | | |`hipsolverDnDDgesv`|5.1.0| | | |6.1.0|
 |`cusolverDnDDgesv_bufferSize`|10.2| | | |`hipsolverDnDDgesv_bufferSize`|5.1.0| | | |6.1.0|
+|`cusolverDnDHgels`|11.0| | | | | | | | | |
 |`cusolverDnDHgesv`|10.2| | | | | | | | | |
 |`cusolverDnDHgesv_bufferSize`|10.2| | | | | | | | | |
+|`cusolverDnDSgels`|11.0| | | | | | | | | |
 |`cusolverDnDSgesv`|10.2| | | | | | | | | |
 |`cusolverDnDSgesv_bufferSize`|10.2| | | | | | | | | |
+|`cusolverDnDXgels`|11.0| | | | | | | | | |
 |`cusolverDnDXgesv`|11.0| | | | | | | | | |
 |`cusolverDnDXgesv_bufferSize`|11.0| | | | | | | | | |
 |`cusolverDnDestroy`| | | | |`hipsolverDnDestroy`|5.1.0| | | |6.1.0|
@@ -154,12 +163,16 @@
 |`cusolverDnIRSParamsSetSolverPrecisions`|10.2| | | | | | | | | |
 |`cusolverDnIRSParamsSetTol`|10.2| | | | | | | | | |
 |`cusolverDnIRSParamsSetTolInner`|10.2| | | | | | | | | |
+|`cusolverDnSBgels`|11.0| | | | | | | | | |
 |`cusolverDnSBgesv`|11.0| | | | | | | | | |
 |`cusolverDnSBgesv_bufferSize`|11.0| | | | | | | | | |
+|`cusolverDnSHgels`|11.0| | | | | | | | | |
 |`cusolverDnSHgesv`|10.2| | | | | | | | | |
 |`cusolverDnSHgesv_bufferSize`|10.2| | | | | | | | | |
+|`cusolverDnSSgels`|11.0| | | |`hipsolverDnSSgels`|5.1.0| | | |6.1.0|
 |`cusolverDnSSgesv`|10.2| | | |`hipsolverDnSSgesv`|5.1.0| | | |6.1.0|
 |`cusolverDnSSgesv_bufferSize`|10.2| | | |`hipsolverDnSSgesv_bufferSize`|5.1.0| | | |6.1.0|
+|`cusolverDnSXgels`|11.0| | | | | | | | | |
 |`cusolverDnSXgesv`|11.0| | | | | | | | | |
 |`cusolverDnSXgesv_bufferSize`|11.0| | | | | | | | | |
 |`cusolverDnSetAdvOptions`|11.0| | | | | | | | | |
@@ -171,14 +184,19 @@
 |`cusolverDnXgetrf`|11.1| | | | | | | | | |
 |`cusolverDnXgetrf_bufferSize`|11.1| | | | | | | | | |
 |`cusolverDnXgetrs`|11.1| | | | | | | | | |
+|`cusolverDnZCgels`|11.0| | | | | | | | | |
 |`cusolverDnZCgesv`|10.2| | | | | | | | | |
 |`cusolverDnZCgesv_bufferSize`|10.2| | | | | | | | | |
+|`cusolverDnZEgels`|11.0| | | | | | | | | |
 |`cusolverDnZEgesv`|11.0| | | | | | | | | |
 |`cusolverDnZEgesv_bufferSize`|11.0| | | | | | | | | |
+|`cusolverDnZKgels`|11.0| | | | | | | | | |
 |`cusolverDnZKgesv`|10.2| | | | | | | | | |
 |`cusolverDnZKgesv_bufferSize`|10.2| | | | | | | | | |
+|`cusolverDnZYgels`|11.0| | | | | | | | | |
 |`cusolverDnZYgesv`|11.0| | | | | | | | | |
 |`cusolverDnZYgesv_bufferSize`|11.0| | | | | | | | | |
+|`cusolverDnZZgels`|11.0| | | |`hipsolverDnZZgels`|5.1.0| | | |6.1.0|
 |`cusolverDnZZgesv`|10.2| | | |`hipsolverDnZZgesv`|5.1.0| | | |6.1.0|
 |`cusolverDnZZgesv_bufferSize`|10.2| | | |`hipsolverDnZZgesv_bufferSize`|5.1.0| | | |6.1.0|
 

--- a/docs/tables/CUSOLVER_API_supported_by_HIP_and_ROC.md
+++ b/docs/tables/CUSOLVER_API_supported_by_HIP_and_ROC.md
@@ -108,24 +108,33 @@
 
 |**CUDA**|**A**|**D**|**C**|**R**|**HIP**|**A**|**D**|**C**|**R**|**E**|**ROC**|**A**|**D**|**C**|**R**|**E**|
 |:--|:-:|:-:|:-:|:-:|:--|:-:|:-:|:-:|:-:|:-:|:--|:-:|:-:|:-:|:-:|:-:|
+|`cusolverDnCCgels`|11.0| | | |`hipsolverDnCCgels`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnCCgesv`|10.2| | | |`hipsolverDnCCgesv`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnCCgesv_bufferSize`|10.2| | | |`hipsolverDnCCgesv_bufferSize`|5.1.0| | | |6.1.0| | | | | | |
+|`cusolverDnCEgels`|11.0| | | | | | | | | | | | | | | |
 |`cusolverDnCEgesv`|11.0| | | | | | | | | | | | | | | |
 |`cusolverDnCEgesv_bufferSize`|11.0| | | | | | | | | | | | | | | |
+|`cusolverDnCKgels`|11.0| | | | | | | | | | | | | | | |
 |`cusolverDnCKgesv`|10.2| | | | | | | | | | | | | | | |
 |`cusolverDnCKgesv_bufferSize`|10.2| | | | | | | | | | | | | | | |
+|`cusolverDnCYgels`|11.0| | | | | | | | | | | | | | | |
 |`cusolverDnCYgesv`|11.0| | | | | | | | | | | | | | | |
 |`cusolverDnCYgesv_bufferSize`|11.0| | | | | | | | | | | | | | | |
 |`cusolverDnCreate`| | | | |`hipsolverDnCreate`|5.1.0| | | |6.1.0|`rocblas_create_handle`| | | | | |
 |`cusolverDnCreateParams`|11.0| | | | | | | | | | | | | | | |
+|`cusolverDnDBgels`|11.0| | | | | | | | | | | | | | | |
 |`cusolverDnDBgesv`|11.0| | | | | | | | | | | | | | | |
 |`cusolverDnDBgesv_bufferSize`|11.0| | | | | | | | | | | | | | | |
+|`cusolverDnDDgels`|11.0| | | |`hipsolverDnDDgels`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnDDgesv`|10.2| | | |`hipsolverDnDDgesv`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnDDgesv_bufferSize`|10.2| | | |`hipsolverDnDDgesv_bufferSize`|5.1.0| | | |6.1.0| | | | | | |
+|`cusolverDnDHgels`|11.0| | | | | | | | | | | | | | | |
 |`cusolverDnDHgesv`|10.2| | | | | | | | | | | | | | | |
 |`cusolverDnDHgesv_bufferSize`|10.2| | | | | | | | | | | | | | | |
+|`cusolverDnDSgels`|11.0| | | | | | | | | | | | | | | |
 |`cusolverDnDSgesv`|10.2| | | | | | | | | | | | | | | |
 |`cusolverDnDSgesv_bufferSize`|10.2| | | | | | | | | | | | | | | |
+|`cusolverDnDXgels`|11.0| | | | | | | | | | | | | | | |
 |`cusolverDnDXgesv`|11.0| | | | | | | | | | | | | | | |
 |`cusolverDnDXgesv_bufferSize`|11.0| | | | | | | | | | | | | | | |
 |`cusolverDnDestroy`| | | | |`hipsolverDnDestroy`|5.1.0| | | |6.1.0|`rocblas_destroy_handle`| | | | | |
@@ -154,12 +163,16 @@
 |`cusolverDnIRSParamsSetSolverPrecisions`|10.2| | | | | | | | | | | | | | | |
 |`cusolverDnIRSParamsSetTol`|10.2| | | | | | | | | | | | | | | |
 |`cusolverDnIRSParamsSetTolInner`|10.2| | | | | | | | | | | | | | | |
+|`cusolverDnSBgels`|11.0| | | | | | | | | | | | | | | |
 |`cusolverDnSBgesv`|11.0| | | | | | | | | | | | | | | |
 |`cusolverDnSBgesv_bufferSize`|11.0| | | | | | | | | | | | | | | |
+|`cusolverDnSHgels`|11.0| | | | | | | | | | | | | | | |
 |`cusolverDnSHgesv`|10.2| | | | | | | | | | | | | | | |
 |`cusolverDnSHgesv_bufferSize`|10.2| | | | | | | | | | | | | | | |
+|`cusolverDnSSgels`|11.0| | | |`hipsolverDnSSgels`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnSSgesv`|10.2| | | |`hipsolverDnSSgesv`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnSSgesv_bufferSize`|10.2| | | |`hipsolverDnSSgesv_bufferSize`|5.1.0| | | |6.1.0| | | | | | |
+|`cusolverDnSXgels`|11.0| | | | | | | | | | | | | | | |
 |`cusolverDnSXgesv`|11.0| | | | | | | | | | | | | | | |
 |`cusolverDnSXgesv_bufferSize`|11.0| | | | | | | | | | | | | | | |
 |`cusolverDnSetAdvOptions`|11.0| | | | | | | | | | | | | | | |
@@ -171,14 +184,19 @@
 |`cusolverDnXgetrf`|11.1| | | | | | | | | | | | | | | |
 |`cusolverDnXgetrf_bufferSize`|11.1| | | | | | | | | | | | | | | |
 |`cusolverDnXgetrs`|11.1| | | | | | | | | | | | | | | |
+|`cusolverDnZCgels`|11.0| | | | | | | | | | | | | | | |
 |`cusolverDnZCgesv`|10.2| | | | | | | | | | | | | | | |
 |`cusolverDnZCgesv_bufferSize`|10.2| | | | | | | | | | | | | | | |
+|`cusolverDnZEgels`|11.0| | | | | | | | | | | | | | | |
 |`cusolverDnZEgesv`|11.0| | | | | | | | | | | | | | | |
 |`cusolverDnZEgesv_bufferSize`|11.0| | | | | | | | | | | | | | | |
+|`cusolverDnZKgels`|11.0| | | | | | | | | | | | | | | |
 |`cusolverDnZKgesv`|10.2| | | | | | | | | | | | | | | |
 |`cusolverDnZKgesv_bufferSize`|10.2| | | | | | | | | | | | | | | |
+|`cusolverDnZYgels`|11.0| | | | | | | | | | | | | | | |
 |`cusolverDnZYgesv`|11.0| | | | | | | | | | | | | | | |
 |`cusolverDnZYgesv_bufferSize`|11.0| | | | | | | | | | | | | | | |
+|`cusolverDnZZgels`|11.0| | | |`hipsolverDnZZgels`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnZZgesv`|10.2| | | |`hipsolverDnZZgesv`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnZZgesv_bufferSize`|10.2| | | |`hipsolverDnZZgesv_bufferSize`|5.1.0| | | |6.1.0| | | | | | |
 

--- a/docs/tables/CUSOLVER_API_supported_by_ROC.md
+++ b/docs/tables/CUSOLVER_API_supported_by_ROC.md
@@ -108,24 +108,33 @@
 
 |**CUDA**|**A**|**D**|**C**|**R**|**ROC**|**A**|**D**|**C**|**R**|**E**|
 |:--|:-:|:-:|:-:|:-:|:--|:-:|:-:|:-:|:-:|:-:|
+|`cusolverDnCCgels`|11.0| | | | | | | | | |
 |`cusolverDnCCgesv`|10.2| | | | | | | | | |
 |`cusolverDnCCgesv_bufferSize`|10.2| | | | | | | | | |
+|`cusolverDnCEgels`|11.0| | | | | | | | | |
 |`cusolverDnCEgesv`|11.0| | | | | | | | | |
 |`cusolverDnCEgesv_bufferSize`|11.0| | | | | | | | | |
+|`cusolverDnCKgels`|11.0| | | | | | | | | |
 |`cusolverDnCKgesv`|10.2| | | | | | | | | |
 |`cusolverDnCKgesv_bufferSize`|10.2| | | | | | | | | |
+|`cusolverDnCYgels`|11.0| | | | | | | | | |
 |`cusolverDnCYgesv`|11.0| | | | | | | | | |
 |`cusolverDnCYgesv_bufferSize`|11.0| | | | | | | | | |
 |`cusolverDnCreate`| | | | |`rocblas_create_handle`| | | | | |
 |`cusolverDnCreateParams`|11.0| | | | | | | | | |
+|`cusolverDnDBgels`|11.0| | | | | | | | | |
 |`cusolverDnDBgesv`|11.0| | | | | | | | | |
 |`cusolverDnDBgesv_bufferSize`|11.0| | | | | | | | | |
+|`cusolverDnDDgels`|11.0| | | | | | | | | |
 |`cusolverDnDDgesv`|10.2| | | | | | | | | |
 |`cusolverDnDDgesv_bufferSize`|10.2| | | | | | | | | |
+|`cusolverDnDHgels`|11.0| | | | | | | | | |
 |`cusolverDnDHgesv`|10.2| | | | | | | | | |
 |`cusolverDnDHgesv_bufferSize`|10.2| | | | | | | | | |
+|`cusolverDnDSgels`|11.0| | | | | | | | | |
 |`cusolverDnDSgesv`|10.2| | | | | | | | | |
 |`cusolverDnDSgesv_bufferSize`|10.2| | | | | | | | | |
+|`cusolverDnDXgels`|11.0| | | | | | | | | |
 |`cusolverDnDXgesv`|11.0| | | | | | | | | |
 |`cusolverDnDXgesv_bufferSize`|11.0| | | | | | | | | |
 |`cusolverDnDestroy`| | | | |`rocblas_destroy_handle`| | | | | |
@@ -154,12 +163,16 @@
 |`cusolverDnIRSParamsSetSolverPrecisions`|10.2| | | | | | | | | |
 |`cusolverDnIRSParamsSetTol`|10.2| | | | | | | | | |
 |`cusolverDnIRSParamsSetTolInner`|10.2| | | | | | | | | |
+|`cusolverDnSBgels`|11.0| | | | | | | | | |
 |`cusolverDnSBgesv`|11.0| | | | | | | | | |
 |`cusolverDnSBgesv_bufferSize`|11.0| | | | | | | | | |
+|`cusolverDnSHgels`|11.0| | | | | | | | | |
 |`cusolverDnSHgesv`|10.2| | | | | | | | | |
 |`cusolverDnSHgesv_bufferSize`|10.2| | | | | | | | | |
+|`cusolverDnSSgels`|11.0| | | | | | | | | |
 |`cusolverDnSSgesv`|10.2| | | | | | | | | |
 |`cusolverDnSSgesv_bufferSize`|10.2| | | | | | | | | |
+|`cusolverDnSXgels`|11.0| | | | | | | | | |
 |`cusolverDnSXgesv`|11.0| | | | | | | | | |
 |`cusolverDnSXgesv_bufferSize`|11.0| | | | | | | | | |
 |`cusolverDnSetAdvOptions`|11.0| | | | | | | | | |
@@ -171,14 +184,19 @@
 |`cusolverDnXgetrf`|11.1| | | | | | | | | |
 |`cusolverDnXgetrf_bufferSize`|11.1| | | | | | | | | |
 |`cusolverDnXgetrs`|11.1| | | | | | | | | |
+|`cusolverDnZCgels`|11.0| | | | | | | | | |
 |`cusolverDnZCgesv`|10.2| | | | | | | | | |
 |`cusolverDnZCgesv_bufferSize`|10.2| | | | | | | | | |
+|`cusolverDnZEgels`|11.0| | | | | | | | | |
 |`cusolverDnZEgesv`|11.0| | | | | | | | | |
 |`cusolverDnZEgesv_bufferSize`|11.0| | | | | | | | | |
+|`cusolverDnZKgels`|11.0| | | | | | | | | |
 |`cusolverDnZKgesv`|10.2| | | | | | | | | |
 |`cusolverDnZKgesv_bufferSize`|10.2| | | | | | | | | |
+|`cusolverDnZYgels`|11.0| | | | | | | | | |
 |`cusolverDnZYgesv`|11.0| | | | | | | | | |
 |`cusolverDnZYgesv_bufferSize`|11.0| | | | | | | | | |
+|`cusolverDnZZgels`|11.0| | | | | | | | | |
 |`cusolverDnZZgesv`|10.2| | | | | | | | | |
 |`cusolverDnZZgesv_bufferSize`|10.2| | | | | | | | | |
 

--- a/src/CUDA2HIP_SOLVER_API_functions.cpp
+++ b/src/CUDA2HIP_SOLVER_API_functions.cpp
@@ -111,6 +111,28 @@ const std::map<llvm::StringRef, hipCounter> CUDA_SOLVER_FUNCTION_MAP {
   {"cusolverDnSHgesv_bufferSize",                         {"hipsolverDnSHgesv_bufferSize",                         "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
   {"cusolverDnSBgesv_bufferSize",                         {"hipsolverDnSBgesv_bufferSize",                         "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
   {"cusolverDnSXgesv_bufferSize",                         {"hipsolverDnSXgesv_bufferSize",                         "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
+  // NOTE: rocsolver_zgels has a harness of rocblas_set_workspace, hipsolverZZgels_bufferSize, hipsolverManageWorkspace, and rocsolver_zgels_outofplace
+  {"cusolverDnZZgels",                                    {"hipsolverDnZZgels",                                    "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
+  {"cusolverDnZCgels",                                    {"hipsolverDnZCgels",                                    "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
+  {"cusolverDnZKgels",                                    {"hipsolverDnZKgels",                                    "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
+  {"cusolverDnZEgels",                                    {"hipsolverDnZEgels",                                    "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
+  {"cusolverDnZYgels",                                    {"hipsolverDnZYgels",                                    "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
+  // NOTE: rocsolver_cgels has a harness of rocblas_set_workspace, hipsolverCCgels_bufferSize, hipsolverManageWorkspace, and rocsolver_cgels_outofplace
+  {"cusolverDnCCgels",                                    {"hipsolverDnCCgels",                                    "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
+  {"cusolverDnCKgels",                                    {"hipsolverDnCKgels",                                    "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
+  {"cusolverDnCEgels",                                    {"hipsolverDnCEgels",                                    "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
+  {"cusolverDnCYgels",                                    {"hipsolverDnCYgels",                                    "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
+  // NOTE: rocsolver_dgels has a harness of rocblas_set_workspace, hipsolverDDgels_bufferSize, hipsolverManageWorkspace, and rocsolver_dgels_outofplace
+  {"cusolverDnDDgels",                                    {"hipsolverDnDDgels",                                    "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
+  {"cusolverDnDSgels",                                    {"hipsolverDnDSgels",                                    "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
+  {"cusolverDnDHgels",                                    {"hipsolverDnDHgels",                                    "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
+  {"cusolverDnDBgels",                                    {"hipsolverDnDBgels",                                    "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
+  {"cusolverDnDXgels",                                    {"hipsolverDnDXgels",                                    "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
+  // NOTE: rocsolver_sgels has a harness of rocblas_set_workspace, hipsolverSSgels_bufferSize, hipsolverManageWorkspace, and rocsolver_sgels_outofplace
+  {"cusolverDnSSgels",                                    {"hipsolverDnSSgels",                                    "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
+  {"cusolverDnSHgels",                                    {"hipsolverDnSHgels",                                    "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
+  {"cusolverDnSBgels",                                    {"hipsolverDnSBgels",                                    "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
+  {"cusolverDnSXgels",                                    {"hipsolverDnSXgels",                                    "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
 };
 
 const std::map<llvm::StringRef, cudaAPIversions> CUDA_SOLVER_FUNCTION_VER_MAP {
@@ -177,6 +199,24 @@ const std::map<llvm::StringRef, cudaAPIversions> CUDA_SOLVER_FUNCTION_VER_MAP {
   {"cusolverDnSHgesv_bufferSize",                         {CUDA_102,  CUDA_0, CUDA_0}},
   {"cusolverDnSBgesv_bufferSize",                         {CUDA_110,  CUDA_0, CUDA_0}},
   {"cusolverDnSXgesv_bufferSize",                         {CUDA_110,  CUDA_0, CUDA_0}},
+  {"cusolverDnZZgels",                                    {CUDA_110,  CUDA_0, CUDA_0}},
+  {"cusolverDnZCgels",                                    {CUDA_110,  CUDA_0, CUDA_0}},
+  {"cusolverDnZKgels",                                    {CUDA_110,  CUDA_0, CUDA_0}},
+  {"cusolverDnZEgels",                                    {CUDA_110,  CUDA_0, CUDA_0}},
+  {"cusolverDnZYgels",                                    {CUDA_110,  CUDA_0, CUDA_0}},
+  {"cusolverDnCCgels",                                    {CUDA_110,  CUDA_0, CUDA_0}},
+  {"cusolverDnCKgels",                                    {CUDA_110,  CUDA_0, CUDA_0}},
+  {"cusolverDnCEgels",                                    {CUDA_110,  CUDA_0, CUDA_0}},
+  {"cusolverDnCYgels",                                    {CUDA_110,  CUDA_0, CUDA_0}},
+  {"cusolverDnDDgels",                                    {CUDA_110,  CUDA_0, CUDA_0}},
+  {"cusolverDnDSgels",                                    {CUDA_110,  CUDA_0, CUDA_0}},
+  {"cusolverDnDHgels",                                    {CUDA_110,  CUDA_0, CUDA_0}},
+  {"cusolverDnDBgels",                                    {CUDA_110,  CUDA_0, CUDA_0}},
+  {"cusolverDnDXgels",                                    {CUDA_110,  CUDA_0, CUDA_0}},
+  {"cusolverDnSSgels",                                    {CUDA_110,  CUDA_0, CUDA_0}},
+  {"cusolverDnSHgels",                                    {CUDA_110,  CUDA_0, CUDA_0}},
+  {"cusolverDnSBgels",                                    {CUDA_110,  CUDA_0, CUDA_0}},
+  {"cusolverDnSXgels",                                    {CUDA_110,  CUDA_0, CUDA_0}},
 };
 
 const std::map<llvm::StringRef, hipAPIversions> HIP_SOLVER_FUNCTION_VER_MAP {
@@ -198,6 +238,10 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_SOLVER_FUNCTION_VER_MAP {
   {"hipsolverDnCCgesv_bufferSize",                        {HIP_5010, HIP_0,    HIP_0,  HIP_LATEST}},
   {"hipsolverDnDDgesv_bufferSize",                        {HIP_5010, HIP_0,    HIP_0,  HIP_LATEST}},
   {"hipsolverDnSSgesv_bufferSize",                        {HIP_5010, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipsolverDnZZgels",                                   {HIP_5010, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipsolverDnCCgels",                                   {HIP_5010, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipsolverDnDDgels",                                   {HIP_5010, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipsolverDnSSgels",                                   {HIP_5010, HIP_0,    HIP_0,  HIP_LATEST}},
 };
 
 const std::map<unsigned int, llvm::StringRef> CUDA_SOLVER_API_SECTION_MAP {

--- a/tests/unit_tests/synthetic/libraries/cusolver2hipsolver.cu
+++ b/tests/unit_tests/synthetic/libraries/cusolver2hipsolver.cu
@@ -144,6 +144,7 @@ int main() {
 
 #if CUDA_VERSION >= 10010
   // CHECK: int solver_int = 0;
+  // CHECK: int lm = 0;
   // CHECK: int ln = 0;
   // CHECK: int lnrhs = 0;
   // CHECK: int ldda = 0;
@@ -153,6 +154,7 @@ int main() {
   // CHECK: int iter = 0;
   // CHECK: int d_info = 0;
   cusolver_int_t solver_int = 0;
+  cusolver_int_t lm = 0;
   cusolver_int_t ln = 0;
   cusolver_int_t lnrhs = 0;
   cusolver_int_t ldda = 0;
@@ -219,6 +221,28 @@ int main() {
   // HIP: HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDnSSgesv_bufferSize(hipsolverHandle_t handle, int n, int nrhs, float* A, int lda, int* devIpiv, float* B, int ldb, float* X, int ldx, void* work, size_t* lwork);
   // CHECK: status = hipsolverDnSSgesv_bufferSize(handle, ln, lnrhs, &fA, ldda, &dipiv, &fB, lddb, &fX, lddx, &Workspace, &lwork_bytes);
   status = cusolverDnSSgesv_bufferSize(handle, ln, lnrhs, &fA, ldda, &dipiv, &fB, lddb, &fX, lddx, &Workspace, &lwork_bytes);
+#endif
+
+#if CUDA_VERSION >= 11000
+  // CUDA: cusolverStatus_t CUSOLVERAPI cusolverDnZZgels(cusolverDnHandle_t handle, cusolver_int_t m, cusolver_int_t n, cusolver_int_t nrhs, cuDoubleComplex * dA, cusolver_int_t ldda, cuDoubleComplex * dB, cusolver_int_t lddb, cuDoubleComplex * dX, cusolver_int_t lddx, void * dWorkspace, size_t lwork_bytes, cusolver_int_t * iter, cusolver_int_t * d_info);
+  // HIP: HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDnZZgels(hipsolverHandle_t handle, int m, int n, int nrhs, hipDoubleComplex* A, int lda, hipDoubleComplex* B, int ldb, hipDoubleComplex* X, int ldx, void* work, size_t lwork, int* niters, int* devInfo);
+  // CHECK: status = hipsolverDnZZgels(handle, lm, ln, lnrhs, &dComplexA, ldda,&dComplexB, lddb, &dComplexX, lddx, &Workspace, lwork_bytes, &iter, &d_info);
+  status = cusolverDnZZgels(handle, lm, ln, lnrhs, &dComplexA, ldda,&dComplexB, lddb, &dComplexX, lddx, &Workspace, lwork_bytes, &iter, &d_info);
+
+  // CUDA: cusolverStatus_t CUSOLVERAPI cusolverDnCCgels(cusolverDnHandle_t handle, cusolver_int_t m, cusolver_int_t n, cusolver_int_t nrhs, cuComplex * dA, cusolver_int_t ldda, cuComplex * dB, cusolver_int_t lddb, cuComplex * dX, cusolver_int_t lddx, void * dWorkspace, size_t lwork_bytes, cusolver_int_t * iter, cusolver_int_t * d_info);
+  // HIP: HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDnCCgels(hipsolverHandle_t handle, int m, int n, int nrhs, hipFloatComplex* A, int lda, hipFloatComplex* B, int ldb, hipFloatComplex* X, int ldx, void* work, size_t lwork, int* niters, int* devInfo);
+  // CHECK: status = hipsolverDnCCgels(handle, lm, ln, lnrhs, &complexA, ldda,&complexB, lddb, &complexX, lddx, &Workspace, lwork_bytes, &iter, &d_info);
+  status = cusolverDnCCgels(handle, lm, ln, lnrhs, &complexA, ldda,&complexB, lddb, &complexX, lddx, &Workspace, lwork_bytes, &iter, &d_info);
+
+  // CUDA: cusolverStatus_t CUSOLVERAPI cusolverDnDDgels(cusolverDnHandle_t handle, cusolver_int_t m, cusolver_int_t n, cusolver_int_t nrhs, double * dA, cusolver_int_t ldda, double * dB, cusolver_int_t lddb, double * dX, cusolver_int_t lddx, void * dWorkspace, size_t lwork_bytes, cusolver_int_t * iter, cusolver_int_t * d_info);
+  // HIP: HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDnDDgels(hipsolverHandle_t handle, int m, int n, int nrhs, double* A, int lda, double* B, int ldb, double* X, int ldx, void* work, size_t lwork, int* niters, int* devInfo);
+  // CHECK: status = hipsolverDnDDgels(handle, lm, ln, lnrhs, &dA, ldda, &dB, lddb, &dX, lddx, &Workspace, lwork_bytes, &iter, &d_info);
+  status = cusolverDnDDgels(handle, lm, ln, lnrhs, &dA, ldda, &dB, lddb, &dX, lddx, &Workspace, lwork_bytes, &iter, &d_info);
+
+  // CUDA: cusolverStatus_t CUSOLVERAPI cusolverDnSSgels(cusolverDnHandle_t handle, cusolver_int_t m, cusolver_int_t n, cusolver_int_t nrhs, float * dA, cusolver_int_t ldda, float * dB, cusolver_int_t lddb, float * dX, cusolver_int_t lddx, void * dWorkspace, size_t lwork_bytes, cusolver_int_t * iter, cusolver_int_t * d_info);
+  // HIP: HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDnSSgels(hipsolverHandle_t handle, int m, int n, int nrhs, float* A, int lda, float* B, int ldb, float* X, int ldx, void* work, size_t lwork, int* niters, int* devInfo);
+  // CHECK: status = hipsolverDnSSgels(handle, lm, ln, lnrhs, &fA, ldda, &fB, lddb, &fX, lddx, &Workspace, lwork_bytes, &iter, &d_info);
+  status = cusolverDnSSgels(handle, lm, ln, lnrhs, &fA, ldda, &fB, lddb, &fX, lddx, &Workspace, lwork_bytes, &iter, &d_info);
 #endif
 
   return 0;


### PR DESCRIPTION
+ `hipsolverDn(ZZ|CC|DD|SS)gels` are `SUPPORTED`
+ `cusolverDnZ(C|K|E|Y)gels`, `cusolverDnC(E|K|Y)gels`, `cusolverDnD(S|H|B|X)gels`, and `cusolverDnS(H|B|X)gels` are `UNSUPPORTED`
+ [NOTE] `rocsolver_(z|c|d|s)gels` have a harness of `rocblas_set_workspace`, `hipsolverDn(ZZ|CC|DD|SS)gels_bufferSize`, `hipsolverManageWorkspace`, and `rocsolver_(z|c|d|s)gels_outofplace`, thus `UNSUPPORTED`
+ Updated `SOLVER` synthetic tests, the regenerated hipify-perl, and `SOLVER` `CUDA2HIP` documentation