### PR TITLE
[HIPIFY][tests][fix][win] Fix incorrect treating of hipify args by the `run_test.bat` script

### DIFF
--- a/tests/run_test.bat
+++ b/tests/run_test.bat
@@ -13,23 +13,30 @@ set all_args=%*
 
 if %NUM% EQU 1 (
   set HIPIFY_OPTS=%6
-  set NUM=%7
+  set clang_args=%%all_args:*%6=%%
 )
 if %NUM% EQU 2 (
   set HIPIFY_OPTS=%6 %7
-  set NUM=%8
+  set clang_args=%%all_args:*%7=%%
 )
 if %NUM% EQU 3 (
   set HIPIFY_OPTS=%6 %7 %8
-  set NUM=%9
+  shift
+  call set clang_args=%%all_args:*%8=%%
 )
 if %NUM% EQU 4 (
   set HIPIFY_OPTS=%6 %7 %8 %9
-  set NUM=%10
+  shift
+  call set clang_args=%%all_args:*%9=%%
 )
-
-call set clang_args=%%all_args:*%NUM%=%%
-set clang_args=%NUM%%clang_args%
+if %NUM% EQU 5 (
+  shift
+  call set HIPIFY_OPTS=%%5 %%6 %%7 %%8 %%9
+)
+if %NUM% EQU 5 (
+  shift
+  call set clang_args=%%all_args:*%9=%%
+)
 
 set test_dir=%~dp2
 set "test_dir=%test_dir:\=/%"


### PR DESCRIPTION
+ [fix] There is no `%10` in batch
+ Add support for 5 hipify arguments
+ [IMP] In a conditional block, a `call` is needed after a single `shift` to correctly read command line arguments, because a conditional block is parsed at once
+ [IMP] Multiple shifts in a single conditional block need splitting into N conditional blocks, if N args readings are needed after each shift
+ [TODO][Linux] Revise and do similar things in `run_test.sh`