### PR TITLE
[HIPIFY][#674][rocSPARSE][6.0.0][feature] rocSPARSE support - Step 80 - Data types (Const)

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -2740,6 +2740,10 @@ sub rocSubstitutions {
     subst("cusparseAction_t", "rocsparse_action", "type");
     subst("cusparseColorInfo", "_rocsparse_color_info", "type");
     subst("cusparseColorInfo_t", "rocsparse_color_info", "type");
+    subst("cusparseConstDnMatDescr_t", "rocsparse_const_dnmat_descr", "type");
+    subst("cusparseConstDnVecDescr_t", "rocsparse_const_dnvec_descr", "type");
+    subst("cusparseConstSpMatDescr_t", "rocsparse_const_spmat_descr", "type");
+    subst("cusparseConstSpVecDescr_t", "rocsparse_const_spvec_descr", "type");
     subst("cusparseContext", "_rocsparse_handle", "type");
     subst("cusparseDenseToSparseAlg_t", "rocsparse_dense_to_sparse_alg", "type");
     subst("cusparseDiagType_t", "rocsparse_diag_type", "type");

--- a/docs/tables/CUSPARSE_API_supported_by_HIP_and_ROC.md
+++ b/docs/tables/CUSPARSE_API_supported_by_HIP_and_ROC.md
@@ -133,10 +133,10 @@
 |`cusparseColorAlg_t`|8.0|12.2| | | | | | | | | | | | | | |
 |`cusparseColorInfo`| |12.2| | | | | | | | |`_rocsparse_color_info`|4.5.0| | | | |
 |`cusparseColorInfo_t`| |12.2| | |`hipsparseColorInfo_t`|4.5.0| | | | |`rocsparse_color_info`|4.5.0| | | | |
-|`cusparseConstDnMatDescr_t`|12.0| | | |`hipsparseConstDnMatDescr_t`|6.0.0| | | | | | | | | | |
-|`cusparseConstDnVecDescr_t`|12.0| | | |`hipsparseConstDnVecDescr_t`|6.0.0| | | | | | | | | | |
-|`cusparseConstSpMatDescr_t`|12.0| | | |`hipsparseConstSpMatDescr_t`|6.0.0| | | | | | | | | | |
-|`cusparseConstSpVecDescr_t`|12.0| | | |`hipsparseConstSpVecDescr_t`|6.0.0| | | | | | | | | | |
+|`cusparseConstDnMatDescr_t`|12.0| | | |`hipsparseConstDnMatDescr_t`|6.0.0| | | | |`rocsparse_const_dnmat_descr`|6.0.0| | | | |
+|`cusparseConstDnVecDescr_t`|12.0| | | |`hipsparseConstDnVecDescr_t`|6.0.0| | | | |`rocsparse_const_dnvec_descr`|6.0.0| | | | |
+|`cusparseConstSpMatDescr_t`|12.0| | | |`hipsparseConstSpMatDescr_t`|6.0.0| | | | |`rocsparse_const_spmat_descr`|6.0.0| | | | |
+|`cusparseConstSpVecDescr_t`|12.0| | | |`hipsparseConstSpVecDescr_t`|6.0.0| | | | |`rocsparse_const_spvec_descr`|6.0.0| | | | |
 |`cusparseContext`| | | | | | | | | | |`_rocsparse_handle`|1.9.0| | | | |
 |`cusparseCsr2CscAlg_t`|10.1| | | |`hipsparseCsr2CscAlg_t`|5.4.0| | | | | | | | | | |
 |`cusparseDenseToSparseAlg_t`|11.1| | | |`hipsparseDenseToSparseAlg_t`|4.2.0| | | | |`rocsparse_dense_to_sparse_alg`|4.1.0| | | | |

--- a/docs/tables/CUSPARSE_API_supported_by_ROC.md
+++ b/docs/tables/CUSPARSE_API_supported_by_ROC.md
@@ -133,10 +133,10 @@
 |`cusparseColorAlg_t`|8.0|12.2| | | | | | | | |
 |`cusparseColorInfo`| |12.2| | |`_rocsparse_color_info`|4.5.0| | | | |
 |`cusparseColorInfo_t`| |12.2| | |`rocsparse_color_info`|4.5.0| | | | |
-|`cusparseConstDnMatDescr_t`|12.0| | | | | | | | | |
-|`cusparseConstDnVecDescr_t`|12.0| | | | | | | | | |
-|`cusparseConstSpMatDescr_t`|12.0| | | | | | | | | |
-|`cusparseConstSpVecDescr_t`|12.0| | | | | | | | | |
+|`cusparseConstDnMatDescr_t`|12.0| | | |`rocsparse_const_dnmat_descr`|6.0.0| | | | |
+|`cusparseConstDnVecDescr_t`|12.0| | | |`rocsparse_const_dnvec_descr`|6.0.0| | | | |
+|`cusparseConstSpMatDescr_t`|12.0| | | |`rocsparse_const_spmat_descr`|6.0.0| | | | |
+|`cusparseConstSpVecDescr_t`|12.0| | | |`rocsparse_const_spvec_descr`|6.0.0| | | | |
 |`cusparseContext`| | | | |`_rocsparse_handle`|1.9.0| | | | |
 |`cusparseCsr2CscAlg_t`|10.1| | | | | | | | | |
 |`cusparseDenseToSparseAlg_t`|11.1| | | |`rocsparse_dense_to_sparse_alg`|4.1.0| | | | |

--- a/src/CUDA2HIP_SPARSE_API_types.cpp
+++ b/src/CUDA2HIP_SPARSE_API_types.cpp
@@ -266,10 +266,10 @@ const std::map<llvm::StringRef, hipCounter> CUDA_SPARSE_TYPE_NAME_MAP {
 
   // 4. Typedefs
   {"cusparseLoggerCallback_t",                  {"hipsparseLoggerCallback_t",                  "",                                                   CONV_TYPE, API_SPARSE, 4, UNSUPPORTED}},
-  {"cusparseConstSpVecDescr_t",                 {"hipsparseConstSpVecDescr_t",                 "",                                                   CONV_TYPE, API_SPARSE, 4, ROC_UNSUPPORTED}},
-  {"cusparseConstDnVecDescr_t",                 {"hipsparseConstDnVecDescr_t",                 "",                                                   CONV_TYPE, API_SPARSE, 4, ROC_UNSUPPORTED}},
-  {"cusparseConstSpMatDescr_t",                 {"hipsparseConstSpMatDescr_t",                 "",                                                   CONV_TYPE, API_SPARSE, 4, ROC_UNSUPPORTED}},
-  {"cusparseConstDnMatDescr_t",                 {"hipsparseConstDnMatDescr_t",                 "",                                                   CONV_TYPE, API_SPARSE, 4, ROC_UNSUPPORTED}},
+  {"cusparseConstSpVecDescr_t",                 {"hipsparseConstSpVecDescr_t",                 "rocsparse_const_spvec_descr",                        CONV_TYPE, API_SPARSE, 4}},
+  {"cusparseConstDnVecDescr_t",                 {"hipsparseConstDnVecDescr_t",                 "rocsparse_const_dnvec_descr",                        CONV_TYPE, API_SPARSE, 4}},
+  {"cusparseConstSpMatDescr_t",                 {"hipsparseConstSpMatDescr_t",                 "rocsparse_const_spmat_descr",                        CONV_TYPE, API_SPARSE, 4}},
+  {"cusparseConstDnMatDescr_t",                 {"hipsparseConstDnMatDescr_t",                 "rocsparse_const_dnmat_descr",                        CONV_TYPE, API_SPARSE, 4}},
 };
 
 const std::map<llvm::StringRef, cudaAPIversions> CUDA_SPARSE_TYPE_NAME_VER_MAP {
@@ -674,4 +674,8 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_SPARSE_TYPE_NAME_VER_MAP {
   {"rocsparse_spgemm_alg_default",               {HIP_4010, HIP_0,    HIP_0   }},
   {"_rocsparse_mat_info",                        {HIP_1090, HIP_0,    HIP_0   }},
   {"rocsparse_mat_info",                         {HIP_1090, HIP_0,    HIP_0   }},
+  {"rocsparse_const_spvec_descr",                {HIP_6000, HIP_0,    HIP_0   }},
+  {"rocsparse_const_spmat_descr",                {HIP_6000, HIP_0,    HIP_0   }},
+  {"rocsparse_const_dnvec_descr",                {HIP_6000, HIP_0,    HIP_0   }},
+  {"rocsparse_const_dnmat_descr",                {HIP_6000, HIP_0,    HIP_0   }},
 };

--- a/tests/unit_tests/synthetic/libraries/cusparse2rocsparse.cu
+++ b/tests/unit_tests/synthetic/libraries/cusparse2rocsparse.cu
@@ -2286,6 +2286,24 @@ int main() {
   status_t = cusparseSaxpyi(handle_t, innz, &fAlpha, &fX, &xInd, &fY, indexBase_t);
 #endif
 
+#if CUDA_VERSION >= 12000
+  // CHECK: rocsparse_const_spvec_descr constSpVecDescr = nullptr;
+  cusparseConstSpVecDescr_t constSpVecDescr = nullptr;
+
+  // CHECK: rocsparse_const_spmat_descr constSpMatDescr = nullptr;
+  // CHECK-NEXT: rocsparse_const_spmat_descr constSpMatDescrB = nullptr;
+  cusparseConstSpMatDescr_t constSpMatDescr = nullptr;
+  cusparseConstSpMatDescr_t constSpMatDescrB = nullptr;
+
+  // CHECK: rocsparse_const_dnvec_descr constDnVecDescr = nullptr;
+  cusparseConstDnVecDescr_t constDnVecDescr = nullptr;
+
+  // CHECK: rocsparse_const_dnmat_descr constDnMatDescr = nullptr;
+  // CHECK-NEXT: rocsparse_const_dnmat_descr constDnMatDescrB = nullptr;
+  cusparseConstDnMatDescr_t constDnMatDescr = nullptr;
+  cusparseConstDnMatDescr_t constDnMatDescrB = nullptr;
+#endif
+
 #if CUDA_VERSION >= 12010 && CUSPARSE_VERSION >= 12100
   // CHECK: rocsparse_spmv_alg SPMV_SELL_ALG1 = rocsparse_spmv_alg_ell;
   cusparseSpMVAlg_t SPMV_SELL_ALG1 = CUSPARSE_SPMV_SELL_ALG1;


### PR DESCRIPTION
+ [ToDo] Update all the `rocSPARSE` functions with const arguments
+ Updated `SPARSE` synthetic tests, the regenerated hipify-perl, and `SPARSE` `CUDA2HIP` documentation
