### PR TITLE
[HIPIFY][#674][rocSPARSE][feature] rocSPARSE support - Step 74 - functions `rocsparse_(s|d)roti`

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -2436,6 +2436,7 @@ sub rocSubstitutions {
     subst("cusparseDpruneDense2csrNnz", "rocsparse_dprune_dense2csr_nnz", "library");
     subst("cusparseDpruneDense2csrNnzByPercentage", "rocsparse_dprune_dense2csr_nnz_by_percentage", "library");
     subst("cusparseDpruneDense2csr_bufferSizeExt", "rocsparse_dprune_dense2csr_buffer_size", "library");
+    subst("cusparseDroti", "rocsparse_droti", "library");
     subst("cusparseDsctr", "rocsparse_dsctr", "library");
     subst("cusparseGather", "rocsparse_gather", "library");
     subst("cusparseGetMatDiagType", "rocsparse_get_mat_diag_type", "library");
@@ -2546,6 +2547,7 @@ sub rocSubstitutions {
     subst("cusparseSpruneDense2csrNnz", "rocsparse_sprune_dense2csr_nnz", "library");
     subst("cusparseSpruneDense2csrNnzByPercentage", "rocsparse_sprune_dense2csr_nnz_by_percentage", "library");
     subst("cusparseSpruneDense2csr_bufferSizeExt", "rocsparse_sprune_dense2csr_buffer_size", "library");
+    subst("cusparseSroti", "rocsparse_sroti", "library");
     subst("cusparseSsctr", "rocsparse_ssctr", "library");
     subst("cusparseXbsric02_zeroPivot", "rocsparse_bsric0_zero_pivot", "library");
     subst("cusparseXbsrilu02_zeroPivot", "rocsparse_bsrilu0_zero_pivot", "library");

--- a/docs/tables/CUSPARSE_API_supported_by_HIP_and_ROC.md
+++ b/docs/tables/CUSPARSE_API_supported_by_HIP_and_ROC.md
@@ -273,13 +273,13 @@
 |`cusparseDdoti`| |10.2| |11.0|`hipsparseDdoti`|1.9.2| | | | | | | | | | |
 |`cusparseDgthr`| |11.0| |12.0|`hipsparseDgthr`|1.9.2| | | | | | | | | | |
 |`cusparseDgthrz`| |11.0| |12.0|`hipsparseDgthrz`|1.9.2| | | | | | | | | | |
-|`cusparseDroti`| |11.0| |12.0|`hipsparseDroti`|1.9.2| | | | | | | | | | |
+|`cusparseDroti`| |11.0| |12.0|`hipsparseDroti`|1.9.2| | | | |`rocsparse_droti`|1.9.0| | | | |
 |`cusparseDsctr`| |11.0| |12.0|`hipsparseDsctr`|1.9.2| | | | |`rocsparse_dsctr`|1.9.0| | | | |
 |`cusparseSaxpyi`| |11.0| |12.0|`hipsparseSaxpyi`|1.9.2| | | | | | | | | | |
 |`cusparseSdoti`| |10.2| |11.0|`hipsparseSdoti`|1.9.2| | | | | | | | | | |
 |`cusparseSgthr`| |11.0| |12.0|`hipsparseSgthr`|1.9.2| | | | | | | | | | |
 |`cusparseSgthrz`| |11.0| |12.0|`hipsparseSgthrz`|1.9.2| | | | | | | | | | |
-|`cusparseSroti`| |11.0| |12.0|`hipsparseSroti`|1.9.2| | | | | | | | | | |
+|`cusparseSroti`| |11.0| |12.0|`hipsparseSroti`|1.9.2| | | | |`rocsparse_sroti`|1.9.0| | | | |
 |`cusparseSsctr`| |11.0| |12.0|`hipsparseSsctr`|1.9.2| | | | |`rocsparse_ssctr`|1.9.0| | | | |
 |`cusparseZaxpyi`| |11.0| |12.0|`hipsparseZaxpyi`|3.1.0| | | | | | | | | | |
 |`cusparseZdotci`| |10.2| |11.0|`hipsparseZdotci`|3.1.0| | | | | | | | | | |

--- a/docs/tables/CUSPARSE_API_supported_by_ROC.md
+++ b/docs/tables/CUSPARSE_API_supported_by_ROC.md
@@ -273,13 +273,13 @@
 |`cusparseDdoti`| |10.2| |11.0| | | | | | |
 |`cusparseDgthr`| |11.0| |12.0| | | | | | |
 |`cusparseDgthrz`| |11.0| |12.0| | | | | | |
-|`cusparseDroti`| |11.0| |12.0| | | | | | |
+|`cusparseDroti`| |11.0| |12.0|`rocsparse_droti`|1.9.0| | | | |
 |`cusparseDsctr`| |11.0| |12.0|`rocsparse_dsctr`|1.9.0| | | | |
 |`cusparseSaxpyi`| |11.0| |12.0| | | | | | |
 |`cusparseSdoti`| |10.2| |11.0| | | | | | |
 |`cusparseSgthr`| |11.0| |12.0| | | | | | |
 |`cusparseSgthrz`| |11.0| |12.0| | | | | | |
-|`cusparseSroti`| |11.0| |12.0| | | | | | |
+|`cusparseSroti`| |11.0| |12.0|`rocsparse_sroti`|1.9.0| | | | |
 |`cusparseSsctr`| |11.0| |12.0|`rocsparse_ssctr`|1.9.0| | | | |
 |`cusparseZaxpyi`| |11.0| |12.0| | | | | | |
 |`cusparseZdotci`| |10.2| |11.0| | | | | | |

--- a/src/CUDA2HIP_SPARSE_API_functions.cpp
+++ b/src/CUDA2HIP_SPARSE_API_functions.cpp
@@ -107,8 +107,8 @@ const std::map<llvm::StringRef, hipCounter> CUDA_SPARSE_FUNCTION_MAP {
   {"cusparseCgthrz",                                    {"hipsparseCgthrz",                                    "",                                                                 CONV_LIB_FUNC, API_SPARSE, 8, ROC_UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED}},
   {"cusparseZgthrz",                                    {"hipsparseZgthrz",                                    "",                                                                 CONV_LIB_FUNC, API_SPARSE, 8, ROC_UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED}},
 
-  {"cusparseSroti",                                     {"hipsparseSroti",                                     "",                                                                 CONV_LIB_FUNC, API_SPARSE, 8, ROC_UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED}},
-  {"cusparseDroti",                                     {"hipsparseDroti",                                     "",                                                                 CONV_LIB_FUNC, API_SPARSE, 8, ROC_UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED}},
+  {"cusparseSroti",                                     {"hipsparseSroti",                                     "rocsparse_sroti",                                                  CONV_LIB_FUNC, API_SPARSE, 8, CUDA_DEPRECATED | CUDA_REMOVED}},
+  {"cusparseDroti",                                     {"hipsparseDroti",                                     "rocsparse_droti",                                                  CONV_LIB_FUNC, API_SPARSE, 8, CUDA_DEPRECATED | CUDA_REMOVED}},
 
   {"cusparseSsctr",                                     {"hipsparseSsctr",                                     "rocsparse_ssctr",                                                  CONV_LIB_FUNC, API_SPARSE, 8, CUDA_DEPRECATED | CUDA_REMOVED}},
   {"cusparseDsctr",                                     {"hipsparseDsctr",                                     "rocsparse_dsctr",                                                  CONV_LIB_FUNC, API_SPARSE, 8, CUDA_DEPRECATED | CUDA_REMOVED}},
@@ -2367,6 +2367,8 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_SPARSE_FUNCTION_VER_MAP {
   {"rocsparse_csctr",                                    {HIP_1090, HIP_0,    HIP_0   }},
   {"rocsparse_dsctr",                                    {HIP_1090, HIP_0,    HIP_0   }},
   {"rocsparse_ssctr",                                    {HIP_1090, HIP_0,    HIP_0   }},
+  {"rocsparse_droti",                                    {HIP_1090, HIP_0,    HIP_0   }},
+  {"rocsparse_sroti",                                    {HIP_1090, HIP_0,    HIP_0   }},
 };
 
 const std::map<llvm::StringRef, cudaAPIChangedVersions> CUDA_SPARSE_FUNCTION_CHANGED_VER_MAP {

--- a/tests/unit_tests/synthetic/libraries/cusparse2hipsparse.cu
+++ b/tests/unit_tests/synthetic/libraries/cusparse2hipsparse.cu
@@ -280,6 +280,7 @@ int main() {
   double dBeta = 0.f;
   double dC = 0.f;
   double dF = 0.f;
+  double dS = 0.f;
   double dX = 0.f;
   double dY = 0.f;
   float fA = 0.f;
@@ -288,6 +289,7 @@ int main() {
   float fBeta = 0.f;
   float fC = 0.f;
   float fF = 0.f;
+  float fS = 0.f;
   float fX = 0.f;
   float fY = 0.f;
   int algo = 0;
@@ -2691,6 +2693,16 @@ int main() {
   // HIP: DEPRECATED_CUDA_11000("The routine will be removed in CUDA 12") HIPSPARSE_EXPORT hipsparseStatus_t hipsparseSsctr(hipsparseHandle_t handle, int nnz, const float* xVal, const int* xInd, float* y, hipsparseIndexBase_t idxBase);
   // CHECK: status_t = hipsparseSsctr(handle_t, innz, &fX, &xInd, &fY, indexBase_t);
   status_t = cusparseSsctr(handle_t, innz, &fX, &xInd, &fY, indexBase_t);
+
+  // CUDA: CUSPARSE_DEPRECATED(cusparseRot) cusparseStatus_t CUSPARSEAPI cusparseDroti(cusparseHandle_t handle, int nnz, double* xVal, const int* xInd, double* y, const double* c, const double* s, cusparseIndexBase_t idxBase);
+  // HIP: DEPRECATED_CUDA_11000("The routine will be removed in CUDA 12") HIPSPARSE_EXPORT hipsparseStatus_t hipsparseDroti(hipsparseHandle_t handle, int nnz, double* xVal, const int* xInd, double* y, const double* c, const double* s, hipsparseIndexBase_t idxBase);
+  // CHECK: status_t = hipsparseDroti(handle_t, innz, &dX, &xInd, &dY, &dC, &dS, indexBase_t);
+  status_t = cusparseDroti(handle_t, innz, &dX, &xInd, &dY, &dC, &dS, indexBase_t);
+
+  // CUDA: CUSPARSE_DEPRECATED(cusparseRot) cusparseStatus_t CUSPARSEAPI cusparseSroti(cusparseHandle_t handle, int nnz, float* xVal, const int* xInd, float* y, const float* c, const float* s, cusparseIndexBase_t idxBase);
+  // HIP: DEPRECATED_CUDA_11000("The routine will be removed in CUDA 12") HIPSPARSE_EXPORT hipsparseStatus_t hipsparseSroti(hipsparseHandle_t handle, int nnz, float* xVal, const int* xInd, float* y, const float* c, const float* s, hipsparseIndexBase_t idxBase);
+  // CHECK: status_t = hipsparseSroti(handle_t, innz, &fX, &xInd, &fY, &fC, &fS, indexBase_t);
+  status_t = cusparseSroti(handle_t, innz, &fX, &xInd, &fY, &fC, &fS, indexBase_t);
 #endif
 
 #if CUDA_VERSION >= 12000

--- a/tests/unit_tests/synthetic/libraries/cusparse2rocsparse.cu
+++ b/tests/unit_tests/synthetic/libraries/cusparse2rocsparse.cu
@@ -260,6 +260,7 @@ int main() {
   double dBeta = 0.f;
   double dC = 0.f;
   double dF = 0.f;
+  double dS = 0.f;
   double dX = 0.f;
   double dY = 0.f;
   float fA = 0.f;
@@ -268,6 +269,7 @@ int main() {
   float fBeta = 0.f;
   float fC = 0.f;
   float fF = 0.f;
+  float fS = 0.f;
   float fX = 0.f;
   float fY = 0.f;
   int algo = 0;
@@ -2180,6 +2182,16 @@ int main() {
   // ROC: ROCSPARSE_EXPORT rocsparse_status rocsparse_ssctr(rocsparse_handle handle, rocsparse_int nnz, const float* x_val, const rocsparse_int* x_ind, float* y, rocsparse_index_base idx_base);
   // CHECK: status_t = rocsparse_ssctr(handle_t, innz, &fX, &xInd, &fY, indexBase_t);
   status_t = cusparseSsctr(handle_t, innz, &fX, &xInd, &fY, indexBase_t);
+
+  // CUDA: CUSPARSE_DEPRECATED(cusparseRot) cusparseStatus_t CUSPARSEAPI cusparseDroti(cusparseHandle_t handle, int nnz, double* xVal, const int* xInd, double* y, const double* c, const double* s, cusparseIndexBase_t idxBase);
+  // ROC: ROCSPARSE_EXPORT rocsparse_status rocsparse_droti(rocsparse_handle handle, rocsparse_int nnz, double* x_val, const rocsparse_int* x_ind, double* y, const double* c, const double* s, rocsparse_index_base idx_base);
+  // CHECK: status_t = rocsparse_droti(handle_t, innz, &dX, &xInd, &dY, &dC, &dS, indexBase_t);
+  status_t = cusparseDroti(handle_t, innz, &dX, &xInd, &dY, &dC, &dS, indexBase_t);
+
+  // CUDA: CUSPARSE_DEPRECATED(cusparseRot) cusparseStatus_t CUSPARSEAPI cusparseSroti(cusparseHandle_t handle, int nnz, float* xVal, const int* xInd, float* y, const float* c, const float* s, cusparseIndexBase_t idxBase);
+  // ROC: ROCSPARSE_EXPORT rocsparse_status rocsparse_sroti(rocsparse_handle handle, rocsparse_int nnz, float* x_val, const rocsparse_int* x_ind, float* y, const float* c, const float* s, rocsparse_index_base idx_base);
+  // CHECK: status_t = rocsparse_sroti(handle_t, innz, &fX, &xInd, &fY, &fC, &fS, indexBase_t);
+  status_t = cusparseSroti(handle_t, innz, &fX, &xInd, &fY, &fC, &fS, indexBase_t);
 #endif
 
 #if CUDA_VERSION >= 12010 && CUSPARSE_VERSION >= 12100


### PR DESCRIPTION
+ Updated `SPARSE` synthetic tests, the regenerated hipify-perl, and `SPARSE` `CUDA2HIP` documentation
