### PR TITLE
[HIPIFY][#675][#677][SOLVER][feature] `cuSOLVER` support - Step 37 - Functions (DN)

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -1101,6 +1101,8 @@ my %experimental_funcs = (
     "cusolverDnZpotrf" => "6.1.0",
     "cusolverDnZhetrd_bufferSize" => "6.1.0",
     "cusolverDnZhetrd" => "6.1.0",
+    "cusolverDnZheevdx_bufferSize" => "6.1.0",
+    "cusolverDnZheevdx" => "6.1.0",
     "cusolverDnZheevd_bufferSize" => "6.1.0",
     "cusolverDnZheevd" => "6.1.0",
     "cusolverDnZgetrs" => "6.1.0",
@@ -1120,6 +1122,8 @@ my %experimental_funcs = (
     "cusolverDnSsytrf" => "6.1.0",
     "cusolverDnSsytrd_bufferSize" => "6.1.0",
     "cusolverDnSsytrd" => "6.1.0",
+    "cusolverDnSsyevdx_bufferSize" => "6.1.0",
+    "cusolverDnSsyevdx" => "6.1.0",
     "cusolverDnSsyevd_bufferSize" => "6.1.0",
     "cusolverDnSsyevd" => "6.1.0",
     "cusolverDnSpotrsBatched" => "6.1.0",
@@ -1159,6 +1163,8 @@ my %experimental_funcs = (
     "cusolverDnDsytrf" => "6.1.0",
     "cusolverDnDsytrd_bufferSize" => "6.1.0",
     "cusolverDnDsytrd" => "6.1.0",
+    "cusolverDnDsyevdx_bufferSize" => "6.1.0",
+    "cusolverDnDsyevdx" => "6.1.0",
     "cusolverDnDsyevd_bufferSize" => "6.1.0",
     "cusolverDnDsyevd" => "6.1.0",
     "cusolverDnDpotrsBatched" => "6.1.0",
@@ -1214,6 +1220,8 @@ my %experimental_funcs = (
     "cusolverDnCpotrf" => "6.1.0",
     "cusolverDnChetrd_bufferSize" => "6.1.0",
     "cusolverDnChetrd" => "6.1.0",
+    "cusolverDnCheevdx_bufferSize" => "6.1.0",
+    "cusolverDnCheevdx" => "6.1.0",
     "cusolverDnCheevd_bufferSize" => "6.1.0",
     "cusolverDnCheevd" => "6.1.0",
     "cusolverDnCgetrs" => "6.1.0",
@@ -1399,6 +1407,8 @@ sub experimentalSubstitutions {
     subst("cusolverDnCgetrs", "hipsolverDnCgetrs", "library");
     subst("cusolverDnCheevd", "hipsolverDnCheevd", "library");
     subst("cusolverDnCheevd_bufferSize", "hipsolverDnCheevd_bufferSize", "library");
+    subst("cusolverDnCheevdx", "hipsolverDnCheevdx", "library");
+    subst("cusolverDnCheevdx_bufferSize", "hipsolverDnCheevdx_bufferSize", "library");
     subst("cusolverDnChetrd", "hipsolverDnChetrd", "library");
     subst("cusolverDnChetrd_bufferSize", "hipsolverDnChetrd_bufferSize", "library");
     subst("cusolverDnCpotrf", "hipsolverDnCpotrf", "library");
@@ -1454,6 +1464,8 @@ sub experimentalSubstitutions {
     subst("cusolverDnDpotrsBatched", "hipsolverDnDpotrsBatched", "library");
     subst("cusolverDnDsyevd", "hipsolverDnDsyevd", "library");
     subst("cusolverDnDsyevd_bufferSize", "hipsolverDnDsyevd_bufferSize", "library");
+    subst("cusolverDnDsyevdx", "hipsolverDnDsyevdx", "library");
+    subst("cusolverDnDsyevdx_bufferSize", "hipsolverDnDsyevdx_bufferSize", "library");
     subst("cusolverDnDsytrd", "hipsolverDnDsytrd", "library");
     subst("cusolverDnDsytrd_bufferSize", "hipsolverDnDsytrd_bufferSize", "library");
     subst("cusolverDnDsytrf", "hipsolverDnDsytrf", "library");
@@ -1492,6 +1504,8 @@ sub experimentalSubstitutions {
     subst("cusolverDnSpotrsBatched", "hipsolverDnSpotrsBatched", "library");
     subst("cusolverDnSsyevd", "hipsolverDnSsyevd", "library");
     subst("cusolverDnSsyevd_bufferSize", "hipsolverDnSsyevd_bufferSize", "library");
+    subst("cusolverDnSsyevdx", "hipsolverDnSsyevdx", "library");
+    subst("cusolverDnSsyevdx_bufferSize", "hipsolverDnSsyevdx_bufferSize", "library");
     subst("cusolverDnSsytrd", "hipsolverDnSsytrd", "library");
     subst("cusolverDnSsytrd_bufferSize", "hipsolverDnSsytrd_bufferSize", "library");
     subst("cusolverDnSsytrf", "hipsolverDnSsytrf", "library");
@@ -1511,6 +1525,8 @@ sub experimentalSubstitutions {
     subst("cusolverDnZgetrs", "hipsolverDnZgetrs", "library");
     subst("cusolverDnZheevd", "hipsolverDnZheevd", "library");
     subst("cusolverDnZheevd_bufferSize", "hipsolverDnZheevd_bufferSize", "library");
+    subst("cusolverDnZheevdx", "hipsolverDnZheevdx", "library");
+    subst("cusolverDnZheevdx_bufferSize", "hipsolverDnZheevdx_bufferSize", "library");
     subst("cusolverDnZhetrd", "hipsolverDnZhetrd", "library");
     subst("cusolverDnZhetrd_bufferSize", "hipsolverDnZhetrd_bufferSize", "library");
     subst("cusolverDnZpotrf", "hipsolverDnZpotrf", "library");

--- a/docs/tables/CUSOLVER_API_supported_by_HIP.md
+++ b/docs/tables/CUSOLVER_API_supported_by_HIP.md
@@ -135,6 +135,8 @@
 |`cusolverDnCgetrs`| | | | |`hipsolverDnCgetrs`|5.1.0| | | |6.1.0|
 |`cusolverDnCheevd`|8.0| | | |`hipsolverDnCheevd`|5.1.0| | | |6.1.0|
 |`cusolverDnCheevd_bufferSize`|8.0| | | |`hipsolverDnCheevd_bufferSize`|5.1.0| | | |6.1.0|
+|`cusolverDnCheevdx`|10.1| | | |`hipsolverDnCheevdx`|5.3.0| | | |6.1.0|
+|`cusolverDnCheevdx_bufferSize`|10.1| | | |`hipsolverDnCheevdx_bufferSize`|5.3.0| | | |6.1.0|
 |`cusolverDnChetrd`|8.0| | | |`hipsolverDnChetrd`|5.1.0| | | |6.1.0|
 |`cusolverDnChetrd_bufferSize`|8.0| | | |`hipsolverDnChetrd_bufferSize`|5.1.0| | | |6.1.0|
 |`cusolverDnClaswp`| | | | | | | | | | |
@@ -215,6 +217,8 @@
 |`cusolverDnDpotrsBatched`|9.1| | | |`hipsolverDnDpotrsBatched`|5.1.0| | | |6.1.0|
 |`cusolverDnDsyevd`|8.0| | | |`hipsolverDnDsyevd`|5.1.0| | | |6.1.0|
 |`cusolverDnDsyevd_bufferSize`|8.0| | | |`hipsolverDnDsyevd_bufferSize`|5.1.0| | | |6.1.0|
+|`cusolverDnDsyevdx`|10.1| | | |`hipsolverDnDsyevdx`|5.3.0| | | |6.1.0|
+|`cusolverDnDsyevdx_bufferSize`|10.1| | | |`hipsolverDnDsyevdx_bufferSize`|5.3.0| | | |6.1.0|
 |`cusolverDnDsytrd`| | | | |`hipsolverDnDsytrd`|5.1.0| | | |6.1.0|
 |`cusolverDnDsytrd_bufferSize`|8.0| | | |`hipsolverDnDsytrd_bufferSize`|5.1.0| | | |6.1.0|
 |`cusolverDnDsytrf`| | | | |`hipsolverDnDsytrf`|5.1.0| | | |6.1.0|
@@ -297,6 +301,8 @@
 |`cusolverDnSpotrsBatched`|9.1| | | |`hipsolverDnSpotrsBatched`|5.1.0| | | |6.1.0|
 |`cusolverDnSsyevd`|8.0| | | |`hipsolverDnSsyevd`|5.1.0| | | |6.1.0|
 |`cusolverDnSsyevd_bufferSize`|8.0| | | |`hipsolverDnSsyevd_bufferSize`|5.1.0| | | |6.1.0|
+|`cusolverDnSsyevdx`|10.1| | | |`hipsolverDnSsyevdx`|5.3.0| | | |6.1.0|
+|`cusolverDnSsyevdx_bufferSize`|10.1| | | |`hipsolverDnSsyevdx_bufferSize`|5.3.0| | | |6.1.0|
 |`cusolverDnSsytrd`| | | | |`hipsolverDnSsytrd`|5.1.0| | | |6.1.0|
 |`cusolverDnSsytrd_bufferSize`|8.0| | | |`hipsolverDnSsytrd_bufferSize`|5.1.0| | | |6.1.0|
 |`cusolverDnSsytrf`| | | | |`hipsolverDnSsytrf`|5.1.0| | | |6.1.0|
@@ -341,6 +347,8 @@
 |`cusolverDnZgetrs`| | | | |`hipsolverDnZgetrs`|5.1.0| | | |6.1.0|
 |`cusolverDnZheevd`|8.0| | | |`hipsolverDnZheevd`|5.1.0| | | |6.1.0|
 |`cusolverDnZheevd_bufferSize`|8.0| | | |`hipsolverDnZheevd_bufferSize`|5.1.0| | | |6.1.0|
+|`cusolverDnZheevdx`|10.1| | | |`hipsolverDnZheevdx`|5.3.0| | | |6.1.0|
+|`cusolverDnZheevdx_bufferSize`|10.1| | | |`hipsolverDnZheevdx_bufferSize`|5.3.0| | | |6.1.0|
 |`cusolverDnZhetrd`|8.0| | | |`hipsolverDnZhetrd`|5.1.0| | | |6.1.0|
 |`cusolverDnZhetrd_bufferSize`|8.0| | | |`hipsolverDnZhetrd_bufferSize`|5.1.0| | | |6.1.0|
 |`cusolverDnZlaswp`| | | | | | | | | | |

--- a/docs/tables/CUSOLVER_API_supported_by_HIP_and_ROC.md
+++ b/docs/tables/CUSOLVER_API_supported_by_HIP_and_ROC.md
@@ -135,6 +135,8 @@
 |`cusolverDnCgetrs`| | | | |`hipsolverDnCgetrs`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnCheevd`|8.0| | | |`hipsolverDnCheevd`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnCheevd_bufferSize`|8.0| | | |`hipsolverDnCheevd_bufferSize`|5.1.0| | | |6.1.0| | | | | | |
+|`cusolverDnCheevdx`|10.1| | | |`hipsolverDnCheevdx`|5.3.0| | | |6.1.0| | | | | | |
+|`cusolverDnCheevdx_bufferSize`|10.1| | | |`hipsolverDnCheevdx_bufferSize`|5.3.0| | | |6.1.0| | | | | | |
 |`cusolverDnChetrd`|8.0| | | |`hipsolverDnChetrd`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnChetrd_bufferSize`|8.0| | | |`hipsolverDnChetrd_bufferSize`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnClaswp`| | | | | | | | | | | | | | | | |
@@ -215,6 +217,8 @@
 |`cusolverDnDpotrsBatched`|9.1| | | |`hipsolverDnDpotrsBatched`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnDsyevd`|8.0| | | |`hipsolverDnDsyevd`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnDsyevd_bufferSize`|8.0| | | |`hipsolverDnDsyevd_bufferSize`|5.1.0| | | |6.1.0| | | | | | |
+|`cusolverDnDsyevdx`|10.1| | | |`hipsolverDnDsyevdx`|5.3.0| | | |6.1.0| | | | | | |
+|`cusolverDnDsyevdx_bufferSize`|10.1| | | |`hipsolverDnDsyevdx_bufferSize`|5.3.0| | | |6.1.0| | | | | | |
 |`cusolverDnDsytrd`| | | | |`hipsolverDnDsytrd`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnDsytrd_bufferSize`|8.0| | | |`hipsolverDnDsytrd_bufferSize`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnDsytrf`| | | | |`hipsolverDnDsytrf`|5.1.0| | | |6.1.0| | | | | | |
@@ -297,6 +301,8 @@
 |`cusolverDnSpotrsBatched`|9.1| | | |`hipsolverDnSpotrsBatched`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnSsyevd`|8.0| | | |`hipsolverDnSsyevd`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnSsyevd_bufferSize`|8.0| | | |`hipsolverDnSsyevd_bufferSize`|5.1.0| | | |6.1.0| | | | | | |
+|`cusolverDnSsyevdx`|10.1| | | |`hipsolverDnSsyevdx`|5.3.0| | | |6.1.0| | | | | | |
+|`cusolverDnSsyevdx_bufferSize`|10.1| | | |`hipsolverDnSsyevdx_bufferSize`|5.3.0| | | |6.1.0| | | | | | |
 |`cusolverDnSsytrd`| | | | |`hipsolverDnSsytrd`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnSsytrd_bufferSize`|8.0| | | |`hipsolverDnSsytrd_bufferSize`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnSsytrf`| | | | |`hipsolverDnSsytrf`|5.1.0| | | |6.1.0| | | | | | |
@@ -341,6 +347,8 @@
 |`cusolverDnZgetrs`| | | | |`hipsolverDnZgetrs`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnZheevd`|8.0| | | |`hipsolverDnZheevd`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnZheevd_bufferSize`|8.0| | | |`hipsolverDnZheevd_bufferSize`|5.1.0| | | |6.1.0| | | | | | |
+|`cusolverDnZheevdx`|10.1| | | |`hipsolverDnZheevdx`|5.3.0| | | |6.1.0| | | | | | |
+|`cusolverDnZheevdx_bufferSize`|10.1| | | |`hipsolverDnZheevdx_bufferSize`|5.3.0| | | |6.1.0| | | | | | |
 |`cusolverDnZhetrd`|8.0| | | |`hipsolverDnZhetrd`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnZhetrd_bufferSize`|8.0| | | |`hipsolverDnZhetrd_bufferSize`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnZlaswp`| | | | | | | | | | | | | | | | |

--- a/docs/tables/CUSOLVER_API_supported_by_ROC.md
+++ b/docs/tables/CUSOLVER_API_supported_by_ROC.md
@@ -135,6 +135,8 @@
 |`cusolverDnCgetrs`| | | | | | | | | | |
 |`cusolverDnCheevd`|8.0| | | | | | | | | |
 |`cusolverDnCheevd_bufferSize`|8.0| | | | | | | | | |
+|`cusolverDnCheevdx`|10.1| | | | | | | | | |
+|`cusolverDnCheevdx_bufferSize`|10.1| | | | | | | | | |
 |`cusolverDnChetrd`|8.0| | | | | | | | | |
 |`cusolverDnChetrd_bufferSize`|8.0| | | | | | | | | |
 |`cusolverDnClaswp`| | | | | | | | | | |
@@ -215,6 +217,8 @@
 |`cusolverDnDpotrsBatched`|9.1| | | | | | | | | |
 |`cusolverDnDsyevd`|8.0| | | | | | | | | |
 |`cusolverDnDsyevd_bufferSize`|8.0| | | | | | | | | |
+|`cusolverDnDsyevdx`|10.1| | | | | | | | | |
+|`cusolverDnDsyevdx_bufferSize`|10.1| | | | | | | | | |
 |`cusolverDnDsytrd`| | | | | | | | | | |
 |`cusolverDnDsytrd_bufferSize`|8.0| | | | | | | | | |
 |`cusolverDnDsytrf`| | | | | | | | | | |
@@ -297,6 +301,8 @@
 |`cusolverDnSpotrsBatched`|9.1| | | | | | | | | |
 |`cusolverDnSsyevd`|8.0| | | | | | | | | |
 |`cusolverDnSsyevd_bufferSize`|8.0| | | | | | | | | |
+|`cusolverDnSsyevdx`|10.1| | | | | | | | | |
+|`cusolverDnSsyevdx_bufferSize`|10.1| | | | | | | | | |
 |`cusolverDnSsytrd`| | | | | | | | | | |
 |`cusolverDnSsytrd_bufferSize`|8.0| | | | | | | | | |
 |`cusolverDnSsytrf`| | | | | | | | | | |
@@ -341,6 +347,8 @@
 |`cusolverDnZgetrs`| | | | | | | | | | |
 |`cusolverDnZheevd`|8.0| | | | | | | | | |
 |`cusolverDnZheevd_bufferSize`|8.0| | | | | | | | | |
+|`cusolverDnZheevdx`|10.1| | | | | | | | | |
+|`cusolverDnZheevdx_bufferSize`|10.1| | | | | | | | | |
 |`cusolverDnZhetrd`|8.0| | | | | | | | | |
 |`cusolverDnZhetrd_bufferSize`|8.0| | | | | | | | | |
 |`cusolverDnZlaswp`| | | | | | | | | | |

--- a/src/CUDA2HIP_SOLVER_API_functions.cpp
+++ b/src/CUDA2HIP_SOLVER_API_functions.cpp
@@ -321,7 +321,7 @@ const std::map<llvm::StringRef, hipCounter> CUDA_SOLVER_FUNCTION_MAP {
   {"cusolverDnDgesvd",                                   {"hipsolverDnDgesvd",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
   {"cusolverDnCgesvd",                                   {"hipsolverDnCgesvd",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
   {"cusolverDnZgesvd",                                   {"hipsolverDnZgesvd",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
-  // NOTE: rocsolver_(s|d|c|z)gesvd have a harness of other HIP and ROC API calls
+  // NOTE: rocsolver_(s|d)syevd and rocsolver_(c|z)heevd have a harness of other HIP and ROC API calls
   {"cusolverDnSsyevd_bufferSize",                        {"hipsolverDnSsyevd_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
   {"cusolverDnDsyevd_bufferSize",                        {"hipsolverDnDsyevd_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
   {"cusolverDnCheevd_bufferSize",                        {"hipsolverDnCheevd_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
@@ -331,6 +331,16 @@ const std::map<llvm::StringRef, hipCounter> CUDA_SOLVER_FUNCTION_MAP {
   {"cusolverDnDsyevd",                                   {"hipsolverDnDsyevd",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
   {"cusolverDnCheevd",                                   {"hipsolverDnCheevd",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
   {"cusolverDnZheevd",                                   {"hipsolverDnZheevd",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
+  // NOTE: rocsolver_(s|d)syevdx_inplace and rocsolver_(c|z)yevdx_inplace have a harness of other ROC API calls
+  {"cusolverDnSsyevdx_bufferSize",                       {"hipsolverDnSsyevdx_bufferSize",                         "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
+  {"cusolverDnDsyevdx_bufferSize",                       {"hipsolverDnDsyevdx_bufferSize",                         "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
+  {"cusolverDnCheevdx_bufferSize",                       {"hipsolverDnCheevdx_bufferSize",                         "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
+  {"cusolverDnZheevdx_bufferSize",                       {"hipsolverDnZheevdx_bufferSize",                         "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
+  // NOTE: rocsolver_(s|d)syevdx_inplace and rocsolver_(c|z)yevdx_inplace have a harness of other ROC and HIP API calls
+  {"cusolverDnSsyevdx",                                  {"hipsolverDnSsyevdx",                                    "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
+  {"cusolverDnDsyevdx",                                  {"hipsolverDnDsyevdx",                                    "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
+  {"cusolverDnCheevdx",                                  {"hipsolverDnCheevdx",                                    "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
+  {"cusolverDnZheevdx",                                  {"hipsolverDnZheevdx",                                    "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
 };
 
 const std::map<llvm::StringRef, cudaAPIversions> CUDA_SOLVER_FUNCTION_VER_MAP {
@@ -523,6 +533,14 @@ const std::map<llvm::StringRef, cudaAPIversions> CUDA_SOLVER_FUNCTION_VER_MAP {
   {"cusolverDnDsyevd",                                    {CUDA_80,   CUDA_0, CUDA_0}},
   {"cusolverDnCheevd",                                    {CUDA_80,   CUDA_0, CUDA_0}},
   {"cusolverDnZheevd",                                    {CUDA_80,   CUDA_0, CUDA_0}},
+  {"cusolverDnSsyevdx_bufferSize",                        {CUDA_101,  CUDA_0, CUDA_0}},
+  {"cusolverDnDsyevdx_bufferSize",                        {CUDA_101,  CUDA_0, CUDA_0}},
+  {"cusolverDnCheevdx_bufferSize",                        {CUDA_101,  CUDA_0, CUDA_0}},
+  {"cusolverDnZheevdx_bufferSize",                        {CUDA_101,  CUDA_0, CUDA_0}},
+  {"cusolverDnSsyevdx",                                   {CUDA_101,  CUDA_0, CUDA_0}},
+  {"cusolverDnDsyevdx",                                   {CUDA_101,  CUDA_0, CUDA_0}},
+  {"cusolverDnCheevdx",                                   {CUDA_101,  CUDA_0, CUDA_0}},
+  {"cusolverDnZheevdx",                                   {CUDA_101,  CUDA_0, CUDA_0}},
 };
 
 const std::map<llvm::StringRef, hipAPIversions> HIP_SOLVER_FUNCTION_VER_MAP {
@@ -674,6 +692,14 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_SOLVER_FUNCTION_VER_MAP {
   {"hipsolverDnDsyevd",                                   {HIP_5010, HIP_0,    HIP_0,  HIP_LATEST}},
   {"hipsolverDnCheevd",                                   {HIP_5010, HIP_0,    HIP_0,  HIP_LATEST}},
   {"hipsolverDnZheevd",                                   {HIP_5010, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipsolverDnSsyevdx_bufferSize",                       {HIP_5030, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipsolverDnDsyevdx_bufferSize",                       {HIP_5030, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipsolverDnCheevdx_bufferSize",                       {HIP_5030, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipsolverDnZheevdx_bufferSize",                       {HIP_5030, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipsolverDnSsyevdx",                                  {HIP_5030, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipsolverDnDsyevdx",                                  {HIP_5030, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipsolverDnCheevdx",                                  {HIP_5030, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipsolverDnZheevdx",                                  {HIP_5030, HIP_0,    HIP_0,  HIP_LATEST}},
 
   {"rocsolver_spotrf",                                    {HIP_3020, HIP_0,    HIP_0,  HIP_LATEST}},
   {"rocsolver_dpotrf",                                    {HIP_3020, HIP_0,    HIP_0,  HIP_LATEST}},

--- a/tests/unit_tests/synthetic/libraries/cusolver2hipsolver.cu
+++ b/tests/unit_tests/synthetic/libraries/cusolver2hipsolver.cu
@@ -12,6 +12,9 @@ int main() {
   int m = 0;
   int n = 0;
   int k = 0;
+  int il = 0;
+  int iu = 0;
+  int imeig = 0;
   int nrhs = 0;
   int lda = 0;
   int ldb = 0;
@@ -31,6 +34,8 @@ int main() {
   float fE = 0.f;
   float fS = 0.f;
   float fU = 0.f;
+  float fvl = 0.f;
+  float fvu = 0.f;
   float fVT = 0.f;
   float fX = 0.f;
   float fW = 0.f;
@@ -44,6 +49,8 @@ int main() {
   double dE = 0.f;
   double dS = 0.f;
   double dU = 0.f;
+  double dvl = 0.f;
+  double dvu = 0.f;
   double dVT = 0.f;
   double dX = 0.f;
   double dW = 0.f;
@@ -439,10 +446,10 @@ int main() {
   cusolverEigType_t EIG_TYPE_2 = CUSOLVER_EIG_TYPE_2;
   cusolverEigType_t EIG_TYPE_3 = CUSOLVER_EIG_TYPE_3;
 
-  // CHECK: hipsolverEigMode_t eigMode;
+  // CHECK: hipsolverEigMode_t eigMode, jobz;
   // CHECK-NEXT: hipsolverEigMode_t SOLVER_EIG_MODE_NOVECTOR = HIPSOLVER_EIG_MODE_NOVECTOR;
   // CHECK-NEXT: hipsolverEigMode_t SOLVER_EIG_MODE_VECTOR = HIPSOLVER_EIG_MODE_VECTOR;
-  cusolverEigMode_t eigMode;
+  cusolverEigMode_t eigMode, jobz;
   cusolverEigMode_t SOLVER_EIG_MODE_NOVECTOR = CUSOLVER_EIG_MODE_NOVECTOR;
   cusolverEigMode_t SOLVER_EIG_MODE_VECTOR = CUSOLVER_EIG_MODE_VECTOR;
 
@@ -816,6 +823,46 @@ int main() {
   // HIP: HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDnZpotri(hipsolverHandle_t handle, hipblasFillMode_t uplo, int n, hipDoubleComplex* A, int lda, hipDoubleComplex* work, int lwork, int* devInfo);
   // CHECK: status = hipsolverDnZpotri(handle, fillMode, n, &dComplexA, lda, &dComplexWorkspace, Lwork, &infoArray);
   status = cusolverDnZpotri(handle, fillMode, n, &dComplexA, lda, &dComplexWorkspace, Lwork, &infoArray);
+
+  // CUDA: cusolverStatus_t CUSOLVERAPI cusolverDnSsyevdx_bufferSize(cusolverDnHandle_t handle, cusolverEigMode_t jobz, cusolverEigRange_t range, cublasFillMode_t uplo, int n, const float * A, int lda, float vl, float vu, int il, int iu, int * meig, const float * W, int * lwork);
+  // HIP: HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDnSsyevdx_bufferSize(hipsolverHandle_t handle, hipsolverEigMode_t jobz, hipsolverEigRange_t range, hipblasFillMode_t uplo, int n, const float* A, int lda, float vl, float vu, int il, int iu, int* nev, const float* W, int* lwork);
+  // CHECK: status = hipsolverDnSsyevdx_bufferSize(handle, jobz, eigRange, fillMode, n, &fA, lda, fvl, fvu, il, iu, &imeig, &fW, &Lwork);
+  status = cusolverDnSsyevdx_bufferSize(handle, jobz, eigRange, fillMode, n, &fA, lda, fvl, fvu, il, iu, &imeig, &fW, &Lwork);
+
+  // CUDA: cusolverStatus_t CUSOLVERAPI cusolverDnDsyevdx_bufferSize(cusolverDnHandle_t handle, cusolverEigMode_t jobz, cusolverEigRange_t range, cublasFillMode_t uplo, int n, const double * A, int lda, double vl, double vu, int il, int iu, int * meig, const double * W, int * lwork);
+  // HIP: HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDnDsyevdx_bufferSize(hipsolverHandle_t handle, hipsolverEigMode_t jobz, hipsolverEigRange_t range, hipblasFillMode_t uplo, int n, const double* A, int lda, double vl, double vu, int il, int iu, int* nev, const double* W, int* lwork);
+  // CHECK: status = hipsolverDnDsyevdx_bufferSize(handle, jobz, eigRange, fillMode, n, &dA, lda, dvl, dvu, il, iu, &imeig, &dW, &Lwork);
+  status = cusolverDnDsyevdx_bufferSize(handle, jobz, eigRange, fillMode, n, &dA, lda, dvl, dvu, il, iu, &imeig, &dW, &Lwork);
+
+  // CUDA: cusolverStatus_t CUSOLVERAPI cusolverDnCheevdx_bufferSize(cusolverDnHandle_t handle, cusolverEigMode_t jobz, cusolverEigRange_t range, cublasFillMode_t uplo, int n, const cuComplex * A, int lda, float vl, float vu, int il, int iu, int * meig, const float * W, int * lwork);
+  // HIP: HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDnCheevdx_bufferSize(hipsolverHandle_t handle, hipsolverEigMode_t jobz, hipsolverEigRange_t range, hipblasFillMode_t uplo, int n, const hipFloatComplex* A, int lda, float vl, float vu, int il, int iu, int* nev, const float* W, int* lwork);
+  // CHECK: status = hipsolverDnCheevdx_bufferSize(handle, jobz, eigRange, fillMode, n, &complexA, lda, fvl, fvu, il, iu, &imeig, &fW, &Lwork);
+  status = cusolverDnCheevdx_bufferSize(handle, jobz, eigRange, fillMode, n, &complexA, lda, fvl, fvu, il, iu, &imeig, &fW, &Lwork);
+
+  // CUDA: cusolverStatus_t CUSOLVERAPI cusolverDnZheevdx_bufferSize(cusolverDnHandle_t handle, cusolverEigMode_t jobz, cusolverEigRange_t range, cublasFillMode_t uplo, int n, const cuDoubleComplex *A, int lda, double vl, double vu, int il, int iu, int * meig, const double * W, int * lwork);
+  // HIP: HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDnZheevdx_bufferSize(hipsolverHandle_t handle, hipsolverEigMode_t jobz, hipsolverEigRange_t range, hipblasFillMode_t uplo, int n, const hipDoubleComplex* A, int lda, double vl, double vu, int il, int iu, int* nev, const double* W, int* lwork);
+  // CHECK: status = hipsolverDnZheevdx_bufferSize(handle, jobz, eigRange, fillMode, n, &dComplexA, lda, dvl, dvu, il, iu, &imeig, &dW, &Lwork);
+  status = cusolverDnZheevdx_bufferSize(handle, jobz, eigRange, fillMode, n, &dComplexA, lda, dvl, dvu, il, iu, &imeig, &dW, &Lwork);
+
+  // CUDA: cusolverStatus_t CUSOLVERAPI cusolverDnSsyevdx(cusolverDnHandle_t handle, cusolverEigMode_t jobz, cusolverEigRange_t range, cublasFillMode_t uplo, int n, float * A, int lda, float vl, float vu, int il, int iu, int * meig, float * W, float * work, int lwork, int * info);
+  // HIP: HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDnSsyevdx(hipsolverHandle_t handle, hipsolverEigMode_t jobz, hipsolverEigRange_t range, hipblasFillMode_t uplo, int n, float* A, int lda, float vl, float vu, int il, int iu, int* nev, float* W, float* work, int lwork, int* devInfo);
+  // CHECK: status = hipsolverDnSsyevdx(handle, jobz, eigRange, fillMode, n, &fA, lda, fvl, fvu, il, iu, &imeig, &fW, &fWorkspace, Lwork, &info);
+  status = cusolverDnSsyevdx(handle, jobz, eigRange, fillMode, n, &fA, lda, fvl, fvu, il, iu, &imeig, &fW, &fWorkspace, Lwork, &info);
+
+  // CUDA: cusolverStatus_t CUSOLVERAPI cusolverDnDsyevdx(cusolverDnHandle_t handle, cusolverEigMode_t jobz, cusolverEigRange_t range, cublasFillMode_t uplo, int n, double * A, int lda, double vl, double vu, int il, int iu, int * meig, double * W, double * work, int lwork, int * info);
+  // HIP: HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDnDsyevdx(hipsolverHandle_t handle, hipsolverEigMode_t jobz, hipsolverEigRange_t range, hipblasFillMode_t uplo, int n, double* A, int lda, double vl, double vu, int il, int iu, int* nev, double* W, double* work, int lwork, int* devInfo);
+  // CHECK: status = hipsolverDnDsyevdx(handle, jobz, eigRange, fillMode, n, &dA, lda, dvl, dvu, il, iu, &imeig, &dW, &dWorkspace, Lwork, &info);
+  status = cusolverDnDsyevdx(handle, jobz, eigRange, fillMode, n, &dA, lda, dvl, dvu, il, iu, &imeig, &dW, &dWorkspace, Lwork, &info);
+
+  // CUDA: cusolverStatus_t CUSOLVERAPI cusolverDnCheevdx(cusolverDnHandle_t handle, cusolverEigMode_t jobz, cusolverEigRange_t range, cublasFillMode_t uplo, int n, cuComplex * A, int lda, float vl, float vu, int il, int iu, int * meig, float * W, cuComplex * work, int lwork, int * info);
+  // HIP: HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDnCheevdx(hipsolverHandle_t handle, hipsolverEigMode_t jobz, hipsolverEigRange_t range, hipblasFillMode_t uplo, int n, hipFloatComplex* A, int lda, float vl, float vu, int il, int iu, int* nev, float* W, hipFloatComplex* work, int lwork, int* devInfo);
+  // CHECK: status = hipsolverDnCheevdx(handle, jobz, eigRange, fillMode, n, &complexA, lda, fvl, fvu, il, iu, &imeig, &fW, &complexWorkspace, Lwork, &info);
+  status = cusolverDnCheevdx(handle, jobz, eigRange, fillMode, n, &complexA, lda, fvl, fvu, il, iu, &imeig, &fW, &complexWorkspace, Lwork, &info);
+
+  // CUDA: cusolverStatus_t CUSOLVERAPI cusolverDnZheevdx(cusolverDnHandle_t handle, cusolverEigMode_t jobz, cusolverEigRange_t range, cublasFillMode_t uplo, int n, cuDoubleComplex * A, int lda, double vl, double vu, int il, int iu, int * meig, double * W, cuDoubleComplex * work, int lwork, int * info);
+  // HIP: HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDnZheevdx(hipsolverHandle_t handle, hipsolverEigMode_t jobz, hipsolverEigRange_t range, hipblasFillMode_t uplo, int n, hipDoubleComplex* A, int lda, double vl, double vu, int il, int iu, int* nev, double* W, hipDoubleComplex* work, int lwork, int* devInfo);
+  // CHECK: status = hipsolverDnZheevdx(handle, jobz, eigRange, fillMode, n, &dComplexA, lda, dvl, dvu, il, iu, &imeig, &dW, &dComplexWorkspace, Lwork, &info);
+  status = cusolverDnZheevdx(handle, jobz, eigRange, fillMode, n, &dComplexA, lda, dvl, dvu, il, iu, &imeig, &dW, &dComplexWorkspace, Lwork, &info);
 #endif
 
 #if CUDA_VERSION >= 10020


### PR DESCRIPTION
+ `cusolverDn(S|D)syevdx_(bufferSize)?` and `cusolverDn(C|Z)heevdx_(bufferSize)?`are `SUPPORTED` by `hipSOLVER` only
+ [NOTE] `rocsolver_(s|d)syevdx_inplace` and `rocsolver_(c|z)yevdx_inplace` have a harness of other HIP and ROC API calls, thus `UNSUPPORTED`
+ Updated `SOLVER` synthetic tests, the regenerated `hipify-perl`, and `SOLVER` `CUDA2HIP` documentation