### PR TITLE
[HIPIFY][#675][#677][SOLVER][feature] `cuSOLVER` support - Step 44 - Functions (DN)

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -1133,6 +1133,11 @@ my %experimental_funcs = (
     "cusolverDnXsyevjSetMaxSweeps" => "6.1.0",
     "cusolverDnXsyevjGetSweeps" => "6.1.0",
     "cusolverDnXsyevjGetResidual" => "6.1.0",
+    "cusolverDnXgesvdjSetTolerance" => "6.1.0",
+    "cusolverDnXgesvdjSetSortEig" => "6.1.0",
+    "cusolverDnXgesvdjSetMaxSweeps" => "6.1.0",
+    "cusolverDnXgesvdjGetSweeps" => "6.1.0",
+    "cusolverDnXgesvdjGetResidual" => "6.1.0",
     "cusolverDnSsytrf_bufferSize" => "6.1.0",
     "cusolverDnSsytrf" => "6.1.0",
     "cusolverDnSsytrd_bufferSize" => "6.1.0",
@@ -1229,6 +1234,7 @@ my %experimental_funcs = (
     "cusolverDnDgebrd_bufferSize" => "6.1.0",
     "cusolverDnDgebrd" => "6.1.0",
     "cusolverDnDestroySyevjInfo" => "6.1.0",
+    "cusolverDnDestroyGesvdjInfo" => "6.1.0",
     "cusolverDnDestroy" => "6.1.0",
     "cusolverDnDDgesv_bufferSize" => "6.1.0",
     "cusolverDnDDgesv" => "6.1.0",
@@ -1247,6 +1253,7 @@ my %experimental_funcs = (
     "cusolverDnCsytrf_bufferSize" => "6.1.0",
     "cusolverDnCsytrf" => "6.1.0",
     "cusolverDnCreateSyevjInfo" => "6.1.0",
+    "cusolverDnCreateGesvdjInfo" => "6.1.0",
     "cusolverDnCreate" => "6.1.0",
     "cusolverDnCpotrsBatched" => "6.1.0",
     "cusolverDnCpotrs" => "6.1.0",
@@ -1476,6 +1483,7 @@ sub experimentalSubstitutions {
     subst("cusolverDnCpotrs", "hipsolverDnCpotrs", "library");
     subst("cusolverDnCpotrsBatched", "hipsolverDnCpotrsBatched", "library");
     subst("cusolverDnCreate", "hipsolverDnCreate", "library");
+    subst("cusolverDnCreateGesvdjInfo", "hipsolverDnCreateGesvdjInfo", "library");
     subst("cusolverDnCreateSyevjInfo", "hipsolverDnCreateSyevjInfo", "library");
     subst("cusolverDnCsytrf", "hipsolverDnCsytrf", "library");
     subst("cusolverDnCsytrf_bufferSize", "hipsolverDnCsytrf_bufferSize", "library");
@@ -1494,6 +1502,7 @@ sub experimentalSubstitutions {
     subst("cusolverDnDDgesv", "hipsolverDnDDgesv", "library");
     subst("cusolverDnDDgesv_bufferSize", "hipsolverDnDDgesv_bufferSize", "library");
     subst("cusolverDnDestroy", "hipsolverDnDestroy", "library");
+    subst("cusolverDnDestroyGesvdjInfo", "hipsolverDnDestroyGesvdjInfo", "library");
     subst("cusolverDnDestroySyevjInfo", "hipsolverDnDestroySyevjInfo", "library");
     subst("cusolverDnDgebrd", "hipsolverDnDgebrd", "library");
     subst("cusolverDnDgebrd_bufferSize", "hipsolverDnDgebrd_bufferSize", "library");
@@ -1589,6 +1598,11 @@ sub experimentalSubstitutions {
     subst("cusolverDnSsytrd_bufferSize", "hipsolverDnSsytrd_bufferSize", "library");
     subst("cusolverDnSsytrf", "hipsolverDnSsytrf", "library");
     subst("cusolverDnSsytrf_bufferSize", "hipsolverDnSsytrf_bufferSize", "library");
+    subst("cusolverDnXgesvdjGetResidual", "hipsolverDnXgesvdjGetResidual", "library");
+    subst("cusolverDnXgesvdjGetSweeps", "hipsolverDnXgesvdjGetSweeps", "library");
+    subst("cusolverDnXgesvdjSetMaxSweeps", "hipsolverDnXgesvdjSetMaxSweeps", "library");
+    subst("cusolverDnXgesvdjSetSortEig", "hipsolverDnXgesvdjSetSortEig", "library");
+    subst("cusolverDnXgesvdjSetTolerance", "hipsolverDnXgesvdjSetTolerance", "library");
     subst("cusolverDnXsyevjGetResidual", "hipsolverDnXsyevjGetResidual", "library");
     subst("cusolverDnXsyevjGetSweeps", "hipsolverDnXsyevjGetSweeps", "library");
     subst("cusolverDnXsyevjSetMaxSweeps", "hipsolverDnXsyevjSetMaxSweeps", "library");

--- a/docs/tables/CUSOLVER_API_supported_by_HIP.md
+++ b/docs/tables/CUSOLVER_API_supported_by_HIP.md
@@ -160,6 +160,7 @@
 |`cusolverDnCpotrs`| | | | |`hipsolverDnCpotrs`|5.1.0| | | |6.1.0|
 |`cusolverDnCpotrsBatched`|9.1| | | |`hipsolverDnCpotrsBatched`|5.1.0| | | |6.1.0|
 |`cusolverDnCreate`| | | | |`hipsolverDnCreate`|5.1.0| | | |6.1.0|
+|`cusolverDnCreateGesvdjInfo`|9.0| | | |`hipsolverDnCreateGesvdjInfo`|5.1.0| | | |6.1.0|
 |`cusolverDnCreateParams`|11.0| | | | | | | | | |
 |`cusolverDnCreateSyevjInfo`|9.0| | | |`hipsolverDnCreateSyevjInfo`|5.1.0| | | |6.1.0|
 |`cusolverDnCsytrf`| | | | |`hipsolverDnCsytrf`|5.1.0| | | |6.1.0|
@@ -197,6 +198,7 @@
 |`cusolverDnDXgesv`|11.0| | | | | | | | | |
 |`cusolverDnDXgesv_bufferSize`|11.0| | | | | | | | | |
 |`cusolverDnDestroy`| | | | |`hipsolverDnDestroy`|5.1.0| | | |6.1.0|
+|`cusolverDnDestroyGesvdjInfo`|9.0| | | |`hipsolverDnDestroyGesvdjInfo`|5.1.0| | | |6.1.0|
 |`cusolverDnDestroySyevjInfo`|9.0| | | |`hipsolverDnDestroySyevjInfo`|5.1.0| | | |6.1.0|
 |`cusolverDnDgebrd`| | | | |`hipsolverDnDgebrd`|5.1.0| | | |6.1.0|
 |`cusolverDnDgebrd_bufferSize`| | | | |`hipsolverDnDgebrd_bufferSize`|5.1.0| | | |6.1.0|
@@ -341,6 +343,11 @@
 |`cusolverDnSsytrf_bufferSize`| | | | |`hipsolverDnSsytrf_bufferSize`|5.1.0| | | |6.1.0|
 |`cusolverDnSsytri`|10.1| | | | | | | | | |
 |`cusolverDnSsytri_bufferSize`|10.1| | | | | | | | | |
+|`cusolverDnXgesvdjGetResidual`|9.0| | | |`hipsolverDnXgesvdjGetResidual`|5.1.0| | | |6.1.0|
+|`cusolverDnXgesvdjGetSweeps`|9.0| | | |`hipsolverDnXgesvdjGetSweeps`|5.1.0| | | |6.1.0|
+|`cusolverDnXgesvdjSetMaxSweeps`|9.0| | | |`hipsolverDnXgesvdjSetMaxSweeps`|5.1.0| | | |6.1.0|
+|`cusolverDnXgesvdjSetSortEig`|9.0| | | |`hipsolverDnXgesvdjSetSortEig`|5.1.0| | | |6.1.0|
+|`cusolverDnXgesvdjSetTolerance`|9.0| | | |`hipsolverDnXgesvdjSetTolerance`|5.1.0| | | |6.1.0|
 |`cusolverDnXgetrf`|11.1| | | | | | | | | |
 |`cusolverDnXgetrf_bufferSize`|11.1| | | | | | | | | |
 |`cusolverDnXgetrs`|11.1| | | | | | | | | |

--- a/docs/tables/CUSOLVER_API_supported_by_HIP_and_ROC.md
+++ b/docs/tables/CUSOLVER_API_supported_by_HIP_and_ROC.md
@@ -160,6 +160,7 @@
 |`cusolverDnCpotrs`| | | | |`hipsolverDnCpotrs`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnCpotrsBatched`|9.1| | | |`hipsolverDnCpotrsBatched`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnCreate`| | | | |`hipsolverDnCreate`|5.1.0| | | |6.1.0|`rocblas_create_handle`| | | | | |
+|`cusolverDnCreateGesvdjInfo`|9.0| | | |`hipsolverDnCreateGesvdjInfo`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnCreateParams`|11.0| | | | | | | | | | | | | | | |
 |`cusolverDnCreateSyevjInfo`|9.0| | | |`hipsolverDnCreateSyevjInfo`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnCsytrf`| | | | |`hipsolverDnCsytrf`|5.1.0| | | |6.1.0| | | | | | |
@@ -197,6 +198,7 @@
 |`cusolverDnDXgesv`|11.0| | | | | | | | | | | | | | | |
 |`cusolverDnDXgesv_bufferSize`|11.0| | | | | | | | | | | | | | | |
 |`cusolverDnDestroy`| | | | |`hipsolverDnDestroy`|5.1.0| | | |6.1.0|`rocblas_destroy_handle`| | | | | |
+|`cusolverDnDestroyGesvdjInfo`|9.0| | | |`hipsolverDnDestroyGesvdjInfo`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnDestroySyevjInfo`|9.0| | | |`hipsolverDnDestroySyevjInfo`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnDgebrd`| | | | |`hipsolverDnDgebrd`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnDgebrd_bufferSize`| | | | |`hipsolverDnDgebrd_bufferSize`|5.1.0| | | |6.1.0| | | | | | |
@@ -341,6 +343,11 @@
 |`cusolverDnSsytrf_bufferSize`| | | | |`hipsolverDnSsytrf_bufferSize`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnSsytri`|10.1| | | | | | | | | | | | | | | |
 |`cusolverDnSsytri_bufferSize`|10.1| | | | | | | | | | | | | | | |
+|`cusolverDnXgesvdjGetResidual`|9.0| | | |`hipsolverDnXgesvdjGetResidual`|5.1.0| | | |6.1.0| | | | | | |
+|`cusolverDnXgesvdjGetSweeps`|9.0| | | |`hipsolverDnXgesvdjGetSweeps`|5.1.0| | | |6.1.0| | | | | | |
+|`cusolverDnXgesvdjSetMaxSweeps`|9.0| | | |`hipsolverDnXgesvdjSetMaxSweeps`|5.1.0| | | |6.1.0| | | | | | |
+|`cusolverDnXgesvdjSetSortEig`|9.0| | | |`hipsolverDnXgesvdjSetSortEig`|5.1.0| | | |6.1.0| | | | | | |
+|`cusolverDnXgesvdjSetTolerance`|9.0| | | |`hipsolverDnXgesvdjSetTolerance`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnXgetrf`|11.1| | | | | | | | | | | | | | | |
 |`cusolverDnXgetrf_bufferSize`|11.1| | | | | | | | | | | | | | | |
 |`cusolverDnXgetrs`|11.1| | | | | | | | | | | | | | | |

--- a/docs/tables/CUSOLVER_API_supported_by_ROC.md
+++ b/docs/tables/CUSOLVER_API_supported_by_ROC.md
@@ -160,6 +160,7 @@
 |`cusolverDnCpotrs`| | | | | | | | | | |
 |`cusolverDnCpotrsBatched`|9.1| | | | | | | | | |
 |`cusolverDnCreate`| | | | |`rocblas_create_handle`| | | | | |
+|`cusolverDnCreateGesvdjInfo`|9.0| | | | | | | | | |
 |`cusolverDnCreateParams`|11.0| | | | | | | | | |
 |`cusolverDnCreateSyevjInfo`|9.0| | | | | | | | | |
 |`cusolverDnCsytrf`| | | | | | | | | | |
@@ -197,6 +198,7 @@
 |`cusolverDnDXgesv`|11.0| | | | | | | | | |
 |`cusolverDnDXgesv_bufferSize`|11.0| | | | | | | | | |
 |`cusolverDnDestroy`| | | | |`rocblas_destroy_handle`| | | | | |
+|`cusolverDnDestroyGesvdjInfo`|9.0| | | | | | | | | |
 |`cusolverDnDestroySyevjInfo`|9.0| | | | | | | | | |
 |`cusolverDnDgebrd`| | | | | | | | | | |
 |`cusolverDnDgebrd_bufferSize`| | | | | | | | | | |
@@ -341,6 +343,11 @@
 |`cusolverDnSsytrf_bufferSize`| | | | | | | | | | |
 |`cusolverDnSsytri`|10.1| | | | | | | | | |
 |`cusolverDnSsytri_bufferSize`|10.1| | | | | | | | | |
+|`cusolverDnXgesvdjGetResidual`|9.0| | | | | | | | | |
+|`cusolverDnXgesvdjGetSweeps`|9.0| | | | | | | | | |
+|`cusolverDnXgesvdjSetMaxSweeps`|9.0| | | | | | | | | |
+|`cusolverDnXgesvdjSetSortEig`|9.0| | | | | | | | | |
+|`cusolverDnXgesvdjSetTolerance`|9.0| | | | | | | | | |
 |`cusolverDnXgetrf`|11.1| | | | | | | | | |
 |`cusolverDnXgetrf_bufferSize`|11.1| | | | | | | | | |
 |`cusolverDnXgetrs`|11.1| | | | | | | | | |

--- a/src/CUDA2HIP_SOLVER_API_functions.cpp
+++ b/src/CUDA2HIP_SOLVER_API_functions.cpp
@@ -399,6 +399,14 @@ const std::map<llvm::StringRef, hipCounter> CUDA_SOLVER_FUNCTION_MAP {
   {"cusolverDnDsygvj",                                   {"hipsolverDnDsygvj",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
   {"cusolverDnChegvj",                                   {"hipsolverDnChegvj",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
   {"cusolverDnZhegvj",                                   {"hipsolverDnZhegvj",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
+  // no ROC analogues
+  {"cusolverDnCreateGesvdjInfo",                         {"hipsolverDnCreateGesvdjInfo",                           "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
+  {"cusolverDnDestroyGesvdjInfo",                        {"hipsolverDnDestroyGesvdjInfo",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
+  {"cusolverDnXgesvdjSetTolerance",                      {"hipsolverDnXgesvdjSetTolerance",                        "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
+  {"cusolverDnXgesvdjSetMaxSweeps",                      {"hipsolverDnXgesvdjSetMaxSweeps",                        "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
+  {"cusolverDnXgesvdjSetSortEig",                        {"hipsolverDnXgesvdjSetSortEig",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
+  {"cusolverDnXgesvdjGetResidual",                       {"hipsolverDnXgesvdjGetResidual",                         "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
+  {"cusolverDnXgesvdjGetSweeps",                         {"hipsolverDnXgesvdjGetSweeps",                           "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
 };
 
 const std::map<llvm::StringRef, cudaAPIversions> CUDA_SOLVER_FUNCTION_VER_MAP {
@@ -646,6 +654,13 @@ const std::map<llvm::StringRef, cudaAPIversions> CUDA_SOLVER_FUNCTION_VER_MAP {
   {"cusolverDnDsygvj",                                    {CUDA_90,   CUDA_0, CUDA_0}},
   {"cusolverDnChegvj",                                    {CUDA_90,   CUDA_0, CUDA_0}},
   {"cusolverDnZhegvj",                                    {CUDA_90,   CUDA_0, CUDA_0}},
+  {"cusolverDnCreateGesvdjInfo",                          {CUDA_90,   CUDA_0, CUDA_0}},
+  {"cusolverDnDestroyGesvdjInfo",                         {CUDA_90,   CUDA_0, CUDA_0}},
+  {"cusolverDnXgesvdjSetTolerance",                       {CUDA_90,   CUDA_0, CUDA_0}},
+  {"cusolverDnXgesvdjSetMaxSweeps",                       {CUDA_90,   CUDA_0, CUDA_0}},
+  {"cusolverDnXgesvdjSetSortEig",                         {CUDA_90,   CUDA_0, CUDA_0}},
+  {"cusolverDnXgesvdjGetResidual",                        {CUDA_90,   CUDA_0, CUDA_0}},
+  {"cusolverDnXgesvdjGetSweeps",                          {CUDA_90,   CUDA_0, CUDA_0}},
 };
 
 const std::map<llvm::StringRef, hipAPIversions> HIP_SOLVER_FUNCTION_VER_MAP {
@@ -852,6 +867,13 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_SOLVER_FUNCTION_VER_MAP {
   {"hipsolverDnDsygvj",                                   {HIP_5010, HIP_0,    HIP_0,  HIP_LATEST}},
   {"hipsolverDnChegvj",                                   {HIP_5010, HIP_0,    HIP_0,  HIP_LATEST}},
   {"hipsolverDnZhegvj",                                   {HIP_5010, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipsolverDnCreateGesvdjInfo",                         {HIP_5010, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipsolverDnDestroyGesvdjInfo",                        {HIP_5010, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipsolverDnXgesvdjSetTolerance",                      {HIP_5010, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipsolverDnXgesvdjSetMaxSweeps",                      {HIP_5010, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipsolverDnXgesvdjSetSortEig",                        {HIP_5010, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipsolverDnXgesvdjGetResidual",                       {HIP_5010, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipsolverDnXgesvdjGetSweeps",                         {HIP_5010, HIP_0,    HIP_0,  HIP_LATEST}},
 
   {"rocsolver_spotrf",                                    {HIP_3020, HIP_0,    HIP_0,  HIP_LATEST}},
   {"rocsolver_dpotrf",                                    {HIP_3020, HIP_0,    HIP_0,  HIP_LATEST}},

--- a/tests/unit_tests/synthetic/libraries/cusolver2hipsolver.cu
+++ b/tests/unit_tests/synthetic/libraries/cusolver2hipsolver.cu
@@ -775,6 +775,41 @@ int main() {
 
   // CHECK: hipsolverGesvdjInfo_t gesvdj_info;
   gesvdjInfo_t gesvdj_info;
+
+  // CUDA: cusolverStatus_t CUSOLVERAPI cusolverDnCreateGesvdjInfo(gesvdjInfo_t *info);
+  // HIP: HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDnCreateGesvdjInfo(hipsolverGesvdjInfo_t* info);
+  // CHECK: status = hipsolverDnCreateGesvdjInfo(&gesvdj_info);
+  status = cusolverDnCreateGesvdjInfo(&gesvdj_info);
+
+  // CUDA: cusolverStatus_t CUSOLVERAPI cusolverDnDestroyGesvdjInfo(gesvdjInfo_t info);
+  // HIP: HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDnDestroyGesvdjInfo(hipsolverGesvdjInfo_t info);
+  // CHECK: status = hipsolverDnDestroyGesvdjInfo(gesvdj_info);
+  status = cusolverDnDestroyGesvdjInfo(gesvdj_info);
+
+  // CUDA: cusolverStatus_t CUSOLVERAPI cusolverDnXgesvdjSetTolerance(gesvdjInfo_t info, double tolerance);
+  // HIP: HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDnXgesvdjSetTolerance(hipsolverGesvdjInfo_t info, double tolerance);
+  // CHECK: status = hipsolverDnXgesvdjSetTolerance(gesvdj_info, dtolerance);
+  status = cusolverDnXgesvdjSetTolerance(gesvdj_info, dtolerance);
+
+  // CUDA: cusolverStatus_t CUSOLVERAPI cusolverDnXgesvdjSetMaxSweeps(gesvdjInfo_t info, int max_sweeps);
+  // HIP: HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDnXgesvdjSetMaxSweeps(hipsolverGesvdjInfo_t info, int max_sweeps);
+  // CHECK: status = hipsolverDnXgesvdjSetMaxSweeps(gesvdj_info, imax_sweeps);
+  status = cusolverDnXgesvdjSetMaxSweeps(gesvdj_info, imax_sweeps);
+
+  // CUDA: cusolverStatus_t CUSOLVERAPI cusolverDnXgesvdjSetSortEig(gesvdjInfo_t info, int sort_svd);
+  // HIP: HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDnXgesvdjSetSortEig(hipsolverGesvdjInfo_t info, int sort_eig);
+  // CHECK: status = hipsolverDnXgesvdjSetSortEig(gesvdj_info, isort_eig);
+  status = cusolverDnXgesvdjSetSortEig(gesvdj_info, isort_eig);
+
+  // CUDA: cusolverStatus_t CUSOLVERAPI cusolverDnXgesvdjGetResidual(cusolverDnHandle_t handle, gesvdjInfo_t info, double * residual);
+  // HIP: HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDnXgesvdjGetResidual(hipsolverDnHandle_t handle, hipsolverGesvdjInfo_t info, double* residual);
+  // CHECK: status = hipsolverDnXgesvdjGetResidual(handle, gesvdj_info, &dresidual);
+  status = cusolverDnXgesvdjGetResidual(handle, gesvdj_info, &dresidual);
+
+  // CUDA: cusolverStatus_t CUSOLVERAPI cusolverDnXgesvdjGetSweeps(cusolverDnHandle_t handle, gesvdjInfo_t info, int * executed_sweeps);
+  // HIP: HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDnXgesvdjGetSweeps(hipsolverDnHandle_t handle, hipsolverGesvdjInfo_t info, int* executed_sweeps);
+  // CHECK: status = hipsolverDnXgesvdjGetSweeps(handle, gesvdj_info, &iexecuted_sweeps);
+  status = cusolverDnXgesvdjGetSweeps(handle, gesvdj_info, &iexecuted_sweeps);
 #endif
 
 #if CUDA_VERSION >= 9010


### PR DESCRIPTION
+ `cusolverDnXgesvdj*` are `SUPPORTED` by `hipSOLVER` only
+ [NOTE] `ROC` analogues are missing
+ Updated `SOLVER` synthetic tests, the regenerated `hipify-perl`, and `SOLVER` `CUDA2HIP` documentation
