### PR TITLE
[HIPIFY][fix] Fix for the warning `-Winconsistent-missing-override`

### DIFF
--- a/src/HipifyAction.cpp
+++ b/src/HipifyAction.cpp
@@ -2712,7 +2712,7 @@ public:
     hipifyAction.Ifndef(Loc, MacroNameTok, MD);
   }
 
-  virtual void SourceRangeSkipped(clang::SourceRange Range, clang::SourceLocation EndifLoc) {
+  void SourceRangeSkipped(clang::SourceRange Range, clang::SourceLocation EndifLoc) override {
     hipifyAction.AddSkippedSourceRange(Range);
   }
 };


### PR DESCRIPTION
+ Fix for the warning: 'SourceRangeSkipped' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
