### PR TITLE
[HIPIFY][#675][SOLVER][fix] Take into account all `cuSOLVER` header files

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -4762,11 +4762,6 @@ sub simpleSubstitutions {
     subst("curand_poisson.h", "hiprand\/hiprand_kernel.h", "include");
     subst("curand_precalc.h", "hiprand\/hiprand_kernel.h", "include");
     subst("curand_uniform.h", "hiprand\/hiprand_kernel.h", "include");
-    subst("cusolverDn.h", "hipsolver.h", "include");
-    subst("cusolverMg.h", "hipsolver.h", "include");
-    subst("cusolverRf.h", "hipsolver.h", "include");
-    subst("cusolverSp.h", "hipsolver.h", "include");
-    subst("cusolver_common.h", "hipsolver.h", "include");
     subst("device_functions.h", "hip\/device_functions.h", "include");
     subst("driver_types.h", "hip\/driver_types.h", "include");
     subst("library_types.h", "hip\/library_types.h", "include");
@@ -4780,6 +4775,12 @@ sub simpleSubstitutions {
     subst("cudnn.h", "hipDNN.h", "include_cuda_main_header");
     subst("cufft.h", "hipfft\/hipfft.h", "include_cuda_main_header");
     subst("curand.h", "hiprand\/hiprand.h", "include_cuda_main_header");
+    subst("cusolverDn.h", "hipsolver.h", "include_cuda_main_header");
+    subst("cusolverMg.h", "hipsolver.h", "include_cuda_main_header");
+    subst("cusolverRf.h", "hipsolver.h", "include_cuda_main_header");
+    subst("cusolverSp.h", "hipsolver.h", "include_cuda_main_header");
+    subst("cusolverSp_LOWLEVEL_PREVIEW.h", "hipsolver.h", "include_cuda_main_header");
+    subst("cusolver_common.h", "hipsolver.h", "include_cuda_main_header");
     subst("cusparse.h", "hipsparse.h", "include_cuda_main_header");
     subst("nvrtc.h", "hiprtc.h", "include_cuda_main_header");
     subst("cublas_v2.h", "hipblas.h", "include_cuda_main_header_v2");

--- a/src/CUDA2HIP.cpp
+++ b/src/CUDA2HIP.cpp
@@ -71,11 +71,12 @@ const std::map <llvm::StringRef, hipCounter> CUDA_INCLUDE_MAP {
   {"cusparse.h",                                            {"hipsparse.h",                                "rocsparse.h", CONV_INCLUDE_CUDA_MAIN_H,    API_SPARSE, 0}},
   {"cusparse_v2.h",                                         {"hipsparse.h",                                "rocsparse.h", CONV_INCLUDE_CUDA_MAIN_V2_H, API_SPARSE, 0}},
   // cuSOLVER includes
-  {"cusolverDn.h",                                          {"hipsolver.h",                      "rocsolver/rocsolver.h", CONV_INCLUDE,                API_SOLVER, 0}},
-  {"cusolverMg.h",                                          {"hipsolver.h",                      "rocsolver/rocsolver.h", CONV_INCLUDE,                API_SOLVER, 0}},
-  {"cusolverRf.h",                                          {"hipsolver.h",                      "rocsolver/rocsolver.h", CONV_INCLUDE,                API_SOLVER, 0}},
-  {"cusolverSp.h",                                          {"hipsolver.h",                      "rocsolver/rocsolver.h", CONV_INCLUDE,                API_SOLVER, 0}},
-  {"cusolver_common.h",                                     {"hipsolver.h",                      "rocsolver/rocsolver.h", CONV_INCLUDE,                API_SOLVER, 0}},
+  {"cusolverDn.h",                                          {"hipsolver.h",                      "rocsolver/rocsolver.h", CONV_INCLUDE_CUDA_MAIN_H,    API_SOLVER, 0}},
+  {"cusolverMg.h",                                          {"hipsolver.h",                      "rocsolver/rocsolver.h", CONV_INCLUDE_CUDA_MAIN_H,    API_SOLVER, 0}},
+  {"cusolverRf.h",                                          {"hipsolver.h",                      "rocsolver/rocsolver.h", CONV_INCLUDE_CUDA_MAIN_H,    API_SOLVER, 0}},
+  {"cusolverSp.h",                                          {"hipsolver.h",                      "rocsolver/rocsolver.h", CONV_INCLUDE_CUDA_MAIN_H,    API_SOLVER, 0}},
+  {"cusolverSp_LOWLEVEL_PREVIEW.h",                         {"hipsolver.h",                      "rocsolver/rocsolver.h", CONV_INCLUDE_CUDA_MAIN_H,    API_SOLVER, 0}},
+  {"cusolver_common.h",                                     {"hipsolver.h",                      "rocsolver/rocsolver.h", CONV_INCLUDE_CUDA_MAIN_H,    API_SOLVER, 0}},
   // CUB includes
   {"cub/cub.cuh",                                           {"hipcub/hipcub.hpp",                                     "", CONV_INCLUDE_CUDA_MAIN_H,    API_CUB, 0}},
   // CAFFE2 includes

--- a/src/HipifyAction.cpp
+++ b/src/HipifyAction.cpp
@@ -1529,6 +1529,10 @@ bool HipifyAction::Exclude(const hipCounter &hipToken) {
           if (insertedSPARSEHeader) return true;
           insertedSPARSEHeader = true;
           return false;
+        case API_SOLVER:
+          if (insertedSOLVERHeader) return true;
+          insertedSOLVERHeader = true;
+          return false;
         default:
           return false;
       }

--- a/src/HipifyAction.h
+++ b/src/HipifyAction.h
@@ -57,6 +57,7 @@ private:
   bool insertedSPARSEHeader = false;
   bool insertedSPARSEHeader_V2 = false;
   bool insertedComplexHeader = false;
+  bool insertedSOLVERHeader = false;
   bool firstHeader = false;
   bool pragmaOnce = false;
   clang::SourceLocation firstHeaderLoc;

--- a/tests/unit_tests/headers/headers_test_12_SOLVER.cu
+++ b/tests/unit_tests/headers/headers_test_12_SOLVER.cu
@@ -1,0 +1,30 @@
+// RUN: %run_test hipify "%s" "%t" %hipify_args %clang_args
+
+// Checks that HIP header file is included after include guard controlling macro,
+// which goes before #pragma once.
+// CHECK: #ifndef HEADERS_TEST_12_SOLVER_H
+// CHECK-NEXT: #include <hip/hip_runtime.h>
+#ifndef HEADERS_TEST_12_SOLVER_H
+// CHECK: #pragma once
+#pragma once
+// CHECK-NOT: #include <hip/hip_runtime.h>
+#define HEADERS_TEST_12_SOLVER_H
+#include <stdio.h>
+static int counter = 0;
+
+// CHECK: #include "hipsolver.h"
+// CHECK-NOT: #include "hipsolver.h"
+// CHECK-NOT: #include "cusolver_common.h"
+// CHECK-NOT: #include "cusolverDn.h"
+// CHECK-NOT: #include "cusolverRf.h"
+// CHECK-NOT: #include "cusolverMg.h"
+// CHECK-NOT: #include "cusolverSp.h"
+// CHECK-NOT: #include "cusolverSp_LOWLEVEL_PREVIEW.h"
+#include "cusolver_common.h"
+#include "cusolverDn.h"
+#include "cusolverRf.h"
+#include "cusolverMg.h"
+#include "cusolverSp.h"
+#include "cusolverSp_LOWLEVEL_PREVIEW.h"
+
+#endif // HEADERS_TEST_12_SOLVER_H


### PR DESCRIPTION
+ Added a corresponding `headers/headers_test_12_SOLVER.cu synthetic test, updated the regenerated `hipify-perl`
