### PR TITLE
[HIPIFY][#674][rocSPARSE][feature] rocSPARSE support - Step 67 - functions `rocsparse_(s|d|c|z)csrmv` and `rocsparse_csrsv_zero_pivot`

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -1837,6 +1837,7 @@ sub rocSubstitutions {
     subst("cusparseCcsrilu02_bufferSize", "rocsparse_ccsrilu0_buffer_size", "library");
     subst("cusparseCcsrilu02_numericBoost", "rocsparse_dccsrilu0_numeric_boost", "library");
     subst("cusparseCcsrmm", "rocsparse_ccsrmm", "library");
+    subst("cusparseCcsrmv", "rocsparse_ccsrmv", "library");
     subst("cusparseCcsrsm2_analysis", "rocsparse_ccsrsm_analysis", "library");
     subst("cusparseCcsrsm2_bufferSizeExt", "rocsparse_ccsrsm_buffer_size", "library");
     subst("cusparseCcsrsm2_solve", "rocsparse_ccsrsm_solve", "library");
@@ -1917,6 +1918,7 @@ sub rocSubstitutions {
     subst("cusparseDcsrilu02_bufferSize", "rocsparse_dcsrilu0_buffer_size", "library");
     subst("cusparseDcsrilu02_numericBoost", "rocsparse_dcsrilu0_numeric_boost", "library");
     subst("cusparseDcsrmm", "rocsparse_dcsrmm", "library");
+    subst("cusparseDcsrmv", "rocsparse_dcsrmv", "library");
     subst("cusparseDcsrsm2_analysis", "rocsparse_dcsrsm_analysis", "library");
     subst("cusparseDcsrsm2_bufferSizeExt", "rocsparse_dcsrsm_buffer_size", "library");
     subst("cusparseDcsrsm2_solve", "rocsparse_dcsrsm_solve", "library");
@@ -2016,6 +2018,7 @@ sub rocSubstitutions {
     subst("cusparseScsrilu02_bufferSize", "rocsparse_scsrilu0_buffer_size", "library");
     subst("cusparseScsrilu02_numericBoost", "rocsparse_dscsrilu0_numeric_boost", "library");
     subst("cusparseScsrmm", "rocsparse_scsrmm", "library");
+    subst("cusparseScsrmv", "rocsparse_scsrmv", "library");
     subst("cusparseScsrsm2_analysis", "rocsparse_scsrsm_analysis", "library");
     subst("cusparseScsrsm2_bufferSizeExt", "rocsparse_scsrsm_buffer_size", "library");
     subst("cusparseScsrsm2_solve", "rocsparse_scsrsm_solve", "library");
@@ -2095,6 +2098,7 @@ sub rocSubstitutions {
     subst("cusparseXcsrsm2_zeroPivot", "rocsparse_csrsm_zero_pivot", "library");
     subst("cusparseXcsrsort", "rocsparse_csrsort", "library");
     subst("cusparseXcsrsort_bufferSizeExt", "rocsparse_csrsort_buffer_size", "library");
+    subst("cusparseXcsrsv2_zeroPivot", "rocsparse_csrsv_zero_pivot", "library");
     subst("cusparseXgebsr2gebsrNnz", "rocsparse_gebsr2gebsr_nnz", "library");
     subst("cusparseZbsr2csr", "rocsparse_zbsr2csr", "library");
     subst("cusparseZbsric02", "rocsparse_zbsric0", "library");
@@ -2126,6 +2130,7 @@ sub rocSubstitutions {
     subst("cusparseZcsrilu02_bufferSize", "rocsparse_zcsrilu0_buffer_size", "library");
     subst("cusparseZcsrilu02_numericBoost", "rocsparse_zcsrilu0_numeric_boost", "library");
     subst("cusparseZcsrmm", "rocsparse_zcsrmm", "library");
+    subst("cusparseZcsrmv", "rocsparse_zcsrmv", "library");
     subst("cusparseZcsrsm2_analysis", "rocsparse_zcsrsm_analysis", "library");
     subst("cusparseZcsrsm2_bufferSizeExt", "rocsparse_zcsrsm_buffer_size", "library");
     subst("cusparseZcsrsm2_solve", "rocsparse_zcsrsm_solve", "library");

--- a/docs/tables/CUSPARSE_API_supported_by_HIP_and_ROC.md
+++ b/docs/tables/CUSPARSE_API_supported_by_HIP_and_ROC.md
@@ -298,7 +298,7 @@
 |`cusparseCbsrsv2_bufferSizeExt`| |12.2| | |`hipsparseCbsrsv2_bufferSizeExt`|3.6.0| | | | | | | | | | |
 |`cusparseCbsrsv2_solve`| |12.2| | |`hipsparseCbsrsv2_solve`|3.6.0| | | | | | | | | | |
 |`cusparseCbsrxmv`| |12.2| | |`hipsparseCbsrxmv`|4.5.0| | | | | | | | | | |
-|`cusparseCcsrmv`| |10.2| |11.0|`hipsparseCcsrmv`|3.1.0| | | | | | | | | | |
+|`cusparseCcsrmv`| |10.2| |11.0|`hipsparseCcsrmv`|3.1.0| | | | |`rocsparse_ccsrmv`|1.9.0| | | | |
 |`cusparseCcsrmv_mp`|8.0|10.2| |11.0| | | | | | | | | | | | |
 |`cusparseCcsrsv2_analysis`| |11.3| |12.0|`hipsparseCcsrsv2_analysis`|3.1.0| | | | |`rocsparse_ccsrsv_analysis`|2.10.0| | | | |
 |`cusparseCcsrsv2_bufferSize`| |11.3| |12.0|`hipsparseCcsrsv2_bufferSize`|3.1.0| | | | | | | | | | |
@@ -321,7 +321,7 @@
 |`cusparseDbsrsv2_bufferSizeExt`| |12.2| | |`hipsparseDbsrsv2_bufferSizeExt`|3.6.0| | | | | | | | | | |
 |`cusparseDbsrsv2_solve`| |12.2| | |`hipsparseDbsrsv2_solve`|3.6.0| | | | | | | | | | |
 |`cusparseDbsrxmv`| |12.2| | |`hipsparseDbsrxmv`|4.5.0| | | | | | | | | | |
-|`cusparseDcsrmv`| |10.2| |11.0|`hipsparseDcsrmv`|1.9.2| | | | | | | | | | |
+|`cusparseDcsrmv`| |10.2| |11.0|`hipsparseDcsrmv`|1.9.2| | | | |`rocsparse_dcsrmv`|1.9.0| | | | |
 |`cusparseDcsrmv_mp`|8.0|10.2| |11.0| | | | | | | | | | | | |
 |`cusparseDcsrsv2_analysis`| |11.3| |12.0|`hipsparseDcsrsv2_analysis`|1.9.2| | | | |`rocsparse_dcsrsv_analysis`|1.9.0| | | | |
 |`cusparseDcsrsv2_bufferSize`| |11.3| |12.0|`hipsparseDcsrsv2_bufferSize`|1.9.2| | | | | | | | | | |
@@ -340,7 +340,7 @@
 |`cusparseSbsrsv2_bufferSizeExt`| |12.2| | |`hipsparseSbsrsv2_bufferSizeExt`|3.6.0| | | | | | | | | | |
 |`cusparseSbsrsv2_solve`| |12.2| | |`hipsparseSbsrsv2_solve`|3.6.0| | | | | | | | | | |
 |`cusparseSbsrxmv`| |12.2| | |`hipsparseSbsrxmv`|4.5.0| | | | | | | | | | |
-|`cusparseScsrmv`| |10.2| |11.0|`hipsparseScsrmv`|1.9.2| | | | | | | | | | |
+|`cusparseScsrmv`| |10.2| |11.0|`hipsparseScsrmv`|1.9.2| | | | |`rocsparse_scsrmv`|1.9.0| | | | |
 |`cusparseScsrmv_mp`|8.0|10.2| |11.0| | | | | | | | | | | | |
 |`cusparseScsrsv2_analysis`| |11.3| |12.0|`hipsparseScsrsv2_analysis`|1.9.2| | | | |`rocsparse_scsrsv_analysis`|1.9.0| | | | |
 |`cusparseScsrsv2_bufferSize`| |11.3| |12.0|`hipsparseScsrsv2_bufferSize`|1.9.2| | | | | | | | | | |
@@ -354,14 +354,14 @@
 |`cusparseShybsv_analysis`| |10.2| |11.0| | | | | | | | | | | | |
 |`cusparseShybsv_solve`| |10.2| |11.0| | | | | | | | | | | | |
 |`cusparseXbsrsv2_zeroPivot`| |12.2| | |`hipsparseXbsrsv2_zeroPivot`|3.6.0| | | | | | | | | | |
-|`cusparseXcsrsv2_zeroPivot`| |11.3| |12.0|`hipsparseXcsrsv2_zeroPivot`|1.9.2| | | | | | | | | | |
+|`cusparseXcsrsv2_zeroPivot`| |11.3| |12.0|`hipsparseXcsrsv2_zeroPivot`|1.9.2| | | | |`rocsparse_csrsv_zero_pivot`|1.9.0| | | | |
 |`cusparseZbsrmv`| | | | |`hipsparseZbsrmv`|3.5.0| | | | | | | | | | |
 |`cusparseZbsrsv2_analysis`| |12.2| | |`hipsparseZbsrsv2_analysis`|3.6.0| | | | | | | | | | |
 |`cusparseZbsrsv2_bufferSize`| |12.2| | |`hipsparseZbsrsv2_bufferSize`|3.6.0| | | | | | | | | | |
 |`cusparseZbsrsv2_bufferSizeExt`| |12.2| | |`hipsparseZbsrsv2_bufferSizeExt`|3.6.0| | | | | | | | | | |
 |`cusparseZbsrsv2_solve`| |12.2| | |`hipsparseZbsrsv2_solve`|3.6.0| | | | | | | | | | |
 |`cusparseZbsrxmv`| |12.2| | |`hipsparseZbsrxmv`|4.5.0| | | | | | | | | | |
-|`cusparseZcsrmv`| |10.2| |11.0|`hipsparseZcsrmv`|3.1.0| | | | | | | | | | |
+|`cusparseZcsrmv`| |10.2| |11.0|`hipsparseZcsrmv`|3.1.0| | | | |`rocsparse_zcsrmv`|1.9.0| | | | |
 |`cusparseZcsrmv_mp`|8.0|10.2| |11.0| | | | | | | | | | | | |
 |`cusparseZcsrsv2_analysis`| |11.3| |12.0|`hipsparseZcsrsv2_analysis`|3.1.0| | | | |`rocsparse_zcsrsv_analysis`|2.10.0| | | | |
 |`cusparseZcsrsv2_bufferSize`| |11.3| |12.0|`hipsparseZcsrsv2_bufferSize`|3.1.0| | | | | | | | | | |

--- a/docs/tables/CUSPARSE_API_supported_by_ROC.md
+++ b/docs/tables/CUSPARSE_API_supported_by_ROC.md
@@ -298,7 +298,7 @@
 |`cusparseCbsrsv2_bufferSizeExt`| |12.2| | | | | | | | |
 |`cusparseCbsrsv2_solve`| |12.2| | | | | | | | |
 |`cusparseCbsrxmv`| |12.2| | | | | | | | |
-|`cusparseCcsrmv`| |10.2| |11.0| | | | | | |
+|`cusparseCcsrmv`| |10.2| |11.0|`rocsparse_ccsrmv`|1.9.0| | | | |
 |`cusparseCcsrmv_mp`|8.0|10.2| |11.0| | | | | | |
 |`cusparseCcsrsv2_analysis`| |11.3| |12.0|`rocsparse_ccsrsv_analysis`|2.10.0| | | | |
 |`cusparseCcsrsv2_bufferSize`| |11.3| |12.0| | | | | | |
@@ -321,7 +321,7 @@
 |`cusparseDbsrsv2_bufferSizeExt`| |12.2| | | | | | | | |
 |`cusparseDbsrsv2_solve`| |12.2| | | | | | | | |
 |`cusparseDbsrxmv`| |12.2| | | | | | | | |
-|`cusparseDcsrmv`| |10.2| |11.0| | | | | | |
+|`cusparseDcsrmv`| |10.2| |11.0|`rocsparse_dcsrmv`|1.9.0| | | | |
 |`cusparseDcsrmv_mp`|8.0|10.2| |11.0| | | | | | |
 |`cusparseDcsrsv2_analysis`| |11.3| |12.0|`rocsparse_dcsrsv_analysis`|1.9.0| | | | |
 |`cusparseDcsrsv2_bufferSize`| |11.3| |12.0| | | | | | |
@@ -340,7 +340,7 @@
 |`cusparseSbsrsv2_bufferSizeExt`| |12.2| | | | | | | | |
 |`cusparseSbsrsv2_solve`| |12.2| | | | | | | | |
 |`cusparseSbsrxmv`| |12.2| | | | | | | | |
-|`cusparseScsrmv`| |10.2| |11.0| | | | | | |
+|`cusparseScsrmv`| |10.2| |11.0|`rocsparse_scsrmv`|1.9.0| | | | |
 |`cusparseScsrmv_mp`|8.0|10.2| |11.0| | | | | | |
 |`cusparseScsrsv2_analysis`| |11.3| |12.0|`rocsparse_scsrsv_analysis`|1.9.0| | | | |
 |`cusparseScsrsv2_bufferSize`| |11.3| |12.0| | | | | | |
@@ -354,14 +354,14 @@
 |`cusparseShybsv_analysis`| |10.2| |11.0| | | | | | |
 |`cusparseShybsv_solve`| |10.2| |11.0| | | | | | |
 |`cusparseXbsrsv2_zeroPivot`| |12.2| | | | | | | | |
-|`cusparseXcsrsv2_zeroPivot`| |11.3| |12.0| | | | | | |
+|`cusparseXcsrsv2_zeroPivot`| |11.3| |12.0|`rocsparse_csrsv_zero_pivot`|1.9.0| | | | |
 |`cusparseZbsrmv`| | | | | | | | | | |
 |`cusparseZbsrsv2_analysis`| |12.2| | | | | | | | |
 |`cusparseZbsrsv2_bufferSize`| |12.2| | | | | | | | |
 |`cusparseZbsrsv2_bufferSizeExt`| |12.2| | | | | | | | |
 |`cusparseZbsrsv2_solve`| |12.2| | | | | | | | |
 |`cusparseZbsrxmv`| |12.2| | | | | | | | |
-|`cusparseZcsrmv`| |10.2| |11.0| | | | | | |
+|`cusparseZcsrmv`| |10.2| |11.0|`rocsparse_zcsrmv`|1.9.0| | | | |
 |`cusparseZcsrmv_mp`|8.0|10.2| |11.0| | | | | | |
 |`cusparseZcsrsv2_analysis`| |11.3| |12.0|`rocsparse_zcsrsv_analysis`|2.10.0| | | | |
 |`cusparseZcsrsv2_bufferSize`| |11.3| |12.0| | | | | | |

--- a/src/CUDA2HIP_SPARSE_API_functions.cpp
+++ b/src/CUDA2HIP_SPARSE_API_functions.cpp
@@ -126,10 +126,10 @@ const std::map<llvm::StringRef, hipCounter> CUDA_SPARSE_FUNCTION_MAP {
   {"cusparseCbsrxmv",                                   {"hipsparseCbsrxmv",                                   "",                                                                 CONV_LIB_FUNC, API_SPARSE, 9, ROC_UNSUPPORTED | CUDA_DEPRECATED}},
   {"cusparseZbsrxmv",                                   {"hipsparseZbsrxmv",                                   "",                                                                 CONV_LIB_FUNC, API_SPARSE, 9, ROC_UNSUPPORTED | CUDA_DEPRECATED}},
 
-  {"cusparseScsrmv",                                    {"hipsparseScsrmv",                                    "",                                                                 CONV_LIB_FUNC, API_SPARSE, 9, ROC_UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED}},
-  {"cusparseDcsrmv",                                    {"hipsparseDcsrmv",                                    "",                                                                 CONV_LIB_FUNC, API_SPARSE, 9, ROC_UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED}},
-  {"cusparseCcsrmv",                                    {"hipsparseCcsrmv",                                    "",                                                                 CONV_LIB_FUNC, API_SPARSE, 9, ROC_UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED}},
-  {"cusparseZcsrmv",                                    {"hipsparseZcsrmv",                                    "",                                                                 CONV_LIB_FUNC, API_SPARSE, 9, ROC_UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED}},
+  {"cusparseScsrmv",                                    {"hipsparseScsrmv",                                    "rocsparse_scsrmv",                                                 CONV_LIB_FUNC, API_SPARSE, 9, CUDA_DEPRECATED | CUDA_REMOVED}},
+  {"cusparseDcsrmv",                                    {"hipsparseDcsrmv",                                    "rocsparse_dcsrmv",                                                 CONV_LIB_FUNC, API_SPARSE, 9, CUDA_DEPRECATED | CUDA_REMOVED}},
+  {"cusparseCcsrmv",                                    {"hipsparseCcsrmv",                                    "rocsparse_ccsrmv",                                                 CONV_LIB_FUNC, API_SPARSE, 9, CUDA_DEPRECATED | CUDA_REMOVED}},
+  {"cusparseZcsrmv",                                    {"hipsparseZcsrmv",                                    "rocsparse_zcsrmv",                                                 CONV_LIB_FUNC, API_SPARSE, 9, CUDA_DEPRECATED | CUDA_REMOVED}},
 
   {"cusparseCsrmvEx",                                   {"hipsparseCsrmvEx",                                   "",                                                                 CONV_LIB_FUNC, API_SPARSE, 9, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED}},
   {"cusparseCsrmvEx_bufferSize",                        {"hipsparseCsrmvEx_bufferSize",                        "",                                                                 CONV_LIB_FUNC, API_SPARSE, 9, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED}},
@@ -200,7 +200,8 @@ const std::map<llvm::StringRef, hipCounter> CUDA_SPARSE_FUNCTION_MAP {
   {"cusparseDcsrsv2_solve",                             {"hipsparseDcsrsv2_solve",                             "rocsparse_dcsrsv_solve",                                           CONV_LIB_FUNC, API_SPARSE, 9, CUDA_DEPRECATED | CUDA_REMOVED}},
   {"cusparseCcsrsv2_solve",                             {"hipsparseCcsrsv2_solve",                             "rocsparse_ccsrsv_solve",                                           CONV_LIB_FUNC, API_SPARSE, 9, CUDA_DEPRECATED | CUDA_REMOVED}},
   {"cusparseZcsrsv2_solve",                             {"hipsparseZcsrsv2_solve",                             "rocsparse_zcsrsv_solve",                                           CONV_LIB_FUNC, API_SPARSE, 9, CUDA_DEPRECATED | CUDA_REMOVED}},
-  {"cusparseXcsrsv2_zeroPivot",                         {"hipsparseXcsrsv2_zeroPivot",                         "",                                                                 CONV_LIB_FUNC, API_SPARSE, 9, ROC_UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED}},
+  // TODO: rocsparse_get_stream and hipStreamSynchronize need to be added correspondingly before and after rocsparse_csrsv_zero_pivot call, because cusparseXcsrsv2_zeroPivot is blocking, and rocsparse_csrsv_zero_pivot is not
+  {"cusparseXcsrsv2_zeroPivot",                         {"hipsparseXcsrsv2_zeroPivot",                         "rocsparse_csrsv_zero_pivot",                                       CONV_LIB_FUNC, API_SPARSE, 9, CUDA_DEPRECATED | CUDA_REMOVED}},
 
   {"cusparseShybmv",                                    {"hipsparseShybmv",                                    "rocsparse_shybmv",                                                 CONV_LIB_FUNC, API_SPARSE, 9, CUDA_DEPRECATED | CUDA_REMOVED}},
   {"cusparseDhybmv",                                    {"hipsparseDhybmv",                                    "rocsparse_dhybmv",                                                 CONV_LIB_FUNC, API_SPARSE, 9, CUDA_DEPRECATED | CUDA_REMOVED}},
@@ -1990,6 +1991,7 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_SPARSE_FUNCTION_VER_MAP {
   {"hipsparseCreateConstDnMat",                          {HIP_6000, HIP_0,    HIP_0,  }},
   {"hipsparseConstDnMatGet",                             {HIP_6000, HIP_0,    HIP_0,  }},
   {"hipsparseConstDnMatGetValues",                       {HIP_6000, HIP_0,    HIP_0,  }},
+
   {"rocsparse_create_handle",                            {HIP_1090, HIP_0,    HIP_0   }},
   {"rocsparse_destroy_handle",                           {HIP_1090, HIP_0,    HIP_0   }},
   {"rocsparse_set_stream",                               {HIP_1090, HIP_0,    HIP_0   }},
@@ -2335,6 +2337,11 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_SPARSE_FUNCTION_VER_MAP {
   {"rocsparse_ccsrsv_buffer_size",                       {HIP_2100, HIP_0,    HIP_0   }},
   {"rocsparse_dcsrsv_buffer_size",                       {HIP_1090, HIP_0,    HIP_0   }},
   {"rocsparse_scsrsv_buffer_size",                       {HIP_1090, HIP_0,    HIP_0   }},
+  {"rocsparse_csrsv_zero_pivot",                         {HIP_1090, HIP_0,    HIP_0   }},
+  {"rocsparse_zcsrmv",                                   {HIP_1090, HIP_0,    HIP_0   }},
+  {"rocsparse_ccsrmv",                                   {HIP_1090, HIP_0,    HIP_0   }},
+  {"rocsparse_dcsrmv",                                   {HIP_1090, HIP_0,    HIP_0   }},
+  {"rocsparse_scsrmv",                                   {HIP_1090, HIP_0,    HIP_0   }},
 };
 
 const std::map<llvm::StringRef, cudaAPIChangedVersions> CUDA_SPARSE_FUNCTION_CHANGED_VER_MAP {

--- a/src/HipifyAction.cpp
+++ b/src/HipifyAction.cpp
@@ -163,6 +163,10 @@ const std::string sCusparseZcsrsv2_analysis = "cusparseZcsrsv2_analysis";
 const std::string sCusparseCcsrsv2_analysis = "cusparseCcsrsv2_analysis";
 const std::string sCusparseDcsrsv2_analysis = "cusparseDcsrsv2_analysis";
 const std::string sCusparseScsrsv2_analysis = "cusparseScsrsv2_analysis";
+const std::string sCusparseZcsrmv = "cusparseZcsrmv";
+const std::string sCusparseCcsrmv = "cusparseCcsrmv";
+const std::string sCusparseDcsrmv = "cusparseDcsrmv";
+const std::string sCusparseScsrmv = "cusparseScsrmv";
 
 // CUDA_OVERLOADED
 const std::string sCudaEventCreate = "cudaEventCreate";
@@ -1211,6 +1215,42 @@ std::map<std::string, ArgCastStruct> FuncArgCasts {
       false
     }
   },
+  {sCusparseZcsrmv,
+    {
+      {
+        {10, {e_add_const_argument, cw_None, "nullptr"}}
+      },
+      true,
+      false
+    }
+  },
+  {sCusparseCcsrmv,
+    {
+      {
+        {10, {e_add_const_argument, cw_None, "nullptr"}}
+      },
+      true,
+      false
+    }
+  },
+  {sCusparseDcsrmv,
+    {
+      {
+        {10, {e_add_const_argument, cw_None, "nullptr"}}
+      },
+      true,
+      false
+    }
+  },
+  {sCusparseScsrmv,
+    {
+      {
+        {10, {e_add_const_argument, cw_None, "nullptr"}}
+      },
+      true,
+      false
+    }
+  },
 };
 
 void HipifyAction::RewriteString(StringRef s, clang::SourceLocation start) {
@@ -2002,7 +2042,11 @@ std::unique_ptr<clang::ASTConsumer> HipifyAction::CreateASTConsumer(clang::Compi
             sCusparseZcsrsv2_analysis,
             sCusparseCcsrsv2_analysis,
             sCusparseDcsrsv2_analysis,
-            sCusparseScsrsv2_analysis
+            sCusparseScsrsv2_analysis,
+            sCusparseZcsrmv,
+            sCusparseCcsrmv,
+            sCusparseDcsrmv,
+            sCusparseScsrmv
           )
         )
       )

--- a/tests/lit.cfg
+++ b/tests/lit.cfg
@@ -84,6 +84,9 @@ if config.cuda_version_major > 10:
 if config.cuda_version_major < 11 or (config.cuda_version_major == 11 and config.cuda_version_minor < 1):
     config.excludes.append('runtime_functions_11010.cu')
 
+if config.cuda_version_major >= 11:
+    config.excludes.append('cusparse2rocsparse_before_11000.cu')
+
 if config.cuda_version_major < 12:
     config.excludes.append('headers_test_06_12000.cu')
     config.excludes.append('headers_test_07_12000.cu')

--- a/tests/unit_tests/synthetic/libraries/cusparse2hipsparse.cu
+++ b/tests/unit_tests/synthetic/libraries/cusparse2hipsparse.cu
@@ -2081,6 +2081,26 @@ int main() {
   // HIP: DEPRECATED_CUDA_10000("The routine will be removed in CUDA 11") HIPSPARSE_EXPORT hipsparseStatus_t hipsparseShybmv(hipsparseHandle_t handle, hipsparseOperation_t transA, const float* alpha, const hipsparseMatDescr_t descrA, const hipsparseHybMat_t hybA, const float* x, const float* beta, float* y);
   // CHECK: status_t = hipsparseShybmv(handle_t, opA, &fAlpha, matDescr_A, hybMat_t, &fX, &fBeta, &fY);
   status_t = cusparseShybmv(handle_t, opA, &fAlpha, matDescr_A, hybMat_t, &fX, &fBeta, &fY);
+
+  // CUDA: CUSPARSE_DEPRECATED_HINT(cusparseSpMV) cusparseStatus_t CUSPARSEAPI cusparseZcsrmv(cusparseHandle_t handle, cusparseOperation_t transA, int m, int n, int nnz, const cuDoubleComplex* alpha, const cusparseMatDescr_t descrA, const cuDoubleComplex* csrSortedValA, const int* csrSortedRowPtrA, const int* csrSortedColIndA, const cuDoubleComplex* x, const cuDoubleComplex* beta, cuDoubleComplex* y);
+  // HIP: DEPRECATED_CUDA_10000("The routine will be removed in CUDA 11") HIPSPARSE_EXPORT hipsparseStatus_t hipsparseZcsrmv(hipsparseHandle_t handle, hipsparseOperation_t transA, int m, int n, int nnz, const hipDoubleComplex* alpha, const hipsparseMatDescr_t descrA, const hipDoubleComplex* csrSortedValA, const int* csrSortedRowPtrA, const int* csrSortedColIndA, const hipDoubleComplex* x, const hipDoubleComplex* beta, hipDoubleComplex* y);
+  // CHECK: status_t = hipsparseZcsrmv(handle_t, opA, m, n, innz, &dcomplexAlpha, matDescr_A, &dComplexcsrSortedValA, &csrRowPtrA, &csrColIndA, &dcomplexX, &dcomplexBeta, &dcomplexY);
+  status_t = cusparseZcsrmv(handle_t, opA, m, n, innz, &dcomplexAlpha, matDescr_A, &dComplexcsrSortedValA, &csrRowPtrA, &csrColIndA, &dcomplexX, &dcomplexBeta, &dcomplexY);
+
+  // CUDA: CUSPARSE_DEPRECATED_HINT(cusparseSpMV) cusparseStatus_t CUSPARSEAPI cusparseCcsrmv(cusparseHandle_t handle, cusparseOperation_t transA, int m, int n, int nnz, const cuComplex* alpha, const cusparseMatDescr_t descrA, const cuComplex* csrSortedValA, const int* csrSortedRowPtrA, const int* csrSortedColIndA, const cuComplex* x, const cuComplex* beta, cuComplex* y);
+  // HIP: DEPRECATED_CUDA_10000("The routine will be removed in CUDA 11") HIPSPARSE_EXPORT hipsparseStatus_t hipsparseCcsrmv(hipsparseHandle_t handle, hipsparseOperation_t transA, int m, int n, int nnz, const hipComplex* alpha, const hipsparseMatDescr_t descrA, const hipComplex* csrSortedValA, const int* csrSortedRowPtrA, const int* csrSortedColIndA, const hipComplex* x, const hipComplex* beta, hipComplex* y);
+  // CHECK: status_t = hipsparseCcsrmv(handle_t, opA, m, n, innz, &complexAlpha, matDescr_A, &complexcsrSortedValA, &csrRowPtrA, &csrColIndA, &complexX, &complexBeta, &complexY);
+  status_t = cusparseCcsrmv(handle_t, opA, m, n, innz, &complexAlpha, matDescr_A, &complexcsrSortedValA, &csrRowPtrA, &csrColIndA, &complexX, &complexBeta, &complexY);
+
+  // CUDA: CUSPARSE_DEPRECATED_HINT(cusparseSpMV) cusparseStatus_t CUSPARSEAPI cusparseDcsrmv(cusparseHandle_t handle, cusparseOperation_t transA, int m, int n, int nnz, const double* alpha, const cusparseMatDescr_t descrA, const double* csrSortedValA, const int* csrSortedRowPtrA, const int* csrSortedColIndA, const double* x, const double* beta, double* y);
+  // HIP: DEPRECATED_CUDA_10000("The routine will be removed in CUDA 11") HIPSPARSE_EXPORT hipsparseStatus_t hipsparseDcsrmv(hipsparseHandle_t handle, hipsparseOperation_t transA, int m, int n, int nnz, const double* alpha, const hipsparseMatDescr_t descrA, const double* csrSortedValA, const int* csrSortedRowPtrA, const int* csrSortedColIndA, const double* x, const double* beta, double* y);
+  // CHECK: status_t = hipsparseDcsrmv(handle_t, opA, m, n, innz, &dAlpha, matDescr_A, &dcsrSortedValA, &csrRowPtrA, &csrColIndA, &dX, &dBeta, &dY);
+  status_t = cusparseDcsrmv(handle_t, opA, m, n, innz, &dAlpha, matDescr_A, &dcsrSortedValA, &csrRowPtrA, &csrColIndA, &dX, &dBeta, &dY);
+
+  // CUDA: CUSPARSE_DEPRECATED_HINT(cusparseSpMV) cusparseStatus_t CUSPARSEAPI cusparseScsrmv(cusparseHandle_t handle, cusparseOperation_t transA, int m, int n, int nnz, const float* alpha, const cusparseMatDescr_t descrA, const float* csrSortedValA, const int* csrSortedRowPtrA, const int* csrSortedColIndA, const float* x, const float* beta, float* y);
+  // HIP: DEPRECATED_CUDA_10000("The routine will be removed in CUDA 11") HIPSPARSE_EXPORT hipsparseStatus_t hipsparseScsrmv(hipsparseHandle_t handle, hipsparseOperation_t transA, int m, int n, int nnz, const float* alpha, const hipsparseMatDescr_t descrA, const float* csrSortedValA, const int* csrSortedRowPtrA, const int* csrSortedColIndA, const float* x, const float* beta, float* y);
+  // CHECK: status_t = hipsparseScsrmv(handle_t, opA, m, n, innz, &fAlpha, matDescr_A, &csrSortedValA, &csrRowPtrA, &csrColIndA, &fX, &fBeta, &fY);
+  status_t = cusparseScsrmv(handle_t, opA, m, n, innz, &fAlpha, matDescr_A, &csrSortedValA, &csrRowPtrA, &csrColIndA, &fX, &fBeta, &fY);
 #endif
 
 #if CUDA_VERSION >= 11000
@@ -2535,6 +2555,11 @@ int main() {
   // HIP: HIPSPARSE_EXPORT hipsparseStatus_t hipsparseScsrsv2_bufferSizeExt(hipsparseHandle_t handle, hipsparseOperation_t transA, int m, int nnz, const hipsparseMatDescr_t descrA, float* csrSortedValA, const int* csrSortedRowPtrA, const int* csrSortedColIndA, csrsv2Info_t info, size_t* pBufferSize);
   // CHECK: status_t = hipsparseScsrsv2_bufferSizeExt(handle_t, opA, m, innz, matDescr_A, &csrSortedValA, &csrRowPtrA, &csrColIndA, csrsv2_info, &bufferSize);
   status_t = cusparseScsrsv2_bufferSizeExt(handle_t, opA, m, innz, matDescr_A, &csrSortedValA, &csrRowPtrA, &csrColIndA, csrsv2_info, &bufferSize);
+
+  // CUDA: CUSPARSE_DEPRECATED(cusparseSpSV) cusparseStatus_t CUSPARSEAPI cusparseXcsrsv2_zeroPivot(cusparseHandle_t handle, csrsv2Info_t info, int* position);
+  // HIP: DEPRECATED_CUDA_11000("The routine will be removed in CUDA 12") HIPSPARSE_EXPORT hipsparseStatus_t hipsparseXcsrsv2_zeroPivot(hipsparseHandle_t handle, csrsv2Info_t info, int* position);
+  // CHECK: status_t = hipsparseXcsrsv2_zeroPivot(handle_t,csrsv2_info, &iposition);
+  status_t = cusparseXcsrsv2_zeroPivot(handle_t,csrsv2_info, &iposition);
 #endif
 
 #if CUDA_VERSION >= 12000

--- a/tests/unit_tests/synthetic/libraries/cusparse2rocsparse.cu
+++ b/tests/unit_tests/synthetic/libraries/cusparse2rocsparse.cu
@@ -2062,6 +2062,11 @@ int main() {
   // ROC: ROCSPARSE_EXPORT rocsparse_status rocsparse_scsrsv_buffer_size(rocsparse_handle handle, rocsparse_operation trans, rocsparse_int m, rocsparse_int nnz, const rocsparse_mat_descr descr, const float* csr_val, const rocsparse_int* csr_row_ptr, const rocsparse_int* csr_col_ind, rocsparse_mat_info info, size_t* buffer_size);
   // CHECK: status_t = rocsparse_scsrsv_buffer_size(handle_t, opA, m, innz, matDescr_A, &csrSortedValA, &csrRowPtrA, &csrColIndA, csrsv2_info, &bufferSize);
   status_t = cusparseScsrsv2_bufferSizeExt(handle_t, opA, m, innz, matDescr_A, &csrSortedValA, &csrRowPtrA, &csrColIndA, csrsv2_info, &bufferSize);
+
+  // CUDA: CUSPARSE_DEPRECATED(cusparseSpSV) cusparseStatus_t CUSPARSEAPI cusparseXcsrsv2_zeroPivot(cusparseHandle_t handle, csrsv2Info_t info, int* position);
+  // ROC: ROCSPARSE_EXPORT rocsparse_status rocsparse_csrsv_zero_pivot(rocsparse_handle handle, const rocsparse_mat_descr descr, rocsparse_mat_info info, rocsparse_int* position);
+  // CHECK: status_t = rocsparse_csrsv_zero_pivot(handle_t,csrsv2_info, &iposition);
+  status_t = cusparseXcsrsv2_zeroPivot(handle_t,csrsv2_info, &iposition);
 #endif
 
 #if CUDA_VERSION >= 12010 && CUSPARSE_VERSION >= 12100

--- a/tests/unit_tests/synthetic/libraries/cusparse2rocsparse_before_11000.cu
+++ b/tests/unit_tests/synthetic/libraries/cusparse2rocsparse_before_11000.cu
@@ -1,0 +1,86 @@
+// RUN: %run_test hipify "%s" "%t" %hipify_args 4 --skip-excluded-preprocessor-conditional-blocks --experimental --roc --use-hip-data-types %clang_args -ferror-limit=500
+
+// CHECK: #include <hip/hip_runtime.h>
+#include <cuda_runtime.h>
+// CHECK: #include "hip/hip_complex.h"
+#include "cuComplex.h"
+#include <stdio.h>
+// CHECK: #include "rocsparse.h"
+#include "cusparse.h"
+// CHECK-NOT: #include "rocsparse.h"
+
+int main() {
+  printf("18.1. cuSPARSE API to rocSPARSE API synthetic test\n");
+
+  // CHECK: rocsparse_status status_t;
+  cusparseStatus_t status_t;
+
+  // CHECK: _rocsparse_handle *handle = nullptr;
+  // CHECK-NEXT: rocsparse_handle handle_t;
+  cusparseContext *handle = nullptr;
+  cusparseHandle_t handle_t;
+
+  // CHECK: _rocsparse_mat_descr *matDescr = nullptr;
+  // CHECK-NEXT: rocsparse_mat_descr matDescr_t, matDescr_t_2, matDescr_A, matDescr_B, matDescr_C, matDescr_D;
+  cusparseMatDescr *matDescr = nullptr;
+  cusparseMatDescr_t matDescr_t, matDescr_t_2, matDescr_A, matDescr_B, matDescr_C, matDescr_D;
+
+  // CHECK: rocsparse_operation opA, opB, opX;
+  cusparseOperation_t opA, opB, opX;
+
+  // CHECK: rocsparse_solve_policy solvePolicy_t;
+  cusparseSolvePolicy_t solvePolicy_t;
+
+  int m = 0;
+  int n = 0;
+  int innz = 0;
+  int csrRowPtrA = 0;
+  int csrColIndA = 0;
+  double dAlpha = 0.f;
+  double dBeta = 0.f;
+  double dF = 0.f;
+  double dX = 0.f;
+  double dY = 0.f;
+  double dcsrSortedValA = 0.f;
+  float fAlpha = 0.f;
+  float fBeta = 0.f;
+  float fF = 0.f;
+  float fX = 0.f;
+  float fY = 0.f;
+  float csrSortedValA = 0.f;
+  void *pBuffer = nullptr;
+
+  // TODO: should be rocsparse_double_complex
+  // TODO: add to TypeOverloads cuDoubleComplex -> rocsparse_double_complex under a new option --sparse
+  // CHECK: rocblas_double_complex dcomplex, dcomplexA, dcomplexAlpha, dcomplexB, dcomplexBeta, dcomplexC, dcomplexF, dcomplexX, dcomplexY, dComplexbsrSortedValA, dComplexbsrSortedValC, dComplexcsrSortedValA, dComplexcsrSortedValB, dComplexcsrSortedValC, dcomplextol, dComplexbsrSortedVal, dComplexbscVal, dComplexcscSortedVal, dcomplexds, dcomplexdl, dcomplexd, dcomplexdu, dcomplexdw, dcomplexx, dcomplex_boost_val;
+  cuDoubleComplex dcomplex, dcomplexA, dcomplexAlpha, dcomplexB, dcomplexBeta, dcomplexC, dcomplexF, dcomplexX, dcomplexY, dComplexbsrSortedValA, dComplexbsrSortedValC, dComplexcsrSortedValA, dComplexcsrSortedValB, dComplexcsrSortedValC, dcomplextol, dComplexbsrSortedVal, dComplexbscVal, dComplexcscSortedVal, dcomplexds, dcomplexdl, dcomplexd, dcomplexdu, dcomplexdw, dcomplexx, dcomplex_boost_val;
+
+  // TODO: should be rocsparse_double_complex
+  // TODO: add to TypeOverloads cuComplex -> rocsparse_float_complex under a new option --sparse
+  // CHECK: rocblas_float_complex complex, complexA, complexAlpha, complexB, complexBeta, complexC, complexF, complexX, complexY, complexbsrValA, complexbsrSortedValC, complexcsrSortedValA, complexcsrSortedValB, complexcsrSortedValC, complextol, complexbsrSortedVal, complexbscVal, complexcscSortedVal, complexds, complexdl, complexd, complexdu, complexdw, complexx, complex_boost_val;
+  cuComplex complex, complexA, complexAlpha, complexB, complexBeta, complexC, complexF, complexX, complexY, complexbsrValA, complexbsrSortedValC, complexcsrSortedValA, complexcsrSortedValB, complexcsrSortedValC, complextol, complexbsrSortedVal, complexbscVal, complexcscSortedVal, complexds, complexdl, complexd, complexdu, complexdw, complexx, complex_boost_val;
+
+#if CUDA_VERSION < 11000
+  // CUDA: CUSPARSE_DEPRECATED_HINT(cusparseSpMV) cusparseStatus_t CUSPARSEAPI cusparseZcsrmv(cusparseHandle_t handle, cusparseOperation_t transA, int m, int n, int nnz, const cuDoubleComplex* alpha, const cusparseMatDescr_t descrA, const cuDoubleComplex* csrSortedValA, const int* csrSortedRowPtrA, const int* csrSortedColIndA, const cuDoubleComplex* x, const cuDoubleComplex* beta, cuDoubleComplex* y);
+  // ROC: ROCSPARSE_EXPORT rocsparse_status rocsparse_zcsrmv(rocsparse_handle handle, rocsparse_operation trans, rocsparse_int m, rocsparse_int n, rocsparse_int nnz, const rocsparse_double_complex* alpha, const rocsparse_mat_descr descr, const rocsparse_double_complex* csr_val, const rocsparse_int* csr_row_ptr, const rocsparse_int* csr_col_ind, rocsparse_mat_info info, const rocsparse_double_complex* x, const rocsparse_double_complex* beta, rocsparse_double_complex* y);
+  // CHECK: status_t = rocsparse_zcsrmv(handle_t, opA, m, n, innz, &dcomplexAlpha, matDescr_A, &dComplexcsrSortedValA, &csrRowPtrA, &csrColIndA, nullptr, &dcomplexX, &dcomplexBeta, &dcomplexY);
+  status_t = cusparseZcsrmv(handle_t, opA, m, n, innz, &dcomplexAlpha, matDescr_A, &dComplexcsrSortedValA, &csrRowPtrA, &csrColIndA, &dcomplexX, &dcomplexBeta, &dcomplexY);
+
+  // CUDA: CUSPARSE_DEPRECATED_HINT(cusparseSpMV) cusparseStatus_t CUSPARSEAPI cusparseCcsrmv(cusparseHandle_t handle, cusparseOperation_t transA, int m, int n, int nnz, const cuComplex* alpha, const cusparseMatDescr_t descrA, const cuComplex* csrSortedValA, const int* csrSortedRowPtrA, const int* csrSortedColIndA, const cuComplex* x, const cuComplex* beta, cuComplex* y);
+  // ROC: ROCSPARSE_EXPORT rocsparse_status rocsparse_ccsrmv(rocsparse_handle handle, rocsparse_operation trans, rocsparse_int m, rocsparse_int n, rocsparse_int nnz, const rocsparse_float_complex* alpha, const rocsparse_mat_descr descr, const rocsparse_float_complex* csr_val, const rocsparse_int* csr_row_ptr, const rocsparse_int* csr_col_ind, rocsparse_mat_info info, const rocsparse_float_complex* x, const rocsparse_float_complex* beta, rocsparse_float_complex* y);
+  // CHECK: status_t = rocsparse_ccsrmv(handle_t, opA, m, n, innz, &complexAlpha, matDescr_A, &complexcsrSortedValA, &csrRowPtrA, &csrColIndA, nullptr, &complexX, &complexBeta, &complexY);
+  status_t = cusparseCcsrmv(handle_t, opA, m, n, innz, &complexAlpha, matDescr_A, &complexcsrSortedValA, &csrRowPtrA, &csrColIndA, &complexX, &complexBeta, &complexY);
+
+  // CUDA: CUSPARSE_DEPRECATED_HINT(cusparseSpMV) cusparseStatus_t CUSPARSEAPI cusparseDcsrmv(cusparseHandle_t handle, cusparseOperation_t transA, int m, int n, int nnz, const double* alpha, const cusparseMatDescr_t descrA, const double* csrSortedValA, const int* csrSortedRowPtrA, const int* csrSortedColIndA, const double* x, const double* beta, double* y);
+  // ROC: ROCSPARSE_EXPORT rocsparse_status rocsparse_dcsrmv(rocsparse_handle handle, rocsparse_operation trans, rocsparse_int m, rocsparse_int n, rocsparse_int nnz, const double* alpha, const rocsparse_mat_descr descr, const double* csr_val, const rocsparse_int* csr_row_ptr, const rocsparse_int* csr_col_ind, rocsparse_mat_info info, const double* x, const double* beta, double* y);
+  // CHECK: status_t = rocsparse_dcsrmv(handle_t, opA, m, n, innz, &dAlpha, matDescr_A, &dcsrSortedValA, &csrRowPtrA, &csrColIndA, nullptr, &dX, &dBeta, &dY);
+  status_t = cusparseDcsrmv(handle_t, opA, m, n, innz, &dAlpha, matDescr_A, &dcsrSortedValA, &csrRowPtrA, &csrColIndA, &dX, &dBeta, &dY);
+
+  // CUDA: CUSPARSE_DEPRECATED_HINT(cusparseSpMV) cusparseStatus_t CUSPARSEAPI cusparseScsrmv(cusparseHandle_t handle, cusparseOperation_t transA, int m, int n, int nnz, const float* alpha, const cusparseMatDescr_t descrA, const float* csrSortedValA, const int* csrSortedRowPtrA, const int* csrSortedColIndA, const float* x, const float* beta, float* y);
+  // ROC: ROCSPARSE_EXPORT rocsparse_status rocsparse_scsrmv(rocsparse_handle handle, rocsparse_operation trans, rocsparse_int m, rocsparse_int n, rocsparse_int nnz, const float* alpha, const rocsparse_mat_descr descr, const float* csr_val, const rocsparse_int* csr_row_ptr, const rocsparse_int* csr_col_ind, rocsparse_mat_info info, const float* x, const float* beta, float* y);
+  // CHECK: status_t = rocsparse_scsrmv(handle_t, opA, m, n, innz, &fAlpha, matDescr_A, &csrSortedValA, &csrRowPtrA, &csrColIndA, nullptr, &fX, &fBeta, &fY);
+  status_t = cusparseScsrmv(handle_t, opA, m, n, innz, &fAlpha, matDescr_A, &csrSortedValA, &csrRowPtrA, &csrColIndA, &fX, &fBeta, &fY);
+#endif
+
+  return 0;
+}


### PR DESCRIPTION
+ Created a synthetic test `cusparse2rocsparse_before_11000.cu` for rocSPARSE APIs with args transformations, which are used in CUDA < 11.0 (FileCheck tool limitation)
+ Updated `hipSPARSE` and `rocSPARSE` synthetic tests, the regenerated hipify-perl, and `SPARSE` `CUDA2HIP` docs