### PR TITLE
[HIPIFY][#674][rocSPARSE][6.0.0][feature] rocSPARSE support - Step 82 - Functions (SpMat)

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -2326,6 +2326,8 @@ sub rocSubstitutions {
     subst("cusparseChybmv", "rocsparse_chybmv", "library");
     subst("cusparseCnnz", "rocsparse_cnnz", "library");
     subst("cusparseCnnz_compress", "rocsparse_cnnz_compress", "library");
+    subst("cusparseConstCooGet", "rocsparse_const_coo_get", "library");
+    subst("cusparseConstCsrGet", "rocsparse_const_csr_get", "library");
     subst("cusparseConstSpVecGet", "rocsparse_const_spvec_get", "library");
     subst("cusparseConstSpVecGetValues", "rocsparse_const_spvec_get_values", "library");
     subst("cusparseCooAoSGet", "rocsparse_coo_aos_get", "library");
@@ -2336,6 +2338,10 @@ sub rocSubstitutions {
     subst("cusparseCreate", "rocsparse_create_handle", "library");
     subst("cusparseCreateBlockedEll", "rocsparse_create_bell_descr", "library");
     subst("cusparseCreateColorInfo", "rocsparse_create_color_info", "library");
+    subst("cusparseCreateConstBlockedEll", "rocsparse_create_const_bell_descr", "library");
+    subst("cusparseCreateConstCoo", "rocsparse_create_const_coo_descr", "library");
+    subst("cusparseCreateConstCsc", "rocsparse_create_const_csc_descr", "library");
+    subst("cusparseCreateConstCsr", "rocsparse_create_const_csr_descr", "library");
     subst("cusparseCreateConstSpVec", "rocsparse_create_const_spvec_descr", "library");
     subst("cusparseCreateCoo", "rocsparse_create_coo_descr", "library");
     subst("cusparseCreateCooAoS", "rocsparse_create_coo_aos_descr", "library");

--- a/docs/tables/CUSPARSE_API_supported_by_HIP_and_ROC.md
+++ b/docs/tables/CUSPARSE_API_supported_by_HIP_and_ROC.md
@@ -802,9 +802,9 @@
 |`cusparseBlockedEllGet`|11.2| | | |`hipsparseBlockedEllGet`|4.5.0| | | | |`rocsparse_bell_get`|4.1.0| | | | |
 |`cusparseBsrSetStridedBatch`|12.1| | | | | | | | | | | | | | | |
 |`cusparseConstBlockedEllGet`|12.0| | | |`hipsparseConstBlockedEllGet`|6.0.0| | | | | | | | | | |
-|`cusparseConstCooGet`|12.0| | | |`hipsparseConstCooGet`|6.0.0| | | | | | | | | | |
+|`cusparseConstCooGet`|12.0| | | |`hipsparseConstCooGet`|6.0.0| | | | |`rocsparse_const_coo_get`|6.0.0| | | | |
 |`cusparseConstCscGet`|12.0| | | | | | | | | | | | | | | |
-|`cusparseConstCsrGet`|12.0| | | |`hipsparseConstCsrGet`|6.0.0| | | | | | | | | | |
+|`cusparseConstCsrGet`|12.0| | | |`hipsparseConstCsrGet`|6.0.0| | | | |`rocsparse_const_csr_get`|6.0.0| | | | |
 |`cusparseConstDnMatGet`|12.0| | | |`hipsparseConstDnMatGet`|6.0.0| | | | | | | | | | |
 |`cusparseConstDnMatGetValues`|12.0| | | |`hipsparseConstDnMatGetValues`|6.0.0| | | | | | | | | | |
 |`cusparseConstDnVecGet`|12.0| | | |`hipsparseConstDnVecGet`|6.0.0| | | | | | | | | | |
@@ -820,11 +820,11 @@
 |`cusparseCooSetStridedBatch`|11.0| | | |`hipsparseCooSetStridedBatch`|5.2.0| | | | |`rocsparse_coo_set_strided_batch`|5.2.0| | | | |
 |`cusparseCreateBlockedEll`|11.2| | | |`hipsparseCreateBlockedEll`|4.5.0| | | | |`rocsparse_create_bell_descr`|4.5.0| | | | |
 |`cusparseCreateBsr`|12.1| | | | | | | | | | | | | | | |
-|`cusparseCreateConstBlockedEll`|12.0| | | |`hipsparseCreateConstBlockedEll`|6.0.0| | | | | | | | | | |
+|`cusparseCreateConstBlockedEll`|12.0| | | |`hipsparseCreateConstBlockedEll`|6.0.0| | | | |`rocsparse_create_const_bell_descr`|6.0.0| | | | |
 |`cusparseCreateConstBsr`|12.1| | | | | | | | | | | | | | | |
-|`cusparseCreateConstCoo`|12.0| | | |`hipsparseCreateConstCoo`|6.0.0| | | | | | | | | | |
-|`cusparseCreateConstCsc`|12.0| | | |`hipsparseCreateConstCsc`|6.0.0| | | | | | | | | | |
-|`cusparseCreateConstCsr`|12.0| | | |`hipsparseCreateConstCsr`|6.0.0| | | | | | | | | | |
+|`cusparseCreateConstCoo`|12.0| | | |`hipsparseCreateConstCoo`|6.0.0| | | | |`rocsparse_create_const_coo_descr`|6.0.0| | | | |
+|`cusparseCreateConstCsc`|12.0| | | |`hipsparseCreateConstCsc`|6.0.0| | | | |`rocsparse_create_const_csc_descr`|6.0.0| | | | |
+|`cusparseCreateConstCsr`|12.0| | | |`hipsparseCreateConstCsr`|6.0.0| | | | |`rocsparse_create_const_csr_descr`|6.0.0| | | | |
 |`cusparseCreateConstDnMat`|12.0| | | |`hipsparseCreateConstDnMat`|6.0.0| | | | | | | | | | |
 |`cusparseCreateConstDnVec`|12.0| | | |`hipsparseCreateConstDnVec`|6.0.0| | | | | | | | | | |
 |`cusparseCreateConstSlicedEll`|12.1| | | | | | | | | | | | | | | |
@@ -847,7 +847,7 @@
 |`cusparseDenseToSparse_convert`|11.1| |12.0| |`hipsparseDenseToSparse_convert`|4.2.0| |6.0.0| | | | | | | | |
 |`cusparseDestroyDnMat`|10.1| |12.0| |`hipsparseDestroyDnMat`|4.2.0| |6.0.0| | |`rocsparse_destroy_dnmat_descr`|4.1.0| | | | |
 |`cusparseDestroyDnVec`|10.2| |12.0| |`hipsparseDestroyDnVec`|4.1.0| |6.0.0| | |`rocsparse_destroy_dnvec_descr`|4.1.0| | | | |
-|`cusparseDestroySpMat`|10.1| |12.0| |`hipsparseDestroySpMat`|4.1.0| |6.0.0| | |`rocsparse_destroy_spmat_descr`|4.1.0| | | | |
+|`cusparseDestroySpMat`|10.1| |12.0| |`hipsparseDestroySpMat`|4.1.0| |6.0.0| | |`rocsparse_destroy_spmat_descr`|4.1.0| |6.0.0| | |
 |`cusparseDestroySpVec`|10.2| |12.0| |`hipsparseDestroySpVec`|4.1.0| |6.0.0| | |`rocsparse_destroy_spvec_descr`|4.1.0| |6.0.0| | |
 |`cusparseDnMatGet`|10.1| | | |`hipsparseDnMatGet`|4.2.0| | | | |`rocsparse_dnmat_get`|4.1.0| | | | |
 |`cusparseDnMatGetStridedBatch`|10.1| |12.0| |`hipsparseDnMatGetStridedBatch`|5.2.0| |6.0.0| | |`rocsparse_dnmat_get_strided_batch`|5.2.0| | | | |

--- a/docs/tables/CUSPARSE_API_supported_by_ROC.md
+++ b/docs/tables/CUSPARSE_API_supported_by_ROC.md
@@ -802,9 +802,9 @@
 |`cusparseBlockedEllGet`|11.2| | | |`rocsparse_bell_get`|4.1.0| | | | |
 |`cusparseBsrSetStridedBatch`|12.1| | | | | | | | | |
 |`cusparseConstBlockedEllGet`|12.0| | | | | | | | | |
-|`cusparseConstCooGet`|12.0| | | | | | | | | |
+|`cusparseConstCooGet`|12.0| | | |`rocsparse_const_coo_get`|6.0.0| | | | |
 |`cusparseConstCscGet`|12.0| | | | | | | | | |
-|`cusparseConstCsrGet`|12.0| | | | | | | | | |
+|`cusparseConstCsrGet`|12.0| | | |`rocsparse_const_csr_get`|6.0.0| | | | |
 |`cusparseConstDnMatGet`|12.0| | | | | | | | | |
 |`cusparseConstDnMatGetValues`|12.0| | | | | | | | | |
 |`cusparseConstDnVecGet`|12.0| | | | | | | | | |
@@ -820,11 +820,11 @@
 |`cusparseCooSetStridedBatch`|11.0| | | |`rocsparse_coo_set_strided_batch`|5.2.0| | | | |
 |`cusparseCreateBlockedEll`|11.2| | | |`rocsparse_create_bell_descr`|4.5.0| | | | |
 |`cusparseCreateBsr`|12.1| | | | | | | | | |
-|`cusparseCreateConstBlockedEll`|12.0| | | | | | | | | |
+|`cusparseCreateConstBlockedEll`|12.0| | | |`rocsparse_create_const_bell_descr`|6.0.0| | | | |
 |`cusparseCreateConstBsr`|12.1| | | | | | | | | |
-|`cusparseCreateConstCoo`|12.0| | | | | | | | | |
-|`cusparseCreateConstCsc`|12.0| | | | | | | | | |
-|`cusparseCreateConstCsr`|12.0| | | | | | | | | |
+|`cusparseCreateConstCoo`|12.0| | | |`rocsparse_create_const_coo_descr`|6.0.0| | | | |
+|`cusparseCreateConstCsc`|12.0| | | |`rocsparse_create_const_csc_descr`|6.0.0| | | | |
+|`cusparseCreateConstCsr`|12.0| | | |`rocsparse_create_const_csr_descr`|6.0.0| | | | |
 |`cusparseCreateConstDnMat`|12.0| | | | | | | | | |
 |`cusparseCreateConstDnVec`|12.0| | | | | | | | | |
 |`cusparseCreateConstSlicedEll`|12.1| | | | | | | | | |
@@ -847,7 +847,7 @@
 |`cusparseDenseToSparse_convert`|11.1| |12.0| | | | | | | |
 |`cusparseDestroyDnMat`|10.1| |12.0| |`rocsparse_destroy_dnmat_descr`|4.1.0| | | | |
 |`cusparseDestroyDnVec`|10.2| |12.0| |`rocsparse_destroy_dnvec_descr`|4.1.0| | | | |
-|`cusparseDestroySpMat`|10.1| |12.0| |`rocsparse_destroy_spmat_descr`|4.1.0| | | | |
+|`cusparseDestroySpMat`|10.1| |12.0| |`rocsparse_destroy_spmat_descr`|4.1.0| |6.0.0| | |
 |`cusparseDestroySpVec`|10.2| |12.0| |`rocsparse_destroy_spvec_descr`|4.1.0| |6.0.0| | |
 |`cusparseDnMatGet`|10.1| | | |`rocsparse_dnmat_get`|4.1.0| | | | |
 |`cusparseDnMatGetStridedBatch`|10.1| |12.0| |`rocsparse_dnmat_get_strided_batch`|5.2.0| | | | |

--- a/src/CUDA2HIP_SPARSE_API_functions.cpp
+++ b/src/CUDA2HIP_SPARSE_API_functions.cpp
@@ -735,19 +735,19 @@ const std::map<llvm::StringRef, hipCounter> CUDA_SPARSE_FUNCTION_MAP {
   // Generic Sparse API helper functions
   // Sparse Matrix descriptor
   {"cusparseCreateCoo",                                 {"hipsparseCreateCoo",                                 "rocsparse_create_coo_descr",                                       CONV_LIB_FUNC, API_SPARSE, 15}},
-  {"cusparseCreateConstCoo",                            {"hipsparseCreateConstCoo",                            "",                                                                 CONV_LIB_FUNC, API_SPARSE, 15, ROC_UNSUPPORTED}},
+  {"cusparseCreateConstCoo",                            {"hipsparseCreateConstCoo",                            "rocsparse_create_const_coo_descr",                                 CONV_LIB_FUNC, API_SPARSE, 15}},
   {"cusparseCreateCooAoS",                              {"hipsparseCreateCooAoS",                              "rocsparse_create_coo_aos_descr",                                   CONV_LIB_FUNC, API_SPARSE, 15, CUDA_DEPRECATED | CUDA_REMOVED}},
   {"cusparseCreateCsr",                                 {"hipsparseCreateCsr",                                 "rocsparse_create_csr_descr",                                       CONV_LIB_FUNC, API_SPARSE, 15}},
-  {"cusparseCreateConstCsr",                            {"hipsparseCreateConstCsr",                            "",                                                                 CONV_LIB_FUNC, API_SPARSE, 15, ROC_UNSUPPORTED}},
+  {"cusparseCreateConstCsr",                            {"hipsparseCreateConstCsr",                            "rocsparse_create_const_csr_descr",                                 CONV_LIB_FUNC, API_SPARSE, 15}},
   {"cusparseCreateCsc",                                 {"hipsparseCreateCsc",                                 "rocsparse_create_csc_descr",                                       CONV_LIB_FUNC, API_SPARSE, 15}},
-  {"cusparseCreateConstCsc",                            {"hipsparseCreateConstCsc",                            "",                                                                 CONV_LIB_FUNC, API_SPARSE, 15, ROC_UNSUPPORTED}},
+  {"cusparseCreateConstCsc",                            {"hipsparseCreateConstCsc",                            "rocsparse_create_const_csc_descr",                                 CONV_LIB_FUNC, API_SPARSE, 15}},
   {"cusparseDestroySpMat",                              {"hipsparseDestroySpMat",                              "rocsparse_destroy_spmat_descr",                                    CONV_LIB_FUNC, API_SPARSE, 15}},
   {"cusparseCooGet",                                    {"hipsparseCooGet",                                    "rocsparse_coo_get",                                                CONV_LIB_FUNC, API_SPARSE, 15}},
   {"cusparseCooAoSGet",                                 {"hipsparseCooAoSGet",                                 "rocsparse_coo_aos_get",                                            CONV_LIB_FUNC, API_SPARSE, 15, CUDA_DEPRECATED | CUDA_REMOVED}},
-  {"cusparseConstCooGet",                               {"hipsparseConstCooGet",                               "",                                                                 CONV_LIB_FUNC, API_SPARSE, 15, ROC_UNSUPPORTED}},
+  {"cusparseConstCooGet",                               {"hipsparseConstCooGet",                               "rocsparse_const_coo_get",                                          CONV_LIB_FUNC, API_SPARSE, 15}},
   {"cusparseCooSetStridedBatch",                        {"hipsparseCooSetStridedBatch",                        "rocsparse_coo_set_strided_batch",                                  CONV_LIB_FUNC, API_SPARSE, 15}},
   {"cusparseCsrGet",                                    {"hipsparseCsrGet",                                    "rocsparse_csr_get",                                                CONV_LIB_FUNC, API_SPARSE, 15}},
-  {"cusparseConstCsrGet",                               {"hipsparseConstCsrGet",                               "",                                                                 CONV_LIB_FUNC, API_SPARSE, 15, ROC_UNSUPPORTED}},
+  {"cusparseConstCsrGet",                               {"hipsparseConstCsrGet",                               "rocsparse_const_csr_get",                                          CONV_LIB_FUNC, API_SPARSE, 15}},
   {"cusparseCsrSetPointers",                            {"hipsparseCsrSetPointers",                            "rocsparse_csr_set_pointers",                                       CONV_LIB_FUNC, API_SPARSE, 15}},
   {"cusparseCscSetPointers",                            {"hipsparseCscSetPointers",                            "rocsparse_csc_set_pointers",                                       CONV_LIB_FUNC, API_SPARSE, 15}},
   {"cusparseCscGet",                                    {"hipsparseCscGet",                                    "",                                                                 CONV_LIB_FUNC, API_SPARSE, 15, UNSUPPORTED}},
@@ -769,7 +769,7 @@ const std::map<llvm::StringRef, hipCounter> CUDA_SPARSE_FUNCTION_MAP {
   {"cusparseBlockedEllGet",                             {"hipsparseBlockedEllGet",                             "rocsparse_bell_get",                                               CONV_LIB_FUNC, API_SPARSE, 15}},
   {"cusparseConstBlockedEllGet",                        {"hipsparseConstBlockedEllGet",                        "",                                                                 CONV_LIB_FUNC, API_SPARSE, 15, ROC_UNSUPPORTED}},
   {"cusparseCreateBlockedEll",                          {"hipsparseCreateBlockedEll",                          "rocsparse_create_bell_descr",                                      CONV_LIB_FUNC, API_SPARSE, 15}},
-  {"cusparseCreateConstBlockedEll",                     {"hipsparseCreateConstBlockedEll",                     "",                                                                 CONV_LIB_FUNC, API_SPARSE, 15, ROC_UNSUPPORTED}},
+  {"cusparseCreateConstBlockedEll",                     {"hipsparseCreateConstBlockedEll",                     "rocsparse_create_const_bell_descr",                                CONV_LIB_FUNC, API_SPARSE, 15}},
   {"cusparseBsrSetStridedBatch",                        {"hipsparseBsrSetStridedBatch",                        "",                                                                 CONV_LIB_FUNC, API_SPARSE, 15, UNSUPPORTED}},
   // NOTE: rocsparse_create_bsr_descr has appeared earlier than cusparseCreateBsr and has a different signature
   {"cusparseCreateBsr",                                 {"hipsparseCreateBsr",                                 "",                                                                 CONV_LIB_FUNC, API_SPARSE, 15, UNSUPPORTED}},
@@ -2394,6 +2394,12 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_SPARSE_FUNCTION_VER_MAP {
   {"rocsparse_create_const_spvec_descr",                 {HIP_6000, HIP_0,    HIP_0   }},
   {"rocsparse_const_spvec_get",                          {HIP_6000, HIP_0,    HIP_0   }},
   {"rocsparse_const_spvec_get_values",                   {HIP_6000, HIP_0,    HIP_0   }},
+  {"rocsparse_create_const_coo_descr",                   {HIP_6000, HIP_0,    HIP_0   }},
+  {"rocsparse_create_const_csr_descr",                   {HIP_6000, HIP_0,    HIP_0   }},
+  {"rocsparse_create_const_csc_descr",                   {HIP_6000, HIP_0,    HIP_0   }},
+  {"rocsparse_create_const_bell_descr",                  {HIP_6000, HIP_0,    HIP_0   }},
+  {"rocsparse_const_coo_get",                            {HIP_6000, HIP_0,    HIP_0   }},
+  {"rocsparse_const_csr_get",                            {HIP_6000, HIP_0,    HIP_0   }},
 };
 
 const std::map<llvm::StringRef, cudaAPIChangedVersions> CUDA_SPARSE_FUNCTION_CHANGED_VER_MAP {
@@ -2487,6 +2493,7 @@ const std::map<llvm::StringRef, hipAPIChangedVersions> HIP_SPARSE_FUNCTION_CHANG
 
   {"rocsparse_destroy_spvec_descr",                      {HIP_6000}},
   {"rocsparse_spvec_get_index_base",                     {HIP_6000}},
+  {"rocsparse_destroy_spmat_descr",                      {HIP_6000}},
 };
 
 const std::map<unsigned int, llvm::StringRef> CUDA_SPARSE_API_SECTION_MAP {

--- a/tests/unit_tests/synthetic/libraries/cusparse2hipsparse.cu
+++ b/tests/unit_tests/synthetic/libraries/cusparse2hipsparse.cu
@@ -1746,7 +1746,6 @@ int main() {
   status_t = cusparseCreateCoo(&spMatDescr_t, rows, cols, nnz, cooRowInd, cooColInd, cooValues, indexType_t, indexBase_t, dataType);
 
 #if CUDA_VERSION < 12000
-  // TODO: Mark as C-Changed in 12.0.0
   // CUDA: cusparseStatus_t CUSPARSEAPI cusparseDestroySpMat(cusparseSpMatDescr_t spMatDescr);
   // HIP: HIPSPARSE_EXPORT hipsparseStatus_t hipsparseDestroySpMat(hipsparseSpMatDescr_t spMatDescr);
   // CHECK: status_t = hipsparseDestroySpMat(spMatDescr_t);

--- a/tests/unit_tests/synthetic/libraries/cusparse2rocsparse.cu
+++ b/tests/unit_tests/synthetic/libraries/cusparse2rocsparse.cu
@@ -199,16 +199,22 @@ int main() {
   void *values = nullptr;
   const void** const values_const = const_cast<const void**>(&values);
   void *cooRowInd = nullptr;
+  const void** const cooRowInd_const = const_cast<const void**>(&cooRowInd);
   int icooRowInd = 0;
   void *cscRowInd = nullptr;
   void *csrColInd = nullptr;
   void *cooColInd = nullptr;
+  const void** const cooColInd_const = const_cast<const void**>(&cooColInd);
   void *ellColInd = nullptr;
+  const void** const csrColInd_const = const_cast<const void**>(&csrColInd);
   void *cooValues = nullptr;
+  const void** const cooValues_const = const_cast<const void**>(&cooValues);
   void *csrValues = nullptr;
+  const void** const csrValues_const = const_cast<const void**>(&csrValues);
   void *cscValues = nullptr;
   void *ellValue = nullptr;
   void *csrRowOffsets = nullptr;
+  const void** const csrRowOffsets_const = const_cast<const void**>(&csrRowOffsets);
   void *cscColOffsets = nullptr;
   void *cooRows = nullptr;
   int icooRows = 0;
@@ -1569,11 +1575,6 @@ int main() {
   // CHECK: status_t = rocsparse_create_coo_descr(&spMatDescr_t, rows, cols, nnz, cooRowInd, cooColInd, cooValues, indexType_t, indexBase_t, dataType);
   status_t = cusparseCreateCoo(&spMatDescr_t, rows, cols, nnz, cooRowInd, cooColInd, cooValues, indexType_t, indexBase_t, dataType);
 
-  // CUDA: cusparseStatus_t CUSPARSEAPI cusparseDestroySpMat(cusparseConstSpMatDescr_t spMatDescr);
-  // ROC: ROCSPARSE_EXPORT rocsparse_status rocsparse_destroy_spmat_descr(rocsparse_spmat_descr descr);
-  // CHECK: status_t = rocsparse_destroy_spmat_descr(spMatDescr_t);
-  status_t = cusparseDestroySpMat(spMatDescr_t);
-
   // CUDA: cusparseStatus_t CUSPARSEAPI cusparseCooGet(cusparseSpMatDescr_t spMatDescr, int64_t* rows, int64_t* cols, int64_t* nnz, void** cooRowInd, void** cooColInd, void** cooValues, cusparseIndexType_t* idxType, cusparseIndexBase_t* idxBase, cudaDataType* valueType);
   // ROC: ROCSPARSE_EXPORT rocsparse_status rocsparse_coo_get(const rocsparse_spmat_descr descr, int64_t* rows, int64_t* cols, int64_t* nnz, void** coo_row_ind, void** coo_col_ind, void** coo_val, rocsparse_indextype* idx_type, rocsparse_index_base* idx_base, rocsparse_datatype* data_type);
   // CHECK: status_t = rocsparse_coo_get(spMatDescr_t, &rows, &cols, &nnz, &cooRowInd, &cooColInd, &cooValues, &indexType_t, &indexBase_t, &dataType);
@@ -1613,6 +1614,13 @@ int main() {
   // ROC: ROCSPARSE_EXPORT rocsparse_status rocsparse_dnmat_set_strided_batch(rocsparse_dnmat_descr descr, int batch_count, int64_t batch_stride);
   // CHECK: status_t = rocsparse_dnmat_set_strided_batch(dnMatDescr_t, batchCount, batchStride);
   status_t = cusparseDnMatSetStridedBatch(dnMatDescr_t, batchCount, batchStride);
+
+#if CUDA_VERSION < 12000
+  // CUDA: cusparseStatus_t CUSPARSEAPI cusparseDestroySpMat(cusparseSpMatDescr_t spMatDescr);
+  // ROC: ROCSPARSE_EXPORT rocsparse_status rocsparse_destroy_spmat_descr(rocsparse_spmat_descr descr);
+  // CHECK: status_t = rocsparse_destroy_spmat_descr(spMatDescr_t);
+  status_t = cusparseDestroySpMat(spMatDescr_t);
+#endif
 #endif
 
 #if CUDA_VERSION >= 10020
@@ -2342,6 +2350,41 @@ int main() {
   // ROC: ROCSPARSE_EXPORT rocsparse_status rocsparse_const_spvec_get_values(rocsparse_const_spvec_descr descr, const void** values);
   // CHECK: status_t = rocsparse_const_spvec_get_values(constSpVecDescr, values_const);
   status_t = cusparseConstSpVecGetValues(constSpVecDescr, values_const);
+
+  // CUDA: cusparseStatus_t CUSPARSEAPI cusparseCreateConstCoo(cusparseConstSpMatDescr_t* spMatDescr, int64_t rows, int64_t cols, int64_t nnz, const void* cooRowInd, const void* cooColInd, const void* cooValues, cusparseIndexType_t cooIdxType, cusparseIndexBase_t idxBase, cudaDataType valueType);
+  // ROC: ROCSPARSE_EXPORT rocsparse_status rocsparse_create_const_coo_descr(rocsparse_const_spmat_descr* descr, int64_t rows, int64_t cols, int64_t nnz, const void* coo_row_ind, const void* coo_col_ind, const void* coo_val, rocsparse_indextype idx_type, rocsparse_index_base idx_base, rocsparse_datatype data_type);
+  // CHECK: status_t = rocsparse_create_const_coo_descr(&constSpMatDescr, rows, cols, nnz, cooRowInd, cooColInd, cooValues, indexType_t, indexBase_t, dataType);
+  status_t = cusparseCreateConstCoo(&constSpMatDescr, rows, cols, nnz, cooRowInd, cooColInd, cooValues, indexType_t, indexBase_t, dataType);
+
+  // CUDA: cusparseStatus_t CUSPARSEAPI cusparseCreateConstCsr(cusparseConstSpMatDescr_t* spMatDescr, int64_t rows, int64_t cols, int64_t nnz, const void* csrRowOffsets, const void* csrColInd, const void* csrValues, cusparseIndexType_t csrRowOffsetsType, cusparseIndexType_t csrColIndType, cusparseIndexBase_t idxBase, cudaDataType valueType);
+  // ROC: ROCSPARSE_EXPORT rocsparse_status rocsparse_create_const_csr_descr(rocsparse_const_spmat_descr* descr, int64_t rows, int64_t cols, int64_t nnz, const void* csr_row_ptr, const void* csr_col_ind, const void* csr_val, rocsparse_indextype row_ptr_type, rocsparse_indextype col_ind_type, rocsparse_index_base idx_base, rocsparse_datatype data_type);
+  // CHECK: status_t = rocsparse_create_const_csr_descr(&constSpMatDescr, rows, cols, nnz, csrRowOffsets, csrColInd, csrValues, csrRowOffsetsType, csrColIndType, indexBase_t, dataType);
+  status_t = cusparseCreateConstCsr(&constSpMatDescr, rows, cols, nnz, csrRowOffsets, csrColInd, csrValues, csrRowOffsetsType, csrColIndType, indexBase_t, dataType);
+
+  // CUDA: cusparseStatus_t CUSPARSEAPI cusparseCreateConstCsc(cusparseConstSpMatDescr_t* spMatDescr, int64_t rows, int64_t cols, int64_t nnz, const void* cscColOffsets, const void* cscRowInd, const void* cscValues, cusparseIndexType_t cscColOffsetsType, cusparseIndexType_t cscRowIndType, cusparseIndexBase_t idxBase, cudaDataType valueType);
+  // ROC: ROCSPARSE_EXPORT rocsparse_status rocsparse_create_const_csc_descr(rocsparse_const_spmat_descr* descr, int64_t rows, int64_t cols, int64_t nnz, const void* csc_col_ptr, const void* csc_row_ind, const void* csc_val, rocsparse_indextype col_ptr_type, rocsparse_indextype row_ind_type, rocsparse_index_base idx_base, rocsparse_datatype data_type);
+  // CHECK: status_t = rocsparse_create_const_csc_descr(&constSpMatDescr, rows, cols, nnz, cscColOffsets, cscRowInd, cscValues, cscColOffsetsType, cscRowIndType, indexBase_t, dataType);
+  status_t = cusparseCreateConstCsc(&constSpMatDescr, rows, cols, nnz, cscColOffsets, cscRowInd, cscValues, cscColOffsetsType, cscRowIndType, indexBase_t, dataType);
+
+  // CUDA: cusparseStatus_t CUSPARSEAPI cusparseCreateConstBlockedEll(cusparseConstSpMatDescr_t* spMatDescr, int64_t rows, int64_t cols, int64_t ellBlockSize, int64_t ellCols, const void* ellColInd, const void* ellValue, cusparseIndexType_t ellIdxType, cusparseIndexBase_t idxBase, cudaDataType valueType);
+  // ROC: ROCSPARSE_EXPORT rocsparse_status rocsparse_create_const_bell_descr(rocsparse_const_spmat_descr* descr, int64_t rows, int64_t cols, rocsparse_direction ell_block_dir, int64_t ell_block_dim, int64_t ell_cols, const void* ell_col_ind, const void* ell_val, rocsparse_indextype idx_type, rocsparse_index_base idx_base, rocsparse_datatype data_type);
+  // CHECK: status_t = rocsparse_create_const_bell_descr(&constSpMatDescr, rows, cols, ellBlockSize, ellCols, ellColInd, ellValue, ellIdxType, indexBase_t, dataType);
+  status_t = cusparseCreateConstBlockedEll(&constSpMatDescr, rows, cols, ellBlockSize, ellCols, ellColInd, ellValue, ellIdxType, indexBase_t, dataType);
+
+  // CUDA: cusparseStatus_t CUSPARSEAPI cusparseDestroySpMat(cusparseConstSpMatDescr_t spMatDescr);
+  // ROC: ROCSPARSE_EXPORT rocsparse_status rocsparse_destroy_spmat_descr(rocsparse_const_spmat_descr descr);
+  // CHECK: status_t = rocsparse_destroy_spmat_descr(constSpMatDescr);
+  status_t = cusparseDestroySpMat(constSpMatDescr);
+
+  // CUDA: cusparseStatus_t CUSPARSEAPI cusparseConstCooGet(cusparseConstSpMatDescr_t spMatDescr, int64_t* rows, int64_t* cols, int64_t* nnz, const void** cooRowInd, const void** cooColInd, const void** cooValues, cusparseIndexType_t* idxType, cusparseIndexBase_t* idxBase, cudaDataType* valueType);
+  // ROC: ROCSPARSE_EXPORT rocsparse_status rocsparse_const_coo_get(rocsparse_const_spmat_descr descr, int64_t* rows, int64_t* cols, int64_t* nnz, const void** coo_row_ind, const void** coo_col_ind, const void** coo_val, rocsparse_indextype* idx_type, rocsparse_index_base* idx_base, rocsparse_datatype* data_type);
+  // CHECK: status_t = rocsparse_const_coo_get(constSpMatDescr, &rows, &cols, &nnz, cooRowInd_const, cooColInd_const, cooValues_const, &indexType_t, &indexBase_t, &dataType);
+  status_t = cusparseConstCooGet(constSpMatDescr, &rows, &cols, &nnz, cooRowInd_const, cooColInd_const, cooValues_const, &indexType_t, &indexBase_t, &dataType);
+
+  // CUDA: cusparseStatus_t CUSPARSEAPI cusparseConstCsrGet(cusparseConstSpMatDescr_t spMatDescr, int64_t* rows, int64_t* cols, int64_t* nnz, const void** csrRowOffsets, const void** csrColInd, const void** csrValues, cusparseIndexType_t* csrRowOffsetsType, cusparseIndexType_t* csrColIndType, cusparseIndexBase_t* idxBase, cudaDataType* valueType);
+  // ROC: ROCSPARSE_EXPORT rocsparse_status rocsparse_const_csr_get(rocsparse_const_spmat_descr descr, int64_t* rows, int64_t* cols, int64_t* nnz, const void** csr_row_ptr, const void** csr_col_ind, const void** csr_val, rocsparse_indextype* row_ptr_type, rocsparse_indextype* col_ind_type, rocsparse_index_base* idx_base, rocsparse_datatype* data_type);
+  // CHECK: status_t = rocsparse_const_csr_get(constSpMatDescr, &rows, &cols, &nnz, csrRowOffsets_const, csrColInd_const, csrValues_const, &csrRowOffsetsType, &csrColIndType, &indexBase_t, &dataType);
+  status_t = cusparseConstCsrGet(constSpMatDescr, &rows, &cols, &nnz, csrRowOffsets_const, csrColInd_const, csrValues_const, &csrRowOffsetsType, &csrColIndType, &indexBase_t, &dataType);
 #endif
 
 #if CUDA_VERSION >= 12010 && CUSPARSE_VERSION >= 12100


### PR DESCRIPTION
+ Added new const `SpMat` functions
+ Marked the `rocsparse_destroy_spmat_descr` function as `CHANGED` due to ABI breakage
+ Updated `SPARSE` synthetic tests, the regenerated hipify-perl, and `SPARSE` `CUDA2HIP` documentation
