### PR TITLE
[HIPIFY][tests][rocSOLVER][fix] Exclude `cusparse2rocsparse_10010_12000.cu` for CUDA < 11000 on Windows

### DIFF
--- a/tests/lit.cfg
+++ b/tests/lit.cfg
@@ -83,6 +83,9 @@ if config.cuda_version_major < 10 or (config.cuda_version_major == 10 and config
 if config.cuda_version_major < 10 or (config.cuda_version_major == 10 and config.cuda_version_minor < 1) or config.cuda_version_major >= 12:
     config.excludes.append('cusparse2rocsparse_10010_12000.cu')
 
+if config.cuda_version_major < 11 and sys.platform in ['win32']:
+    config.excludes.append('cusparse2rocsparse_10010_12000.cu')
+
 if config.cuda_version_major < 11 or (config.cuda_version_major == 11 and config.cuda_version_minor < 1) or config.cuda_version_major >= 12:
     config.excludes.append('cusparse2rocsparse_11010_12000.cu')
 


### PR DESCRIPTION
[Reason] APIs in the test were not supported on Windows until CUDA 11.0
