### PR TITLE
[HIPIFY][#674][rocSPARSE][feature] rocSPARSE support - Step 76 - functions `rocsparse_(s|d|c|z)gthr`

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -2310,6 +2310,7 @@ sub rocSubstitutions {
     subst("cusparseCgemvi_bufferSize", "rocsparse_cgemvi_buffer_size", "library");
     subst("cusparseCgpsvInterleavedBatch", "rocsparse_cgpsv_interleaved_batch", "library");
     subst("cusparseCgpsvInterleavedBatch_bufferSizeExt", "rocsparse_cgpsv_interleaved_batch_buffer_size", "library");
+    subst("cusparseCgthr", "rocsparse_cgthr", "library");
     subst("cusparseCgthrz", "rocsparse_cgthrz", "library");
     subst("cusparseCgtsv2", "rocsparse_cgtsv", "library");
     subst("cusparseCgtsv2StridedBatch", "rocsparse_cgtsv_no_pivot_strided_batch", "library");
@@ -2406,6 +2407,7 @@ sub rocSubstitutions {
     subst("cusparseDgemvi_bufferSize", "rocsparse_dgemvi_buffer_size", "library");
     subst("cusparseDgpsvInterleavedBatch", "rocsparse_dgpsv_interleaved_batch", "library");
     subst("cusparseDgpsvInterleavedBatch_bufferSizeExt", "rocsparse_dgpsv_interleaved_batch_buffer_size", "library");
+    subst("cusparseDgthr", "rocsparse_dgthr", "library");
     subst("cusparseDgthrz", "rocsparse_dgthrz", "library");
     subst("cusparseDgtsv2", "rocsparse_dgtsv", "library");
     subst("cusparseDgtsv2StridedBatch", "rocsparse_dgtsv_no_pivot_strided_batch", "library");
@@ -2512,6 +2514,7 @@ sub rocSubstitutions {
     subst("cusparseSgemvi_bufferSize", "rocsparse_sgemvi_buffer_size", "library");
     subst("cusparseSgpsvInterleavedBatch", "rocsparse_sgpsv_interleaved_batch", "library");
     subst("cusparseSgpsvInterleavedBatch_bufferSizeExt", "rocsparse_sgpsv_interleaved_batch_buffer_size", "library");
+    subst("cusparseSgthr", "rocsparse_sgthr", "library");
     subst("cusparseSgthrz", "rocsparse_sgthrz", "library");
     subst("cusparseSgtsv2", "rocsparse_sgtsv", "library");
     subst("cusparseSgtsv2StridedBatch", "rocsparse_sgtsv_no_pivot_strided_batch", "library");
@@ -2627,6 +2630,7 @@ sub rocSubstitutions {
     subst("cusparseZgemvi_bufferSize", "rocsparse_zgemvi_buffer_size", "library");
     subst("cusparseZgpsvInterleavedBatch", "rocsparse_zgpsv_interleaved_batch", "library");
     subst("cusparseZgpsvInterleavedBatch_bufferSizeExt", "rocsparse_zgpsv_interleaved_batch_buffer_size", "library");
+    subst("cusparseZgthr", "rocsparse_zgthr", "library");
     subst("cusparseZgthrz", "rocsparse_zgthrz", "library");
     subst("cusparseZgtsv2", "rocsparse_zgtsv", "library");
     subst("cusparseZgtsv2StridedBatch", "rocsparse_zgtsv_no_pivot_strided_batch", "library");

--- a/docs/tables/CUSPARSE_API_supported_by_HIP_and_ROC.md
+++ b/docs/tables/CUSPARSE_API_supported_by_HIP_and_ROC.md
@@ -266,25 +266,25 @@
 |`cusparseCaxpyi`| |11.0| |12.0|`hipsparseCaxpyi`|3.1.0| | | | | | | | | | |
 |`cusparseCdotci`| |10.2| |11.0|`hipsparseCdotci`|3.1.0| | | | | | | | | | |
 |`cusparseCdoti`| |10.2| |11.0|`hipsparseCdoti`|3.1.0| | | | | | | | | | |
-|`cusparseCgthr`| |11.0| |12.0|`hipsparseCgthr`|3.1.0| | | | | | | | | | |
+|`cusparseCgthr`| |11.0| |12.0|`hipsparseCgthr`|3.1.0| | | | |`rocsparse_cgthr`|1.9.0| | | | |
 |`cusparseCgthrz`| |11.0| |12.0|`hipsparseCgthrz`|3.1.0| | | | |`rocsparse_cgthrz`|1.9.0| | | | |
 |`cusparseCsctr`| |11.0| |12.0|`hipsparseCsctr`|3.1.0| | | | |`rocsparse_csctr`|1.9.0| | | | |
 |`cusparseDaxpyi`| |11.0| |12.0|`hipsparseDaxpyi`|1.9.2| | | | | | | | | | |
 |`cusparseDdoti`| |10.2| |11.0|`hipsparseDdoti`|1.9.2| | | | | | | | | | |
-|`cusparseDgthr`| |11.0| |12.0|`hipsparseDgthr`|1.9.2| | | | | | | | | | |
+|`cusparseDgthr`| |11.0| |12.0|`hipsparseDgthr`|1.9.2| | | | |`rocsparse_dgthr`|1.9.0| | | | |
 |`cusparseDgthrz`| |11.0| |12.0|`hipsparseDgthrz`|1.9.2| | | | |`rocsparse_dgthrz`|1.9.0| | | | |
 |`cusparseDroti`| |11.0| |12.0|`hipsparseDroti`|1.9.2| | | | |`rocsparse_droti`|1.9.0| | | | |
 |`cusparseDsctr`| |11.0| |12.0|`hipsparseDsctr`|1.9.2| | | | |`rocsparse_dsctr`|1.9.0| | | | |
 |`cusparseSaxpyi`| |11.0| |12.0|`hipsparseSaxpyi`|1.9.2| | | | | | | | | | |
 |`cusparseSdoti`| |10.2| |11.0|`hipsparseSdoti`|1.9.2| | | | | | | | | | |
-|`cusparseSgthr`| |11.0| |12.0|`hipsparseSgthr`|1.9.2| | | | | | | | | | |
+|`cusparseSgthr`| |11.0| |12.0|`hipsparseSgthr`|1.9.2| | | | |`rocsparse_sgthr`|1.9.0| | | | |
 |`cusparseSgthrz`| |11.0| |12.0|`hipsparseSgthrz`|1.9.2| | | | |`rocsparse_sgthrz`|1.9.0| | | | |
 |`cusparseSroti`| |11.0| |12.0|`hipsparseSroti`|1.9.2| | | | |`rocsparse_sroti`|1.9.0| | | | |
 |`cusparseSsctr`| |11.0| |12.0|`hipsparseSsctr`|1.9.2| | | | |`rocsparse_ssctr`|1.9.0| | | | |
 |`cusparseZaxpyi`| |11.0| |12.0|`hipsparseZaxpyi`|3.1.0| | | | | | | | | | |
 |`cusparseZdotci`| |10.2| |11.0|`hipsparseZdotci`|3.1.0| | | | | | | | | | |
 |`cusparseZdoti`| |10.2| |11.0|`hipsparseZdoti`|3.1.0| | | | | | | | | | |
-|`cusparseZgthr`| |11.0| |12.0|`hipsparseZgthr`|3.1.0| | | | | | | | | | |
+|`cusparseZgthr`| |11.0| |12.0|`hipsparseZgthr`|3.1.0| | | | |`rocsparse_zgthr`|1.9.0| | | | |
 |`cusparseZgthrz`| |11.0| |12.0|`hipsparseZgthrz`|3.1.0| | | | |`rocsparse_zgthrz`|1.9.0| | | | |
 |`cusparseZsctr`| |11.0| |12.0|`hipsparseZsctr`|3.1.0| | | | |`rocsparse_zsctr`|1.9.0| | | | |
 

--- a/docs/tables/CUSPARSE_API_supported_by_ROC.md
+++ b/docs/tables/CUSPARSE_API_supported_by_ROC.md
@@ -266,25 +266,25 @@
 |`cusparseCaxpyi`| |11.0| |12.0| | | | | | |
 |`cusparseCdotci`| |10.2| |11.0| | | | | | |
 |`cusparseCdoti`| |10.2| |11.0| | | | | | |
-|`cusparseCgthr`| |11.0| |12.0| | | | | | |
+|`cusparseCgthr`| |11.0| |12.0|`rocsparse_cgthr`|1.9.0| | | | |
 |`cusparseCgthrz`| |11.0| |12.0|`rocsparse_cgthrz`|1.9.0| | | | |
 |`cusparseCsctr`| |11.0| |12.0|`rocsparse_csctr`|1.9.0| | | | |
 |`cusparseDaxpyi`| |11.0| |12.0| | | | | | |
 |`cusparseDdoti`| |10.2| |11.0| | | | | | |
-|`cusparseDgthr`| |11.0| |12.0| | | | | | |
+|`cusparseDgthr`| |11.0| |12.0|`rocsparse_dgthr`|1.9.0| | | | |
 |`cusparseDgthrz`| |11.0| |12.0|`rocsparse_dgthrz`|1.9.0| | | | |
 |`cusparseDroti`| |11.0| |12.0|`rocsparse_droti`|1.9.0| | | | |
 |`cusparseDsctr`| |11.0| |12.0|`rocsparse_dsctr`|1.9.0| | | | |
 |`cusparseSaxpyi`| |11.0| |12.0| | | | | | |
 |`cusparseSdoti`| |10.2| |11.0| | | | | | |
-|`cusparseSgthr`| |11.0| |12.0| | | | | | |
+|`cusparseSgthr`| |11.0| |12.0|`rocsparse_sgthr`|1.9.0| | | | |
 |`cusparseSgthrz`| |11.0| |12.0|`rocsparse_sgthrz`|1.9.0| | | | |
 |`cusparseSroti`| |11.0| |12.0|`rocsparse_sroti`|1.9.0| | | | |
 |`cusparseSsctr`| |11.0| |12.0|`rocsparse_ssctr`|1.9.0| | | | |
 |`cusparseZaxpyi`| |11.0| |12.0| | | | | | |
 |`cusparseZdotci`| |10.2| |11.0| | | | | | |
 |`cusparseZdoti`| |10.2| |11.0| | | | | | |
-|`cusparseZgthr`| |11.0| |12.0| | | | | | |
+|`cusparseZgthr`| |11.0| |12.0|`rocsparse_zgthr`|1.9.0| | | | |
 |`cusparseZgthrz`| |11.0| |12.0|`rocsparse_zgthrz`|1.9.0| | | | |
 |`cusparseZsctr`| |11.0| |12.0|`rocsparse_zsctr`|1.9.0| | | | |
 

--- a/src/CUDA2HIP_SPARSE_API_functions.cpp
+++ b/src/CUDA2HIP_SPARSE_API_functions.cpp
@@ -97,10 +97,10 @@ const std::map<llvm::StringRef, hipCounter> CUDA_SPARSE_FUNCTION_MAP {
   {"cusparseCdotci",                                    {"hipsparseCdotci",                                    "",                                                                 CONV_LIB_FUNC, API_SPARSE, 8, ROC_UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED}},
   {"cusparseZdotci",                                    {"hipsparseZdotci",                                    "",                                                                 CONV_LIB_FUNC, API_SPARSE, 8, ROC_UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED}},
 
-  {"cusparseSgthr",                                     {"hipsparseSgthr",                                     "",                                                                 CONV_LIB_FUNC, API_SPARSE, 8, ROC_UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED}},
-  {"cusparseDgthr",                                     {"hipsparseDgthr",                                     "",                                                                 CONV_LIB_FUNC, API_SPARSE, 8, ROC_UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED}},
-  {"cusparseCgthr",                                     {"hipsparseCgthr",                                     "",                                                                 CONV_LIB_FUNC, API_SPARSE, 8, ROC_UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED}},
-  {"cusparseZgthr",                                     {"hipsparseZgthr",                                     "",                                                                 CONV_LIB_FUNC, API_SPARSE, 8, ROC_UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED}},
+  {"cusparseSgthr",                                     {"hipsparseSgthr",                                     "rocsparse_sgthr",                                                  CONV_LIB_FUNC, API_SPARSE, 8, CUDA_DEPRECATED | CUDA_REMOVED}},
+  {"cusparseDgthr",                                     {"hipsparseDgthr",                                     "rocsparse_dgthr",                                                  CONV_LIB_FUNC, API_SPARSE, 8, CUDA_DEPRECATED | CUDA_REMOVED}},
+  {"cusparseCgthr",                                     {"hipsparseCgthr",                                     "rocsparse_cgthr",                                                  CONV_LIB_FUNC, API_SPARSE, 8, CUDA_DEPRECATED | CUDA_REMOVED}},
+  {"cusparseZgthr",                                     {"hipsparseZgthr",                                     "rocsparse_zgthr",                                                  CONV_LIB_FUNC, API_SPARSE, 8, CUDA_DEPRECATED | CUDA_REMOVED}},
 
   {"cusparseSgthrz",                                    {"hipsparseSgthrz",                                    "rocsparse_sgthrz",                                                 CONV_LIB_FUNC, API_SPARSE, 8, CUDA_DEPRECATED | CUDA_REMOVED}},
   {"cusparseDgthrz",                                    {"hipsparseDgthrz",                                    "rocsparse_dgthrz",                                                 CONV_LIB_FUNC, API_SPARSE, 8, CUDA_DEPRECATED | CUDA_REMOVED}},
@@ -2373,6 +2373,10 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_SPARSE_FUNCTION_VER_MAP {
   {"rocsparse_cgthrz",                                   {HIP_1090, HIP_0,    HIP_0   }},
   {"rocsparse_dgthrz",                                   {HIP_1090, HIP_0,    HIP_0   }},
   {"rocsparse_sgthrz",                                   {HIP_1090, HIP_0,    HIP_0   }},
+  {"rocsparse_sgthr",                                    {HIP_1090, HIP_0,    HIP_0   }},
+  {"rocsparse_dgthr",                                    {HIP_1090, HIP_0,    HIP_0   }},
+  {"rocsparse_cgthr",                                    {HIP_1090, HIP_0,    HIP_0   }},
+  {"rocsparse_zgthr",                                    {HIP_1090, HIP_0,    HIP_0   }},
 };
 
 const std::map<llvm::StringRef, cudaAPIChangedVersions> CUDA_SPARSE_FUNCTION_CHANGED_VER_MAP {

--- a/tests/unit_tests/synthetic/libraries/cusparse2hipsparse.cu
+++ b/tests/unit_tests/synthetic/libraries/cusparse2hipsparse.cu
@@ -2723,6 +2723,26 @@ int main() {
   // HIP: DEPRECATED_CUDA_11000("The routine will be removed in CUDA 12") HIPSPARSE_EXPORT hipsparseStatus_t hipsparseSgthrz(hipsparseHandle_t handle, int nnz, float* y, float* xVal, const int* xInd, hipsparseIndexBase_t idxBase);
   // CHECK: status_t = hipsparseSgthrz(handle_t, innz, &fY, &fX, &xInd, indexBase_t);
   status_t = cusparseSgthrz(handle_t, innz, &fY, &fX, &xInd, indexBase_t);
+
+  // CUDA: CUSPARSE_DEPRECATED(cusparseGather) cusparseStatus_t CUSPARSEAPI cusparseZgthr(cusparseHandle_t handle, int nnz, const cuDoubleComplex* y, cuDoubleComplex* xVal, const int* xInd, cusparseIndexBase_t idxBase);
+  // HIP: DEPRECATED_CUDA_11000("The routine will be removed in CUDA 12") HIPSPARSE_EXPORT hipsparseStatus_t hipsparseZgthr(hipsparseHandle_t handle, int nnz, const hipDoubleComplex* y, hipDoubleComplex* xVal, const int* xInd, hipsparseIndexBase_t idxBase);
+  // CHECK: status_t = hipsparseZgthr(handle_t, innz, &dcomplexY, &dcomplexX, &xInd, indexBase_t);
+  status_t = cusparseZgthr(handle_t, innz, &dcomplexY, &dcomplexX, &xInd, indexBase_t);
+
+  // CUDA: CUSPARSE_DEPRECATED(cusparseGather) cusparseStatus_t CUSPARSEAPI cusparseCgthr(cusparseHandle_t handle, int nnz, const cuComplex* y, cuComplex* xVal, const int* xInd, cusparseIndexBase_t idxBase);
+  // HIP: DEPRECATED_CUDA_11000("The routine will be removed in CUDA 12") HIPSPARSE_EXPORT hipsparseStatus_t hipsparseCgthr(hipsparseHandle_t handle, int nnz, const hipComplex* y, hipComplex* xVal, const int* xInd, hipsparseIndexBase_t idxBase);
+  // CHECK: status_t = hipsparseCgthr(handle_t, innz, &complexY, &complexX, &xInd, indexBase_t);
+  status_t = cusparseCgthr(handle_t, innz, &complexY, &complexX, &xInd, indexBase_t);
+
+  // CUDA: CUSPARSE_DEPRECATED(cusparseGather) cusparseStatus_t CUSPARSEAPI cusparseDgthr(cusparseHandle_t handle, int nnz, const double* y, double* xVal, const int* xInd, cusparseIndexBase_t idxBase);
+  // HIP: DEPRECATED_CUDA_11000("The routine will be removed in CUDA 12") HIPSPARSE_EXPORT hipsparseStatus_t hipsparseDgthr(hipsparseHandle_t handle, int nnz, const double* y, double* xVal, const int* xInd, hipsparseIndexBase_t idxBase);
+  // CHECK: status_t = hipsparseDgthr(handle_t, innz, &dY, &dX, &xInd, indexBase_t);
+  status_t = cusparseDgthr(handle_t, innz, &dY, &dX, &xInd, indexBase_t);
+
+  // CUDA: CUSPARSE_DEPRECATED(cusparseGather) cusparseStatus_t CUSPARSEAPI cusparseSgthr(cusparseHandle_t handle, int nnz, const float* y, float* xVal, const int* xInd, cusparseIndexBase_t idxBase);
+  // HIP: DEPRECATED_CUDA_11000("The routine will be removed in CUDA 12") HIPSPARSE_EXPORT hipsparseStatus_t hipsparseSgthr(hipsparseHandle_t handle, int nnz, const float* y, float* xVal, const int* xInd, hipsparseIndexBase_t idxBase);
+  // CHECK: status_t = hipsparseSgthr(handle_t, innz, &fY, &fX, &xInd, indexBase_t);
+  status_t = cusparseSgthr(handle_t, innz, &fY, &fX, &xInd, indexBase_t);
 #endif
 
 #if CUDA_VERSION >= 12000

--- a/tests/unit_tests/synthetic/libraries/cusparse2rocsparse.cu
+++ b/tests/unit_tests/synthetic/libraries/cusparse2rocsparse.cu
@@ -2212,6 +2212,26 @@ int main() {
   // ROC: ROCSPARSE_EXPORT rocsparse_status rocsparse_sgthrz(rocsparse_handle handle, rocsparse_int nnz, float* y, float* x_val, const rocsparse_int* x_ind, rocsparse_index_base idx_base);
   // CHECK: status_t = rocsparse_sgthrz(handle_t, innz, &fY, &fX, &xInd, indexBase_t);
   status_t = cusparseSgthrz(handle_t, innz, &fY, &fX, &xInd, indexBase_t);
+
+  // CUDA: CUSPARSE_DEPRECATED(cusparseGather) cusparseStatus_t CUSPARSEAPI cusparseZgthr(cusparseHandle_t handle, int nnz, const cuDoubleComplex* y, cuDoubleComplex* xVal, const int* xInd, cusparseIndexBase_t idxBase);
+  // ROC: ROCSPARSE_EXPORT rocsparse_status rocsparse_zgthr(rocsparse_handle handle, rocsparse_int nnz, const rocsparse_double_complex* y, rocsparse_double_complex* x_val, const rocsparse_int* x_ind, rocsparse_index_base idx_base);
+  // CHECK: status_t = rocsparse_zgthr(handle_t, innz, &dcomplexY, &dcomplexX, &xInd, indexBase_t);
+  status_t = cusparseZgthr(handle_t, innz, &dcomplexY, &dcomplexX, &xInd, indexBase_t);
+
+  // CUDA: CUSPARSE_DEPRECATED(cusparseGather) cusparseStatus_t CUSPARSEAPI cusparseCgthr(cusparseHandle_t handle, int nnz, const cuComplex* y, cuComplex* xVal, const int* xInd, cusparseIndexBase_t idxBase);
+  // ROC: ROCSPARSE_EXPORT rocsparse_status rocsparse_cgthr(rocsparse_handle handle, rocsparse_int nnz, const rocsparse_float_complex* y, rocsparse_float_complex* x_val, const rocsparse_int* x_ind, rocsparse_index_base idx_base);
+  // CHECK: status_t = rocsparse_cgthr(handle_t, innz, &complexY, &complexX, &xInd, indexBase_t);
+  status_t = cusparseCgthr(handle_t, innz, &complexY, &complexX, &xInd, indexBase_t);
+
+  // CUDA: CUSPARSE_DEPRECATED(cusparseGather) cusparseStatus_t CUSPARSEAPI cusparseDgthr(cusparseHandle_t handle, int nnz, const double* y, double* xVal, const int* xInd, cusparseIndexBase_t idxBase);
+  // ROC: ROCSPARSE_EXPORT rocsparse_status rocsparse_dgthr(rocsparse_handle handle, rocsparse_int nnz, const double* y, double* x_val, const rocsparse_int* x_ind, rocsparse_index_base idx_base);
+  // CHECK: status_t = rocsparse_dgthr(handle_t, innz, &dY, &dX, &xInd, indexBase_t);
+  status_t = cusparseDgthr(handle_t, innz, &dY, &dX, &xInd, indexBase_t);
+
+  // CUDA: CUSPARSE_DEPRECATED(cusparseGather) cusparseStatus_t CUSPARSEAPI cusparseSgthr(cusparseHandle_t handle, int nnz, const float* y, float* xVal, const int* xInd, cusparseIndexBase_t idxBase);
+  // ROC: ROCSPARSE_EXPORT rocsparse_status rocsparse_sgthr(rocsparse_handle handle, rocsparse_int nnz, const float* y, float* x_val, const rocsparse_int* x_ind, rocsparse_index_base idx_base);
+  // CHECK: status_t = rocsparse_sgthr(handle_t, innz, &fY, &fX, &xInd, indexBase_t);
+  status_t = cusparseSgthr(handle_t, innz, &fY, &fX, &xInd, indexBase_t);
 #endif
 
 #if CUDA_VERSION >= 12010 && CUSPARSE_VERSION >= 12100


### PR DESCRIPTION
+ Updated `SPARSE` synthetic tests, the regenerated hipify-perl, and `SPARSE` `CUDA2HIP` documentation
