### PR TITLE
[HIPIFY][#674][rocSPARSE][feature] rocSPARSE support - Step 96 - functions `rocsparse_(s|d|c|z)bsrilu0_buffer_size`

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -2264,6 +2264,7 @@ sub rocSubstitutions {
     subst("cusparseCbsric02_bufferSize", "rocsparse_cbsric0_buffer_size", "library");
     subst("cusparseCbsrilu02", "rocsparse_cbsrilu0", "library");
     subst("cusparseCbsrilu02_analysis", "rocsparse_cbsrilu0_analysis", "library");
+    subst("cusparseCbsrilu02_bufferSize", "rocsparse_cbsrilu0_buffer_size", "library");
     subst("cusparseCbsrilu02_numericBoost", "rocsparse_dcbsrilu0_numeric_boost", "library");
     subst("cusparseCbsrmm", "rocsparse_cbsrmm", "library");
     subst("cusparseCbsrmv", "rocsparse_cbsrmv", "library");
@@ -2390,6 +2391,7 @@ sub rocSubstitutions {
     subst("cusparseDbsric02_bufferSize", "rocsparse_dbsric0_buffer_size", "library");
     subst("cusparseDbsrilu02", "rocsparse_dbsrilu0", "library");
     subst("cusparseDbsrilu02_analysis", "rocsparse_dbsrilu0_analysis", "library");
+    subst("cusparseDbsrilu02_bufferSize", "rocsparse_dbsrilu0_buffer_size", "library");
     subst("cusparseDbsrilu02_numericBoost", "rocsparse_dbsrilu0_numeric_boost", "library");
     subst("cusparseDbsrmm", "rocsparse_dbsrmm", "library");
     subst("cusparseDbsrmv", "rocsparse_dbsrmv", "library");
@@ -2518,6 +2520,7 @@ sub rocSubstitutions {
     subst("cusparseSbsric02_bufferSize", "rocsparse_sbsric0_buffer_size", "library");
     subst("cusparseSbsrilu02", "rocsparse_sbsrilu0", "library");
     subst("cusparseSbsrilu02_analysis", "rocsparse_sbsrilu0_analysis", "library");
+    subst("cusparseSbsrilu02_bufferSize", "rocsparse_sbsrilu0_buffer_size", "library");
     subst("cusparseSbsrilu02_numericBoost", "rocsparse_dsbsrilu0_numeric_boost", "library");
     subst("cusparseSbsrmm", "rocsparse_sbsrmm", "library");
     subst("cusparseSbsrmv", "rocsparse_sbsrmv", "library");
@@ -2649,6 +2652,7 @@ sub rocSubstitutions {
     subst("cusparseZbsric02_bufferSize", "rocsparse_zbsric0_buffer_size", "library");
     subst("cusparseZbsrilu02", "rocsparse_zbsrilu0", "library");
     subst("cusparseZbsrilu02_analysis", "rocsparse_zbsrilu0_analysis", "library");
+    subst("cusparseZbsrilu02_bufferSize", "rocsparse_zbsrilu0_buffer_size", "library");
     subst("cusparseZbsrilu02_numericBoost", "rocsparse_zbsrilu0_numeric_boost", "library");
     subst("cusparseZbsrmm", "rocsparse_zbsrmm", "library");
     subst("cusparseZbsrmv", "rocsparse_zbsrmv", "library");

--- a/docs/tables/CUSPARSE_API_supported_by_HIP_and_ROC.md
+++ b/docs/tables/CUSPARSE_API_supported_by_HIP_and_ROC.md
@@ -477,7 +477,7 @@
 |`cusparseCbsric02_bufferSizeExt`| |12.2| | | | | | | | | | | | | | |
 |`cusparseCbsrilu02`| |12.2| | |`hipsparseCbsrilu02`|3.9.0| | | | |`rocsparse_cbsrilu0`|3.9.0| | | | |
 |`cusparseCbsrilu02_analysis`| |12.2| | |`hipsparseCbsrilu02_analysis`|3.9.0| | | | |`rocsparse_cbsrilu0_analysis`|3.6.0| | | | |
-|`cusparseCbsrilu02_bufferSize`| |12.2| | |`hipsparseCbsrilu02_bufferSize`|3.9.0| | | | | | | | | | |
+|`cusparseCbsrilu02_bufferSize`| |12.2| | |`hipsparseCbsrilu02_bufferSize`|3.9.0| | | | |`rocsparse_cbsrilu0_buffer_size`|3.8.0| | | | |
 |`cusparseCbsrilu02_bufferSizeExt`| |12.2| | | | | | | | | | | | | | |
 |`cusparseCbsrilu02_numericBoost`| |12.2| | |`hipsparseCbsrilu02_numericBoost`|3.9.0| | | | |`rocsparse_dcbsrilu0_numeric_boost`|4.5.0| | | | |
 |`cusparseCcsric0`| |10.2| |11.0| | | | | | | | | | | | |
@@ -511,7 +511,7 @@
 |`cusparseDbsric02_bufferSizeExt`| |12.2| | | | | | | | | | | | | | |
 |`cusparseDbsrilu02`| |12.2| | |`hipsparseDbsrilu02`|3.9.0| | | | |`rocsparse_dbsrilu0`|3.9.0| | | | |
 |`cusparseDbsrilu02_analysis`| |12.2| | |`hipsparseDbsrilu02_analysis`|3.9.0| | | | |`rocsparse_dbsrilu0_analysis`|3.6.0| | | | |
-|`cusparseDbsrilu02_bufferSize`| |12.2| | |`hipsparseDbsrilu02_bufferSize`|3.9.0| | | | | | | | | | |
+|`cusparseDbsrilu02_bufferSize`| |12.2| | |`hipsparseDbsrilu02_bufferSize`|3.9.0| | | | |`rocsparse_dbsrilu0_buffer_size`|3.8.0| | | | |
 |`cusparseDbsrilu02_bufferSizeExt`| |12.2| | | | | | | | | | | | | | |
 |`cusparseDbsrilu02_numericBoost`| |12.2| | |`hipsparseDbsrilu02_numericBoost`|3.9.0| | | | |`rocsparse_dbsrilu0_numeric_boost`|3.9.0| | | | |
 |`cusparseDcsric0`| |10.2| |11.0| | | | | | | | | | | | |
@@ -544,7 +544,7 @@
 |`cusparseSbsric02_bufferSizeExt`| |12.2| | | | | | | | | | | | | | |
 |`cusparseSbsrilu02`| |12.2| | |`hipsparseSbsrilu02`|3.9.0| | | | |`rocsparse_sbsrilu0`|3.9.0| | | | |
 |`cusparseSbsrilu02_analysis`| |12.2| | |`hipsparseSbsrilu02_analysis`|3.9.0| | | | |`rocsparse_sbsrilu0_analysis`|3.6.0| | | | |
-|`cusparseSbsrilu02_bufferSize`| |12.2| | |`hipsparseSbsrilu02_bufferSize`|3.9.0| | | | | | | | | | |
+|`cusparseSbsrilu02_bufferSize`| |12.2| | |`hipsparseSbsrilu02_bufferSize`|3.9.0| | | | |`rocsparse_sbsrilu0_buffer_size`|3.8.0| | | | |
 |`cusparseSbsrilu02_bufferSizeExt`| |12.2| | | | | | | | | | | | | | |
 |`cusparseSbsrilu02_numericBoost`| |12.2| | |`hipsparseSbsrilu02_numericBoost`|3.9.0| | | | |`rocsparse_dsbsrilu0_numeric_boost`|4.5.0| | | | |
 |`cusparseScsric0`| |10.2| |11.0| | | | | | | | | | | | |
@@ -581,7 +581,7 @@
 |`cusparseZbsric02_bufferSizeExt`| |12.2| | | | | | | | | | | | | | |
 |`cusparseZbsrilu02`| |12.2| | |`hipsparseZbsrilu02`|3.9.0| | | | |`rocsparse_zbsrilu0`|3.9.0| | | | |
 |`cusparseZbsrilu02_analysis`| |12.2| | |`hipsparseZbsrilu02_analysis`|3.9.0| | | | |`rocsparse_zbsrilu0_analysis`|3.6.0| | | | |
-|`cusparseZbsrilu02_bufferSize`| |12.2| | |`hipsparseZbsrilu02_bufferSize`|3.9.0| | | | | | | | | | |
+|`cusparseZbsrilu02_bufferSize`| |12.2| | |`hipsparseZbsrilu02_bufferSize`|3.9.0| | | | |`rocsparse_zbsrilu0_buffer_size`|3.8.0| | | | |
 |`cusparseZbsrilu02_bufferSizeExt`| |12.2| | | | | | | | | | | | | | |
 |`cusparseZbsrilu02_numericBoost`| |12.2| | |`hipsparseZbsrilu02_numericBoost`|3.9.0| | | | |`rocsparse_zbsrilu0_numeric_boost`|3.9.0| | | | |
 |`cusparseZcsric0`| |10.2| |11.0| | | | | | | | | | | | |

--- a/docs/tables/CUSPARSE_API_supported_by_ROC.md
+++ b/docs/tables/CUSPARSE_API_supported_by_ROC.md
@@ -477,7 +477,7 @@
 |`cusparseCbsric02_bufferSizeExt`| |12.2| | | | | | | | |
 |`cusparseCbsrilu02`| |12.2| | |`rocsparse_cbsrilu0`|3.9.0| | | | |
 |`cusparseCbsrilu02_analysis`| |12.2| | |`rocsparse_cbsrilu0_analysis`|3.6.0| | | | |
-|`cusparseCbsrilu02_bufferSize`| |12.2| | | | | | | | |
+|`cusparseCbsrilu02_bufferSize`| |12.2| | |`rocsparse_cbsrilu0_buffer_size`|3.8.0| | | | |
 |`cusparseCbsrilu02_bufferSizeExt`| |12.2| | | | | | | | |
 |`cusparseCbsrilu02_numericBoost`| |12.2| | |`rocsparse_dcbsrilu0_numeric_boost`|4.5.0| | | | |
 |`cusparseCcsric0`| |10.2| |11.0| | | | | | |
@@ -511,7 +511,7 @@
 |`cusparseDbsric02_bufferSizeExt`| |12.2| | | | | | | | |
 |`cusparseDbsrilu02`| |12.2| | |`rocsparse_dbsrilu0`|3.9.0| | | | |
 |`cusparseDbsrilu02_analysis`| |12.2| | |`rocsparse_dbsrilu0_analysis`|3.6.0| | | | |
-|`cusparseDbsrilu02_bufferSize`| |12.2| | | | | | | | |
+|`cusparseDbsrilu02_bufferSize`| |12.2| | |`rocsparse_dbsrilu0_buffer_size`|3.8.0| | | | |
 |`cusparseDbsrilu02_bufferSizeExt`| |12.2| | | | | | | | |
 |`cusparseDbsrilu02_numericBoost`| |12.2| | |`rocsparse_dbsrilu0_numeric_boost`|3.9.0| | | | |
 |`cusparseDcsric0`| |10.2| |11.0| | | | | | |
@@ -544,7 +544,7 @@
 |`cusparseSbsric02_bufferSizeExt`| |12.2| | | | | | | | |
 |`cusparseSbsrilu02`| |12.2| | |`rocsparse_sbsrilu0`|3.9.0| | | | |
 |`cusparseSbsrilu02_analysis`| |12.2| | |`rocsparse_sbsrilu0_analysis`|3.6.0| | | | |
-|`cusparseSbsrilu02_bufferSize`| |12.2| | | | | | | | |
+|`cusparseSbsrilu02_bufferSize`| |12.2| | |`rocsparse_sbsrilu0_buffer_size`|3.8.0| | | | |
 |`cusparseSbsrilu02_bufferSizeExt`| |12.2| | | | | | | | |
 |`cusparseSbsrilu02_numericBoost`| |12.2| | |`rocsparse_dsbsrilu0_numeric_boost`|4.5.0| | | | |
 |`cusparseScsric0`| |10.2| |11.0| | | | | | |
@@ -581,7 +581,7 @@
 |`cusparseZbsric02_bufferSizeExt`| |12.2| | | | | | | | |
 |`cusparseZbsrilu02`| |12.2| | |`rocsparse_zbsrilu0`|3.9.0| | | | |
 |`cusparseZbsrilu02_analysis`| |12.2| | |`rocsparse_zbsrilu0_analysis`|3.6.0| | | | |
-|`cusparseZbsrilu02_bufferSize`| |12.2| | | | | | | | |
+|`cusparseZbsrilu02_bufferSize`| |12.2| | |`rocsparse_zbsrilu0_buffer_size`|3.8.0| | | | |
 |`cusparseZbsrilu02_bufferSizeExt`| |12.2| | | | | | | | |
 |`cusparseZbsrilu02_numericBoost`| |12.2| | |`rocsparse_zbsrilu0_numeric_boost`|3.9.0| | | | |
 |`cusparseZcsric0`| |10.2| |11.0| | | | | | |

--- a/src/CUDA2HIP_SPARSE_API_functions.cpp
+++ b/src/CUDA2HIP_SPARSE_API_functions.cpp
@@ -413,13 +413,13 @@ const std::map<llvm::StringRef, hipCounter> CUDA_SPARSE_FUNCTION_MAP {
   {"cusparseZbsrilu02_numericBoost",                    {"hipsparseZbsrilu02_numericBoost",                    "rocsparse_zbsrilu0_numeric_boost",                                 CONV_LIB_FUNC, API_SPARSE, 12, CUDA_DEPRECATED}},
 
   // NOTE: rocsparse_(s|d|c|z)bsrilu0_buffer_size have an additional parameter void* temp_buffer
-  {"cusparseSbsrilu02_bufferSize",                      {"hipsparseSbsrilu02_bufferSize",                      "",                                                                 CONV_LIB_FUNC, API_SPARSE, 12, ROC_UNSUPPORTED | CUDA_DEPRECATED}},
+  {"cusparseSbsrilu02_bufferSize",                      {"hipsparseSbsrilu02_bufferSize",                      "rocsparse_sbsrilu0_buffer_size",                                   CONV_LIB_FUNC, API_SPARSE, 12, CUDA_DEPRECATED}},
   {"cusparseSbsrilu02_bufferSizeExt",                   {"hipsparseSbsrilu02_bufferSizeExt",                   "",                                                                 CONV_LIB_FUNC, API_SPARSE, 12, UNSUPPORTED | CUDA_DEPRECATED}},
-  {"cusparseDbsrilu02_bufferSize",                      {"hipsparseDbsrilu02_bufferSize",                      "",                                                                 CONV_LIB_FUNC, API_SPARSE, 12, ROC_UNSUPPORTED | CUDA_DEPRECATED}},
+  {"cusparseDbsrilu02_bufferSize",                      {"hipsparseDbsrilu02_bufferSize",                      "rocsparse_dbsrilu0_buffer_size",                                   CONV_LIB_FUNC, API_SPARSE, 12, CUDA_DEPRECATED}},
   {"cusparseDbsrilu02_bufferSizeExt",                   {"hipsparseDbsrilu02_bufferSizeExt",                   "",                                                                 CONV_LIB_FUNC, API_SPARSE, 12, UNSUPPORTED | CUDA_DEPRECATED}},
-  {"cusparseCbsrilu02_bufferSize",                      {"hipsparseCbsrilu02_bufferSize",                      "",                                                                 CONV_LIB_FUNC, API_SPARSE, 12, ROC_UNSUPPORTED | CUDA_DEPRECATED}},
+  {"cusparseCbsrilu02_bufferSize",                      {"hipsparseCbsrilu02_bufferSize",                      "rocsparse_cbsrilu0_buffer_size",                                   CONV_LIB_FUNC, API_SPARSE, 12, CUDA_DEPRECATED}},
   {"cusparseCbsrilu02_bufferSizeExt",                   {"hipsparseCbsrilu02_bufferSizeExt",                   "",                                                                 CONV_LIB_FUNC, API_SPARSE, 12, UNSUPPORTED | CUDA_DEPRECATED}},
-  {"cusparseZbsrilu02_bufferSize",                      {"hipsparseZbsrilu02_bufferSize",                      "",                                                                 CONV_LIB_FUNC, API_SPARSE, 12, ROC_UNSUPPORTED | CUDA_DEPRECATED}},
+  {"cusparseZbsrilu02_bufferSize",                      {"hipsparseZbsrilu02_bufferSize",                      "rocsparse_zbsrilu0_buffer_size",                                   CONV_LIB_FUNC, API_SPARSE, 12, CUDA_DEPRECATED}},
   {"cusparseZbsrilu02_bufferSizeExt",                   {"hipsparseZbsrilu02_bufferSizeExt",                   "",                                                                 CONV_LIB_FUNC, API_SPARSE, 12, UNSUPPORTED | CUDA_DEPRECATED}},
 
   {"cusparseSbsrilu02_analysis",                        {"hipsparseSbsrilu02_analysis",                        "rocsparse_sbsrilu0_analysis",                                      CONV_LIB_FUNC, API_SPARSE, 12, CUDA_DEPRECATED}},
@@ -1386,10 +1386,10 @@ const std::map<llvm::StringRef, cudaAPIversions> CUDA_SPARSE_FUNCTION_VER_MAP {
   {"cusparseCbsrilu02_numericBoost",                    {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
   {"cusparseZbsrilu02_numericBoost",                    {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
   {"cusparseXbsrilu02_zeroPivot",                       {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseSbsrilu02_bufferSize",                      {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseDbsrilu02_bufferSize",                      {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseCbsrilu02_bufferSize",                      {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseZbsrilu02_bufferSize",                      {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
+  {"cusparseSbsrilu02_bufferSize",                      {CUDA_0,   CUDA_122, CUDA_0  }}, // D: CUSPARSE_VERSION 12102
+  {"cusparseDbsrilu02_bufferSize",                      {CUDA_0,   CUDA_122, CUDA_0  }}, // D: CUSPARSE_VERSION 12102
+  {"cusparseCbsrilu02_bufferSize",                      {CUDA_0,   CUDA_122, CUDA_0  }}, // D: CUSPARSE_VERSION 12102
+  {"cusparseZbsrilu02_bufferSize",                      {CUDA_0,   CUDA_122, CUDA_0  }}, // D: CUSPARSE_VERSION 12102
   {"cusparseSbsrilu02_bufferSizeExt",                   {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
   {"cusparseDbsrilu02_bufferSizeExt",                   {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
   {"cusparseCbsrilu02_bufferSizeExt",                   {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
@@ -2419,6 +2419,10 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_SPARSE_FUNCTION_VER_MAP {
   {"rocsparse_dcsrgemm",                                 {HIP_2080, HIP_0,    HIP_0   }},
   {"rocsparse_ccsrgemm",                                 {HIP_2080, HIP_0,    HIP_0   }},
   {"rocsparse_zcsrgemm",                                 {HIP_2080, HIP_0,    HIP_0   }},
+  {"rocsparse_sbsrilu0_buffer_size",                     {HIP_3080, HIP_0,    HIP_0   }},
+  {"rocsparse_dbsrilu0_buffer_size",                     {HIP_3080, HIP_0,    HIP_0   }},
+  {"rocsparse_cbsrilu0_buffer_size",                     {HIP_3080, HIP_0,    HIP_0   }},
+  {"rocsparse_zbsrilu0_buffer_size",                     {HIP_3080, HIP_0,    HIP_0   }},
 };
 
 const std::map<llvm::StringRef, cudaAPIChangedVersions> CUDA_SPARSE_FUNCTION_CHANGED_VER_MAP {

--- a/src/HipifyAction.cpp
+++ b/src/HipifyAction.cpp
@@ -199,6 +199,10 @@ const std::string sCusparseZcsrilu02_bufferSize = "cusparseZcsrilu02_bufferSize"
 const std::string sCusparseCcsrilu02_bufferSize = "cusparseCcsrilu02_bufferSize";
 const std::string sCusparseDcsrilu02_bufferSize = "cusparseDcsrilu02_bufferSize";
 const std::string sCusparseScsrilu02_bufferSize = "cusparseScsrilu02_bufferSize";
+const std::string sCusparseZbsrilu02_bufferSize = "cusparseZbsrilu02_bufferSize";
+const std::string sCusparseCbsrilu02_bufferSize = "cusparseCbsrilu02_bufferSize";
+const std::string sCusparseDbsrilu02_bufferSize = "cusparseDbsrilu02_bufferSize";
+const std::string sCusparseSbsrilu02_bufferSize = "cusparseSbsrilu02_bufferSize";
 
 // CUDA_OVERLOADED
 const std::string sCudaEventCreate = "cudaEventCreate";
@@ -1575,6 +1579,42 @@ std::map<std::string, ArgCastStruct> FuncArgCasts {
       false
     }
   },
+  {sCusparseZbsrilu02_bufferSize,
+    {
+      {
+        {10, {e_reinterpret_cast_size_t, cw_None}}
+      },
+      true,
+      false
+    }
+  },
+  {sCusparseCbsrilu02_bufferSize,
+    {
+      {
+        {10, {e_reinterpret_cast_size_t, cw_None}}
+      },
+      true,
+      false
+    }
+  },
+  {sCusparseDbsrilu02_bufferSize,
+    {
+      {
+        {10, {e_reinterpret_cast_size_t, cw_None}}
+      },
+      true,
+      false
+    }
+  },
+  {sCusparseSbsrilu02_bufferSize,
+    {
+      {
+        {10, {e_reinterpret_cast_size_t, cw_None}}
+      },
+      true,
+      false
+    }
+  },
 };
 
 void HipifyAction::RewriteString(StringRef s, clang::SourceLocation start) {
@@ -2414,7 +2454,11 @@ std::unique_ptr<clang::ASTConsumer> HipifyAction::CreateASTConsumer(clang::Compi
             sCusparseZcsrilu02_bufferSize,
             sCusparseCcsrilu02_bufferSize,
             sCusparseDcsrilu02_bufferSize,
-            sCusparseScsrilu02_bufferSize
+            sCusparseScsrilu02_bufferSize,
+            sCusparseZbsrilu02_bufferSize,
+            sCusparseCbsrilu02_bufferSize,
+            sCusparseDbsrilu02_bufferSize,
+            sCusparseSbsrilu02_bufferSize
           )
         )
       )

--- a/tests/unit_tests/synthetic/libraries/cusparse2hipsparse.cu
+++ b/tests/unit_tests/synthetic/libraries/cusparse2hipsparse.cu
@@ -1234,6 +1234,26 @@ int main() {
   // CHECK: status_t = hipsparseSbsrmv(handle_t, direction_t, opA, mb, nb, nnzb, &fAlpha, matDescr_t, &fbsrSortedValA, &bsrSortedMaskPtrA, &bsrRowPtrA, blockDim, &fX, &fBeta, &fY);
   status_t = cusparseSbsrmv(handle_t, direction_t, opA, mb, nb, nnzb, &fAlpha, matDescr_t, &fbsrSortedValA, &bsrSortedMaskPtrA, &bsrRowPtrA, blockDim, &fX, &fBeta, &fY);
 
+  // CUDA: CUSPARSE_DEPRECATED cusparseStatus_t CUSPARSEAPI cusparseZbsrilu02_bufferSize(cusparseHandle_t handle, cusparseDirection_t dirA, int mb, int nnzb, const cusparseMatDescr_t descrA, cuDoubleComplex* bsrSortedVal, const int* bsrSortedRowPtr, const int* bsrSortedColInd, int blockDim, bsrilu02Info_t info, int* pBufferSizeInBytes);
+  // HIP: HIPSPARSE_EXPORT hipsparseStatus_t hipsparseZbsrilu02_bufferSize(hipsparseHandle_t handle, hipsparseDirection_t dirA, int mb, int nnzb, const hipsparseMatDescr_t descrA, hipDoubleComplex* bsrSortedValA, const int* bsrSortedRowPtrA, const int* bsrSortedColIndA, int blockDim, bsrilu02Info_t info, int* pBufferSizeInBytes);
+  // CHECK: status_t = hipsparseZbsrilu02_bufferSize(handle_t, direction_t, mb, nnzb, matDescr_A, &dComplexbsrSortedVal, &bsrSortedRowPtr, &bsrSortedColInd, blockDim, bsrilu02_info, &bufferSizeInBytes);
+  status_t = cusparseZbsrilu02_bufferSize(handle_t, direction_t, mb, nnzb, matDescr_A, &dComplexbsrSortedVal, &bsrSortedRowPtr, &bsrSortedColInd, blockDim, bsrilu02_info, &bufferSizeInBytes);
+
+  // CUDA: CUSPARSE_DEPRECATED cusparseStatus_t CUSPARSEAPI cusparseCbsrilu02_bufferSize(cusparseHandle_t handle, cusparseDirection_t dirA, int mb, int nnzb, const cusparseMatDescr_t descrA, cuComplex* bsrSortedVal, const int* bsrSortedRowPtr, const int* bsrSortedColInd, int blockDim, bsrilu02Info_t info, int* pBufferSizeInBytes);
+  // HIP: HIPSPARSE_EXPORT hipsparseStatus_t hipsparseCbsrilu02_bufferSize(hipsparseHandle_t handle, hipsparseDirection_t dirA, int mb, int nnzb, const hipsparseMatDescr_t descrA, hipComplex* bsrSortedValA, const int* bsrSortedRowPtrA, const int* bsrSortedColIndA, int blockDim, bsrilu02Info_t info, int* pBufferSizeInBytes);
+  // CHECK: status_t = hipsparseCbsrilu02_bufferSize(handle_t, direction_t, mb, nnzb, matDescr_A, &complexbsrValA, &bsrSortedRowPtr, &bsrSortedColInd, blockDim, bsrilu02_info, &bufferSizeInBytes);
+  status_t = cusparseCbsrilu02_bufferSize(handle_t, direction_t, mb, nnzb, matDescr_A, &complexbsrValA, &bsrSortedRowPtr, &bsrSortedColInd, blockDim, bsrilu02_info, &bufferSizeInBytes);
+
+  // CUDA: CUSPARSE_DEPRECATED ccusparseStatus_t CUSPARSEAPI cusparseDbsrilu02_bufferSize(cusparseHandle_t handle, cusparseDirection_t dirA, int mb, int nnzb, const cusparseMatDescr_t descrA, double* bsrSortedVal, const int* bsrSortedRowPtr, const int* bsrSortedColInd, int blockDim, bsrilu02Info_t info, int* pBufferSizeInBytes);
+  // HIP: HIPSPARSE_EXPORT hipsparseStatus_t hipsparseDbsrilu02_bufferSize(hipsparseHandle_t handle, hipsparseDirection_t dirA, int mb, int nnzb, const hipsparseMatDescr_t descrA, double* bsrSortedValA, const int* bsrSortedRowPtrA, const int* bsrSortedColIndA, int blockDim, bsrilu02Info_t info, int* pBufferSizeInBytes);
+  // CHECK: status_t = hipsparseDbsrilu02_bufferSize(handle_t, direction_t, mb, nnzb, matDescr_A, &dbsrSortedValA, &bsrSortedRowPtr, &bsrSortedColInd, blockDim, bsrilu02_info, &bufferSizeInBytes);
+  status_t = cusparseDbsrilu02_bufferSize(handle_t, direction_t, mb, nnzb, matDescr_A, &dbsrSortedValA, &bsrSortedRowPtr, &bsrSortedColInd, blockDim, bsrilu02_info, &bufferSizeInBytes);
+
+  // CUDA: CUSPARSE_DEPRECATED cusparseStatus_t CUSPARSEAPI cusparseSbsrilu02_bufferSize(cusparseHandle_t handle, cusparseDirection_t dirA, int mb, int nnzb, const cusparseMatDescr_t descrA, float* bsrSortedVal, const int* bsrSortedRowPtr, const int* bsrSortedColInd, int blockDim, bsrilu02Info_t info, int* pBufferSizeInBytes);
+  // HIP: HIPSPARSE_EXPORT hipsparseStatus_t hipsparseSbsrilu02_bufferSize(hipsparseHandle_t handle, hipsparseDirection_t dirA, int mb, int nnzb, const hipsparseMatDescr_t descrA, float* bsrSortedValA, const int* bsrSortedRowPtrA, const int* bsrSortedColIndA, int blockDim, bsrilu02Info_t info, int* pBufferSizeInBytes);
+  // CHECK: status_t = hipsparseSbsrilu02_bufferSize(handle_t, direction_t, mb, nnzb, matDescr_A, &fbsrSortedValA, &bsrSortedRowPtr, &bsrSortedColInd, blockDim, bsrilu02_info, &bufferSizeInBytes);
+  status_t = cusparseSbsrilu02_bufferSize(handle_t, direction_t, mb, nnzb, matDescr_A, &fbsrSortedValA, &bsrSortedRowPtr, &bsrSortedColInd, blockDim, bsrilu02_info, &bufferSizeInBytes);
+
   // CUDA: CUSPARSE_DEPRECATED cusparseStatus_t CUSPARSEAPI cusparseCreateCsric02Info(csric02Info_t* info);
   // HIP: HIPSPARSE_EXPORT hipsparseStatus_t hipsparseCreateCsric02Info(csric02Info_t* info);
   // CHECK: status_t = hipsparseCreateCsric02Info(&csric02_info);

--- a/tests/unit_tests/synthetic/libraries/cusparse2rocsparse.cu
+++ b/tests/unit_tests/synthetic/libraries/cusparse2rocsparse.cu
@@ -1241,6 +1241,26 @@ int main() {
   // CHECK: status_t = rocsparse_sbsrmv(handle_t, direction_t, opA, mb, nb, nnzb, &fAlpha, matDescr_t, &fbsrSortedValA, &bsrSortedMaskPtrA, &bsrRowPtrA, blockDim, &fX, &fBeta, &fY);
   status_t = cusparseSbsrmv(handle_t, direction_t, opA, mb, nb, nnzb, &fAlpha, matDescr_t, &fbsrSortedValA, &bsrSortedMaskPtrA, &bsrRowPtrA, blockDim, &fX, &fBeta, &fY);
 
+  // CUDA: CUSPARSE_DEPRECATED cusparseStatus_t CUSPARSEAPI cusparseZbsrilu02_bufferSize(cusparseHandle_t handle, cusparseDirection_t dirA, int mb, int nnzb, const cusparseMatDescr_t descrA, cuDoubleComplex* bsrSortedVal, const int* bsrSortedRowPtr, const int* bsrSortedColInd, int blockDim, bsrilu02Info_t info, int* pBufferSizeInBytes);
+  // ROC: ROCSPARSE_EXPORT rocsparse_status rocsparse_zbsrilu0_buffer_size(rocsparse_handle handle, rocsparse_direction dir, rocsparse_int mb, rocsparse_int nnzb, const rocsparse_mat_descr descr, const rocsparse_double_complex* bsr_val, const rocsparse_int* bsr_row_ptr, const rocsparse_int* bsr_col_ind, rocsparse_int block_dim, rocsparse_mat_info info, size_t* buffer_size);
+  // CHECK: status_t = rocsparse_zbsrilu0_buffer_size(handle_t, direction_t, mb, nnzb, matDescr_A, &dComplexbsrSortedVal, &bsrSortedRowPtr, &bsrSortedColInd, blockDim, bsrilu02_info, reinterpret_cast<size_t*>(&bufferSizeInBytes));
+  status_t = cusparseZbsrilu02_bufferSize(handle_t, direction_t, mb, nnzb, matDescr_A, &dComplexbsrSortedVal, &bsrSortedRowPtr, &bsrSortedColInd, blockDim, bsrilu02_info, &bufferSizeInBytes);
+
+  // CUDA: CUSPARSE_DEPRECATED cusparseStatus_t CUSPARSEAPI cusparseCbsrilu02_bufferSize(cusparseHandle_t handle, cusparseDirection_t dirA, int mb, int nnzb, const cusparseMatDescr_t descrA, cuComplex* bsrSortedVal, const int* bsrSortedRowPtr, const int* bsrSortedColInd, int blockDim, bsrilu02Info_t info, int* pBufferSizeInBytes);
+  // ROC: ROCSPARSE_EXPORT rocsparse_status rocsparse_cbsrilu0_buffer_size(rocsparse_handle handle, rocsparse_direction dir, rocsparse_int mb, rocsparse_int nnzb, const rocsparse_mat_descr descr, const rocsparse_float_complex* bsr_val, const rocsparse_int* bsr_row_ptr, const rocsparse_int* bsr_col_ind, rocsparse_int block_dim, rocsparse_mat_info info, size_t* buffer_size);
+  // CHECK: status_t = rocsparse_cbsrilu0_buffer_size(handle_t, direction_t, mb, nnzb, matDescr_A, &complexbsrValA, &bsrSortedRowPtr, &bsrSortedColInd, blockDim, bsrilu02_info, reinterpret_cast<size_t*>(&bufferSizeInBytes));
+  status_t = cusparseCbsrilu02_bufferSize(handle_t, direction_t, mb, nnzb, matDescr_A, &complexbsrValA, &bsrSortedRowPtr, &bsrSortedColInd, blockDim, bsrilu02_info, &bufferSizeInBytes);
+
+  // CUDA: CUSPARSE_DEPRECATED ccusparseStatus_t CUSPARSEAPI cusparseDbsrilu02_bufferSize(cusparseHandle_t handle, cusparseDirection_t dirA, int mb, int nnzb, const cusparseMatDescr_t descrA, double* bsrSortedVal, const int* bsrSortedRowPtr, const int* bsrSortedColInd, int blockDim, bsrilu02Info_t info, int* pBufferSizeInBytes);
+  // ROC: ROCSPARSE_EXPORT rocsparse_status rocsparse_dbsrilu0_buffer_size(rocsparse_handle handle, rocsparse_direction dir, rocsparse_int mb, rocsparse_int nnzb, const rocsparse_mat_descr descr, const double* bsr_val, const rocsparse_int* bsr_row_ptr, const rocsparse_int* bsr_col_ind, rocsparse_int block_dim, rocsparse_mat_info info, size_t* buffer_size);
+  // CHECK: status_t = rocsparse_dbsrilu0_buffer_size(handle_t, direction_t, mb, nnzb, matDescr_A, &dbsrSortedValA, &bsrSortedRowPtr, &bsrSortedColInd, blockDim, bsrilu02_info, reinterpret_cast<size_t*>(&bufferSizeInBytes));
+  status_t = cusparseDbsrilu02_bufferSize(handle_t, direction_t, mb, nnzb, matDescr_A, &dbsrSortedValA, &bsrSortedRowPtr, &bsrSortedColInd, blockDim, bsrilu02_info, &bufferSizeInBytes);
+
+  // CUDA: CUSPARSE_DEPRECATED cusparseStatus_t CUSPARSEAPI cusparseSbsrilu02_bufferSize(cusparseHandle_t handle, cusparseDirection_t dirA, int mb, int nnzb, const cusparseMatDescr_t descrA, float* bsrSortedVal, const int* bsrSortedRowPtr, const int* bsrSortedColInd, int blockDim, bsrilu02Info_t info, int* pBufferSizeInBytes);
+  // ROC: ROCSPARSE_EXPORT rocsparse_status rocsparse_sbsrilu0_buffer_size(rocsparse_handle handle, rocsparse_direction dir, rocsparse_int mb, rocsparse_int nnzb, const rocsparse_mat_descr descr, const float* bsr_val, const rocsparse_int* bsr_row_ptr, const rocsparse_int* bsr_col_ind, rocsparse_int block_dim, rocsparse_mat_info info, size_t* buffer_size);
+  // CHECK: status_t = rocsparse_sbsrilu0_buffer_size(handle_t, direction_t, mb, nnzb, matDescr_A, &fbsrSortedValA, &bsrSortedRowPtr, &bsrSortedColInd, blockDim, bsrilu02_info, reinterpret_cast<size_t*>(&bufferSizeInBytes));
+  status_t = cusparseSbsrilu02_bufferSize(handle_t, direction_t, mb, nnzb, matDescr_A, &fbsrSortedValA, &bsrSortedRowPtr, &bsrSortedColInd, blockDim, bsrilu02_info, &bufferSizeInBytes);
+
   // CUDA: CUSPARSE_DEPRECATED cusparseStatus_t CUSPARSEAPI cusparseCreateCsric02Info(csric02Info_t* info);
   // ROC: ROCSPARSE_EXPORT rocsparse_status rocsparse_create_mat_info(rocsparse_mat_info* info);
   // CHECK: status_t = rocsparse_create_mat_info(&csric02_info);


### PR DESCRIPTION
+ Updated `SPARSE` synthetic tests, the regenerated hipify-perl, and `SPARSE` `CUDA2HIP` documentation
