### PR TITLE
[HIPIFY][#968][tests][fix] Take into account an `OFF` value of CUDA-related path variables

### DIFF
--- a/tests/lit.cfg
+++ b/tests/lit.cfg
@@ -221,19 +221,19 @@ elif config.cuda_version_major == 11:
         clang_arguments += " --cuda-gpu-arch=sm_86"
 
 # cuDNN ROOT
-if config.cuda_dnn_root:
+if config.cuda_dnn_root and config.cuda_dnn_root != "OFF":
     clang_arguments += " -I'%s'/include"
 # CUB ROOT
-if config.cuda_cub_root:
+if config.cuda_cub_root and config.cuda_cub_root != "OFF":
     clang_arguments += " -I'%s'"
 
-if config.cuda_dnn_root and config.cuda_cub_root:
+if config.cuda_sdk_root and config.cuda_sdk_root != "OFF" and config.cuda_dnn_root and config.cuda_dnn_root != "OFF" and config.cuda_cub_root and config.cuda_cub_root != "OFF":
     config.substitutions.append(("%clang_args", clang_arguments % (config.cuda_sdk_root, config.cuda_dnn_root, config.cuda_cub_root)))
-elif config.cuda_dnn_root:
+elif config.cuda_sdk_root and config.cuda_sdk_root != "OFF" and config.cuda_dnn_root and config.cuda_dnn_root != "OFF":
     config.substitutions.append(("%clang_args", clang_arguments % (config.cuda_sdk_root, config.cuda_dnn_root)))
-elif config.cuda_cub_root:
+elif config.cuda_sdk_root and config.cuda_sdk_root != "OFF" and config.cuda_cub_root and config.cuda_cub_root != "OFF":
     config.substitutions.append(("%clang_args", clang_arguments % (config.cuda_sdk_root, config.cuda_cub_root)))
-else:
+elif config.cuda_sdk_root and config.cuda_sdk_root != "OFF":
     config.substitutions.append(("%clang_args", clang_arguments % config.cuda_sdk_root))
 
 if config.llvm_version_major < 4:
@@ -241,6 +241,7 @@ if config.llvm_version_major < 4:
 else:
     hipify_arguments = "\"--cuda-path=%s\""
 
-config.substitutions.append(("%hipify_args", hipify_arguments % config.cuda_root))
+if config.cuda_root and config.cuda_root != "OFF":
+    config.substitutions.append(("%hipify_args", hipify_arguments % config.cuda_root))
 config.substitutions.append(("hipify", '"' + hipify_path + "/hipify-clang" + '"'))
 config.substitutions.append(("%run_test", '"' + config.test_source_root + "/run_test" + run_test_ext + '"'))


### PR DESCRIPTION
**[Reasons]**
+ In cases when `CUDA_DNN_ROOT_DIR` or `CUDA_CUB_ROOT_DIR` are set to `OFF` by cmake, `-IOFF` are appeared on hipify-clang's command line
+ In cases when `CUDA_TOOLKIT_ROOT_DIR` or `CUDA_SDK_ROOT_DIR` are set to `OFF` by cmake, `--cuda-path=OFF` and `-isystemOFF/samples/common` are appeared on hipify-clang's command line