### PR TITLE
[HIPIFY][#675][#677][SOLVER][feature] `cuSOLVER` support - Step 46 - Functions (DN)

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -1118,8 +1118,10 @@ my %experimental_funcs = (
     "cusolverDnZgetrs" => "6.1.0",
     "cusolverDnZgetrf_bufferSize" => "6.1.0",
     "cusolverDnZgetrf" => "6.1.0",
+    "cusolverDnZgesvdj_bufferSize" => "6.1.0",
     "cusolverDnZgesvdjBatched_bufferSize" => "6.1.0",
     "cusolverDnZgesvdjBatched" => "6.1.0",
+    "cusolverDnZgesvdj" => "6.1.0",
     "cusolverDnZgesvd_bufferSize" => "6.1.0",
     "cusolverDnZgesvd" => "6.1.0",
     "cusolverDnZgeqrf_bufferSize" => "6.1.0",
@@ -1178,8 +1180,10 @@ my %experimental_funcs = (
     "cusolverDnSgetrs" => "6.1.0",
     "cusolverDnSgetrf_bufferSize" => "6.1.0",
     "cusolverDnSgetrf" => "6.1.0",
+    "cusolverDnSgesvdj_bufferSize" => "6.1.0",
     "cusolverDnSgesvdjBatched_bufferSize" => "6.1.0",
     "cusolverDnSgesvdjBatched" => "6.1.0",
+    "cusolverDnSgesvdj" => "6.1.0",
     "cusolverDnSgesvd_bufferSize" => "6.1.0",
     "cusolverDnSgesvd" => "6.1.0",
     "cusolverDnSgeqrf_bufferSize" => "6.1.0",
@@ -1231,8 +1235,10 @@ my %experimental_funcs = (
     "cusolverDnDgetrs" => "6.1.0",
     "cusolverDnDgetrf_bufferSize" => "6.1.0",
     "cusolverDnDgetrf" => "6.1.0",
+    "cusolverDnDgesvdj_bufferSize" => "6.1.0",
     "cusolverDnDgesvdjBatched_bufferSize" => "6.1.0",
     "cusolverDnDgesvdjBatched" => "6.1.0",
+    "cusolverDnDgesvdj" => "6.1.0",
     "cusolverDnDgesvd_bufferSize" => "6.1.0",
     "cusolverDnDgesvd" => "6.1.0",
     "cusolverDnDgeqrf_bufferSize" => "6.1.0",
@@ -1287,8 +1293,10 @@ my %experimental_funcs = (
     "cusolverDnCgetrs" => "6.1.0",
     "cusolverDnCgetrf_bufferSize" => "6.1.0",
     "cusolverDnCgetrf" => "6.1.0",
+    "cusolverDnCgesvdj_bufferSize" => "6.1.0",
     "cusolverDnCgesvdjBatched_bufferSize" => "6.1.0",
     "cusolverDnCgesvdjBatched" => "6.1.0",
+    "cusolverDnCgesvdj" => "6.1.0",
     "cusolverDnCgesvd_bufferSize" => "6.1.0",
     "cusolverDnCgesvd" => "6.1.0",
     "cusolverDnCgeqrf_bufferSize" => "6.1.0",
@@ -1464,8 +1472,10 @@ sub experimentalSubstitutions {
     subst("cusolverDnCgeqrf_bufferSize", "hipsolverDnCgeqrf_bufferSize", "library");
     subst("cusolverDnCgesvd", "hipsolverDnCgesvd", "library");
     subst("cusolverDnCgesvd_bufferSize", "hipsolverDnCgesvd_bufferSize", "library");
+    subst("cusolverDnCgesvdj", "hipsolverDnCgesvdj", "library");
     subst("cusolverDnCgesvdjBatched", "hipsolverDnCgesvdjBatched", "library");
     subst("cusolverDnCgesvdjBatched_bufferSize", "hipsolverDnCgesvdjBatched_bufferSize", "library");
+    subst("cusolverDnCgesvdj_bufferSize", "hipsolverDnCgesvdj_bufferSize", "library");
     subst("cusolverDnCgetrf", "hipsolverDnCgetrf", "library");
     subst("cusolverDnCgetrf_bufferSize", "hipsolverDnCgetrf_bufferSize", "library");
     subst("cusolverDnCgetrs", "hipsolverDnCgetrs", "library");
@@ -1520,8 +1530,10 @@ sub experimentalSubstitutions {
     subst("cusolverDnDgeqrf_bufferSize", "hipsolverDnDgeqrf_bufferSize", "library");
     subst("cusolverDnDgesvd", "hipsolverDnDgesvd", "library");
     subst("cusolverDnDgesvd_bufferSize", "hipsolverDnDgesvd_bufferSize", "library");
+    subst("cusolverDnDgesvdj", "hipsolverDnDgesvdj", "library");
     subst("cusolverDnDgesvdjBatched", "hipsolverDnDgesvdjBatched", "library");
     subst("cusolverDnDgesvdjBatched_bufferSize", "hipsolverDnDgesvdjBatched_bufferSize", "library");
+    subst("cusolverDnDgesvdj_bufferSize", "hipsolverDnDgesvdj_bufferSize", "library");
     subst("cusolverDnDgetrf", "hipsolverDnDgetrf", "library");
     subst("cusolverDnDgetrf_bufferSize", "hipsolverDnDgetrf_bufferSize", "library");
     subst("cusolverDnDgetrs", "hipsolverDnDgetrs", "library");
@@ -1572,8 +1584,10 @@ sub experimentalSubstitutions {
     subst("cusolverDnSgeqrf_bufferSize", "hipsolverDnSgeqrf_bufferSize", "library");
     subst("cusolverDnSgesvd", "hipsolverDnSgesvd", "library");
     subst("cusolverDnSgesvd_bufferSize", "hipsolverDnSgesvd_bufferSize", "library");
+    subst("cusolverDnSgesvdj", "hipsolverDnSgesvdj", "library");
     subst("cusolverDnSgesvdjBatched", "hipsolverDnSgesvdjBatched", "library");
     subst("cusolverDnSgesvdjBatched_bufferSize", "hipsolverDnSgesvdjBatched_bufferSize", "library");
+    subst("cusolverDnSgesvdj_bufferSize", "hipsolverDnSgesvdj_bufferSize", "library");
     subst("cusolverDnSgetrf", "hipsolverDnSgetrf", "library");
     subst("cusolverDnSgetrf_bufferSize", "hipsolverDnSgetrf_bufferSize", "library");
     subst("cusolverDnSgetrs", "hipsolverDnSgetrs", "library");
@@ -1632,8 +1646,10 @@ sub experimentalSubstitutions {
     subst("cusolverDnZgeqrf_bufferSize", "hipsolverDnZgeqrf_bufferSize", "library");
     subst("cusolverDnZgesvd", "hipsolverDnZgesvd", "library");
     subst("cusolverDnZgesvd_bufferSize", "hipsolverDnZgesvd_bufferSize", "library");
+    subst("cusolverDnZgesvdj", "hipsolverDnZgesvdj", "library");
     subst("cusolverDnZgesvdjBatched", "hipsolverDnZgesvdjBatched", "library");
     subst("cusolverDnZgesvdjBatched_bufferSize", "hipsolverDnZgesvdjBatched_bufferSize", "library");
+    subst("cusolverDnZgesvdj_bufferSize", "hipsolverDnZgesvdj_bufferSize", "library");
     subst("cusolverDnZgetrf", "hipsolverDnZgetrf", "library");
     subst("cusolverDnZgetrf_bufferSize", "hipsolverDnZgetrf_bufferSize", "library");
     subst("cusolverDnZgetrs", "hipsolverDnZgetrs", "library");

--- a/docs/tables/CUSOLVER_API_supported_by_HIP.md
+++ b/docs/tables/CUSOLVER_API_supported_by_HIP.md
@@ -130,8 +130,10 @@
 |`cusolverDnCgeqrf_bufferSize`| | | | |`hipsolverDnCgeqrf_bufferSize`|5.1.0| | | |6.1.0|
 |`cusolverDnCgesvd`| | | | |`hipsolverDnCgesvd`|5.1.0| | | |6.1.0|
 |`cusolverDnCgesvd_bufferSize`| | | | |`hipsolverDnCgesvd_bufferSize`|5.1.0| | | |6.1.0|
+|`cusolverDnCgesvdj`|9.0| | | |`hipsolverDnCgesvdj`|5.1.0| | | |6.1.0|
 |`cusolverDnCgesvdjBatched`|9.0| | | |`hipsolverDnCgesvdjBatched`|5.1.0| | | |6.1.0|
 |`cusolverDnCgesvdjBatched_bufferSize`|9.0| | | |`hipsolverDnCgesvdjBatched_bufferSize`|5.1.0| | | |6.1.0|
+|`cusolverDnCgesvdj_bufferSize`|9.0| | | |`hipsolverDnCgesvdj_bufferSize`|5.1.0| | | |6.1.0|
 |`cusolverDnCgetrf`| | | | |`hipsolverDnCgetrf`|5.1.0| | | |6.1.0|
 |`cusolverDnCgetrf_bufferSize`| | | | |`hipsolverDnCgetrf_bufferSize`|5.1.0| | | |6.1.0|
 |`cusolverDnCgetrs`| | | | |`hipsolverDnCgetrs`|5.1.0| | | |6.1.0|
@@ -208,8 +210,10 @@
 |`cusolverDnDgeqrf_bufferSize`| | | | |`hipsolverDnDgeqrf_bufferSize`|5.1.0| | | |6.1.0|
 |`cusolverDnDgesvd`| | | | |`hipsolverDnDgesvd`|5.1.0| | | |6.1.0|
 |`cusolverDnDgesvd_bufferSize`| | | | |`hipsolverDnDgesvd_bufferSize`|5.1.0| | | |6.1.0|
+|`cusolverDnDgesvdj`|9.0| | | |`hipsolverDnDgesvdj`|5.1.0| | | |6.1.0|
 |`cusolverDnDgesvdjBatched`|9.0| | | |`hipsolverDnDgesvdjBatched`|5.1.0| | | |6.1.0|
 |`cusolverDnDgesvdjBatched_bufferSize`|9.0| | | |`hipsolverDnDgesvdjBatched_bufferSize`|5.1.0| | | |6.1.0|
+|`cusolverDnDgesvdj_bufferSize`|9.0| | | |`hipsolverDnDgesvdj_bufferSize`|5.1.0| | | |6.1.0|
 |`cusolverDnDgetrf`| | | | |`hipsolverDnDgetrf`|5.1.0| | | |6.1.0|
 |`cusolverDnDgetrf_bufferSize`| | | | |`hipsolverDnDgetrf_bufferSize`|5.1.0| | | |6.1.0|
 |`cusolverDnDgetrs`| | | | |`hipsolverDnDgetrs`|5.1.0| | | |6.1.0|
@@ -304,8 +308,10 @@
 |`cusolverDnSgeqrf_bufferSize`| | | | |`hipsolverDnSgeqrf_bufferSize`|5.1.0| | | |6.1.0|
 |`cusolverDnSgesvd`| | | | |`hipsolverDnSgesvd`|5.1.0| | | |6.1.0|
 |`cusolverDnSgesvd_bufferSize`| | | | |`hipsolverDnSgesvd_bufferSize`|5.1.0| | | |6.1.0|
+|`cusolverDnSgesvdj`|9.0| | | |`hipsolverDnSgesvdj`|5.1.0| | | |6.1.0|
 |`cusolverDnSgesvdjBatched`|9.0| | | |`hipsolverDnSgesvdjBatched`|5.1.0| | | |6.1.0|
 |`cusolverDnSgesvdjBatched_bufferSize`|9.0| | | |`hipsolverDnSgesvdjBatched_bufferSize`|5.1.0| | | |6.1.0|
+|`cusolverDnSgesvdj_bufferSize`|9.0| | | |`hipsolverDnSgesvdj_bufferSize`|5.1.0| | | |6.1.0|
 |`cusolverDnSgetrf`| | | | |`hipsolverDnSgetrf`|5.1.0| | | |6.1.0|
 |`cusolverDnSgetrf_bufferSize`| | | | |`hipsolverDnSgetrf_bufferSize`|5.1.0| | | |6.1.0|
 |`cusolverDnSgetrs`| | | | |`hipsolverDnSgetrs`|5.1.0| | | |6.1.0|
@@ -392,8 +398,10 @@
 |`cusolverDnZgeqrf_bufferSize`| | | | |`hipsolverDnZgeqrf_bufferSize`|5.1.0| | | |6.1.0|
 |`cusolverDnZgesvd`| | | | |`hipsolverDnZgesvd`|5.1.0| | | |6.1.0|
 |`cusolverDnZgesvd_bufferSize`| | | | |`hipsolverDnZgesvd_bufferSize`|5.1.0| | | |6.1.0|
+|`cusolverDnZgesvdj`|9.0| | | |`hipsolverDnZgesvdj`|5.1.0| | | |6.1.0|
 |`cusolverDnZgesvdjBatched`|9.0| | | |`hipsolverDnZgesvdjBatched`|5.1.0| | | |6.1.0|
 |`cusolverDnZgesvdjBatched_bufferSize`|9.0| | | |`hipsolverDnZgesvdjBatched_bufferSize`|5.1.0| | | |6.1.0|
+|`cusolverDnZgesvdj_bufferSize`|9.0| | | |`hipsolverDnZgesvdj_bufferSize`|5.1.0| | | |6.1.0|
 |`cusolverDnZgetrf`| | | | |`hipsolverDnZgetrf`|5.1.0| | | |6.1.0|
 |`cusolverDnZgetrf_bufferSize`| | | | |`hipsolverDnZgetrf_bufferSize`|5.1.0| | | |6.1.0|
 |`cusolverDnZgetrs`| | | | |`hipsolverDnZgetrs`|5.1.0| | | |6.1.0|

--- a/docs/tables/CUSOLVER_API_supported_by_HIP_and_ROC.md
+++ b/docs/tables/CUSOLVER_API_supported_by_HIP_and_ROC.md
@@ -130,8 +130,10 @@
 |`cusolverDnCgeqrf_bufferSize`| | | | |`hipsolverDnCgeqrf_bufferSize`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnCgesvd`| | | | |`hipsolverDnCgesvd`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnCgesvd_bufferSize`| | | | |`hipsolverDnCgesvd_bufferSize`|5.1.0| | | |6.1.0| | | | | | |
+|`cusolverDnCgesvdj`|9.0| | | |`hipsolverDnCgesvdj`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnCgesvdjBatched`|9.0| | | |`hipsolverDnCgesvdjBatched`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnCgesvdjBatched_bufferSize`|9.0| | | |`hipsolverDnCgesvdjBatched_bufferSize`|5.1.0| | | |6.1.0| | | | | | |
+|`cusolverDnCgesvdj_bufferSize`|9.0| | | |`hipsolverDnCgesvdj_bufferSize`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnCgetrf`| | | | |`hipsolverDnCgetrf`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnCgetrf_bufferSize`| | | | |`hipsolverDnCgetrf_bufferSize`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnCgetrs`| | | | |`hipsolverDnCgetrs`|5.1.0| | | |6.1.0| | | | | | |
@@ -208,8 +210,10 @@
 |`cusolverDnDgeqrf_bufferSize`| | | | |`hipsolverDnDgeqrf_bufferSize`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnDgesvd`| | | | |`hipsolverDnDgesvd`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnDgesvd_bufferSize`| | | | |`hipsolverDnDgesvd_bufferSize`|5.1.0| | | |6.1.0| | | | | | |
+|`cusolverDnDgesvdj`|9.0| | | |`hipsolverDnDgesvdj`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnDgesvdjBatched`|9.0| | | |`hipsolverDnDgesvdjBatched`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnDgesvdjBatched_bufferSize`|9.0| | | |`hipsolverDnDgesvdjBatched_bufferSize`|5.1.0| | | |6.1.0| | | | | | |
+|`cusolverDnDgesvdj_bufferSize`|9.0| | | |`hipsolverDnDgesvdj_bufferSize`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnDgetrf`| | | | |`hipsolverDnDgetrf`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnDgetrf_bufferSize`| | | | |`hipsolverDnDgetrf_bufferSize`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnDgetrs`| | | | |`hipsolverDnDgetrs`|5.1.0| | | |6.1.0| | | | | | |
@@ -304,8 +308,10 @@
 |`cusolverDnSgeqrf_bufferSize`| | | | |`hipsolverDnSgeqrf_bufferSize`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnSgesvd`| | | | |`hipsolverDnSgesvd`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnSgesvd_bufferSize`| | | | |`hipsolverDnSgesvd_bufferSize`|5.1.0| | | |6.1.0| | | | | | |
+|`cusolverDnSgesvdj`|9.0| | | |`hipsolverDnSgesvdj`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnSgesvdjBatched`|9.0| | | |`hipsolverDnSgesvdjBatched`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnSgesvdjBatched_bufferSize`|9.0| | | |`hipsolverDnSgesvdjBatched_bufferSize`|5.1.0| | | |6.1.0| | | | | | |
+|`cusolverDnSgesvdj_bufferSize`|9.0| | | |`hipsolverDnSgesvdj_bufferSize`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnSgetrf`| | | | |`hipsolverDnSgetrf`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnSgetrf_bufferSize`| | | | |`hipsolverDnSgetrf_bufferSize`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnSgetrs`| | | | |`hipsolverDnSgetrs`|5.1.0| | | |6.1.0| | | | | | |
@@ -392,8 +398,10 @@
 |`cusolverDnZgeqrf_bufferSize`| | | | |`hipsolverDnZgeqrf_bufferSize`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnZgesvd`| | | | |`hipsolverDnZgesvd`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnZgesvd_bufferSize`| | | | |`hipsolverDnZgesvd_bufferSize`|5.1.0| | | |6.1.0| | | | | | |
+|`cusolverDnZgesvdj`|9.0| | | |`hipsolverDnZgesvdj`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnZgesvdjBatched`|9.0| | | |`hipsolverDnZgesvdjBatched`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnZgesvdjBatched_bufferSize`|9.0| | | |`hipsolverDnZgesvdjBatched_bufferSize`|5.1.0| | | |6.1.0| | | | | | |
+|`cusolverDnZgesvdj_bufferSize`|9.0| | | |`hipsolverDnZgesvdj_bufferSize`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnZgetrf`| | | | |`hipsolverDnZgetrf`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnZgetrf_bufferSize`| | | | |`hipsolverDnZgetrf_bufferSize`|5.1.0| | | |6.1.0| | | | | | |
 |`cusolverDnZgetrs`| | | | |`hipsolverDnZgetrs`|5.1.0| | | |6.1.0| | | | | | |

--- a/docs/tables/CUSOLVER_API_supported_by_ROC.md
+++ b/docs/tables/CUSOLVER_API_supported_by_ROC.md
@@ -130,8 +130,10 @@
 |`cusolverDnCgeqrf_bufferSize`| | | | | | | | | | |
 |`cusolverDnCgesvd`| | | | | | | | | | |
 |`cusolverDnCgesvd_bufferSize`| | | | | | | | | | |
+|`cusolverDnCgesvdj`|9.0| | | | | | | | | |
 |`cusolverDnCgesvdjBatched`|9.0| | | | | | | | | |
 |`cusolverDnCgesvdjBatched_bufferSize`|9.0| | | | | | | | | |
+|`cusolverDnCgesvdj_bufferSize`|9.0| | | | | | | | | |
 |`cusolverDnCgetrf`| | | | | | | | | | |
 |`cusolverDnCgetrf_bufferSize`| | | | | | | | | | |
 |`cusolverDnCgetrs`| | | | | | | | | | |
@@ -208,8 +210,10 @@
 |`cusolverDnDgeqrf_bufferSize`| | | | | | | | | | |
 |`cusolverDnDgesvd`| | | | | | | | | | |
 |`cusolverDnDgesvd_bufferSize`| | | | | | | | | | |
+|`cusolverDnDgesvdj`|9.0| | | | | | | | | |
 |`cusolverDnDgesvdjBatched`|9.0| | | | | | | | | |
 |`cusolverDnDgesvdjBatched_bufferSize`|9.0| | | | | | | | | |
+|`cusolverDnDgesvdj_bufferSize`|9.0| | | | | | | | | |
 |`cusolverDnDgetrf`| | | | | | | | | | |
 |`cusolverDnDgetrf_bufferSize`| | | | | | | | | | |
 |`cusolverDnDgetrs`| | | | | | | | | | |
@@ -304,8 +308,10 @@
 |`cusolverDnSgeqrf_bufferSize`| | | | | | | | | | |
 |`cusolverDnSgesvd`| | | | | | | | | | |
 |`cusolverDnSgesvd_bufferSize`| | | | | | | | | | |
+|`cusolverDnSgesvdj`|9.0| | | | | | | | | |
 |`cusolverDnSgesvdjBatched`|9.0| | | | | | | | | |
 |`cusolverDnSgesvdjBatched_bufferSize`|9.0| | | | | | | | | |
+|`cusolverDnSgesvdj_bufferSize`|9.0| | | | | | | | | |
 |`cusolverDnSgetrf`| | | | | | | | | | |
 |`cusolverDnSgetrf_bufferSize`| | | | | | | | | | |
 |`cusolverDnSgetrs`| | | | | | | | | | |
@@ -392,8 +398,10 @@
 |`cusolverDnZgeqrf_bufferSize`| | | | | | | | | | |
 |`cusolverDnZgesvd`| | | | | | | | | | |
 |`cusolverDnZgesvd_bufferSize`| | | | | | | | | | |
+|`cusolverDnZgesvdj`|9.0| | | | | | | | | |
 |`cusolverDnZgesvdjBatched`|9.0| | | | | | | | | |
 |`cusolverDnZgesvdjBatched_bufferSize`|9.0| | | | | | | | | |
+|`cusolverDnZgesvdj_bufferSize`|9.0| | | | | | | | | |
 |`cusolverDnZgetrf`| | | | | | | | | | |
 |`cusolverDnZgetrf_bufferSize`| | | | | | | | | | |
 |`cusolverDnZgetrs`| | | | | | | | | | |

--- a/src/CUDA2HIP_SOLVER_API_functions.cpp
+++ b/src/CUDA2HIP_SOLVER_API_functions.cpp
@@ -417,6 +417,16 @@ const std::map<llvm::StringRef, hipCounter> CUDA_SOLVER_FUNCTION_MAP {
   {"cusolverDnDgesvdjBatched",                           {"hipsolverDnDgesvdjBatched",                             "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
   {"cusolverDnCgesvdjBatched",                           {"hipsolverDnCgesvdjBatched",                             "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
   {"cusolverDnZgesvdjBatched",                           {"hipsolverDnZgesvdjBatched",                             "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
+  // NOTE: rocsolver_(s|d|c|z)gesvdj_notransv have a harness of other ROC and HIP API calls
+  {"cusolverDnSgesvdj_bufferSize",                       {"hipsolverDnSgesvdj_bufferSize",                         "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
+  {"cusolverDnDgesvdj_bufferSize",                       {"hipsolverDnDgesvdj_bufferSize",                         "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
+  {"cusolverDnCgesvdj_bufferSize",                       {"hipsolverDnCgesvdj_bufferSize",                         "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
+  {"cusolverDnZgesvdj_bufferSize",                       {"hipsolverDnZgesvdj_bufferSize",                         "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
+  // NOTE: rocsolver_(s|d|c|z)gesvdj_notransv have a harness of other ROC and HIP API calls
+  {"cusolverDnSgesvdj",                                  {"hipsolverDnSgesvdj",                                    "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
+  {"cusolverDnDgesvdj",                                  {"hipsolverDnDgesvdj",                                    "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
+  {"cusolverDnCgesvdj",                                  {"hipsolverDnCgesvdj",                                    "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
+  {"cusolverDnZgesvdj",                                  {"hipsolverDnZgesvdj",                                    "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
 };
 
 const std::map<llvm::StringRef, cudaAPIversions> CUDA_SOLVER_FUNCTION_VER_MAP {
@@ -679,6 +689,14 @@ const std::map<llvm::StringRef, cudaAPIversions> CUDA_SOLVER_FUNCTION_VER_MAP {
   {"cusolverDnDgesvdjBatched",                            {CUDA_90,   CUDA_0, CUDA_0}},
   {"cusolverDnCgesvdjBatched",                            {CUDA_90,   CUDA_0, CUDA_0}},
   {"cusolverDnZgesvdjBatched",                            {CUDA_90,   CUDA_0, CUDA_0}},
+  {"cusolverDnSgesvdj_bufferSize",                        {CUDA_90,   CUDA_0, CUDA_0}},
+  {"cusolverDnDgesvdj_bufferSize",                        {CUDA_90,   CUDA_0, CUDA_0}},
+  {"cusolverDnCgesvdj_bufferSize",                        {CUDA_90,   CUDA_0, CUDA_0}},
+  {"cusolverDnZgesvdj_bufferSize",                        {CUDA_90,   CUDA_0, CUDA_0}},
+  {"cusolverDnSgesvdj",                                   {CUDA_90,   CUDA_0, CUDA_0}},
+  {"cusolverDnDgesvdj",                                   {CUDA_90,   CUDA_0, CUDA_0}},
+  {"cusolverDnCgesvdj",                                   {CUDA_90,   CUDA_0, CUDA_0}},
+  {"cusolverDnZgesvdj",                                   {CUDA_90,   CUDA_0, CUDA_0}},
 };
 
 const std::map<llvm::StringRef, hipAPIversions> HIP_SOLVER_FUNCTION_VER_MAP {
@@ -900,6 +918,14 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_SOLVER_FUNCTION_VER_MAP {
   {"hipsolverDnDgesvdjBatched",                           {HIP_5010, HIP_0,    HIP_0,  HIP_LATEST}},
   {"hipsolverDnCgesvdjBatched",                           {HIP_5010, HIP_0,    HIP_0,  HIP_LATEST}},
   {"hipsolverDnZgesvdjBatched",                           {HIP_5010, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipsolverDnSgesvdj_bufferSize",                       {HIP_5010, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipsolverDnDgesvdj_bufferSize",                       {HIP_5010, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipsolverDnCgesvdj_bufferSize",                       {HIP_5010, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipsolverDnZgesvdj_bufferSize",                       {HIP_5010, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipsolverDnSgesvdj",                                  {HIP_5010, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipsolverDnDgesvdj",                                  {HIP_5010, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipsolverDnCgesvdj",                                  {HIP_5010, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipsolverDnZgesvdj",                                  {HIP_5010, HIP_0,    HIP_0,  HIP_LATEST}},
 
   {"rocsolver_spotrf",                                    {HIP_3020, HIP_0,    HIP_0,  HIP_LATEST}},
   {"rocsolver_dpotrf",                                    {HIP_3020, HIP_0,    HIP_0,  HIP_LATEST}},

--- a/tests/unit_tests/synthetic/libraries/cusolver2hipsolver.cu
+++ b/tests/unit_tests/synthetic/libraries/cusolver2hipsolver.cu
@@ -31,6 +31,7 @@ int main() {
   int imax_sweeps = 0;
   int isort_eig = 0;
   int iexecuted_sweeps = 0;
+  int iecon = 0;
   float fA = 0.f;
   float fB = 0.f;
   float fC = 0.f;
@@ -1008,6 +1009,46 @@ int main() {
   // HIP: HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDnZgesvdjBatched(hipsolverDnHandle_t handle, hipsolverEigMode_t jobz, int m, int n, hipDoubleComplex* A, int lda, double* S, hipDoubleComplex* U, int ldu, hipDoubleComplex* V, int ldv, hipDoubleComplex* work, int lwork, int* devInfo, hipsolverGesvdjInfo_t params, int batch_count);
   // CHECK: status = hipsolverDnZgesvdjBatched(handle, jobz, m, n, &dComplexA, lda, &dS, &dComplexU, ldu, &dComplexV, ldv, &dComplexWorkspace, Lwork, &info, gesvdj_info, batchSize);
   status = cusolverDnZgesvdjBatched(handle, jobz, m, n, &dComplexA, lda, &dS, &dComplexU, ldu, &dComplexV, ldv, &dComplexWorkspace, Lwork, &info, gesvdj_info, batchSize);
+
+  // CUDA: cusolverStatus_t CUSOLVERAPI cusolverDnSgesvdj_bufferSize(cusolverDnHandle_t handle, cusolverEigMode_t jobz, int econ, int m, int n, const float * A, int lda, const float * S, const float * U, int ldu, const float * V, int ldv, int * lwork, gesvdjInfo_t params);
+  // HIP: HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDnSgesvdj_bufferSize(hipsolverDnHandle_t handle, hipsolverEigMode_t jobz, int econ, int m, int n, const float* A, int lda, const float* S, const float* U, int ldu, const float* V, int ldv, int* lwork, hipsolverGesvdjInfo_t params);
+  // CHECK: status = hipsolverDnSgesvdj_bufferSize(handle, jobz, iecon, m, n, &fA, lda, &fS, &fU, ldu, &fV, ldv, &Lwork, gesvdj_info);
+  status = cusolverDnSgesvdj_bufferSize(handle, jobz, iecon, m, n, &fA, lda, &fS, &fU, ldu, &fV, ldv, &Lwork, gesvdj_info);
+
+  // CUDA: cusolverStatus_t CUSOLVERAPI cusolverDnDgesvdj_bufferSize(cusolverDnHandle_t handle, cusolverEigMode_t jobz, int econ, int m, int n, const double * A, int lda, const double * S, const double * U, int ldu, const double * V, int ldv, int * lwork, gesvdjInfo_t params);
+  // HIP: HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDnDgesvdj_bufferSize(hipsolverDnHandle_t handle, hipsolverEigMode_t jobz, int econ, int m, int n, const double* A, int lda, const double* S, const double* U, int ldu, const double* V, int ldv, int* lwork, hipsolverGesvdjInfo_t params);
+  // CHECK: status = hipsolverDnDgesvdj_bufferSize(handle, jobz, iecon, m, n, &dA, lda, &dS, &dU, ldu, &dV, ldv, &Lwork, gesvdj_info);
+  status = cusolverDnDgesvdj_bufferSize(handle, jobz, iecon, m, n, &dA, lda, &dS, &dU, ldu, &dV, ldv, &Lwork, gesvdj_info);
+
+  // CUDA: cusolverStatus_t CUSOLVERAPI cusolverDnCgesvdj_bufferSize(cusolverDnHandle_t handle, cusolverEigMode_t jobz, int econ, int m, int n, const cuComplex * A, int lda, const float * S, const cuComplex * U, int ldu, const cuComplex * V, int ldv, int * lwork, gesvdjInfo_t params);
+  // HIP: HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDnCgesvdj_bufferSize(hipsolverDnHandle_t handle, hipsolverEigMode_t jobz, int econ, int m, int n, const hipFloatComplex* A, int lda, const float* S, const hipFloatComplex* U, int ldu, const hipFloatComplex* V, int ldv, int* lwork, hipsolverGesvdjInfo_t  params);
+  // CHECK: status = hipsolverDnCgesvdj_bufferSize(handle, jobz, iecon, m, n, &complexA, lda, &fS, &complexU, ldu, &complexV, ldv, &Lwork, gesvdj_info);
+  status = cusolverDnCgesvdj_bufferSize(handle, jobz, iecon, m, n, &complexA, lda, &fS, &complexU, ldu, &complexV, ldv, &Lwork, gesvdj_info);
+
+  // CUDA: cusolverStatus_t CUSOLVERAPI cusolverDnZgesvdj_bufferSize(cusolverDnHandle_t handle, cusolverEigMode_t jobz, int econ, int m, int n, const cuDoubleComplex *A, int lda, const double * S, const cuDoubleComplex *U, int ldu, const cuDoubleComplex *V, int ldv, int * lwork, gesvdjInfo_t params);
+  // HIP: HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDnZgesvdj_bufferSize(hipsolverDnHandle_t handle, hipsolverEigMode_t jobz, int econ, int m, int n, const hipDoubleComplex* A, int lda, const double* S, const hipDoubleComplex* U, int ldu, const hipDoubleComplex* V, int ldv, int* lwork, hipsolverGesvdjInfo_t params);
+  // CHECK: status = hipsolverDnZgesvdj_bufferSize(handle, jobz, iecon, m, n, &dComplexA, lda, &dS, &dComplexU, ldu, &dComplexV, ldv, &Lwork, gesvdj_info);
+  status = cusolverDnZgesvdj_bufferSize(handle, jobz, iecon, m, n, &dComplexA, lda, &dS, &dComplexU, ldu, &dComplexV, ldv, &Lwork, gesvdj_info);
+
+  // CUDA: cusolverStatus_t CUSOLVERAPI cusolverDnSgesvdj(cusolverDnHandle_t handle, cusolverEigMode_t jobz, int econ, int m, int n, float * A, int lda, float * S, float * U, int ldu, float * V, int ldv, float * work, int lwork, int * info, gesvdjInfo_t params);
+  // HIP: HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDnSgesvdj(hipsolverDnHandle_t handle, hipsolverEigMode_t jobz, int econ, int m, int n, float* A, int lda, float* S, float* U, int ldu, float* V, int ldv, float* work, int lwork, int* devInfo, hipsolverGesvdjInfo_t params);
+  // CHECK: status = hipsolverDnSgesvdj(handle, jobz, iecon, m, n, &fA, lda, &fS, &fU, ldu, &fV, ldv, &fWorkspace, Lwork, &info, gesvdj_info);
+  status = cusolverDnSgesvdj(handle, jobz, iecon, m, n, &fA, lda, &fS, &fU, ldu, &fV, ldv, &fWorkspace, Lwork, &info, gesvdj_info);
+
+  // CUDA: cusolverStatus_t CUSOLVERAPI cusolverDnDgesvdj(cusolverDnHandle_t handle, cusolverEigMode_t jobz, int econ, int m, int n, double * A, int lda, double * S, double * U, int ldu, double * V, int ldv, double * work, int lwork, int * info, gesvdjInfo_t params);
+  // HIP: HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDnDgesvdj(hipsolverDnHandle_t handle, hipsolverEigMode_t jobz, int econ, int m, int n, double* A, int lda, double* S, double* U, int ldu, double* V, int ldv, double* work, int lwork, int* devInfo, hipsolverGesvdjInfo_t params);
+  // CHECK: status = hipsolverDnDgesvdj(handle, jobz, iecon, m, n, &dA, lda, &dS, &dU, ldu, &dV, ldv, &dWorkspace, Lwork, &info, gesvdj_info);
+  status = cusolverDnDgesvdj(handle, jobz, iecon, m, n, &dA, lda, &dS, &dU, ldu, &dV, ldv, &dWorkspace, Lwork, &info, gesvdj_info);
+
+  // CUDA: cusolverStatus_t CUSOLVERAPI cusolverDnCgesvdj(cusolverDnHandle_t handle, cusolverEigMode_t jobz, int econ, int m, int n, cuComplex * A, int lda, float * S, cuComplex * U, int ldu, cuComplex * V, int ldv, cuComplex * work, int lwork, int * info, gesvdjInfo_t params);
+  // HIP: HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDnCgesvdj(hipsolverDnHandle_t handle, hipsolverEigMode_t jobz, int econ, int m, int n, hipFloatComplex* A, int lda, float* S, hipFloatComplex* U, int ldu, hipFloatComplex* V, int ldv, hipFloatComplex* work, int lwork, int* devInfo, hipsolverGesvdjInfo_t params);
+  // CHECK: status = hipsolverDnCgesvdj(handle, jobz, iecon, m, n, &complexA, lda, &fS, &complexU, ldu, &complexV, ldv, &complexWorkspace, Lwork, &info, gesvdj_info);
+  status = cusolverDnCgesvdj(handle, jobz, iecon, m, n, &complexA, lda, &fS, &complexU, ldu, &complexV, ldv, &complexWorkspace, Lwork, &info, gesvdj_info);
+
+  // CUDA: cusolverStatus_t CUSOLVERAPI cusolverDnZgesvdj(cusolverDnHandle_t handle, cusolverEigMode_t jobz, int econ, int m, int n, cuDoubleComplex * A, int lda, double * S, cuDoubleComplex * U, int ldu, cuDoubleComplex * V, int ldv, cuDoubleComplex * work, int lwork, int * info, gesvdjInfo_t params);
+  // HIP: HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDnZgesvdj(hipsolverDnHandle_t handle, hipsolverEigMode_t jobz, int econ, int m, int n, hipDoubleComplex* A, int lda, double* S, hipDoubleComplex* U, int ldu, hipDoubleComplex* V, int ldv, hipDoubleComplex* work, int lwork, int* devInfo, hipsolverGesvdjInfo_t params);
+  // CHECK: status = hipsolverDnZgesvdj(handle, jobz, iecon, m, n, &dComplexA, lda, &dS, &dComplexU, ldu, &dComplexV, ldv, &dComplexWorkspace, Lwork, &info, gesvdj_info);
+  status = cusolverDnZgesvdj(handle, jobz, iecon, m, n, &dComplexA, lda, &dS, &dComplexU, ldu, &dComplexV, ldv, &dComplexWorkspace, Lwork, &info, gesvdj_info);
 #endif
 
 #if CUDA_VERSION >= 9010


### PR DESCRIPTION
+ `cusolverDn(S|D|C|Z)gesvdj(_bufferSize)?` are `SUPPORTED` by `hipSOLVER` only
+ [NOTE] `rocsolver_(s|d|c|z)gesvdj_notransv` have a harness of other `ROC` and `HIP` API calls, thus `UNSUPPORTED`
+ Updated `SOLVER` synthetic tests, the regenerated `hipify-perl`, and `SOLVER` `CUDA2HIP` documentation
