### PR TITLE
[HIPIFY][#675][#677][SOLVER][feature] `cuSOLVER` support - Step 42 - Functions (DN)

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -1105,8 +1105,10 @@ my %experimental_funcs = (
     "cusolverDnZhegvdx" => "6.1.0",
     "cusolverDnZhegvd_bufferSize" => "6.1.0",
     "cusolverDnZhegvd" => "6.1.0",
+    "cusolverDnZheevj_bufferSize" => "6.1.0",
     "cusolverDnZheevjBatched_bufferSize" => "6.1.0",
     "cusolverDnZheevjBatched" => "6.1.0",
+    "cusolverDnZheevj" => "6.1.0",
     "cusolverDnZheevdx_bufferSize" => "6.1.0",
     "cusolverDnZheevdx" => "6.1.0",
     "cusolverDnZheevd_bufferSize" => "6.1.0",
@@ -1137,8 +1139,10 @@ my %experimental_funcs = (
     "cusolverDnSsygvdx" => "6.1.0",
     "cusolverDnSsygvd_bufferSize" => "6.1.0",
     "cusolverDnSsygvd" => "6.1.0",
+    "cusolverDnSsyevj_bufferSize" => "6.1.0",
     "cusolverDnSsyevjBatched_bufferSize" => "6.1.0",
     "cusolverDnSsyevjBatched" => "6.1.0",
+    "cusolverDnSsyevj" => "6.1.0",
     "cusolverDnSsyevdx_bufferSize" => "6.1.0",
     "cusolverDnSsyevdx" => "6.1.0",
     "cusolverDnSsyevd_bufferSize" => "6.1.0",
@@ -1184,8 +1188,10 @@ my %experimental_funcs = (
     "cusolverDnDsygvdx" => "6.1.0",
     "cusolverDnDsygvd_bufferSize" => "6.1.0",
     "cusolverDnDsygvd" => "6.1.0",
+    "cusolverDnDsyevj_bufferSize" => "6.1.0",
     "cusolverDnDsyevjBatched_bufferSize" => "6.1.0",
     "cusolverDnDsyevjBatched" => "6.1.0",
+    "cusolverDnDsyevj" => "6.1.0",
     "cusolverDnDsyevdx_bufferSize" => "6.1.0",
     "cusolverDnDsyevdx" => "6.1.0",
     "cusolverDnDsyevd_bufferSize" => "6.1.0",
@@ -1249,8 +1255,10 @@ my %experimental_funcs = (
     "cusolverDnChegvdx" => "6.1.0",
     "cusolverDnChegvd_bufferSize" => "6.1.0",
     "cusolverDnChegvd" => "6.1.0",
+    "cusolverDnCheevj_bufferSize" => "6.1.0",
     "cusolverDnCheevjBatched_bufferSize" => "6.1.0",
     "cusolverDnCheevjBatched" => "6.1.0",
+    "cusolverDnCheevj" => "6.1.0",
     "cusolverDnCheevdx_bufferSize" => "6.1.0",
     "cusolverDnCheevdx" => "6.1.0",
     "cusolverDnCheevd_bufferSize" => "6.1.0",
@@ -1440,8 +1448,10 @@ sub experimentalSubstitutions {
     subst("cusolverDnCheevd_bufferSize", "hipsolverDnCheevd_bufferSize", "library");
     subst("cusolverDnCheevdx", "hipsolverDnCheevdx", "library");
     subst("cusolverDnCheevdx_bufferSize", "hipsolverDnCheevdx_bufferSize", "library");
+    subst("cusolverDnCheevj", "hipsolverDnCheevj", "library");
     subst("cusolverDnCheevjBatched", "hipsolverDnCheevjBatched", "library");
     subst("cusolverDnCheevjBatched_bufferSize", "hipsolverDnCheevjBatched_bufferSize", "library");
+    subst("cusolverDnCheevj_bufferSize", "hipsolverDnCheevj_bufferSize", "library");
     subst("cusolverDnChegvd", "hipsolverDnChegvd", "library");
     subst("cusolverDnChegvd_bufferSize", "hipsolverDnChegvd_bufferSize", "library");
     subst("cusolverDnChegvdx", "hipsolverDnChegvdx", "library");
@@ -1505,8 +1515,10 @@ sub experimentalSubstitutions {
     subst("cusolverDnDsyevd_bufferSize", "hipsolverDnDsyevd_bufferSize", "library");
     subst("cusolverDnDsyevdx", "hipsolverDnDsyevdx", "library");
     subst("cusolverDnDsyevdx_bufferSize", "hipsolverDnDsyevdx_bufferSize", "library");
+    subst("cusolverDnDsyevj", "hipsolverDnDsyevj", "library");
     subst("cusolverDnDsyevjBatched", "hipsolverDnDsyevjBatched", "library");
     subst("cusolverDnDsyevjBatched_bufferSize", "hipsolverDnDsyevjBatched_bufferSize", "library");
+    subst("cusolverDnDsyevj_bufferSize", "hipsolverDnDsyevj_bufferSize", "library");
     subst("cusolverDnDsygvd", "hipsolverDnDsygvd", "library");
     subst("cusolverDnDsygvd_bufferSize", "hipsolverDnDsygvd_bufferSize", "library");
     subst("cusolverDnDsygvdx", "hipsolverDnDsygvdx", "library");
@@ -1551,8 +1563,10 @@ sub experimentalSubstitutions {
     subst("cusolverDnSsyevd_bufferSize", "hipsolverDnSsyevd_bufferSize", "library");
     subst("cusolverDnSsyevdx", "hipsolverDnSsyevdx", "library");
     subst("cusolverDnSsyevdx_bufferSize", "hipsolverDnSsyevdx_bufferSize", "library");
+    subst("cusolverDnSsyevj", "hipsolverDnSsyevj", "library");
     subst("cusolverDnSsyevjBatched", "hipsolverDnSsyevjBatched", "library");
     subst("cusolverDnSsyevjBatched_bufferSize", "hipsolverDnSsyevjBatched_bufferSize", "library");
+    subst("cusolverDnSsyevj_bufferSize", "hipsolverDnSsyevj_bufferSize", "library");
     subst("cusolverDnSsygvd", "hipsolverDnSsygvd", "library");
     subst("cusolverDnSsygvd_bufferSize", "hipsolverDnSsygvd_bufferSize", "library");
     subst("cusolverDnSsygvdx", "hipsolverDnSsygvdx", "library");
@@ -1583,8 +1597,10 @@ sub experimentalSubstitutions {
     subst("cusolverDnZheevd_bufferSize", "hipsolverDnZheevd_bufferSize", "library");
     subst("cusolverDnZheevdx", "hipsolverDnZheevdx", "library");
     subst("cusolverDnZheevdx_bufferSize", "hipsolverDnZheevdx_bufferSize", "library");
+    subst("cusolverDnZheevj", "hipsolverDnZheevj", "library");
     subst("cusolverDnZheevjBatched", "hipsolverDnZheevjBatched", "library");
     subst("cusolverDnZheevjBatched_bufferSize", "hipsolverDnZheevjBatched_bufferSize", "library");
+    subst("cusolverDnZheevj_bufferSize", "hipsolverDnZheevj_bufferSize", "library");
     subst("cusolverDnZhegvd", "hipsolverDnZhegvd", "library");
     subst("cusolverDnZhegvd_bufferSize", "hipsolverDnZhegvd_bufferSize", "library");
     subst("cusolverDnZhegvdx", "hipsolverDnZhegvdx", "library");

--- a/docs/tables/CUSOLVER_API_supported_by_HIP.md
+++ b/docs/tables/CUSOLVER_API_supported_by_HIP.md
@@ -137,8 +137,10 @@
 |`cusolverDnCheevd_bufferSize`|8.0| | | |`hipsolverDnCheevd_bufferSize`|5.1.0| | | |6.1.0|
 |`cusolverDnCheevdx`|10.1| | | |`hipsolverDnCheevdx`|5.3.0| | | |6.1.0|
 |`cusolverDnCheevdx_bufferSize`|10.1| | | |`hipsolverDnCheevdx_bufferSize`|5.3.0| | | |6.1.0|
+|`cusolverDnCheevj`|9.0| | | |`hipsolverDnCheevj`|5.1.0| | | |6.1.0|
 |`cusolverDnCheevjBatched`|9.0| | | |`hipsolverDnCheevjBatched`|5.1.0| | | |6.1.0|
 |`cusolverDnCheevjBatched_bufferSize`|9.0| | | |`hipsolverDnCheevjBatched_bufferSize`|5.1.0| | | |6.1.0|
+|`cusolverDnCheevj_bufferSize`|9.0| | | |`hipsolverDnCheevj_bufferSize`|5.1.0| | | |6.1.0|
 |`cusolverDnChegvd`|8.0| | | |`hipsolverDnChegvd`|5.1.0| | | |6.1.0|
 |`cusolverDnChegvd_bufferSize`|8.0| | | |`hipsolverDnChegvd_bufferSize`|5.1.0| | | |6.1.0|
 |`cusolverDnChegvdx`|10.1| | | |`hipsolverDnChegvdx`|5.3.0| | | |6.1.0|
@@ -227,8 +229,10 @@
 |`cusolverDnDsyevd_bufferSize`|8.0| | | |`hipsolverDnDsyevd_bufferSize`|5.1.0| | | |6.1.0|
 |`cusolverDnDsyevdx`|10.1| | | |`hipsolverDnDsyevdx`|5.3.0| | | |6.1.0|
 |`cusolverDnDsyevdx_bufferSize`|10.1| | | |`hipsolverDnDsyevdx_bufferSize`|5.3.0| | | |6.1.0|
+|`cusolverDnDsyevj`|9.0| | | |`hipsolverDnDsyevj`|5.1.0| | | |6.1.0|
 |`cusolverDnDsyevjBatched`|9.0| | | |`hipsolverDnDsyevjBatched`|5.1.0| | | |6.1.0|
 |`cusolverDnDsyevjBatched_bufferSize`|9.0| | | |`hipsolverDnDsyevjBatched_bufferSize`|5.1.0| | | |6.1.0|
+|`cusolverDnDsyevj_bufferSize`|9.0| | | |`hipsolverDnDsyevj_bufferSize`|5.1.0| | | |6.1.0|
 |`cusolverDnDsygvd`|8.0| | | |`hipsolverDnDsygvd`|5.1.0| | | |6.1.0|
 |`cusolverDnDsygvd_bufferSize`|8.0| | | |`hipsolverDnDsygvd_bufferSize`|5.1.0| | | |6.1.0|
 |`cusolverDnDsygvdx`|10.1| | | |`hipsolverDnDsygvdx`|5.3.0| | | |6.1.0|
@@ -317,8 +321,10 @@
 |`cusolverDnSsyevd_bufferSize`|8.0| | | |`hipsolverDnSsyevd_bufferSize`|5.1.0| | | |6.1.0|
 |`cusolverDnSsyevdx`|10.1| | | |`hipsolverDnSsyevdx`|5.3.0| | | |6.1.0|
 |`cusolverDnSsyevdx_bufferSize`|10.1| | | |`hipsolverDnSsyevdx_bufferSize`|5.3.0| | | |6.1.0|
+|`cusolverDnSsyevj`|9.0| | | |`hipsolverDnSsyevj`|5.1.0| | | |6.1.0|
 |`cusolverDnSsyevjBatched`|9.0| | | |`hipsolverDnSsyevjBatched`|5.1.0| | | |6.1.0|
 |`cusolverDnSsyevjBatched_bufferSize`|9.0| | | |`hipsolverDnSsyevjBatched_bufferSize`|5.1.0| | | |6.1.0|
+|`cusolverDnSsyevj_bufferSize`|9.0| | | |`hipsolverDnSsyevj_bufferSize`|5.1.0| | | |6.1.0|
 |`cusolverDnSsygvd`|8.0| | | |`hipsolverDnSsygvd`|5.1.0| | | |6.1.0|
 |`cusolverDnSsygvd_bufferSize`|8.0| | | |`hipsolverDnSsygvd_bufferSize`|5.1.0| | | |6.1.0|
 |`cusolverDnSsygvdx`|10.1| | | |`hipsolverDnSsygvdx`|5.3.0| | | |6.1.0|
@@ -374,8 +380,10 @@
 |`cusolverDnZheevd_bufferSize`|8.0| | | |`hipsolverDnZheevd_bufferSize`|5.1.0| | | |6.1.0|
 |`cusolverDnZheevdx`|10.1| | | |`hipsolverDnZheevdx`|5.3.0| | | |6.1.0|
 |`cusolverDnZheevdx_bufferSize`|10.1| | | |`hipsolverDnZheevdx_bufferSize`|5.3.0| | | |6.1.0|
+|`cusolverDnZheevj`|9.0| | | |`hipsolverDnZheevj`|5.1.0| | | |6.1.0|
 |`cusolverDnZheevjBatched`|9.0| | | |`hipsolverDnZheevjBatched`|5.1.0| | | |6.1.0|
 |`cusolverDnZheevjBatched_bufferSize`|9.0| | | |`hipsolverDnZheevjBatched_bufferSize`|5.1.0| | | |6.1.0|
+|`cusolverDnZheevj_bufferSize`|9.0| | | |`hipsolverDnZheevj_bufferSize`|5.1.0| | | |6.1.0|
 |`cusolverDnZhegvd`|8.0| | | |`hipsolverDnZhegvd`|5.1.0| | | |6.1.0|
 |`cusolverDnZhegvd_bufferSize`|8.0| | | |`hipsolverDnZhegvd_bufferSize`|5.1.0| | | |6.1.0|
 |`cusolverDnZhegvdx`|10.1| | | |`hipsolverDnZhegvdx`|5.3.0| | | |6.1.0|

--- a/docs/tables/CUSOLVER_API_supported_by_HIP_and_ROC.md
+++ b/docs/tables/CUSOLVER_API_supported_by_HIP_and_ROC.md
@@ -137,8 +137,10 @@
 |`cusolverDnCheevd_bufferSize`|8.0| | | |`hipsolverDnCheevd_bufferSize`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnCheevdx`|10.1| | | |`hipsolverDnCheevdx`|5.3.0| | | |6.1.0| | | | | | |
 |`cusolverDnCheevdx_bufferSize`|10.1| | | |`hipsolverDnCheevdx_bufferSize`|5.3.0| | | |6.1.0| | | | | | |
+|`cusolverDnCheevj`|9.0| | | |`hipsolverDnCheevj`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnCheevjBatched`|9.0| | | |`hipsolverDnCheevjBatched`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnCheevjBatched_bufferSize`|9.0| | | |`hipsolverDnCheevjBatched_bufferSize`|5.1.0| | | |6.1.0| | | | | | |
+|`cusolverDnCheevj_bufferSize`|9.0| | | |`hipsolverDnCheevj_bufferSize`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnChegvd`|8.0| | | |`hipsolverDnChegvd`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnChegvd_bufferSize`|8.0| | | |`hipsolverDnChegvd_bufferSize`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnChegvdx`|10.1| | | |`hipsolverDnChegvdx`|5.3.0| | | |6.1.0| | | | | | |
@@ -227,8 +229,10 @@
 |`cusolverDnDsyevd_bufferSize`|8.0| | | |`hipsolverDnDsyevd_bufferSize`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnDsyevdx`|10.1| | | |`hipsolverDnDsyevdx`|5.3.0| | | |6.1.0| | | | | | |
 |`cusolverDnDsyevdx_bufferSize`|10.1| | | |`hipsolverDnDsyevdx_bufferSize`|5.3.0| | | |6.1.0| | | | | | |
+|`cusolverDnDsyevj`|9.0| | | |`hipsolverDnDsyevj`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnDsyevjBatched`|9.0| | | |`hipsolverDnDsyevjBatched`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnDsyevjBatched_bufferSize`|9.0| | | |`hipsolverDnDsyevjBatched_bufferSize`|5.1.0| | | |6.1.0| | | | | | |
+|`cusolverDnDsyevj_bufferSize`|9.0| | | |`hipsolverDnDsyevj_bufferSize`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnDsygvd`|8.0| | | |`hipsolverDnDsygvd`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnDsygvd_bufferSize`|8.0| | | |`hipsolverDnDsygvd_bufferSize`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnDsygvdx`|10.1| | | |`hipsolverDnDsygvdx`|5.3.0| | | |6.1.0| | | | | | |
@@ -317,8 +321,10 @@
 |`cusolverDnSsyevd_bufferSize`|8.0| | | |`hipsolverDnSsyevd_bufferSize`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnSsyevdx`|10.1| | | |`hipsolverDnSsyevdx`|5.3.0| | | |6.1.0| | | | | | |
 |`cusolverDnSsyevdx_bufferSize`|10.1| | | |`hipsolverDnSsyevdx_bufferSize`|5.3.0| | | |6.1.0| | | | | | |
+|`cusolverDnSsyevj`|9.0| | | |`hipsolverDnSsyevj`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnSsyevjBatched`|9.0| | | |`hipsolverDnSsyevjBatched`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnSsyevjBatched_bufferSize`|9.0| | | |`hipsolverDnSsyevjBatched_bufferSize`|5.1.0| | | |6.1.0| | | | | | |
+|`cusolverDnSsyevj_bufferSize`|9.0| | | |`hipsolverDnSsyevj_bufferSize`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnSsygvd`|8.0| | | |`hipsolverDnSsygvd`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnSsygvd_bufferSize`|8.0| | | |`hipsolverDnSsygvd_bufferSize`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnSsygvdx`|10.1| | | |`hipsolverDnSsygvdx`|5.3.0| | | |6.1.0| | | | | | |
@@ -374,8 +380,10 @@
 |`cusolverDnZheevd_bufferSize`|8.0| | | |`hipsolverDnZheevd_bufferSize`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnZheevdx`|10.1| | | |`hipsolverDnZheevdx`|5.3.0| | | |6.1.0| | | | | | |
 |`cusolverDnZheevdx_bufferSize`|10.1| | | |`hipsolverDnZheevdx_bufferSize`|5.3.0| | | |6.1.0| | | | | | |
+|`cusolverDnZheevj`|9.0| | | |`hipsolverDnZheevj`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnZheevjBatched`|9.0| | | |`hipsolverDnZheevjBatched`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnZheevjBatched_bufferSize`|9.0| | | |`hipsolverDnZheevjBatched_bufferSize`|5.1.0| | | |6.1.0| | | | | | |
+|`cusolverDnZheevj_bufferSize`|9.0| | | |`hipsolverDnZheevj_bufferSize`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnZhegvd`|8.0| | | |`hipsolverDnZhegvd`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnZhegvd_bufferSize`|8.0| | | |`hipsolverDnZhegvd_bufferSize`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnZhegvdx`|10.1| | | |`hipsolverDnZhegvdx`|5.3.0| | | |6.1.0| | | | | | |

--- a/docs/tables/CUSOLVER_API_supported_by_ROC.md
+++ b/docs/tables/CUSOLVER_API_supported_by_ROC.md
@@ -137,8 +137,10 @@
 |`cusolverDnCheevd_bufferSize`|8.0| | | | | | | | | |
 |`cusolverDnCheevdx`|10.1| | | | | | | | | |
 |`cusolverDnCheevdx_bufferSize`|10.1| | | | | | | | | |
+|`cusolverDnCheevj`|9.0| | | | | | | | | |
 |`cusolverDnCheevjBatched`|9.0| | | | | | | | | |
 |`cusolverDnCheevjBatched_bufferSize`|9.0| | | | | | | | | |
+|`cusolverDnCheevj_bufferSize`|9.0| | | | | | | | | |
 |`cusolverDnChegvd`|8.0| | | | | | | | | |
 |`cusolverDnChegvd_bufferSize`|8.0| | | | | | | | | |
 |`cusolverDnChegvdx`|10.1| | | | | | | | | |
@@ -227,8 +229,10 @@
 |`cusolverDnDsyevd_bufferSize`|8.0| | | | | | | | | |
 |`cusolverDnDsyevdx`|10.1| | | | | | | | | |
 |`cusolverDnDsyevdx_bufferSize`|10.1| | | | | | | | | |
+|`cusolverDnDsyevj`|9.0| | | | | | | | | |
 |`cusolverDnDsyevjBatched`|9.0| | | | | | | | | |
 |`cusolverDnDsyevjBatched_bufferSize`|9.0| | | | | | | | | |
+|`cusolverDnDsyevj_bufferSize`|9.0| | | | | | | | | |
 |`cusolverDnDsygvd`|8.0| | | | | | | | | |
 |`cusolverDnDsygvd_bufferSize`|8.0| | | | | | | | | |
 |`cusolverDnDsygvdx`|10.1| | | | | | | | | |
@@ -317,8 +321,10 @@
 |`cusolverDnSsyevd_bufferSize`|8.0| | | | | | | | | |
 |`cusolverDnSsyevdx`|10.1| | | | | | | | | |
 |`cusolverDnSsyevdx_bufferSize`|10.1| | | | | | | | | |
+|`cusolverDnSsyevj`|9.0| | | | | | | | | |
 |`cusolverDnSsyevjBatched`|9.0| | | | | | | | | |
 |`cusolverDnSsyevjBatched_bufferSize`|9.0| | | | | | | | | |
+|`cusolverDnSsyevj_bufferSize`|9.0| | | | | | | | | |
 |`cusolverDnSsygvd`|8.0| | | | | | | | | |
 |`cusolverDnSsygvd_bufferSize`|8.0| | | | | | | | | |
 |`cusolverDnSsygvdx`|10.1| | | | | | | | | |
@@ -374,8 +380,10 @@
 |`cusolverDnZheevd_bufferSize`|8.0| | | | | | | | | |
 |`cusolverDnZheevdx`|10.1| | | | | | | | | |
 |`cusolverDnZheevdx_bufferSize`|10.1| | | | | | | | | |
+|`cusolverDnZheevj`|9.0| | | | | | | | | |
 |`cusolverDnZheevjBatched`|9.0| | | | | | | | | |
 |`cusolverDnZheevjBatched_bufferSize`|9.0| | | | | | | | | |
+|`cusolverDnZheevj_bufferSize`|9.0| | | | | | | | | |
 |`cusolverDnZhegvd`|8.0| | | | | | | | | |
 |`cusolverDnZhegvd_bufferSize`|8.0| | | | | | | | | |
 |`cusolverDnZhegvdx`|10.1| | | | | | | | | |

--- a/src/CUDA2HIP_SOLVER_API_functions.cpp
+++ b/src/CUDA2HIP_SOLVER_API_functions.cpp
@@ -379,6 +379,16 @@ const std::map<llvm::StringRef, hipCounter> CUDA_SOLVER_FUNCTION_MAP {
   {"cusolverDnDsyevjBatched",                            {"hipsolverDnDsyevjBatched",                              "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
   {"cusolverDnCheevjBatched",                            {"hipsolverDnCheevjBatched",                              "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
   {"cusolverDnZheevjBatched",                            {"hipsolverDnZheevjBatched",                              "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
+  // NOTE: rocsolver_(s|d)syevj and rocsolver_(c|z)heevj have a harness of other ROC and HIP API calls
+  {"cusolverDnSsyevj_bufferSize",                        {"hipsolverDnSsyevj_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
+  {"cusolverDnDsyevj_bufferSize",                        {"hipsolverDnDsyevj_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
+  {"cusolverDnCheevj_bufferSize",                        {"hipsolverDnCheevj_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
+  {"cusolverDnZheevj_bufferSize",                        {"hipsolverDnZheevj_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
+  // NOTE: rocsolver_(s|d)syevj and rocsolver_(c|z)heevj have a harness of other ROC and HIP API calls
+  {"cusolverDnSsyevj",                                   {"hipsolverDnSsyevj",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
+  {"cusolverDnDsyevj",                                   {"hipsolverDnDsyevj",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
+  {"cusolverDnCheevj",                                   {"hipsolverDnCheevj",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
+  {"cusolverDnZheevj",                                   {"hipsolverDnZheevj",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
 };
 
 const std::map<llvm::StringRef, cudaAPIversions> CUDA_SOLVER_FUNCTION_VER_MAP {
@@ -610,6 +620,14 @@ const std::map<llvm::StringRef, cudaAPIversions> CUDA_SOLVER_FUNCTION_VER_MAP {
   {"cusolverDnDsyevjBatched",                             {CUDA_90,   CUDA_0, CUDA_0}},
   {"cusolverDnCheevjBatched",                             {CUDA_90,   CUDA_0, CUDA_0}},
   {"cusolverDnZheevjBatched",                             {CUDA_90,   CUDA_0, CUDA_0}},
+  {"cusolverDnSsyevj_bufferSize",                         {CUDA_90,   CUDA_0, CUDA_0}},
+  {"cusolverDnDsyevj_bufferSize",                         {CUDA_90,   CUDA_0, CUDA_0}},
+  {"cusolverDnCheevj_bufferSize",                         {CUDA_90,   CUDA_0, CUDA_0}},
+  {"cusolverDnZheevj_bufferSize",                         {CUDA_90,   CUDA_0, CUDA_0}},
+  {"cusolverDnSsyevj",                                    {CUDA_90,   CUDA_0, CUDA_0}},
+  {"cusolverDnDsyevj",                                    {CUDA_90,   CUDA_0, CUDA_0}},
+  {"cusolverDnCheevj",                                    {CUDA_90,   CUDA_0, CUDA_0}},
+  {"cusolverDnZheevj",                                    {CUDA_90,   CUDA_0, CUDA_0}},
 };
 
 const std::map<llvm::StringRef, hipAPIversions> HIP_SOLVER_FUNCTION_VER_MAP {
@@ -800,6 +818,14 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_SOLVER_FUNCTION_VER_MAP {
   {"hipsolverDnDsyevjBatched",                            {HIP_5010, HIP_0,    HIP_0,  HIP_LATEST}},
   {"hipsolverDnCheevjBatched",                            {HIP_5010, HIP_0,    HIP_0,  HIP_LATEST}},
   {"hipsolverDnZheevjBatched",                            {HIP_5010, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipsolverDnSsyevj_bufferSize",                        {HIP_5010, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipsolverDnDsyevj_bufferSize",                        {HIP_5010, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipsolverDnCheevj_bufferSize",                        {HIP_5010, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipsolverDnZheevj_bufferSize",                        {HIP_5010, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipsolverDnSsyevj",                                   {HIP_5010, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipsolverDnDsyevj",                                   {HIP_5010, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipsolverDnCheevj",                                   {HIP_5010, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipsolverDnZheevj",                                   {HIP_5010, HIP_0,    HIP_0,  HIP_LATEST}},
 
   {"rocsolver_spotrf",                                    {HIP_3020, HIP_0,    HIP_0,  HIP_LATEST}},
   {"rocsolver_dpotrf",                                    {HIP_3020, HIP_0,    HIP_0,  HIP_LATEST}},

--- a/tests/unit_tests/synthetic/libraries/cusolver2hipsolver.cu
+++ b/tests/unit_tests/synthetic/libraries/cusolver2hipsolver.cu
@@ -892,6 +892,46 @@ int main() {
   // HIP: HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDnZheevjBatched(hipsolverDnHandle_t handle, hipsolverEigMode_t jobz, hipblasFillMode_t uplo, int n, hipDoubleComplex* A, int lda, double* W, hipDoubleComplex* work, int lwork, int* devInfo, hipsolverSyevjInfo_t params, int batch_count);
   // CHECK: status = hipsolverDnZheevjBatched(handle, jobz, fillMode, n, &dComplexA, lda, &dW, &dComplexWorkspace, Lwork, &info, syevj_info, batchSize);
   status = cusolverDnZheevjBatched(handle, jobz, fillMode, n, &dComplexA, lda, &dW, &dComplexWorkspace, Lwork, &info, syevj_info, batchSize);
+
+  // CUDA: cusolverStatus_t CUSOLVERAPI cusolverDnSsyevj_bufferSize(cusolverDnHandle_t handle, cusolverEigMode_t jobz, cublasFillMode_t uplo, int n, const float * A, int lda, const float * W, int * lwork, syevjInfo_t params);
+  // HIP: HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDnSsyevj_bufferSize(hipsolverDnHandle_t handle, hipsolverEigMode_t jobz, hipblasFillMode_t uplo, int n, const float* A, int lda, const float* W, int* lwork, hipsolverSyevjInfo_t params);
+  // CHECK: status = hipsolverDnSsyevj_bufferSize(handle, jobz, fillMode, n, &fA, lda, &fW, &Lwork, syevj_info);
+  status = cusolverDnSsyevj_bufferSize(handle, jobz, fillMode, n, &fA, lda, &fW, &Lwork, syevj_info);
+
+  // CUDA: cusolverStatus_t CUSOLVERAPI cusolverDnDsyevj_bufferSize(cusolverDnHandle_t handle, cusolverEigMode_t jobz, cublasFillMode_t uplo, int n, const double * A, int lda, const double * W, int * lwork, syevjInfo_t params);
+  // HIP: HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDnDsyevj_bufferSize(hipsolverDnHandle_t handle, hipsolverEigMode_t jobz, hipblasFillMode_t uplo, int n, const double* A, int lda, const double* W, int* lwork, hipsolverSyevjInfo_t params);
+  // CHECK: status = hipsolverDnDsyevj_bufferSize(handle, jobz, fillMode, n, &dA, lda, &dW, &Lwork, syevj_info);
+  status = cusolverDnDsyevj_bufferSize(handle, jobz, fillMode, n, &dA, lda, &dW, &Lwork, syevj_info);
+
+  // CUDA: cusolverStatus_t CUSOLVERAPI cusolverDnCheevj_bufferSize(cusolverDnHandle_t handle, cusolverEigMode_t jobz, cublasFillMode_t uplo, int n, const cuComplex * A, int lda, const float * W, int * lwork, syevjInfo_t params);
+  // HIP: HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDnCheevj_bufferSize(hipsolverDnHandle_t handle, hipsolverEigMode_t jobz, hipblasFillMode_t uplo, int n, const hipFloatComplex* A, int lda, const float* W, int* lwork, hipsolverSyevjInfo_t params);
+  // CHECK: status = hipsolverDnCheevj_bufferSize(handle, jobz, fillMode, n, &complexA, lda, &fW, &Lwork, syevj_info);
+  status = cusolverDnCheevj_bufferSize(handle, jobz, fillMode, n, &complexA, lda, &fW, &Lwork, syevj_info);
+
+  // CUDA: cusolverStatus_t CUSOLVERAPI cusolverDnZheevj_bufferSize(cusolverDnHandle_t handle, cusolverEigMode_t jobz, cublasFillMode_t uplo, int n, const cuDoubleComplex *A, int lda, const double * W, int * lwork, syevjInfo_t params);
+  // HIP: HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDnZheevj_bufferSize(hipsolverDnHandle_t handle, hipsolverEigMode_t jobz, hipblasFillMode_t uplo, int n, const hipDoubleComplex* A, int lda, const double* W, int* lwork, hipsolverSyevjInfo_t params);
+  // CHECK: status = hipsolverDnZheevj_bufferSize(handle, jobz, fillMode, n, &dComplexA, lda, &dW, &Lwork, syevj_info);
+  status = cusolverDnZheevj_bufferSize(handle, jobz, fillMode, n, &dComplexA, lda, &dW, &Lwork, syevj_info);
+
+  // CUDA: cusolverStatus_t CUSOLVERAPI cusolverDnSsyevj(cusolverDnHandle_t handle, cusolverEigMode_t jobz, cublasFillMode_t uplo, int n, float * A, int lda, float * W, float * work, int lwork, int * info, syevjInfo_t params);
+  // HIP: HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDnSsyevj(hipsolverDnHandle_t handle, hipsolverEigMode_t jobz, hipblasFillMode_t uplo, int n, float* A, int lda, float* W, float* work, int lwork, int* devInfo, hipsolverSyevjInfo_t params);
+  // CHECK: status = hipsolverDnSsyevj(handle, jobz, fillMode, n, &fA, lda, &fW, &fWorkspace, Lwork, &info, syevj_info);
+  status = cusolverDnSsyevj(handle, jobz, fillMode, n, &fA, lda, &fW, &fWorkspace, Lwork, &info, syevj_info);
+
+  // CUDA: cusolverStatus_t CUSOLVERAPI cusolverDnDsyevj(cusolverDnHandle_t handle, cusolverEigMode_t jobz, cublasFillMode_t uplo, int n, double * A, int lda, double * W, double * work, int lwork, int * info, syevjInfo_t params);
+  // HIP: HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDnDsyevj(hipsolverDnHandle_t  handle, hipsolverEigMode_t jobz, hipblasFillMode_t uplo, int n, double* A, int lda, double* W, double* work, int lwork, int* devInfo, hipsolverSyevjInfo_t params);B
+  // CHECK: status = hipsolverDnDsyevj(handle, jobz, fillMode, n, &dA, lda, &dW, &dWorkspace, Lwork, &info, syevj_info);
+  status = cusolverDnDsyevj(handle, jobz, fillMode, n, &dA, lda, &dW, &dWorkspace, Lwork, &info, syevj_info);
+
+  // CUDA: cusolverStatus_t CUSOLVERAPI cusolverDnCheevj(cusolverDnHandle_t handle, cusolverEigMode_t jobz, cublasFillMode_t uplo, int n, cuComplex * A, int lda, float * W, cuComplex * work, int lwork, int * info, syevjInfo_t params);
+  // HIP: HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDnCheevj(hipsolverDnHandle_t handle, hipsolverEigMode_t jobz, hipblasFillMode_t uplo, int n, hipFloatComplex* A, int lda, float* W, hipFloatComplex* work, int lwork, int* devInfo, hipsolverSyevjInfo_t params);
+  // CHECK: status = hipsolverDnCheevj(handle, jobz, fillMode, n, &complexA, lda, &fW, &complexWorkspace, Lwork, &info, syevj_info);
+  status = cusolverDnCheevj(handle, jobz, fillMode, n, &complexA, lda, &fW, &complexWorkspace, Lwork, &info, syevj_info);
+
+  // CUDA: cusolverStatus_t CUSOLVERAPI cusolverDnZheevj(cusolverDnHandle_t handle, cusolverEigMode_t jobz, cublasFillMode_t uplo, int n, cuDoubleComplex * A, int lda, double * W, cuDoubleComplex * work, int lwork, int * info, syevjInfo_t params);
+  // HIP: HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDnZheevj(hipsolverDnHandle_t handle, hipsolverEigMode_t jobz, hipblasFillMode_t uplo, int n, hipDoubleComplex* A, int lda, double* W, hipDoubleComplex* work, int lwork, int* devInfo, hipsolverSyevjInfo_t params);
+  // CHECK: status = hipsolverDnZheevj(handle, jobz, fillMode, n, &dComplexA, lda, &dW, &dComplexWorkspace, Lwork, &info, syevj_info);
+  status = cusolverDnZheevj(handle, jobz, fillMode, n, &dComplexA, lda, &dW, &dComplexWorkspace, Lwork, &info, syevj_info);
 #endif
 
 #if CUDA_VERSION >= 10010


### PR DESCRIPTION
+ `cusolverDn(S|D)syevj(_bufferSize)?` and `cusolverDn(C|Z)heevj(_bufferSize)?`are `SUPPORTED` by `hipSOLVER` only
+ [NOTE] `rocsolver_(s|d)syevj` and `rocsolver_(c|z)heevj` have a harness of other `ROC` and `HIP` API calls, thus `UNSUPPORTED`
+ Updated `SOLVER` synthetic tests, the regenerated `hipify-perl`, and `SOLVER` `CUDA2HIP` documentation