### PR TITLE
[HIPIFY][#675][#677][SOLVER][feature] `cuSOLVER` support - Step 31 - Functions (DN)

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -1084,6 +1084,8 @@ my %experimental_funcs = (
     "cusolverDnZunmqr" => "6.1.0",
     "cusolverDnZungqr_bufferSize" => "6.1.0",
     "cusolverDnZungqr" => "6.1.0",
+    "cusolverDnZungbr_bufferSize" => "6.1.0",
+    "cusolverDnZungbr" => "6.1.0",
     "cusolverDnZsytrf_bufferSize" => "6.1.0",
     "cusolverDnZsytrf" => "6.1.0",
     "cusolverDnZpotrsBatched" => "6.1.0",
@@ -1117,6 +1119,8 @@ my %experimental_funcs = (
     "cusolverDnSormqr" => "6.1.0",
     "cusolverDnSorgqr_bufferSize" => "6.1.0",
     "cusolverDnSorgqr" => "6.1.0",
+    "cusolverDnSorgbr_bufferSize" => "6.1.0",
+    "cusolverDnSorgbr" => "6.1.0",
     "cusolverDnSgetrs" => "6.1.0",
     "cusolverDnSgetrf_bufferSize" => "6.1.0",
     "cusolverDnSgetrf" => "6.1.0",
@@ -1144,6 +1148,8 @@ my %experimental_funcs = (
     "cusolverDnDormqr" => "6.1.0",
     "cusolverDnDorgqr_bufferSize" => "6.1.0",
     "cusolverDnDorgqr" => "6.1.0",
+    "cusolverDnDorgbr_bufferSize" => "6.1.0",
+    "cusolverDnDorgbr" => "6.1.0",
     "cusolverDnDgetrs" => "6.1.0",
     "cusolverDnDgetrf_bufferSize" => "6.1.0",
     "cusolverDnDgetrf" => "6.1.0",
@@ -1160,6 +1166,8 @@ my %experimental_funcs = (
     "cusolverDnCunmqr" => "6.1.0",
     "cusolverDnCungqr_bufferSize" => "6.1.0",
     "cusolverDnCungqr" => "6.1.0",
+    "cusolverDnCungbr_bufferSize" => "6.1.0",
+    "cusolverDnCungbr" => "6.1.0",
     "cusolverDnCsytrf_bufferSize" => "6.1.0",
     "cusolverDnCsytrf" => "6.1.0",
     "cusolverDnCreate" => "6.1.0",
@@ -1357,6 +1365,8 @@ sub experimentalSubstitutions {
     subst("cusolverDnCreate", "hipsolverDnCreate", "library");
     subst("cusolverDnCsytrf", "hipsolverDnCsytrf", "library");
     subst("cusolverDnCsytrf_bufferSize", "hipsolverDnCsytrf_bufferSize", "library");
+    subst("cusolverDnCungbr", "hipsolverDnCungbr", "library");
+    subst("cusolverDnCungbr_bufferSize", "hipsolverDnCungbr_bufferSize", "library");
     subst("cusolverDnCungqr", "hipsolverDnCungqr", "library");
     subst("cusolverDnCungqr_bufferSize", "hipsolverDnCungqr_bufferSize", "library");
     subst("cusolverDnCunmqr", "hipsolverDnCunmqr", "library");
@@ -1373,6 +1383,8 @@ sub experimentalSubstitutions {
     subst("cusolverDnDgetrf", "hipsolverDnDgetrf", "library");
     subst("cusolverDnDgetrf_bufferSize", "hipsolverDnDgetrf_bufferSize", "library");
     subst("cusolverDnDgetrs", "hipsolverDnDgetrs", "library");
+    subst("cusolverDnDorgbr", "hipsolverDnDorgbr", "library");
+    subst("cusolverDnDorgbr_bufferSize", "hipsolverDnDorgbr_bufferSize", "library");
     subst("cusolverDnDorgqr", "hipsolverDnDorgqr", "library");
     subst("cusolverDnDorgqr_bufferSize", "hipsolverDnDorgqr_bufferSize", "library");
     subst("cusolverDnDormqr", "hipsolverDnDormqr", "library");
@@ -1399,6 +1411,8 @@ sub experimentalSubstitutions {
     subst("cusolverDnSgetrf", "hipsolverDnSgetrf", "library");
     subst("cusolverDnSgetrf_bufferSize", "hipsolverDnSgetrf_bufferSize", "library");
     subst("cusolverDnSgetrs", "hipsolverDnSgetrs", "library");
+    subst("cusolverDnSorgbr", "hipsolverDnSorgbr", "library");
+    subst("cusolverDnSorgbr_bufferSize", "hipsolverDnSorgbr_bufferSize", "library");
     subst("cusolverDnSorgqr", "hipsolverDnSorgqr", "library");
     subst("cusolverDnSorgqr_bufferSize", "hipsolverDnSorgqr_bufferSize", "library");
     subst("cusolverDnSormqr", "hipsolverDnSormqr", "library");
@@ -1432,6 +1446,8 @@ sub experimentalSubstitutions {
     subst("cusolverDnZpotrsBatched", "hipsolverDnZpotrsBatched", "library");
     subst("cusolverDnZsytrf", "hipsolverDnZsytrf", "library");
     subst("cusolverDnZsytrf_bufferSize", "hipsolverDnZsytrf_bufferSize", "library");
+    subst("cusolverDnZungbr", "hipsolverDnZungbr", "library");
+    subst("cusolverDnZungbr_bufferSize", "hipsolverDnZungbr_bufferSize", "library");
     subst("cusolverDnZungqr", "hipsolverDnZungqr", "library");
     subst("cusolverDnZungqr_bufferSize", "hipsolverDnZungqr_bufferSize", "library");
     subst("cusolverDnZunmqr", "hipsolverDnZunmqr", "library");

--- a/docs/tables/CUSOLVER_API_supported_by_HIP.md
+++ b/docs/tables/CUSOLVER_API_supported_by_HIP.md
@@ -147,6 +147,8 @@
 |`cusolverDnCsytrf_bufferSize`| | | | |`hipsolverDnCsytrf_bufferSize`|5.1.0| | | |6.1.0|
 |`cusolverDnCsytri`|10.1| | | | | | | | | |
 |`cusolverDnCsytri_bufferSize`|10.1| | | | | | | | | |
+|`cusolverDnCungbr`|8.0| | | |`hipsolverDnCungbr`|5.1.0| | | |6.1.0|
+|`cusolverDnCungbr_bufferSize`|8.0| | | |`hipsolverDnCungbr_bufferSize`|5.1.0| | | |6.1.0|
 |`cusolverDnCungqr`|8.0| | | |`hipsolverDnCungqr`|5.1.0| | | |6.1.0|
 |`cusolverDnCungqr_bufferSize`|8.0| | | |`hipsolverDnCungqr_bufferSize`|5.1.0| | | |6.1.0|
 |`cusolverDnCunmqr`| | | | |`hipsolverDnCunmqr`|5.1.0| | | |6.1.0|
@@ -182,6 +184,8 @@
 |`cusolverDnDlaswp`| | | | | | | | | | |
 |`cusolverDnDlauum`|10.1| | | | | | | | | |
 |`cusolverDnDlauum_bufferSize`|10.1| | | | | | | | | |
+|`cusolverDnDorgbr`|8.0| | | |`hipsolverDnDorgbr`|5.1.0| | | |6.1.0|
+|`cusolverDnDorgbr_bufferSize`|8.0| | | |`hipsolverDnDorgbr_bufferSize`|5.1.0| | | |6.1.0|
 |`cusolverDnDorgqr`|8.0| | | |`hipsolverDnDorgqr`|5.1.0| | | |6.1.0|
 |`cusolverDnDorgqr_bufferSize`|8.0| | | |`hipsolverDnDorgqr_bufferSize`|5.1.0| | | |6.1.0|
 |`cusolverDnDormqr`| | | | |`hipsolverDnDormqr`|5.1.0| | | |6.1.0|
@@ -252,6 +256,8 @@
 |`cusolverDnSlaswp`| | | | | | | | | | |
 |`cusolverDnSlauum`|10.1| | | | | | | | | |
 |`cusolverDnSlauum_bufferSize`|10.1| | | | | | | | | |
+|`cusolverDnSorgbr`|8.0| | | |`hipsolverDnSorgbr`|5.1.0| | | |6.1.0|
+|`cusolverDnSorgbr_bufferSize`|8.0| | | |`hipsolverDnSorgbr_bufferSize`|5.1.0| | | |6.1.0|
 |`cusolverDnSorgqr`|8.0| | | |`hipsolverDnSorgqr`|5.1.0| | | |6.1.0|
 |`cusolverDnSorgqr_bufferSize`|8.0| | | |`hipsolverDnSorgqr_bufferSize`|5.1.0| | | |6.1.0|
 |`cusolverDnSormqr`| | | | |`hipsolverDnSormqr`|5.1.0| | | |6.1.0|
@@ -315,6 +321,8 @@
 |`cusolverDnZsytrf_bufferSize`| | | | |`hipsolverDnZsytrf_bufferSize`|5.1.0| | | |6.1.0|
 |`cusolverDnZsytri`|10.1| | | | | | | | | |
 |`cusolverDnZsytri_bufferSize`|10.1| | | | | | | | | |
+|`cusolverDnZungbr`|8.0| | | |`hipsolverDnZungbr`|5.1.0| | | |6.1.0|
+|`cusolverDnZungbr_bufferSize`|8.0| | | |`hipsolverDnZungbr_bufferSize`|5.1.0| | | |6.1.0|
 |`cusolverDnZungqr`|8.0| | | |`hipsolverDnZungqr`|5.1.0| | | |6.1.0|
 |`cusolverDnZungqr_bufferSize`|8.0| | | |`hipsolverDnZungqr_bufferSize`|5.1.0| | | |6.1.0|
 |`cusolverDnZunmqr`| | | | |`hipsolverDnZunmqr`|5.1.0| | | |6.1.0|

--- a/docs/tables/CUSOLVER_API_supported_by_HIP_and_ROC.md
+++ b/docs/tables/CUSOLVER_API_supported_by_HIP_and_ROC.md
@@ -147,6 +147,8 @@
 |`cusolverDnCsytrf_bufferSize`| | | | |`hipsolverDnCsytrf_bufferSize`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnCsytri`|10.1| | | | | | | | | | | | | | | |
 |`cusolverDnCsytri_bufferSize`|10.1| | | | | | | | | | | | | | | |
+|`cusolverDnCungbr`|8.0| | | |`hipsolverDnCungbr`|5.1.0| | | |6.1.0| | | | | | |
+|`cusolverDnCungbr_bufferSize`|8.0| | | |`hipsolverDnCungbr_bufferSize`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnCungqr`|8.0| | | |`hipsolverDnCungqr`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnCungqr_bufferSize`|8.0| | | |`hipsolverDnCungqr_bufferSize`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnCunmqr`| | | | |`hipsolverDnCunmqr`|5.1.0| | | |6.1.0| | | | | | |
@@ -182,6 +184,8 @@
 |`cusolverDnDlaswp`| | | | | | | | | | | | | | | | |
 |`cusolverDnDlauum`|10.1| | | | | | | | | | | | | | | |
 |`cusolverDnDlauum_bufferSize`|10.1| | | | | | | | | | | | | | | |
+|`cusolverDnDorgbr`|8.0| | | |`hipsolverDnDorgbr`|5.1.0| | | |6.1.0| | | | | | |
+|`cusolverDnDorgbr_bufferSize`|8.0| | | |`hipsolverDnDorgbr_bufferSize`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnDorgqr`|8.0| | | |`hipsolverDnDorgqr`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnDorgqr_bufferSize`|8.0| | | |`hipsolverDnDorgqr_bufferSize`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnDormqr`| | | | |`hipsolverDnDormqr`|5.1.0| | | |6.1.0| | | | | | |
@@ -252,6 +256,8 @@
 |`cusolverDnSlaswp`| | | | | | | | | | | | | | | | |
 |`cusolverDnSlauum`|10.1| | | | | | | | | | | | | | | |
 |`cusolverDnSlauum_bufferSize`|10.1| | | | | | | | | | | | | | | |
+|`cusolverDnSorgbr`|8.0| | | |`hipsolverDnSorgbr`|5.1.0| | | |6.1.0| | | | | | |
+|`cusolverDnSorgbr_bufferSize`|8.0| | | |`hipsolverDnSorgbr_bufferSize`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnSorgqr`|8.0| | | |`hipsolverDnSorgqr`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnSorgqr_bufferSize`|8.0| | | |`hipsolverDnSorgqr_bufferSize`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnSormqr`| | | | |`hipsolverDnSormqr`|5.1.0| | | |6.1.0| | | | | | |
@@ -315,6 +321,8 @@
 |`cusolverDnZsytrf_bufferSize`| | | | |`hipsolverDnZsytrf_bufferSize`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnZsytri`|10.1| | | | | | | | | | | | | | | |
 |`cusolverDnZsytri_bufferSize`|10.1| | | | | | | | | | | | | | | |
+|`cusolverDnZungbr`|8.0| | | |`hipsolverDnZungbr`|5.1.0| | | |6.1.0| | | | | | |
+|`cusolverDnZungbr_bufferSize`|8.0| | | |`hipsolverDnZungbr_bufferSize`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnZungqr`|8.0| | | |`hipsolverDnZungqr`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnZungqr_bufferSize`|8.0| | | |`hipsolverDnZungqr_bufferSize`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnZunmqr`| | | | |`hipsolverDnZunmqr`|5.1.0| | | |6.1.0| | | | | | |

--- a/docs/tables/CUSOLVER_API_supported_by_ROC.md
+++ b/docs/tables/CUSOLVER_API_supported_by_ROC.md
@@ -147,6 +147,8 @@
 |`cusolverDnCsytrf_bufferSize`| | | | | | | | | | |
 |`cusolverDnCsytri`|10.1| | | | | | | | | |
 |`cusolverDnCsytri_bufferSize`|10.1| | | | | | | | | |
+|`cusolverDnCungbr`|8.0| | | | | | | | | |
+|`cusolverDnCungbr_bufferSize`|8.0| | | | | | | | | |
 |`cusolverDnCungqr`|8.0| | | | | | | | | |
 |`cusolverDnCungqr_bufferSize`|8.0| | | | | | | | | |
 |`cusolverDnCunmqr`| | | | | | | | | | |
@@ -182,6 +184,8 @@
 |`cusolverDnDlaswp`| | | | | | | | | | |
 |`cusolverDnDlauum`|10.1| | | | | | | | | |
 |`cusolverDnDlauum_bufferSize`|10.1| | | | | | | | | |
+|`cusolverDnDorgbr`|8.0| | | | | | | | | |
+|`cusolverDnDorgbr_bufferSize`|8.0| | | | | | | | | |
 |`cusolverDnDorgqr`|8.0| | | | | | | | | |
 |`cusolverDnDorgqr_bufferSize`|8.0| | | | | | | | | |
 |`cusolverDnDormqr`| | | | | | | | | | |
@@ -252,6 +256,8 @@
 |`cusolverDnSlaswp`| | | | | | | | | | |
 |`cusolverDnSlauum`|10.1| | | | | | | | | |
 |`cusolverDnSlauum_bufferSize`|10.1| | | | | | | | | |
+|`cusolverDnSorgbr`|8.0| | | | | | | | | |
+|`cusolverDnSorgbr_bufferSize`|8.0| | | | | | | | | |
 |`cusolverDnSorgqr`|8.0| | | | | | | | | |
 |`cusolverDnSorgqr_bufferSize`|8.0| | | | | | | | | |
 |`cusolverDnSormqr`| | | | | | | | | | |
@@ -315,6 +321,8 @@
 |`cusolverDnZsytrf_bufferSize`| | | | | | | | | | |
 |`cusolverDnZsytri`|10.1| | | | | | | | | |
 |`cusolverDnZsytri_bufferSize`|10.1| | | | | | | | | |
+|`cusolverDnZungbr`|8.0| | | | | | | | | |
+|`cusolverDnZungbr_bufferSize`|8.0| | | | | | | | | |
 |`cusolverDnZungqr`|8.0| | | | | | | | | |
 |`cusolverDnZungqr_bufferSize`|8.0| | | | | | | | | |
 |`cusolverDnZunmqr`| | | | | | | | | | |

--- a/src/CUDA2HIP_SOLVER_API_functions.cpp
+++ b/src/CUDA2HIP_SOLVER_API_functions.cpp
@@ -271,6 +271,16 @@ const std::map<llvm::StringRef, hipCounter> CUDA_SOLVER_FUNCTION_MAP {
   {"cusolverDnDgebrd",                                   {"hipsolverDnDgebrd",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
   {"cusolverDnCgebrd",                                   {"hipsolverDnCgebrd",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
   {"cusolverDnZgebrd",                                   {"hipsolverDnZgebrd",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
+  // NOTE: rocsolver_(s|d)orgbr and rocsolver_(c|z)ungbr have a harness of other HIP and ROC API calls
+  {"cusolverDnSorgbr_bufferSize",                        {"hipsolverDnSorgbr_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
+  {"cusolverDnDorgbr_bufferSize",                        {"hipsolverDnDorgbr_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
+  {"cusolverDnCungbr_bufferSize",                        {"hipsolverDnCungbr_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
+  {"cusolverDnZungbr_bufferSize",                        {"hipsolverDnZungbr_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
+  // NOTE: rocsolver_(s|d)orgbr and rocsolver_(c|z)ungbr have a harness of other HIP and ROC API calls
+  {"cusolverDnSorgbr",                                   {"hipsolverDnSorgbr",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
+  {"cusolverDnDorgbr",                                   {"hipsolverDnDorgbr",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
+  {"cusolverDnCungbr",                                   {"hipsolverDnCungbr",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
+  {"cusolverDnZungbr",                                   {"hipsolverDnZungbr",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
 };
 
 const std::map<llvm::StringRef, cudaAPIversions> CUDA_SOLVER_FUNCTION_VER_MAP {
@@ -425,6 +435,14 @@ const std::map<llvm::StringRef, cudaAPIversions> CUDA_SOLVER_FUNCTION_VER_MAP {
   {"cusolverDnDsytri",                                    {CUDA_101,  CUDA_0, CUDA_0}},
   {"cusolverDnCsytri",                                    {CUDA_101,  CUDA_0, CUDA_0}},
   {"cusolverDnZsytri",                                    {CUDA_101,  CUDA_0, CUDA_0}},
+  {"cusolverDnSorgbr_bufferSize",                         {CUDA_80,   CUDA_0, CUDA_0}},
+  {"cusolverDnDorgbr_bufferSize",                         {CUDA_80,   CUDA_0, CUDA_0}},
+  {"cusolverDnCungbr_bufferSize",                         {CUDA_80,   CUDA_0, CUDA_0}},
+  {"cusolverDnZungbr_bufferSize",                         {CUDA_80,   CUDA_0, CUDA_0}},
+  {"cusolverDnSorgbr",                                    {CUDA_80,   CUDA_0, CUDA_0}},
+  {"cusolverDnDorgbr",                                    {CUDA_80,   CUDA_0, CUDA_0}},
+  {"cusolverDnCungbr",                                    {CUDA_80,   CUDA_0, CUDA_0}},
+  {"cusolverDnZungbr",                                    {CUDA_80,   CUDA_0, CUDA_0}},
 };
 
 const std::map<llvm::StringRef, hipAPIversions> HIP_SOLVER_FUNCTION_VER_MAP {
@@ -528,6 +546,14 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_SOLVER_FUNCTION_VER_MAP {
   {"hipsolverDnDgebrd",                                   {HIP_5010, HIP_0,    HIP_0,  HIP_LATEST}},
   {"hipsolverDnCgebrd",                                   {HIP_5010, HIP_0,    HIP_0,  HIP_LATEST}},
   {"hipsolverDnZgebrd",                                   {HIP_5010, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipsolverDnSorgbr_bufferSize",                        {HIP_5010, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipsolverDnDorgbr_bufferSize",                        {HIP_5010, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipsolverDnCungbr_bufferSize",                        {HIP_5010, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipsolverDnZungbr_bufferSize",                        {HIP_5010, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipsolverDnSorgbr",                                   {HIP_5010, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipsolverDnDorgbr",                                   {HIP_5010, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipsolverDnCungbr",                                   {HIP_5010, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipsolverDnZungbr",                                   {HIP_5010, HIP_0,    HIP_0,  HIP_LATEST}},
 
   {"rocsolver_spotrf",                                    {HIP_3020, HIP_0,    HIP_0,  HIP_LATEST}},
   {"rocsolver_dpotrf",                                    {HIP_3020, HIP_0,    HIP_0,  HIP_LATEST}},

--- a/tests/unit_tests/synthetic/libraries/cusolver2hipsolver.cu
+++ b/tests/unit_tests/synthetic/libraries/cusolver2hipsolver.cu
@@ -460,6 +460,46 @@ int main() {
   // HIP: HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDnZunmqr(hipsolverHandle_t handle, hipblasSideMode_t side, hipblasOperation_t trans, int m, int n, int k, const hipDoubleComplex* A, int lda, const hipDoubleComplex* tau, hipDoubleComplex* C, int ldc, hipDoubleComplex* work, int lwork, int* devInfo);
   // CHECK: status = hipsolverDnZunmqr(handle, blasSideMode, blasOperation, m, n, k, &dComplexA, lda, &dComplexTAU, &dComplexC, ldc, &dComplexWorkspace, Lwork, &devInfo);
   status = cusolverDnZunmqr(handle, blasSideMode, blasOperation, m, n, k, &dComplexA, lda, &dComplexTAU, &dComplexC, ldc, &dComplexWorkspace, Lwork, &devInfo);
+
+  // CUDA: cusolverStatus_t CUSOLVERAPI cusolverDnSorgbr_bufferSize(cusolverDnHandle_t handle, cublasSideMode_t side, int m, int n, int k, const float * A, int lda, const float * tau, int * lwork);
+  // HIP: HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDnSorgbr_bufferSize(hipsolverHandle_t handle, hipblasSideMode_t side, int m, int n, int k, const float* A, int lda, const float* tau, int* lwork);
+  // CHECK: status = hipsolverDnSorgbr_bufferSize(handle, blasSideMode, m, n, k, &fA, lda, &fTAU, &Lwork);
+  status = cusolverDnSorgbr_bufferSize(handle, blasSideMode, m, n, k, &fA, lda, &fTAU, &Lwork);
+
+  // CUDA: cusolverStatus_t CUSOLVERAPI cusolverDnDorgbr_bufferSize(cusolverDnHandle_t handle, cublasSideMode_t side, int m, int n, int k, const double * A, int lda, const double * tau, int * lwork);
+  // HIP: HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDnDorgbr_bufferSize(hipsolverHandle_t handle, hipblasSideMode_t side, int m, int n, int k, const double* A, int lda, const double* tau, int* lwork);
+  // CHECK: status = hipsolverDnDorgbr_bufferSize(handle, blasSideMode, m, n, k, &dA, lda, &dTAU, &Lwork);
+  status = cusolverDnDorgbr_bufferSize(handle, blasSideMode, m, n, k, &dA, lda, &dTAU, &Lwork);
+
+  // CUDA: cusolverStatus_t CUSOLVERAPI cusolverDnCungbr_bufferSize(cusolverDnHandle_t handle, cublasSideMode_t side, int m, int n, int k, const cuComplex * A, int lda, const cuComplex * tau, int * lwork);
+  // HIP: HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDnCungbr_bufferSize(hipsolverHandle_t handle, hipblasSideMode_t side, int m, int n, int k, const hipFloatComplex* A, int lda, const hipFloatComplex* tau, int* lwork);
+  // CHECK: status = hipsolverDnCungbr_bufferSize(handle, blasSideMode, m, n, k, &complexA, lda, &complexTAU, &Lwork);
+  status = cusolverDnCungbr_bufferSize(handle, blasSideMode, m, n, k, &complexA, lda, &complexTAU, &Lwork);
+
+  // CUDA: cusolverStatus_t CUSOLVERAPI cusolverDnZungbr_bufferSize(cusolverDnHandle_t handle, cublasSideMode_t side, int m, int n, int k, const cuDoubleComplex *A, int lda, const cuDoubleComplex *tau, int * lwork);
+  // HIP: HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDnZungbr_bufferSize(hipsolverHandle_t handle, hipblasSideMode_t side, int m, int n, int k, const hipDoubleComplex* A, int lda, const hipDoubleComplex* tau, int* lwork);
+  // CHECK: status = hipsolverDnZungbr_bufferSize(handle, blasSideMode, m, n, k, &dComplexA, lda, &dComplexTAU, &Lwork);
+  status = cusolverDnZungbr_bufferSize(handle, blasSideMode, m, n, k, &dComplexA, lda, &dComplexTAU, &Lwork);
+
+  // CUDA: cusolverStatus_t CUSOLVERAPI cusolverDnSorgbr(cusolverDnHandle_t handle, cublasSideMode_t side, int m, int n, int k, float * A, int lda, const float * tau, float * work, int lwork, int * info);
+  // HIP: HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDnSorgbr(hipsolverHandle_t handle, hipblasSideMode_t side, int m, int n, int k, float* A, int lda, const float* tau, float* work, int lwork, int* devInfo);
+  // CHECK: status = hipsolverDnSorgbr(handle, blasSideMode, m, n, k, &fA, lda, &fTAU, &fWorkspace, Lwork, &info);
+  status = cusolverDnSorgbr(handle, blasSideMode, m, n, k, &fA, lda, &fTAU, &fWorkspace, Lwork, &info);
+
+  // CUDA: cusolverStatus_t CUSOLVERAPI cusolverDnDorgbr(cusolverDnHandle_t handle, cublasSideMode_t side, int m, int n, int k, double * A, int lda, const double * tau, double * work, int lwork, int * info);
+  // HIP: HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDnDorgbr(hipsolverHandle_t handle, hipblasSideMode_t side, int m, int n, int k, double* A, int lda, const double* tau, double* work, int lwork, int* devInfo);
+  // CHECK: status = hipsolverDnDorgbr(handle, blasSideMode, m, n, k, &dA, lda, &dTAU, &dWorkspace, Lwork, &info);
+  status = cusolverDnDorgbr(handle, blasSideMode, m, n, k, &dA, lda, &dTAU, &dWorkspace, Lwork, &info);
+
+  // CUDA: cusolverStatus_t CUSOLVERAPI cusolverDnCungbr(cusolverDnHandle_t handle, cublasSideMode_t side, int m, int n, int k, cuComplex * A, int lda, const cuComplex * tau, cuComplex * work, int lwork, int * info);
+  // HIP: HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDnCungbr(hipsolverHandle_t handle, hipblasSideMode_t side, int m, int n, int k, hipFloatComplex* A, int lda, const hipFloatComplex* tau, hipFloatComplex* work, int lwork, int* devInfo);
+  // CHECK: status = hipsolverDnCungbr(handle, blasSideMode, m, n, k, &complexA, lda, &complexTAU, &complexWorkspace, Lwork, &info);
+  status = cusolverDnCungbr(handle, blasSideMode, m, n, k, &complexA, lda, &complexTAU, &complexWorkspace, Lwork, &info);
+
+  // CUDA: cusolverStatus_t CUSOLVERAPI cusolverDnZungbr(cusolverDnHandle_t handle, cublasSideMode_t side, int m, int n, int k, cuDoubleComplex * A, int lda, const cuDoubleComplex *tau, cuDoubleComplex * work, int lwork, int * info);
+  // HIP: HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDnZungbr(hipsolverHandle_t handle, hipblasSideMode_t side, int m, int n, int k, hipDoubleComplex* A, int lda, const hipDoubleComplex* tau, hipDoubleComplex* work, int lwork, int* devInfo);
+  // CHECK: status = hipsolverDnZungbr(handle, blasSideMode, m, n, k, &dComplexA, lda, &dComplexTAU, &dComplexWorkspace, Lwork, &info);
+  status = cusolverDnZungbr(handle, blasSideMode, m, n, k, &dComplexA, lda, &dComplexTAU, &dComplexWorkspace, Lwork, &info);
 #endif
 
 #if CUDA_VERSION >= 9000


### PR DESCRIPTION
+ `cusolverDn(S|D)orgbr_(bufferSize)?` and `cusolverDn(C|Z)ungbr_(bufferSize)?`are `SUPPORTED` by `hipSOLVER` only
+ [NOTE] `rocsolver_(s|d)orgbr` and `rocsolver_(c|z)ungbr` have a harness of other HIP and ROC API calls, thus `UNSUPPORTED`
+ Updated `SOLVER` synthetic tests, the regenerated `hipify-perl`, and `SOLVER` `CUDA2HIP` documentation