### PR TITLE
[HIPIFY][tests][fix] Fix the test `headers/headers_test_12_SOLVER.cu` failed on CUDA < 10010

### DIFF
--- a/tests/unit_tests/headers/headers_test_12_SOLVER.cu
+++ b/tests/unit_tests/headers/headers_test_12_SOLVER.cu
@@ -1,15 +1,12 @@
-// RUN: %run_test hipify "%s" "%t" %hipify_args %clang_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args 1 --skip-excluded-preprocessor-conditional-blocks %clang_args
 
-// Checks that HIP header file is included after include guard controlling macro,
-// which goes before #pragma once.
-// CHECK: #ifndef HEADERS_TEST_12_SOLVER_H
-// CHECK-NEXT: #include <hip/hip_runtime.h>
 #ifndef HEADERS_TEST_12_SOLVER_H
 // CHECK: #pragma once
 #pragma once
-// CHECK-NOT: #include <hip/hip_runtime.h>
 #define HEADERS_TEST_12_SOLVER_H
-#include <stdio.h>
+// CHECK: #include <hip/hip_runtime.h>
+// CHECK-NOT: #include <cuda_runtime.h>
+#include <cuda_runtime.h>
 static int counter = 0;
 
 // CHECK: #include "hipsolver.h"
@@ -17,13 +14,14 @@ static int counter = 0;
 // CHECK-NOT: #include "cusolver_common.h"
 // CHECK-NOT: #include "cusolverDn.h"
 // CHECK-NOT: #include "cusolverRf.h"
-// CHECK-NOT: #include "cusolverMg.h"
 // CHECK-NOT: #include "cusolverSp.h"
 // CHECK-NOT: #include "cusolverSp_LOWLEVEL_PREVIEW.h"
 #include "cusolver_common.h"
 #include "cusolverDn.h"
 #include "cusolverRf.h"
+#if CUDA_VERSION >= 10010
 #include "cusolverMg.h"
+#endif
 #include "cusolverSp.h"
 #include "cusolverSp_LOWLEVEL_PREVIEW.h"
 


### PR DESCRIPTION
[Reason] `cusolverMg.h` appeared in CUDA 10.1
