### PR TITLE
[HIPIFY][SWDEV-440338][fix] Do not rewrite tokens in code blocks skipped by Preprocessor

### DIFF
--- a/src/ArgParse.cpp
+++ b/src/ArgParse.cpp
@@ -149,6 +149,11 @@ cl::opt<bool> DefaultPreprocessor("default-preprocessor",
   cl::value_desc("default-preprocessor"),
   cl::cat(ToolTemplateCategory));
 
+cl::opt<bool> HipifyAMAP("amap",
+  cl::desc("Try to hipify as much as possible; ignores 'default-preprocessor'"),
+  cl::value_desc("amap"),
+  cl::cat(ToolTemplateCategory));
+
 cl::opt<std::string> CudaGpuArch("cuda-gpu-arch",
   cl::desc("CUDA GPU architecture (e.g. sm_35); may be specified more than once"),
   cl::value_desc("value"),

--- a/src/ArgParse.h
+++ b/src/ArgParse.h
@@ -68,3 +68,4 @@ extern cl::opt<bool> Versions;
 extern cl::opt<bool> NoUndocumented;
 extern cl::opt<bool> NoWarningsUndocumented;
 extern cl::opt<bool> UseHipDataType;
+extern cl::opt<bool> HipifyAMAP;

--- a/src/HipifyAction.h
+++ b/src/HipifyAction.h
@@ -42,6 +42,7 @@ class HipifyAction : public clang::ASTFrontendAction,
 private:
   ct::Replacements *replacements;
   std::map<std::string, clang::SourceLocation> Ifndefs;
+  std::vector<clang::SourceRange> SkippedSourceRanges;
   std::unique_ptr<mat::MatchFinder> Finder;
   // CUDA implicitly adds its runtime header. We rewrite explicitly-provided CUDA includes with equivalent
   // ones, and track - using this flag - if the result led to us including the hip runtime header. If it did
@@ -98,6 +99,8 @@ public:
   // Called by the preprocessor for each ifndef directive during the non-raw lexing pass.
   // Found ifndef will be used in EndSourceFileAction() for catching include guard controlling macro.
   void Ifndef(clang::SourceLocation Loc, const clang::Token &MacroNameTok, const clang::MacroDefinition &MD);
+  //
+  void AddSkippedSourceRange(clang::SourceRange Range);
 
 protected:
   // Add a Replacement for the current file. These will all be applied after executing the FrontendAction.


### PR DESCRIPTION
+ [IMP] This affects hipification with the default Preprocessor behavior switched on (`--default-preprocessor` or `--skip-excluded-preprocessor-conditional-blocks`)
+ [IMP] The default hipification, when nothing is skipped by Preprocessor, is unaffected
+ Introduced the option `--amap` to hipify as much as possible ignoring 'default-preprocessor' behavior - to be used in the existing testing, first
+ [IMP] The testing is broken - will be fixed in the upcoming commits
