### PR TITLE
[HIPIFY][#674][rocSPARSE][6.0.0][feature] rocSPARSE support - Step 81 - Functions (SpVec, Management)

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -2326,6 +2326,8 @@ sub rocSubstitutions {
     subst("cusparseChybmv", "rocsparse_chybmv", "library");
     subst("cusparseCnnz", "rocsparse_cnnz", "library");
     subst("cusparseCnnz_compress", "rocsparse_cnnz_compress", "library");
+    subst("cusparseConstSpVecGet", "rocsparse_const_spvec_get", "library");
+    subst("cusparseConstSpVecGetValues", "rocsparse_const_spvec_get_values", "library");
     subst("cusparseCooAoSGet", "rocsparse_coo_aos_get", "library");
     subst("cusparseCooGet", "rocsparse_coo_get", "library");
     subst("cusparseCooSetPointers", "rocsparse_coo_set_pointers", "library");
@@ -2334,6 +2336,7 @@ sub rocSubstitutions {
     subst("cusparseCreate", "rocsparse_create_handle", "library");
     subst("cusparseCreateBlockedEll", "rocsparse_create_bell_descr", "library");
     subst("cusparseCreateColorInfo", "rocsparse_create_color_info", "library");
+    subst("cusparseCreateConstSpVec", "rocsparse_create_const_spvec_descr", "library");
     subst("cusparseCreateCoo", "rocsparse_create_coo_descr", "library");
     subst("cusparseCreateCooAoS", "rocsparse_create_coo_aos_descr", "library");
     subst("cusparseCreateCsc", "rocsparse_create_csc_descr", "library");
@@ -2448,6 +2451,8 @@ sub rocSubstitutions {
     subst("cusparseDroti", "rocsparse_droti", "library");
     subst("cusparseDsctr", "rocsparse_dsctr", "library");
     subst("cusparseGather", "rocsparse_gather", "library");
+    subst("cusparseGetErrorName", "rocsparse_get_status_name", "library");
+    subst("cusparseGetErrorString", "rocsparse_get_status_description", "library");
     subst("cusparseGetMatDiagType", "rocsparse_get_mat_diag_type", "library");
     subst("cusparseGetMatFillMode", "rocsparse_get_mat_fill_mode", "library");
     subst("cusparseGetMatIndexBase", "rocsparse_get_mat_index_base", "library");

--- a/docs/tables/CUSPARSE_API_supported_by_HIP_and_ROC.md
+++ b/docs/tables/CUSPARSE_API_supported_by_HIP_and_ROC.md
@@ -197,8 +197,8 @@
 |:--|:-:|:-:|:-:|:-:|:--|:-:|:-:|:-:|:-:|:-:|:--|:-:|:-:|:-:|:-:|:-:|
 |`cusparseCreate`| | | | |`hipsparseCreate`|1.9.2| | | | |`rocsparse_create_handle`|1.9.0| | | | |
 |`cusparseDestroy`| | | | |`hipsparseDestroy`|1.9.2| | | | |`rocsparse_destroy_handle`|1.9.0| | | | |
-|`cusparseGetErrorName`|10.2| | | |`hipsparseGetErrorName`|6.0.0| | | | | | | | | | |
-|`cusparseGetErrorString`|10.2| | | |`hipsparseGetErrorString`|6.0.0| | | | | | | | | | |
+|`cusparseGetErrorName`|10.2| | | |`hipsparseGetErrorName`|6.0.0| | | | |`rocsparse_get_status_name`|6.0.0| | | | |
+|`cusparseGetErrorString`|10.2| | | |`hipsparseGetErrorString`|6.0.0| | | | |`rocsparse_get_status_description`|6.0.0| | | | |
 |`cusparseGetPointerMode`| | | | |`hipsparseGetPointerMode`|1.9.2| | | | |`rocsparse_get_pointer_mode`|1.9.0| | | | |
 |`cusparseGetStream`|8.0| | | |`hipsparseGetStream`|1.9.2| | | | |`rocsparse_get_stream`|1.9.0| | | | |
 |`cusparseGetVersion`| | | | |`hipsparseGetVersion`|1.9.2| | | | |`rocsparse_get_version`|1.9.0| | | | |
@@ -810,8 +810,8 @@
 |`cusparseConstDnVecGet`|12.0| | | |`hipsparseConstDnVecGet`|6.0.0| | | | | | | | | | |
 |`cusparseConstDnVecGetValues`|12.0| | | |`hipsparseConstDnVecGetValues`|6.0.0| | | | | | | | | | |
 |`cusparseConstSpMatGetValues`|12.0| | | |`hipsparseConstSpMatGetValues`|6.0.0| | | | | | | | | | |
-|`cusparseConstSpVecGet`|12.0| | | |`hipsparseConstSpVecGet`|6.0.0| | | | | | | | | | |
-|`cusparseConstSpVecGetValues`|12.0| | | |`hipsparseConstSpVecGetValues`|6.0.0| | | | | | | | | | |
+|`cusparseConstSpVecGet`|12.0| | | |`hipsparseConstSpVecGet`|6.0.0| | | | |`rocsparse_const_spvec_get`|6.0.0| | | | |
+|`cusparseConstSpVecGetValues`|12.0| | | |`hipsparseConstSpVecGetValues`|6.0.0| | | | |`rocsparse_const_spvec_get_values`|6.0.0| | | | |
 |`cusparseConstrainedGeMM`|10.2|11.2| |12.0| | | | | | | | | | | | |
 |`cusparseConstrainedGeMM_bufferSize`|10.2|11.2| |12.0| | | | | | | | | | | | |
 |`cusparseCooAoSGet`|10.2|11.2| |12.0|`hipsparseCooAoSGet`|4.1.0| | | | |`rocsparse_coo_aos_get`|4.1.0| | | | |
@@ -828,7 +828,7 @@
 |`cusparseCreateConstDnMat`|12.0| | | |`hipsparseCreateConstDnMat`|6.0.0| | | | | | | | | | |
 |`cusparseCreateConstDnVec`|12.0| | | |`hipsparseCreateConstDnVec`|6.0.0| | | | | | | | | | |
 |`cusparseCreateConstSlicedEll`|12.1| | | | | | | | | | | | | | | |
-|`cusparseCreateConstSpVec`|12.0| | | |`hipsparseCreateConstSpVec`|6.0.0| | | | | | | | | | |
+|`cusparseCreateConstSpVec`|12.0| | | |`hipsparseCreateConstSpVec`|6.0.0| | | | |`rocsparse_create_const_spvec_descr`|6.0.0| | | | |
 |`cusparseCreateCoo`|10.1| | | |`hipsparseCreateCoo`|4.1.0| | | | |`rocsparse_create_coo_descr`|4.1.0| | | | |
 |`cusparseCreateCooAoS`|10.2|11.2| |12.0|`hipsparseCreateCooAoS`|4.1.0| | | | |`rocsparse_create_coo_aos_descr`|4.1.0| | | | |
 |`cusparseCreateCsc`|11.1| | | |`hipsparseCreateCsc`|4.2.0| | | | |`rocsparse_create_csc_descr`|4.1.0| | | | |
@@ -848,7 +848,7 @@
 |`cusparseDestroyDnMat`|10.1| |12.0| |`hipsparseDestroyDnMat`|4.2.0| |6.0.0| | |`rocsparse_destroy_dnmat_descr`|4.1.0| | | | |
 |`cusparseDestroyDnVec`|10.2| |12.0| |`hipsparseDestroyDnVec`|4.1.0| |6.0.0| | |`rocsparse_destroy_dnvec_descr`|4.1.0| | | | |
 |`cusparseDestroySpMat`|10.1| |12.0| |`hipsparseDestroySpMat`|4.1.0| |6.0.0| | |`rocsparse_destroy_spmat_descr`|4.1.0| | | | |
-|`cusparseDestroySpVec`|10.2| |12.0| |`hipsparseDestroySpVec`|4.1.0| |6.0.0| | |`rocsparse_destroy_spvec_descr`|4.1.0| | | | |
+|`cusparseDestroySpVec`|10.2| |12.0| |`hipsparseDestroySpVec`|4.1.0| |6.0.0| | |`rocsparse_destroy_spvec_descr`|4.1.0| |6.0.0| | |
 |`cusparseDnMatGet`|10.1| | | |`hipsparseDnMatGet`|4.2.0| | | | |`rocsparse_dnmat_get`|4.1.0| | | | |
 |`cusparseDnMatGetStridedBatch`|10.1| |12.0| |`hipsparseDnMatGetStridedBatch`|5.2.0| |6.0.0| | |`rocsparse_dnmat_get_strided_batch`|5.2.0| | | | |
 |`cusparseDnMatGetValues`|10.2| | | |`hipsparseDnMatGetValues`|4.2.0| | | | |`rocsparse_dnmat_get_values`|4.1.0| | | | |
@@ -907,7 +907,7 @@
 |`cusparseSpVV`|10.2| |12.0| |`hipsparseSpVV`|4.1.0| |6.0.0| | | | | | | | |
 |`cusparseSpVV_bufferSize`|10.2| |12.0| |`hipsparseSpVV_bufferSize`|4.1.0| |6.0.0| | | | | | | | |
 |`cusparseSpVecGet`|10.2| | | |`hipsparseSpVecGet`|4.1.0| | | | |`rocsparse_spvec_get`|4.1.0| | | | |
-|`cusparseSpVecGetIndexBase`|10.2| |12.0| |`hipsparseSpVecGetIndexBase`|4.1.0| |6.0.0| | |`rocsparse_spvec_get_index_base`|4.1.0| | | | |
+|`cusparseSpVecGetIndexBase`|10.2| |12.0| |`hipsparseSpVecGetIndexBase`|4.1.0| |6.0.0| | |`rocsparse_spvec_get_index_base`|4.1.0| |6.0.0| | |
 |`cusparseSpVecGetValues`|10.2| | | |`hipsparseSpVecGetValues`|4.1.0| | | | |`rocsparse_spvec_get_values`|4.1.0| | | | |
 |`cusparseSpVecSetValues`|10.2| | | |`hipsparseSpVecSetValues`|4.1.0| | | | |`rocsparse_spvec_set_values`|4.1.0| | | | |
 |`cusparseSparseToDense`|11.1| |12.0| |`hipsparseSparseToDense`|4.2.0| |6.0.0| | | | | | | | |

--- a/docs/tables/CUSPARSE_API_supported_by_ROC.md
+++ b/docs/tables/CUSPARSE_API_supported_by_ROC.md
@@ -197,8 +197,8 @@
 |:--|:-:|:-:|:-:|:-:|:--|:-:|:-:|:-:|:-:|:-:|
 |`cusparseCreate`| | | | |`rocsparse_create_handle`|1.9.0| | | | |
 |`cusparseDestroy`| | | | |`rocsparse_destroy_handle`|1.9.0| | | | |
-|`cusparseGetErrorName`|10.2| | | | | | | | | |
-|`cusparseGetErrorString`|10.2| | | | | | | | | |
+|`cusparseGetErrorName`|10.2| | | |`rocsparse_get_status_name`|6.0.0| | | | |
+|`cusparseGetErrorString`|10.2| | | |`rocsparse_get_status_description`|6.0.0| | | | |
 |`cusparseGetPointerMode`| | | | |`rocsparse_get_pointer_mode`|1.9.0| | | | |
 |`cusparseGetStream`|8.0| | | |`rocsparse_get_stream`|1.9.0| | | | |
 |`cusparseGetVersion`| | | | |`rocsparse_get_version`|1.9.0| | | | |
@@ -810,8 +810,8 @@
 |`cusparseConstDnVecGet`|12.0| | | | | | | | | |
 |`cusparseConstDnVecGetValues`|12.0| | | | | | | | | |
 |`cusparseConstSpMatGetValues`|12.0| | | | | | | | | |
-|`cusparseConstSpVecGet`|12.0| | | | | | | | | |
-|`cusparseConstSpVecGetValues`|12.0| | | | | | | | | |
+|`cusparseConstSpVecGet`|12.0| | | |`rocsparse_const_spvec_get`|6.0.0| | | | |
+|`cusparseConstSpVecGetValues`|12.0| | | |`rocsparse_const_spvec_get_values`|6.0.0| | | | |
 |`cusparseConstrainedGeMM`|10.2|11.2| |12.0| | | | | | |
 |`cusparseConstrainedGeMM_bufferSize`|10.2|11.2| |12.0| | | | | | |
 |`cusparseCooAoSGet`|10.2|11.2| |12.0|`rocsparse_coo_aos_get`|4.1.0| | | | |
@@ -828,7 +828,7 @@
 |`cusparseCreateConstDnMat`|12.0| | | | | | | | | |
 |`cusparseCreateConstDnVec`|12.0| | | | | | | | | |
 |`cusparseCreateConstSlicedEll`|12.1| | | | | | | | | |
-|`cusparseCreateConstSpVec`|12.0| | | | | | | | | |
+|`cusparseCreateConstSpVec`|12.0| | | |`rocsparse_create_const_spvec_descr`|6.0.0| | | | |
 |`cusparseCreateCoo`|10.1| | | |`rocsparse_create_coo_descr`|4.1.0| | | | |
 |`cusparseCreateCooAoS`|10.2|11.2| |12.0|`rocsparse_create_coo_aos_descr`|4.1.0| | | | |
 |`cusparseCreateCsc`|11.1| | | |`rocsparse_create_csc_descr`|4.1.0| | | | |
@@ -848,7 +848,7 @@
 |`cusparseDestroyDnMat`|10.1| |12.0| |`rocsparse_destroy_dnmat_descr`|4.1.0| | | | |
 |`cusparseDestroyDnVec`|10.2| |12.0| |`rocsparse_destroy_dnvec_descr`|4.1.0| | | | |
 |`cusparseDestroySpMat`|10.1| |12.0| |`rocsparse_destroy_spmat_descr`|4.1.0| | | | |
-|`cusparseDestroySpVec`|10.2| |12.0| |`rocsparse_destroy_spvec_descr`|4.1.0| | | | |
+|`cusparseDestroySpVec`|10.2| |12.0| |`rocsparse_destroy_spvec_descr`|4.1.0| |6.0.0| | |
 |`cusparseDnMatGet`|10.1| | | |`rocsparse_dnmat_get`|4.1.0| | | | |
 |`cusparseDnMatGetStridedBatch`|10.1| |12.0| |`rocsparse_dnmat_get_strided_batch`|5.2.0| | | | |
 |`cusparseDnMatGetValues`|10.2| | | |`rocsparse_dnmat_get_values`|4.1.0| | | | |
@@ -907,7 +907,7 @@
 |`cusparseSpVV`|10.2| |12.0| | | | | | | |
 |`cusparseSpVV_bufferSize`|10.2| |12.0| | | | | | | |
 |`cusparseSpVecGet`|10.2| | | |`rocsparse_spvec_get`|4.1.0| | | | |
-|`cusparseSpVecGetIndexBase`|10.2| |12.0| |`rocsparse_spvec_get_index_base`|4.1.0| | | | |
+|`cusparseSpVecGetIndexBase`|10.2| |12.0| |`rocsparse_spvec_get_index_base`|4.1.0| |6.0.0| | |
 |`cusparseSpVecGetValues`|10.2| | | |`rocsparse_spvec_get_values`|4.1.0| | | | |
 |`cusparseSpVecSetValues`|10.2| | | |`rocsparse_spvec_set_values`|4.1.0| | | | |
 |`cusparseSparseToDense`|11.1| |12.0| | | | | | | |

--- a/src/CUDA2HIP_SPARSE_API_functions.cpp
+++ b/src/CUDA2HIP_SPARSE_API_functions.cpp
@@ -32,8 +32,8 @@ const std::map<llvm::StringRef, hipCounter> CUDA_SPARSE_FUNCTION_MAP {
   {"cusparseSetPointerMode",                            {"hipsparseSetPointerMode",                            "rocsparse_set_pointer_mode",                                       CONV_LIB_FUNC, API_SPARSE, 5}},
   {"cusparseSetStream",                                 {"hipsparseSetStream",                                 "rocsparse_set_stream",                                             CONV_LIB_FUNC, API_SPARSE, 5}},
   {"cusparseGetStream",                                 {"hipsparseGetStream",                                 "rocsparse_get_stream",                                             CONV_LIB_FUNC, API_SPARSE, 5}},
-  {"cusparseGetErrorName",                              {"hipsparseGetErrorName",                              "",                                                                 CONV_LIB_FUNC, API_SPARSE, 5, ROC_UNSUPPORTED}},
-  {"cusparseGetErrorString",                            {"hipsparseGetErrorString",                            "",                                                                 CONV_LIB_FUNC, API_SPARSE, 5, ROC_UNSUPPORTED}},
+  {"cusparseGetErrorName",                              {"hipsparseGetErrorName",                              "rocsparse_get_status_name",                                        CONV_LIB_FUNC, API_SPARSE, 5}},
+  {"cusparseGetErrorString",                            {"hipsparseGetErrorString",                            "rocsparse_get_status_description",                                 CONV_LIB_FUNC, API_SPARSE, 5}},
 
   // 6. cuSPARSE Logging
   {"cusparseLoggerSetCallback",                         {"hipsparseLoggerSetCallback",                         "",                                                                 CONV_LIB_FUNC, API_SPARSE, 6, UNSUPPORTED}},
@@ -778,13 +778,13 @@ const std::map<llvm::StringRef, hipCounter> CUDA_SPARSE_FUNCTION_MAP {
   {"cusparseCreateConstSlicedEll",                      {"hipsparseCreateConstSlicedEll",                      "",                                                                 CONV_LIB_FUNC, API_SPARSE, 15, UNSUPPORTED}},
   // Sparse Vector descriptor
   {"cusparseCreateSpVec",                               {"hipsparseCreateSpVec",                               "rocsparse_create_spvec_descr",                                     CONV_LIB_FUNC, API_SPARSE, 15}},
-  {"cusparseCreateConstSpVec",                          {"hipsparseCreateConstSpVec",                          "",                                                                 CONV_LIB_FUNC, API_SPARSE, 15, ROC_UNSUPPORTED}},
+  {"cusparseCreateConstSpVec",                          {"hipsparseCreateConstSpVec",                          "rocsparse_create_const_spvec_descr",                               CONV_LIB_FUNC, API_SPARSE, 15}},
   {"cusparseDestroySpVec",                              {"hipsparseDestroySpVec",                              "rocsparse_destroy_spvec_descr",                                    CONV_LIB_FUNC, API_SPARSE, 15}},
   {"cusparseSpVecGet",                                  {"hipsparseSpVecGet",                                  "rocsparse_spvec_get",                                              CONV_LIB_FUNC, API_SPARSE, 15}},
-  {"cusparseConstSpVecGet",                             {"hipsparseConstSpVecGet",                             "",                                                                 CONV_LIB_FUNC, API_SPARSE, 15, ROC_UNSUPPORTED}},
+  {"cusparseConstSpVecGet",                             {"hipsparseConstSpVecGet",                             "rocsparse_const_spvec_get",                                        CONV_LIB_FUNC, API_SPARSE, 15}},
   {"cusparseSpVecGetIndexBase",                         {"hipsparseSpVecGetIndexBase",                         "rocsparse_spvec_get_index_base",                                   CONV_LIB_FUNC, API_SPARSE, 15}},
   {"cusparseSpVecGetValues",                            {"hipsparseSpVecGetValues",                            "rocsparse_spvec_get_values",                                       CONV_LIB_FUNC, API_SPARSE, 15}},
-  {"cusparseConstSpVecGetValues",                       {"hipsparseConstSpVecGetValues",                       "",                                                                 CONV_LIB_FUNC, API_SPARSE, 15, ROC_UNSUPPORTED}},
+  {"cusparseConstSpVecGetValues",                       {"hipsparseConstSpVecGetValues",                       "rocsparse_const_spvec_get_values",                                 CONV_LIB_FUNC, API_SPARSE, 15}},
   {"cusparseSpVecSetValues",                            {"hipsparseSpVecSetValues",                            "rocsparse_spvec_set_values",                                       CONV_LIB_FUNC, API_SPARSE, 15}},
 
   // Generic Dense API helper functions
@@ -2389,6 +2389,11 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_SPARSE_FUNCTION_VER_MAP {
   {"rocsparse_daxpyi",                                   {HIP_1090, HIP_0,    HIP_0   }},
   {"rocsparse_caxpyi",                                   {HIP_1090, HIP_0,    HIP_0   }},
   {"rocsparse_zaxpyi",                                   {HIP_1090, HIP_0,    HIP_0   }},
+  {"rocsparse_get_status_name",                          {HIP_6000, HIP_0,    HIP_0   }},
+  {"rocsparse_get_status_description",                   {HIP_6000, HIP_0,    HIP_0   }},
+  {"rocsparse_create_const_spvec_descr",                 {HIP_6000, HIP_0,    HIP_0   }},
+  {"rocsparse_const_spvec_get",                          {HIP_6000, HIP_0,    HIP_0   }},
+  {"rocsparse_const_spvec_get_values",                   {HIP_6000, HIP_0,    HIP_0   }},
 };
 
 const std::map<llvm::StringRef, cudaAPIChangedVersions> CUDA_SPARSE_FUNCTION_CHANGED_VER_MAP {
@@ -2479,6 +2484,9 @@ const std::map<llvm::StringRef, hipAPIChangedVersions> HIP_SPARSE_FUNCTION_CHANG
   {"hipsparseDenseToSparse_analysis",                    {HIP_6000}},
   {"hipsparseDenseToSparse_bufferSize",                  {HIP_6000}},
   {"hipsparseDenseToSparse_convert",                     {HIP_6000}},
+
+  {"rocsparse_destroy_spvec_descr",                      {HIP_6000}},
+  {"rocsparse_spvec_get_index_base",                     {HIP_6000}},
 };
 
 const std::map<unsigned int, llvm::StringRef> CUDA_SPARSE_API_SECTION_MAP {

--- a/tests/unit_tests/synthetic/libraries/cusparse2hipsparse.cu
+++ b/tests/unit_tests/synthetic/libraries/cusparse2hipsparse.cu
@@ -1845,13 +1845,11 @@ int main() {
   status_t = cusparseCreateSpVec(&spVecDescr_t, size, nnz, indices, values, indexType_t, indexBase_t, dataType);
 
 #if CUDA_VERSION < 12000
-  // TODO: Mark as C-Changed in 12.0.0
   // CUDA: cusparseStatus_t CUSPARSEAPI cusparseDestroySpVec(cusparseSpVecDescr_t spVecDescr);
   // HIP: hipsparseStatus_t hipsparseDestroySpVec(hipsparseSpVecDescr_t spVecDescr);
   // CHECK: status_t = hipsparseDestroySpVec(spVecDescr_t);
   status_t = cusparseDestroySpVec(spVecDescr_t);
 
-  // TODO: Mark as C-Changed in 12.0.0
   // CUDA: cusparseStatus_t CUSPARSEAPI cusparseSpVecGetIndexBase(cusparseSpVecDescr_t spVecDescr, cusparseIndexBase_t* idxBase);
   // HIP: HIPSPARSE_EXPORT hipsparseStatus_t hipsparseSpVecGetIndexBase(const hipsparseSpVecDescr_t spVecDescr, hipsparseIndexBase_t* idxBase);
   // CHECK: status_t = hipsparseSpVecGetIndexBase(spVecDescr_t, &indexBase_t);

--- a/tests/unit_tests/synthetic/libraries/cusparse2rocsparse.cu
+++ b/tests/unit_tests/synthetic/libraries/cusparse2rocsparse.cu
@@ -101,7 +101,7 @@ int main() {
   cusparsePointerMode_t POINTER_MODE_HOST = CUSPARSE_POINTER_MODE_HOST;
   cusparsePointerMode_t POINTER_MODE_DEVICE = CUSPARSE_POINTER_MODE_DEVICE;
 
-  // CHECK: rocsparse_status status_t;
+  // CHECK: rocsparse_status status_t, status_2;
   // CHECK-NEXT: rocsparse_status STATUS_SUCCESS = rocsparse_status_success;
   // CHECK-NEXT: rocsparse_status STATUS_NOT_INITIALIZED = rocsparse_status_not_initialized;
   // CHECK-NEXT: rocsparse_status STATUS_ALLOC_FAILED = rocsparse_status_memory_error;
@@ -109,7 +109,7 @@ int main() {
   // CHECK-NEXT: rocsparse_status STATUS_ARCH_MISMATCH = rocsparse_status_arch_mismatch;
   // CHECK-NEXT: rocsparse_status STATUS_INTERNAL_ERROR = rocsparse_status_internal_error;
   // CHECK-NEXT: rocsparse_status STATUS_ZERO_PIVOT = rocsparse_status_zero_pivot;
-  cusparseStatus_t status_t;
+  cusparseStatus_t status_t, status_2;
   cusparseStatus_t STATUS_SUCCESS = CUSPARSE_STATUS_SUCCESS;
   cusparseStatus_t STATUS_NOT_INITIALIZED = CUSPARSE_STATUS_NOT_INITIALIZED;
   cusparseStatus_t STATUS_ALLOC_FAILED = CUSPARSE_STATUS_ALLOC_FAILED;
@@ -195,7 +195,9 @@ int main() {
   int64_t columnsValuesBatchStride = 0;
   int64_t ld = 0;
   void *indices = nullptr;
+  const void** const indices_const = const_cast<const void**>(&indices);
   void *values = nullptr;
+  const void** const values_const = const_cast<const void**>(&values);
   void *cooRowInd = nullptr;
   int icooRowInd = 0;
   void *cscRowInd = nullptr;
@@ -289,6 +291,7 @@ int main() {
   float fx = 0.f;
   double dboost_val = 0.f;
   float boost_val = 0.f;
+  const char* const_ch = nullptr;
 
   // CHECK: rocsparse_mat_info csrilu02_info;
   csrilu02Info_t csrilu02_info;
@@ -1636,20 +1639,10 @@ int main() {
   // CHECK: status_t = rocsparse_create_spvec_descr(&spVecDescr_t, size, nnz, indices, values, indexType_t, indexBase_t, dataType);
   status_t = cusparseCreateSpVec(&spVecDescr_t, size, nnz, indices, values, indexType_t, indexBase_t, dataType);
 
-  // CUDA: cusparseStatus_t CUSPARSEAPI cusparseDestroySpVec(cusparseConstSpVecDescr_t spVecDescr);
-  // ROC: ROCSPARSE_EXPORT rocsparse_status rocsparse_destroy_spvec_descr(rocsparse_spvec_descr descr);
-  // CHECK: status_t = rocsparse_destroy_spvec_descr(spVecDescr_t);
-  status_t = cusparseDestroySpVec(spVecDescr_t);
-
   // CUDA: cusparseStatus_t CUSPARSEAPI cusparseSpVecGet(cusparseSpVecDescr_t spVecDescr, int64_t* size, int64_t* nnz, void** indices, void** values, cusparseIndexType_t* idxType, cusparseIndexBase_t* idxBase, cudaDataType* valueType);
   // ROC: ROCSPARSE_EXPORT rocsparse_status rocsparse_spvec_get(const rocsparse_spvec_descr descr, int64_t* size, int64_t* nnz, void** indices, void** values, rocsparse_indextype* idx_type, rocsparse_index_base* idx_base, rocsparse_datatype* data_type);
   // CHECK: status_t = rocsparse_spvec_get(spVecDescr_t, &size, &nnz, &indices, &values, &indexType_t, &indexBase_t, &dataType);
   status_t = cusparseSpVecGet(spVecDescr_t, &size, &nnz, &indices, &values, &indexType_t, &indexBase_t, &dataType);
-
-  // CUDA: cusparseStatus_t CUSPARSEAPI cusparseSpVecGetIndexBase(cusparseConstSpVecDescr_t spVecDescr, cusparseIndexBase_t* idxBase);
-  // ROC: ROCSPARSE_EXPORT rocsparse_status rocsparse_spvec_get_index_base(const rocsparse_spvec_descr descr, rocsparse_index_base* idx_base);
-  // CHECK: status_t = rocsparse_spvec_get_index_base(spVecDescr_t, &indexBase_t);
-  status_t = cusparseSpVecGetIndexBase(spVecDescr_t, &indexBase_t);
 
   // CUDA: cusparseStatus_t CUSPARSEAPI cusparseSpVecGetValues(cusparseSpVecDescr_t spVecDescr, void** values);
   // ROC: ROCSPARSE_EXPORT rocsparse_status rocsparse_spvec_get_values(const rocsparse_spvec_descr descr, void** values);
@@ -1725,9 +1718,8 @@ int main() {
   // ROC: ROCSPARSE_EXPORT rocsparse_status rocsparse_spmv(rocsparse_handle handle, rocsparse_operation trans, const void* alpha, const rocsparse_spmat_descr mat, const rocsparse_dnvec_descr x, const void* beta, const rocsparse_dnvec_descr y, rocsparse_datatype compute_type, rocsparse_spmv_alg alg, size_t* buffer_size, void* temp_buffer);
   // CHECK: status_t = rocsparse_spmv(handle_t, opA, alpha, spMatDescr_t, vecX, beta, vecY, dataType, spMVAlg_t, tempBuffer);
   status_t = cusparseSpMV(handle_t, opA, alpha, spMatDescr_t, vecX, beta, vecY, dataType, spMVAlg_t, tempBuffer);
-#endif
 
-#if (CUDA_VERSION >= 10020 && CUDA_VERSION < 11000 && !defined(_WIN32)) || (CUDA_VERSION >= 11000 && CUDA_VERSION < 12000)
+#if CUDA_VERSION < 12000
   // CHECK: rocsparse_format FORMAT_COO_AOS = rocsparse_format_coo_aos;
   cusparseFormat_t FORMAT_COO_AOS = CUSPARSE_FORMAT_COO_AOS;
 
@@ -1745,6 +1737,29 @@ int main() {
   // ROC: ROCSPARSE_EXPORT rocsparse_status rocsparse_spmat_set_strided_batch(rocsparse_spmat_descr descr, int batch_count);
   // CHECK: status_t = rocsparse_spmat_set_strided_batch(spMatDescr_t, batchCount);
   status_t = cusparseSpMatSetStridedBatch(spMatDescr_t, batchCount);
+
+  // CUDA: cusparseStatus_t CUSPARSEAPI cusparseDestroySpVec(cusparseSpVecDescr_t spVecDescr);
+  // ROC: ROCSPARSE_EXPORT rocsparse_status rocsparse_destroy_spvec_descr(rocsparse_spvec_descr descr);
+  // CHECK: status_t = rocsparse_destroy_spvec_descr(spVecDescr_t);
+  status_t = cusparseDestroySpVec(spVecDescr_t);
+
+  // CUDA: cusparseStatus_t CUSPARSEAPI cusparseSpVecGetIndexBase(cusparseConstSpVecDescr_t spVecDescr, cusparseIndexBase_t* idxBase);
+  // ROC: ROCSPARSE_EXPORT rocsparse_status rocsparse_spvec_get_index_base(const rocsparse_spvec_descr descr, rocsparse_index_base* idx_base);
+  // CHECK: status_t = rocsparse_spvec_get_index_base(spVecDescr_t, &indexBase_t);
+  status_t = cusparseSpVecGetIndexBase(spVecDescr_t, &indexBase_t);
+#endif
+#endif
+
+#if CUDA_VERSION >= 10020 && CUSPARSE_VERSION >= 10301
+  // CUDA: const char* CUSPARSEAPI cusparseGetErrorName(cusparseStatus_t status);
+  // ROC: ROCSPARSE_EXPORT const char* rocsparse_get_status_name(rocsparse_status status);
+  // CHECK: const_ch = rocsparse_get_status_name(status_2);
+  const_ch = cusparseGetErrorName(status_2);
+
+  // CUDA: const char* CUSPARSEAPI cusparseGetErrorString(cusparseStatus_t status);
+  // ROC: ROCSPARSE_EXPORT const char* rocsparse_get_status_description(rocsparse_status status);
+  // CHECK: const_ch = rocsparse_get_status_description(status_2);
+  const_ch = cusparseGetErrorString(status_2);
 #endif
 
 #if CUDA_VERSION < 11000
@@ -2302,6 +2317,31 @@ int main() {
   // CHECK-NEXT: rocsparse_const_dnmat_descr constDnMatDescrB = nullptr;
   cusparseConstDnMatDescr_t constDnMatDescr = nullptr;
   cusparseConstDnMatDescr_t constDnMatDescrB = nullptr;
+
+  // CUDA: cusparseStatus_t CUSPARSEAPI cusparseCreateConstSpVec(cusparseConstSpVecDescr_t* spVecDescr, int64_t size, int64_t nnz, const void* indices, const void* values, cusparseIndexType_t idxType, cusparseIndexBase_t idxBase, cudaDataType valueType);
+  // ROC: ROCSPARSE_EXPORT rocsparse_status rocsparse_create_const_spvec_descr(rocsparse_const_spvec_descr* descr, int64_t size, int64_t nnz, const void* indices, const void* values, rocsparse_indextype idx_type, rocsparse_index_base idx_base, rocsparse_datatype data_type);
+  // CHECK: status_t = rocsparse_create_const_spvec_descr(&constSpVecDescr, size, nnz, indices, values, indexType_t, indexBase_t, dataType);
+  status_t = cusparseCreateConstSpVec(&constSpVecDescr, size, nnz, indices, values, indexType_t, indexBase_t, dataType);
+
+  // CUDA: cusparseStatus_t CUSPARSEAPI cusparseDestroySpVec(cusparseConstSpVecDescr_t spVecDescr);
+  // ROC: ROCSPARSE_EXPORT rocsparse_status rocsparse_destroy_spvec_descr(rocsparse_const_spvec_descr descr);
+  // CHECK: status_t = rocsparse_destroy_spvec_descr(constSpVecDescr);
+  status_t = cusparseDestroySpVec(constSpVecDescr);
+
+  // CUDA: cusparseStatus_t CUSPARSEAPI cusparseConstSpVecGet(cusparseConstSpVecDescr_t spVecDescr, int64_t* size, int64_t* nnz, const void** indices, const void** values, cusparseIndexType_t* idxType, cusparseIndexBase_t* idxBase, cudaDataType* valueType);
+  // ROC: ROCSPARSE_EXPORT rocsparse_status rocsparse_const_spvec_get(rocsparse_const_spvec_descr descr, int64_t* size, int64_t* nnz, const void** indices, const void** values, rocsparse_indextype* idx_type, rocsparse_index_base* idx_base, rocsparse_datatype* data_type);
+  // CHECK: status_t = rocsparse_const_spvec_get(constSpVecDescr, &size, &nnz, indices_const, values_const, &indexType_t, &indexBase_t, &dataType);
+  status_t = cusparseConstSpVecGet(constSpVecDescr, &size, &nnz, indices_const, values_const, &indexType_t, &indexBase_t, &dataType);
+
+  // CUDA: cusparseStatus_t CUSPARSEAPI cusparseSpVecGetIndexBase(cusparseSpVecDescr_t spVecDescr, cusparseIndexBase_t* idxBase);
+  // ROC: ROCSPARSE_EXPORT rocsparse_status rocsparse_spvec_get_index_base(rocsparse_const_spvec_descr descr, rocsparse_index_base* idx_base);
+  // CHECK: status_t = rocsparse_spvec_get_index_base(constSpVecDescr, &indexBase_t);
+  status_t = cusparseSpVecGetIndexBase(constSpVecDescr, &indexBase_t);
+
+  // CUDA: cusparseStatus_t CUSPARSEAPI cusparseConstSpVecGetValues(cusparseConstSpVecDescr_t spVecDescr, const void** values);
+  // ROC: ROCSPARSE_EXPORT rocsparse_status rocsparse_const_spvec_get_values(rocsparse_const_spvec_descr descr, const void** values);
+  // CHECK: status_t = rocsparse_const_spvec_get_values(constSpVecDescr, values_const);
+  status_t = cusparseConstSpVecGetValues(constSpVecDescr, values_const);
 #endif
 
 #if CUDA_VERSION >= 12010 && CUSPARSE_VERSION >= 12100


### PR DESCRIPTION
+ Added new const `SpVec` functions
+ Marked existing `SpVec` `rocSPARSE` `rocsparse_destroy_spvec_descr` and `rocsparse_spvec_get_index_base` functions as `CHANGED` due to ABI breakage
+ Updated `SPARSE` synthetic tests, the regenerated hipify-perl, and `SPARSE` `CUDA2HIP` documentation
