### PR TITLE
[HIPIFY][#675][#677][SOLVER][feature] `cuSOLVER` support - Step 43 - Functions (DN)

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -1101,6 +1101,8 @@ my %experimental_funcs = (
     "cusolverDnZpotrf" => "6.1.0",
     "cusolverDnZhetrd_bufferSize" => "6.1.0",
     "cusolverDnZhetrd" => "6.1.0",
+    "cusolverDnZhegvj_bufferSize" => "6.1.0",
+    "cusolverDnZhegvj" => "6.1.0",
     "cusolverDnZhegvdx_bufferSize" => "6.1.0",
     "cusolverDnZhegvdx" => "6.1.0",
     "cusolverDnZhegvd_bufferSize" => "6.1.0",
@@ -1135,6 +1137,8 @@ my %experimental_funcs = (
     "cusolverDnSsytrf" => "6.1.0",
     "cusolverDnSsytrd_bufferSize" => "6.1.0",
     "cusolverDnSsytrd" => "6.1.0",
+    "cusolverDnSsygvj_bufferSize" => "6.1.0",
+    "cusolverDnSsygvj" => "6.1.0",
     "cusolverDnSsygvdx_bufferSize" => "6.1.0",
     "cusolverDnSsygvdx" => "6.1.0",
     "cusolverDnSsygvd_bufferSize" => "6.1.0",
@@ -1184,6 +1188,8 @@ my %experimental_funcs = (
     "cusolverDnDsytrf" => "6.1.0",
     "cusolverDnDsytrd_bufferSize" => "6.1.0",
     "cusolverDnDsytrd" => "6.1.0",
+    "cusolverDnDsygvj_bufferSize" => "6.1.0",
+    "cusolverDnDsygvj" => "6.1.0",
     "cusolverDnDsygvdx_bufferSize" => "6.1.0",
     "cusolverDnDsygvdx" => "6.1.0",
     "cusolverDnDsygvd_bufferSize" => "6.1.0",
@@ -1251,6 +1257,8 @@ my %experimental_funcs = (
     "cusolverDnCpotrf" => "6.1.0",
     "cusolverDnChetrd_bufferSize" => "6.1.0",
     "cusolverDnChetrd" => "6.1.0",
+    "cusolverDnChegvj_bufferSize" => "6.1.0",
+    "cusolverDnChegvj" => "6.1.0",
     "cusolverDnChegvdx_bufferSize" => "6.1.0",
     "cusolverDnChegvdx" => "6.1.0",
     "cusolverDnChegvd_bufferSize" => "6.1.0",
@@ -1456,6 +1464,8 @@ sub experimentalSubstitutions {
     subst("cusolverDnChegvd_bufferSize", "hipsolverDnChegvd_bufferSize", "library");
     subst("cusolverDnChegvdx", "hipsolverDnChegvdx", "library");
     subst("cusolverDnChegvdx_bufferSize", "hipsolverDnChegvdx_bufferSize", "library");
+    subst("cusolverDnChegvj", "hipsolverDnChegvj", "library");
+    subst("cusolverDnChegvj_bufferSize", "hipsolverDnChegvj_bufferSize", "library");
     subst("cusolverDnChetrd", "hipsolverDnChetrd", "library");
     subst("cusolverDnChetrd_bufferSize", "hipsolverDnChetrd_bufferSize", "library");
     subst("cusolverDnCpotrf", "hipsolverDnCpotrf", "library");
@@ -1523,6 +1533,8 @@ sub experimentalSubstitutions {
     subst("cusolverDnDsygvd_bufferSize", "hipsolverDnDsygvd_bufferSize", "library");
     subst("cusolverDnDsygvdx", "hipsolverDnDsygvdx", "library");
     subst("cusolverDnDsygvdx_bufferSize", "hipsolverDnDsygvdx_bufferSize", "library");
+    subst("cusolverDnDsygvj", "hipsolverDnDsygvj", "library");
+    subst("cusolverDnDsygvj_bufferSize", "hipsolverDnDsygvj_bufferSize", "library");
     subst("cusolverDnDsytrd", "hipsolverDnDsytrd", "library");
     subst("cusolverDnDsytrd_bufferSize", "hipsolverDnDsytrd_bufferSize", "library");
     subst("cusolverDnDsytrf", "hipsolverDnDsytrf", "library");
@@ -1571,6 +1583,8 @@ sub experimentalSubstitutions {
     subst("cusolverDnSsygvd_bufferSize", "hipsolverDnSsygvd_bufferSize", "library");
     subst("cusolverDnSsygvdx", "hipsolverDnSsygvdx", "library");
     subst("cusolverDnSsygvdx_bufferSize", "hipsolverDnSsygvdx_bufferSize", "library");
+    subst("cusolverDnSsygvj", "hipsolverDnSsygvj", "library");
+    subst("cusolverDnSsygvj_bufferSize", "hipsolverDnSsygvj_bufferSize", "library");
     subst("cusolverDnSsytrd", "hipsolverDnSsytrd", "library");
     subst("cusolverDnSsytrd_bufferSize", "hipsolverDnSsytrd_bufferSize", "library");
     subst("cusolverDnSsytrf", "hipsolverDnSsytrf", "library");
@@ -1605,6 +1619,8 @@ sub experimentalSubstitutions {
     subst("cusolverDnZhegvd_bufferSize", "hipsolverDnZhegvd_bufferSize", "library");
     subst("cusolverDnZhegvdx", "hipsolverDnZhegvdx", "library");
     subst("cusolverDnZhegvdx_bufferSize", "hipsolverDnZhegvdx_bufferSize", "library");
+    subst("cusolverDnZhegvj", "hipsolverDnZhegvj", "library");
+    subst("cusolverDnZhegvj_bufferSize", "hipsolverDnZhegvj_bufferSize", "library");
     subst("cusolverDnZhetrd", "hipsolverDnZhetrd", "library");
     subst("cusolverDnZhetrd_bufferSize", "hipsolverDnZhetrd_bufferSize", "library");
     subst("cusolverDnZpotrf", "hipsolverDnZpotrf", "library");

--- a/docs/tables/CUSOLVER_API_supported_by_HIP.md
+++ b/docs/tables/CUSOLVER_API_supported_by_HIP.md
@@ -145,6 +145,8 @@
 |`cusolverDnChegvd_bufferSize`|8.0| | | |`hipsolverDnChegvd_bufferSize`|5.1.0| | | |6.1.0|
 |`cusolverDnChegvdx`|10.1| | | |`hipsolverDnChegvdx`|5.3.0| | | |6.1.0|
 |`cusolverDnChegvdx_bufferSize`|10.1| | | |`hipsolverDnChegvdx_bufferSize`|5.3.0| | | |6.1.0|
+|`cusolverDnChegvj`|9.0| | | |`hipsolverDnChegvj`|5.1.0| | | |6.1.0|
+|`cusolverDnChegvj_bufferSize`|9.0| | | |`hipsolverDnChegvj_bufferSize`|5.1.0| | | |6.1.0|
 |`cusolverDnChetrd`|8.0| | | |`hipsolverDnChetrd`|5.1.0| | | |6.1.0|
 |`cusolverDnChetrd_bufferSize`|8.0| | | |`hipsolverDnChetrd_bufferSize`|5.1.0| | | |6.1.0|
 |`cusolverDnClaswp`| | | | | | | | | | |
@@ -237,6 +239,8 @@
 |`cusolverDnDsygvd_bufferSize`|8.0| | | |`hipsolverDnDsygvd_bufferSize`|5.1.0| | | |6.1.0|
 |`cusolverDnDsygvdx`|10.1| | | |`hipsolverDnDsygvdx`|5.3.0| | | |6.1.0|
 |`cusolverDnDsygvdx_bufferSize`|10.1| | | |`hipsolverDnDsygvdx_bufferSize`|5.3.0| | | |6.1.0|
+|`cusolverDnDsygvj`|9.0| | | |`hipsolverDnDsygvj`|5.1.0| | | |6.1.0|
+|`cusolverDnDsygvj_bufferSize`|9.0| | | |`hipsolverDnDsygvj_bufferSize`|5.1.0| | | |6.1.0|
 |`cusolverDnDsytrd`| | | | |`hipsolverDnDsytrd`|5.1.0| | | |6.1.0|
 |`cusolverDnDsytrd_bufferSize`|8.0| | | |`hipsolverDnDsytrd_bufferSize`|5.1.0| | | |6.1.0|
 |`cusolverDnDsytrf`| | | | |`hipsolverDnDsytrf`|5.1.0| | | |6.1.0|
@@ -329,6 +333,8 @@
 |`cusolverDnSsygvd_bufferSize`|8.0| | | |`hipsolverDnSsygvd_bufferSize`|5.1.0| | | |6.1.0|
 |`cusolverDnSsygvdx`|10.1| | | |`hipsolverDnSsygvdx`|5.3.0| | | |6.1.0|
 |`cusolverDnSsygvdx_bufferSize`|10.1| | | |`hipsolverDnSsygvdx_bufferSize`|5.3.0| | | |6.1.0|
+|`cusolverDnSsygvj`|9.0| | | |`hipsolverDnSsygvj`|5.1.0| | | |6.1.0|
+|`cusolverDnSsygvj_bufferSize`|9.0| | | |`hipsolverDnSsygvj_bufferSize`|5.1.0| | | |6.1.0|
 |`cusolverDnSsytrd`| | | | |`hipsolverDnSsytrd`|5.1.0| | | |6.1.0|
 |`cusolverDnSsytrd_bufferSize`|8.0| | | |`hipsolverDnSsytrd_bufferSize`|5.1.0| | | |6.1.0|
 |`cusolverDnSsytrf`| | | | |`hipsolverDnSsytrf`|5.1.0| | | |6.1.0|
@@ -388,6 +394,8 @@
 |`cusolverDnZhegvd_bufferSize`|8.0| | | |`hipsolverDnZhegvd_bufferSize`|5.1.0| | | |6.1.0|
 |`cusolverDnZhegvdx`|10.1| | | |`hipsolverDnZhegvdx`|5.3.0| | | |6.1.0|
 |`cusolverDnZhegvdx_bufferSize`|10.1| | | |`hipsolverDnZhegvdx_bufferSize`|5.3.0| | | |6.1.0|
+|`cusolverDnZhegvj`|9.0| | | |`hipsolverDnZhegvj`|5.1.0| | | |6.1.0|
+|`cusolverDnZhegvj_bufferSize`|9.0| | | |`hipsolverDnZhegvj_bufferSize`|5.1.0| | | |6.1.0|
 |`cusolverDnZhetrd`|8.0| | | |`hipsolverDnZhetrd`|5.1.0| | | |6.1.0|
 |`cusolverDnZhetrd_bufferSize`|8.0| | | |`hipsolverDnZhetrd_bufferSize`|5.1.0| | | |6.1.0|
 |`cusolverDnZlaswp`| | | | | | | | | | |

--- a/docs/tables/CUSOLVER_API_supported_by_HIP_and_ROC.md
+++ b/docs/tables/CUSOLVER_API_supported_by_HIP_and_ROC.md
@@ -145,6 +145,8 @@
 |`cusolverDnChegvd_bufferSize`|8.0| | | |`hipsolverDnChegvd_bufferSize`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnChegvdx`|10.1| | | |`hipsolverDnChegvdx`|5.3.0| | | |6.1.0| | | | | | |
 |`cusolverDnChegvdx_bufferSize`|10.1| | | |`hipsolverDnChegvdx_bufferSize`|5.3.0| | | |6.1.0| | | | | | |
+|`cusolverDnChegvj`|9.0| | | |`hipsolverDnChegvj`|5.1.0| | | |6.1.0| | | | | | |
+|`cusolverDnChegvj_bufferSize`|9.0| | | |`hipsolverDnChegvj_bufferSize`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnChetrd`|8.0| | | |`hipsolverDnChetrd`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnChetrd_bufferSize`|8.0| | | |`hipsolverDnChetrd_bufferSize`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnClaswp`| | | | | | | | | | | | | | | | |
@@ -237,6 +239,8 @@
 |`cusolverDnDsygvd_bufferSize`|8.0| | | |`hipsolverDnDsygvd_bufferSize`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnDsygvdx`|10.1| | | |`hipsolverDnDsygvdx`|5.3.0| | | |6.1.0| | | | | | |
 |`cusolverDnDsygvdx_bufferSize`|10.1| | | |`hipsolverDnDsygvdx_bufferSize`|5.3.0| | | |6.1.0| | | | | | |
+|`cusolverDnDsygvj`|9.0| | | |`hipsolverDnDsygvj`|5.1.0| | | |6.1.0| | | | | | |
+|`cusolverDnDsygvj_bufferSize`|9.0| | | |`hipsolverDnDsygvj_bufferSize`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnDsytrd`| | | | |`hipsolverDnDsytrd`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnDsytrd_bufferSize`|8.0| | | |`hipsolverDnDsytrd_bufferSize`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnDsytrf`| | | | |`hipsolverDnDsytrf`|5.1.0| | | |6.1.0| | | | | | |
@@ -329,6 +333,8 @@
 |`cusolverDnSsygvd_bufferSize`|8.0| | | |`hipsolverDnSsygvd_bufferSize`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnSsygvdx`|10.1| | | |`hipsolverDnSsygvdx`|5.3.0| | | |6.1.0| | | | | | |
 |`cusolverDnSsygvdx_bufferSize`|10.1| | | |`hipsolverDnSsygvdx_bufferSize`|5.3.0| | | |6.1.0| | | | | | |
+|`cusolverDnSsygvj`|9.0| | | |`hipsolverDnSsygvj`|5.1.0| | | |6.1.0| | | | | | |
+|`cusolverDnSsygvj_bufferSize`|9.0| | | |`hipsolverDnSsygvj_bufferSize`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnSsytrd`| | | | |`hipsolverDnSsytrd`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnSsytrd_bufferSize`|8.0| | | |`hipsolverDnSsytrd_bufferSize`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnSsytrf`| | | | |`hipsolverDnSsytrf`|5.1.0| | | |6.1.0| | | | | | |
@@ -388,6 +394,8 @@
 |`cusolverDnZhegvd_bufferSize`|8.0| | | |`hipsolverDnZhegvd_bufferSize`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnZhegvdx`|10.1| | | |`hipsolverDnZhegvdx`|5.3.0| | | |6.1.0| | | | | | |
 |`cusolverDnZhegvdx_bufferSize`|10.1| | | |`hipsolverDnZhegvdx_bufferSize`|5.3.0| | | |6.1.0| | | | | | |
+|`cusolverDnZhegvj`|9.0| | | |`hipsolverDnZhegvj`|5.1.0| | | |6.1.0| | | | | | |
+|`cusolverDnZhegvj_bufferSize`|9.0| | | |`hipsolverDnZhegvj_bufferSize`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnZhetrd`|8.0| | | |`hipsolverDnZhetrd`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnZhetrd_bufferSize`|8.0| | | |`hipsolverDnZhetrd_bufferSize`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnZlaswp`| | | | | | | | | | | | | | | | |

--- a/docs/tables/CUSOLVER_API_supported_by_ROC.md
+++ b/docs/tables/CUSOLVER_API_supported_by_ROC.md
@@ -145,6 +145,8 @@
 |`cusolverDnChegvd_bufferSize`|8.0| | | | | | | | | |
 |`cusolverDnChegvdx`|10.1| | | | | | | | | |
 |`cusolverDnChegvdx_bufferSize`|10.1| | | | | | | | | |
+|`cusolverDnChegvj`|9.0| | | | | | | | | |
+|`cusolverDnChegvj_bufferSize`|9.0| | | | | | | | | |
 |`cusolverDnChetrd`|8.0| | | | | | | | | |
 |`cusolverDnChetrd_bufferSize`|8.0| | | | | | | | | |
 |`cusolverDnClaswp`| | | | | | | | | | |
@@ -237,6 +239,8 @@
 |`cusolverDnDsygvd_bufferSize`|8.0| | | | | | | | | |
 |`cusolverDnDsygvdx`|10.1| | | | | | | | | |
 |`cusolverDnDsygvdx_bufferSize`|10.1| | | | | | | | | |
+|`cusolverDnDsygvj`|9.0| | | | | | | | | |
+|`cusolverDnDsygvj_bufferSize`|9.0| | | | | | | | | |
 |`cusolverDnDsytrd`| | | | | | | | | | |
 |`cusolverDnDsytrd_bufferSize`|8.0| | | | | | | | | |
 |`cusolverDnDsytrf`| | | | | | | | | | |
@@ -329,6 +333,8 @@
 |`cusolverDnSsygvd_bufferSize`|8.0| | | | | | | | | |
 |`cusolverDnSsygvdx`|10.1| | | | | | | | | |
 |`cusolverDnSsygvdx_bufferSize`|10.1| | | | | | | | | |
+|`cusolverDnSsygvj`|9.0| | | | | | | | | |
+|`cusolverDnSsygvj_bufferSize`|9.0| | | | | | | | | |
 |`cusolverDnSsytrd`| | | | | | | | | | |
 |`cusolverDnSsytrd_bufferSize`|8.0| | | | | | | | | |
 |`cusolverDnSsytrf`| | | | | | | | | | |
@@ -388,6 +394,8 @@
 |`cusolverDnZhegvd_bufferSize`|8.0| | | | | | | | | |
 |`cusolverDnZhegvdx`|10.1| | | | | | | | | |
 |`cusolverDnZhegvdx_bufferSize`|10.1| | | | | | | | | |
+|`cusolverDnZhegvj`|9.0| | | | | | | | | |
+|`cusolverDnZhegvj_bufferSize`|9.0| | | | | | | | | |
 |`cusolverDnZhetrd`|8.0| | | | | | | | | |
 |`cusolverDnZhetrd_bufferSize`|8.0| | | | | | | | | |
 |`cusolverDnZlaswp`| | | | | | | | | | |

--- a/src/CUDA2HIP_SOLVER_API_functions.cpp
+++ b/src/CUDA2HIP_SOLVER_API_functions.cpp
@@ -389,6 +389,16 @@ const std::map<llvm::StringRef, hipCounter> CUDA_SOLVER_FUNCTION_MAP {
   {"cusolverDnDsyevj",                                   {"hipsolverDnDsyevj",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
   {"cusolverDnCheevj",                                   {"hipsolverDnCheevj",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
   {"cusolverDnZheevj",                                   {"hipsolverDnZheevj",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
+  // NOTE: rocsolver_(s|d)sygvj and rocsolver_(c|z)hegvj have a harness of other ROC and HIP API calls
+  {"cusolverDnSsygvj_bufferSize",                        {"hipsolverDnSsygvj_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
+  {"cusolverDnDsygvj_bufferSize",                        {"hipsolverDnDsygvj_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
+  {"cusolverDnChegvj_bufferSize",                        {"hipsolverDnChegvj_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
+  {"cusolverDnZhegvj_bufferSize",                        {"hipsolverDnZhegvj_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
+  // NOTE: rocsolver_(s|d)sygvj and rocsolver_(c|z)hegvj have a harness of other ROC and HIP API calls
+  {"cusolverDnSsygvj",                                   {"hipsolverDnSsygvj",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
+  {"cusolverDnDsygvj",                                   {"hipsolverDnDsygvj",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
+  {"cusolverDnChegvj",                                   {"hipsolverDnChegvj",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
+  {"cusolverDnZhegvj",                                   {"hipsolverDnZhegvj",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
 };
 
 const std::map<llvm::StringRef, cudaAPIversions> CUDA_SOLVER_FUNCTION_VER_MAP {
@@ -628,6 +638,14 @@ const std::map<llvm::StringRef, cudaAPIversions> CUDA_SOLVER_FUNCTION_VER_MAP {
   {"cusolverDnDsyevj",                                    {CUDA_90,   CUDA_0, CUDA_0}},
   {"cusolverDnCheevj",                                    {CUDA_90,   CUDA_0, CUDA_0}},
   {"cusolverDnZheevj",                                    {CUDA_90,   CUDA_0, CUDA_0}},
+  {"cusolverDnSsygvj_bufferSize",                         {CUDA_90,   CUDA_0, CUDA_0}},
+  {"cusolverDnDsygvj_bufferSize",                         {CUDA_90,   CUDA_0, CUDA_0}},
+  {"cusolverDnChegvj_bufferSize",                         {CUDA_90,   CUDA_0, CUDA_0}},
+  {"cusolverDnZhegvj_bufferSize",                         {CUDA_90,   CUDA_0, CUDA_0}},
+  {"cusolverDnSsygvj",                                    {CUDA_90,   CUDA_0, CUDA_0}},
+  {"cusolverDnDsygvj",                                    {CUDA_90,   CUDA_0, CUDA_0}},
+  {"cusolverDnChegvj",                                    {CUDA_90,   CUDA_0, CUDA_0}},
+  {"cusolverDnZhegvj",                                    {CUDA_90,   CUDA_0, CUDA_0}},
 };
 
 const std::map<llvm::StringRef, hipAPIversions> HIP_SOLVER_FUNCTION_VER_MAP {
@@ -826,6 +844,14 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_SOLVER_FUNCTION_VER_MAP {
   {"hipsolverDnDsyevj",                                   {HIP_5010, HIP_0,    HIP_0,  HIP_LATEST}},
   {"hipsolverDnCheevj",                                   {HIP_5010, HIP_0,    HIP_0,  HIP_LATEST}},
   {"hipsolverDnZheevj",                                   {HIP_5010, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipsolverDnSsygvj_bufferSize",                        {HIP_5010, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipsolverDnDsygvj_bufferSize",                        {HIP_5010, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipsolverDnChegvj_bufferSize",                        {HIP_5010, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipsolverDnZhegvj_bufferSize",                        {HIP_5010, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipsolverDnSsygvj",                                   {HIP_5010, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipsolverDnDsygvj",                                   {HIP_5010, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipsolverDnChegvj",                                   {HIP_5010, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipsolverDnZhegvj",                                   {HIP_5010, HIP_0,    HIP_0,  HIP_LATEST}},
 
   {"rocsolver_spotrf",                                    {HIP_3020, HIP_0,    HIP_0,  HIP_LATEST}},
   {"rocsolver_dpotrf",                                    {HIP_3020, HIP_0,    HIP_0,  HIP_LATEST}},

--- a/tests/unit_tests/synthetic/libraries/cusolver2hipsolver.cu
+++ b/tests/unit_tests/synthetic/libraries/cusolver2hipsolver.cu
@@ -932,6 +932,46 @@ int main() {
   // HIP: HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDnZheevj(hipsolverDnHandle_t handle, hipsolverEigMode_t jobz, hipblasFillMode_t uplo, int n, hipDoubleComplex* A, int lda, double* W, hipDoubleComplex* work, int lwork, int* devInfo, hipsolverSyevjInfo_t params);
   // CHECK: status = hipsolverDnZheevj(handle, jobz, fillMode, n, &dComplexA, lda, &dW, &dComplexWorkspace, Lwork, &info, syevj_info);
   status = cusolverDnZheevj(handle, jobz, fillMode, n, &dComplexA, lda, &dW, &dComplexWorkspace, Lwork, &info, syevj_info);
+
+  // CUDA: cusolverStatus_t CUSOLVERAPI cusolverDnSsygvj_bufferSize(cusolverDnHandle_t handle, cusolverEigType_t itype, cusolverEigMode_t  jobz, cublasFillMode_t uplo, int n, const float * A, int lda, const float * B, int ldb, const float * W, int * lwork, syevjInfo_t params);
+  // HIP: HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDnSsygvj_bufferSize(hipsolverDnHandle_t handle, hipsolverEigType_t itype, hipsolverEigMode_t jobz, hipblasFillMode_t uplo, int n, const float* A, int lda, const float* B, int ldb, const float* W, int* lwork, hipsolverSyevjInfo_t params);
+  // CHECK: status = hipsolverDnSsygvj_bufferSize(handle, eigType, jobz, fillMode, n, &fA, lda, &fB, ldb, &fW, &Lwork, syevj_info);
+  status = cusolverDnSsygvj_bufferSize(handle, eigType, jobz, fillMode, n, &fA, lda, &fB, ldb, &fW, &Lwork, syevj_info);
+
+  // CUDA: cusolverStatus_t CUSOLVERAPI cusolverDnDsygvj_bufferSize(cusolverDnHandle_t handle, cusolverEigType_t itype, cusolverEigMode_t jobz, cublasFillMode_t uplo, int n, const double * A, int lda, const double * B, int ldb, const double * W, int * lwork, syevjInfo_t params);
+  // HIP: HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDnDsygvj_bufferSize(hipsolverDnHandle_t handle, hipsolverEigType_t itype, hipsolverEigMode_t jobz, hipblasFillMode_t uplo, int n, const double* A, int lda, const double* B, int ldb, const double* W, int* lwork, hipsolverSyevjInfo_t params);
+  // CHECK: status = hipsolverDnDsygvj_bufferSize(handle, eigType, jobz, fillMode, n, &dA, lda, &dB, ldb, &dW, &Lwork, syevj_info);
+  status = cusolverDnDsygvj_bufferSize(handle, eigType, jobz, fillMode, n, &dA, lda, &dB, ldb, &dW, &Lwork, syevj_info);
+
+  // CUDA: cusolverStatus_t CUSOLVERAPI cusolverDnChegvj_bufferSize(cusolverDnHandle_t handle, cusolverEigType_t itype, cusolverEigMode_t jobz, cublasFillMode_t uplo, int n, const cuComplex * A, int lda, const cuComplex * B, int ldb, const float * W, int * lwork, syevjInfo_t params);
+  // HIP: HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDnChegvj_bufferSize(hipsolverDnHandle_t handle, hipsolverEigType_t itype, hipsolverEigMode_t jobz, hipblasFillMode_t uplo, int n, const hipFloatComplex* A, int lda, const hipFloatComplex* B, int ldb, const float* W, int* lwork, hipsolverSyevjInfo_t params);
+  // CHECK: status = hipsolverDnChegvj_bufferSize(handle, eigType, jobz, fillMode, n, &complexA, lda, &complexB, ldb, &fW, &Lwork, syevj_info);
+  status = cusolverDnChegvj_bufferSize(handle, eigType, jobz, fillMode, n, &complexA, lda, &complexB, ldb, &fW, &Lwork, syevj_info);
+
+  // CUDA: cusolverStatus_t CUSOLVERAPI cusolverDnZhegvj_bufferSize(cusolverDnHandle_t handle, cusolverEigType_t itype, cusolverEigMode_t jobz, cublasFillMode_t uplo, int n, const cuDoubleComplex *A, int lda, const cuDoubleComplex *B, int ldb, const double * W, int * lwork, syevjInfo_t params);
+  // HIP: HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDnZhegvj_bufferSize(hipsolverDnHandle_t handle, hipsolverEigType_t itype, hipsolverEigMode_t jobz, hipblasFillMode_t uplo, int n, const hipDoubleComplex* A, int lda, const hipDoubleComplex* B, int ldb, const double* W, int* lwork, hipsolverSyevjInfo_t params);
+  // CHECK: status = hipsolverDnZhegvj_bufferSize(handle, eigType, jobz, fillMode, n, &dComplexA, lda, &dComplexB, ldb, &dW, &Lwork, syevj_info);
+  status = cusolverDnZhegvj_bufferSize(handle, eigType, jobz, fillMode, n, &dComplexA, lda, &dComplexB, ldb, &dW, &Lwork, syevj_info);
+
+  // CUDA: cusolverStatus_t CUSOLVERAPI cusolverDnSsygvj(cusolverDnHandle_t handle, cusolverEigType_t itype, cusolverEigMode_t jobz, cublasFillMode_t uplo, int n, float * A, int lda, float * B, int ldb, float * W, float * work, int lwork, int * info, syevjInfo_t params);
+  // HIP: HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDnSsygvj(hipsolverDnHandle_t handle, hipsolverEigType_t itype, hipsolverEigMode_t jobz, hipblasFillMode_t uplo, int n, float* A, int lda, float* B, int ldb, float* W, float* work, int lwork, int* devInfo, hipsolverSyevjInfo_t params);
+  // CHECK: status = hipsolverDnSsygvj(handle, eigType, jobz, fillMode, n, &fA, lda, &fB, ldb, &fW, &fWorkspace, Lwork, &info, syevj_info);
+  status = cusolverDnSsygvj(handle, eigType, jobz, fillMode, n, &fA, lda, &fB, ldb, &fW, &fWorkspace, Lwork, &info, syevj_info);
+
+  // CUDA: cusolverStatus_t CUSOLVERAPI cusolverDnDsygvj(cusolverDnHandle_t handle, cusolverEigType_t itype, cusolverEigMode_t jobz, cublasFillMode_t uplo, int n, double * A, int lda, double * B, int ldb, double * W, double * work, int lwork, int * info, syevjInfo_t params);
+  // HIP: HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDnDsygvj(hipsolverDnHandle_t handle, hipsolverEigType_t itype, hipsolverEigMode_t jobz, hipblasFillMode_t uplo, int n, double* A, int lda, double* B, int ldb, double* W, double* work, int lwork, int* devInfo, hipsolverSyevjInfo_t params);
+  // CHECK: status = hipsolverDnDsygvj(handle, eigType, jobz, fillMode, n, &dA, lda, &dB, ldb, &dW, &dWorkspace, Lwork, &info, syevj_info);
+  status = cusolverDnDsygvj(handle, eigType, jobz, fillMode, n, &dA, lda, &dB, ldb, &dW, &dWorkspace, Lwork, &info, syevj_info);
+
+  // CUDA: cusolverStatus_t CUSOLVERAPI cusolverDnChegvj(cusolverDnHandle_t handle, cusolverEigType_t itype, cusolverEigMode_t jobz, cublasFillMode_t uplo, int n, cuComplex * A, int lda, cuComplex * B, int ldb, float * W, cuComplex * work, int lwork, int * info, syevjInfo_t params);
+  // HIP: HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDnChegvj(hipsolverDnHandle_t handle, hipsolverEigType_t itype, hipsolverEigMode_t jobz, hipblasFillMode_t uplo, int n, hipFloatComplex* A, int lda, hipFloatComplex* B, int ldb, float* W, hipFloatComplex* work, int lwork, int* devInfo, hipsolverSyevjInfo_t params);
+  // CHECK: status = hipsolverDnChegvj(handle, eigType, jobz, fillMode, n, &complexA, lda, &complexB, ldb, &fW, &complexWorkspace, Lwork, &info, syevj_info);
+  status = cusolverDnChegvj(handle, eigType, jobz, fillMode, n, &complexA, lda, &complexB, ldb, &fW, &complexWorkspace, Lwork, &info, syevj_info);
+
+  // CUDA: cusolverStatus_t CUSOLVERAPI cusolverDnZhegvj(cusolverDnHandle_t handle, cusolverEigType_t itype, cusolverEigMode_t jobz, cublasFillMode_t uplo, int n, cuDoubleComplex * A, int lda, cuDoubleComplex * B, int ldb, double * W, cuDoubleComplex * work, int lwork, int * info, syevjInfo_t params);
+  // HIP: HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDnZhegvj(hipsolverDnHandle_t handle, hipsolverEigType_t itype, hipsolverEigMode_t jobz, hipblasFillMode_t uplo, int n, hipDoubleComplex* A, int lda, hipDoubleComplex* B, int ldb, double* W, hipDoubleComplex* work, int lwork, int* devInfo, hipsolverSyevjInfo_t params);
+  // CHECK: status = hipsolverDnZhegvj(handle, eigType, jobz, fillMode, n, &dComplexA, lda, &dComplexB, ldb, &dW, &dComplexWorkspace, Lwork, &info, syevj_info);
+  status = cusolverDnZhegvj(handle, eigType, jobz, fillMode, n, &dComplexA, lda, &dComplexB, ldb, &dW, &dComplexWorkspace, Lwork, &info, syevj_info);
 #endif
 
 #if CUDA_VERSION >= 10010


### PR DESCRIPTION
+ `cusolverDn(S|D)sygvj(_bufferSize)?` and `cusolverDn(C|Z)hegvj(_bufferSize)?`are `SUPPORTED` by `hipSOLVER` only
+ [NOTE] `rocsolver_(s|d)sygvj` and `rocsolver_(c|z)hegvj` have a harness of other `ROC` and `HIP` API calls, thus `UNSUPPORTED`
+ Updated `SOLVER` synthetic tests, the regenerated `hipify-perl`, and `SOLVER` `CUDA2HIP` documentation