### PR TITLE
[HIPIFY][#675][#677][SOLVER][feature] `cuSOLVER` support - Step 32 - Functions (DN)

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -1095,6 +1095,8 @@ my %experimental_funcs = (
     "cusolverDnZpotrf_bufferSize" => "6.1.0",
     "cusolverDnZpotrfBatched" => "6.1.0",
     "cusolverDnZpotrf" => "6.1.0",
+    "cusolverDnZhetrd_bufferSize" => "6.1.0",
+    "cusolverDnZhetrd" => "6.1.0",
     "cusolverDnZgetrs" => "6.1.0",
     "cusolverDnZgetrf_bufferSize" => "6.1.0",
     "cusolverDnZgetrf" => "6.1.0",
@@ -1108,6 +1110,8 @@ my %experimental_funcs = (
     "cusolverDnZZgels" => "6.1.0",
     "cusolverDnSsytrf_bufferSize" => "6.1.0",
     "cusolverDnSsytrf" => "6.1.0",
+    "cusolverDnSsytrd_bufferSize" => "6.1.0",
+    "cusolverDnSsytrd" => "6.1.0",
     "cusolverDnSpotrsBatched" => "6.1.0",
     "cusolverDnSpotrs" => "6.1.0",
     "cusolverDnSpotri_bufferSize" => "6.1.0",
@@ -1137,6 +1141,8 @@ my %experimental_funcs = (
     "cusolverDnGetStream" => "6.1.0",
     "cusolverDnDsytrf_bufferSize" => "6.1.0",
     "cusolverDnDsytrf" => "6.1.0",
+    "cusolverDnDsytrd_bufferSize" => "6.1.0",
+    "cusolverDnDsytrd" => "6.1.0",
     "cusolverDnDpotrsBatched" => "6.1.0",
     "cusolverDnDpotrs" => "6.1.0",
     "cusolverDnDpotri_bufferSize" => "6.1.0",
@@ -1178,6 +1184,8 @@ my %experimental_funcs = (
     "cusolverDnCpotrf_bufferSize" => "6.1.0",
     "cusolverDnCpotrfBatched" => "6.1.0",
     "cusolverDnCpotrf" => "6.1.0",
+    "cusolverDnChetrd_bufferSize" => "6.1.0",
+    "cusolverDnChetrd" => "6.1.0",
     "cusolverDnCgetrs" => "6.1.0",
     "cusolverDnCgetrf_bufferSize" => "6.1.0",
     "cusolverDnCgetrf" => "6.1.0",
@@ -1355,6 +1363,8 @@ sub experimentalSubstitutions {
     subst("cusolverDnCgetrf", "hipsolverDnCgetrf", "library");
     subst("cusolverDnCgetrf_bufferSize", "hipsolverDnCgetrf_bufferSize", "library");
     subst("cusolverDnCgetrs", "hipsolverDnCgetrs", "library");
+    subst("cusolverDnChetrd", "hipsolverDnChetrd", "library");
+    subst("cusolverDnChetrd_bufferSize", "hipsolverDnChetrd_bufferSize", "library");
     subst("cusolverDnCpotrf", "hipsolverDnCpotrf", "library");
     subst("cusolverDnCpotrfBatched", "hipsolverDnCpotrfBatched", "library");
     subst("cusolverDnCpotrf_bufferSize", "hipsolverDnCpotrf_bufferSize", "library");
@@ -1396,6 +1406,8 @@ sub experimentalSubstitutions {
     subst("cusolverDnDpotri_bufferSize", "hipsolverDnDpotri_bufferSize", "library");
     subst("cusolverDnDpotrs", "hipsolverDnDpotrs", "library");
     subst("cusolverDnDpotrsBatched", "hipsolverDnDpotrsBatched", "library");
+    subst("cusolverDnDsytrd", "hipsolverDnDsytrd", "library");
+    subst("cusolverDnDsytrd_bufferSize", "hipsolverDnDsytrd_bufferSize", "library");
     subst("cusolverDnDsytrf", "hipsolverDnDsytrf", "library");
     subst("cusolverDnDsytrf_bufferSize", "hipsolverDnDsytrf_bufferSize", "library");
     subst("cusolverDnGetStream", "hipsolverGetStream", "library");
@@ -1424,6 +1436,8 @@ sub experimentalSubstitutions {
     subst("cusolverDnSpotri_bufferSize", "hipsolverDnSpotri_bufferSize", "library");
     subst("cusolverDnSpotrs", "hipsolverDnSpotrs", "library");
     subst("cusolverDnSpotrsBatched", "hipsolverDnSpotrsBatched", "library");
+    subst("cusolverDnSsytrd", "hipsolverDnSsytrd", "library");
+    subst("cusolverDnSsytrd_bufferSize", "hipsolverDnSsytrd_bufferSize", "library");
     subst("cusolverDnSsytrf", "hipsolverDnSsytrf", "library");
     subst("cusolverDnSsytrf_bufferSize", "hipsolverDnSsytrf_bufferSize", "library");
     subst("cusolverDnZZgels", "hipsolverDnZZgels", "library");
@@ -1437,6 +1451,8 @@ sub experimentalSubstitutions {
     subst("cusolverDnZgetrf", "hipsolverDnZgetrf", "library");
     subst("cusolverDnZgetrf_bufferSize", "hipsolverDnZgetrf_bufferSize", "library");
     subst("cusolverDnZgetrs", "hipsolverDnZgetrs", "library");
+    subst("cusolverDnZhetrd", "hipsolverDnZhetrd", "library");
+    subst("cusolverDnZhetrd_bufferSize", "hipsolverDnZhetrd_bufferSize", "library");
     subst("cusolverDnZpotrf", "hipsolverDnZpotrf", "library");
     subst("cusolverDnZpotrfBatched", "hipsolverDnZpotrfBatched", "library");
     subst("cusolverDnZpotrf_bufferSize", "hipsolverDnZpotrf_bufferSize", "library");

--- a/docs/tables/CUSOLVER_API_supported_by_HIP.md
+++ b/docs/tables/CUSOLVER_API_supported_by_HIP.md
@@ -131,6 +131,8 @@
 |`cusolverDnCgetrf`| | | | |`hipsolverDnCgetrf`|5.1.0| | | |6.1.0|
 |`cusolverDnCgetrf_bufferSize`| | | | |`hipsolverDnCgetrf_bufferSize`|5.1.0| | | |6.1.0|
 |`cusolverDnCgetrs`| | | | |`hipsolverDnCgetrs`|5.1.0| | | |6.1.0|
+|`cusolverDnChetrd`|8.0| | | |`hipsolverDnChetrd`|5.1.0| | | |6.1.0|
+|`cusolverDnChetrd_bufferSize`|8.0| | | |`hipsolverDnChetrd_bufferSize`|5.1.0| | | |6.1.0|
 |`cusolverDnClaswp`| | | | | | | | | | |
 |`cusolverDnClauum`|10.1| | | | | | | | | |
 |`cusolverDnClauum_bufferSize`|10.1| | | | | | | | | |
@@ -197,6 +199,8 @@
 |`cusolverDnDpotri_bufferSize`|10.1| | | |`hipsolverDnDpotri_bufferSize`|5.1.0| | | |6.1.0|
 |`cusolverDnDpotrs`| | | | |`hipsolverDnDpotrs`|5.1.0| | | |6.1.0|
 |`cusolverDnDpotrsBatched`|9.1| | | |`hipsolverDnDpotrsBatched`|5.1.0| | | |6.1.0|
+|`cusolverDnDsytrd`| | | | |`hipsolverDnDsytrd`|5.1.0| | | |6.1.0|
+|`cusolverDnDsytrd_bufferSize`|8.0| | | |`hipsolverDnDsytrd_bufferSize`|5.1.0| | | |6.1.0|
 |`cusolverDnDsytrf`| | | | |`hipsolverDnDsytrf`|5.1.0| | | |6.1.0|
 |`cusolverDnDsytrf_bufferSize`| | | | |`hipsolverDnDsytrf_bufferSize`|5.1.0| | | |6.1.0|
 |`cusolverDnDsytri`|10.1| | | | | | | | | |
@@ -269,6 +273,8 @@
 |`cusolverDnSpotri_bufferSize`|10.1| | | |`hipsolverDnSpotri_bufferSize`|5.1.0| | | |6.1.0|
 |`cusolverDnSpotrs`| | | | |`hipsolverDnSpotrs`|5.1.0| | | |6.1.0|
 |`cusolverDnSpotrsBatched`|9.1| | | |`hipsolverDnSpotrsBatched`|5.1.0| | | |6.1.0|
+|`cusolverDnSsytrd`| | | | |`hipsolverDnSsytrd`|5.1.0| | | |6.1.0|
+|`cusolverDnSsytrd_bufferSize`|8.0| | | |`hipsolverDnSsytrd_bufferSize`|5.1.0| | | |6.1.0|
 |`cusolverDnSsytrf`| | | | |`hipsolverDnSsytrf`|5.1.0| | | |6.1.0|
 |`cusolverDnSsytrf_bufferSize`| | | | |`hipsolverDnSsytrf_bufferSize`|5.1.0| | | |6.1.0|
 |`cusolverDnSsytri`|10.1| | | | | | | | | |
@@ -307,6 +313,8 @@
 |`cusolverDnZgetrf`| | | | |`hipsolverDnZgetrf`|5.1.0| | | |6.1.0|
 |`cusolverDnZgetrf_bufferSize`| | | | |`hipsolverDnZgetrf_bufferSize`|5.1.0| | | |6.1.0|
 |`cusolverDnZgetrs`| | | | |`hipsolverDnZgetrs`|5.1.0| | | |6.1.0|
+|`cusolverDnZhetrd`|8.0| | | |`hipsolverDnZhetrd`|5.1.0| | | |6.1.0|
+|`cusolverDnZhetrd_bufferSize`|8.0| | | |`hipsolverDnZhetrd_bufferSize`|5.1.0| | | |6.1.0|
 |`cusolverDnZlaswp`| | | | | | | | | | |
 |`cusolverDnZlauum`|10.1| | | | | | | | | |
 |`cusolverDnZlauum_bufferSize`|10.1| | | | | | | | | |

--- a/docs/tables/CUSOLVER_API_supported_by_HIP_and_ROC.md
+++ b/docs/tables/CUSOLVER_API_supported_by_HIP_and_ROC.md
@@ -131,6 +131,8 @@
 |`cusolverDnCgetrf`| | | | |`hipsolverDnCgetrf`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnCgetrf_bufferSize`| | | | |`hipsolverDnCgetrf_bufferSize`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnCgetrs`| | | | |`hipsolverDnCgetrs`|5.1.0| | | |6.1.0| | | | | | |
+|`cusolverDnChetrd`|8.0| | | |`hipsolverDnChetrd`|5.1.0| | | |6.1.0| | | | | | |
+|`cusolverDnChetrd_bufferSize`|8.0| | | |`hipsolverDnChetrd_bufferSize`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnClaswp`| | | | | | | | | | | | | | | | |
 |`cusolverDnClauum`|10.1| | | | | | | | | | | | | | | |
 |`cusolverDnClauum_bufferSize`|10.1| | | | | | | | | | | | | | | |
@@ -197,6 +199,8 @@
 |`cusolverDnDpotri_bufferSize`|10.1| | | |`hipsolverDnDpotri_bufferSize`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnDpotrs`| | | | |`hipsolverDnDpotrs`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnDpotrsBatched`|9.1| | | |`hipsolverDnDpotrsBatched`|5.1.0| | | |6.1.0| | | | | | |
+|`cusolverDnDsytrd`| | | | |`hipsolverDnDsytrd`|5.1.0| | | |6.1.0| | | | | | |
+|`cusolverDnDsytrd_bufferSize`|8.0| | | |`hipsolverDnDsytrd_bufferSize`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnDsytrf`| | | | |`hipsolverDnDsytrf`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnDsytrf_bufferSize`| | | | |`hipsolverDnDsytrf_bufferSize`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnDsytri`|10.1| | | | | | | | | | | | | | | |
@@ -269,6 +273,8 @@
 |`cusolverDnSpotri_bufferSize`|10.1| | | |`hipsolverDnSpotri_bufferSize`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnSpotrs`| | | | |`hipsolverDnSpotrs`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnSpotrsBatched`|9.1| | | |`hipsolverDnSpotrsBatched`|5.1.0| | | |6.1.0| | | | | | |
+|`cusolverDnSsytrd`| | | | |`hipsolverDnSsytrd`|5.1.0| | | |6.1.0| | | | | | |
+|`cusolverDnSsytrd_bufferSize`|8.0| | | |`hipsolverDnSsytrd_bufferSize`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnSsytrf`| | | | |`hipsolverDnSsytrf`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnSsytrf_bufferSize`| | | | |`hipsolverDnSsytrf_bufferSize`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnSsytri`|10.1| | | | | | | | | | | | | | | |
@@ -307,6 +313,8 @@
 |`cusolverDnZgetrf`| | | | |`hipsolverDnZgetrf`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnZgetrf_bufferSize`| | | | |`hipsolverDnZgetrf_bufferSize`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnZgetrs`| | | | |`hipsolverDnZgetrs`|5.1.0| | | |6.1.0| | | | | | |
+|`cusolverDnZhetrd`|8.0| | | |`hipsolverDnZhetrd`|5.1.0| | | |6.1.0| | | | | | |
+|`cusolverDnZhetrd_bufferSize`|8.0| | | |`hipsolverDnZhetrd_bufferSize`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnZlaswp`| | | | | | | | | | | | | | | | |
 |`cusolverDnZlauum`|10.1| | | | | | | | | | | | | | | |
 |`cusolverDnZlauum_bufferSize`|10.1| | | | | | | | | | | | | | | |

--- a/docs/tables/CUSOLVER_API_supported_by_ROC.md
+++ b/docs/tables/CUSOLVER_API_supported_by_ROC.md
@@ -131,6 +131,8 @@
 |`cusolverDnCgetrf`| | | | | | | | | | |
 |`cusolverDnCgetrf_bufferSize`| | | | | | | | | | |
 |`cusolverDnCgetrs`| | | | | | | | | | |
+|`cusolverDnChetrd`|8.0| | | | | | | | | |
+|`cusolverDnChetrd_bufferSize`|8.0| | | | | | | | | |
 |`cusolverDnClaswp`| | | | | | | | | | |
 |`cusolverDnClauum`|10.1| | | | | | | | | |
 |`cusolverDnClauum_bufferSize`|10.1| | | | | | | | | |
@@ -197,6 +199,8 @@
 |`cusolverDnDpotri_bufferSize`|10.1| | | | | | | | | |
 |`cusolverDnDpotrs`| | | | | | | | | | |
 |`cusolverDnDpotrsBatched`|9.1| | | | | | | | | |
+|`cusolverDnDsytrd`| | | | | | | | | | |
+|`cusolverDnDsytrd_bufferSize`|8.0| | | | | | | | | |
 |`cusolverDnDsytrf`| | | | | | | | | | |
 |`cusolverDnDsytrf_bufferSize`| | | | | | | | | | |
 |`cusolverDnDsytri`|10.1| | | | | | | | | |
@@ -269,6 +273,8 @@
 |`cusolverDnSpotri_bufferSize`|10.1| | | | | | | | | |
 |`cusolverDnSpotrs`| | | | | | | | | | |
 |`cusolverDnSpotrsBatched`|9.1| | | | | | | | | |
+|`cusolverDnSsytrd`| | | | | | | | | | |
+|`cusolverDnSsytrd_bufferSize`|8.0| | | | | | | | | |
 |`cusolverDnSsytrf`| | | | | | | | | | |
 |`cusolverDnSsytrf_bufferSize`| | | | | | | | | | |
 |`cusolverDnSsytri`|10.1| | | | | | | | | |
@@ -307,6 +313,8 @@
 |`cusolverDnZgetrf`| | | | | | | | | | |
 |`cusolverDnZgetrf_bufferSize`| | | | | | | | | | |
 |`cusolverDnZgetrs`| | | | | | | | | | |
+|`cusolverDnZhetrd`|8.0| | | | | | | | | |
+|`cusolverDnZhetrd_bufferSize`|8.0| | | | | | | | | |
 |`cusolverDnZlaswp`| | | | | | | | | | |
 |`cusolverDnZlauum`|10.1| | | | | | | | | |
 |`cusolverDnZlauum_bufferSize`|10.1| | | | | | | | | |

--- a/src/CUDA2HIP_SOLVER_API_functions.cpp
+++ b/src/CUDA2HIP_SOLVER_API_functions.cpp
@@ -281,6 +281,16 @@ const std::map<llvm::StringRef, hipCounter> CUDA_SOLVER_FUNCTION_MAP {
   {"cusolverDnDorgbr",                                   {"hipsolverDnDorgbr",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
   {"cusolverDnCungbr",                                   {"hipsolverDnCungbr",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
   {"cusolverDnZungbr",                                   {"hipsolverDnZungbr",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
+  // NOTE: rocsolver_(s|d)sytrd and rocsolver_(c|z)hetrd have a harness of other HIP and ROC API calls
+  {"cusolverDnSsytrd_bufferSize",                        {"hipsolverDnSsytrd_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
+  {"cusolverDnDsytrd_bufferSize",                        {"hipsolverDnDsytrd_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
+  {"cusolverDnChetrd_bufferSize",                        {"hipsolverDnChetrd_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
+  {"cusolverDnZhetrd_bufferSize",                        {"hipsolverDnZhetrd_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
+  // NOTE: rocsolver_(s|d)sytrd and rocsolver_(c|z)hetrd have a harness of other HIP and ROC API calls
+  {"cusolverDnSsytrd",                                   {"hipsolverDnSsytrd",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
+  {"cusolverDnDsytrd",                                   {"hipsolverDnDsytrd",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
+  {"cusolverDnChetrd",                                   {"hipsolverDnChetrd",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
+  {"cusolverDnZhetrd",                                   {"hipsolverDnZhetrd",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
 };
 
 const std::map<llvm::StringRef, cudaAPIversions> CUDA_SOLVER_FUNCTION_VER_MAP {
@@ -443,6 +453,12 @@ const std::map<llvm::StringRef, cudaAPIversions> CUDA_SOLVER_FUNCTION_VER_MAP {
   {"cusolverDnDorgbr",                                    {CUDA_80,   CUDA_0, CUDA_0}},
   {"cusolverDnCungbr",                                    {CUDA_80,   CUDA_0, CUDA_0}},
   {"cusolverDnZungbr",                                    {CUDA_80,   CUDA_0, CUDA_0}},
+  {"cusolverDnSsytrd_bufferSize",                         {CUDA_80,   CUDA_0, CUDA_0}},
+  {"cusolverDnDsytrd_bufferSize",                         {CUDA_80,   CUDA_0, CUDA_0}},
+  {"cusolverDnChetrd_bufferSize",                         {CUDA_80,   CUDA_0, CUDA_0}},
+  {"cusolverDnZhetrd_bufferSize",                         {CUDA_80,   CUDA_0, CUDA_0}},
+  {"cusolverDnChetrd",                                    {CUDA_80,   CUDA_0, CUDA_0}},
+  {"cusolverDnZhetrd",                                    {CUDA_80,   CUDA_0, CUDA_0}},
 };
 
 const std::map<llvm::StringRef, hipAPIversions> HIP_SOLVER_FUNCTION_VER_MAP {
@@ -554,6 +570,14 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_SOLVER_FUNCTION_VER_MAP {
   {"hipsolverDnDorgbr",                                   {HIP_5010, HIP_0,    HIP_0,  HIP_LATEST}},
   {"hipsolverDnCungbr",                                   {HIP_5010, HIP_0,    HIP_0,  HIP_LATEST}},
   {"hipsolverDnZungbr",                                   {HIP_5010, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipsolverDnSsytrd_bufferSize",                        {HIP_5010, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipsolverDnDsytrd_bufferSize",                        {HIP_5010, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipsolverDnChetrd_bufferSize",                        {HIP_5010, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipsolverDnZhetrd_bufferSize",                        {HIP_5010, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipsolverDnSsytrd",                                   {HIP_5010, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipsolverDnDsytrd",                                   {HIP_5010, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipsolverDnChetrd",                                   {HIP_5010, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipsolverDnZhetrd",                                   {HIP_5010, HIP_0,    HIP_0,  HIP_LATEST}},
 
   {"rocsolver_spotrf",                                    {HIP_3020, HIP_0,    HIP_0,  HIP_LATEST}},
   {"rocsolver_dpotrf",                                    {HIP_3020, HIP_0,    HIP_0,  HIP_LATEST}},

--- a/tests/unit_tests/synthetic/libraries/cusolver2hipsolver.cu
+++ b/tests/unit_tests/synthetic/libraries/cusolver2hipsolver.cu
@@ -364,6 +364,16 @@ int main() {
   // CHECK: status = hipsolverDnZgebrd(handle, m, n, &dComplexA, lda, &dD, &dE, &dComplexTAUQ, &dComplexTAUP, &dComplexWorkspace, Lwork, &devInfo);
   status = cusolverDnZgebrd(handle, m, n, &dComplexA, lda, &dD, &dE, &dComplexTAUQ, &dComplexTAUP, &dComplexWorkspace, Lwork, &devInfo);
 
+  // CUDA: cusolverStatus_t CUSOLVERAPI cusolverDnSsytrd(cusolverDnHandle_t handle, cublasFillMode_t uplo, int n, float * A, int lda, float * d, float * e, float * tau, float * work, int lwork, int * info);
+  // HIP: HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDnSsytrd(hipsolverHandle_t handle, hipblasFillMode_t uplo, int n, float* A, int lda, float* D, float* E, float* tau, float* work, int lwork, int* devInfo);
+  // CHECK: status = hipsolverDnSsytrd(handle, fillMode, n, &fA, lda, &fD, &fE, &fTAU, &fWorkspace, Lwork, &info);
+  status = cusolverDnSsytrd(handle, fillMode, n, &fA, lda, &fD, &fE, &fTAU, &fWorkspace, Lwork, &info);
+
+  // CUDA: cusolverStatus_t CUSOLVERAPI cusolverDnDsytrd(cusolverDnHandle_t handle, cublasFillMode_t uplo, int n, double * A,int lda, double * d, double * e, double * tau, double * work, int lwork, int * info);
+  // HIP: HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDnDsytrd(hipsolverHandle_t handle, hipblasFillMode_t uplo, int n, double* A, int lda, double* D, double* E, double* tau, double* work, int lwork, int* devInfo);
+  // CHECK: status = hipsolverDnDsytrd(handle, fillMode, n, &dA, lda, &dD, &dE, &dTAU, &dWorkspace, Lwork, &info);
+  status = cusolverDnDsytrd(handle, fillMode, n, &dA, lda, &dD, &dE, &dTAU, &dWorkspace, Lwork, &info);
+
 #if CUDA_VERSION >= 8000
   // CHECK: hipsolverEigType_t eigType;
   // CHECK-NEXT: hipsolverEigType_t EIG_TYPE_1 = HIPSOLVER_EIG_TYPE_1;
@@ -500,6 +510,36 @@ int main() {
   // HIP: HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDnZungbr(hipsolverHandle_t handle, hipblasSideMode_t side, int m, int n, int k, hipDoubleComplex* A, int lda, const hipDoubleComplex* tau, hipDoubleComplex* work, int lwork, int* devInfo);
   // CHECK: status = hipsolverDnZungbr(handle, blasSideMode, m, n, k, &dComplexA, lda, &dComplexTAU, &dComplexWorkspace, Lwork, &info);
   status = cusolverDnZungbr(handle, blasSideMode, m, n, k, &dComplexA, lda, &dComplexTAU, &dComplexWorkspace, Lwork, &info);
+
+  // CUDA: cusolverStatus_t CUSOLVERAPI cusolverDnSsytrd_bufferSize(cusolverDnHandle_t handle, cublasFillMode_t uplo, int n, const float * A, int lda, const float * d, const float * e, const float * tau, int * lwork);
+  // HIP: HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDnSsytrd_bufferSize(hipsolverHandle_t handle, hipblasFillMode_t uplo, int n, const float* A, int lda, const float* D, const float* E, const float* tau, int* lwork);
+  // CHECK: status = hipsolverDnSsytrd_bufferSize(handle, fillMode, n, &fA, lda, &fD, &fE, &fTAU, &Lwork);
+  status = cusolverDnSsytrd_bufferSize(handle, fillMode, n, &fA, lda, &fD, &fE, &fTAU, &Lwork);
+
+  // CUDA: cusolverStatus_t CUSOLVERAPI cusolverDnDsytrd_bufferSize(cusolverDnHandle_t handle, cublasFillMode_t uplo, int n, const double * A, int lda, const double * d, const double * e, const double * tau, int * lwork);
+  // HIP: HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDnDsytrd_bufferSize(hipsolverHandle_t handle, hipblasFillMode_t uplo, int n, const double* A, int lda, const double* D, const double* E, const double* tau, int* lwork);
+  // CHECK: status = hipsolverDnDsytrd_bufferSize(handle, fillMode, n, &dA, lda, &dD, &dE, &dTAU, &Lwork);
+  status = cusolverDnDsytrd_bufferSize(handle, fillMode, n, &dA, lda, &dD, &dE, &dTAU, &Lwork);
+
+  // CUDA: cusolverStatus_t CUSOLVERAPI cusolverDnChetrd_bufferSize(cusolverDnHandle_t handle, cublasFillMode_t uplo, int n, const cuComplex * A, int lda, const float * d, const float * e, const cuComplex * tau, int * lwork);
+  // HIP: HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDnChetrd_bufferSize(hipsolverHandle_t handle, hipblasFillMode_t uplo, int n, const hipFloatComplex* A, int lda, const float* D, const float* E, const hipFloatComplex* tau, int* lwork);
+  // CHECK: status = hipsolverDnChetrd_bufferSize(handle, fillMode, n, &complexA, lda, &fD, &fE, &complexTAU, &Lwork);
+  status = cusolverDnChetrd_bufferSize(handle, fillMode, n, &complexA, lda, &fD, &fE, &complexTAU, &Lwork);
+
+  // CUDA: cusolverStatus_t CUSOLVERAPI cusolverDnZhetrd_bufferSize(cusolverDnHandle_t handle, cublasFillMode_t uplo, int n, const cuDoubleComplex *A, int lda, const double * d, const double * e, const cuDoubleComplex *tau, int * lwork);
+  // HIP: HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDnZhetrd_bufferSize(hipsolverHandle_t handle, hipblasFillMode_t uplo, int n, const hipDoubleComplex* A, int lda, const double* D, const double* E, const hipDoubleComplex* tau, int* lwork);
+  // CHECK: status = hipsolverDnZhetrd_bufferSize(handle, fillMode, n, &dComplexA, lda, &dD, &dE, &dComplexTAU, &Lwork);
+  status = cusolverDnZhetrd_bufferSize(handle, fillMode, n, &dComplexA, lda, &dD, &dE, &dComplexTAU, &Lwork);
+
+  // CUDA: cusolverStatus_t CUSOLVERAPI cusolverDnChetrd(cusolverDnHandle_t handle, cublasFillMode_t uplo, int n, cuComplex * A, int lda, float * d, float * e, cuComplex * tau, cuComplex * work, int lwork, int * info);
+  // HIP: HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDnChetrd(hipsolverHandle_t handle, hipblasFillMode_t uplo, int n, hipFloatComplex* A, int lda, float* D, float* E, hipFloatComplex* tau, hipFloatComplex* work, int lwork, int* devInfo);
+  // CHECK: status = hipsolverDnChetrd(handle, fillMode, n, &complexA, lda, &fD, &fE, &complexTAU, &complexWorkspace, Lwork, &info);
+  status = cusolverDnChetrd(handle, fillMode, n, &complexA, lda, &fD, &fE, &complexTAU, &complexWorkspace, Lwork, &info);
+
+  // CUDA: cusolverStatus_t CUSOLVERAPI cusolverDnZhetrd(cusolverDnHandle_t handle, cublasFillMode_t uplo, int n, cuDoubleComplex * A, int lda, double * d, double * e, cuDoubleComplex * tau, cuDoubleComplex * work, int lwork, int * info);
+  // HIP: HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDnZhetrd(hipsolverHandle_t handle, hipblasFillMode_t uplo, int n, hipDoubleComplex* A, int lda, double* D, double* E, hipDoubleComplex* tau, hipDoubleComplex* work, int lwork, int* devInfo);
+  // CHECK: status = hipsolverDnZhetrd(handle, fillMode, n, &dComplexA, lda, &dD, &dE, &dComplexTAU, &dComplexWorkspace, Lwork, &info);
+  status = cusolverDnZhetrd(handle, fillMode, n, &dComplexA, lda, &dD, &dE, &dComplexTAU, &dComplexWorkspace, Lwork, &info);
 #endif
 
 #if CUDA_VERSION >= 9000


### PR DESCRIPTION
+ `cusolverDn(S|D)ytrd_(bufferSize)?` and `cusolverDn(C|Z)hetrd_(bufferSize)?`are `SUPPORTED` by `hipSOLVER` only
+ [NOTE] `rocsolver_(s|d)ytrd` and `rocsolver_(c|z)hetrd` have a harness of other HIP and ROC API calls, thus `UNSUPPORTED`
+ Updated `SOLVER` synthetic tests, the regenerated `hipify-perl`, and `SOLVER` `CUDA2HIP` documentation