### PR TITLE
[HIPIFY][#674][rocSPARSE][6.0.0][feature] rocSPARSE support - Step 84 - Functions (DnVec, DnMat)

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -2330,6 +2330,10 @@ sub rocSubstitutions {
     subst("cusparseConstCooGet", "rocsparse_const_coo_get", "library");
     subst("cusparseConstCscGet", "rocsparse_const_csc_get", "library");
     subst("cusparseConstCsrGet", "rocsparse_const_csr_get", "library");
+    subst("cusparseConstDnMatGet", "rocsparse_const_dnmat_get", "library");
+    subst("cusparseConstDnMatGetValues", "rocsparse_const_dnmat_get_values", "library");
+    subst("cusparseConstDnVecGet", "rocsparse_const_dnvec_get", "library");
+    subst("cusparseConstDnVecGetValues", "rocsparse_const_dnvec_get_values", "library");
     subst("cusparseConstSpMatGetValues", "rocsparse_const_spmat_get_values", "library");
     subst("cusparseConstSpVecGet", "rocsparse_const_spvec_get", "library");
     subst("cusparseConstSpVecGetValues", "rocsparse_const_spvec_get_values", "library");
@@ -2345,6 +2349,8 @@ sub rocSubstitutions {
     subst("cusparseCreateConstCoo", "rocsparse_create_const_coo_descr", "library");
     subst("cusparseCreateConstCsc", "rocsparse_create_const_csc_descr", "library");
     subst("cusparseCreateConstCsr", "rocsparse_create_const_csr_descr", "library");
+    subst("cusparseCreateConstDnMat", "rocsparse_create_const_dnmat_descr", "library");
+    subst("cusparseCreateConstDnVec", "rocsparse_create_const_dnvec_descr", "library");
     subst("cusparseCreateConstSpVec", "rocsparse_create_const_spvec_descr", "library");
     subst("cusparseCreateCoo", "rocsparse_create_coo_descr", "library");
     subst("cusparseCreateCooAoS", "rocsparse_create_coo_aos_descr", "library");

--- a/docs/tables/CUSPARSE_API_supported_by_HIP_and_ROC.md
+++ b/docs/tables/CUSPARSE_API_supported_by_HIP_and_ROC.md
@@ -805,10 +805,10 @@
 |`cusparseConstCooGet`|12.0| | | |`hipsparseConstCooGet`|6.0.0| | | | |`rocsparse_const_coo_get`|6.0.0| | | | |
 |`cusparseConstCscGet`|12.0| | | | | | | | | |`rocsparse_const_csc_get`|6.0.0| | | | |
 |`cusparseConstCsrGet`|12.0| | | |`hipsparseConstCsrGet`|6.0.0| | | | |`rocsparse_const_csr_get`|6.0.0| | | | |
-|`cusparseConstDnMatGet`|12.0| | | |`hipsparseConstDnMatGet`|6.0.0| | | | | | | | | | |
-|`cusparseConstDnMatGetValues`|12.0| | | |`hipsparseConstDnMatGetValues`|6.0.0| | | | | | | | | | |
-|`cusparseConstDnVecGet`|12.0| | | |`hipsparseConstDnVecGet`|6.0.0| | | | | | | | | | |
-|`cusparseConstDnVecGetValues`|12.0| | | |`hipsparseConstDnVecGetValues`|6.0.0| | | | | | | | | | |
+|`cusparseConstDnMatGet`|12.0| | | |`hipsparseConstDnMatGet`|6.0.0| | | | |`rocsparse_const_dnmat_get`|6.0.0| | | | |
+|`cusparseConstDnMatGetValues`|12.0| | | |`hipsparseConstDnMatGetValues`|6.0.0| | | | |`rocsparse_const_dnmat_get_values`|6.0.0| | | | |
+|`cusparseConstDnVecGet`|12.0| | | |`hipsparseConstDnVecGet`|6.0.0| | | | |`rocsparse_const_dnvec_get`|6.0.0| | | | |
+|`cusparseConstDnVecGetValues`|12.0| | | |`hipsparseConstDnVecGetValues`|6.0.0| | | | |`rocsparse_const_dnvec_get_values`|6.0.0| | | | |
 |`cusparseConstSpMatGetValues`|12.0| | | |`hipsparseConstSpMatGetValues`|6.0.0| | | | |`rocsparse_const_spmat_get_values`|6.0.0| | | | |
 |`cusparseConstSpVecGet`|12.0| | | |`hipsparseConstSpVecGet`|6.0.0| | | | |`rocsparse_const_spvec_get`|6.0.0| | | | |
 |`cusparseConstSpVecGetValues`|12.0| | | |`hipsparseConstSpVecGetValues`|6.0.0| | | | |`rocsparse_const_spvec_get_values`|6.0.0| | | | |
@@ -825,8 +825,8 @@
 |`cusparseCreateConstCoo`|12.0| | | |`hipsparseCreateConstCoo`|6.0.0| | | | |`rocsparse_create_const_coo_descr`|6.0.0| | | | |
 |`cusparseCreateConstCsc`|12.0| | | |`hipsparseCreateConstCsc`|6.0.0| | | | |`rocsparse_create_const_csc_descr`|6.0.0| | | | |
 |`cusparseCreateConstCsr`|12.0| | | |`hipsparseCreateConstCsr`|6.0.0| | | | |`rocsparse_create_const_csr_descr`|6.0.0| | | | |
-|`cusparseCreateConstDnMat`|12.0| | | |`hipsparseCreateConstDnMat`|6.0.0| | | | | | | | | | |
-|`cusparseCreateConstDnVec`|12.0| | | |`hipsparseCreateConstDnVec`|6.0.0| | | | | | | | | | |
+|`cusparseCreateConstDnMat`|12.0| | | |`hipsparseCreateConstDnMat`|6.0.0| | | | |`rocsparse_create_const_dnmat_descr`|6.0.0| | | | |
+|`cusparseCreateConstDnVec`|12.0| | | |`hipsparseCreateConstDnVec`|6.0.0| | | | |`rocsparse_create_const_dnvec_descr`|6.0.0| | | | |
 |`cusparseCreateConstSlicedEll`|12.1| | | | | | | | | | | | | | | |
 |`cusparseCreateConstSpVec`|12.0| | | |`hipsparseCreateConstSpVec`|6.0.0| | | | |`rocsparse_create_const_spvec_descr`|6.0.0| | | | |
 |`cusparseCreateCoo`|10.1| | | |`hipsparseCreateCoo`|4.1.0| | | | |`rocsparse_create_coo_descr`|4.1.0| | | | |
@@ -845,12 +845,12 @@
 |`cusparseDenseToSparse_analysis`|11.1| |12.0| |`hipsparseDenseToSparse_analysis`|4.2.0| |6.0.0| | | | | | | | |
 |`cusparseDenseToSparse_bufferSize`|11.1| |12.0| |`hipsparseDenseToSparse_bufferSize`|4.2.0| |6.0.0| | | | | | | | |
 |`cusparseDenseToSparse_convert`|11.1| |12.0| |`hipsparseDenseToSparse_convert`|4.2.0| |6.0.0| | | | | | | | |
-|`cusparseDestroyDnMat`|10.1| |12.0| |`hipsparseDestroyDnMat`|4.2.0| |6.0.0| | |`rocsparse_destroy_dnmat_descr`|4.1.0| | | | |
-|`cusparseDestroyDnVec`|10.2| |12.0| |`hipsparseDestroyDnVec`|4.1.0| |6.0.0| | |`rocsparse_destroy_dnvec_descr`|4.1.0| | | | |
+|`cusparseDestroyDnMat`|10.1| |12.0| |`hipsparseDestroyDnMat`|4.2.0| |6.0.0| | |`rocsparse_destroy_dnmat_descr`|4.1.0| |6.0.0| | |
+|`cusparseDestroyDnVec`|10.2| |12.0| |`hipsparseDestroyDnVec`|4.1.0| |6.0.0| | |`rocsparse_destroy_dnvec_descr`|4.1.0| |6.0.0| | |
 |`cusparseDestroySpMat`|10.1| |12.0| |`hipsparseDestroySpMat`|4.1.0| |6.0.0| | |`rocsparse_destroy_spmat_descr`|4.1.0| |6.0.0| | |
 |`cusparseDestroySpVec`|10.2| |12.0| |`hipsparseDestroySpVec`|4.1.0| |6.0.0| | |`rocsparse_destroy_spvec_descr`|4.1.0| |6.0.0| | |
 |`cusparseDnMatGet`|10.1| | | |`hipsparseDnMatGet`|4.2.0| | | | |`rocsparse_dnmat_get`|4.1.0| | | | |
-|`cusparseDnMatGetStridedBatch`|10.1| |12.0| |`hipsparseDnMatGetStridedBatch`|5.2.0| |6.0.0| | |`rocsparse_dnmat_get_strided_batch`|5.2.0| | | | |
+|`cusparseDnMatGetStridedBatch`|10.1| |12.0| |`hipsparseDnMatGetStridedBatch`|5.2.0| |6.0.0| | |`rocsparse_dnmat_get_strided_batch`|5.2.0| |6.0.0| | |
 |`cusparseDnMatGetValues`|10.2| | | |`hipsparseDnMatGetValues`|4.2.0| | | | |`rocsparse_dnmat_get_values`|4.1.0| | | | |
 |`cusparseDnMatSetStridedBatch`|10.1| | | |`hipsparseDnMatSetStridedBatch`|5.2.0| | | | |`rocsparse_dnmat_set_strided_batch`|5.2.0| | | | |
 |`cusparseDnMatSetValues`|10.2| | | |`hipsparseDnMatSetValues`|4.2.0| | | | |`rocsparse_dnmat_set_values`|4.1.0| | | | |

--- a/docs/tables/CUSPARSE_API_supported_by_ROC.md
+++ b/docs/tables/CUSPARSE_API_supported_by_ROC.md
@@ -805,10 +805,10 @@
 |`cusparseConstCooGet`|12.0| | | |`rocsparse_const_coo_get`|6.0.0| | | | |
 |`cusparseConstCscGet`|12.0| | | |`rocsparse_const_csc_get`|6.0.0| | | | |
 |`cusparseConstCsrGet`|12.0| | | |`rocsparse_const_csr_get`|6.0.0| | | | |
-|`cusparseConstDnMatGet`|12.0| | | | | | | | | |
-|`cusparseConstDnMatGetValues`|12.0| | | | | | | | | |
-|`cusparseConstDnVecGet`|12.0| | | | | | | | | |
-|`cusparseConstDnVecGetValues`|12.0| | | | | | | | | |
+|`cusparseConstDnMatGet`|12.0| | | |`rocsparse_const_dnmat_get`|6.0.0| | | | |
+|`cusparseConstDnMatGetValues`|12.0| | | |`rocsparse_const_dnmat_get_values`|6.0.0| | | | |
+|`cusparseConstDnVecGet`|12.0| | | |`rocsparse_const_dnvec_get`|6.0.0| | | | |
+|`cusparseConstDnVecGetValues`|12.0| | | |`rocsparse_const_dnvec_get_values`|6.0.0| | | | |
 |`cusparseConstSpMatGetValues`|12.0| | | |`rocsparse_const_spmat_get_values`|6.0.0| | | | |
 |`cusparseConstSpVecGet`|12.0| | | |`rocsparse_const_spvec_get`|6.0.0| | | | |
 |`cusparseConstSpVecGetValues`|12.0| | | |`rocsparse_const_spvec_get_values`|6.0.0| | | | |
@@ -825,8 +825,8 @@
 |`cusparseCreateConstCoo`|12.0| | | |`rocsparse_create_const_coo_descr`|6.0.0| | | | |
 |`cusparseCreateConstCsc`|12.0| | | |`rocsparse_create_const_csc_descr`|6.0.0| | | | |
 |`cusparseCreateConstCsr`|12.0| | | |`rocsparse_create_const_csr_descr`|6.0.0| | | | |
-|`cusparseCreateConstDnMat`|12.0| | | | | | | | | |
-|`cusparseCreateConstDnVec`|12.0| | | | | | | | | |
+|`cusparseCreateConstDnMat`|12.0| | | |`rocsparse_create_const_dnmat_descr`|6.0.0| | | | |
+|`cusparseCreateConstDnVec`|12.0| | | |`rocsparse_create_const_dnvec_descr`|6.0.0| | | | |
 |`cusparseCreateConstSlicedEll`|12.1| | | | | | | | | |
 |`cusparseCreateConstSpVec`|12.0| | | |`rocsparse_create_const_spvec_descr`|6.0.0| | | | |
 |`cusparseCreateCoo`|10.1| | | |`rocsparse_create_coo_descr`|4.1.0| | | | |
@@ -845,12 +845,12 @@
 |`cusparseDenseToSparse_analysis`|11.1| |12.0| | | | | | | |
 |`cusparseDenseToSparse_bufferSize`|11.1| |12.0| | | | | | | |
 |`cusparseDenseToSparse_convert`|11.1| |12.0| | | | | | | |
-|`cusparseDestroyDnMat`|10.1| |12.0| |`rocsparse_destroy_dnmat_descr`|4.1.0| | | | |
-|`cusparseDestroyDnVec`|10.2| |12.0| |`rocsparse_destroy_dnvec_descr`|4.1.0| | | | |
+|`cusparseDestroyDnMat`|10.1| |12.0| |`rocsparse_destroy_dnmat_descr`|4.1.0| |6.0.0| | |
+|`cusparseDestroyDnVec`|10.2| |12.0| |`rocsparse_destroy_dnvec_descr`|4.1.0| |6.0.0| | |
 |`cusparseDestroySpMat`|10.1| |12.0| |`rocsparse_destroy_spmat_descr`|4.1.0| |6.0.0| | |
 |`cusparseDestroySpVec`|10.2| |12.0| |`rocsparse_destroy_spvec_descr`|4.1.0| |6.0.0| | |
 |`cusparseDnMatGet`|10.1| | | |`rocsparse_dnmat_get`|4.1.0| | | | |
-|`cusparseDnMatGetStridedBatch`|10.1| |12.0| |`rocsparse_dnmat_get_strided_batch`|5.2.0| | | | |
+|`cusparseDnMatGetStridedBatch`|10.1| |12.0| |`rocsparse_dnmat_get_strided_batch`|5.2.0| |6.0.0| | |
 |`cusparseDnMatGetValues`|10.2| | | |`rocsparse_dnmat_get_values`|4.1.0| | | | |
 |`cusparseDnMatSetStridedBatch`|10.1| | | |`rocsparse_dnmat_set_strided_batch`|5.2.0| | | | |
 |`cusparseDnMatSetValues`|10.2| | | |`rocsparse_dnmat_set_values`|4.1.0| | | | |

--- a/src/CUDA2HIP_SPARSE_API_functions.cpp
+++ b/src/CUDA2HIP_SPARSE_API_functions.cpp
@@ -790,23 +790,23 @@ const std::map<llvm::StringRef, hipCounter> CUDA_SPARSE_FUNCTION_MAP {
   // Generic Dense API helper functions
   // Dense Matrix descriptor
   {"cusparseCreateDnMat",                               {"hipsparseCreateDnMat",                               "rocsparse_create_dnmat_descr",                                     CONV_LIB_FUNC, API_SPARSE, 15}},
-  {"cusparseCreateConstDnMat",                          {"hipsparseCreateConstDnMat",                          "",                                                                 CONV_LIB_FUNC, API_SPARSE, 15, ROC_UNSUPPORTED}},
+  {"cusparseCreateConstDnMat",                          {"hipsparseCreateConstDnMat",                          "rocsparse_create_const_dnmat_descr",                               CONV_LIB_FUNC, API_SPARSE, 15}},
   {"cusparseDestroyDnMat",                              {"hipsparseDestroyDnMat",                              "rocsparse_destroy_dnmat_descr",                                    CONV_LIB_FUNC, API_SPARSE, 15}},
   {"cusparseDnMatGet",                                  {"hipsparseDnMatGet",                                  "rocsparse_dnmat_get",                                              CONV_LIB_FUNC, API_SPARSE, 15}},
-  {"cusparseConstDnMatGet",                             {"hipsparseConstDnMatGet",                             "",                                                                 CONV_LIB_FUNC, API_SPARSE, 15, ROC_UNSUPPORTED}},
+  {"cusparseConstDnMatGet",                             {"hipsparseConstDnMatGet",                             "rocsparse_const_dnmat_get",                                        CONV_LIB_FUNC, API_SPARSE, 15,}},
   {"cusparseDnMatGetValues",                            {"hipsparseDnMatGetValues",                            "rocsparse_dnmat_get_values",                                       CONV_LIB_FUNC, API_SPARSE, 15}},
-  {"cusparseConstDnMatGetValues",                       {"hipsparseConstDnMatGetValues",                       "",                                                                 CONV_LIB_FUNC, API_SPARSE, 15, ROC_UNSUPPORTED}},
+  {"cusparseConstDnMatGetValues",                       {"hipsparseConstDnMatGetValues",                       "rocsparse_const_dnmat_get_values",                                 CONV_LIB_FUNC, API_SPARSE, 15}},
   {"cusparseDnMatSetValues",                            {"hipsparseDnMatSetValues",                            "rocsparse_dnmat_set_values",                                       CONV_LIB_FUNC, API_SPARSE, 15}},
   {"cusparseDnMatSetStridedBatch",                      {"hipsparseDnMatSetStridedBatch",                      "rocsparse_dnmat_set_strided_batch",                                CONV_LIB_FUNC, API_SPARSE, 15}},
   {"cusparseDnMatGetStridedBatch",                      {"hipsparseDnMatGetStridedBatch",                      "rocsparse_dnmat_get_strided_batch",                                CONV_LIB_FUNC, API_SPARSE, 15}},
   // Dense Vector descriptor
   {"cusparseCreateDnVec",                               {"hipsparseCreateDnVec",                               "rocsparse_create_dnvec_descr",                                     CONV_LIB_FUNC, API_SPARSE, 15}},
-  {"cusparseCreateConstDnVec",                          {"hipsparseCreateConstDnVec",                          "",                                                                 CONV_LIB_FUNC, API_SPARSE, 15, ROC_UNSUPPORTED}},
+  {"cusparseCreateConstDnVec",                          {"hipsparseCreateConstDnVec",                          "rocsparse_create_const_dnvec_descr",                               CONV_LIB_FUNC, API_SPARSE, 15}},
   {"cusparseDestroyDnVec",                              {"hipsparseDestroyDnVec",                              "rocsparse_destroy_dnvec_descr",                                    CONV_LIB_FUNC, API_SPARSE, 15}},
   {"cusparseDnVecGet",                                  {"hipsparseDnVecGet",                                  "rocsparse_dnvec_get",                                              CONV_LIB_FUNC, API_SPARSE, 15}},
-  {"cusparseConstDnVecGet",                             {"hipsparseConstDnVecGet",                             "",                                                                 CONV_LIB_FUNC, API_SPARSE, 15, ROC_UNSUPPORTED}},
+  {"cusparseConstDnVecGet",                             {"hipsparseConstDnVecGet",                             "rocsparse_const_dnvec_get",                                        CONV_LIB_FUNC, API_SPARSE, 15}},
   {"cusparseDnVecGetValues",                            {"hipsparseDnVecGetValues",                            "rocsparse_dnvec_get_values",                                       CONV_LIB_FUNC, API_SPARSE, 15}},
-  {"cusparseConstDnVecGetValues",                       {"hipsparseConstDnVecGetValues",                       "",                                                                 CONV_LIB_FUNC, API_SPARSE, 15, ROC_UNSUPPORTED}},
+  {"cusparseConstDnVecGetValues",                       {"hipsparseConstDnVecGetValues",                       "rocsparse_const_dnvec_get_values",                                 CONV_LIB_FUNC, API_SPARSE, 15}},
   {"cusparseDnVecSetValues",                            {"hipsparseDnVecSetValues",                            "rocsparse_dnvec_set_values",                                       CONV_LIB_FUNC, API_SPARSE, 15}},
 
   {"cusparseSpGEMM_createDescr",                        {"hipsparseSpGEMM_createDescr",                        "",                                                                 CONV_LIB_FUNC, API_SPARSE, 15, ROC_UNSUPPORTED}},
@@ -2403,6 +2403,12 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_SPARSE_FUNCTION_VER_MAP {
   {"rocsparse_const_csc_get",                            {HIP_6000, HIP_0,    HIP_0   }},
   {"rocsparse_const_bell_get",                           {HIP_6000, HIP_0,    HIP_0   }},
   {"rocsparse_const_spmat_get_values",                   {HIP_6000, HIP_0,    HIP_0   }},
+  {"rocsparse_create_const_dnvec_descr",                 {HIP_6000, HIP_0,    HIP_0   }},
+  {"rocsparse_const_dnvec_get",                          {HIP_6000, HIP_0,    HIP_0   }},
+  {"rocsparse_const_dnvec_get_values",                   {HIP_6000, HIP_0,    HIP_0   }},
+  {"rocsparse_create_const_dnmat_descr",                 {HIP_6000, HIP_0,    HIP_0   }},
+  {"rocsparse_const_dnmat_get",                          {HIP_6000, HIP_0,    HIP_0   }},
+  {"rocsparse_const_dnmat_get_values",                   {HIP_6000, HIP_0,    HIP_0   }},
 };
 
 const std::map<llvm::StringRef, cudaAPIChangedVersions> CUDA_SPARSE_FUNCTION_CHANGED_VER_MAP {
@@ -2502,6 +2508,9 @@ const std::map<llvm::StringRef, hipAPIChangedVersions> HIP_SPARSE_FUNCTION_CHANG
   {"rocsparse_spmat_get_index_base",                     {HIP_6000}},
   {"rocsparse_spmat_get_strided_batch",                  {HIP_6000}},
   {"rocsparse_spmat_get_attribute",                      {HIP_6000}},
+  {"rocsparse_destroy_dnvec_descr",                      {HIP_6000}},
+  {"rocsparse_destroy_dnmat_descr",                      {HIP_6000}},
+  {"rocsparse_dnmat_get_strided_batch",                  {HIP_6000}},
 };
 
 const std::map<unsigned int, llvm::StringRef> CUDA_SPARSE_API_SECTION_MAP {

--- a/tests/unit_tests/synthetic/libraries/cusparse2hipsparse.cu
+++ b/tests/unit_tests/synthetic/libraries/cusparse2hipsparse.cu
@@ -1761,13 +1761,11 @@ int main() {
   // CHECK: status_t = hipsparseSpMatGetIndexBase(spMatDescr_t, &indexBase_t);
   status_t = cusparseSpMatGetIndexBase(spMatDescr_t, &indexBase_t);
 
-  // TODO: Mark as C-Changed in 12.0.0
   // CUDA: cusparseStatus_t CUSPARSEAPI cusparseDestroyDnMat(cusparseDnMatDescr_t dnMatDescr);
   // HIP: HIPSPARSE_EXPORT hipsparseStatus_t hipsparseDestroyDnMat(hipsparseDnMatDescr_t dnMatDescr);
   // CHECK: status_t = hipsparseDestroyDnMat(dnMatDescr_t);
   status_t = cusparseDestroyDnMat(dnMatDescr_t);
 
-  // TODO: Mark as C-Changed in 12.0.0
   // CUDA: cusparseStatus_t CUSPARSEAPI cusparseDnMatGetStridedBatch(cusparseDnMatDescr_t dnMatDescr, int* batchCount, int64_t* batchStride);
   // HIP: HIPSPARSE_EXPORT hipsparseStatus_t hipsparseDnMatGetStridedBatch(hipsparseDnMatDescr_t dnMatDescr, int* batchCount, int64_t* batchStride);
   // CHECK: status_t = hipsparseDnMatGetStridedBatch(dnMatDescr_t, &batchCount, &batchStride);
@@ -1857,7 +1855,6 @@ int main() {
   // CHECK: status_t = hipsparseSpMatGetStridedBatch(spMatDescr_t, &batchCount);
   status_t = cusparseSpMatGetStridedBatch(spMatDescr_t, &batchCount);
 
-  // TODO: Mark as C-Changed in 12.0.0
   // CUDA: cusparseStatus_t CUSPARSEAPI cusparseDestroyDnVec(cusparseDnVecDescr_t dnVecDescr);
   // HIP: HIPSPARSE_EXPORT hipsparseStatus_t hipsparseDestroyDnVec(hipsparseDnVecDescr_t dnVecDescr);
   // CHECK: status_t = hipsparseDestroyDnVec(dnVecDescr_t);
@@ -3105,6 +3102,11 @@ int main() {
   // HIP: HIPSPARSE_EXPORT hipsparseStatus_t hipsparseSpSM_solve(hipsparseHandle_t handle, hipsparseOperation_t opA, hipsparseOperation_t opB, const void* alpha, hipsparseConstSpMatDescr_t matA, hipsparseConstDnMatDescr_t matB, const hipsparseDnMatDescr_t matC, hipDataType computeType, hipsparseSpSMAlg_t alg, hipsparseSpSMDescr_t spsmDescr, void* externalBuffer);
   // CHECK: status_t = hipsparseSpSM_solve(handle_t, opA, opB, alpha, constSpMatDescr, constDnMatDescrB, dnmatC, dataType, spSMAlg_t, spSMDescr);
   status_t = cusparseSpSM_solve(handle_t, opA, opB, alpha, constSpMatDescr, constDnMatDescrB, dnmatC, dataType, spSMAlg_t, spSMDescr);
+
+  // CUDA: cusparseStatus_t CUSPARSEAPI cusparseConstDnVecGetValues(cusparseConstDnVecDescr_t dnVecDescr, const void** values);
+  // HIP: HIPSPARSE_EXPORT hipsparseStatus_t hipsparseConstDnVecGetValues(hipsparseConstDnVecDescr_t dnVecDescr, const void** values);
+  // CHECK: status_t = hipsparseConstDnVecGetValues(constDnVecDescr, values_const);
+  status_t = cusparseConstDnVecGetValues(constDnVecDescr, values_const);
 #endif
 
   return 0;

--- a/tests/unit_tests/synthetic/libraries/cusparse2rocsparse.cu
+++ b/tests/unit_tests/synthetic/libraries/cusparse2rocsparse.cu
@@ -1590,20 +1590,10 @@ int main() {
   // CHECK: status_t = rocsparse_create_dnmat_descr(&dnMatDescr_t, rows, cols, ld, values, dataType, order_t);
   status_t = cusparseCreateDnMat(&dnMatDescr_t, rows, cols, ld, values, dataType, order_t);
 
-  // CUDA: cusparseStatus_t CUSPARSEAPI cusparseDestroyDnMat(cusparseConstDnMatDescr_t dnMatDescr);
-  // ROC: ROCSPARSE_EXPORT rocsparse_status rocsparse_destroy_dnmat_descr(rocsparse_dnmat_descr descr);
-  // CHECK: status_t = rocsparse_destroy_dnmat_descr(dnMatDescr_t);
-  status_t = cusparseDestroyDnMat(dnMatDescr_t);
-
   // CUDA: cusparseStatus_t CUSPARSEAPI cusparseDnMatGet(cusparseDnMatDescr_t dnMatDescr, int64_t* rows, int64_t* cols, int64_t* ld, void** values, cudaDataType* type, cusparseOrder_t* order);
   // ROC: ROCSPARSE_EXPORT rocsparse_status rocsparse_dnmat_get(const rocsparse_dnmat_descr descr, int64_t* rows, int64_t* cols, int64_t* ld, void** values, rocsparse_datatype* data_type, rocsparse_order* order);
   // CHECK: status_t = rocsparse_dnmat_get(dnMatDescr_t, &rows, &cols, &ld, &values, &dataType, &order_t);
   status_t = cusparseDnMatGet(dnMatDescr_t, &rows, &cols, &ld, &values, &dataType, &order_t);
-
-  // CUDA: cusparseStatus_t CUSPARSEAPI cusparseDnMatGetStridedBatch(cusparseConstDnMatDescr_t dnMatDescr, int* batchCount, int64_t* batchStride);
-  // ROC: ROCSPARSE_EXPORT rocsparse_status rocsparse_dnmat_get_strided_batch(rocsparse_dnmat_descr descr, int* batch_count, int64_t* batch_stride);
-  // CHECK: status_t = rocsparse_dnmat_get_strided_batch(dnMatDescr_t, &batchCount, &batchStride);
-  status_t = cusparseDnMatGetStridedBatch(dnMatDescr_t, &batchCount, &batchStride);
 
   // CUDA: cusparseStatus_t CUSPARSEAPI cusparseDnMatSetStridedBatch(cusparseDnMatDescr_t dnMatDescr, int batchCount, int64_t batchStride);
   // ROC: ROCSPARSE_EXPORT rocsparse_status rocsparse_dnmat_set_strided_batch(rocsparse_dnmat_descr descr, int batch_count, int64_t batch_stride);
@@ -1625,6 +1615,16 @@ int main() {
   // ROC: ROCSPARSE_EXPORT rocsparse_status rocsparse_spmat_get_index_base(const rocsparse_spmat_descr descr, rocsparse_index_base* idx_base);
   // CHECK: status_t = rocsparse_spmat_get_index_base(spMatDescr_t, &indexBase_t);
   status_t = cusparseSpMatGetIndexBase(spMatDescr_t, &indexBase_t);
+
+  // CUDA: cusparseStatus_t CUSPARSEAPI cusparseDestroyDnMat(cusparseConstDnMatDescr_t dnMatDescr);
+  // ROC: ROCSPARSE_EXPORT rocsparse_status rocsparse_destroy_dnmat_descr(rocsparse_dnmat_descr descr);
+  // CHECK: status_t = rocsparse_destroy_dnmat_descr(dnMatDescr_t);
+  status_t = cusparseDestroyDnMat(dnMatDescr_t);
+
+  // CUDA: cusparseStatus_t CUSPARSEAPI cusparseDnMatGetStridedBatch(cusparseConstDnMatDescr_t dnMatDescr, int* batchCount, int64_t* batchStride);
+  // ROC: ROCSPARSE_EXPORT rocsparse_status rocsparse_dnmat_get_strided_batch(rocsparse_dnmat_descr descr, int* batch_count, int64_t* batch_stride);
+  // CHECK: status_t = rocsparse_dnmat_get_strided_batch(dnMatDescr_t, &batchCount, &batchStride);
+  status_t = cusparseDnMatGetStridedBatch(dnMatDescr_t, &batchCount, &batchStride);
 #endif
 #endif
 
@@ -1692,11 +1692,6 @@ int main() {
   // CHECK: status_t = rocsparse_create_dnvec_descr(&dnVecDescr_t, size, values, dataType);
   status_t = cusparseCreateDnVec(&dnVecDescr_t, size, values, dataType);
 
-  // CUDA: cusparseStatus_t CUSPARSEAPI cusparseDestroyDnVec(cusparseConstDnVecDescr_t dnVecDescr);
-  // ROC: ROCSPARSE_EXPORT rocsparse_status rocsparse_destroy_dnvec_descr(rocsparse_dnvec_descr descr);
-  // CHECK: status_t = rocsparse_destroy_dnvec_descr(dnVecDescr_t);
-  status_t = cusparseDestroyDnVec(dnVecDescr_t);
-
   // CUDA: cusparseStatus_t CUSPARSEAPI cusparseDnVecGet(cusparseDnVecDescr_t dnVecDescr, int64_t* size, void** values, cudaDataType* valueType);
   // ROC: ROCSPARSE_EXPORT rocsparse_status rocsparse_dnvec_get(const rocsparse_dnvec_descr descr, int64_t* size, void** values, rocsparse_datatype* data_type);
   // CHECK: status_t = rocsparse_dnvec_get(dnVecDescr_t, &size, &values, &dataType);
@@ -1760,6 +1755,11 @@ int main() {
   // ROC: ROCSPARSE_EXPORT rocsparse_status rocsparse_spmat_get_strided_batch(rocsparse_spmat_descr descr, int* batch_count);
   // CHECK: status_t = rocsparse_spmat_get_strided_batch(spMatDescr_t, &batchCount);
   status_t = cusparseSpMatGetStridedBatch(spMatDescr_t, &batchCount);
+
+  // CUDA: cusparseStatus_t CUSPARSEAPI cusparseDestroyDnVec(cusparseConstDnVecDescr_t dnVecDescr);
+  // ROC: ROCSPARSE_EXPORT rocsparse_status rocsparse_destroy_dnvec_descr(rocsparse_dnvec_descr descr);
+  // CHECK: status_t = rocsparse_destroy_dnvec_descr(dnVecDescr_t);
+  status_t = cusparseDestroyDnVec(dnVecDescr_t);
 #endif
 #endif
 
@@ -2434,6 +2434,51 @@ int main() {
   // ROC: ROCSPARSE_EXPORT rocsparse_status rocsparse_spmat_get_attribute(rocsparse_const_spmat_descr descr, rocsparse_spmat_attribute attribute, void* data, size_t data_size);
   // CHECK: status_t = rocsparse_spmat_get_attribute(constSpMatDescr, spMatAttribute_t, &data, dataSize);
   status_t = cusparseSpMatGetAttribute(constSpMatDescr, spMatAttribute_t, &data, dataSize);
+
+  // CUDA: cusparseStatus_t CUSPARSEAPI cusparseCreateConstDnVec(cusparseConstDnVecDescr_t* dnVecDescr, int64_t size, const void* values, cudaDataType valueType);
+  // ROC: ROCSPARSE_EXPORT rocsparse_status rocsparse_create_const_dnvec_descr(rocsparse_const_dnvec_descr* descr, int64_t size, const void* values, rocsparse_datatype data_type);
+  // CHECK: status_t = rocsparse_create_const_dnvec_descr(&constDnVecDescr, size, values, dataType);
+  status_t = cusparseCreateConstDnVec(&constDnVecDescr, size, values, dataType);
+
+  // CUDA: cusparseStatus_t CUSPARSEAPI cusparseDestroyDnVec(cusparseConstDnVecDescr_t dnVecDescr);
+  // ROC: ROCSPARSE_EXPORT rocsparse_status rocsparse_destroy_dnvec_descr(rocsparse_const_dnvec_descr descr);
+  // CHECK: status_t = rocsparse_destroy_dnvec_descr(constDnVecDescr);
+  status_t = cusparseDestroyDnVec(constDnVecDescr);
+
+  // CUDA: cusparseStatus_t CUSPARSEAPI cusparseConstDnVecGet(cusparseConstDnVecDescr_t dnVecDescr, int64_t* size, const void** values, cudaDataType* valueType);
+  // ROC: ROCSPARSE_EXPORT rocsparse_status rocsparse_const_dnvec_get(rocsparse_const_dnvec_descr descr, int64_t* size, const void** values, rocsparse_datatype* data_type);
+  // CHECK: status_t = rocsparse_const_dnvec_get(constDnVecDescr, &size, values_const, &dataType);
+  status_t = cusparseConstDnVecGet(constDnVecDescr, &size, values_const, &dataType);
+
+  // CUDA: cusparseStatus_t CUSPARSEAPI cusparseConstDnVecGetValues(cusparseConstDnVecDescr_t dnVecDescr, const void** values);
+  // ROC: ROCSPARSE_EXPORT rocsparse_status rocsparse_const_dnvec_get_values(rocsparse_const_dnvec_descr descr, const void** values);
+  // CHECK: status_t = rocsparse_const_dnvec_get_values(constDnVecDescr, values_const);
+  status_t = cusparseConstDnVecGetValues(constDnVecDescr, values_const);
+
+  // CUDA: cusparseStatus_t CUSPARSEAPI cusparseCreateConstDnMat(cusparseConstDnMatDescr_t* dnMatDescr, int64_t rows, int64_t cols, int64_t ld, const void* values, cudaDataType valueType, cusparseOrder_t order);
+  // ROC: ROCSPARSE_EXPORT rocsparse_status rocsparse_create_const_dnmat_descr(rocsparse_const_dnmat_descr* descr, int64_t rows, int64_t cols, int64_t ld, const void* values, rocsparse_datatype data_type, rocsparse_order order);
+  // CHECK: status_t = rocsparse_create_const_dnmat_descr(&constDnMatDescr, rows, cols, ld, values, dataType, order_t);
+  status_t = cusparseCreateConstDnMat(&constDnMatDescr, rows, cols, ld, values, dataType, order_t);
+
+  // CUDA: cusparseStatus_t CUSPARSEAPI cusparseDestroyDnMat(cusparseConstDnMatDescr_t dnMatDescr);
+  // ROC: ROCSPARSE_EXPORT rocsparse_status rocsparse_destroy_dnmat_descr(rocsparse_const_dnmat_descr descr);
+  // CHECK: status_t = rocsparse_destroy_dnmat_descr(constDnMatDescr);
+  status_t = cusparseDestroyDnMat(constDnMatDescr);
+
+  // CUDA: cusparseStatus_t CUSPARSEAPI cusparseConstDnMatGet(cusparseConstDnMatDescr_t dnMatDescr, int64_t* rows, int64_t* cols, int64_t* ld, const void** values, cudaDataType* type, cusparseOrder_t* order);
+  // ROC: ROCSPARSE_EXPORT rocsparse_status rocsparse_const_dnmat_get(rocsparse_const_dnmat_descr descr, int64_t* rows, int64_t* cols, int64_t* ld, const void** values, rocsparse_datatype* data_type, rocsparse_order* order);
+  // CHECK: status_t = rocsparse_const_dnmat_get(constDnMatDescr, &rows, &cols, &ld, values_const, &dataType, &order_t);
+  status_t = cusparseConstDnMatGet(constDnMatDescr, &rows, &cols, &ld, values_const, &dataType, &order_t);
+
+  // CUDA: cusparseStatus_t CUSPARSEAPI cusparseConstDnMatGetValues(cusparseConstDnMatDescr_t dnMatDescr, const void** values);
+  // ROC: ROCSPARSE_EXPORT rocsparse_status rocsparse_const_dnmat_get_values(rocsparse_const_dnmat_descr descr, const void** values);
+  // CHECK: status_t = rocsparse_const_dnmat_get_values(constDnMatDescr, values_const);
+  status_t = cusparseConstDnMatGetValues(constDnMatDescr, values_const);
+
+  // CUDA: cusparseStatus_t CUSPARSEAPI cusparseDnMatGetStridedBatch(cusparseConstDnMatDescr_t dnMatDescr, int* batchCount, int64_t* batchStride);
+  // ROC: ROCSPARSE_EXPORT rocsparse_status rocsparse_dnmat_get_strided_batch(rocsparse_const_dnmat_descr descr, int* batch_count, int64_t* batch_stride);
+  // CHECK: status_t = rocsparse_dnmat_get_strided_batch(constDnMatDescr, &batchCount, &batchStride);
+  status_t = cusparseDnMatGetStridedBatch(constDnMatDescr, &batchCount, &batchStride);
 #endif
 
 #if CUDA_VERSION >= 12010 && CUSPARSE_VERSION >= 12100


### PR DESCRIPTION
+ Added new const `Dn` functions
+ Marked some const `Dn` functions as `CHANGED` due to ABI breakage
+ Updated `SPARSE` synthetic tests, the regenerated hipify-perl, and `SPARSE` `CUDA2HIP` documentation
