### PR TITLE
[HIPIFY][#674][rocSPARSE][feature] rocSPARSE support - Step 78 - functions `rocsparse_(s|d|c|z)doti`

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -2302,6 +2302,7 @@ sub rocSubstitutions {
     subst("cusparseCdense2csc", "rocsparse_cdense2csc", "library");
     subst("cusparseCdense2csr", "rocsparse_cdense2csr", "library");
     subst("cusparseCdotci", "rocsparse_cdotci", "library");
+    subst("cusparseCdoti", "rocsparse_cdoti", "library");
     subst("cusparseCgebsr2csr", "rocsparse_cgebsr2csr", "library");
     subst("cusparseCgebsr2gebsc", "rocsparse_cgebsr2gebsc", "library");
     subst("cusparseCgebsr2gebsc_bufferSize", "rocsparse_cgebsr2gebsc_buffer_size", "library");
@@ -2391,6 +2392,7 @@ sub rocSubstitutions {
     subst("cusparseDcsrsv2_solve", "rocsparse_dcsrsv_solve", "library");
     subst("cusparseDdense2csc", "rocsparse_ddense2csc", "library");
     subst("cusparseDdense2csr", "rocsparse_ddense2csr", "library");
+    subst("cusparseDdoti", "rocsparse_ddoti", "library");
     subst("cusparseDestroy", "rocsparse_destroy_handle", "library");
     subst("cusparseDestroyColorInfo", "rocsparse_destroy_color_info", "library");
     subst("cusparseDestroyDnMat", "rocsparse_destroy_dnmat_descr", "library");
@@ -2500,6 +2502,7 @@ sub rocSubstitutions {
     subst("cusparseScsrsv2_solve", "rocsparse_scsrsv_solve", "library");
     subst("cusparseSdense2csc", "rocsparse_sdense2csc", "library");
     subst("cusparseSdense2csr", "rocsparse_sdense2csr", "library");
+    subst("cusparseSdoti", "rocsparse_sdoti", "library");
     subst("cusparseSetMatDiagType", "rocsparse_set_mat_diag_type", "library");
     subst("cusparseSetMatFillMode", "rocsparse_set_mat_fill_mode", "library");
     subst("cusparseSetMatIndexBase", "rocsparse_set_mat_index_base", "library");
@@ -2623,6 +2626,7 @@ sub rocSubstitutions {
     subst("cusparseZdense2csc", "rocsparse_zdense2csc", "library");
     subst("cusparseZdense2csr", "rocsparse_zdense2csr", "library");
     subst("cusparseZdotci", "rocsparse_zdotci", "library");
+    subst("cusparseZdoti", "rocsparse_zdoti", "library");
     subst("cusparseZgebsr2csr", "rocsparse_zgebsr2csr", "library");
     subst("cusparseZgebsr2gebsc", "rocsparse_zgebsr2gebsc", "library");
     subst("cusparseZgebsr2gebsc_bufferSize", "rocsparse_zgebsr2gebsc_buffer_size", "library");

--- a/docs/tables/CUSPARSE_API_supported_by_HIP_and_ROC.md
+++ b/docs/tables/CUSPARSE_API_supported_by_HIP_and_ROC.md
@@ -265,25 +265,25 @@
 |:--|:-:|:-:|:-:|:-:|:--|:-:|:-:|:-:|:-:|:-:|:--|:-:|:-:|:-:|:-:|:-:|
 |`cusparseCaxpyi`| |11.0| |12.0|`hipsparseCaxpyi`|3.1.0| | | | | | | | | | |
 |`cusparseCdotci`| |10.2| |11.0|`hipsparseCdotci`|3.1.0| | | | |`rocsparse_cdotci`|3.0.0| | | | |
-|`cusparseCdoti`| |10.2| |11.0|`hipsparseCdoti`|3.1.0| | | | | | | | | | |
+|`cusparseCdoti`| |10.2| |11.0|`hipsparseCdoti`|3.1.0| | | | |`rocsparse_cdoti`|1.9.0| | | | |
 |`cusparseCgthr`| |11.0| |12.0|`hipsparseCgthr`|3.1.0| | | | |`rocsparse_cgthr`|1.9.0| | | | |
 |`cusparseCgthrz`| |11.0| |12.0|`hipsparseCgthrz`|3.1.0| | | | |`rocsparse_cgthrz`|1.9.0| | | | |
 |`cusparseCsctr`| |11.0| |12.0|`hipsparseCsctr`|3.1.0| | | | |`rocsparse_csctr`|1.9.0| | | | |
 |`cusparseDaxpyi`| |11.0| |12.0|`hipsparseDaxpyi`|1.9.2| | | | | | | | | | |
-|`cusparseDdoti`| |10.2| |11.0|`hipsparseDdoti`|1.9.2| | | | | | | | | | |
+|`cusparseDdoti`| |10.2| |11.0|`hipsparseDdoti`|1.9.2| | | | |`rocsparse_ddoti`|1.9.0| | | | |
 |`cusparseDgthr`| |11.0| |12.0|`hipsparseDgthr`|1.9.2| | | | |`rocsparse_dgthr`|1.9.0| | | | |
 |`cusparseDgthrz`| |11.0| |12.0|`hipsparseDgthrz`|1.9.2| | | | |`rocsparse_dgthrz`|1.9.0| | | | |
 |`cusparseDroti`| |11.0| |12.0|`hipsparseDroti`|1.9.2| | | | |`rocsparse_droti`|1.9.0| | | | |
 |`cusparseDsctr`| |11.0| |12.0|`hipsparseDsctr`|1.9.2| | | | |`rocsparse_dsctr`|1.9.0| | | | |
 |`cusparseSaxpyi`| |11.0| |12.0|`hipsparseSaxpyi`|1.9.2| | | | | | | | | | |
-|`cusparseSdoti`| |10.2| |11.0|`hipsparseSdoti`|1.9.2| | | | | | | | | | |
+|`cusparseSdoti`| |10.2| |11.0|`hipsparseSdoti`|1.9.2| | | | |`rocsparse_sdoti`|1.9.0| | | | |
 |`cusparseSgthr`| |11.0| |12.0|`hipsparseSgthr`|1.9.2| | | | |`rocsparse_sgthr`|1.9.0| | | | |
 |`cusparseSgthrz`| |11.0| |12.0|`hipsparseSgthrz`|1.9.2| | | | |`rocsparse_sgthrz`|1.9.0| | | | |
 |`cusparseSroti`| |11.0| |12.0|`hipsparseSroti`|1.9.2| | | | |`rocsparse_sroti`|1.9.0| | | | |
 |`cusparseSsctr`| |11.0| |12.0|`hipsparseSsctr`|1.9.2| | | | |`rocsparse_ssctr`|1.9.0| | | | |
 |`cusparseZaxpyi`| |11.0| |12.0|`hipsparseZaxpyi`|3.1.0| | | | | | | | | | |
 |`cusparseZdotci`| |10.2| |11.0|`hipsparseZdotci`|3.1.0| | | | |`rocsparse_zdotci`|3.0.0| | | | |
-|`cusparseZdoti`| |10.2| |11.0|`hipsparseZdoti`|3.1.0| | | | | | | | | | |
+|`cusparseZdoti`| |10.2| |11.0|`hipsparseZdoti`|3.1.0| | | | |`rocsparse_zdoti`|1.9.0| | | | |
 |`cusparseZgthr`| |11.0| |12.0|`hipsparseZgthr`|3.1.0| | | | |`rocsparse_zgthr`|1.9.0| | | | |
 |`cusparseZgthrz`| |11.0| |12.0|`hipsparseZgthrz`|3.1.0| | | | |`rocsparse_zgthrz`|1.9.0| | | | |
 |`cusparseZsctr`| |11.0| |12.0|`hipsparseZsctr`|3.1.0| | | | |`rocsparse_zsctr`|1.9.0| | | | |

--- a/docs/tables/CUSPARSE_API_supported_by_ROC.md
+++ b/docs/tables/CUSPARSE_API_supported_by_ROC.md
@@ -265,25 +265,25 @@
 |:--|:-:|:-:|:-:|:-:|:--|:-:|:-:|:-:|:-:|:-:|
 |`cusparseCaxpyi`| |11.0| |12.0| | | | | | |
 |`cusparseCdotci`| |10.2| |11.0|`rocsparse_cdotci`|3.0.0| | | | |
-|`cusparseCdoti`| |10.2| |11.0| | | | | | |
+|`cusparseCdoti`| |10.2| |11.0|`rocsparse_cdoti`|1.9.0| | | | |
 |`cusparseCgthr`| |11.0| |12.0|`rocsparse_cgthr`|1.9.0| | | | |
 |`cusparseCgthrz`| |11.0| |12.0|`rocsparse_cgthrz`|1.9.0| | | | |
 |`cusparseCsctr`| |11.0| |12.0|`rocsparse_csctr`|1.9.0| | | | |
 |`cusparseDaxpyi`| |11.0| |12.0| | | | | | |
-|`cusparseDdoti`| |10.2| |11.0| | | | | | |
+|`cusparseDdoti`| |10.2| |11.0|`rocsparse_ddoti`|1.9.0| | | | |
 |`cusparseDgthr`| |11.0| |12.0|`rocsparse_dgthr`|1.9.0| | | | |
 |`cusparseDgthrz`| |11.0| |12.0|`rocsparse_dgthrz`|1.9.0| | | | |
 |`cusparseDroti`| |11.0| |12.0|`rocsparse_droti`|1.9.0| | | | |
 |`cusparseDsctr`| |11.0| |12.0|`rocsparse_dsctr`|1.9.0| | | | |
 |`cusparseSaxpyi`| |11.0| |12.0| | | | | | |
-|`cusparseSdoti`| |10.2| |11.0| | | | | | |
+|`cusparseSdoti`| |10.2| |11.0|`rocsparse_sdoti`|1.9.0| | | | |
 |`cusparseSgthr`| |11.0| |12.0|`rocsparse_sgthr`|1.9.0| | | | |
 |`cusparseSgthrz`| |11.0| |12.0|`rocsparse_sgthrz`|1.9.0| | | | |
 |`cusparseSroti`| |11.0| |12.0|`rocsparse_sroti`|1.9.0| | | | |
 |`cusparseSsctr`| |11.0| |12.0|`rocsparse_ssctr`|1.9.0| | | | |
 |`cusparseZaxpyi`| |11.0| |12.0| | | | | | |
 |`cusparseZdotci`| |10.2| |11.0|`rocsparse_zdotci`|3.0.0| | | | |
-|`cusparseZdoti`| |10.2| |11.0| | | | | | |
+|`cusparseZdoti`| |10.2| |11.0|`rocsparse_zdoti`|1.9.0| | | | |
 |`cusparseZgthr`| |11.0| |12.0|`rocsparse_zgthr`|1.9.0| | | | |
 |`cusparseZgthrz`| |11.0| |12.0|`rocsparse_zgthrz`|1.9.0| | | | |
 |`cusparseZsctr`| |11.0| |12.0|`rocsparse_zsctr`|1.9.0| | | | |

--- a/src/CUDA2HIP_SPARSE_API_functions.cpp
+++ b/src/CUDA2HIP_SPARSE_API_functions.cpp
@@ -89,10 +89,11 @@ const std::map<llvm::StringRef, hipCounter> CUDA_SPARSE_FUNCTION_MAP {
   {"cusparseCaxpyi",                                    {"hipsparseCaxpyi",                                    "",                                                                 CONV_LIB_FUNC, API_SPARSE, 8, ROC_UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED}},
   {"cusparseZaxpyi",                                    {"hipsparseZaxpyi",                                    "",                                                                 CONV_LIB_FUNC, API_SPARSE, 8, ROC_UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED}},
 
-  {"cusparseSdoti",                                     {"hipsparseSdoti",                                     "",                                                                 CONV_LIB_FUNC, API_SPARSE, 8, ROC_UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED}},
-  {"cusparseDdoti",                                     {"hipsparseDdoti",                                     "",                                                                 CONV_LIB_FUNC, API_SPARSE, 8, ROC_UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED}},
-  {"cusparseCdoti",                                     {"hipsparseCdoti",                                     "",                                                                 CONV_LIB_FUNC, API_SPARSE, 8, ROC_UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED}},
-  {"cusparseZdoti",                                     {"hipsparseZdoti",                                     "",                                                                 CONV_LIB_FUNC, API_SPARSE, 8, ROC_UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED}},
+  // TODO: rocsparse_get_stream and hipStreamSynchronize need to be added correspondingly before and after rocsparse_(s|d|c|z)doti call, because cusparse(S|D|C|Z)doti is blocking, and rocsparse_(s|d|c|z)doti is not
+  {"cusparseSdoti",                                     {"hipsparseSdoti",                                     "rocsparse_sdoti",                                                  CONV_LIB_FUNC, API_SPARSE, 8, CUDA_DEPRECATED | CUDA_REMOVED}},
+  {"cusparseDdoti",                                     {"hipsparseDdoti",                                     "rocsparse_ddoti",                                                  CONV_LIB_FUNC, API_SPARSE, 8, CUDA_DEPRECATED | CUDA_REMOVED}},
+  {"cusparseCdoti",                                     {"hipsparseCdoti",                                     "rocsparse_cdoti",                                                  CONV_LIB_FUNC, API_SPARSE, 8, CUDA_DEPRECATED | CUDA_REMOVED}},
+  {"cusparseZdoti",                                     {"hipsparseZdoti",                                     "rocsparse_zdoti",                                                  CONV_LIB_FUNC, API_SPARSE, 8, CUDA_DEPRECATED | CUDA_REMOVED}},
 
   // TODO: rocsparse_get_stream and hipStreamSynchronize need to be added correspondingly before and after rocsparse_(c|z)dotci call, because cusparse(C|Z)dotci is blocking, and rocsparse_(c|z)dotci is not
   {"cusparseCdotci",                                    {"hipsparseCdotci",                                    "rocsparse_cdotci",                                                 CONV_LIB_FUNC, API_SPARSE, 8, CUDA_DEPRECATED | CUDA_REMOVED}},
@@ -2380,6 +2381,10 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_SPARSE_FUNCTION_VER_MAP {
   {"rocsparse_zgthr",                                    {HIP_1090, HIP_0,    HIP_0   }},
   {"rocsparse_cdotci",                                   {HIP_3000, HIP_0,    HIP_0   }},
   {"rocsparse_zdotci",                                   {HIP_3000, HIP_0,    HIP_0   }},
+  {"rocsparse_sdoti",                                    {HIP_1090, HIP_0,    HIP_0   }},
+  {"rocsparse_ddoti",                                    {HIP_1090, HIP_0,    HIP_0   }},
+  {"rocsparse_cdoti",                                    {HIP_1090, HIP_0,    HIP_0   }},
+  {"rocsparse_zdoti",                                    {HIP_1090, HIP_0,    HIP_0   }},
 };
 
 const std::map<llvm::StringRef, cudaAPIChangedVersions> CUDA_SPARSE_FUNCTION_CHANGED_VER_MAP {

--- a/tests/unit_tests/synthetic/libraries/cusparse2hipsparse.cu
+++ b/tests/unit_tests/synthetic/libraries/cusparse2hipsparse.cu
@@ -266,6 +266,8 @@ int main() {
   float fbsrSortedValC = 0.f;
   float fcsrSortedValC = 0.f;
   double dcsrSortedValC = 0.f;
+  double d_resultDevHostPtr = 0.f;
+  float f_resultDevHostPtr = 0.f;
   double percentage = 0.f;
   float fpercentage = 0.f;
   double dthreshold = 0.f;
@@ -2227,6 +2229,26 @@ int main() {
   // HIP: DEPRECATED_CUDA_10000("The routine will be removed in CUDA 11") HIPSPARSE_EXPORT hipsparseStatus_t hipsparseCdotci(hipsparseHandle_t handle, int nnz, const hipComplex* xVal, const int* xInd, const hipComplex* y, hipComplex* result, hipsparseIndexBase_t idxBase);
   // CHECK: status_t = hipsparseCdotci(handle_t, innz, &complexX, &xInd, &complexY, &complex_resultDevHostPtr, indexBase_t);
   status_t = cusparseCdotci(handle_t, innz, &complexX, &xInd, &complexY, &complex_resultDevHostPtr, indexBase_t);
+
+  // CUDA: CUSPARSE_DEPRECATED_HINT(cusparseSpVV) cusparseStatus_t CUSPARSEAPI cusparseZdoti(cusparseHandle_t handle, int nnz, const cuDoubleComplex* xVal, const int* xInd, const cuDoubleComplex* y, cuDoubleComplex* resultDevHostPtr, cusparseIndexBase_t idxBase);
+  // HIP: DEPRECATED_CUDA_10000("The routine will be removed in CUDA 11") HIPSPARSE_EXPORT hipsparseStatus_t hipsparseZdoti(hipsparseHandle_t handle, int nnz, const hipDoubleComplex* xVal, const int* xInd, const hipDoubleComplex* y, hipDoubleComplex* result, hipsparseIndexBase_t idxBase);
+  // CHECK: status_t = hipsparseZdoti(handle_t, innz, &dcomplexX, &xInd, &dcomplexY, &dcomplex_resultDevHostPtr, indexBase_t);
+  status_t = cusparseZdoti(handle_t, innz, &dcomplexX, &xInd, &dcomplexY, &dcomplex_resultDevHostPtr, indexBase_t);
+
+  // CUDA: CUSPARSE_DEPRECATED_HINT(cusparseSpVV) cusparseStatus_t CUSPARSEAPI cusparseCdoti(cusparseHandle_t handle, int nnz, const cuComplex* xVal, const int* xInd, const cuComplex* y, cuComplex* resultDevHostPtr, cusparseIndexBase_t idxBase);
+  // HIP: DEPRECATED_CUDA_10000("The routine will be removed in CUDA 11") HIPSPARSE_EXPORT hipsparseStatus_t hipsparseCdoti(hipsparseHandle_t handle, int nnz, const hipComplex* xVal, const int* xInd, const hipComplex* y, hipComplex* result, hipsparseIndexBase_t idxBase);
+  // CHECK: status_t = hipsparseCdoti(handle_t, innz, &complexX, &xInd, &complexY, &complex_resultDevHostPtr, indexBase_t);
+  status_t = cusparseCdoti(handle_t, innz, &complexX, &xInd, &complexY, &complex_resultDevHostPtr, indexBase_t);
+
+  // CUDA: CUSPARSE_DEPRECATED_HINT(cusparseSpVV) cusparseStatus_t CUSPARSEAPI cusparseDdoti(cusparseHandle_t handle, int nnz, const double* xVal, const int* xInd, const double* y, double* resultDevHostPtr, cusparseIndexBase_t idxBase);
+  // HIP: DEPRECATED_CUDA_10000("The routine will be removed in CUDA 11") HIPSPARSE_EXPORT hipsparseStatus_t hipsparseDdoti(hipsparseHandle_t handle, int nnz, const double* xVal, const int* xInd, const double* y, double* result, hipsparseIndexBase_t idxBase);
+  // CHECK: status_t = hipsparseDdoti(handle_t, innz, &dX, &xInd, &dY, &d_resultDevHostPtr, indexBase_t);
+  status_t = cusparseDdoti(handle_t, innz, &dX, &xInd, &dY, &d_resultDevHostPtr, indexBase_t);
+
+  // CUDA: CUSPARSE_DEPRECATED_HINT(cusparseSpVV) cusparseStatus_t CUSPARSEAPI cusparseSdoti(cusparseHandle_t handle, int nnz, const float* xVal, const int* xInd, const float* y, float* resultDevHostPtr, cusparseIndexBase_t idxBase);
+  // HIP: DEPRECATED_CUDA_10000("The routine will be removed in CUDA 11") HIPSPARSE_EXPORT hipsparseStatus_t hipsparseSdoti(hipsparseHandle_t handle, int nnz, const float* xVal, const int* xInd, const float* y, float* result, hipsparseIndexBase_t idxBase);
+  // CHECK: status_t = hipsparseSdoti(handle_t, innz, &fX, &xInd, &fY, &f_resultDevHostPtr, indexBase_t);
+  status_t = cusparseSdoti(handle_t, innz, &fX, &xInd, &fY, &f_resultDevHostPtr, indexBase_t);
 #endif
 
 #if CUDA_VERSION >= 11000

--- a/tests/unit_tests/synthetic/libraries/cusparse2rocsparse.cu
+++ b/tests/unit_tests/synthetic/libraries/cusparse2rocsparse.cu
@@ -246,6 +246,8 @@ int main() {
   float fbsrSortedValC = 0.f;
   float fcsrSortedValC = 0.f;
   double dcsrSortedValC = 0.f;
+  double d_resultDevHostPtr = 0.f;
+  float f_resultDevHostPtr = 0.f;
   double percentage = 0.f;
   float fpercentage = 0.f;
   double dthreshold = 0.f;
@@ -1864,6 +1866,26 @@ int main() {
   // ROC: ROCSPARSE_EXPORT rocsparse_status rocsparse_cdotci(rocsparse_handle handle, rocsparse_int nnz, const rocsparse_float_complex* x_val, const rocsparse_int* x_ind, const rocsparse_float_complex* y, rocsparse_float_complex* result, rocsparse_index_base idx_base);
   // CHECK: status_t = rocsparse_cdotci(handle_t, innz, &complexX, &xInd, &complexY, &complex_resultDevHostPtr, indexBase_t);
   status_t = cusparseCdotci(handle_t, innz, &complexX, &xInd, &complexY, &complex_resultDevHostPtr, indexBase_t);
+
+  // CUDA: CUSPARSE_DEPRECATED_HINT(cusparseSpVV) cusparseStatus_t CUSPARSEAPI cusparseZdoti(cusparseHandle_t handle, int nnz, const cuDoubleComplex* xVal, const int* xInd, const cuDoubleComplex* y, cuDoubleComplex* resultDevHostPtr, cusparseIndexBase_t idxBase);
+  // ROC: ROCSPARSE_EXPORT rocsparse_status rocsparse_zdoti(rocsparse_handle handle, rocsparse_int nnz, const rocsparse_double_complex* x_val, const rocsparse_int* x_ind, const rocsparse_double_complex* y, rocsparse_double_complex* result, rocsparse_index_base idx_base);
+  // CHECK: status_t = rocsparse_zdoti(handle_t, innz, &dcomplexX, &xInd, &dcomplexY, &dcomplex_resultDevHostPtr, indexBase_t);
+  status_t = cusparseZdoti(handle_t, innz, &dcomplexX, &xInd, &dcomplexY, &dcomplex_resultDevHostPtr, indexBase_t);
+
+  // CUDA: CUSPARSE_DEPRECATED_HINT(cusparseSpVV) cusparseStatus_t CUSPARSEAPI cusparseCdoti(cusparseHandle_t handle, int nnz, const cuComplex* xVal, const int* xInd, const cuComplex* y, cuComplex* resultDevHostPtr, cusparseIndexBase_t idxBase);
+  // ROC: ROCSPARSE_EXPORT rocsparse_status rocsparse_cdoti(rocsparse_handle handle, rocsparse_int nnz, const rocsparse_float_complex* x_val, const rocsparse_int* x_ind, const rocsparse_float_complex* y, rocsparse_float_complex* result, rocsparse_index_base idx_base);
+  // CHECK: status_t = rocsparse_cdoti(handle_t, innz, &complexX, &xInd, &complexY, &complex_resultDevHostPtr, indexBase_t);
+  status_t = cusparseCdoti(handle_t, innz, &complexX, &xInd, &complexY, &complex_resultDevHostPtr, indexBase_t);
+
+  // CUDA: CUSPARSE_DEPRECATED_HINT(cusparseSpVV) cusparseStatus_t CUSPARSEAPI cusparseDdoti(cusparseHandle_t handle, int nnz, const double* xVal, const int* xInd, const double* y, double* resultDevHostPtr, cusparseIndexBase_t idxBase);
+  // ROC: ROCSPARSE_EXPORT rocsparse_status rocsparse_ddoti(rocsparse_handle handle, rocsparse_int nnz, const double* x_val, const rocsparse_int* x_ind, const double* y, double* result, rocsparse_index_base idx_base);
+  // CHECK: status_t = rocsparse_ddoti(handle_t, innz, &dX, &xInd, &dY, &d_resultDevHostPtr, indexBase_t);
+  status_t = cusparseDdoti(handle_t, innz, &dX, &xInd, &dY, &d_resultDevHostPtr, indexBase_t);
+
+  // CUDA: CUSPARSE_DEPRECATED_HINT(cusparseSpVV) cusparseStatus_t CUSPARSEAPI cusparseSdoti(cusparseHandle_t handle, int nnz, const float* xVal, const int* xInd, const float* y, float* resultDevHostPtr, cusparseIndexBase_t idxBase);
+  // ROC: ROCSPARSE_EXPORT rocsparse_status rocsparse_sdoti(rocsparse_handle handle, rocsparse_int nnz, const float* x_val, const rocsparse_int* x_ind, const float* y, float* result, rocsparse_index_base idx_base);
+  // CHECK: status_t = rocsparse_sdoti(handle_t, innz, &fX, &xInd, &fY, &f_resultDevHostPtr, indexBase_t);
+  status_t = cusparseSdoti(handle_t, innz, &fX, &xInd, &fY, &f_resultDevHostPtr, indexBase_t);
 #endif
 
 #if CUDA_VERSION >= 11000


### PR DESCRIPTION
+ [TODO] `rocsparse_get_stream` and `hipStreamSynchronize` need to be added correspondingly before and after `rocsparse_(s|d|c|z)doti` call, because `cusparse(S|D|C|Z)doti` is blocking, and `rocsparse_(s|d|c|z)doti` is not
+ Updated `SPARSE` synthetic tests, the regenerated hipify-perl, and `SPARSE` `CUDA2HIP` documentation
