### PR TITLE
[HIPIFY][tests][fix] Split the test `headers/headers_test_12_SOLVER.cu`

### DIFF
--- a/tests/lit.cfg
+++ b/tests/lit.cfg
@@ -48,6 +48,7 @@ if config.cuda_version_major == 7 and config.cuda_version_minor == 0:
     config.excludes.append('headers_test_09.cu')
     config.excludes.append('cudnn_convolution_forward.cu')
     config.excludes.append('cusparse2rocsparse_7500.cu')
+    config.excludes.append('headers_test_12_SOLVER_7050.cu')
 
 if config.cuda_version_major < 8:
     config.excludes.append('cuSPARSE_02.cu')
@@ -75,6 +76,9 @@ if config.cuda_version_major < 10:
     config.excludes.append('cuSPARSE_11.cu')
     config.excludes.append('simple_mechs.cu')
     config.excludes.append('cusparse2rocsparse_10000.cu')
+
+if config.cuda_version_major <= 10:
+    config.excludes.append('headers_test_12_SOLVER_10010.cu')
 
 if config.cuda_version_major > 10:
     clang_arguments += " -DTHRUST_IGNORE_CUB_VERSION_CHECK"

--- a/tests/unit_tests/headers/headers_test_12_SOLVER_10010.cu
+++ b/tests/unit_tests/headers/headers_test_12_SOLVER_10010.cu
@@ -1,0 +1,30 @@
+// RUN: %run_test hipify "%s" "%t" %hipify_args %clang_args
+
+// Checks that HIP header file is included after include guard controlling macro,
+// which goes before #pragma once.
+// CHECK: #ifndef HEADERS_TEST_12_SOLVER_H
+// CHECK-NEXT: #include <hip/hip_runtime.h>
+#ifndef HEADERS_TEST_12_SOLVER_H
+// CHECK: #pragma once
+#pragma once
+// CHECK-NOT: #include <hip/hip_runtime.h>
+#define HEADERS_TEST_12_SOLVER_H
+#include <stdio.h>
+static int counter = 0;
+
+// CHECK: #include "hipsolver.h"
+// CHECK-NOT: #include "hipsolver.h"
+// CHECK-NOT: #include "cusolver_common.h"
+// CHECK-NOT: #include "cusolverDn.h"
+// CHECK-NOT: #include "cusolverRf.h"
+// CHECK-NOT: #include "cusolverMg.h"
+// CHECK-NOT: #include "cusolverSp.h"
+// CHECK-NOT: #include "cusolverSp_LOWLEVEL_PREVIEW.h"
+#include "cusolver_common.h"
+#include "cusolverDn.h"
+#include "cusolverRf.h"
+#include "cusolverMg.h"
+#include "cusolverSp.h"
+#include "cusolverSp_LOWLEVEL_PREVIEW.h"
+
+#endif // HEADERS_TEST_12_SOLVER_H

--- a/tests/unit_tests/headers/headers_test_12_SOLVER_7050.cu
+++ b/tests/unit_tests/headers/headers_test_12_SOLVER_7050.cu
@@ -15,8 +15,10 @@ static int counter = 0;
 // CHECK-NOT: #include "cusolverDn.h"
 // CHECK-NOT: #include "cusolverRf.h"
 // CHECK-NOT: #include "cusolverSp.h"
+// CHECK-NOT: #include "cusolverSp_LOWLEVEL_PREVIEW.h"
 #include "cusolver_common.h"
 #include "cusolverDn.h"
 #include "cusolverRf.h"
 #include "cusolverSp.h"
+#include "cusolverSp_LOWLEVEL_PREVIEW.h"
 #endif // HEADERS_TEST_12_SOLVER_H


### PR DESCRIPTION
[Reasons]
+ `cusolverMg.h` appeared in CUDA 10.1
+ `cusolverSp_LOWLEVEL_PREVIEW.h` appeared in CUDA 7.5
