### PR TITLE
[HIPIFY][doc] Ubuntu 23.10 is supported

### DIFF
--- a/docs/hipify-clang.md
+++ b/docs/hipify-clang.md
@@ -184,7 +184,7 @@ After applying all the matchers, the output HIP source is produced.
       <td colspan=2 bgcolor="eefaeb"><font color="green"><b>LATEST STABLE CONFIG</b></font></td>
     </tr>
     <tr align="center">
-      <td><a href="https://github.com/llvm/llvm-project">18.0.0git</a></td>
+      <td><a href="https://github.com/llvm/llvm-project">19.0.0git</a></td>
       <td><a href="https://developer.nvidia.com/cuda-downloads">12.3.2</a></td>
       <td>+</td>
       <td>+</td>
@@ -414,21 +414,21 @@ On Linux the following configurations are tested:
 
 Ubuntu 14: LLVM 4.0.0 - 7.1.0, CUDA 7.0 - 9.0, cuDNN 5.0.5 - 7.6.5
 
-Ubuntu 16-18: LLVM 8.0.0 - 14.0.6, CUDA 7.0 - 10.2, cuDNN 5.1.10 - 8.0.5
+Ubuntu 16-19: LLVM 8.0.0 - 14.0.6, CUDA 7.0 - 10.2, cuDNN 5.1.10 - 8.0.5
 
 Ubuntu 20-21: LLVM 9.0.0 - 17.0.6, CUDA 7.0 - 12.3.2, cuDNN 5.1.10 - 8.9.7
 
-Ubuntu 22: LLVM 13.0.0 - 17.0.6, CUDA 7.0 - 12.3.2, cuDNN 8.0.5 - 8.9.7
+Ubuntu 22-23: LLVM 13.0.0 - 17.0.6, CUDA 7.0 - 12.3.2, cuDNN 8.0.5 - 8.9.7
 
 Minimum build system requirements for the above configurations:
 
-cmake 3.16.8, GNU C/C++ 7.5, Python 2.7.
+cmake 3.16.8, GNU C/C++ 9.2, Python 2.7.
 
 Recommended build system requirements:
 
-cmake 3.28.0, GNU C/C++ 12.x, Python 3.12.0.
+cmake 3.28.1, GNU C/C++ 13.2, Python 3.11.6.
 
-Here is an example of building `hipify-clang` with testing support on `Ubuntu 21.10.0`:
+Here is an example of building `hipify-clang` with testing support on `Ubuntu 23.10.01`:
 
 ```bash
 cmake
@@ -436,9 +436,9 @@ cmake
  -DCMAKE_BUILD_TYPE=Release \
  -DCMAKE_INSTALL_PREFIX=../dist \
  -DCMAKE_PREFIX_PATH=/usr/llvm/17.0.6/dist \
- -DCUDA_TOOLKIT_ROOT_DIR=/usr/local/cuda \
- -DCUDA_DNN_ROOT_DIR=/usr/local/cuda \
- -DCUDA_CUB_ROOT_DIR=/usr/CUB \
+ -DCUDA_TOOLKIT_ROOT_DIR=/usr/local/cuda-12.3.2 \
+ -DCUDA_DNN_ROOT_DIR=/usr/local/cudnn-8.9.7 \
+ -DCUDA_CUB_ROOT_DIR=/usr/local/cub-2.1.0 \
  -DLLVM_EXTERNAL_LIT=/usr/llvm/17.0.6/build/bin/llvm-lit \
  ../hipify
 ```
