### PR TITLE
[HIPIFY][#675][#677][SOLVER][feature] `cuSOLVER` support - Step 35 - Functions (DN)

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -1104,6 +1104,8 @@ my %experimental_funcs = (
     "cusolverDnZgetrs" => "6.1.0",
     "cusolverDnZgetrf_bufferSize" => "6.1.0",
     "cusolverDnZgetrf" => "6.1.0",
+    "cusolverDnZgesvd_bufferSize" => "6.1.0",
+    "cusolverDnZgesvd" => "6.1.0",
     "cusolverDnZgeqrf_bufferSize" => "6.1.0",
     "cusolverDnZgeqrf" => "6.1.0",
     "cusolverDnZgebrd_bufferSize" => "6.1.0",
@@ -1136,6 +1138,8 @@ my %experimental_funcs = (
     "cusolverDnSgetrs" => "6.1.0",
     "cusolverDnSgetrf_bufferSize" => "6.1.0",
     "cusolverDnSgetrf" => "6.1.0",
+    "cusolverDnSgesvd_bufferSize" => "6.1.0",
+    "cusolverDnSgesvd" => "6.1.0",
     "cusolverDnSgeqrf_bufferSize" => "6.1.0",
     "cusolverDnSgeqrf" => "6.1.0",
     "cusolverDnSgebrd_bufferSize" => "6.1.0",
@@ -1171,6 +1175,8 @@ my %experimental_funcs = (
     "cusolverDnDgetrs" => "6.1.0",
     "cusolverDnDgetrf_bufferSize" => "6.1.0",
     "cusolverDnDgetrf" => "6.1.0",
+    "cusolverDnDgesvd_bufferSize" => "6.1.0",
+    "cusolverDnDgesvd" => "6.1.0",
     "cusolverDnDgeqrf_bufferSize" => "6.1.0",
     "cusolverDnDgeqrf" => "6.1.0",
     "cusolverDnDgebrd_bufferSize" => "6.1.0",
@@ -1205,6 +1211,8 @@ my %experimental_funcs = (
     "cusolverDnCgetrs" => "6.1.0",
     "cusolverDnCgetrf_bufferSize" => "6.1.0",
     "cusolverDnCgetrf" => "6.1.0",
+    "cusolverDnCgesvd_bufferSize" => "6.1.0",
+    "cusolverDnCgesvd" => "6.1.0",
     "cusolverDnCgeqrf_bufferSize" => "6.1.0",
     "cusolverDnCgeqrf" => "6.1.0",
     "cusolverDnCgebrd_bufferSize" => "6.1.0",
@@ -1376,6 +1384,8 @@ sub experimentalSubstitutions {
     subst("cusolverDnCgebrd_bufferSize", "hipsolverDnCgebrd_bufferSize", "library");
     subst("cusolverDnCgeqrf", "hipsolverDnCgeqrf", "library");
     subst("cusolverDnCgeqrf_bufferSize", "hipsolverDnCgeqrf_bufferSize", "library");
+    subst("cusolverDnCgesvd", "hipsolverDnCgesvd", "library");
+    subst("cusolverDnCgesvd_bufferSize", "hipsolverDnCgesvd_bufferSize", "library");
     subst("cusolverDnCgetrf", "hipsolverDnCgetrf", "library");
     subst("cusolverDnCgetrf_bufferSize", "hipsolverDnCgetrf_bufferSize", "library");
     subst("cusolverDnCgetrs", "hipsolverDnCgetrs", "library");
@@ -1410,6 +1420,8 @@ sub experimentalSubstitutions {
     subst("cusolverDnDgebrd_bufferSize", "hipsolverDnDgebrd_bufferSize", "library");
     subst("cusolverDnDgeqrf", "hipsolverDnDgeqrf", "library");
     subst("cusolverDnDgeqrf_bufferSize", "hipsolverDnDgeqrf_bufferSize", "library");
+    subst("cusolverDnDgesvd", "hipsolverDnDgesvd", "library");
+    subst("cusolverDnDgesvd_bufferSize", "hipsolverDnDgesvd_bufferSize", "library");
     subst("cusolverDnDgetrf", "hipsolverDnDgetrf", "library");
     subst("cusolverDnDgetrf_bufferSize", "hipsolverDnDgetrf_bufferSize", "library");
     subst("cusolverDnDgetrs", "hipsolverDnDgetrs", "library");
@@ -1444,6 +1456,8 @@ sub experimentalSubstitutions {
     subst("cusolverDnSgebrd_bufferSize", "hipsolverDnSgebrd_bufferSize", "library");
     subst("cusolverDnSgeqrf", "hipsolverDnSgeqrf", "library");
     subst("cusolverDnSgeqrf_bufferSize", "hipsolverDnSgeqrf_bufferSize", "library");
+    subst("cusolverDnSgesvd", "hipsolverDnSgesvd", "library");
+    subst("cusolverDnSgesvd_bufferSize", "hipsolverDnSgesvd_bufferSize", "library");
     subst("cusolverDnSgetrf", "hipsolverDnSgetrf", "library");
     subst("cusolverDnSgetrf_bufferSize", "hipsolverDnSgetrf_bufferSize", "library");
     subst("cusolverDnSgetrs", "hipsolverDnSgetrs", "library");
@@ -1476,6 +1490,8 @@ sub experimentalSubstitutions {
     subst("cusolverDnZgebrd_bufferSize", "hipsolverDnZgebrd_bufferSize", "library");
     subst("cusolverDnZgeqrf", "hipsolverDnZgeqrf", "library");
     subst("cusolverDnZgeqrf_bufferSize", "hipsolverDnZgeqrf_bufferSize", "library");
+    subst("cusolverDnZgesvd", "hipsolverDnZgesvd", "library");
+    subst("cusolverDnZgesvd_bufferSize", "hipsolverDnZgesvd_bufferSize", "library");
     subst("cusolverDnZgetrf", "hipsolverDnZgetrf", "library");
     subst("cusolverDnZgetrf_bufferSize", "hipsolverDnZgetrf_bufferSize", "library");
     subst("cusolverDnZgetrs", "hipsolverDnZgetrs", "library");

--- a/docs/tables/CUSOLVER_API_supported_by_HIP.md
+++ b/docs/tables/CUSOLVER_API_supported_by_HIP.md
@@ -128,6 +128,8 @@
 |`cusolverDnCgebrd_bufferSize`| | | | |`hipsolverDnCgebrd_bufferSize`|5.1.0| | | |6.1.0|
 |`cusolverDnCgeqrf`| | | | |`hipsolverDnCgeqrf`|5.1.0| | | |6.1.0|
 |`cusolverDnCgeqrf_bufferSize`| | | | |`hipsolverDnCgeqrf_bufferSize`|5.1.0| | | |6.1.0|
+|`cusolverDnCgesvd`| | | | |`hipsolverDnCgesvd`|5.1.0| | | |6.1.0|
+|`cusolverDnCgesvd_bufferSize`| | | | |`hipsolverDnCgesvd_bufferSize`|5.1.0| | | |6.1.0|
 |`cusolverDnCgetrf`| | | | |`hipsolverDnCgetrf`|5.1.0| | | |6.1.0|
 |`cusolverDnCgetrf_bufferSize`| | | | |`hipsolverDnCgetrf_bufferSize`|5.1.0| | | |6.1.0|
 |`cusolverDnCgetrs`| | | | |`hipsolverDnCgetrs`|5.1.0| | | |6.1.0|
@@ -184,6 +186,8 @@
 |`cusolverDnDgebrd_bufferSize`| | | | |`hipsolverDnDgebrd_bufferSize`|5.1.0| | | |6.1.0|
 |`cusolverDnDgeqrf`| | | | |`hipsolverDnDgeqrf`|5.1.0| | | |6.1.0|
 |`cusolverDnDgeqrf_bufferSize`| | | | |`hipsolverDnDgeqrf_bufferSize`|5.1.0| | | |6.1.0|
+|`cusolverDnDgesvd`| | | | |`hipsolverDnDgesvd`|5.1.0| | | |6.1.0|
+|`cusolverDnDgesvd_bufferSize`| | | | |`hipsolverDnDgesvd_bufferSize`|5.1.0| | | |6.1.0|
 |`cusolverDnDgetrf`| | | | |`hipsolverDnDgetrf`|5.1.0| | | |6.1.0|
 |`cusolverDnDgetrf_bufferSize`| | | | |`hipsolverDnDgetrf_bufferSize`|5.1.0| | | |6.1.0|
 |`cusolverDnDgetrs`| | | | |`hipsolverDnDgetrs`|5.1.0| | | |6.1.0|
@@ -262,6 +266,8 @@
 |`cusolverDnSgebrd_bufferSize`| | | | |`hipsolverDnSgebrd_bufferSize`|5.1.0| | | |6.1.0|
 |`cusolverDnSgeqrf`| | | | |`hipsolverDnSgeqrf`|5.1.0| | | |6.1.0|
 |`cusolverDnSgeqrf_bufferSize`| | | | |`hipsolverDnSgeqrf_bufferSize`|5.1.0| | | |6.1.0|
+|`cusolverDnSgesvd`| | | | |`hipsolverDnSgesvd`|5.1.0| | | |6.1.0|
+|`cusolverDnSgesvd_bufferSize`| | | | |`hipsolverDnSgesvd_bufferSize`|5.1.0| | | |6.1.0|
 |`cusolverDnSgetrf`| | | | |`hipsolverDnSgetrf`|5.1.0| | | |6.1.0|
 |`cusolverDnSgetrf_bufferSize`| | | | |`hipsolverDnSgetrf_bufferSize`|5.1.0| | | |6.1.0|
 |`cusolverDnSgetrs`| | | | |`hipsolverDnSgetrs`|5.1.0| | | |6.1.0|
@@ -322,6 +328,8 @@
 |`cusolverDnZgebrd_bufferSize`| | | | |`hipsolverDnZgebrd_bufferSize`|5.1.0| | | |6.1.0|
 |`cusolverDnZgeqrf`| | | | |`hipsolverDnZgeqrf`|5.1.0| | | |6.1.0|
 |`cusolverDnZgeqrf_bufferSize`| | | | |`hipsolverDnZgeqrf_bufferSize`|5.1.0| | | |6.1.0|
+|`cusolverDnZgesvd`| | | | |`hipsolverDnZgesvd`|5.1.0| | | |6.1.0|
+|`cusolverDnZgesvd_bufferSize`| | | | |`hipsolverDnZgesvd_bufferSize`|5.1.0| | | |6.1.0|
 |`cusolverDnZgetrf`| | | | |`hipsolverDnZgetrf`|5.1.0| | | |6.1.0|
 |`cusolverDnZgetrf_bufferSize`| | | | |`hipsolverDnZgetrf_bufferSize`|5.1.0| | | |6.1.0|
 |`cusolverDnZgetrs`| | | | |`hipsolverDnZgetrs`|5.1.0| | | |6.1.0|

--- a/docs/tables/CUSOLVER_API_supported_by_HIP_and_ROC.md
+++ b/docs/tables/CUSOLVER_API_supported_by_HIP_and_ROC.md
@@ -128,6 +128,8 @@
 |`cusolverDnCgebrd_bufferSize`| | | | |`hipsolverDnCgebrd_bufferSize`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnCgeqrf`| | | | |`hipsolverDnCgeqrf`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnCgeqrf_bufferSize`| | | | |`hipsolverDnCgeqrf_bufferSize`|5.1.0| | | |6.1.0| | | | | | |
+|`cusolverDnCgesvd`| | | | |`hipsolverDnCgesvd`|5.1.0| | | |6.1.0| | | | | | |
+|`cusolverDnCgesvd_bufferSize`| | | | |`hipsolverDnCgesvd_bufferSize`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnCgetrf`| | | | |`hipsolverDnCgetrf`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnCgetrf_bufferSize`| | | | |`hipsolverDnCgetrf_bufferSize`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnCgetrs`| | | | |`hipsolverDnCgetrs`|5.1.0| | | |6.1.0| | | | | | |
@@ -184,6 +186,8 @@
 |`cusolverDnDgebrd_bufferSize`| | | | |`hipsolverDnDgebrd_bufferSize`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnDgeqrf`| | | | |`hipsolverDnDgeqrf`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnDgeqrf_bufferSize`| | | | |`hipsolverDnDgeqrf_bufferSize`|5.1.0| | | |6.1.0| | | | | | |
+|`cusolverDnDgesvd`| | | | |`hipsolverDnDgesvd`|5.1.0| | | |6.1.0| | | | | | |
+|`cusolverDnDgesvd_bufferSize`| | | | |`hipsolverDnDgesvd_bufferSize`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnDgetrf`| | | | |`hipsolverDnDgetrf`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnDgetrf_bufferSize`| | | | |`hipsolverDnDgetrf_bufferSize`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnDgetrs`| | | | |`hipsolverDnDgetrs`|5.1.0| | | |6.1.0| | | | | | |
@@ -262,6 +266,8 @@
 |`cusolverDnSgebrd_bufferSize`| | | | |`hipsolverDnSgebrd_bufferSize`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnSgeqrf`| | | | |`hipsolverDnSgeqrf`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnSgeqrf_bufferSize`| | | | |`hipsolverDnSgeqrf_bufferSize`|5.1.0| | | |6.1.0| | | | | | |
+|`cusolverDnSgesvd`| | | | |`hipsolverDnSgesvd`|5.1.0| | | |6.1.0| | | | | | |
+|`cusolverDnSgesvd_bufferSize`| | | | |`hipsolverDnSgesvd_bufferSize`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnSgetrf`| | | | |`hipsolverDnSgetrf`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnSgetrf_bufferSize`| | | | |`hipsolverDnSgetrf_bufferSize`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnSgetrs`| | | | |`hipsolverDnSgetrs`|5.1.0| | | |6.1.0| | | | | | |
@@ -322,6 +328,8 @@
 |`cusolverDnZgebrd_bufferSize`| | | | |`hipsolverDnZgebrd_bufferSize`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnZgeqrf`| | | | |`hipsolverDnZgeqrf`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnZgeqrf_bufferSize`| | | | |`hipsolverDnZgeqrf_bufferSize`|5.1.0| | | |6.1.0| | | | | | |
+|`cusolverDnZgesvd`| | | | |`hipsolverDnZgesvd`|5.1.0| | | |6.1.0| | | | | | |
+|`cusolverDnZgesvd_bufferSize`| | | | |`hipsolverDnZgesvd_bufferSize`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnZgetrf`| | | | |`hipsolverDnZgetrf`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnZgetrf_bufferSize`| | | | |`hipsolverDnZgetrf_bufferSize`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnZgetrs`| | | | |`hipsolverDnZgetrs`|5.1.0| | | |6.1.0| | | | | | |

--- a/docs/tables/CUSOLVER_API_supported_by_ROC.md
+++ b/docs/tables/CUSOLVER_API_supported_by_ROC.md
@@ -128,6 +128,8 @@
 |`cusolverDnCgebrd_bufferSize`| | | | | | | | | | |
 |`cusolverDnCgeqrf`| | | | | | | | | | |
 |`cusolverDnCgeqrf_bufferSize`| | | | | | | | | | |
+|`cusolverDnCgesvd`| | | | | | | | | | |
+|`cusolverDnCgesvd_bufferSize`| | | | | | | | | | |
 |`cusolverDnCgetrf`| | | | | | | | | | |
 |`cusolverDnCgetrf_bufferSize`| | | | | | | | | | |
 |`cusolverDnCgetrs`| | | | | | | | | | |
@@ -184,6 +186,8 @@
 |`cusolverDnDgebrd_bufferSize`| | | | | | | | | | |
 |`cusolverDnDgeqrf`| | | | | | | | | | |
 |`cusolverDnDgeqrf_bufferSize`| | | | | | | | | | |
+|`cusolverDnDgesvd`| | | | | | | | | | |
+|`cusolverDnDgesvd_bufferSize`| | | | | | | | | | |
 |`cusolverDnDgetrf`| | | | | | | | | | |
 |`cusolverDnDgetrf_bufferSize`| | | | | | | | | | |
 |`cusolverDnDgetrs`| | | | | | | | | | |
@@ -262,6 +266,8 @@
 |`cusolverDnSgebrd_bufferSize`| | | | | | | | | | |
 |`cusolverDnSgeqrf`| | | | | | | | | | |
 |`cusolverDnSgeqrf_bufferSize`| | | | | | | | | | |
+|`cusolverDnSgesvd`| | | | | | | | | | |
+|`cusolverDnSgesvd_bufferSize`| | | | | | | | | | |
 |`cusolverDnSgetrf`| | | | | | | | | | |
 |`cusolverDnSgetrf_bufferSize`| | | | | | | | | | |
 |`cusolverDnSgetrs`| | | | | | | | | | |
@@ -322,6 +328,8 @@
 |`cusolverDnZgebrd_bufferSize`| | | | | | | | | | |
 |`cusolverDnZgeqrf`| | | | | | | | | | |
 |`cusolverDnZgeqrf_bufferSize`| | | | | | | | | | |
+|`cusolverDnZgesvd`| | | | | | | | | | |
+|`cusolverDnZgesvd_bufferSize`| | | | | | | | | | |
 |`cusolverDnZgetrf`| | | | | | | | | | |
 |`cusolverDnZgetrf_bufferSize`| | | | | | | | | | |
 |`cusolverDnZgetrs`| | | | | | | | | | |

--- a/src/CUDA2HIP_SOLVER_API_functions.cpp
+++ b/src/CUDA2HIP_SOLVER_API_functions.cpp
@@ -311,6 +311,16 @@ const std::map<llvm::StringRef, hipCounter> CUDA_SOLVER_FUNCTION_MAP {
   {"cusolverDnDormtr",                                   {"hipsolverDnDormtr",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
   {"cusolverDnCunmtr",                                   {"hipsolverDnCunmtr",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
   {"cusolverDnZunmtr",                                   {"hipsolverDnZunmtr",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
+  // NOTE: rocsolver_(s|d|c|z)gesvd have a harness of other HIP and ROC API calls
+  {"cusolverDnSgesvd_bufferSize",                        {"hipsolverDnSgesvd_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
+  {"cusolverDnDgesvd_bufferSize",                        {"hipsolverDnDgesvd_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
+  {"cusolverDnCgesvd_bufferSize",                        {"hipsolverDnCgesvd_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
+  {"cusolverDnZgesvd_bufferSize",                        {"hipsolverDnZgesvd_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
+  // NOTE: rocsolver_(s|d|c|z)gesvd have a harness of other HIP and ROC API calls
+  {"cusolverDnSgesvd",                                   {"hipsolverDnSgesvd",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
+  {"cusolverDnDgesvd",                                   {"hipsolverDnDgesvd",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
+  {"cusolverDnCgesvd",                                   {"hipsolverDnCgesvd",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
+  {"cusolverDnZgesvd",                                   {"hipsolverDnZgesvd",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
 };
 
 const std::map<llvm::StringRef, cudaAPIversions> CUDA_SOLVER_FUNCTION_VER_MAP {
@@ -630,6 +640,14 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_SOLVER_FUNCTION_VER_MAP {
   {"hipsolverDnDormtr",                                   {HIP_5010, HIP_0,    HIP_0,  HIP_LATEST}},
   {"hipsolverDnCunmtr",                                   {HIP_5010, HIP_0,    HIP_0,  HIP_LATEST}},
   {"hipsolverDnZunmtr",                                   {HIP_5010, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipsolverDnSgesvd_bufferSize",                        {HIP_5010, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipsolverDnDgesvd_bufferSize",                        {HIP_5010, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipsolverDnCgesvd_bufferSize",                        {HIP_5010, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipsolverDnZgesvd_bufferSize",                        {HIP_5010, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipsolverDnSgesvd",                                   {HIP_5010, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipsolverDnDgesvd",                                   {HIP_5010, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipsolverDnCgesvd",                                   {HIP_5010, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipsolverDnZgesvd",                                   {HIP_5010, HIP_0,    HIP_0,  HIP_LATEST}},
 
   {"rocsolver_spotrf",                                    {HIP_3020, HIP_0,    HIP_0,  HIP_LATEST}},
   {"rocsolver_dpotrf",                                    {HIP_3020, HIP_0,    HIP_0,  HIP_LATEST}},

--- a/tests/unit_tests/synthetic/libraries/cusolver2hipsolver.cu
+++ b/tests/unit_tests/synthetic/libraries/cusolver2hipsolver.cu
@@ -16,6 +16,8 @@ int main() {
   int lda = 0;
   int ldb = 0;
   int ldc = 0;
+  int ldu = 0;
+  int ldvt = 0;
   int Lwork = 0;
   int devIpiv = 0;
   int devInfo = 0;
@@ -27,6 +29,9 @@ int main() {
   float fC = 0.f;
   float fD = 0.f;
   float fE = 0.f;
+  float fS = 0.f;
+  float fU = 0.f;
+  float fVT = 0.f;
   float fX = 0.f;
   float fTAU = 0.f;
   float fTAUQ = 0.f;
@@ -36,25 +41,33 @@ int main() {
   double dC = 0.f;
   double dD = 0.f;
   double dE = 0.f;
+  double dS = 0.f;
+  double dU = 0.f;
+  double dVT = 0.f;
   double dX = 0.f;
   double dTAU = 0.f;
   double dTAUQ = 0.f;
   double dTAUP = 0.f;
   float fWorkspace = 0.f;
+  float frWork = 0.f;
   double dWorkspace = 0.f;
+  double drWork = 0.f;
   void *Workspace = nullptr;
   size_t lwork_bytes = 0;
+
+  signed char jobu = 0;
+  signed char jobvt = 0;
 
   float** fAarray = 0;
   float** fBarray = 0;
   double** dAarray = 0;
   double** dBarray = 0;
 
-  // CHECK: hipDoubleComplex dComplexA, dComplexB, dComplexC, dComplexD, dComplexE, dComplexX, dComplexWorkspace, dComplexTAU, dComplexTAUQ, dComplexTAUP;
-  cuDoubleComplex dComplexA, dComplexB, dComplexC, dComplexD, dComplexE, dComplexX, dComplexWorkspace, dComplexTAU, dComplexTAUQ, dComplexTAUP;
+  // CHECK: hipDoubleComplex dComplexA, dComplexB, dComplexC, dComplexD, dComplexE, dComplexS, dComplexU, dComplexVT, dComplexX, dComplexWorkspace, dComplexrWork, dComplexTAU, dComplexTAUQ, dComplexTAUP;
+  cuDoubleComplex dComplexA, dComplexB, dComplexC, dComplexD, dComplexE, dComplexS, dComplexU, dComplexVT, dComplexX, dComplexWorkspace, dComplexrWork, dComplexTAU, dComplexTAUQ, dComplexTAUP;
 
-  // CHECK: hipComplex complexA, complexB, complexC, complexD, complexE, complexX, complexWorkspace, complexTAU, complexTAUQ, complexTAUP;
-  cuComplex complexA, complexB, complexC, complexD, complexE, complexX, complexWorkspace, complexTAU, complexTAUQ, complexTAUP;
+  // CHECK: hipComplex complexA, complexB, complexC, complexD, complexE, complexS, complexU, complexVT, complexX, complexWorkspace, complexrWork, complexTAU, complexTAUQ, complexTAUP;
+  cuComplex complexA, complexB, complexC, complexD, complexE, complexS, complexU, complexVT, complexX, complexWorkspace, complexrWork, complexTAU, complexTAUQ, complexTAUP;
 
   // CHECK: hipDoubleComplex** dcomplexAarray = 0;
   // CHECK-NEXT: hipDoubleComplex** dcomplexBarray = 0;
@@ -373,6 +386,46 @@ int main() {
   // HIP: HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDnDsytrd(hipsolverHandle_t handle, hipblasFillMode_t uplo, int n, double* A, int lda, double* D, double* E, double* tau, double* work, int lwork, int* devInfo);
   // CHECK: status = hipsolverDnDsytrd(handle, fillMode, n, &dA, lda, &dD, &dE, &dTAU, &dWorkspace, Lwork, &info);
   status = cusolverDnDsytrd(handle, fillMode, n, &dA, lda, &dD, &dE, &dTAU, &dWorkspace, Lwork, &info);
+
+  // CUDA: cusolverStatus_t CUSOLVERAPI cusolverDnSgesvd_bufferSize(cusolverDnHandle_t handle, int m, int n, int * lwork);
+  // HIP: HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDnSgesvd_bufferSize(hipsolverHandle_t handle, int m, int n, int* lwork);
+  // CHECK: status = hipsolverDnSgesvd_bufferSize(handle, m, n, &Lwork);
+  status = cusolverDnSgesvd_bufferSize(handle, m, n, &Lwork);
+
+  // CUDA: cusolverStatus_t CUSOLVERAPI cusolverDnDgesvd_bufferSize(cusolverDnHandle_t handle, int m, int n, int * lwork);
+  // HIP: HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDnDgesvd_bufferSize(hipsolverHandle_t handle, int m, int n, int* lwork);
+  // CHECK: status = hipsolverDnDgesvd_bufferSize(handle, m, n, &Lwork);
+  status = cusolverDnDgesvd_bufferSize(handle, m, n, &Lwork);
+
+  // CUDA: cusolverStatus_t CUSOLVERAPI cusolverDnCgesvd_bufferSize(cusolverDnHandle_t handle, int m, int n, int * lwork);
+  // HIP: HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDnCgesvd_bufferSize(hipsolverHandle_t handle, int m, int n, int* lwork);
+  // CHECK: status = hipsolverDnCgesvd_bufferSize(handle, m, n, &Lwork);
+  status = cusolverDnCgesvd_bufferSize(handle, m, n, &Lwork);
+
+  // CUDA: cusolverStatus_t CUSOLVERAPI cusolverDnZgesvd_bufferSize(cusolverDnHandle_t handle, int m, int n, int * lwork);
+  // HIP: HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDnZgesvd_bufferSize(hipsolverHandle_t handle, int m, int n, int* lwork);
+  // CHECK: status = hipsolverDnZgesvd_bufferSize(handle, m, n, &Lwork);
+  status = cusolverDnZgesvd_bufferSize(handle, m, n, &Lwork);
+
+  // CUDA: cusolverStatus_t CUSOLVERAPI cusolverDnSgesvd(cusolverDnHandle_t handle, signed char jobu, signed char jobvt, int m, int n, float * A, int lda, float * S, float * U, int ldu, float * VT, int ldvt, float * work, int lwork, float * rwork, int * info);
+  // HIP: HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDnSgesvd(hipsolverHandle_t handle, signed char jobu, signed char jobv, int m, int n, float* A, int lda, float* S, float* U, int ldu, float* V, int ldv, float* work, int lwork, float* rwork, int* devInfo);
+  // CHECK: status = hipsolverDnSgesvd(handle, jobu, jobvt, m, n, &fA, lda, &fS, &fU, ldu, &fVT, ldvt, &fWorkspace, Lwork, &frWork, &info);
+  status = cusolverDnSgesvd(handle, jobu, jobvt, m, n, &fA, lda, &fS, &fU, ldu, &fVT, ldvt, &fWorkspace, Lwork, &frWork, &info);
+
+  // CUDA: cusolverStatus_t CUSOLVERAPI cusolverDnDgesvd(cusolverDnHandle_t handle, signed char jobu, signed char jobvt, int m, int n, double * A, int lda, double * S, double * U, int ldu, double * VT, int ldvt, double * work, int lwork, double * rwork, int * info);
+  // HIP: HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDnDgesvd(hipsolverHandle_t handle, signed char jobu, signed char jobv, int m, int n, double* A, int lda, double* S, double* U, int ldu, double* V, int ldv, double* work, int lwork, double* rwork, int* devInfo);
+  // CHECK: status = hipsolverDnDgesvd(handle, jobu, jobvt, m, n, &dA, lda, &dS, &dU, ldu, &dVT, ldvt, &dWorkspace, Lwork, &drWork, &info);
+  status = cusolverDnDgesvd(handle, jobu, jobvt, m, n, &dA, lda, &dS, &dU, ldu, &dVT, ldvt, &dWorkspace, Lwork, &drWork, &info);
+
+  // CUDA: cusolverStatus_t CUSOLVERAPI cusolverDnCgesvd(cusolverDnHandle_t handle, signed char jobu, signed char jobvt, int m, int n, cuComplex * A, int lda, float * S, cuComplex * U, int ldu, cuComplex * VT, int ldvt, cuComplex * work, int lwork, float * rwork, int * info);
+  // HIP: HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDnCgesvd(hipsolverHandle_t handle, signed char jobu, signed char jobv, int m, int n, hipFloatComplex* A, int lda, float* S, hipFloatComplex* U, int ldu, hipFloatComplex* V, int ldv, hipFloatComplex* work, int lwork, float* rwork, int* devInfo);
+  // CHECK: status = hipsolverDnCgesvd(handle, jobu, jobvt, m, n, &complexA, lda, &fS, &complexU, ldu, &complexVT, ldvt, &complexWorkspace, Lwork, &frWork, &info);
+  status = cusolverDnCgesvd(handle, jobu, jobvt, m, n, &complexA, lda, &fS, &complexU, ldu, &complexVT, ldvt, &complexWorkspace, Lwork, &frWork, &info);
+
+  // CUDA: cusolverStatus_t CUSOLVERAPI cusolverDnZgesvd(cusolverDnHandle_t handle, signed char jobu, signed char jobvt, int m, int n, cuDoubleComplex * A, int lda, double * S, cuDoubleComplex * U, int ldu, cuDoubleComplex * VT, int ldvt, cuDoubleComplex * work, int lwork, double * rwork, int * info);
+  // HIP: HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDnZgesvd(hipsolverHandle_t handle, signed char jobu, signed char jobv, int m, int n, hipDoubleComplex* A, int lda, double* S, hipDoubleComplex* U, int ldu, hipDoubleComplex* V, int ldv, hipDoubleComplex* work, int lwork, double* rwork, int* devInfo);
+  // CHECK: status = hipsolverDnZgesvd(handle, jobu, jobvt, m, n, &dComplexA, lda, &dS, &dComplexU, ldu, &dComplexVT, ldvt, &dComplexWorkspace, Lwork, &drWork, &info);
+  status = cusolverDnZgesvd(handle, jobu, jobvt, m, n, &dComplexA, lda, &dS, &dComplexU, ldu, &dComplexVT, ldvt, &dComplexWorkspace, Lwork, &drWork, &info);
 
 #if CUDA_VERSION >= 8000
   // CHECK: hipsolverEigType_t eigType;


### PR DESCRIPTION
+ `cusolverDn(S|D|C|Z)gesvd_(bufferSize)?` are `SUPPORTED` by `hipSOLVER` only
+ [NOTE] `rocsolver_(s|d|c|z)gesvd` have a harness of other HIP and ROC API calls, thus `UNSUPPORTED`
+ Updated `SOLVER` synthetic tests, the regenerated `hipify-perl`, and `SOLVER` `CUDA2HIP` documentation