### PR TITLE
[HIPIFY][#675][#677][SOLVER][feature] `cuSOLVER` support - Step 40 - Functions (DN)

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -1122,6 +1122,11 @@ my %experimental_funcs = (
     "cusolverDnZZgesv" => "6.1.0",
     "cusolverDnZZgels_bufferSize" => "6.1.0",
     "cusolverDnZZgels" => "6.1.0",
+    "cusolverDnXsyevjSetTolerance" => "6.1.0",
+    "cusolverDnXsyevjSetSortEig" => "6.1.0",
+    "cusolverDnXsyevjSetMaxSweeps" => "6.1.0",
+    "cusolverDnXsyevjGetSweeps" => "6.1.0",
+    "cusolverDnXsyevjGetResidual" => "6.1.0",
     "cusolverDnSsytrf_bufferSize" => "6.1.0",
     "cusolverDnSsytrf" => "6.1.0",
     "cusolverDnSsytrd_bufferSize" => "6.1.0",
@@ -1205,6 +1210,7 @@ my %experimental_funcs = (
     "cusolverDnDgeqrf" => "6.1.0",
     "cusolverDnDgebrd_bufferSize" => "6.1.0",
     "cusolverDnDgebrd" => "6.1.0",
+    "cusolverDnDestroySyevjInfo" => "6.1.0",
     "cusolverDnDestroy" => "6.1.0",
     "cusolverDnDDgesv_bufferSize" => "6.1.0",
     "cusolverDnDDgesv" => "6.1.0",
@@ -1222,6 +1228,7 @@ my %experimental_funcs = (
     "cusolverDnCungbr" => "6.1.0",
     "cusolverDnCsytrf_bufferSize" => "6.1.0",
     "cusolverDnCsytrf" => "6.1.0",
+    "cusolverDnCreateSyevjInfo" => "6.1.0",
     "cusolverDnCreate" => "6.1.0",
     "cusolverDnCpotrsBatched" => "6.1.0",
     "cusolverDnCpotrs" => "6.1.0",
@@ -1439,6 +1446,7 @@ sub experimentalSubstitutions {
     subst("cusolverDnCpotrs", "hipsolverDnCpotrs", "library");
     subst("cusolverDnCpotrsBatched", "hipsolverDnCpotrsBatched", "library");
     subst("cusolverDnCreate", "hipsolverDnCreate", "library");
+    subst("cusolverDnCreateSyevjInfo", "hipsolverDnCreateSyevjInfo", "library");
     subst("cusolverDnCsytrf", "hipsolverDnCsytrf", "library");
     subst("cusolverDnCsytrf_bufferSize", "hipsolverDnCsytrf_bufferSize", "library");
     subst("cusolverDnCungbr", "hipsolverDnCungbr", "library");
@@ -1456,6 +1464,7 @@ sub experimentalSubstitutions {
     subst("cusolverDnDDgesv", "hipsolverDnDDgesv", "library");
     subst("cusolverDnDDgesv_bufferSize", "hipsolverDnDDgesv_bufferSize", "library");
     subst("cusolverDnDestroy", "hipsolverDnDestroy", "library");
+    subst("cusolverDnDestroySyevjInfo", "hipsolverDnDestroySyevjInfo", "library");
     subst("cusolverDnDgebrd", "hipsolverDnDgebrd", "library");
     subst("cusolverDnDgebrd_bufferSize", "hipsolverDnDgebrd_bufferSize", "library");
     subst("cusolverDnDgeqrf", "hipsolverDnDgeqrf", "library");
@@ -1538,6 +1547,11 @@ sub experimentalSubstitutions {
     subst("cusolverDnSsytrd_bufferSize", "hipsolverDnSsytrd_bufferSize", "library");
     subst("cusolverDnSsytrf", "hipsolverDnSsytrf", "library");
     subst("cusolverDnSsytrf_bufferSize", "hipsolverDnSsytrf_bufferSize", "library");
+    subst("cusolverDnXsyevjGetResidual", "hipsolverDnXsyevjGetResidual", "library");
+    subst("cusolverDnXsyevjGetSweeps", "hipsolverDnXsyevjGetSweeps", "library");
+    subst("cusolverDnXsyevjSetMaxSweeps", "hipsolverDnXsyevjSetMaxSweeps", "library");
+    subst("cusolverDnXsyevjSetSortEig", "hipsolverDnXsyevjSetSortEig", "library");
+    subst("cusolverDnXsyevjSetTolerance", "hipsolverDnXsyevjSetTolerance", "library");
     subst("cusolverDnZZgels", "hipsolverDnZZgels", "library");
     subst("cusolverDnZZgels_bufferSize", "hipsolverDnZZgels_bufferSize", "library");
     subst("cusolverDnZZgesv", "hipsolverDnZZgesv", "library");

--- a/docs/tables/CUSOLVER_API_supported_by_HIP.md
+++ b/docs/tables/CUSOLVER_API_supported_by_HIP.md
@@ -155,6 +155,7 @@
 |`cusolverDnCpotrsBatched`|9.1| | | |`hipsolverDnCpotrsBatched`|5.1.0| | | |6.1.0|
 |`cusolverDnCreate`| | | | |`hipsolverDnCreate`|5.1.0| | | |6.1.0|
 |`cusolverDnCreateParams`|11.0| | | | | | | | | |
+|`cusolverDnCreateSyevjInfo`|9.0| | | |`hipsolverDnCreateSyevjInfo`|5.1.0| | | |6.1.0|
 |`cusolverDnCsytrf`| | | | |`hipsolverDnCsytrf`|5.1.0| | | |6.1.0|
 |`cusolverDnCsytrf_bufferSize`| | | | |`hipsolverDnCsytrf_bufferSize`|5.1.0| | | |6.1.0|
 |`cusolverDnCsytri`|10.1| | | | | | | | | |
@@ -190,6 +191,7 @@
 |`cusolverDnDXgesv`|11.0| | | | | | | | | |
 |`cusolverDnDXgesv_bufferSize`|11.0| | | | | | | | | |
 |`cusolverDnDestroy`| | | | |`hipsolverDnDestroy`|5.1.0| | | |6.1.0|
+|`cusolverDnDestroySyevjInfo`|9.0| | | |`hipsolverDnDestroySyevjInfo`|5.1.0| | | |6.1.0|
 |`cusolverDnDgebrd`| | | | |`hipsolverDnDgebrd`|5.1.0| | | |6.1.0|
 |`cusolverDnDgebrd_bufferSize`| | | | |`hipsolverDnDgebrd_bufferSize`|5.1.0| | | |6.1.0|
 |`cusolverDnDgeqrf`| | | | |`hipsolverDnDgeqrf`|5.1.0| | | |6.1.0|
@@ -324,6 +326,11 @@
 |`cusolverDnXgetrf`|11.1| | | | | | | | | |
 |`cusolverDnXgetrf_bufferSize`|11.1| | | | | | | | | |
 |`cusolverDnXgetrs`|11.1| | | | | | | | | |
+|`cusolverDnXsyevjGetResidual`|9.0| | | |`hipsolverDnXsyevjGetResidual`|5.1.0| | | |6.1.0|
+|`cusolverDnXsyevjGetSweeps`|9.0| | | |`hipsolverDnXsyevjGetSweeps`|5.1.0| | | |6.1.0|
+|`cusolverDnXsyevjSetMaxSweeps`|9.0| | | |`hipsolverDnXsyevjSetMaxSweeps`|5.1.0| | | |6.1.0|
+|`cusolverDnXsyevjSetSortEig`|9.0| | | |`hipsolverDnXsyevjSetSortEig`|5.1.0| | | |6.1.0|
+|`cusolverDnXsyevjSetTolerance`|9.0| | | |`hipsolverDnXsyevjSetTolerance`|5.1.0| | | |6.1.0|
 |`cusolverDnXsytrs`|11.3| | | | | | | | | |
 |`cusolverDnXsytrs_bufferSize`|11.3| | | | | | | | | |
 |`cusolverDnXtrtri`|11.4| | | | | | | | | |

--- a/docs/tables/CUSOLVER_API_supported_by_HIP_and_ROC.md
+++ b/docs/tables/CUSOLVER_API_supported_by_HIP_and_ROC.md
@@ -155,6 +155,7 @@
 |`cusolverDnCpotrsBatched`|9.1| | | |`hipsolverDnCpotrsBatched`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnCreate`| | | | |`hipsolverDnCreate`|5.1.0| | | |6.1.0|`rocblas_create_handle`| | | | | |
 |`cusolverDnCreateParams`|11.0| | | | | | | | | | | | | | | |
+|`cusolverDnCreateSyevjInfo`|9.0| | | |`hipsolverDnCreateSyevjInfo`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnCsytrf`| | | | |`hipsolverDnCsytrf`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnCsytrf_bufferSize`| | | | |`hipsolverDnCsytrf_bufferSize`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnCsytri`|10.1| | | | | | | | | | | | | | | |
@@ -190,6 +191,7 @@
 |`cusolverDnDXgesv`|11.0| | | | | | | | | | | | | | | |
 |`cusolverDnDXgesv_bufferSize`|11.0| | | | | | | | | | | | | | | |
 |`cusolverDnDestroy`| | | | |`hipsolverDnDestroy`|5.1.0| | | |6.1.0|`rocblas_destroy_handle`| | | | | |
+|`cusolverDnDestroySyevjInfo`|9.0| | | |`hipsolverDnDestroySyevjInfo`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnDgebrd`| | | | |`hipsolverDnDgebrd`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnDgebrd_bufferSize`| | | | |`hipsolverDnDgebrd_bufferSize`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnDgeqrf`| | | | |`hipsolverDnDgeqrf`|5.1.0| | | |6.1.0| | | | | | |
@@ -324,6 +326,11 @@
 |`cusolverDnXgetrf`|11.1| | | | | | | | | | | | | | | |
 |`cusolverDnXgetrf_bufferSize`|11.1| | | | | | | | | | | | | | | |
 |`cusolverDnXgetrs`|11.1| | | | | | | | | | | | | | | |
+|`cusolverDnXsyevjGetResidual`|9.0| | | |`hipsolverDnXsyevjGetResidual`|5.1.0| | | |6.1.0| | | | | | |
+|`cusolverDnXsyevjGetSweeps`|9.0| | | |`hipsolverDnXsyevjGetSweeps`|5.1.0| | | |6.1.0| | | | | | |
+|`cusolverDnXsyevjSetMaxSweeps`|9.0| | | |`hipsolverDnXsyevjSetMaxSweeps`|5.1.0| | | |6.1.0| | | | | | |
+|`cusolverDnXsyevjSetSortEig`|9.0| | | |`hipsolverDnXsyevjSetSortEig`|5.1.0| | | |6.1.0| | | | | | |
+|`cusolverDnXsyevjSetTolerance`|9.0| | | |`hipsolverDnXsyevjSetTolerance`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnXsytrs`|11.3| | | | | | | | | | | | | | | |
 |`cusolverDnXsytrs_bufferSize`|11.3| | | | | | | | | | | | | | | |
 |`cusolverDnXtrtri`|11.4| | | | | | | | | | | | | | | |

--- a/docs/tables/CUSOLVER_API_supported_by_ROC.md
+++ b/docs/tables/CUSOLVER_API_supported_by_ROC.md
@@ -155,6 +155,7 @@
 |`cusolverDnCpotrsBatched`|9.1| | | | | | | | | |
 |`cusolverDnCreate`| | | | |`rocblas_create_handle`| | | | | |
 |`cusolverDnCreateParams`|11.0| | | | | | | | | |
+|`cusolverDnCreateSyevjInfo`|9.0| | | | | | | | | |
 |`cusolverDnCsytrf`| | | | | | | | | | |
 |`cusolverDnCsytrf_bufferSize`| | | | | | | | | | |
 |`cusolverDnCsytri`|10.1| | | | | | | | | |
@@ -190,6 +191,7 @@
 |`cusolverDnDXgesv`|11.0| | | | | | | | | |
 |`cusolverDnDXgesv_bufferSize`|11.0| | | | | | | | | |
 |`cusolverDnDestroy`| | | | |`rocblas_destroy_handle`| | | | | |
+|`cusolverDnDestroySyevjInfo`|9.0| | | | | | | | | |
 |`cusolverDnDgebrd`| | | | | | | | | | |
 |`cusolverDnDgebrd_bufferSize`| | | | | | | | | | |
 |`cusolverDnDgeqrf`| | | | | | | | | | |
@@ -324,6 +326,11 @@
 |`cusolverDnXgetrf`|11.1| | | | | | | | | |
 |`cusolverDnXgetrf_bufferSize`|11.1| | | | | | | | | |
 |`cusolverDnXgetrs`|11.1| | | | | | | | | |
+|`cusolverDnXsyevjGetResidual`|9.0| | | | | | | | | |
+|`cusolverDnXsyevjGetSweeps`|9.0| | | | | | | | | |
+|`cusolverDnXsyevjSetMaxSweeps`|9.0| | | | | | | | | |
+|`cusolverDnXsyevjSetSortEig`|9.0| | | | | | | | | |
+|`cusolverDnXsyevjSetTolerance`|9.0| | | | | | | | | |
 |`cusolverDnXsytrs`|11.3| | | | | | | | | |
 |`cusolverDnXsytrs_bufferSize`|11.3| | | | | | | | | |
 |`cusolverDnXtrtri`|11.4| | | | | | | | | |

--- a/src/CUDA2HIP_SOLVER_API_functions.cpp
+++ b/src/CUDA2HIP_SOLVER_API_functions.cpp
@@ -361,6 +361,14 @@ const std::map<llvm::StringRef, hipCounter> CUDA_SOLVER_FUNCTION_MAP {
   {"cusolverDnDsygvd",                                   {"hipsolverDnDsygvd",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
   {"cusolverDnChegvd",                                   {"hipsolverDnChegvd",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
   {"cusolverDnZhegvd",                                   {"hipsolverDnZhegvd",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
+  // no ROC analogues
+  {"cusolverDnCreateSyevjInfo",                          {"hipsolverDnCreateSyevjInfo",                            "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
+  {"cusolverDnDestroySyevjInfo",                         {"hipsolverDnDestroySyevjInfo",                           "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
+  {"cusolverDnXsyevjSetTolerance",                       {"hipsolverDnXsyevjSetTolerance",                         "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
+  {"cusolverDnXsyevjSetMaxSweeps",                       {"hipsolverDnXsyevjSetMaxSweeps",                         "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
+  {"cusolverDnXsyevjSetSortEig",                         {"hipsolverDnXsyevjSetSortEig",                           "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
+  {"cusolverDnXsyevjGetResidual",                        {"hipsolverDnXsyevjGetResidual",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
+  {"cusolverDnXsyevjGetSweeps",                          {"hipsolverDnXsyevjGetSweeps",                            "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
 };
 
 const std::map<llvm::StringRef, cudaAPIversions> CUDA_SOLVER_FUNCTION_VER_MAP {
@@ -577,6 +585,13 @@ const std::map<llvm::StringRef, cudaAPIversions> CUDA_SOLVER_FUNCTION_VER_MAP {
   {"cusolverDnDsygvd",                                    {CUDA_80,   CUDA_0, CUDA_0}},
   {"cusolverDnChegvd",                                    {CUDA_80,   CUDA_0, CUDA_0}},
   {"cusolverDnZhegvd",                                    {CUDA_80,   CUDA_0, CUDA_0}},
+  {"cusolverDnCreateSyevjInfo",                           {CUDA_90,   CUDA_0, CUDA_0}},
+  {"cusolverDnDestroySyevjInfo",                          {CUDA_90,   CUDA_0, CUDA_0}},
+  {"cusolverDnXsyevjSetTolerance",                        {CUDA_90,   CUDA_0, CUDA_0}},
+  {"cusolverDnXsyevjSetMaxSweeps",                        {CUDA_90,   CUDA_0, CUDA_0}},
+  {"cusolverDnXsyevjSetSortEig",                          {CUDA_90,   CUDA_0, CUDA_0}},
+  {"cusolverDnXsyevjGetResidual",                         {CUDA_90,   CUDA_0, CUDA_0}},
+  {"cusolverDnXsyevjGetSweeps",                           {CUDA_90,   CUDA_0, CUDA_0}},
 };
 
 const std::map<llvm::StringRef, hipAPIversions> HIP_SOLVER_FUNCTION_VER_MAP {
@@ -752,6 +767,13 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_SOLVER_FUNCTION_VER_MAP {
   {"hipsolverDnDsygvd",                                   {HIP_5010, HIP_0,    HIP_0,  HIP_LATEST}},
   {"hipsolverDnChegvd",                                   {HIP_5010, HIP_0,    HIP_0,  HIP_LATEST}},
   {"hipsolverDnZhegvd",                                   {HIP_5010, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipsolverDnCreateSyevjInfo",                          {HIP_5010, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipsolverDnDestroySyevjInfo",                         {HIP_5010, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipsolverDnXsyevjSetTolerance",                       {HIP_5010, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipsolverDnXsyevjSetMaxSweeps",                       {HIP_5010, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipsolverDnXsyevjSetSortEig",                         {HIP_5010, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipsolverDnXsyevjGetResidual",                        {HIP_5010, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipsolverDnXsyevjGetSweeps",                          {HIP_5010, HIP_0,    HIP_0,  HIP_LATEST}},
 
   {"rocsolver_spotrf",                                    {HIP_3020, HIP_0,    HIP_0,  HIP_LATEST}},
   {"rocsolver_dpotrf",                                    {HIP_3020, HIP_0,    HIP_0,  HIP_LATEST}},

--- a/tests/unit_tests/synthetic/libraries/cusolver2hipsolver.cu
+++ b/tests/unit_tests/synthetic/libraries/cusolver2hipsolver.cu
@@ -27,6 +27,9 @@ int main() {
   int info = 0;
   int infoArray = 0;
   int batchSize = 0;
+  int imax_sweeps = 0;
+  int isort_eig = 0;
+  int iexecuted_sweeps = 0;
   float fA = 0.f;
   float fB = 0.f;
   float fC = 0.f;
@@ -57,6 +60,8 @@ int main() {
   double dTAU = 0.f;
   double dTAUQ = 0.f;
   double dTAUP = 0.f;
+  double dtolerance = 0.f;
+  double dresidual = 0.f;
   float fWorkspace = 0.f;
   float frWork = 0.f;
   double dWorkspace = 0.f;
@@ -812,6 +817,41 @@ int main() {
   // HIP: HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDnZpotrsBatched(hipsolverHandle_t handle, hipblasFillMode_t uplo, int n, int nrhs, hipDoubleComplex* A[], int lda, hipDoubleComplex* B[], int ldb, int* devInfo, int batch_count);
   // CHECK: status = hipsolverDnZpotrsBatched(handle, fillMode, n, nrhs, dcomplexAarray, lda, dcomplexBarray, ldb, &infoArray, batchSize);
   status = cusolverDnZpotrsBatched(handle, fillMode, n, nrhs, dcomplexAarray, lda, dcomplexBarray, ldb, &infoArray, batchSize);
+
+  // CUDA: cusolverStatus_t CUSOLVERAPI cusolverDnCreateSyevjInfo(syevjInfo_t *info);
+  // HIP: HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDnCreateSyevjInfo(hipsolverSyevjInfo_t* info);
+  // CHECK: status = hipsolverDnCreateSyevjInfo(&syevj_info);
+  status = cusolverDnCreateSyevjInfo(&syevj_info);
+
+  // CUDA: cusolverStatus_t CUSOLVERAPI cusolverDnDestroySyevjInfo(syevjInfo_t info);
+  // HIP: HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDnDestroySyevjInfo(hipsolverSyevjInfo_t info);
+  // CHECK: status = hipsolverDnDestroySyevjInfo(syevj_info);
+  status = cusolverDnDestroySyevjInfo(syevj_info);
+
+  // CUDA: cusolverStatus_t CUSOLVERAPI cusolverDnXsyevjSetTolerance(syevjInfo_t info, double tolerance);
+  // HIP: HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDnXsyevjSetTolerance(hipsolverSyevjInfo_t info, double tolerance);
+  // CHECK: status = hipsolverDnXsyevjSetTolerance(syevj_info, dtolerance);
+  status = cusolverDnXsyevjSetTolerance(syevj_info, dtolerance);
+
+  // CUDA: cusolverStatus_t CUSOLVERAPI cusolverDnXsyevjSetMaxSweeps(syevjInfo_t info, int max_sweeps);
+  // HIP: HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDnXsyevjSetMaxSweeps(hipsolverSyevjInfo_t info, int max_sweeps);
+  // CHECK: status = hipsolverDnXsyevjSetMaxSweeps(syevj_info, imax_sweeps);
+  status = cusolverDnXsyevjSetMaxSweeps(syevj_info, imax_sweeps);
+
+  // CUDA: cusolverStatus_t CUSOLVERAPI cusolverDnXsyevjSetSortEig(syevjInfo_t info, int sort_eig);
+  // HIP: HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDnXsyevjSetSortEig(hipsolverSyevjInfo_t info, int sort_eig);
+  // CHECK: status = hipsolverDnXsyevjSetSortEig(syevj_info, isort_eig);
+  status = cusolverDnXsyevjSetSortEig(syevj_info, isort_eig);
+
+  // CUDA: cusolverStatus_t CUSOLVERAPI cusolverDnXsyevjGetResidual(cusolverDnHandle_t handle, syevjInfo_t info, double * residual);
+  // HIP: HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDnXsyevjGetResidual(hipsolverDnHandle_t handle, hipsolverSyevjInfo_t info, double* residual);
+  // CHECK: status = hipsolverDnXsyevjGetResidual(handle, syevj_info, &dresidual);
+  status = cusolverDnXsyevjGetResidual(handle, syevj_info, &dresidual);
+
+  // CUDA: cusolverStatus_t CUSOLVERAPI cusolverDnXsyevjGetSweeps(cusolverDnHandle_t handle, syevjInfo_t info, int * executed_sweeps);
+  // HIP: HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDnXsyevjGetSweeps(hipsolverDnHandle_t handle, hipsolverSyevjInfo_t info, int* executed_sweeps);
+  // CHECK: status = hipsolverDnXsyevjGetSweeps(handle, syevj_info, &iexecuted_sweeps);
+  status = cusolverDnXsyevjGetSweeps(handle, syevj_info, &iexecuted_sweeps);
 #endif
 
 #if CUDA_VERSION >= 10010


### PR DESCRIPTION
+ `cusolverDnXsyevj*` are `SUPPORTED` by `hipSOLVER` only
+ [NOTE] `ROC` analogues are missing
+ Updated `SOLVER` synthetic tests, the regenerated `hipify-perl`, and `SOLVER` `CUDA2HIP` documentation