@@ -446,8 +446,8 @@ cmake
 *A corresponding successful output:*
 
 ```shell
--- The C compiler identification is GNU 11.2.0
--- The CXX compiler identification is GNU 11.2.0
+-- The C compiler identification is GNU 13.2.0
+-- The CXX compiler identification is GNU 13.2.0
 -- Detecting C compiler ABI info
 -- Detecting C compiler ABI info - done
 -- Check for working C compiler: /usr/bin/cc - skipped
@@ -458,23 +458,37 @@ cmake
 -- Check for working CXX compiler: /usr/bin/c++ - skipped
 -- Detecting CXX compile features
 -- Detecting CXX compile features - done
--- Found ZLIB: /usr/lib/x86_64-linux-gnu/libz.so (found version "1.2.11")
+-- HIPIFY config:
+--    - Build hipify-clang : ON
+--    - Test  hipify-clang : ON
+--    - Is part of HIP SDK : OFF
+-- Found ZLIB: /usr/lib/x86_64-linux-gnu/libz.so (found version "1.2.13")
 -- Found LLVM 17.0.6:
---    - CMake module path: /usr/llvm/17.0.6/dist/lib/cmake/llvm
---    - Include path     : /usr/llvm/17.0.6/dist/include
---    - Binary path      : /usr/llvm/17.0.6/dist/bin
+--    - CMake module path  : /usr/llvm/17.0.6/dist/lib/cmake/llvm
+--    - Clang include path : /usr/llvm/17.0.6/dist/include
+--    - LLVM Include path  : /usr/llvm/17.0.6/dist/include
+--    - Binary path        : /usr/llvm/17.0.6/dist/bin
 -- Linker detection: GNU ld
--- Found PythonInterp: /usr/bin/python (found suitable version "3.9.7", minimum required is "2.7")
+-- ---- The below configuring for hipify-clang testing only ----
+-- Found Python: /usr/bin/python3.11 (found version "3.11.6") found components: Interpreter 
 -- Found lit: /usr/local/bin/lit
--- Found FileCheck: /usr/llvm/17.0.6/dist/bin/FileCheck
--- Looking for pthread.h
--- Looking for pthread.h - found
+-- Found FileCheck: /GIT/LLVM/trunk/dist/FileCheck
+-- Initial CUDA to configure:
+--    - CUDA Toolkit path  : /usr/local/cuda-12.3.2
+--    - CUDA Samples path  : OFF
+--    - cuDNN path         : /usr/local/cudnn-8.9.7
+--    - CUB path           : /usr/local/cub-2.1.0
+-- Found CUDAToolkit: /usr/local/cuda-12.3.2/targets/x86_64-linux/include (found version "12.3.107")
 -- Performing Test CMAKE_HAVE_LIBC_PTHREAD
 -- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Success
 -- Found Threads: TRUE
--- Found CUDA: /usr/local/cuda (found version "12.3")
--- Configuring done
--- Generating done
+-- Found CUDA config:
+--    - CUDA Toolkit path  : /usr/local/cuda-12.3.2
+--    - CUDA Samples path  : OFF
+--    - cuDNN path         : /usr/local/cudnn-8.9.7
+--    - CUB path           : /usr/local/cub-2.1.0
+-- Configuring done (0.5s)
+-- Generating done (0.0s)
 -- Build files have been written to: /usr/hipify/build
 ```
 
