### PR TITLE
[HIPIFY][#675][#677][SOLVER][feature] `cuSOLVER` support - Step 39 - Functions (DN)

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -1103,6 +1103,8 @@ my %experimental_funcs = (
     "cusolverDnZhetrd" => "6.1.0",
     "cusolverDnZhegvdx_bufferSize" => "6.1.0",
     "cusolverDnZhegvdx" => "6.1.0",
+    "cusolverDnZhegvd_bufferSize" => "6.1.0",
+    "cusolverDnZhegvd" => "6.1.0",
     "cusolverDnZheevdx_bufferSize" => "6.1.0",
     "cusolverDnZheevdx" => "6.1.0",
     "cusolverDnZheevd_bufferSize" => "6.1.0",
@@ -1126,6 +1128,8 @@ my %experimental_funcs = (
     "cusolverDnSsytrd" => "6.1.0",
     "cusolverDnSsygvdx_bufferSize" => "6.1.0",
     "cusolverDnSsygvdx" => "6.1.0",
+    "cusolverDnSsygvd_bufferSize" => "6.1.0",
+    "cusolverDnSsygvd" => "6.1.0",
     "cusolverDnSsyevdx_bufferSize" => "6.1.0",
     "cusolverDnSsyevdx" => "6.1.0",
     "cusolverDnSsyevd_bufferSize" => "6.1.0",
@@ -1169,6 +1173,8 @@ my %experimental_funcs = (
     "cusolverDnDsytrd" => "6.1.0",
     "cusolverDnDsygvdx_bufferSize" => "6.1.0",
     "cusolverDnDsygvdx" => "6.1.0",
+    "cusolverDnDsygvd_bufferSize" => "6.1.0",
+    "cusolverDnDsygvd" => "6.1.0",
     "cusolverDnDsyevdx_bufferSize" => "6.1.0",
     "cusolverDnDsyevdx" => "6.1.0",
     "cusolverDnDsyevd_bufferSize" => "6.1.0",
@@ -1228,6 +1234,8 @@ my %experimental_funcs = (
     "cusolverDnChetrd" => "6.1.0",
     "cusolverDnChegvdx_bufferSize" => "6.1.0",
     "cusolverDnChegvdx" => "6.1.0",
+    "cusolverDnChegvd_bufferSize" => "6.1.0",
+    "cusolverDnChegvd" => "6.1.0",
     "cusolverDnCheevdx_bufferSize" => "6.1.0",
     "cusolverDnCheevdx" => "6.1.0",
     "cusolverDnCheevd_bufferSize" => "6.1.0",
@@ -1417,6 +1425,8 @@ sub experimentalSubstitutions {
     subst("cusolverDnCheevd_bufferSize", "hipsolverDnCheevd_bufferSize", "library");
     subst("cusolverDnCheevdx", "hipsolverDnCheevdx", "library");
     subst("cusolverDnCheevdx_bufferSize", "hipsolverDnCheevdx_bufferSize", "library");
+    subst("cusolverDnChegvd", "hipsolverDnChegvd", "library");
+    subst("cusolverDnChegvd_bufferSize", "hipsolverDnChegvd_bufferSize", "library");
     subst("cusolverDnChegvdx", "hipsolverDnChegvdx", "library");
     subst("cusolverDnChegvdx_bufferSize", "hipsolverDnChegvdx_bufferSize", "library");
     subst("cusolverDnChetrd", "hipsolverDnChetrd", "library");
@@ -1476,6 +1486,8 @@ sub experimentalSubstitutions {
     subst("cusolverDnDsyevd_bufferSize", "hipsolverDnDsyevd_bufferSize", "library");
     subst("cusolverDnDsyevdx", "hipsolverDnDsyevdx", "library");
     subst("cusolverDnDsyevdx_bufferSize", "hipsolverDnDsyevdx_bufferSize", "library");
+    subst("cusolverDnDsygvd", "hipsolverDnDsygvd", "library");
+    subst("cusolverDnDsygvd_bufferSize", "hipsolverDnDsygvd_bufferSize", "library");
     subst("cusolverDnDsygvdx", "hipsolverDnDsygvdx", "library");
     subst("cusolverDnDsygvdx_bufferSize", "hipsolverDnDsygvdx_bufferSize", "library");
     subst("cusolverDnDsytrd", "hipsolverDnDsytrd", "library");
@@ -1518,6 +1530,8 @@ sub experimentalSubstitutions {
     subst("cusolverDnSsyevd_bufferSize", "hipsolverDnSsyevd_bufferSize", "library");
     subst("cusolverDnSsyevdx", "hipsolverDnSsyevdx", "library");
     subst("cusolverDnSsyevdx_bufferSize", "hipsolverDnSsyevdx_bufferSize", "library");
+    subst("cusolverDnSsygvd", "hipsolverDnSsygvd", "library");
+    subst("cusolverDnSsygvd_bufferSize", "hipsolverDnSsygvd_bufferSize", "library");
     subst("cusolverDnSsygvdx", "hipsolverDnSsygvdx", "library");
     subst("cusolverDnSsygvdx_bufferSize", "hipsolverDnSsygvdx_bufferSize", "library");
     subst("cusolverDnSsytrd", "hipsolverDnSsytrd", "library");
@@ -1541,6 +1555,8 @@ sub experimentalSubstitutions {
     subst("cusolverDnZheevd_bufferSize", "hipsolverDnZheevd_bufferSize", "library");
     subst("cusolverDnZheevdx", "hipsolverDnZheevdx", "library");
     subst("cusolverDnZheevdx_bufferSize", "hipsolverDnZheevdx_bufferSize", "library");
+    subst("cusolverDnZhegvd", "hipsolverDnZhegvd", "library");
+    subst("cusolverDnZhegvd_bufferSize", "hipsolverDnZhegvd_bufferSize", "library");
     subst("cusolverDnZhegvdx", "hipsolverDnZhegvdx", "library");
     subst("cusolverDnZhegvdx_bufferSize", "hipsolverDnZhegvdx_bufferSize", "library");
     subst("cusolverDnZhetrd", "hipsolverDnZhetrd", "library");

--- a/docs/tables/CUSOLVER_API_supported_by_HIP.md
+++ b/docs/tables/CUSOLVER_API_supported_by_HIP.md
@@ -137,6 +137,8 @@
 |`cusolverDnCheevd_bufferSize`|8.0| | | |`hipsolverDnCheevd_bufferSize`|5.1.0| | | |6.1.0|
 |`cusolverDnCheevdx`|10.1| | | |`hipsolverDnCheevdx`|5.3.0| | | |6.1.0|
 |`cusolverDnCheevdx_bufferSize`|10.1| | | |`hipsolverDnCheevdx_bufferSize`|5.3.0| | | |6.1.0|
+|`cusolverDnChegvd`|8.0| | | |`hipsolverDnChegvd`|5.1.0| | | |6.1.0|
+|`cusolverDnChegvd_bufferSize`|8.0| | | |`hipsolverDnChegvd_bufferSize`|5.1.0| | | |6.1.0|
 |`cusolverDnChegvdx`|10.1| | | |`hipsolverDnChegvdx`|5.3.0| | | |6.1.0|
 |`cusolverDnChegvdx_bufferSize`|10.1| | | |`hipsolverDnChegvdx_bufferSize`|5.3.0| | | |6.1.0|
 |`cusolverDnChetrd`|8.0| | | |`hipsolverDnChetrd`|5.1.0| | | |6.1.0|
@@ -221,6 +223,8 @@
 |`cusolverDnDsyevd_bufferSize`|8.0| | | |`hipsolverDnDsyevd_bufferSize`|5.1.0| | | |6.1.0|
 |`cusolverDnDsyevdx`|10.1| | | |`hipsolverDnDsyevdx`|5.3.0| | | |6.1.0|
 |`cusolverDnDsyevdx_bufferSize`|10.1| | | |`hipsolverDnDsyevdx_bufferSize`|5.3.0| | | |6.1.0|
+|`cusolverDnDsygvd`|8.0| | | |`hipsolverDnDsygvd`|5.1.0| | | |6.1.0|
+|`cusolverDnDsygvd_bufferSize`|8.0| | | |`hipsolverDnDsygvd_bufferSize`|5.1.0| | | |6.1.0|
 |`cusolverDnDsygvdx`|10.1| | | |`hipsolverDnDsygvdx`|5.3.0| | | |6.1.0|
 |`cusolverDnDsygvdx_bufferSize`|10.1| | | |`hipsolverDnDsygvdx_bufferSize`|5.3.0| | | |6.1.0|
 |`cusolverDnDsytrd`| | | | |`hipsolverDnDsytrd`|5.1.0| | | |6.1.0|
@@ -307,6 +311,8 @@
 |`cusolverDnSsyevd_bufferSize`|8.0| | | |`hipsolverDnSsyevd_bufferSize`|5.1.0| | | |6.1.0|
 |`cusolverDnSsyevdx`|10.1| | | |`hipsolverDnSsyevdx`|5.3.0| | | |6.1.0|
 |`cusolverDnSsyevdx_bufferSize`|10.1| | | |`hipsolverDnSsyevdx_bufferSize`|5.3.0| | | |6.1.0|
+|`cusolverDnSsygvd`|8.0| | | |`hipsolverDnSsygvd`|5.1.0| | | |6.1.0|
+|`cusolverDnSsygvd_bufferSize`|8.0| | | |`hipsolverDnSsygvd_bufferSize`|5.1.0| | | |6.1.0|
 |`cusolverDnSsygvdx`|10.1| | | |`hipsolverDnSsygvdx`|5.3.0| | | |6.1.0|
 |`cusolverDnSsygvdx_bufferSize`|10.1| | | |`hipsolverDnSsygvdx_bufferSize`|5.3.0| | | |6.1.0|
 |`cusolverDnSsytrd`| | | | |`hipsolverDnSsytrd`|5.1.0| | | |6.1.0|
@@ -355,6 +361,8 @@
 |`cusolverDnZheevd_bufferSize`|8.0| | | |`hipsolverDnZheevd_bufferSize`|5.1.0| | | |6.1.0|
 |`cusolverDnZheevdx`|10.1| | | |`hipsolverDnZheevdx`|5.3.0| | | |6.1.0|
 |`cusolverDnZheevdx_bufferSize`|10.1| | | |`hipsolverDnZheevdx_bufferSize`|5.3.0| | | |6.1.0|
+|`cusolverDnZhegvd`|8.0| | | |`hipsolverDnZhegvd`|5.1.0| | | |6.1.0|
+|`cusolverDnZhegvd_bufferSize`|8.0| | | |`hipsolverDnZhegvd_bufferSize`|5.1.0| | | |6.1.0|
 |`cusolverDnZhegvdx`|10.1| | | |`hipsolverDnZhegvdx`|5.3.0| | | |6.1.0|
 |`cusolverDnZhegvdx_bufferSize`|10.1| | | |`hipsolverDnZhegvdx_bufferSize`|5.3.0| | | |6.1.0|
 |`cusolverDnZhetrd`|8.0| | | |`hipsolverDnZhetrd`|5.1.0| | | |6.1.0|

--- a/docs/tables/CUSOLVER_API_supported_by_HIP_and_ROC.md
+++ b/docs/tables/CUSOLVER_API_supported_by_HIP_and_ROC.md
@@ -137,6 +137,8 @@
 |`cusolverDnCheevd_bufferSize`|8.0| | | |`hipsolverDnCheevd_bufferSize`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnCheevdx`|10.1| | | |`hipsolverDnCheevdx`|5.3.0| | | |6.1.0| | | | | | |
 |`cusolverDnCheevdx_bufferSize`|10.1| | | |`hipsolverDnCheevdx_bufferSize`|5.3.0| | | |6.1.0| | | | | | |
+|`cusolverDnChegvd`|8.0| | | |`hipsolverDnChegvd`|5.1.0| | | |6.1.0| | | | | | |
+|`cusolverDnChegvd_bufferSize`|8.0| | | |`hipsolverDnChegvd_bufferSize`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnChegvdx`|10.1| | | |`hipsolverDnChegvdx`|5.3.0| | | |6.1.0| | | | | | |
 |`cusolverDnChegvdx_bufferSize`|10.1| | | |`hipsolverDnChegvdx_bufferSize`|5.3.0| | | |6.1.0| | | | | | |
 |`cusolverDnChetrd`|8.0| | | |`hipsolverDnChetrd`|5.1.0| | | |6.1.0| | | | | | |
@@ -221,6 +223,8 @@
 |`cusolverDnDsyevd_bufferSize`|8.0| | | |`hipsolverDnDsyevd_bufferSize`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnDsyevdx`|10.1| | | |`hipsolverDnDsyevdx`|5.3.0| | | |6.1.0| | | | | | |
 |`cusolverDnDsyevdx_bufferSize`|10.1| | | |`hipsolverDnDsyevdx_bufferSize`|5.3.0| | | |6.1.0| | | | | | |
+|`cusolverDnDsygvd`|8.0| | | |`hipsolverDnDsygvd`|5.1.0| | | |6.1.0| | | | | | |
+|`cusolverDnDsygvd_bufferSize`|8.0| | | |`hipsolverDnDsygvd_bufferSize`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnDsygvdx`|10.1| | | |`hipsolverDnDsygvdx`|5.3.0| | | |6.1.0| | | | | | |
 |`cusolverDnDsygvdx_bufferSize`|10.1| | | |`hipsolverDnDsygvdx_bufferSize`|5.3.0| | | |6.1.0| | | | | | |
 |`cusolverDnDsytrd`| | | | |`hipsolverDnDsytrd`|5.1.0| | | |6.1.0| | | | | | |
@@ -307,6 +311,8 @@
 |`cusolverDnSsyevd_bufferSize`|8.0| | | |`hipsolverDnSsyevd_bufferSize`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnSsyevdx`|10.1| | | |`hipsolverDnSsyevdx`|5.3.0| | | |6.1.0| | | | | | |
 |`cusolverDnSsyevdx_bufferSize`|10.1| | | |`hipsolverDnSsyevdx_bufferSize`|5.3.0| | | |6.1.0| | | | | | |
+|`cusolverDnSsygvd`|8.0| | | |`hipsolverDnSsygvd`|5.1.0| | | |6.1.0| | | | | | |
+|`cusolverDnSsygvd_bufferSize`|8.0| | | |`hipsolverDnSsygvd_bufferSize`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnSsygvdx`|10.1| | | |`hipsolverDnSsygvdx`|5.3.0| | | |6.1.0| | | | | | |
 |`cusolverDnSsygvdx_bufferSize`|10.1| | | |`hipsolverDnSsygvdx_bufferSize`|5.3.0| | | |6.1.0| | | | | | |
 |`cusolverDnSsytrd`| | | | |`hipsolverDnSsytrd`|5.1.0| | | |6.1.0| | | | | | |
@@ -355,6 +361,8 @@
 |`cusolverDnZheevd_bufferSize`|8.0| | | |`hipsolverDnZheevd_bufferSize`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnZheevdx`|10.1| | | |`hipsolverDnZheevdx`|5.3.0| | | |6.1.0| | | | | | |
 |`cusolverDnZheevdx_bufferSize`|10.1| | | |`hipsolverDnZheevdx_bufferSize`|5.3.0| | | |6.1.0| | | | | | |
+|`cusolverDnZhegvd`|8.0| | | |`hipsolverDnZhegvd`|5.1.0| | | |6.1.0| | | | | | |
+|`cusolverDnZhegvd_bufferSize`|8.0| | | |`hipsolverDnZhegvd_bufferSize`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnZhegvdx`|10.1| | | |`hipsolverDnZhegvdx`|5.3.0| | | |6.1.0| | | | | | |
 |`cusolverDnZhegvdx_bufferSize`|10.1| | | |`hipsolverDnZhegvdx_bufferSize`|5.3.0| | | |6.1.0| | | | | | |
 |`cusolverDnZhetrd`|8.0| | | |`hipsolverDnZhetrd`|5.1.0| | | |6.1.0| | | | | | |

--- a/docs/tables/CUSOLVER_API_supported_by_ROC.md
+++ b/docs/tables/CUSOLVER_API_supported_by_ROC.md
@@ -137,6 +137,8 @@
 |`cusolverDnCheevd_bufferSize`|8.0| | | | | | | | | |
 |`cusolverDnCheevdx`|10.1| | | | | | | | | |
 |`cusolverDnCheevdx_bufferSize`|10.1| | | | | | | | | |
+|`cusolverDnChegvd`|8.0| | | | | | | | | |
+|`cusolverDnChegvd_bufferSize`|8.0| | | | | | | | | |
 |`cusolverDnChegvdx`|10.1| | | | | | | | | |
 |`cusolverDnChegvdx_bufferSize`|10.1| | | | | | | | | |
 |`cusolverDnChetrd`|8.0| | | | | | | | | |
@@ -221,6 +223,8 @@
 |`cusolverDnDsyevd_bufferSize`|8.0| | | | | | | | | |
 |`cusolverDnDsyevdx`|10.1| | | | | | | | | |
 |`cusolverDnDsyevdx_bufferSize`|10.1| | | | | | | | | |
+|`cusolverDnDsygvd`|8.0| | | | | | | | | |
+|`cusolverDnDsygvd_bufferSize`|8.0| | | | | | | | | |
 |`cusolverDnDsygvdx`|10.1| | | | | | | | | |
 |`cusolverDnDsygvdx_bufferSize`|10.1| | | | | | | | | |
 |`cusolverDnDsytrd`| | | | | | | | | | |
@@ -307,6 +311,8 @@
 |`cusolverDnSsyevd_bufferSize`|8.0| | | | | | | | | |
 |`cusolverDnSsyevdx`|10.1| | | | | | | | | |
 |`cusolverDnSsyevdx_bufferSize`|10.1| | | | | | | | | |
+|`cusolverDnSsygvd`|8.0| | | | | | | | | |
+|`cusolverDnSsygvd_bufferSize`|8.0| | | | | | | | | |
 |`cusolverDnSsygvdx`|10.1| | | | | | | | | |
 |`cusolverDnSsygvdx_bufferSize`|10.1| | | | | | | | | |
 |`cusolverDnSsytrd`| | | | | | | | | | |
@@ -355,6 +361,8 @@
 |`cusolverDnZheevd_bufferSize`|8.0| | | | | | | | | |
 |`cusolverDnZheevdx`|10.1| | | | | | | | | |
 |`cusolverDnZheevdx_bufferSize`|10.1| | | | | | | | | |
+|`cusolverDnZhegvd`|8.0| | | | | | | | | |
+|`cusolverDnZhegvd_bufferSize`|8.0| | | | | | | | | |
 |`cusolverDnZhegvdx`|10.1| | | | | | | | | |
 |`cusolverDnZhegvdx_bufferSize`|10.1| | | | | | | | | |
 |`cusolverDnZhetrd`|8.0| | | | | | | | | |

--- a/src/CUDA2HIP_SOLVER_API_functions.cpp
+++ b/src/CUDA2HIP_SOLVER_API_functions.cpp
@@ -351,6 +351,16 @@ const std::map<llvm::StringRef, hipCounter> CUDA_SOLVER_FUNCTION_MAP {
   {"cusolverDnDsygvdx",                                  {"hipsolverDnDsygvdx",                                    "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
   {"cusolverDnChegvdx",                                  {"hipsolverDnChegvdx",                                    "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
   {"cusolverDnZhegvdx",                                  {"hipsolverDnZhegvdx",                                    "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
+  // NOTE: rocsolver_(s|d)sygvd and rocsolver_(c|z)hegvd have a harness of other ROC and HIP API calls
+  {"cusolverDnSsygvd_bufferSize",                        {"hipsolverDnSsygvd_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
+  {"cusolverDnDsygvd_bufferSize",                        {"hipsolverDnDsygvd_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
+  {"cusolverDnChegvd_bufferSize",                        {"hipsolverDnChegvd_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
+  {"cusolverDnZhegvd_bufferSize",                        {"hipsolverDnZhegvd_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
+  // NOTE: rocsolver_(s|d)sygvd and rocsolver_(c|z)hegvd have a harness of other ROC and HIP API calls
+  {"cusolverDnSsygvd",                                   {"hipsolverDnSsygvd",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
+  {"cusolverDnDsygvd",                                   {"hipsolverDnDsygvd",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
+  {"cusolverDnChegvd",                                   {"hipsolverDnChegvd",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
+  {"cusolverDnZhegvd",                                   {"hipsolverDnZhegvd",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
 };
 
 const std::map<llvm::StringRef, cudaAPIversions> CUDA_SOLVER_FUNCTION_VER_MAP {
@@ -559,6 +569,14 @@ const std::map<llvm::StringRef, cudaAPIversions> CUDA_SOLVER_FUNCTION_VER_MAP {
   {"cusolverDnDsygvdx",                                   {CUDA_101,  CUDA_0, CUDA_0}},
   {"cusolverDnChegvdx",                                   {CUDA_101,  CUDA_0, CUDA_0}},
   {"cusolverDnZhegvdx",                                   {CUDA_101,  CUDA_0, CUDA_0}},
+  {"cusolverDnSsygvd_bufferSize",                         {CUDA_80,   CUDA_0, CUDA_0}},
+  {"cusolverDnDsygvd_bufferSize",                         {CUDA_80,   CUDA_0, CUDA_0}},
+  {"cusolverDnChegvd_bufferSize",                         {CUDA_80,   CUDA_0, CUDA_0}},
+  {"cusolverDnZhegvd_bufferSize",                         {CUDA_80,   CUDA_0, CUDA_0}},
+  {"cusolverDnSsygvd",                                    {CUDA_80,   CUDA_0, CUDA_0}},
+  {"cusolverDnDsygvd",                                    {CUDA_80,   CUDA_0, CUDA_0}},
+  {"cusolverDnChegvd",                                    {CUDA_80,   CUDA_0, CUDA_0}},
+  {"cusolverDnZhegvd",                                    {CUDA_80,   CUDA_0, CUDA_0}},
 };
 
 const std::map<llvm::StringRef, hipAPIversions> HIP_SOLVER_FUNCTION_VER_MAP {
@@ -726,6 +744,14 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_SOLVER_FUNCTION_VER_MAP {
   {"hipsolverDnDsygvdx",                                  {HIP_5030, HIP_0,    HIP_0,  HIP_LATEST}},
   {"hipsolverDnChegvdx",                                  {HIP_5030, HIP_0,    HIP_0,  HIP_LATEST}},
   {"hipsolverDnZhegvdx",                                  {HIP_5030, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipsolverDnSsygvd_bufferSize",                        {HIP_5010, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipsolverDnDsygvd_bufferSize",                        {HIP_5010, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipsolverDnChegvd_bufferSize",                        {HIP_5010, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipsolverDnZhegvd_bufferSize",                        {HIP_5010, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipsolverDnSsygvd",                                   {HIP_5010, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipsolverDnDsygvd",                                   {HIP_5010, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipsolverDnChegvd",                                   {HIP_5010, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipsolverDnZhegvd",                                   {HIP_5010, HIP_0,    HIP_0,  HIP_LATEST}},
 
   {"rocsolver_spotrf",                                    {HIP_3020, HIP_0,    HIP_0,  HIP_LATEST}},
   {"rocsolver_dpotrf",                                    {HIP_3020, HIP_0,    HIP_0,  HIP_LATEST}},

--- a/tests/unit_tests/synthetic/libraries/cusolver2hipsolver.cu
+++ b/tests/unit_tests/synthetic/libraries/cusolver2hipsolver.cu
@@ -722,6 +722,46 @@ int main() {
   // HIP: HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDnZheevd(hipsolverHandle_t handle, hipsolverEigMode_t jobz, hipblasFillMode_t uplo, int n, hipDoubleComplex* A, int lda, double* W, hipDoubleComplex* work, int lwork, int* devInfo);
   // CHECK: status = hipsolverDnZheevd(handle, eigMode, fillMode, n, &dComplexA, lda, &dW, &dComplexWorkspace, Lwork, &info);
   status = cusolverDnZheevd(handle, eigMode, fillMode, n, &dComplexA, lda, &dW, &dComplexWorkspace, Lwork, &info);
+
+  // CUDA: cusolverStatus_t CUSOLVERAPI cusolverDnSsygvd_bufferSize(cusolverDnHandle_t handle, cusolverEigType_t itype, cusolverEigMode_t jobz, cublasFillMode_t uplo, int n, const float * A, int lda, const float * B, int ldb, const float * W, int * lwork);
+  // HIP: HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDnSsygvd_bufferSize(hipsolverHandle_t handle, hipsolverEigType_t itype, hipsolverEigMode_t jobz, hipblasFillMode_t uplo, int n, const float* A, int lda, const float* B, int ldb, const float* W, int* lwork);
+  // CHECK: status = hipsolverDnSsygvd_bufferSize(handle, eigType, jobz, fillMode, n, &fA, lda, &fB, ldb, &fW, &Lwork);
+  status = cusolverDnSsygvd_bufferSize(handle, eigType, jobz, fillMode, n, &fA, lda, &fB, ldb, &fW, &Lwork);
+
+  // CUDA: cusolverStatus_t CUSOLVERAPI cusolverDnDsygvd_bufferSize(cusolverDnHandle_t handle, cusolverEigType_t itype, cusolverEigMode_t jobz, cublasFillMode_t uplo, int n, const double * A, int lda, const double * B, int ldb, const double * W, int * lwork);
+  // HIP: HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDnDsygvd_bufferSize(hipsolverHandle_t handle, hipsolverEigType_t itype, hipsolverEigMode_t jobz, hipblasFillMode_t uplo, int n, const double* A, int lda, const double* B, int ldb, const double* W, int* lwork);
+  // CHECK: status = hipsolverDnDsygvd_bufferSize(handle, eigType, jobz, fillMode, n, &dA, lda, &dB, ldb, &dW, &Lwork);
+  status = cusolverDnDsygvd_bufferSize(handle, eigType, jobz, fillMode, n, &dA, lda, &dB, ldb, &dW, &Lwork);
+
+  // CUDA: cusolverStatus_t CUSOLVERAPI cusolverDnChegvd_bufferSize(cusolverDnHandle_t handle, cusolverEigType_t itype, cusolverEigMode_t jobz, cublasFillMode_t uplo, int n, const cuComplex * A, int lda, const cuComplex * B, int ldb, const float * W, int * lwork);
+  // HIP: HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDnChegvd_bufferSize(hipsolverHandle_t handle, hipsolverEigType_t itype, hipsolverEigMode_t jobz, hipblasFillMode_t uplo, int n, const hipFloatComplex* A, int lda, const hipFloatComplex* B, int ldb, const float* W, int* lwork);
+  // CHECK: status = hipsolverDnChegvd_bufferSize(handle, eigType, jobz, fillMode, n, &complexA, lda, &complexB, ldb, &fW, &Lwork);
+  status = cusolverDnChegvd_bufferSize(handle, eigType, jobz, fillMode, n, &complexA, lda, &complexB, ldb, &fW, &Lwork);
+
+  // CUDA: cusolverStatus_t CUSOLVERAPI cusolverDnZhegvd_bufferSize(cusolverDnHandle_t handle, cusolverEigType_t itype, cusolverEigMode_t jobz, cublasFillMode_t uplo, int n, const cuDoubleComplex *A, int lda, const cuDoubleComplex *B, int ldb, const double * W, int * lwork);
+  // HIP: HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDnZhegvd_bufferSize(hipsolverHandle_t handle, hipsolverEigType_t itype, hipsolverEigMode_t jobz, hipblasFillMode_t uplo, int n, const hipDoubleComplex* A, int lda, const hipDoubleComplex* B, int ldb, const double* W, int* lwork);
+  // CHECK: status = hipsolverDnZhegvd_bufferSize(handle, eigType, jobz, fillMode, n, &dComplexA, lda, &dComplexB, ldb, &dW, &Lwork);
+  status = cusolverDnZhegvd_bufferSize(handle, eigType, jobz, fillMode, n, &dComplexA, lda, &dComplexB, ldb, &dW, &Lwork);
+
+  // CUDA: cusolverStatus_t CUSOLVERAPI cusolverDnSsygvd(cusolverDnHandle_t handle, cusolverEigType_t itype, cusolverEigMode_t jobz, cublasFillMode_t uplo, int n, float * A, int lda, float * B, int ldb, float * W, float * work, int lwork, int * info);
+  // HIP: HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDnSsygvd(hipsolverHandle_t handle, hipsolverEigType_t itype, hipsolverEigMode_t jobz, hipblasFillMode_t uplo, int n, float* A, int lda, float* B, int ldb, float* W, float* work, int lwork, int* devInfo);
+  // CHECK: status = hipsolverDnSsygvd(handle, eigType, jobz, fillMode, n, &fA, lda, &fB, ldb, &fW, &fWorkspace, Lwork, &info);
+  status = cusolverDnSsygvd(handle, eigType, jobz, fillMode, n, &fA, lda, &fB, ldb, &fW, &fWorkspace, Lwork, &info);
+
+  // CUDA: cusolverStatus_t CUSOLVERAPI cusolverDnDsygvd(cusolverDnHandle_t handle, cusolverEigType_t itype, cusolverEigMode_t jobz, cublasFillMode_t uplo, int n, double * A, int lda, double * B, int ldb, double * W, double * work, int lwork, int * info);
+  // HIP: HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDnDsygvd(hipsolverHandle_t handle, hipsolverEigType_t itype, hipsolverEigMode_t jobz, hipblasFillMode_t uplo, int n, double* A, int lda, double* B, int ldb, double* W, double* work, int lwork, int* devInfo);
+  // CHECK: status = hipsolverDnDsygvd(handle, eigType, jobz, fillMode, n, &dA, lda, &dB, ldb, &dW, &dWorkspace, Lwork, &info);
+  status = cusolverDnDsygvd(handle, eigType, jobz, fillMode, n, &dA, lda, &dB, ldb, &dW, &dWorkspace, Lwork, &info);
+
+  // CUDA: cusolverStatus_t CUSOLVERAPI cusolverDnChegvd(cusolverDnHandle_t handle, cusolverEigType_t itype, cusolverEigMode_t jobz, cublasFillMode_t uplo, int n, cuComplex * A, int lda, cuComplex * B, int ldb, float * W, cuComplex * work, int lwork, int * info);
+  // HIP: HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDnChegvd(hipsolverHandle_t handle, hipsolverEigType_t itype, hipsolverEigMode_t jobz, hipblasFillMode_t uplo, int n, hipFloatComplex* A, int lda, hipFloatComplex* B, int ldb, float* W, hipFloatComplex* work, int lwork, int* devInfo);
+  // CHECK: status = hipsolverDnChegvd(handle, eigType, jobz, fillMode, n, &complexA, lda, &complexB, ldb, &fW, &complexWorkspace, Lwork, &info);
+  status = cusolverDnChegvd(handle, eigType, jobz, fillMode, n, &complexA, lda, &complexB, ldb, &fW, &complexWorkspace, Lwork, &info);
+
+  // CUDA: cusolverStatus_t CUSOLVERAPI cusolverDnZhegvd(cusolverDnHandle_t handle, cusolverEigType_t itype, cusolverEigMode_t jobz, cublasFillMode_t uplo, int n, cuDoubleComplex * A, int lda, cuDoubleComplex * B, int ldb, double * W, cuDoubleComplex * work, int lwork, int * info);
+  // HIP: HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDnZhegvd(hipsolverHandle_t handle, hipsolverEigType_t itype, hipsolverEigMode_t jobz, hipblasFillMode_t uplo, int n, hipDoubleComplex* A, int lda, hipDoubleComplex* B, int ldb, double* W, hipDoubleComplex* work, int lwork, int* devInfo);
+  // CHECK: status = hipsolverDnZhegvd(handle, eigType, jobz, fillMode, n, &dComplexA, lda, &dComplexB, ldb, &dW, &dComplexWorkspace, Lwork, &info);
+  status = cusolverDnZhegvd(handle, eigType, jobz, fillMode, n, &dComplexA, lda, &dComplexB, ldb, &dW, &dComplexWorkspace, Lwork, &info);
 #endif
 
 #if CUDA_VERSION >= 9000


### PR DESCRIPTION
+ `cusolverDn(S|D)sygvd_(bufferSize)?` and `cusolverDn(C|Z)hegvd_(bufferSize)?`are `SUPPORTED` by `hipSOLVER` only
+ [NOTE] `rocsolver_(s|d)sygvd` and `rocsolver_(c|z)hegvd` have a harness of other HIP and ROC API calls, thus `UNSUPPORTED`
+ Updated `SOLVER` synthetic tests, the regenerated `hipify-perl`, and `SOLVER` `CUDA2HIP` documentation