### PR TITLE
[HIPIFY][#674][rocSPARSE][feature] rocSPARSE support - Step 85 - functions (Csrsm2, Csrsv2)

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -2356,6 +2356,8 @@ sub rocSubstitutions {
     subst("cusparseCreateCooAoS", "rocsparse_create_coo_aos_descr", "library");
     subst("cusparseCreateCsc", "rocsparse_create_csc_descr", "library");
     subst("cusparseCreateCsr", "rocsparse_create_csr_descr", "library");
+    subst("cusparseCreateCsrsm2Info", "rocsparse_create_mat_info", "library");
+    subst("cusparseCreateCsrsv2Info", "rocsparse_create_mat_info", "library");
     subst("cusparseCreateDnMat", "rocsparse_create_dnmat_descr", "library");
     subst("cusparseCreateDnVec", "rocsparse_create_dnvec_descr", "library");
     subst("cusparseCreateHybMat", "rocsparse_create_hyb_mat", "library");
@@ -2415,6 +2417,8 @@ sub rocSubstitutions {
     subst("cusparseDdoti", "rocsparse_ddoti", "library");
     subst("cusparseDestroy", "rocsparse_destroy_handle", "library");
     subst("cusparseDestroyColorInfo", "rocsparse_destroy_color_info", "library");
+    subst("cusparseDestroyCsrsm2Info", "rocsparse_destroy_mat_info", "library");
+    subst("cusparseDestroyCsrsv2Info", "rocsparse_destroy_mat_info", "library");
     subst("cusparseDestroyDnMat", "rocsparse_destroy_dnmat_descr", "library");
     subst("cusparseDestroyDnVec", "rocsparse_destroy_dnvec_descr", "library");
     subst("cusparseDestroyHybMat", "rocsparse_destroy_hyb_mat", "library");

--- a/docs/tables/CUSPARSE_API_supported_by_HIP.md
+++ b/docs/tables/CUSPARSE_API_supported_by_HIP.md
@@ -229,7 +229,7 @@
 |`cusparseCreateCsrgemm2Info`| |11.0| |12.0|`hipsparseCreateCsrgemm2Info`|2.8.0| | | | |
 |`cusparseCreateCsric02Info`| |12.2| | |`hipsparseCreateCsric02Info`|3.1.0| | | | |
 |`cusparseCreateCsrilu02Info`| |12.2| | |`hipsparseCreateCsrilu02Info`|1.9.2| | | | |
-|`cusparseCreateCsrsm2Info`|10.0|11.3| |12.0|`hipsparseCreateCsrsm2Info`|3.1.0| | | | |
+|`cusparseCreateCsrsm2Info`|9.2|11.3| |12.0|`hipsparseCreateCsrsm2Info`|3.1.0| | | | |
 |`cusparseCreateCsrsv2Info`| |11.3| |12.0|`hipsparseCreateCsrsv2Info`|1.9.2| | | | |
 |`cusparseCreateHybMat`| |10.2| |11.0|`hipsparseCreateHybMat`|1.9.2| | | | |
 |`cusparseCreateMatDescr`| | | | |`hipsparseCreateMatDescr`|1.9.2| | | | |
@@ -243,7 +243,7 @@
 |`cusparseDestroyCsrgemm2Info`| |11.0| |12.0|`hipsparseDestroyCsrgemm2Info`|2.8.0| | | | |
 |`cusparseDestroyCsric02Info`| |12.2| | |`hipsparseDestroyCsric02Info`|3.1.0| | | | |
 |`cusparseDestroyCsrilu02Info`| |12.2| | |`hipsparseDestroyCsrilu02Info`|1.9.2| | | | |
-|`cusparseDestroyCsrsm2Info`|10.0|11.3| |12.0|`hipsparseDestroyCsrsm2Info`|3.1.0| | | | |
+|`cusparseDestroyCsrsm2Info`|9.2|11.3| |12.0|`hipsparseDestroyCsrsm2Info`|3.1.0| | | | |
 |`cusparseDestroyCsrsv2Info`| |11.3| |12.0|`hipsparseDestroyCsrsv2Info`|1.9.2| | | | |
 |`cusparseDestroyHybMat`| |10.2| |11.0|`hipsparseDestroyHybMat`|1.9.2| | | | |
 |`cusparseDestroyMatDescr`| | | | |`hipsparseDestroyMatDescr`|1.9.2| | | | |

--- a/docs/tables/CUSPARSE_API_supported_by_HIP_and_ROC.md
+++ b/docs/tables/CUSPARSE_API_supported_by_HIP_and_ROC.md
@@ -229,8 +229,8 @@
 |`cusparseCreateCsrgemm2Info`| |11.0| |12.0|`hipsparseCreateCsrgemm2Info`|2.8.0| | | | | | | | | | |
 |`cusparseCreateCsric02Info`| |12.2| | |`hipsparseCreateCsric02Info`|3.1.0| | | | | | | | | | |
 |`cusparseCreateCsrilu02Info`| |12.2| | |`hipsparseCreateCsrilu02Info`|1.9.2| | | | | | | | | | |
-|`cusparseCreateCsrsm2Info`|10.0|11.3| |12.0|`hipsparseCreateCsrsm2Info`|3.1.0| | | | | | | | | | |
-|`cusparseCreateCsrsv2Info`| |11.3| |12.0|`hipsparseCreateCsrsv2Info`|1.9.2| | | | | | | | | | |
+|`cusparseCreateCsrsm2Info`|9.2|11.3| |12.0|`hipsparseCreateCsrsm2Info`|3.1.0| | | | |`rocsparse_create_mat_info`|1.9.0| | | | |
+|`cusparseCreateCsrsv2Info`| |11.3| |12.0|`hipsparseCreateCsrsv2Info`|1.9.2| | | | |`rocsparse_create_mat_info`|1.9.0| | | | |
 |`cusparseCreateHybMat`| |10.2| |11.0|`hipsparseCreateHybMat`|1.9.2| | | | |`rocsparse_create_hyb_mat`|1.9.0| | | | |
 |`cusparseCreateMatDescr`| | | | |`hipsparseCreateMatDescr`|1.9.2| | | | |`rocsparse_create_mat_descr`|1.9.0| | | | |
 |`cusparseCreatePruneInfo`|9.0|12.2| | |`hipsparseCreatePruneInfo`|3.9.0| | | | | | | | | | |
@@ -243,8 +243,8 @@
 |`cusparseDestroyCsrgemm2Info`| |11.0| |12.0|`hipsparseDestroyCsrgemm2Info`|2.8.0| | | | | | | | | | |
 |`cusparseDestroyCsric02Info`| |12.2| | |`hipsparseDestroyCsric02Info`|3.1.0| | | | | | | | | | |
 |`cusparseDestroyCsrilu02Info`| |12.2| | |`hipsparseDestroyCsrilu02Info`|1.9.2| | | | | | | | | | |
-|`cusparseDestroyCsrsm2Info`|10.0|11.3| |12.0|`hipsparseDestroyCsrsm2Info`|3.1.0| | | | | | | | | | |
-|`cusparseDestroyCsrsv2Info`| |11.3| |12.0|`hipsparseDestroyCsrsv2Info`|1.9.2| | | | | | | | | | |
+|`cusparseDestroyCsrsm2Info`|9.2|11.3| |12.0|`hipsparseDestroyCsrsm2Info`|3.1.0| | | | |`rocsparse_destroy_mat_info`|1.9.0| | | | |
+|`cusparseDestroyCsrsv2Info`| |11.3| |12.0|`hipsparseDestroyCsrsv2Info`|1.9.2| | | | |`rocsparse_destroy_mat_info`|1.9.0| | | | |
 |`cusparseDestroyHybMat`| |10.2| |11.0|`hipsparseDestroyHybMat`|1.9.2| | | | |`rocsparse_destroy_hyb_mat`|1.9.0| | | | |
 |`cusparseDestroyMatDescr`| | | | |`hipsparseDestroyMatDescr`|1.9.2| | | | |`rocsparse_destroy_mat_descr`|1.9.0| | | | |
 |`cusparseDestroyPruneInfo`|9.0|12.2| | |`hipsparseDestroyPruneInfo`|3.9.0| | | | | | | | | | |

--- a/docs/tables/CUSPARSE_API_supported_by_ROC.md
+++ b/docs/tables/CUSPARSE_API_supported_by_ROC.md
@@ -229,8 +229,8 @@
 |`cusparseCreateCsrgemm2Info`| |11.0| |12.0| | | | | | |
 |`cusparseCreateCsric02Info`| |12.2| | | | | | | | |
 |`cusparseCreateCsrilu02Info`| |12.2| | | | | | | | |
-|`cusparseCreateCsrsm2Info`|10.0|11.3| |12.0| | | | | | |
-|`cusparseCreateCsrsv2Info`| |11.3| |12.0| | | | | | |
+|`cusparseCreateCsrsm2Info`|9.2|11.3| |12.0|`rocsparse_create_mat_info`|1.9.0| | | | |
+|`cusparseCreateCsrsv2Info`| |11.3| |12.0|`rocsparse_create_mat_info`|1.9.0| | | | |
 |`cusparseCreateHybMat`| |10.2| |11.0|`rocsparse_create_hyb_mat`|1.9.0| | | | |
 |`cusparseCreateMatDescr`| | | | |`rocsparse_create_mat_descr`|1.9.0| | | | |
 |`cusparseCreatePruneInfo`|9.0|12.2| | | | | | | | |
@@ -243,8 +243,8 @@
 |`cusparseDestroyCsrgemm2Info`| |11.0| |12.0| | | | | | |
 |`cusparseDestroyCsric02Info`| |12.2| | | | | | | | |
 |`cusparseDestroyCsrilu02Info`| |12.2| | | | | | | | |
-|`cusparseDestroyCsrsm2Info`|10.0|11.3| |12.0| | | | | | |
-|`cusparseDestroyCsrsv2Info`| |11.3| |12.0| | | | | | |
+|`cusparseDestroyCsrsm2Info`|9.2|11.3| |12.0|`rocsparse_destroy_mat_info`|1.9.0| | | | |
+|`cusparseDestroyCsrsv2Info`| |11.3| |12.0|`rocsparse_destroy_mat_info`|1.9.0| | | | |
 |`cusparseDestroyHybMat`| |10.2| |11.0|`rocsparse_destroy_hyb_mat`|1.9.0| | | | |
 |`cusparseDestroyMatDescr`| | | | |`rocsparse_destroy_mat_descr`|1.9.0| | | | |
 |`cusparseDestroyPruneInfo`|9.0|12.2| | | | | | | | |

--- a/src/CUDA2HIP_SPARSE_API_functions.cpp
+++ b/src/CUDA2HIP_SPARSE_API_functions.cpp
@@ -60,10 +60,10 @@ const std::map<llvm::StringRef, hipCounter> CUDA_SPARSE_FUNCTION_MAP {
   {"cusparseSetMatFillMode",                            {"hipsparseSetMatFillMode",                            "rocsparse_set_mat_fill_mode",                                      CONV_LIB_FUNC, API_SPARSE, 7}},
   {"cusparseSetMatIndexBase",                           {"hipsparseSetMatIndexBase",                           "rocsparse_set_mat_index_base",                                     CONV_LIB_FUNC, API_SPARSE, 7}},
   {"cusparseSetMatType",                                {"hipsparseSetMatType",                                "rocsparse_set_mat_type",                                           CONV_LIB_FUNC, API_SPARSE, 7}},
-  {"cusparseCreateCsrsv2Info",                          {"hipsparseCreateCsrsv2Info",                          "",                                                                 CONV_LIB_FUNC, API_SPARSE, 7, ROC_UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED}},
-  {"cusparseDestroyCsrsv2Info",                         {"hipsparseDestroyCsrsv2Info",                         "",                                                                 CONV_LIB_FUNC, API_SPARSE, 7, ROC_UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED}},
-  {"cusparseCreateCsrsm2Info",                          {"hipsparseCreateCsrsm2Info",                          "",                                                                 CONV_LIB_FUNC, API_SPARSE, 7, ROC_UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED}},
-  {"cusparseDestroyCsrsm2Info",                         {"hipsparseDestroyCsrsm2Info",                         "",                                                                 CONV_LIB_FUNC, API_SPARSE, 7, ROC_UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED}},
+  {"cusparseCreateCsrsv2Info",                          {"hipsparseCreateCsrsv2Info",                          "rocsparse_create_mat_info",                                        CONV_LIB_FUNC, API_SPARSE, 7, CUDA_DEPRECATED | CUDA_REMOVED}},
+  {"cusparseDestroyCsrsv2Info",                         {"hipsparseDestroyCsrsv2Info",                         "rocsparse_destroy_mat_info",                                       CONV_LIB_FUNC, API_SPARSE, 7, CUDA_DEPRECATED | CUDA_REMOVED}},
+  {"cusparseCreateCsrsm2Info",                          {"hipsparseCreateCsrsm2Info",                          "rocsparse_create_mat_info",                                        CONV_LIB_FUNC, API_SPARSE, 7, CUDA_DEPRECATED | CUDA_REMOVED}},
+  {"cusparseDestroyCsrsm2Info",                         {"hipsparseDestroyCsrsm2Info",                         "rocsparse_destroy_mat_info",                                       CONV_LIB_FUNC, API_SPARSE, 7, CUDA_DEPRECATED | CUDA_REMOVED}},
   {"cusparseCreateCsric02Info",                         {"hipsparseCreateCsric02Info",                         "",                                                                 CONV_LIB_FUNC, API_SPARSE, 7, ROC_UNSUPPORTED | CUDA_DEPRECATED}},
   {"cusparseDestroyCsric02Info",                        {"hipsparseDestroyCsric02Info",                        "",                                                                 CONV_LIB_FUNC, API_SPARSE, 7, ROC_UNSUPPORTED | CUDA_DEPRECATED}},
   {"cusparseCreateCsrilu02Info",                        {"hipsparseCreateCsrilu02Info",                        "",                                                                 CONV_LIB_FUNC, API_SPARSE, 7, ROC_UNSUPPORTED | CUDA_DEPRECATED}},
@@ -878,14 +878,14 @@ const std::map<llvm::StringRef, hipCounter> CUDA_SPARSE_FUNCTION_MAP {
 
 const std::map<llvm::StringRef, cudaAPIversions> CUDA_SPARSE_FUNCTION_VER_MAP {
   {"cusparseCreateCsrgemm2Info",                        {CUDA_0,   CUDA_110, CUDA_120}},
-  {"cusparseCreateCsrsm2Info",                          {CUDA_100, CUDA_113, CUDA_120}},
+  {"cusparseCreateCsrsm2Info",                          {CUDA_92,  CUDA_113, CUDA_120}}, // D: CUSPARSE_VERSION 11600, R: CUSPARSE_VERSION 12000
+  {"cusparseDestroyCsrsm2Info",                         {CUDA_92,  CUDA_113, CUDA_120}}, // D: CUSPARSE_VERSION 11600, R: CUSPARSE_VERSION 12000
   {"cusparseCreateHybMat",                              {CUDA_0,   CUDA_102, CUDA_110}},
-  {"cusparseCreatePruneInfo",                           {CUDA_90,  CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
+  {"cusparseCreatePruneInfo",                           {CUDA_90,  CUDA_122, CUDA_0  }}, // D: CUSPARSE_VERSION 12120
   {"cusparseCreateSolveAnalysisInfo",                   {CUDA_0,   CUDA_102, CUDA_110}},
   {"cusparseDestroyCsrgemm2Info",                       {CUDA_0,   CUDA_110, CUDA_120}},
-  {"cusparseDestroyCsrsm2Info",                         {CUDA_100, CUDA_113, CUDA_120}},
   {"cusparseDestroyHybMat",                             {CUDA_0,   CUDA_102, CUDA_110}},
-  {"cusparseDestroyPruneInfo",                          {CUDA_90,  CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
+  {"cusparseDestroyPruneInfo",                          {CUDA_90,  CUDA_122, CUDA_0  }}, // D: CUSPARSE_VERSION 12120
   {"cusparseDestroySolveAnalysisInfo",                  {CUDA_0,   CUDA_102, CUDA_110}},
   {"cusparseGetLevelInfo",                              {CUDA_0,   CUDA_0,   CUDA_110}},
   {"cusparseSdoti",                                     {CUDA_0,   CUDA_102, CUDA_110}},
@@ -1228,8 +1228,8 @@ const std::map<llvm::StringRef, cudaAPIversions> CUDA_SPARSE_FUNCTION_VER_MAP {
   {"cusparseDenseToSparse_bufferSize",                  {CUDA_111, CUDA_0,   CUDA_0  }},
   {"cusparseDenseToSparse_analysis",                    {CUDA_111, CUDA_0,   CUDA_0  }},
   {"cusparseDenseToSparse_convert",                     {CUDA_111, CUDA_0,   CUDA_0  }},
-  {"cusparseCreateCsrsv2Info",                          {CUDA_0,   CUDA_113, CUDA_120}},
-  {"cusparseDestroyCsrsv2Info",                         {CUDA_0,   CUDA_113, CUDA_120}},
+  {"cusparseCreateCsrsv2Info",                          {CUDA_0,   CUDA_113, CUDA_120}}, // D: CUSPARSE_VERSION 11500 R: CUSPARSE_VERSION 12120
+  {"cusparseDestroyCsrsv2Info",                         {CUDA_0,   CUDA_113, CUDA_120}}, // D: CUSPARSE_VERSION 11500 R: CUSPARSE_VERSION 12120
   {"cusparseXcsrsv2_zeroPivot",                         {CUDA_0,   CUDA_113, CUDA_120}},
   {"cusparseScsrsv2_bufferSize",                        {CUDA_0,   CUDA_113, CUDA_120}},
   {"cusparseDcsrsv2_bufferSize",                        {CUDA_0,   CUDA_113, CUDA_120}},
@@ -2409,6 +2409,8 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_SPARSE_FUNCTION_VER_MAP {
   {"rocsparse_create_const_dnmat_descr",                 {HIP_6000, HIP_0,    HIP_0   }},
   {"rocsparse_const_dnmat_get",                          {HIP_6000, HIP_0,    HIP_0   }},
   {"rocsparse_const_dnmat_get_values",                   {HIP_6000, HIP_0,    HIP_0   }},
+  {"rocsparse_create_mat_info",                          {HIP_1090, HIP_0,    HIP_0   }},
+  {"rocsparse_destroy_mat_info",                         {HIP_1090, HIP_0,    HIP_0   }},
 };
 
 const std::map<llvm::StringRef, cudaAPIChangedVersions> CUDA_SPARSE_FUNCTION_CHANGED_VER_MAP {

--- a/tests/unit_tests/synthetic/libraries/cusparse2hipsparse.cu
+++ b/tests/unit_tests/synthetic/libraries/cusparse2hipsparse.cu
@@ -1685,6 +1685,16 @@ int main() {
   // HIP: DEPRECATED_CUDA_11000("The routine will be removed in CUDA 12") HIPSPARSE_EXPORT hipsparseStatus_t hipsparseXcsrsm2_zeroPivot(hipsparseHandle_t handle, csrsm2Info_t info, int* position);
   // CHECK: status_t = hipsparseXcsrsm2_zeroPivot(handle_t, csrsm2_info, &iposition);
   status_t = cusparseXcsrsm2_zeroPivot(handle_t, csrsm2_info, &iposition);
+
+  // CUDA: CUSPARSE_DEPRECATED(cusparseSpSM) cusparseStatus_t CUSPARSEAPI cusparseCreateCsrsm2Info(csrsm2Info_t* info);
+  // HIP: DEPRECATED_CUDA_11000("The routine will be removed in CUDA 12") HIPSPARSE_EXPORT hipsparseStatus_t hipsparseCreateCsrsm2Info(csrsm2Info_t* info);
+  // CHECK: status_t = hipsparseCreateCsrsm2Info(&csrsm2_info);
+  status_t = cusparseCreateCsrsm2Info(&csrsm2_info);
+
+  // CUDA: CUSPARSE_DEPRECATED(cusparseSpSM) cusparseStatus_t CUSPARSEAPI cusparseDestroyCsrsm2Info(csrsm2Info_t info);
+  // HIP: DEPRECATED_CUDA_11000("The routine will be removed in CUDA 12") HIPSPARSE_EXPORT hipsparseStatus_t hipsparseDestroyCsrsm2Info(csrsm2Info_t info);
+  // CHECK: status_t = hipsparseDestroyCsrsm2Info(csrsm2_info);
+  status_t = cusparseDestroyCsrsm2Info(csrsm2_info);
 #endif
 #endif
 
@@ -1822,6 +1832,16 @@ int main() {
 #if CUDA_VERSION < 12000
   csrgemm2Info_t csrgemm2_info;
   csrsv2Info_t csrsv2_info;
+
+  // CUDA: CUSPARSE_DEPRECATED(cusparseSpSV) cusparseStatus_t CUSPARSEAPI cusparseCreateCsrsv2Info(csrsv2Info_t* info);
+  // HIP: DEPRECATED_CUDA_11000("The routine will be removed in CUDA 12") HIPSPARSE_EXPORT hipsparseStatus_t hipsparseCreateCsrsv2Info(csrsv2Info_t* info);
+  // CHECK: status_t = hipsparseCreateCsrsv2Info(&csrsv2_info);
+  status_t = cusparseCreateCsrsv2Info(&csrsv2_info);
+
+  // CUDA: CUSPARSE_DEPRECATED(cusparseSpSV) cusparseStatus_t CUSPARSEAPI cusparseDestroyCsrsv2Info(csrsv2Info_t info);
+  // HIP: DEPRECATED_CUDA_11000("The routine will be removed in CUDA 12") HIPSPARSE_EXPORT hipsparseStatus_t hipsparseDestroyCsrsv2Info(csrsv2Info_t info);
+  // CHECK: status_t = hipsparseDestroyCsrsv2Info(csrsv2_info);
+  status_t = cusparseDestroyCsrsv2Info(csrsv2_info);
 #endif
 
 #if (CUDA_VERSION >= 10020 && CUDA_VERSION < 11000 && !defined(_WIN32)) || CUDA_VERSION >= 11000
@@ -2692,8 +2712,8 @@ int main() {
 
   // CUDA: CUSPARSE_DEPRECATED(cusparseSpSV) cusparseStatus_t CUSPARSEAPI cusparseXcsrsv2_zeroPivot(cusparseHandle_t handle, csrsv2Info_t info, int* position);
   // HIP: DEPRECATED_CUDA_11000("The routine will be removed in CUDA 12") HIPSPARSE_EXPORT hipsparseStatus_t hipsparseXcsrsv2_zeroPivot(hipsparseHandle_t handle, csrsv2Info_t info, int* position);
-  // CHECK: status_t = hipsparseXcsrsv2_zeroPivot(handle_t,csrsv2_info, &iposition);
-  status_t = cusparseXcsrsv2_zeroPivot(handle_t,csrsv2_info, &iposition);
+  // CHECK: status_t = hipsparseXcsrsv2_zeroPivot(handle_t, csrsv2_info, &iposition);
+  status_t = cusparseXcsrsv2_zeroPivot(handle_t, csrsv2_info, &iposition);
 
   // CUDA: CUSPARSE_DEPRECATED(cusparseScatter) cusparseStatus_t CUSPARSEAPI cusparseZsctr(cusparseHandle_t handle, int nnz, const cuDoubleComplex* xVal, const int* xInd, cuDoubleComplex* y, cusparseIndexBase_t idxBase);
   // HIP: DEPRECATED_CUDA_11000("The routine will be removed in CUDA 12") HIPSPARSE_EXPORT hipsparseStatus_t hipsparseZsctr(hipsparseHandle_t handle, int nnz, const hipDoubleComplex* xVal, const int* xInd, hipDoubleComplex* y, hipsparseIndexBase_t idxBase);

--- a/tests/unit_tests/synthetic/libraries/cusparse2rocsparse.cu
+++ b/tests/unit_tests/synthetic/libraries/cusparse2rocsparse.cu
@@ -2224,8 +2224,8 @@ int main() {
 
   // CUDA: CUSPARSE_DEPRECATED(cusparseSpSV) cusparseStatus_t CUSPARSEAPI cusparseXcsrsv2_zeroPivot(cusparseHandle_t handle, csrsv2Info_t info, int* position);
   // ROC: ROCSPARSE_EXPORT rocsparse_status rocsparse_csrsv_zero_pivot(rocsparse_handle handle, const rocsparse_mat_descr descr, rocsparse_mat_info info, rocsparse_int* position);
-  // CHECK: status_t = rocsparse_csrsv_zero_pivot(handle_t,csrsv2_info, &iposition);
-  status_t = cusparseXcsrsv2_zeroPivot(handle_t,csrsv2_info, &iposition);
+  // CHECK: status_t = rocsparse_csrsv_zero_pivot(handle_t, csrsv2_info, &iposition);
+  status_t = cusparseXcsrsv2_zeroPivot(handle_t, csrsv2_info, &iposition);
 
   // CUDA: CUSPARSE_DEPRECATED(cusparseScatter) cusparseStatus_t CUSPARSEAPI cusparseZsctr(cusparseHandle_t handle, int nnz, const cuDoubleComplex* xVal, const int* xInd, cuDoubleComplex* y, cusparseIndexBase_t idxBase);
   // ROC: ROCSPARSE_EXPORT rocsparse_status rocsparse_zsctr(rocsparse_handle handle, rocsparse_int nnz, const rocsparse_double_complex* x_val, const rocsparse_int* x_ind, rocsparse_double_complex* y, rocsparse_index_base idx_base);
@@ -2316,6 +2316,16 @@ int main() {
   // ROC: ROCSPARSE_EXPORT rocsparse_status rocsparse_saxpyi(rocsparse_handle handle, rocsparse_int nnz, const float* alpha, const float* x_val, const rocsparse_int* x_ind, float* y, rocsparse_index_base idx_base);
   // CHECK: status_t = rocsparse_saxpyi(handle_t, innz, &fAlpha, &fX, &xInd, &fY, indexBase_t);
   status_t = cusparseSaxpyi(handle_t, innz, &fAlpha, &fX, &xInd, &fY, indexBase_t);
+
+  // CUDA: CUSPARSE_DEPRECATED(cusparseSpSV) cusparseStatus_t CUSPARSEAPI cusparseCreateCsrsv2Info(csrsv2Info_t* info);
+  // ROC: ROCSPARSE_EXPORT rocsparse_status rocsparse_create_mat_info(rocsparse_mat_info* info);
+  // CHECK: status_t = rocsparse_create_mat_info(&csrsv2_info);
+  status_t = cusparseCreateCsrsv2Info(&csrsv2_info);
+
+  // CUDA: CUSPARSE_DEPRECATED(cusparseSpSV) cusparseStatus_t CUSPARSEAPI cusparseDestroyCsrsv2Info(csrsv2Info_t info);
+  // ROC: ROCSPARSE_EXPORT rocsparse_status rocsparse_destroy_mat_info(rocsparse_mat_info info);
+  // CHECK: status_t = rocsparse_destroy_mat_info(csrsv2_info);
+  status_t = cusparseDestroyCsrsv2Info(csrsv2_info);
 #endif
 
 #if CUDA_VERSION >= 12000

--- a/tests/unit_tests/synthetic/libraries/cusparse2rocsparse_9200_12000.cu
+++ b/tests/unit_tests/synthetic/libraries/cusparse2rocsparse_9200_12000.cu
@@ -145,6 +145,16 @@ int main() {
   // ROC: ROCSPARSE_EXPORT rocsparse_status rocsparse_csrsm_zero_pivot(rocsparse_handle handle, rocsparse_mat_info info, rocsparse_int* position);
   // CHECK: status_t = rocsparse_csrsm_zero_pivot(handle_t, csrsm2_info, &iposition);
   status_t = cusparseXcsrsm2_zeroPivot(handle_t, csrsm2_info, &iposition);
+
+  // CUDA: CUSPARSE_DEPRECATED(cusparseSpSM) cusparseStatus_t CUSPARSEAPI cusparseCreateCsrsm2Info(csrsm2Info_t* info);
+  // ROC: ROCSPARSE_EXPORT rocsparse_status rocsparse_create_mat_info(rocsparse_mat_info* info);
+  // CHECK: status_t = rocsparse_create_mat_info(&csrsm2_info);
+  status_t = cusparseCreateCsrsm2Info(&csrsm2_info);
+
+  // CUDA: CUSPARSE_DEPRECATED(cusparseSpSM) cusparseStatus_t CUSPARSEAPI cusparseDestroyCsrsm2Info(csrsm2Info_t info);
+  // ROC: ROCSPARSE_EXPORT rocsparse_status rocsparse_destroy_mat_info(rocsparse_mat_info info);
+  // CHECK: status_t = rocsparse_destroy_mat_info(csrsm2_info);
+  status_t = cusparseDestroyCsrsm2Info(csrsm2_info);
 #endif
 #endif
 


### PR DESCRIPTION
+ Added partial support for `rocsparse_create_mat_info` and `rocsparse_destroy_mat_info`
+ Fixed `CUDA` versions
+ Updated `SPARSE` synthetic tests, the regenerated hipify-perl, and `SPARSE` `CUDA2HIP` documentation
