### PR TITLE
[HIPIFY][tests][fix] Exclude `cusparse2rocsparse_11010_12000.cu` from running against CUDA 11.1.x

### DIFF
--- a/tests/lit.cfg
+++ b/tests/lit.cfg
@@ -86,7 +86,9 @@ if config.cuda_version_major < 10 or (config.cuda_version_major == 10 and config
 if config.cuda_version_major < 11 and sys.platform in ['win32']:
     config.excludes.append('cusparse2rocsparse_10010_12000.cu')
 
-if config.cuda_version_major < 11 or (config.cuda_version_major == 11 and config.cuda_version_minor < 1) or config.cuda_version_major >= 12:
+# [NOTE] cmake doesn't load lib VERSIONs, including CUSPARSE_VERSION, which equals 11200 for CUDA 11.1.0 and 11300 for CUDA 11.1.1
+# [NOTE] Both CUDA 11.1.0 CUDA 11.1.1 have the same CUDA_VERSION 11010, and we can't distinguish them, thus exclude the below tests from both 11.1.0 and 11.1.1
+if config.cuda_version_major < 11 or (config.cuda_version_major == 11 and config.cuda_version_minor <= 1) or config.cuda_version_major >= 12:
     config.excludes.append('cusparse2rocsparse_11010_12000.cu')
 
 if config.cuda_version_major <= 10:


### PR DESCRIPTION
**[Reason]**
cmake doesn't load lib VERSIONs, including CUSPARSE_VERSION, which equals 11200 for CUDA 11.1.0 and 11300 for CUDA 11.1.1. Both CUDA 11.1.0 CUDA 11.1.1 have the same CUDA_VERSION 11010, and we can't distinguish them, thus exclude the `cusparse2rocsparse_11010_12000.cu` tests from both 11.1.0 and 11.1.1.