@@ -486,109 +500,19 @@ make test-hipify
 
 ```shell
 Running HIPify regression tests
-========================================
+===============================================================
 CUDA 12.3.107 - will be used for testing
 LLVM 17.0.6 - will be used for testing
 x86_64 - Platform architecture
-Linux 5.13.0-21-generic - Platform OS
+Linux 6.5.0-15-generic - Platform OS
 64 - hipify-clang binary bitness
-64 - python 3.9.7 binary bitness
-========================================
--- Testing: 91 tests, 12 threads --
-PASS: hipify :: unit_tests/casts/reinterpret_cast.cu (1 of 91)
-PASS: hipify :: unit_tests/device/atomics.cu (2 of 91)
-PASS: hipify :: unit_tests/compilation_database/cd_intro.cu (3 of 91)
-PASS: hipify :: unit_tests/device/device_symbols.cu (4 of 91)
-PASS: hipify :: unit_tests/device/math_functions.cu (5 of 91)
-PASS: hipify :: unit_tests/headers/headers_test_01.cu (6 of 91)
-PASS: hipify :: unit_tests/headers/headers_test_02.cu (7 of 91)
-PASS: hipify :: unit_tests/headers/headers_test_03.cu (8 of 91)
-PASS: hipify :: unit_tests/headers/headers_test_05.cu (9 of 91)
-PASS: hipify :: unit_tests/headers/headers_test_06_12000.cu (10 of 91)
-PASS: hipify :: unit_tests/headers/headers_test_04.cu (11 of 91)
-PASS: hipify :: unit_tests/headers/headers_test_07_12000.cu (12 of 91)
-PASS: hipify :: unit_tests/headers/headers_test_10.cu (13 of 91)
-PASS: hipify :: unit_tests/headers/headers_test_11.cu (14 of 91)
-PASS: hipify :: unit_tests/headers/headers_test_08_12000.cu (15 of 91)
-PASS: hipify :: unit_tests/kernel_launch/kernel_launch_01.cu (16 of 91)
-PASS: hipify :: unit_tests/headers/headers_test_09_12000.cu (17 of 91)
-PASS: hipify :: unit_tests/libraries/CAFFE2/caffe2_02.cu (18 of 91)
-PASS: hipify :: unit_tests/libraries/CAFFE2/caffe2_01.cu (19 of 91)
-PASS: hipify :: unit_tests/libraries/cuBLAS/cublas_sgemm_matrix_multiplication.cu (20 of 91)
-PASS: hipify :: unit_tests/libraries/cuBLAS/cublas_0_based_indexing_v2.cu (21 of 91)
-PASS: hipify :: unit_tests/libraries/cuBLAS/rocBLAS/cublas_1_based_indexing_rocblas.cu (22 of 91)
-PASS: hipify :: unit_tests/libraries/cuBLAS/rocBLAS/cublas_0_based_indexing_rocblas_v2.cu (23 of 91)
-PASS: hipify :: unit_tests/libraries/cuBLAS/cublas_1_based_indexing.cu (24 of 91)
-PASS: hipify :: unit_tests/libraries/cuBLAS/cublas_v1.cu (25 of 91)
-PASS: hipify :: unit_tests/libraries/cuComplex/cuComplex_Julia.cu (26 of 91)
-PASS: hipify :: unit_tests/libraries/cuDNN/cudnn_softmax.cu (27 of 91)
-PASS: hipify :: unit_tests/libraries/cuFFT/simple_cufft.cu (28 of 91)
-PASS: hipify :: unit_tests/libraries/cuBLAS/rocBLAS/cublas_sgemm_matrix_multiplication_rocblas.cu (29 of 91)
-PASS: hipify :: unit_tests/libraries/cuRAND/poisson_api_example.cu (30 of 91)
-PASS: hipify :: unit_tests/libraries/cuSPARSE/cuSPARSE_03.cu (31 of 91)
-PASS: hipify :: unit_tests/libraries/cuRAND/benchmark_curand_generate.cpp (32 of 91)
-PASS: hipify :: unit_tests/libraries/cuRAND/benchmark_curand_kernel.cpp (33 of 91)
-PASS: hipify :: unit_tests/libraries/cuSPARSE/cuSPARSE_04.cu (34 of 91)
-PASS: hipify :: unit_tests/libraries/cuSPARSE/cuSPARSE_05.cu (35 of 91)
-PASS: hipify :: unit_tests/libraries/cuSPARSE/cuSPARSE_06.cu (36 of 91)
-PASS: hipify :: unit_tests/libraries/cuSPARSE/cuSPARSE_07.cu (37 of 91)
-PASS: hipify :: unit_tests/libraries/cuSPARSE/cuSPARSE_08.cu (38 of 91)
-PASS: hipify :: unit_tests/libraries/cuSPARSE/cuSPARSE_09.cu (39 of 91)
-PASS: hipify :: unit_tests/namespace/ns_kernel_launch.cu (40 of 91)
-PASS: hipify :: unit_tests/libraries/cuSPARSE/cuSPARSE_10.cu (41 of 91)
-PASS: hipify :: unit_tests/pp/pp_if_else_conditionals.cu (42 of 91)
-PASS: hipify :: unit_tests/pp/pp_if_else_conditionals_01.cu (43 of 91)
-PASS: hipify :: unit_tests/pp/pp_if_else_conditionals_01_LLVM_10.cu (44 of 91)
-PASS: hipify :: unit_tests/pp/pp_if_else_conditionals_LLVM_10.cu (45 of 91)
-PASS: hipify :: unit_tests/samples/2_Cookbook/0_MatrixTranspose/MatrixTranspose.cpp (46 of 91)
-PASS: hipify :: unit_tests/samples/2_Cookbook/11_texture_driver/texture2dDrv.cpp (47 of 91)
-PASS: hipify :: unit_tests/samples/2_Cookbook/13_occupancy/occupancy.cpp (48 of 91)
-PASS: hipify :: unit_tests/samples/2_Cookbook/1_hipEvent/hipEvent.cpp (49 of 91)
-PASS: hipify :: unit_tests/samples/2_Cookbook/2_Profiler/Profiler.cpp (50 of 91)
-PASS: hipify :: unit_tests/samples/2_Cookbook/7_streams/stream.cpp (51 of 91)
-PASS: hipify :: unit_tests/samples/MallocManaged.cpp (52 of 91)
-PASS: hipify :: unit_tests/samples/2_Cookbook/8_peer2peer/peer2peer.cpp (53 of 91)
-PASS: hipify :: unit_tests/samples/allocators.cu (54 of 91)
-PASS: hipify :: unit_tests/samples/half2_allocators.cu (55 of 91)
-PASS: hipify :: unit_tests/samples/coalescing.cu (56 of 91)
-PASS: hipify :: unit_tests/samples/dynamic_shared_memory.cu (57 of 91)
-PASS: hipify :: unit_tests/samples/axpy.cu (58 of 91)
-PASS: hipify :: unit_tests/samples/cudaRegister.cu (59 of 91)
-PASS: hipify :: unit_tests/samples/intro.cu (60 of 91)
-PASS: hipify :: unit_tests/samples/square.cu (61 of 91)
-PASS: hipify :: unit_tests/samples/static_shared_memory.cu (62 of 91)
-PASS: hipify :: unit_tests/samples/vec_add.cu (63 of 91)
-PASS: hipify :: unit_tests/kernel_launch/kernel_launch_syntax.cu (64 of 91)
-PASS: hipify :: unit_tests/synthetic/driver_structs.cu (65 of 91)
-PASS: hipify :: unit_tests/synthetic/driver_enums.cu (66 of 91)
-PASS: hipify :: unit_tests/synthetic/driver_defines.cu (67 of 91)
-PASS: hipify :: unit_tests/synthetic/driver_typedefs.cu (68 of 91)
-PASS: hipify :: unit_tests/synthetic/driver_functions.cu (69 of 91)
-PASS: hipify :: unit_tests/synthetic/driver_functions_internal.cu (70 of 91)
-PASS: hipify :: unit_tests/synthetic/driver_unions.cu (71 of 91)
-PASS: hipify :: unit_tests/synthetic/runtime_defines.cu (72 of 91)
-PASS: hipify :: unit_tests/synthetic/runtime_enums.cu (73 of 91)
-PASS: hipify :: unit_tests/synthetic/runtime_unions.cu (74 of 91)
-PASS: hipify :: unit_tests/synthetic/runtime_structs.cu (75 of 91)
-PASS: hipify :: unit_tests/synthetic/runtime_typedefs.cu (76 of 91)
-PASS: hipify :: unit_tests/synthetic/runtime_functions.cu (77 of 91)
-PASS: hipify :: unit_tests/synthetic/runtime_functions_11010.cu (78 of 91)
-PASS: hipify :: unit_tests/synthetic/runtime_functions_12000.cu (79 of 91)
-PASS: hipify :: unit_tests/synthetic/libraries/cudnn2miopen.cu (80 of 91)
-PASS: hipify :: unit_tests/synthetic/libraries/cublas2hipblas.cu (81 of 91)
-PASS: hipify :: unit_tests/synthetic/libraries/cublas2hipblas_v2.cu (82 of 91)
-PASS: hipify :: unit_tests/synthetic/libraries/cublas2rocblas.cu (83 of 91)
-PASS: hipify :: unit_tests/synthetic/libraries/cublas2rocblas_v2.cu (84 of 91)
-PASS: hipify :: unit_tests/synthetic/libraries/cusparse2hipsparse.cu (85 of 91)
-PASS: hipify :: unit_tests/synthetic/libraries/cusparse2rocsparse.cu (86 of 91)
-PASS: hipify :: unit_tests/graph/simple_mechs.cu (87 of 91)
-PASS: hipify :: unit_tests/options/kernel-execution-syntax/both-kernel-execution-syntax.cu (88 of 91)
-PASS: hipify :: unit_tests/options/kernel-execution-syntax/cuda-kernel-execution-syntax.cu (89 of 91)
-PASS: hipify :: unit_tests/options/kernel-execution-syntax/hip-kernel-execution-syntax.cu (90 of 91)
-PASS: hipify :: unit_tests/options/kernel-execution-syntax/none-kernel-execution-syntax.cu (91 of 91)
-Testing Time: 7.90s
-  Expected Passes    : 90
-[100%] Built target test-hipify
+64 - python 3.11.6 binary bitness
+===============================================================
+-- Testing: 102 tests, 12 threads --
+Testing Time: 6.70s
+
+Total Discovered Tests: 102
+  Passed: 102 (100.00%)
 ```
 
 ## <a name="windows"></a>hipify-clang: Windows testing
