### PR TITLE
[HIPIFY][#674][rocSPARSE][feature] rocSPARSE support - Step 89 - functions (Csrgemm2, Prune)

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -2360,6 +2360,7 @@ sub rocSubstitutions {
     subst("cusparseCreateCooAoS", "rocsparse_create_coo_aos_descr", "library");
     subst("cusparseCreateCsc", "rocsparse_create_csc_descr", "library");
     subst("cusparseCreateCsr", "rocsparse_create_csr_descr", "library");
+    subst("cusparseCreateCsrgemm2Info", "rocsparse_create_mat_info", "library");
     subst("cusparseCreateCsric02Info", "rocsparse_create_mat_info", "library");
     subst("cusparseCreateCsrilu02Info", "rocsparse_create_mat_info", "library");
     subst("cusparseCreateCsrsm2Info", "rocsparse_create_mat_info", "library");
@@ -2369,6 +2370,7 @@ sub rocSubstitutions {
     subst("cusparseCreateHybMat", "rocsparse_create_hyb_mat", "library");
     subst("cusparseCreateIdentityPermutation", "rocsparse_create_identity_permutation", "library");
     subst("cusparseCreateMatDescr", "rocsparse_create_mat_descr", "library");
+    subst("cusparseCreatePruneInfo", "rocsparse_create_mat_info", "library");
     subst("cusparseCreateSpVec", "rocsparse_create_spvec_descr", "library");
     subst("cusparseCscSetPointers", "rocsparse_csc_set_pointers", "library");
     subst("cusparseCsctr", "rocsparse_csctr", "library");
@@ -2427,6 +2429,7 @@ sub rocSubstitutions {
     subst("cusparseDestroyBsrsm2Info", "rocsparse_destroy_mat_info", "library");
     subst("cusparseDestroyBsrsv2Info", "rocsparse_destroy_mat_info", "library");
     subst("cusparseDestroyColorInfo", "rocsparse_destroy_color_info", "library");
+    subst("cusparseDestroyCsrgemm2Info", "rocsparse_destroy_mat_info", "library");
     subst("cusparseDestroyCsric02Info", "rocsparse_destroy_mat_info", "library");
     subst("cusparseDestroyCsrilu02Info", "rocsparse_destroy_mat_info", "library");
     subst("cusparseDestroyCsrsm2Info", "rocsparse_destroy_mat_info", "library");
@@ -2435,6 +2438,7 @@ sub rocSubstitutions {
     subst("cusparseDestroyDnVec", "rocsparse_destroy_dnvec_descr", "library");
     subst("cusparseDestroyHybMat", "rocsparse_destroy_hyb_mat", "library");
     subst("cusparseDestroyMatDescr", "rocsparse_destroy_mat_descr", "library");
+    subst("cusparseDestroyPruneInfo", "rocsparse_destroy_mat_info", "library");
     subst("cusparseDestroySpMat", "rocsparse_destroy_spmat_descr", "library");
     subst("cusparseDestroySpVec", "rocsparse_destroy_spvec_descr", "library");
     subst("cusparseDgebsr2csr", "rocsparse_dgebsr2csr", "library");

--- a/docs/tables/CUSPARSE_API_supported_by_HIP_and_ROC.md
+++ b/docs/tables/CUSPARSE_API_supported_by_HIP_and_ROC.md
@@ -226,28 +226,28 @@
 |`cusparseCreateBsrsm2Info`| |12.2| | |`hipsparseCreateBsrsm2Info`|4.5.0| | | | |`rocsparse_create_mat_info`|1.9.0| | | | |
 |`cusparseCreateBsrsv2Info`| |12.2| | |`hipsparseCreateBsrsv2Info`|3.6.0| | | | |`rocsparse_create_mat_info`|1.9.0| | | | |
 |`cusparseCreateColorInfo`| |12.2| | |`hipsparseCreateColorInfo`|4.5.0| | | | |`rocsparse_create_color_info`|4.5.0| | | | |
-|`cusparseCreateCsrgemm2Info`| |11.0| |12.0|`hipsparseCreateCsrgemm2Info`|2.8.0| | | | | | | | | | |
+|`cusparseCreateCsrgemm2Info`| |11.0| |12.0|`hipsparseCreateCsrgemm2Info`|2.8.0| | | | |`rocsparse_create_mat_info`|1.9.0| | | | |
 |`cusparseCreateCsric02Info`| |12.2| | |`hipsparseCreateCsric02Info`|3.1.0| | | | |`rocsparse_create_mat_info`|1.9.0| | | | |
 |`cusparseCreateCsrilu02Info`| |12.2| | |`hipsparseCreateCsrilu02Info`|1.9.2| | | | |`rocsparse_create_mat_info`|1.9.0| | | | |
 |`cusparseCreateCsrsm2Info`|9.2|11.3| |12.0|`hipsparseCreateCsrsm2Info`|3.1.0| | | | |`rocsparse_create_mat_info`|1.9.0| | | | |
 |`cusparseCreateCsrsv2Info`| |11.3| |12.0|`hipsparseCreateCsrsv2Info`|1.9.2| | | | |`rocsparse_create_mat_info`|1.9.0| | | | |
 |`cusparseCreateHybMat`| |10.2| |11.0|`hipsparseCreateHybMat`|1.9.2| | | | |`rocsparse_create_hyb_mat`|1.9.0| | | | |
 |`cusparseCreateMatDescr`| | | | |`hipsparseCreateMatDescr`|1.9.2| | | | |`rocsparse_create_mat_descr`|1.9.0| | | | |
-|`cusparseCreatePruneInfo`|9.0|12.2| | |`hipsparseCreatePruneInfo`|3.9.0| | | | | | | | | | |
+|`cusparseCreatePruneInfo`|9.0|12.2| | |`hipsparseCreatePruneInfo`|3.9.0| | | | |`rocsparse_create_mat_info`|1.9.0| | | | |
 |`cusparseCreateSolveAnalysisInfo`| |10.2| |11.0| | | | | | | | | | | | |
 |`cusparseDestroyBsric02Info`| |12.2| | |`hipsparseDestroyBsric02Info`|3.8.0| | | | |`rocsparse_destroy_mat_info`|1.9.0| | | | |
 |`cusparseDestroyBsrilu02Info`| |12.2| | |`hipsparseDestroyBsrilu02Info`|3.9.0| | | | |`rocsparse_destroy_mat_info`|1.9.0| | | | |
 |`cusparseDestroyBsrsm2Info`| |12.2| | |`hipsparseDestroyBsrsm2Info`|4.5.0| | | | |`rocsparse_destroy_mat_info`|1.9.0| | | | |
 |`cusparseDestroyBsrsv2Info`| |12.2| | |`hipsparseDestroyBsrsv2Info`|3.6.0| | | | |`rocsparse_destroy_mat_info`|1.9.0| | | | |
 |`cusparseDestroyColorInfo`| |12.2| | |`hipsparseDestroyColorInfo`|4.5.0| | | | |`rocsparse_destroy_color_info`|4.5.0| | | | |
-|`cusparseDestroyCsrgemm2Info`| |11.0| |12.0|`hipsparseDestroyCsrgemm2Info`|2.8.0| | | | | | | | | | |
+|`cusparseDestroyCsrgemm2Info`| |11.0| |12.0|`hipsparseDestroyCsrgemm2Info`|2.8.0| | | | |`rocsparse_destroy_mat_info`|1.9.0| | | | |
 |`cusparseDestroyCsric02Info`| |12.2| | |`hipsparseDestroyCsric02Info`|3.1.0| | | | |`rocsparse_destroy_mat_info`|1.9.0| | | | |
 |`cusparseDestroyCsrilu02Info`| |12.2| | |`hipsparseDestroyCsrilu02Info`|1.9.2| | | | |`rocsparse_destroy_mat_info`|1.9.0| | | | |
 |`cusparseDestroyCsrsm2Info`|9.2|11.3| |12.0|`hipsparseDestroyCsrsm2Info`|3.1.0| | | | |`rocsparse_destroy_mat_info`|1.9.0| | | | |
 |`cusparseDestroyCsrsv2Info`| |11.3| |12.0|`hipsparseDestroyCsrsv2Info`|1.9.2| | | | |`rocsparse_destroy_mat_info`|1.9.0| | | | |
 |`cusparseDestroyHybMat`| |10.2| |11.0|`hipsparseDestroyHybMat`|1.9.2| | | | |`rocsparse_destroy_hyb_mat`|1.9.0| | | | |
 |`cusparseDestroyMatDescr`| | | | |`hipsparseDestroyMatDescr`|1.9.2| | | | |`rocsparse_destroy_mat_descr`|1.9.0| | | | |
-|`cusparseDestroyPruneInfo`|9.0|12.2| | |`hipsparseDestroyPruneInfo`|3.9.0| | | | | | | | | | |
+|`cusparseDestroyPruneInfo`|9.0|12.2| | |`hipsparseDestroyPruneInfo`|3.9.0| | | | |`rocsparse_destroy_mat_info`|1.9.0| | | | |
 |`cusparseDestroySolveAnalysisInfo`| |10.2| |11.0| | | | | | | | | | | | |
 |`cusparseGetLevelInfo`| | | |11.0| | | | | | | | | | | | |
 |`cusparseGetMatDiagType`| | | | |`hipsparseGetMatDiagType`|1.9.2| | | | |`rocsparse_get_mat_diag_type`|1.9.0| | | | |

--- a/docs/tables/CUSPARSE_API_supported_by_ROC.md
+++ b/docs/tables/CUSPARSE_API_supported_by_ROC.md
@@ -226,28 +226,28 @@
 |`cusparseCreateBsrsm2Info`| |12.2| | |`rocsparse_create_mat_info`|1.9.0| | | | |
 |`cusparseCreateBsrsv2Info`| |12.2| | |`rocsparse_create_mat_info`|1.9.0| | | | |
 |`cusparseCreateColorInfo`| |12.2| | |`rocsparse_create_color_info`|4.5.0| | | | |
-|`cusparseCreateCsrgemm2Info`| |11.0| |12.0| | | | | | |
+|`cusparseCreateCsrgemm2Info`| |11.0| |12.0|`rocsparse_create_mat_info`|1.9.0| | | | |
 |`cusparseCreateCsric02Info`| |12.2| | |`rocsparse_create_mat_info`|1.9.0| | | | |
 |`cusparseCreateCsrilu02Info`| |12.2| | |`rocsparse_create_mat_info`|1.9.0| | | | |
 |`cusparseCreateCsrsm2Info`|9.2|11.3| |12.0|`rocsparse_create_mat_info`|1.9.0| | | | |
 |`cusparseCreateCsrsv2Info`| |11.3| |12.0|`rocsparse_create_mat_info`|1.9.0| | | | |
 |`cusparseCreateHybMat`| |10.2| |11.0|`rocsparse_create_hyb_mat`|1.9.0| | | | |
 |`cusparseCreateMatDescr`| | | | |`rocsparse_create_mat_descr`|1.9.0| | | | |
-|`cusparseCreatePruneInfo`|9.0|12.2| | | | | | | | |
+|`cusparseCreatePruneInfo`|9.0|12.2| | |`rocsparse_create_mat_info`|1.9.0| | | | |
 |`cusparseCreateSolveAnalysisInfo`| |10.2| |11.0| | | | | | |
 |`cusparseDestroyBsric02Info`| |12.2| | |`rocsparse_destroy_mat_info`|1.9.0| | | | |
 |`cusparseDestroyBsrilu02Info`| |12.2| | |`rocsparse_destroy_mat_info`|1.9.0| | | | |
 |`cusparseDestroyBsrsm2Info`| |12.2| | |`rocsparse_destroy_mat_info`|1.9.0| | | | |
 |`cusparseDestroyBsrsv2Info`| |12.2| | |`rocsparse_destroy_mat_info`|1.9.0| | | | |
 |`cusparseDestroyColorInfo`| |12.2| | |`rocsparse_destroy_color_info`|4.5.0| | | | |
-|`cusparseDestroyCsrgemm2Info`| |11.0| |12.0| | | | | | |
+|`cusparseDestroyCsrgemm2Info`| |11.0| |12.0|`rocsparse_destroy_mat_info`|1.9.0| | | | |
 |`cusparseDestroyCsric02Info`| |12.2| | |`rocsparse_destroy_mat_info`|1.9.0| | | | |
 |`cusparseDestroyCsrilu02Info`| |12.2| | |`rocsparse_destroy_mat_info`|1.9.0| | | | |
 |`cusparseDestroyCsrsm2Info`|9.2|11.3| |12.0|`rocsparse_destroy_mat_info`|1.9.0| | | | |
 |`cusparseDestroyCsrsv2Info`| |11.3| |12.0|`rocsparse_destroy_mat_info`|1.9.0| | | | |
 |`cusparseDestroyHybMat`| |10.2| |11.0|`rocsparse_destroy_hyb_mat`|1.9.0| | | | |
 |`cusparseDestroyMatDescr`| | | | |`rocsparse_destroy_mat_descr`|1.9.0| | | | |
-|`cusparseDestroyPruneInfo`|9.0|12.2| | | | | | | | |
+|`cusparseDestroyPruneInfo`|9.0|12.2| | |`rocsparse_destroy_mat_info`|1.9.0| | | | |
 |`cusparseDestroySolveAnalysisInfo`| |10.2| |11.0| | | | | | |
 |`cusparseGetLevelInfo`| | | |11.0| | | | | | |
 |`cusparseGetMatDiagType`| | | | |`rocsparse_get_mat_diag_type`|1.9.0| | | | |

--- a/src/CUDA2HIP_SPARSE_API_functions.cpp
+++ b/src/CUDA2HIP_SPARSE_API_functions.cpp
@@ -76,10 +76,10 @@ const std::map<llvm::StringRef, hipCounter> CUDA_SPARSE_FUNCTION_MAP {
   {"cusparseDestroyBsric02Info",                        {"hipsparseDestroyBsric02Info",                        "rocsparse_destroy_mat_info",                                       CONV_LIB_FUNC, API_SPARSE, 7, CUDA_DEPRECATED}},
   {"cusparseCreateBsrilu02Info",                        {"hipsparseCreateBsrilu02Info",                        "rocsparse_create_mat_info",                                        CONV_LIB_FUNC, API_SPARSE, 7, CUDA_DEPRECATED}},
   {"cusparseDestroyBsrilu02Info",                       {"hipsparseDestroyBsrilu02Info",                       "rocsparse_destroy_mat_info",                                       CONV_LIB_FUNC, API_SPARSE, 7, CUDA_DEPRECATED}},
-  {"cusparseCreateCsrgemm2Info",                        {"hipsparseCreateCsrgemm2Info",                        "",                                                                 CONV_LIB_FUNC, API_SPARSE, 7, ROC_UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED}},
-  {"cusparseDestroyCsrgemm2Info",                       {"hipsparseDestroyCsrgemm2Info",                       "",                                                                 CONV_LIB_FUNC, API_SPARSE, 7, ROC_UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED}},
-  {"cusparseCreatePruneInfo",                           {"hipsparseCreatePruneInfo",                           "",                                                                 CONV_LIB_FUNC, API_SPARSE, 7, ROC_UNSUPPORTED | CUDA_DEPRECATED}},
-  {"cusparseDestroyPruneInfo",                          {"hipsparseDestroyPruneInfo",                          "",                                                                 CONV_LIB_FUNC, API_SPARSE, 7, ROC_UNSUPPORTED | CUDA_DEPRECATED}},
+  {"cusparseCreateCsrgemm2Info",                        {"hipsparseCreateCsrgemm2Info",                        "rocsparse_create_mat_info",                                        CONV_LIB_FUNC, API_SPARSE, 7, CUDA_DEPRECATED | CUDA_REMOVED}},
+  {"cusparseDestroyCsrgemm2Info",                       {"hipsparseDestroyCsrgemm2Info",                       "rocsparse_destroy_mat_info",                                       CONV_LIB_FUNC, API_SPARSE, 7, CUDA_DEPRECATED | CUDA_REMOVED}},
+  {"cusparseCreatePruneInfo",                           {"hipsparseCreatePruneInfo",                           "rocsparse_create_mat_info",                                        CONV_LIB_FUNC, API_SPARSE, 7, CUDA_DEPRECATED}},
+  {"cusparseDestroyPruneInfo",                          {"hipsparseDestroyPruneInfo",                          "rocsparse_destroy_mat_info",                                       CONV_LIB_FUNC, API_SPARSE, 7, CUDA_DEPRECATED}},
   {"cusparseCreateColorInfo",                           {"hipsparseCreateColorInfo",                           "rocsparse_create_color_info",                                      CONV_LIB_FUNC, API_SPARSE, 7, CUDA_DEPRECATED}},
   {"cusparseDestroyColorInfo",                          {"hipsparseDestroyColorInfo",                          "rocsparse_destroy_color_info",                                     CONV_LIB_FUNC, API_SPARSE, 7, CUDA_DEPRECATED}},
 
@@ -877,15 +877,15 @@ const std::map<llvm::StringRef, hipCounter> CUDA_SPARSE_FUNCTION_MAP {
 };
 
 const std::map<llvm::StringRef, cudaAPIversions> CUDA_SPARSE_FUNCTION_VER_MAP {
-  {"cusparseCreateCsrgemm2Info",                        {CUDA_0,   CUDA_110, CUDA_120}},
+  {"cusparseCreateCsrgemm2Info",                        {CUDA_0,   CUDA_110, CUDA_120}}, // D: CUSPARSE_VERSION 11000, R: CUSPARSE_VERSION 12000
+  {"cusparseDestroyCsrgemm2Info",                       {CUDA_0,   CUDA_110, CUDA_120}}, // D: CUSPARSE_VERSION 11000, R: CUSPARSE_VERSION 12000
   {"cusparseCreateCsrsm2Info",                          {CUDA_92,  CUDA_113, CUDA_120}}, // D: CUSPARSE_VERSION 11600, R: CUSPARSE_VERSION 12000
   {"cusparseDestroyCsrsm2Info",                         {CUDA_92,  CUDA_113, CUDA_120}}, // D: CUSPARSE_VERSION 11600, R: CUSPARSE_VERSION 12000
   {"cusparseCreateHybMat",                              {CUDA_0,   CUDA_102, CUDA_110}},
-  {"cusparseCreatePruneInfo",                           {CUDA_90,  CUDA_122, CUDA_0  }}, // D: CUSPARSE_VERSION 12120
-  {"cusparseCreateSolveAnalysisInfo",                   {CUDA_0,   CUDA_102, CUDA_110}},
-  {"cusparseDestroyCsrgemm2Info",                       {CUDA_0,   CUDA_110, CUDA_120}},
   {"cusparseDestroyHybMat",                             {CUDA_0,   CUDA_102, CUDA_110}},
-  {"cusparseDestroyPruneInfo",                          {CUDA_90,  CUDA_122, CUDA_0  }}, // D: CUSPARSE_VERSION 12120
+  {"cusparseCreatePruneInfo",                           {CUDA_90,  CUDA_122, CUDA_0  }}, // D: CUSPARSE_VERSION 12102
+  {"cusparseDestroyPruneInfo",                          {CUDA_90,  CUDA_122, CUDA_0  }}, // D: CUSPARSE_VERSION 12102
+  {"cusparseCreateSolveAnalysisInfo",                   {CUDA_0,   CUDA_102, CUDA_110}},
   {"cusparseDestroySolveAnalysisInfo",                  {CUDA_0,   CUDA_102, CUDA_110}},
   {"cusparseGetLevelInfo",                              {CUDA_0,   CUDA_0,   CUDA_110}},
   {"cusparseSdoti",                                     {CUDA_0,   CUDA_102, CUDA_110}},
@@ -1228,8 +1228,8 @@ const std::map<llvm::StringRef, cudaAPIversions> CUDA_SPARSE_FUNCTION_VER_MAP {
   {"cusparseDenseToSparse_bufferSize",                  {CUDA_111, CUDA_0,   CUDA_0  }},
   {"cusparseDenseToSparse_analysis",                    {CUDA_111, CUDA_0,   CUDA_0  }},
   {"cusparseDenseToSparse_convert",                     {CUDA_111, CUDA_0,   CUDA_0  }},
-  {"cusparseCreateCsrsv2Info",                          {CUDA_0,   CUDA_113, CUDA_120}}, // D: CUSPARSE_VERSION 11500 R: CUSPARSE_VERSION 12120
-  {"cusparseDestroyCsrsv2Info",                         {CUDA_0,   CUDA_113, CUDA_120}}, // D: CUSPARSE_VERSION 11500 R: CUSPARSE_VERSION 12120
+  {"cusparseCreateCsrsv2Info",                          {CUDA_0,   CUDA_113, CUDA_120}}, // D: CUSPARSE_VERSION 11500 R: CUSPARSE_VERSION 12000
+  {"cusparseDestroyCsrsv2Info",                         {CUDA_0,   CUDA_113, CUDA_120}}, // D: CUSPARSE_VERSION 11500 R: CUSPARSE_VERSION 12000
   {"cusparseXcsrsv2_zeroPivot",                         {CUDA_0,   CUDA_113, CUDA_120}},
   {"cusparseScsrsv2_bufferSize",                        {CUDA_0,   CUDA_113, CUDA_120}},
   {"cusparseDcsrsv2_bufferSize",                        {CUDA_0,   CUDA_113, CUDA_120}},

--- a/tests/unit_tests/synthetic/libraries/cusparse2hipsparse.cu
+++ b/tests/unit_tests/synthetic/libraries/cusparse2hipsparse.cu
@@ -1595,6 +1595,16 @@ int main() {
   // HIP: HIPSPARSE_EXPORT hipsparseStatus_t hipsparseSgtsv2StridedBatch_bufferSizeExt(hipsparseHandle_t handle, int m, const float* dl, const float* d, const float* du, const float* x, int batchCount, int batchStride, size_t* pBufferSizeInBytes);
   // CHECK: status_t = hipsparseSgtsv2StridedBatch_bufferSizeExt(handle_t, m, &fdl, &fd, &fdu, &fx, batchCount, ibatchStride, &bufferSize);
   status_t = cusparseSgtsv2StridedBatch_bufferSizeExt(handle_t, m, &fdl, &fd, &fdu, &fx, batchCount, ibatchStride, &bufferSize);
+
+  // CUDA: CUSPARSE_DEPRECATED cusparseStatus_t CUSPARSEAPI cusparseCreatePruneInfo(pruneInfo_t* info);
+  // HIP: HIPSPARSE_EXPORT hipsparseStatus_t hipsparseCreatePruneInfo(pruneInfo_t* info);
+  // CHECK: status_t = hipsparseCreatePruneInfo(&prune_info);
+  status_t = cusparseCreatePruneInfo(&prune_info);
+
+  // CUDA: CUSPARSE_DEPRECATED cusparseStatus_t CUSPARSEAPI cusparseDestroyPruneInfo(pruneInfo_t info);
+  // HIP: HIPSPARSE_EXPORT hipsparseStatus_t hipsparseDestroyPruneInfo(pruneInfo_t info);
+  // CHECK: status_t = hipsparseDestroyPruneInfo(prune_info);
+  status_t = cusparseDestroyPruneInfo(prune_info);
 #endif
 
 #if CUDA_VERSION >= 9020
@@ -1902,6 +1912,16 @@ int main() {
   // HIP: DEPRECATED_CUDA_11000("The routine will be removed in CUDA 12") HIPSPARSE_EXPORT hipsparseStatus_t hipsparseDestroyCsrsv2Info(csrsv2Info_t info);
   // CHECK: status_t = hipsparseDestroyCsrsv2Info(csrsv2_info);
   status_t = cusparseDestroyCsrsv2Info(csrsv2_info);
+
+  // CUDA: CUSPARSE_DEPRECATED(cusparseSpGEMM) cusparseStatus_t CUSPARSEAPI cusparseCreateCsrgemm2Info(csrgemm2Info_t* info);
+  // HIP: DEPRECATED_CUDA_11000("The routine will be removed in CUDA 12") HIPSPARSE_EXPORT hipsparseStatus_t hipsparseCreateCsrgemm2Info(csrgemm2Info_t* info);
+  // CHECK: status_t = hipsparseCreateCsrgemm2Info(&csrgemm2_info);
+  status_t = cusparseCreateCsrgemm2Info(&csrgemm2_info);
+
+  // CUDA: CUSPARSE_DEPRECATED(cusparseSpGEMM) cusparseStatus_t CUSPARSEAPI cusparseDestroyCsrgemm2Info(csrgemm2Info_t info);
+  // HIP: DEPRECATED_CUDA_11000("The routine will be removed in CUDA 12") HIPSPARSE_EXPORT hipsparseStatus_t hipsparseDestroyCsrgemm2Info(csrgemm2Info_t info);
+  // CHECK: status_t = hipsparseDestroyCsrgemm2Info(csrgemm2_info);
+  status_t = cusparseDestroyCsrgemm2Info(csrgemm2_info);
 #endif
 
 #if (CUDA_VERSION >= 10020 && CUDA_VERSION < 11000 && !defined(_WIN32)) || CUDA_VERSION >= 11000

--- a/tests/unit_tests/synthetic/libraries/cusparse2rocsparse.cu
+++ b/tests/unit_tests/synthetic/libraries/cusparse2rocsparse.cu
@@ -1584,6 +1584,16 @@ int main() {
   // ROC: ROCSPARSE_EXPORT rocsparse_status rocsparse_sgtsv_no_pivot_strided_batch_buffer_size(rocsparse_handle handle, rocsparse_int m, const float* dl, const float* d, const float* du, const float* x, rocsparse_int batch_count, rocsparse_int batch_stride, size_t* buffer_size);
   // CHECK: status_t = rocsparse_sgtsv_no_pivot_strided_batch_buffer_size(handle_t, m, &fdl, &fd, &fdu, &fx, batchCount, ibatchStride, &bufferSize);
   status_t = cusparseSgtsv2StridedBatch_bufferSizeExt(handle_t, m, &fdl, &fd, &fdu, &fx, batchCount, ibatchStride, &bufferSize);
+
+  // CUDA: CUSPARSE_DEPRECATED cusparseStatus_t CUSPARSEAPI cusparseCreatePruneInfo(pruneInfo_t* info);
+  // ROC: ROCSPARSE_EXPORT rocsparse_status rocsparse_create_mat_info(rocsparse_mat_info* info);
+  // CHECK: status_t = rocsparse_create_mat_info(&prune_info);
+  status_t = cusparseCreatePruneInfo(&prune_info);
+
+  // CUDA: CUSPARSE_DEPRECATED cusparseStatus_t CUSPARSEAPI cusparseDestroyPruneInfo(pruneInfo_t info);
+  // ROC: ROCSPARSE_EXPORT rocsparse_status rocsparse_destroy_mat_info(rocsparse_mat_info info);
+  // CHECK: status_t = rocsparse_destroy_mat_info(prune_info);
+  status_t = cusparseDestroyPruneInfo(prune_info);
 #endif
 
 #if (CUDA_VERSION >= 10010 && CUDA_VERSION < 11000 && !defined(_WIN32)) || CUDA_VERSION >= 11000
@@ -2386,6 +2396,16 @@ int main() {
   // ROC: ROCSPARSE_EXPORT rocsparse_status rocsparse_destroy_mat_info(rocsparse_mat_info info);
   // CHECK: status_t = rocsparse_destroy_mat_info(csrsv2_info);
   status_t = cusparseDestroyCsrsv2Info(csrsv2_info);
+
+  // CUDA: CUSPARSE_DEPRECATED(cusparseSpGEMM) cusparseStatus_t CUSPARSEAPI cusparseCreateCsrgemm2Info(csrgemm2Info_t* info);
+  // ROC: ROCSPARSE_EXPORT rocsparse_status rocsparse_create_mat_info(rocsparse_mat_info* info);
+  // CHECK: status_t = rocsparse_create_mat_info(&csrgemm2_info);
+  status_t = cusparseCreateCsrgemm2Info(&csrgemm2_info);
+
+  // CUDA: CUSPARSE_DEPRECATED(cusparseSpGEMM) cusparseStatus_t CUSPARSEAPI cusparseDestroyCsrgemm2Info(csrgemm2Info_t info);
+  // ROC: ROCSPARSE_EXPORT rocsparse_status rocsparse_destroy_mat_info(rocsparse_mat_info info);
+  // CHECK: status_t = rocsparse_destroy_mat_info(csrgemm2_info);
+  status_t = cusparseDestroyCsrgemm2Info(csrgemm2_info);
 #endif
 
 #if CUDA_VERSION >= 12000


### PR DESCRIPTION
+ Added partial support for `rocsparse_create_mat_info` and `rocsparse_destroy_mat_info`
+ Updated `SPARSE` synthetic tests, the regenerated hipify-perl, and `SPARSE` `CUDA2HIP` documentation
