### PR TITLE
[HIPIFY][BLAS][6.1][sync] Sync with `hipBLAS` and `rocBLAS` - Step 2 - AMAX 64bit

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -1972,20 +1972,28 @@ sub rocSubstitutions {
     subst("cublasHgemmBatched", "rocblas_hgemm_batched", "library");
     subst("cublasHgemmStridedBatched", "rocblas_hgemm_strided_batched", "library");
     subst("cublasIcamax", "rocblas_icamax", "library");
+    subst("cublasIcamax_64", "rocblas_icamax_64", "library");
     subst("cublasIcamax_v2", "rocblas_icamax", "library");
+    subst("cublasIcamax_v2_64", "rocblas_icamax_64", "library");
     subst("cublasIcamin", "rocblas_icamin", "library");
     subst("cublasIcamin_v2", "rocblas_icamin", "library");
     subst("cublasIdamax", "rocblas_idamax", "library");
+    subst("cublasIdamax_64", "rocblas_idamax_64", "library");
     subst("cublasIdamax_v2", "rocblas_idamax", "library");
+    subst("cublasIdamax_v2_64", "rocblas_idamax_64", "library");
     subst("cublasIdamin", "rocblas_idamin", "library");
     subst("cublasIdamin_v2", "rocblas_idamin", "library");
     subst("cublasInit", "rocblas_initialize", "library");
     subst("cublasIsamax", "rocblas_isamax", "library");
+    subst("cublasIsamax_64", "rocblas_isamax_64", "library");
     subst("cublasIsamax_v2", "rocblas_isamax", "library");
+    subst("cublasIsamax_v2_64", "rocblas_isamax_64", "library");
     subst("cublasIsamin", "rocblas_isamin", "library");
     subst("cublasIsamin_v2", "rocblas_isamin", "library");
     subst("cublasIzamax", "rocblas_izamax", "library");
+    subst("cublasIzamax_64", "rocblas_izamax_64", "library");
     subst("cublasIzamax_v2", "rocblas_izamax", "library");
+    subst("cublasIzamax_v2_64", "rocblas_izamax_64", "library");
     subst("cublasIzamin", "rocblas_izamin", "library");
     subst("cublasIzamin_v2", "rocblas_izamin", "library");
     subst("cublasNrm2Ex", "rocblas_nrm2_ex", "library");
@@ -3895,19 +3903,27 @@ sub simpleSubstitutions {
     subst("cublasHgemmBatched", "hipblasHgemmBatched", "library");
     subst("cublasHgemmStridedBatched", "hipblasHgemmStridedBatched", "library");
     subst("cublasIcamax", "hipblasIcamax_v2", "library");
+    subst("cublasIcamax_64", "hipblasIcamax_v2_64", "library");
     subst("cublasIcamax_v2", "hipblasIcamax_v2", "library");
+    subst("cublasIcamax_v2_64", "hipblasIcamax_v2_64", "library");
     subst("cublasIcamin", "hipblasIcamin_v2", "library");
     subst("cublasIcamin_v2", "hipblasIcamin_v2", "library");
     subst("cublasIdamax", "hipblasIdamax", "library");
+    subst("cublasIdamax_64", "hipblasIdamax_64", "library");
     subst("cublasIdamax_v2", "hipblasIdamax", "library");
+    subst("cublasIdamax_v2_64", "hipblasIdamax_64", "library");
     subst("cublasIdamin", "hipblasIdamin", "library");
     subst("cublasIdamin_v2", "hipblasIdamin", "library");
     subst("cublasIsamax", "hipblasIsamax", "library");
+    subst("cublasIsamax_64", "hipblasIsamax_64", "library");
     subst("cublasIsamax_v2", "hipblasIsamax", "library");
+    subst("cublasIsamax_v2_64", "hipblasIsamax_64", "library");
     subst("cublasIsamin", "hipblasIsamin", "library");
     subst("cublasIsamin_v2", "hipblasIsamin", "library");
     subst("cublasIzamax", "hipblasIzamax_v2", "library");
+    subst("cublasIzamax_64", "hipblasIzamax_v2_64", "library");
     subst("cublasIzamax_v2", "hipblasIzamax_v2", "library");
+    subst("cublasIzamax_v2_64", "hipblasIzamax_v2_64", "library");
     subst("cublasIzamin", "hipblasIzamin_v2", "library");
     subst("cublasIzamin_v2", "hipblasIzamin_v2", "library");
     subst("cublasNrm2Ex", "hipblasNrm2Ex_v2", "library");
@@ -10853,21 +10869,13 @@ sub warnHipOnlyUnsupportedFunctions {
         "cublasLogCallback",
         "cublasIzamin_v2_64",
         "cublasIzamin_64",
-        "cublasIzamax_v2_64",
-        "cublasIzamax_64",
         "cublasIsamin_v2_64",
         "cublasIsamin_64",
-        "cublasIsamax_v2_64",
-        "cublasIsamax_64",
         "cublasInit",
         "cublasIdamin_v2_64",
         "cublasIdamin_64",
-        "cublasIdamax_v2_64",
-        "cublasIdamax_64",
         "cublasIcamin_v2_64",
         "cublasIcamin_64",
-        "cublasIcamax_v2_64",
-        "cublasIcamax_64",
         "cublasIaminEx_64",
         "cublasIaminEx",
         "cublasIamaxEx_64",
@@ -11375,20 +11383,12 @@ sub warnRocOnlyUnsupportedFunctions {
         "cublasLogCallback",
         "cublasIzamin_v2_64",
         "cublasIzamin_64",
-        "cublasIzamax_v2_64",
-        "cublasIzamax_64",
         "cublasIsamin_v2_64",
         "cublasIsamin_64",
-        "cublasIsamax_v2_64",
-        "cublasIsamax_64",
         "cublasIdamin_v2_64",
         "cublasIdamin_64",
-        "cublasIdamax_v2_64",
-        "cublasIdamax_64",
         "cublasIcamin_v2_64",
         "cublasIcamin_64",
-        "cublasIcamax_v2_64",
-        "cublasIcamax_64",
         "cublasIaminEx_64",
         "cublasIaminEx",
         "cublasIamaxEx_64",

--- a/docs/tables/CUBLAS_API_supported_by_HIP.md
+++ b/docs/tables/CUBLAS_API_supported_by_HIP.md
@@ -290,33 +290,33 @@
 |`cublasDznrm2_v2`| | | | |`hipblasDznrm2_v2`|6.0.0| | | | |
 |`cublasDznrm2_v2_64`|12.0| | | | | | | | | |
 |`cublasIcamax`| | | | |`hipblasIcamax_v2`|6.0.0| | | | |
-|`cublasIcamax_64`|12.0| | | | | | | | | |
+|`cublasIcamax_64`|12.0| | | |`hipblasIcamax_v2_64`|6.1.0| | | | |
 |`cublasIcamax_v2`| | | | |`hipblasIcamax_v2`|6.0.0| | | | |
-|`cublasIcamax_v2_64`|12.0| | | | | | | | | |
+|`cublasIcamax_v2_64`|12.0| | | |`hipblasIcamax_v2_64`|6.1.0| | | | |
 |`cublasIcamin`| | | | |`hipblasIcamin_v2`|6.0.0| | | | |
 |`cublasIcamin_64`|12.0| | | | | | | | | |
 |`cublasIcamin_v2`| | | | |`hipblasIcamin_v2`|6.0.0| | | | |
 |`cublasIcamin_v2_64`|12.0| | | | | | | | | |
 |`cublasIdamax`| | | | |`hipblasIdamax`|1.8.2| | | | |
-|`cublasIdamax_64`|12.0| | | | | | | | | |
+|`cublasIdamax_64`|12.0| | | |`hipblasIdamax_64`|6.1.0| | | | |
 |`cublasIdamax_v2`| | | | |`hipblasIdamax`|1.8.2| | | | |
-|`cublasIdamax_v2_64`|12.0| | | | | | | | | |
+|`cublasIdamax_v2_64`|12.0| | | |`hipblasIdamax_64`|6.1.0| | | | |
 |`cublasIdamin`| | | | |`hipblasIdamin`|3.0.0| | | | |
 |`cublasIdamin_64`|12.0| | | | | | | | | |
 |`cublasIdamin_v2`| | | | |`hipblasIdamin`|3.0.0| | | | |
 |`cublasIdamin_v2_64`|12.0| | | | | | | | | |
 |`cublasIsamax`| | | | |`hipblasIsamax`|1.8.2| | | | |
-|`cublasIsamax_64`|12.0| | | | | | | | | |
+|`cublasIsamax_64`|12.0| | | |`hipblasIsamax_64`|6.1.0| | | | |
 |`cublasIsamax_v2`| | | | |`hipblasIsamax`|1.8.2| | | | |
-|`cublasIsamax_v2_64`|12.0| | | | | | | | | |
+|`cublasIsamax_v2_64`|12.0| | | |`hipblasIsamax_64`|6.1.0| | | | |
 |`cublasIsamin`| | | | |`hipblasIsamin`|3.0.0| | | | |
 |`cublasIsamin_64`|12.0| | | | | | | | | |
 |`cublasIsamin_v2`| | | | |`hipblasIsamin`|3.0.0| | | | |
 |`cublasIsamin_v2_64`|12.0| | | | | | | | | |
 |`cublasIzamax`| | | | |`hipblasIzamax_v2`|6.0.0| | | | |
-|`cublasIzamax_64`|12.0| | | | | | | | | |
+|`cublasIzamax_64`|12.0| | | |`hipblasIzamax_v2_64`|6.1.0| | | | |
 |`cublasIzamax_v2`| | | | |`hipblasIzamax_v2`|6.0.0| | | | |
-|`cublasIzamax_v2_64`|12.0| | | | | | | | | |
+|`cublasIzamax_v2_64`|12.0| | | |`hipblasIzamax_v2_64`|6.1.0| | | | |
 |`cublasIzamin`| | | | |`hipblasIzamin_v2`|6.0.0| | | | |
 |`cublasIzamin_64`|12.0| | | | | | | | | |
 |`cublasIzamin_v2`| | | | |`hipblasIzamin_v2`|6.0.0| | | | |

--- a/docs/tables/CUBLAS_API_supported_by_HIP_and_ROC.md
+++ b/docs/tables/CUBLAS_API_supported_by_HIP_and_ROC.md
@@ -290,33 +290,33 @@
 |`cublasDznrm2_v2`| | | | |`hipblasDznrm2_v2`|6.0.0| | | | |`rocblas_dznrm2`|1.5.0| | | | |
 |`cublasDznrm2_v2_64`|12.0| | | | | | | | | | | | | | | |
 |`cublasIcamax`| | | | |`hipblasIcamax_v2`|6.0.0| | | | |`rocblas_icamax`|3.5.0| | | | |
-|`cublasIcamax_64`|12.0| | | | | | | | | | | | | | | |
+|`cublasIcamax_64`|12.0| | | |`hipblasIcamax_v2_64`|6.1.0| | | | |`rocblas_icamax_64`|6.1.0| | | | |
 |`cublasIcamax_v2`| | | | |`hipblasIcamax_v2`|6.0.0| | | | |`rocblas_icamax`|3.5.0| | | | |
-|`cublasIcamax_v2_64`|12.0| | | | | | | | | | | | | | | |
+|`cublasIcamax_v2_64`|12.0| | | |`hipblasIcamax_v2_64`|6.1.0| | | | |`rocblas_icamax_64`|6.1.0| | | | |
 |`cublasIcamin`| | | | |`hipblasIcamin_v2`|6.0.0| | | | |`rocblas_icamin`|3.5.0| | | | |
 |`cublasIcamin_64`|12.0| | | | | | | | | | | | | | | |
 |`cublasIcamin_v2`| | | | |`hipblasIcamin_v2`|6.0.0| | | | |`rocblas_icamin`|3.5.0| | | | |
 |`cublasIcamin_v2_64`|12.0| | | | | | | | | | | | | | | |
 |`cublasIdamax`| | | | |`hipblasIdamax`|1.8.2| | | | |`rocblas_idamax`|1.6.4| | | | |
-|`cublasIdamax_64`|12.0| | | | | | | | | | | | | | | |
+|`cublasIdamax_64`|12.0| | | |`hipblasIdamax_64`|6.1.0| | | | |`rocblas_idamax_64`|6.1.0| | | | |
 |`cublasIdamax_v2`| | | | |`hipblasIdamax`|1.8.2| | | | |`rocblas_idamax`|1.6.4| | | | |
-|`cublasIdamax_v2_64`|12.0| | | | | | | | | | | | | | | |
+|`cublasIdamax_v2_64`|12.0| | | |`hipblasIdamax_64`|6.1.0| | | | |`rocblas_idamax_64`|6.1.0| | | | |
 |`cublasIdamin`| | | | |`hipblasIdamin`|3.0.0| | | | |`rocblas_idamin`|1.6.4| | | | |
 |`cublasIdamin_64`|12.0| | | | | | | | | | | | | | | |
 |`cublasIdamin_v2`| | | | |`hipblasIdamin`|3.0.0| | | | |`rocblas_idamin`|1.6.4| | | | |
 |`cublasIdamin_v2_64`|12.0| | | | | | | | | | | | | | | |
 |`cublasIsamax`| | | | |`hipblasIsamax`|1.8.2| | | | |`rocblas_isamax`|1.6.4| | | | |
-|`cublasIsamax_64`|12.0| | | | | | | | | | | | | | | |
+|`cublasIsamax_64`|12.0| | | |`hipblasIsamax_64`|6.1.0| | | | |`rocblas_isamax_64`|6.1.0| | | | |
 |`cublasIsamax_v2`| | | | |`hipblasIsamax`|1.8.2| | | | |`rocblas_isamax`|1.6.4| | | | |
-|`cublasIsamax_v2_64`|12.0| | | | | | | | | | | | | | | |
+|`cublasIsamax_v2_64`|12.0| | | |`hipblasIsamax_64`|6.1.0| | | | |`rocblas_isamax_64`|6.1.0| | | | |
 |`cublasIsamin`| | | | |`hipblasIsamin`|3.0.0| | | | |`rocblas_isamin`|1.6.4| | | | |
 |`cublasIsamin_64`|12.0| | | | | | | | | | | | | | | |
 |`cublasIsamin_v2`| | | | |`hipblasIsamin`|3.0.0| | | | |`rocblas_isamin`|1.6.4| | | | |
 |`cublasIsamin_v2_64`|12.0| | | | | | | | | | | | | | | |
 |`cublasIzamax`| | | | |`hipblasIzamax_v2`|6.0.0| | | | |`rocblas_izamax`|3.5.0| | | | |
-|`cublasIzamax_64`|12.0| | | | | | | | | | | | | | | |
+|`cublasIzamax_64`|12.0| | | |`hipblasIzamax_v2_64`|6.1.0| | | | |`rocblas_izamax_64`|6.1.0| | | | |
 |`cublasIzamax_v2`| | | | |`hipblasIzamax_v2`|6.0.0| | | | |`rocblas_izamax`|3.5.0| | | | |
-|`cublasIzamax_v2_64`|12.0| | | | | | | | | | | | | | | |
+|`cublasIzamax_v2_64`|12.0| | | |`hipblasIzamax_v2_64`|6.1.0| | | | |`rocblas_izamax_64`|6.1.0| | | | |
 |`cublasIzamin`| | | | |`hipblasIzamin_v2`|6.0.0| | | | |`rocblas_izamin`|3.5.0| | | | |
 |`cublasIzamin_64`|12.0| | | | | | | | | | | | | | | |
 |`cublasIzamin_v2`| | | | |`hipblasIzamin_v2`|6.0.0| | | | |`rocblas_izamin`|3.5.0| | | | |

--- a/docs/tables/CUBLAS_API_supported_by_ROC.md
+++ b/docs/tables/CUBLAS_API_supported_by_ROC.md
@@ -290,33 +290,33 @@
 |`cublasDznrm2_v2`| | | | |`rocblas_dznrm2`|1.5.0| | | | |
 |`cublasDznrm2_v2_64`|12.0| | | | | | | | | |
 |`cublasIcamax`| | | | |`rocblas_icamax`|3.5.0| | | | |
-|`cublasIcamax_64`|12.0| | | | | | | | | |
+|`cublasIcamax_64`|12.0| | | |`rocblas_icamax_64`|6.1.0| | | | |
 |`cublasIcamax_v2`| | | | |`rocblas_icamax`|3.5.0| | | | |
-|`cublasIcamax_v2_64`|12.0| | | | | | | | | |
+|`cublasIcamax_v2_64`|12.0| | | |`rocblas_icamax_64`|6.1.0| | | | |
 |`cublasIcamin`| | | | |`rocblas_icamin`|3.5.0| | | | |
 |`cublasIcamin_64`|12.0| | | | | | | | | |
 |`cublasIcamin_v2`| | | | |`rocblas_icamin`|3.5.0| | | | |
 |`cublasIcamin_v2_64`|12.0| | | | | | | | | |
 |`cublasIdamax`| | | | |`rocblas_idamax`|1.6.4| | | | |
-|`cublasIdamax_64`|12.0| | | | | | | | | |
+|`cublasIdamax_64`|12.0| | | |`rocblas_idamax_64`|6.1.0| | | | |
 |`cublasIdamax_v2`| | | | |`rocblas_idamax`|1.6.4| | | | |
-|`cublasIdamax_v2_64`|12.0| | | | | | | | | |
+|`cublasIdamax_v2_64`|12.0| | | |`rocblas_idamax_64`|6.1.0| | | | |
 |`cublasIdamin`| | | | |`rocblas_idamin`|1.6.4| | | | |
 |`cublasIdamin_64`|12.0| | | | | | | | | |
 |`cublasIdamin_v2`| | | | |`rocblas_idamin`|1.6.4| | | | |
 |`cublasIdamin_v2_64`|12.0| | | | | | | | | |
 |`cublasIsamax`| | | | |`rocblas_isamax`|1.6.4| | | | |
-|`cublasIsamax_64`|12.0| | | | | | | | | |
+|`cublasIsamax_64`|12.0| | | |`rocblas_isamax_64`|6.1.0| | | | |
 |`cublasIsamax_v2`| | | | |`rocblas_isamax`|1.6.4| | | | |
-|`cublasIsamax_v2_64`|12.0| | | | | | | | | |
+|`cublasIsamax_v2_64`|12.0| | | |`rocblas_isamax_64`|6.1.0| | | | |
 |`cublasIsamin`| | | | |`rocblas_isamin`|1.6.4| | | | |
 |`cublasIsamin_64`|12.0| | | | | | | | | |
 |`cublasIsamin_v2`| | | | |`rocblas_isamin`|1.6.4| | | | |
 |`cublasIsamin_v2_64`|12.0| | | | | | | | | |
 |`cublasIzamax`| | | | |`rocblas_izamax`|3.5.0| | | | |
-|`cublasIzamax_64`|12.0| | | | | | | | | |
+|`cublasIzamax_64`|12.0| | | |`rocblas_izamax_64`|6.1.0| | | | |
 |`cublasIzamax_v2`| | | | |`rocblas_izamax`|3.5.0| | | | |
-|`cublasIzamax_v2_64`|12.0| | | | | | | | | |
+|`cublasIzamax_v2_64`|12.0| | | |`rocblas_izamax_64`|6.1.0| | | | |
 |`cublasIzamin`| | | | |`rocblas_izamin`|3.5.0| | | | |
 |`cublasIzamin_64`|12.0| | | | | | | | | |
 |`cublasIzamin_v2`| | | | |`rocblas_izamin`|3.5.0| | | | |

--- a/src/CUDA2HIP_BLAS_API_functions.cpp
+++ b/src/CUDA2HIP_BLAS_API_functions.cpp
@@ -160,13 +160,13 @@ const std::map<llvm::StringRef, hipCounter> CUDA_BLAS_FUNCTION_MAP {
 
   // AMAX
   {"cublasIsamax",                   {"hipblasIsamax",                   "rocblas_isamax",                           CONV_LIB_FUNC, API_BLAS, 5, HIP_SUPPORTED_V2_ONLY}},
-  {"cublasIsamax_64",                {"hipblasIsamax_64",                "",                                         CONV_LIB_FUNC, API_BLAS, 5, UNSUPPORTED}},
+  {"cublasIsamax_64",                {"hipblasIsamax_64",                "rocblas_isamax_64",                        CONV_LIB_FUNC, API_BLAS, 5}},
   {"cublasIdamax",                   {"hipblasIdamax",                   "rocblas_idamax",                           CONV_LIB_FUNC, API_BLAS, 5, HIP_SUPPORTED_V2_ONLY}},
-  {"cublasIdamax_64",                {"hipblasIdamax_64",                "",                                         CONV_LIB_FUNC, API_BLAS, 5, UNSUPPORTED}},
+  {"cublasIdamax_64",                {"hipblasIdamax_64",                "rocblas_idamax_64",                        CONV_LIB_FUNC, API_BLAS, 5}},
   {"cublasIcamax",                   {"hipblasIcamax_v2",                "rocblas_icamax",                           CONV_LIB_FUNC, API_BLAS, 5, HIP_SUPPORTED_V2_ONLY}},
-  {"cublasIcamax_64",                {"hipblasIcamax_64",                "",                                         CONV_LIB_FUNC, API_BLAS, 5, UNSUPPORTED}},
+  {"cublasIcamax_64",                {"hipblasIcamax_v2_64",             "rocblas_icamax_64",                        CONV_LIB_FUNC, API_BLAS, 5}},
   {"cublasIzamax",                   {"hipblasIzamax_v2",                "rocblas_izamax",                           CONV_LIB_FUNC, API_BLAS, 5, HIP_SUPPORTED_V2_ONLY}},
-  {"cublasIzamax_64",                {"hipblasIzamax_64",                "",                                         CONV_LIB_FUNC, API_BLAS, 5, UNSUPPORTED}},
+  {"cublasIzamax_64",                {"hipblasIzamax_v2_64",             "rocblas_izamax_64",                        CONV_LIB_FUNC, API_BLAS, 5}},
 
   // AMIN
   {"cublasIsamin",                   {"hipblasIsamin",                   "rocblas_isamin",                           CONV_LIB_FUNC, API_BLAS, 5, HIP_SUPPORTED_V2_ONLY}},
@@ -1004,13 +1004,13 @@ const std::map<llvm::StringRef, hipCounter> CUDA_BLAS_FUNCTION_MAP {
   {"cublasIamaxEx",                  {"hipblasIamaxEx",                  "",                                         CONV_LIB_FUNC, API_BLAS, 8, UNSUPPORTED}},
   {"cublasIamaxEx_64",               {"hipblasIamaxEx_64",               "",                                         CONV_LIB_FUNC, API_BLAS, 8, UNSUPPORTED}},
   {"cublasIsamax_v2",                {"hipblasIsamax",                   "rocblas_isamax",                           CONV_LIB_FUNC, API_BLAS, 5}},
-  {"cublasIsamax_v2_64",             {"hipblasIsamax_64",                "",                                         CONV_LIB_FUNC, API_BLAS, 5, UNSUPPORTED}},
+  {"cublasIsamax_v2_64",             {"hipblasIsamax_64",                "rocblas_isamax_64",                        CONV_LIB_FUNC, API_BLAS, 5}},
   {"cublasIdamax_v2",                {"hipblasIdamax",                   "rocblas_idamax",                           CONV_LIB_FUNC, API_BLAS, 5}},
-  {"cublasIdamax_v2_64",             {"hipblasIdamax_64",                "",                                         CONV_LIB_FUNC, API_BLAS, 5, UNSUPPORTED}},
+  {"cublasIdamax_v2_64",             {"hipblasIdamax_64",                "rocblas_idamax_64",                        CONV_LIB_FUNC, API_BLAS, 5}},
   {"cublasIcamax_v2",                {"hipblasIcamax_v2",                "rocblas_icamax",                           CONV_LIB_FUNC, API_BLAS, 5}},
-  {"cublasIcamax_v2_64",             {"hipblasIcamax_64",                "",                                         CONV_LIB_FUNC, API_BLAS, 5, UNSUPPORTED}},
+  {"cublasIcamax_v2_64",             {"hipblasIcamax_v2_64",             "rocblas_icamax_64",                        CONV_LIB_FUNC, API_BLAS, 5}},
   {"cublasIzamax_v2",                {"hipblasIzamax_v2",                "rocblas_izamax",                           CONV_LIB_FUNC, API_BLAS, 5}},
-  {"cublasIzamax_v2_64",             {"hipblasIzamax_64",                "",                                         CONV_LIB_FUNC, API_BLAS, 5, UNSUPPORTED}},
+  {"cublasIzamax_v2_64",             {"hipblasIzamax_v2_64",             "rocblas_izamax_64",                        CONV_LIB_FUNC, API_BLAS, 5}},
 
   // AMIN
   {"cublasIaminEx",                  {"hipblasIaminEx",                  "",                                         CONV_LIB_FUNC, API_BLAS, 8, UNSUPPORTED}},
@@ -1871,6 +1871,10 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_BLAS_FUNCTION_VER_MAP {
   {"hipblasScalEx_v2",                           {HIP_6000, HIP_0,    HIP_0,  }},
   {"hipblasSetMathMode",                         {HIP_6010, HIP_0,    HIP_0,  }},
   {"hipblasGetMathMode",                         {HIP_6010, HIP_0,    HIP_0,  }},
+  {"hipblasIsamax_64",                           {HIP_6010, HIP_0,    HIP_0,  }},
+  {"hipblasIdamax_64",                           {HIP_6010, HIP_0,    HIP_0,  }},
+  {"hipblasIcamax_v2_64",                        {HIP_6010, HIP_0,    HIP_0,  }},
+  {"hipblasIzamax_v2_64",                        {HIP_6010, HIP_0,    HIP_0,  }},
 
   {"rocblas_status_to_string",                   {HIP_3050, HIP_0,    HIP_0   }},
   {"rocblas_sscal",                              {HIP_1050, HIP_0,    HIP_0   }},
@@ -2107,6 +2111,10 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_BLAS_FUNCTION_VER_MAP {
   {"rocblas_hssgemv_strided_batched",            {HIP_6000, HIP_0,    HIP_0,  }},
   {"rocblas_tstgemv_strided_batched",            {HIP_6000, HIP_0,    HIP_0,  }},
   {"rocblas_tssgemv_strided_batched",            {HIP_6000, HIP_0,    HIP_0,  }},
+  {"rocblas_isamax_64",                          {HIP_6010, HIP_0,    HIP_0,  }},
+  {"rocblas_idamax_64",                          {HIP_6010, HIP_0,    HIP_0,  }},
+  {"rocblas_icamax_64",                          {HIP_6010, HIP_0,    HIP_0,  }},
+  {"rocblas_izamax_64",                          {HIP_6010, HIP_0,    HIP_0,  }},
 };
 
 const std::map<llvm::StringRef, hipAPIChangedVersions> HIP_BLAS_FUNCTION_CHANGED_VER_MAP {

--- a/tests/unit_tests/synthetic/libraries/cublas2hipblas_v2.cu
+++ b/tests/unit_tests/synthetic/libraries/cublas2hipblas_v2.cu
@@ -141,6 +141,7 @@ int main() {
   blasStatus = cublasGetPointerMode_v2(blasHandle, &blasPointerMode);
 
   int n = 0;
+  int64_t n_64 = 0;
   int nrhs = 0;
   int m = 0;
   int num = 0;
@@ -148,8 +149,11 @@ int main() {
   int ldb = 0;
   int ldc = 0;
   int res = 0;
+  int64_t res_64 = 0;
   int incx = 0;
+  int64_t incx_64 = 0;
   int incy = 0;
+  int64_t incy_64 = 0;
   int k = 0;
   int kl = 0;
   int ku = 0;
@@ -1832,6 +1836,36 @@ int main() {
   // HIP: HIPBLAS_EXPORT hipblasStatus_t hipblasGemmStridedBatchedEx_v2(hipblasHandle_t handle, hipblasOperation_t transA, hipblasOperation_t transB, int m, int n, int k, const void* alpha, const void* A, hipDataType aType, int lda, hipblasStride strideA, const void* B, hipDataType bType, int ldb, hipblasStride strideB, const void* beta, void* C, hipDataType cType, int ldc, hipblasStride strideC, int batchCount, hipblasComputeType_t computeType, hipblasGemmAlgo_t algo);
   // CHECK: blasStatus = hipblasGemmStridedBatchedEx_v2(blasHandle, transa, transb, m, n, k, aptr, Aptr, Atype, lda, strideA, Bptr, Btype, ldb, strideB, bptr, Cptr, Ctype, ldc, strideC, batchCount, blasComputeType, blasGemmAlgo);
   blasStatus = cublasGemmStridedBatchedEx(blasHandle, transa, transb, m, n, k, aptr, Aptr, Atype, lda, strideA, Bptr, Btype, ldb, strideB, bptr, Cptr, Ctype, ldc, strideC, batchCount, blasComputeType, blasGemmAlgo);
+#endif
+
+#if CUDA_VERSION >= 12000
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasIsamax_v2_64(cublasHandle_t handle, int64_t n, const float* x, int64_t incx, int64_t* result);
+  // HIP: HIPBLAS_EXPORT hipblasStatus_t hipblasIsamax_64(hipblasHandle_t handle, int64_t n, const float* x, int64_t incx, int64_t* result);
+  // CHECK: blasStatus = hipblasIsamax_64(blasHandle, n_64, &fx, incx_64, &res_64);
+  // CHECK-NEXT: blasStatus = hipblasIsamax_64(blasHandle, n_64, &fx, incx_64, &res_64);
+  blasStatus = cublasIsamax_64(blasHandle, n_64, &fx, incx_64, &res_64);
+  blasStatus = cublasIsamax_v2_64(blasHandle, n_64, &fx, incx_64, &res_64);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasIdamax_v2_64(cublasHandle_t handle, int64_t n, const double* x, int64_t incx, int64_t* result);
+  // HIP: HIPBLAS_EXPORT hipblasStatus_t hipblasIdamax_64(hipblasHandle_t handle, int64_t n, const double* x, int64_t incx, int64_t* result);
+  // CHECK: blasStatus = hipblasIdamax_64(blasHandle, n_64, &dx, incx_64, &res_64);
+  // CHECK-NEXT: blasStatus = hipblasIdamax_64(blasHandle, n_64, &dx, incx_64, &res_64);
+  blasStatus = cublasIdamax_64(blasHandle, n_64, &dx, incx_64, &res_64);
+  blasStatus = cublasIdamax_v2_64(blasHandle, n_64, &dx, incx_64, &res_64);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasIcamax_v2_64(cublasHandle_t handle, int64_t n, const cuComplex* x, int64_t incx, int64_t* result);
+  // HIP: HIPBLAS_EXPORT hipblasStatus_t hipblasIcamax_v2_64(hipblasHandle_t handle, int64_t n, const hipComplex* x, int64_t incx, int64_t* result);
+  // CHECK: blasStatus = hipblasIcamax_v2_64(blasHandle, n_64, &complexx, incx_64, &res_64);
+  // CHECK-NEXT: blasStatus = hipblasIcamax_v2_64(blasHandle, n_64, &complexx, incx_64, &res_64);
+  blasStatus = cublasIcamax_64(blasHandle, n_64, &complexx, incx_64, &res_64);
+  blasStatus = cublasIcamax_v2_64(blasHandle, n_64, &complexx, incx_64, &res_64);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasIzamax_v2_64(cublasHandle_t handle, int64_t n, const cuDoubleComplex* x, int64_t incx, int64_t* result);
+  // HIP: HIPBLAS_EXPORT hipblasStatus_t hipblasIzamax_v2_64(hipblasHandle_t handle, int64_t n, const hipDoubleComplex* x, int64_t incx, int64_t* result);
+  // CHECK: blasStatus = hipblasIzamax_v2_64(blasHandle, n_64, &dcomplexx, incx_64, &res_64);
+  // CHECK-NEXT: blasStatus = hipblasIzamax_v2_64(blasHandle, n_64, &dcomplexx, incx_64, &res_64);
+  blasStatus = cublasIzamax_64(blasHandle, n_64, &dcomplexx, incx_64, &res_64);
+  blasStatus = cublasIzamax_v2_64(blasHandle, n_64, &dcomplexx, incx_64, &res_64);
 #endif
 
   return 0;

--- a/tests/unit_tests/synthetic/libraries/cublas2rocblas_v2.cu
+++ b/tests/unit_tests/synthetic/libraries/cublas2rocblas_v2.cu
@@ -145,14 +145,19 @@ int main() {
   blasStatus = cublasGetPointerMode_v2(blasHandle, &blasPointerMode);
 
   int n = 0;
+  int64_t n_64 = 0;
+  int nrhs = 0;
   int m = 0;
   int num = 0;
   int lda = 0;
   int ldb = 0;
   int ldc = 0;
   int res = 0;
+  int64_t res_64 = 0;
   int incx = 0;
+  int64_t incx_64 = 0;
   int incy = 0;
+  int64_t incy_64 = 0;
   int k = 0;
   int kl = 0;
   int ku = 0;
@@ -1916,6 +1921,36 @@ int main() {
   // ROC: ROCBLAS_EXPORT const char* rocblas_status_to_string(rocblas_status status);
   // CHECK: const_ch = rocblas_status_to_string(blasStatus);
   const_ch = cublasGetStatusString(blasStatus);
+#endif
+
+#if CUDA_VERSION >= 12000
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasIsamax_v2_64(cublasHandle_t handle, int64_t n, const float* x, int64_t incx, int64_t* result);
+  // ROC: ROCBLAS_EXPORT rocblas_status rocblas_isamax_64(rocblas_handle handle, int64_t n, const float* x, int64_t incx, int64_t* result);
+  // CHECK: blasStatus = rocblas_isamax_64(blasHandle, n_64, &fx, incx_64, &res_64);
+  // CHECK-NEXT: blasStatus = rocblas_isamax_64(blasHandle, n_64, &fx, incx_64, &res_64);
+  blasStatus = cublasIsamax_64(blasHandle, n_64, &fx, incx_64, &res_64);
+  blasStatus = cublasIsamax_v2_64(blasHandle, n_64, &fx, incx_64, &res_64);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasIdamax_v2_64(cublasHandle_t handle, int64_t n, const double* x, int64_t incx, int64_t* result);
+  // ROC: ROCBLAS_EXPORT rocblas_status rocblas_idamax_64(rocblas_handle handle, int64_t n, const double* x, int64_t incx, int64_t* result);
+  // CHECK: blasStatus = rocblas_idamax_64(blasHandle, n_64, &dx, incx_64, &res_64);
+  // CHECK-NEXT: blasStatus = rocblas_idamax_64(blasHandle, n_64, &dx, incx_64, &res_64);
+  blasStatus = cublasIdamax_64(blasHandle, n_64, &dx, incx_64, &res_64);
+  blasStatus = cublasIdamax_v2_64(blasHandle, n_64, &dx, incx_64, &res_64);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasIcamax_v2_64(cublasHandle_t handle, int64_t n, const cuComplex* x, int64_t incx, int64_t* result);
+  // ROC: ROCBLAS_EXPORT rocblas_status rocblas_icamax_64(rocblas_handle handle, int64_t n, const rocblas_float_complex* x, int64_t incx, int64_t* result);
+  // CHECK: blasStatus = rocblas_icamax_64(blasHandle, n_64, &complexx, incx_64, &res_64);
+  // CHECK-NEXT: blasStatus = rocblas_icamax_64(blasHandle, n_64, &complexx, incx_64, &res_64);
+  blasStatus = cublasIcamax_64(blasHandle, n_64, &complexx, incx_64, &res_64);
+  blasStatus = cublasIcamax_v2_64(blasHandle, n_64, &complexx, incx_64, &res_64);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasIzamax_v2_64(cublasHandle_t handle, int64_t n, const cuDoubleComplex* x, int64_t incx, int64_t* result);
+  // ROC: ROCBLAS_EXPORT rocblas_status rocblas_izamax_64(rocblas_handle handle, int64_t n, const rocblas_double_complex* x, int64_t incx, int64_t* result);
+  // CHECK: blasStatus = rocblas_izamax_64(blasHandle, n_64, &dcomplexx, incx_64, &res_64);
+  // CHECK-NEXT: blasStatus = rocblas_izamax_64(blasHandle, n_64, &dcomplexx, incx_64, &res_64);
+  blasStatus = cublasIzamax_64(blasHandle, n_64, &dcomplexx, incx_64, &res_64);
+  blasStatus = cublasIzamax_v2_64(blasHandle, n_64, &dcomplexx, incx_64, &res_64);
 #endif
 
   return 0;


### PR DESCRIPTION
+ Updated `BLAS` synthetic tests, the regenerated hipify-perl, and `BLAS` `CUDA2HIP` documentation