@@ -609,7 +533,7 @@ Testing Time: 7.90s
 | 15.0.0 - 15.0.7 | 7.0 - 11.8.0 | 8.0.5  - 8.8.1 | 2019.16.11.25, 2022.17.5.2                | 3.26.0          | 3.11.2        |
 | 16.0.0 - 16.0.6 | 7.0 - 12.2.2 | 8.0.5  - 8.9.5 | 2019.16.11.29, 2022.17.7.1                | 3.27.3          | 3.11.4        |
 | 17.0.1** 17.0.6 | 7.0 - 12.3.2 | 8.0.5  - 8.9.7 | 2019.16.11.32, 2022.17.8.3                | 3.28.1          | 3.12.1        |
-| 18.0.0git       | 7.0 - 12.3.2 | 8.0.5  - 8.9.7 | 2019.16.11.32, 2022.17.8.3                | 3.28.1          | 3.12.1        |
+| 19.0.0git       | 7.0 - 12.3.2 | 8.0.5  - 8.9.7 | 2019.16.11.32, 2022.17.8.3                | 3.28.1          | 3.12.1        |
 
 `*` LLVM 14.x.x is the latest major release supporting Visual Studio 2017.
 To build LLVM 14.x.x correctly by Visual Studio 2017, `-DLLVM_FORCE_USE_OLD_TOOLCHAIN=ON` should be added to a corresponding cmake command line.


### PR DESCRIPTION
+ Updated Linux-related sections
+ Remove the test log from the documentation
+ LLVM 18.0.0git -> 19.0.0git
