### PR TITLE
[HIPIFY][BLAS][6.1][sync] Sync with `hipBLAS` and `rocBLAS` - Step 6 - COPY 64bit

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -1786,7 +1786,9 @@ sub rocSubstitutions {
     subst("cublasCaxpy_v2", "rocblas_caxpy", "library");
     subst("cublasCaxpy_v2_64", "rocblas_caxpy_64", "library");
     subst("cublasCcopy", "rocblas_ccopy", "library");
+    subst("cublasCcopy_64", "rocblas_ccopy_64", "library");
     subst("cublasCcopy_v2", "rocblas_ccopy", "library");
+    subst("cublasCcopy_v2_64", "rocblas_ccopy_64", "library");
     subst("cublasCdgmm", "rocblas_cdgmm", "library");
     subst("cublasCdotc", "rocblas_cdotc", "library");
     subst("cublasCdotc_v2", "rocblas_cdotc", "library");
@@ -1881,7 +1883,9 @@ sub rocSubstitutions {
     subst("cublasDaxpy_v2", "rocblas_daxpy", "library");
     subst("cublasDaxpy_v2_64", "rocblas_daxpy_64", "library");
     subst("cublasDcopy", "rocblas_dcopy", "library");
+    subst("cublasDcopy_64", "rocblas_dcopy_64", "library");
     subst("cublasDcopy_v2", "rocblas_dcopy", "library");
+    subst("cublasDcopy_v2_64", "rocblas_dcopy_64", "library");
     subst("cublasDdgmm", "rocblas_ddgmm", "library");
     subst("cublasDdot", "rocblas_ddot", "library");
     subst("cublasDdot_v2", "rocblas_ddot", "library");
@@ -2030,7 +2034,9 @@ sub rocSubstitutions {
     subst("cublasScnrm2", "rocblas_scnrm2", "library");
     subst("cublasScnrm2_v2", "rocblas_scnrm2", "library");
     subst("cublasScopy", "rocblas_scopy", "library");
+    subst("cublasScopy_64", "rocblas_scopy_64", "library");
     subst("cublasScopy_v2", "rocblas_scopy", "library");
+    subst("cublasScopy_v2_64", "rocblas_scopy_64", "library");
     subst("cublasSdgmm", "rocblas_sdgmm", "library");
     subst("cublasSdot", "rocblas_sdot", "library");
     subst("cublasSdot_v2", "rocblas_sdot", "library");
@@ -2116,7 +2122,9 @@ sub rocSubstitutions {
     subst("cublasZaxpy_v2", "rocblas_zaxpy", "library");
     subst("cublasZaxpy_v2_64", "rocblas_zaxpy_64", "library");
     subst("cublasZcopy", "rocblas_zcopy", "library");
+    subst("cublasZcopy_64", "rocblas_zcopy_64", "library");
     subst("cublasZcopy_v2", "rocblas_zcopy", "library");
+    subst("cublasZcopy_v2_64", "rocblas_zcopy_64", "library");
     subst("cublasZdgmm", "rocblas_zdgmm", "library");
     subst("cublasZdotc", "rocblas_zdotc", "library");
     subst("cublasZdotc_v2", "rocblas_zdotc", "library");
@@ -3736,7 +3744,9 @@ sub simpleSubstitutions {
     subst("cublasCaxpy_v2", "hipblasCaxpy_v2", "library");
     subst("cublasCaxpy_v2_64", "hipblasCaxpy_v2_64", "library");
     subst("cublasCcopy", "hipblasCcopy_v2", "library");
+    subst("cublasCcopy_64", "hipblasCcopy_v2_64", "library");
     subst("cublasCcopy_v2", "hipblasCcopy_v2", "library");
+    subst("cublasCcopy_v2_64", "hipblasCcopy_v2_64", "library");
     subst("cublasCdgmm", "hipblasCdgmm_v2", "library");
     subst("cublasCdotc", "hipblasCdotc_v2", "library");
     subst("cublasCdotc_v2", "hipblasCdotc_v2", "library");
@@ -3836,7 +3846,9 @@ sub simpleSubstitutions {
     subst("cublasDaxpy_v2", "hipblasDaxpy", "library");
     subst("cublasDaxpy_v2_64", "hipblasDaxpy_64", "library");
     subst("cublasDcopy", "hipblasDcopy", "library");
+    subst("cublasDcopy_64", "hipblasDcopy_64", "library");
     subst("cublasDcopy_v2", "hipblasDcopy", "library");
+    subst("cublasDcopy_v2_64", "hipblasDcopy_64", "library");
     subst("cublasDdgmm", "hipblasDdgmm", "library");
     subst("cublasDdot", "hipblasDdot", "library");
     subst("cublasDdot_v2", "hipblasDdot", "library");
@@ -3984,7 +3996,9 @@ sub simpleSubstitutions {
     subst("cublasScnrm2", "hipblasScnrm2_v2", "library");
     subst("cublasScnrm2_v2", "hipblasScnrm2_v2", "library");
     subst("cublasScopy", "hipblasScopy", "library");
+    subst("cublasScopy_64", "hipblasScopy_64", "library");
     subst("cublasScopy_v2", "hipblasScopy", "library");
+    subst("cublasScopy_v2_64", "hipblasScopy_64", "library");
     subst("cublasSdgmm", "hipblasSdgmm", "library");
     subst("cublasSdot", "hipblasSdot", "library");
     subst("cublasSdot_v2", "hipblasSdot", "library");
@@ -4071,7 +4085,9 @@ sub simpleSubstitutions {
     subst("cublasZaxpy_v2", "hipblasZaxpy_v2", "library");
     subst("cublasZaxpy_v2_64", "hipblasZaxpy_v2_64", "library");
     subst("cublasZcopy", "hipblasZcopy_v2", "library");
+    subst("cublasZcopy_64", "hipblasZcopy_v2_64", "library");
     subst("cublasZcopy_v2", "hipblasZcopy_v2", "library");
+    subst("cublasZcopy_v2_64", "hipblasZcopy_v2_64", "library");
     subst("cublasZdgmm", "hipblasZdgmm_v2", "library");
     subst("cublasZdotc", "hipblasZdotc_v2", "library");
     subst("cublasZdotc_v2", "hipblasZdotc_v2", "library");
@@ -10800,8 +10816,6 @@ sub warnHipOnlyUnsupportedFunctions {
         "cublasZdotc_v2_64",
         "cublasZdotc_64",
         "cublasZdgmm_64",
-        "cublasZcopy_v2_64",
-        "cublasZcopy_64",
         "cublasXerbla",
         "cublasUint8gemmBias",
         "cublasTSTgemvStridedBatched_64",
@@ -10893,8 +10907,6 @@ sub warnHipOnlyUnsupportedFunctions {
         "cublasSdot_v2_64",
         "cublasSdot_64",
         "cublasSdgmm_64",
-        "cublasScopy_v2_64",
-        "cublasScopy_64",
         "cublasScnrm2_v2_64",
         "cublasScnrm2_64",
         "cublasScalEx_64",
@@ -11013,8 +11025,6 @@ sub warnHipOnlyUnsupportedFunctions {
         "cublasDdot_v2_64",
         "cublasDdot_64",
         "cublasDdgmm_64",
-        "cublasDcopy_v2_64",
-        "cublasDcopy_64",
         "cublasCtrttp",
         "cublasCtrsv_v2_64",
         "cublasCtrsv_64",
@@ -11120,8 +11130,6 @@ sub warnHipOnlyUnsupportedFunctions {
         "cublasCdotc_v2_64",
         "cublasCdotc_64",
         "cublasCdgmm_64",
-        "cublasCcopy_v2_64",
-        "cublasCcopy_64",
         "cublasAxpyEx_64",
         "cublasAsumEx_64",
         "cublasAsumEx",
@@ -11289,8 +11297,6 @@ sub warnRocOnlyUnsupportedFunctions {
         "cublasZdotc_v2_64",
         "cublasZdotc_64",
         "cublasZdgmm_64",
-        "cublasZcopy_v2_64",
-        "cublasZcopy_64",
         "cublasXerbla",
         "cublasUint8gemmBias",
         "cublasTSTgemvStridedBatched_64",
@@ -11383,8 +11389,6 @@ sub warnRocOnlyUnsupportedFunctions {
         "cublasSdot_v2_64",
         "cublasSdot_64",
         "cublasSdgmm_64",
-        "cublasScopy_v2_64",
-        "cublasScopy_64",
         "cublasScnrm2_v2_64",
         "cublasScnrm2_64",
         "cublasScalEx_64",
@@ -11502,8 +11506,6 @@ sub warnRocOnlyUnsupportedFunctions {
         "cublasDdot_v2_64",
         "cublasDdot_64",
         "cublasDdgmm_64",
-        "cublasDcopy_v2_64",
-        "cublasDcopy_64",
         "cublasCtrttp",
         "cublasCtrsv_v2_64",
         "cublasCtrsv_64",
@@ -11613,8 +11615,6 @@ sub warnRocOnlyUnsupportedFunctions {
         "cublasCdotc_v2_64",
         "cublasCdotc_64",
         "cublasCdgmm_64",
-        "cublasCcopy_v2_64",
-        "cublasCcopy_64",
         "cublasAxpyEx_64",
         "cublasAsumEx_64",
         "cublasAsumEx",

--- a/docs/tables/CUBLAS_API_supported_by_HIP.md
+++ b/docs/tables/CUBLAS_API_supported_by_HIP.md
@@ -208,9 +208,9 @@
 |`cublasCaxpy_v2`| | | | |`hipblasCaxpy_v2`|6.0.0| | | | |
 |`cublasCaxpy_v2_64`|12.0| | | |`hipblasCaxpy_v2_64`|6.1.0| | | | |
 |`cublasCcopy`| | | | |`hipblasCcopy_v2`|6.0.0| | | | |
-|`cublasCcopy_64`|12.0| | | | | | | | | |
+|`cublasCcopy_64`|12.0| | | |`hipblasCcopy_v2_64`|6.1.0| | | | |
 |`cublasCcopy_v2`| | | | |`hipblasCcopy_v2`|6.0.0| | | | |
-|`cublasCcopy_v2_64`|12.0| | | | | | | | | |
+|`cublasCcopy_v2_64`|12.0| | | |`hipblasCcopy_v2_64`|6.1.0| | | | |
 |`cublasCdotc`| | | | |`hipblasCdotc_v2`|6.0.0| | | | |
 |`cublasCdotc_64`|12.0| | | | | | | | | |
 |`cublasCdotc_v2`| | | | |`hipblasCdotc_v2`|6.0.0| | | | |
@@ -250,9 +250,9 @@
 |`cublasDaxpy_v2`| | | | |`hipblasDaxpy`|1.8.2| | | | |
 |`cublasDaxpy_v2_64`|12.0| | | |`hipblasDaxpy_64`|6.1.0| | | | |
 |`cublasDcopy`| | | | |`hipblasDcopy`|1.8.2| | | | |
-|`cublasDcopy_64`|12.0| | | | | | | | | |
+|`cublasDcopy_64`|12.0| | | |`hipblasDcopy_64`|6.1.0| | | | |
 |`cublasDcopy_v2`| | | | |`hipblasDcopy`|1.8.2| | | | |
-|`cublasDcopy_v2_64`|12.0| | | | | | | | | |
+|`cublasDcopy_v2_64`|12.0| | | |`hipblasDcopy_64`|6.1.0| | | | |
 |`cublasDdot`| | | | |`hipblasDdot`|3.0.0| | | | |
 |`cublasDdot_64`|12.0| | | | | | | | | |
 |`cublasDdot_v2`| | | | |`hipblasDdot`|3.0.0| | | | |
@@ -340,9 +340,9 @@
 |`cublasScnrm2_v2`| | | | |`hipblasScnrm2_v2`|6.0.0| | | | |
 |`cublasScnrm2_v2_64`|12.0| | | | | | | | | |
 |`cublasScopy`| | | | |`hipblasScopy`|1.8.2| | | | |
-|`cublasScopy_64`|12.0| | | | | | | | | |
+|`cublasScopy_64`|12.0| | | |`hipblasScopy_64`|6.1.0| | | | |
 |`cublasScopy_v2`| | | | |`hipblasScopy`|1.8.2| | | | |
-|`cublasScopy_v2_64`|12.0| | | | | | | | | |
+|`cublasScopy_v2_64`|12.0| | | |`hipblasScopy_64`|6.1.0| | | | |
 |`cublasSdot`| | | | |`hipblasSdot`|3.0.0| | | | |
 |`cublasSdot_64`|12.0| | | | | | | | | |
 |`cublasSdot_v2`| | | | |`hipblasSdot`|3.0.0| | | | |
@@ -376,9 +376,9 @@
 |`cublasZaxpy_v2`| | | | |`hipblasZaxpy_v2`|6.0.0| | | | |
 |`cublasZaxpy_v2_64`|12.0| | | |`hipblasZaxpy_v2_64`|6.1.0| | | | |
 |`cublasZcopy`| | | | |`hipblasZcopy_v2`|6.0.0| | | | |
-|`cublasZcopy_64`|12.0| | | | | | | | | |
+|`cublasZcopy_64`|12.0| | | |`hipblasZcopy_v2_64`|6.1.0| | | | |
 |`cublasZcopy_v2`| | | | |`hipblasZcopy_v2`|6.0.0| | | | |
-|`cublasZcopy_v2_64`|12.0| | | | | | | | | |
+|`cublasZcopy_v2_64`|12.0| | | |`hipblasZcopy_v2_64`|6.1.0| | | | |
 |`cublasZdotc`| | | | |`hipblasZdotc_v2`|6.0.0| | | | |
 |`cublasZdotc_64`|12.0| | | | | | | | | |
 |`cublasZdotc_v2`| | | | |`hipblasZdotc_v2`|6.0.0| | | | |

--- a/docs/tables/CUBLAS_API_supported_by_HIP_and_ROC.md
+++ b/docs/tables/CUBLAS_API_supported_by_HIP_and_ROC.md
@@ -208,9 +208,9 @@
 |`cublasCaxpy_v2`| | | | |`hipblasCaxpy_v2`|6.0.0| | | | |`rocblas_caxpy`|1.5.0| | | | |
 |`cublasCaxpy_v2_64`|12.0| | | |`hipblasCaxpy_v2_64`|6.1.0| | | | |`rocblas_caxpy_64`|6.1.0| | | | |
 |`cublasCcopy`| | | | |`hipblasCcopy_v2`|6.0.0| | | | |`rocblas_ccopy`|1.5.0| | | | |
-|`cublasCcopy_64`|12.0| | | | | | | | | | | | | | | |
+|`cublasCcopy_64`|12.0| | | |`hipblasCcopy_v2_64`|6.1.0| | | | |`rocblas_ccopy_64`|6.1.0| | | | |
 |`cublasCcopy_v2`| | | | |`hipblasCcopy_v2`|6.0.0| | | | |`rocblas_ccopy`|1.5.0| | | | |
-|`cublasCcopy_v2_64`|12.0| | | | | | | | | | | | | | | |
+|`cublasCcopy_v2_64`|12.0| | | |`hipblasCcopy_v2_64`|6.1.0| | | | |`rocblas_ccopy_64`|6.1.0| | | | |
 |`cublasCdotc`| | | | |`hipblasCdotc_v2`|6.0.0| | | | |`rocblas_cdotc`|3.5.0| | | | |
 |`cublasCdotc_64`|12.0| | | | | | | | | | | | | | | |
 |`cublasCdotc_v2`| | | | |`hipblasCdotc_v2`|6.0.0| | | | |`rocblas_cdotc`|3.5.0| | | | |
@@ -250,9 +250,9 @@
 |`cublasDaxpy_v2`| | | | |`hipblasDaxpy`|1.8.2| | | | |`rocblas_daxpy`|1.5.0| | | | |
 |`cublasDaxpy_v2_64`|12.0| | | |`hipblasDaxpy_64`|6.1.0| | | | |`rocblas_daxpy_64`|6.1.0| | | | |
 |`cublasDcopy`| | | | |`hipblasDcopy`|1.8.2| | | | |`rocblas_dcopy`|1.5.0| | | | |
-|`cublasDcopy_64`|12.0| | | | | | | | | | | | | | | |
+|`cublasDcopy_64`|12.0| | | |`hipblasDcopy_64`|6.1.0| | | | |`rocblas_dcopy_64`|6.1.0| | | | |
 |`cublasDcopy_v2`| | | | |`hipblasDcopy`|1.8.2| | | | |`rocblas_dcopy`|1.5.0| | | | |
-|`cublasDcopy_v2_64`|12.0| | | | | | | | | | | | | | | |
+|`cublasDcopy_v2_64`|12.0| | | |`hipblasDcopy_64`|6.1.0| | | | |`rocblas_dcopy_64`|6.1.0| | | | |
 |`cublasDdot`| | | | |`hipblasDdot`|3.0.0| | | | |`rocblas_ddot`|1.5.0| | | | |
 |`cublasDdot_64`|12.0| | | | | | | | | | | | | | | |
 |`cublasDdot_v2`| | | | |`hipblasDdot`|3.0.0| | | | |`rocblas_ddot`|1.5.0| | | | |
@@ -340,9 +340,9 @@
 |`cublasScnrm2_v2`| | | | |`hipblasScnrm2_v2`|6.0.0| | | | |`rocblas_scnrm2`|1.5.0| | | | |
 |`cublasScnrm2_v2_64`|12.0| | | | | | | | | | | | | | | |
 |`cublasScopy`| | | | |`hipblasScopy`|1.8.2| | | | |`rocblas_scopy`|1.5.0| | | | |
-|`cublasScopy_64`|12.0| | | | | | | | | | | | | | | |
+|`cublasScopy_64`|12.0| | | |`hipblasScopy_64`|6.1.0| | | | |`rocblas_scopy_64`|6.1.0| | | | |
 |`cublasScopy_v2`| | | | |`hipblasScopy`|1.8.2| | | | |`rocblas_scopy`|1.5.0| | | | |
-|`cublasScopy_v2_64`|12.0| | | | | | | | | | | | | | | |
+|`cublasScopy_v2_64`|12.0| | | |`hipblasScopy_64`|6.1.0| | | | |`rocblas_scopy_64`|6.1.0| | | | |
 |`cublasSdot`| | | | |`hipblasSdot`|3.0.0| | | | |`rocblas_sdot`|1.5.0| | | | |
 |`cublasSdot_64`|12.0| | | | | | | | | | | | | | | |
 |`cublasSdot_v2`| | | | |`hipblasSdot`|3.0.0| | | | |`rocblas_sdot`|1.5.0| | | | |
@@ -376,9 +376,9 @@
 |`cublasZaxpy_v2`| | | | |`hipblasZaxpy_v2`|6.0.0| | | | |`rocblas_zaxpy`|1.5.0| | | | |
 |`cublasZaxpy_v2_64`|12.0| | | |`hipblasZaxpy_v2_64`|6.1.0| | | | |`rocblas_zaxpy_64`|6.1.0| | | | |
 |`cublasZcopy`| | | | |`hipblasZcopy_v2`|6.0.0| | | | |`rocblas_zcopy`|1.5.0| | | | |
-|`cublasZcopy_64`|12.0| | | | | | | | | | | | | | | |
+|`cublasZcopy_64`|12.0| | | |`hipblasZcopy_v2_64`|6.1.0| | | | |`rocblas_zcopy_64`|6.1.0| | | | |
 |`cublasZcopy_v2`| | | | |`hipblasZcopy_v2`|6.0.0| | | | |`rocblas_zcopy`|1.5.0| | | | |
-|`cublasZcopy_v2_64`|12.0| | | | | | | | | | | | | | | |
+|`cublasZcopy_v2_64`|12.0| | | |`hipblasZcopy_v2_64`|6.1.0| | | | |`rocblas_zcopy_64`|6.1.0| | | | |
 |`cublasZdotc`| | | | |`hipblasZdotc_v2`|6.0.0| | | | |`rocblas_zdotc`|3.5.0| | | | |
 |`cublasZdotc_64`|12.0| | | | | | | | | | | | | | | |
 |`cublasZdotc_v2`| | | | |`hipblasZdotc_v2`|6.0.0| | | | |`rocblas_zdotc`|3.5.0| | | | |

--- a/docs/tables/CUBLAS_API_supported_by_ROC.md
+++ b/docs/tables/CUBLAS_API_supported_by_ROC.md
@@ -208,9 +208,9 @@
 |`cublasCaxpy_v2`| | | | |`rocblas_caxpy`|1.5.0| | | | |
 |`cublasCaxpy_v2_64`|12.0| | | |`rocblas_caxpy_64`|6.1.0| | | | |
 |`cublasCcopy`| | | | |`rocblas_ccopy`|1.5.0| | | | |
-|`cublasCcopy_64`|12.0| | | | | | | | | |
+|`cublasCcopy_64`|12.0| | | |`rocblas_ccopy_64`|6.1.0| | | | |
 |`cublasCcopy_v2`| | | | |`rocblas_ccopy`|1.5.0| | | | |
-|`cublasCcopy_v2_64`|12.0| | | | | | | | | |
+|`cublasCcopy_v2_64`|12.0| | | |`rocblas_ccopy_64`|6.1.0| | | | |
 |`cublasCdotc`| | | | |`rocblas_cdotc`|3.5.0| | | | |
 |`cublasCdotc_64`|12.0| | | | | | | | | |
 |`cublasCdotc_v2`| | | | |`rocblas_cdotc`|3.5.0| | | | |
@@ -250,9 +250,9 @@
 |`cublasDaxpy_v2`| | | | |`rocblas_daxpy`|1.5.0| | | | |
 |`cublasDaxpy_v2_64`|12.0| | | |`rocblas_daxpy_64`|6.1.0| | | | |
 |`cublasDcopy`| | | | |`rocblas_dcopy`|1.5.0| | | | |
-|`cublasDcopy_64`|12.0| | | | | | | | | |
+|`cublasDcopy_64`|12.0| | | |`rocblas_dcopy_64`|6.1.0| | | | |
 |`cublasDcopy_v2`| | | | |`rocblas_dcopy`|1.5.0| | | | |
-|`cublasDcopy_v2_64`|12.0| | | | | | | | | |
+|`cublasDcopy_v2_64`|12.0| | | |`rocblas_dcopy_64`|6.1.0| | | | |
 |`cublasDdot`| | | | |`rocblas_ddot`|1.5.0| | | | |
 |`cublasDdot_64`|12.0| | | | | | | | | |
 |`cublasDdot_v2`| | | | |`rocblas_ddot`|1.5.0| | | | |
@@ -340,9 +340,9 @@
 |`cublasScnrm2_v2`| | | | |`rocblas_scnrm2`|1.5.0| | | | |
 |`cublasScnrm2_v2_64`|12.0| | | | | | | | | |
 |`cublasScopy`| | | | |`rocblas_scopy`|1.5.0| | | | |
-|`cublasScopy_64`|12.0| | | | | | | | | |
+|`cublasScopy_64`|12.0| | | |`rocblas_scopy_64`|6.1.0| | | | |
 |`cublasScopy_v2`| | | | |`rocblas_scopy`|1.5.0| | | | |
-|`cublasScopy_v2_64`|12.0| | | | | | | | | |
+|`cublasScopy_v2_64`|12.0| | | |`rocblas_scopy_64`|6.1.0| | | | |
 |`cublasSdot`| | | | |`rocblas_sdot`|1.5.0| | | | |
 |`cublasSdot_64`|12.0| | | | | | | | | |
 |`cublasSdot_v2`| | | | |`rocblas_sdot`|1.5.0| | | | |
@@ -376,9 +376,9 @@
 |`cublasZaxpy_v2`| | | | |`rocblas_zaxpy`|1.5.0| | | | |
 |`cublasZaxpy_v2_64`|12.0| | | |`rocblas_zaxpy_64`|6.1.0| | | | |
 |`cublasZcopy`| | | | |`rocblas_zcopy`|1.5.0| | | | |
-|`cublasZcopy_64`|12.0| | | | | | | | | |
+|`cublasZcopy_64`|12.0| | | |`rocblas_zcopy_64`|6.1.0| | | | |
 |`cublasZcopy_v2`| | | | |`rocblas_zcopy`|1.5.0| | | | |
-|`cublasZcopy_v2_64`|12.0| | | | | | | | | |
+|`cublasZcopy_v2_64`|12.0| | | |`rocblas_zcopy_64`|6.1.0| | | | |
 |`cublasZdotc`| | | | |`rocblas_zdotc`|3.5.0| | | | |
 |`cublasZdotc_64`|12.0| | | | | | | | | |
 |`cublasZdotc_v2`| | | | |`rocblas_zdotc`|3.5.0| | | | |

--- a/src/CUDA2HIP_BLAS_API_functions.cpp
+++ b/src/CUDA2HIP_BLAS_API_functions.cpp
@@ -140,13 +140,13 @@ const std::map<llvm::StringRef, hipCounter> CUDA_BLAS_FUNCTION_MAP {
 
   // COPY
   {"cublasScopy",                    {"hipblasScopy",                    "rocblas_scopy",                            CONV_LIB_FUNC, API_BLAS, 5, HIP_SUPPORTED_V2_ONLY}},
-  {"cublasScopy_64",                 {"hipblasScopy_64",                 "",                                         CONV_LIB_FUNC, API_BLAS, 5, UNSUPPORTED}},
+  {"cublasScopy_64",                 {"hipblasScopy_64",                 "rocblas_scopy_64",                         CONV_LIB_FUNC, API_BLAS, 5}},
   {"cublasDcopy",                    {"hipblasDcopy",                    "rocblas_dcopy",                            CONV_LIB_FUNC, API_BLAS, 5, HIP_SUPPORTED_V2_ONLY}},
-  {"cublasDcopy_64",                 {"hipblasDcopy_64",                 "",                                         CONV_LIB_FUNC, API_BLAS, 5, UNSUPPORTED}},
+  {"cublasDcopy_64",                 {"hipblasDcopy_64",                 "rocblas_dcopy_64",                         CONV_LIB_FUNC, API_BLAS, 5}},
   {"cublasCcopy",                    {"hipblasCcopy_v2",                 "rocblas_ccopy",                            CONV_LIB_FUNC, API_BLAS, 5, HIP_SUPPORTED_V2_ONLY}},
-  {"cublasCcopy_64",                 {"hipblasCcopy_64",                 "",                                         CONV_LIB_FUNC, API_BLAS, 5, UNSUPPORTED}},
+  {"cublasCcopy_64",                 {"hipblasCcopy_v2_64",              "rocblas_ccopy_64",                         CONV_LIB_FUNC, API_BLAS, 5}},
   {"cublasZcopy",                    {"hipblasZcopy_v2",                 "rocblas_zcopy",                            CONV_LIB_FUNC, API_BLAS, 5, HIP_SUPPORTED_V2_ONLY}},
-  {"cublasZcopy_64",                 {"hipblasZcopy_64",                 "",                                         CONV_LIB_FUNC, API_BLAS, 5, UNSUPPORTED}},
+  {"cublasZcopy_64",                 {"hipblasZcopy_v2_64",              "rocblas_zcopy_64",                         CONV_LIB_FUNC, API_BLAS, 5}},
 
   // SWAP
   {"cublasSswap",                    {"hipblasSswap",                    "rocblas_sswap",                            CONV_LIB_FUNC, API_BLAS, 5, HIP_SUPPORTED_V2_ONLY}},
@@ -980,13 +980,13 @@ const std::map<llvm::StringRef, hipCounter> CUDA_BLAS_FUNCTION_MAP {
   {"cublasCopyEx",                   {"hipblasCopyEx",                   "",                                         CONV_LIB_FUNC, API_BLAS, 8, UNSUPPORTED}},
   {"cublasCopyEx_64",                {"hipblasCopyEx_64",                "",                                         CONV_LIB_FUNC, API_BLAS, 8, UNSUPPORTED}},
   {"cublasScopy_v2",                 {"hipblasScopy",                    "rocblas_scopy",                            CONV_LIB_FUNC, API_BLAS, 5}},
-  {"cublasScopy_v2_64",              {"hipblasScopy_64",                 "",                                         CONV_LIB_FUNC, API_BLAS, 5, UNSUPPORTED}},
+  {"cublasScopy_v2_64",              {"hipblasScopy_64",                 "rocblas_scopy_64",                         CONV_LIB_FUNC, API_BLAS, 5}},
   {"cublasDcopy_v2",                 {"hipblasDcopy",                    "rocblas_dcopy",                            CONV_LIB_FUNC, API_BLAS, 5}},
-  {"cublasDcopy_v2_64",              {"hipblasDcopy_64",                 "",                                         CONV_LIB_FUNC, API_BLAS, 5, UNSUPPORTED}},
+  {"cublasDcopy_v2_64",              {"hipblasDcopy_64",                 "rocblas_dcopy_64",                         CONV_LIB_FUNC, API_BLAS, 5}},
   {"cublasCcopy_v2",                 {"hipblasCcopy_v2",                 "rocblas_ccopy",                            CONV_LIB_FUNC, API_BLAS, 5}},
-  {"cublasCcopy_v2_64",              {"hipblasCcopy_64",                 "",                                         CONV_LIB_FUNC, API_BLAS, 5, UNSUPPORTED}},
+  {"cublasCcopy_v2_64",              {"hipblasCcopy_v2_64",              "rocblas_ccopy_64",                         CONV_LIB_FUNC, API_BLAS, 5}},
   {"cublasZcopy_v2",                 {"hipblasZcopy_v2",                 "rocblas_zcopy",                            CONV_LIB_FUNC, API_BLAS, 5}},
-  {"cublasZcopy_v2_64",              {"hipblasZcopy_64",                 "",                                         CONV_LIB_FUNC, API_BLAS, 5, UNSUPPORTED}},
+  {"cublasZcopy_v2_64",              {"hipblasZcopy_v2_64",              "rocblas_zcopy_64",                         CONV_LIB_FUNC, API_BLAS, 5}},
 
   // SWAP
   {"cublasSwapEx",                   {"hipblasSwapEx",                   "",                                         CONV_LIB_FUNC, API_BLAS, 8, UNSUPPORTED}},
@@ -1887,6 +1887,10 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_BLAS_FUNCTION_VER_MAP {
   {"hipblasDaxpy_64",                            {HIP_6010, HIP_0,    HIP_0,  }},
   {"hipblasCaxpy_v2_64",                         {HIP_6010, HIP_0,    HIP_0,  }},
   {"hipblasZaxpy_v2_64",                         {HIP_6010, HIP_0,    HIP_0,  }},
+  {"hipblasScopy_64",                            {HIP_6010, HIP_0,    HIP_0,  }},
+  {"hipblasDcopy_64",                            {HIP_6010, HIP_0,    HIP_0,  }},
+  {"hipblasCcopy_v2_64",                         {HIP_6010, HIP_0,    HIP_0,  }},
+  {"hipblasZcopy_v2_64",                         {HIP_6010, HIP_0,    HIP_0,  }},
 
   {"rocblas_status_to_string",                   {HIP_3050, HIP_0,    HIP_0   }},
   {"rocblas_sscal",                              {HIP_1050, HIP_0,    HIP_0   }},
@@ -2139,6 +2143,10 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_BLAS_FUNCTION_VER_MAP {
   {"rocblas_daxpy_64",                           {HIP_6010, HIP_0,    HIP_0,  }},
   {"rocblas_caxpy_64",                           {HIP_6010, HIP_0,    HIP_0,  }},
   {"rocblas_zaxpy_64",                           {HIP_6010, HIP_0,    HIP_0,  }},
+  {"rocblas_scopy_64",                           {HIP_6010, HIP_0,    HIP_0,  }},
+  {"rocblas_dcopy_64",                           {HIP_6010, HIP_0,    HIP_0,  }},
+  {"rocblas_ccopy_64",                           {HIP_6010, HIP_0,    HIP_0,  }},
+  {"rocblas_zcopy_64",                           {HIP_6010, HIP_0,    HIP_0,  }},
 };
 
 const std::map<llvm::StringRef, hipAPIChangedVersions> HIP_BLAS_FUNCTION_CHANGED_VER_MAP {

--- a/tests/unit_tests/synthetic/libraries/cublas2hipblas_v2.cu
+++ b/tests/unit_tests/synthetic/libraries/cublas2hipblas_v2.cu
@@ -1950,6 +1950,34 @@ int main() {
   // CHECK-NEXT: blasStatus = hipblasZaxpy_v2_64(blasHandle, n_64, &dcomplexa, &dcomplexx, incx_64, &dcomplexy, incy_64);
   blasStatus = cublasZaxpy_64(blasHandle, n_64, &dcomplexa, &dcomplexx, incx_64, &dcomplexy, incy_64);
   blasStatus = cublasZaxpy_v2_64(blasHandle, n_64, &dcomplexa, &dcomplexx, incx_64, &dcomplexy, incy_64);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasScopy_v2_64(cublasHandle_t handle, int64_t n, const float* x, int64_t incx, float* y, int64_t incy);
+  // HIP: HIPBLAS_EXPORT hipblasStatus_t hipblasScopy_64(hipblasHandle_t handle, int64_t n, const float* x, int64_t incx, float* y, int64_t incy);
+  // CHECK: blasStatus = hipblasScopy_64(blasHandle, n_64, &fx, incx_64, &fy, incy_64);
+  // CHECK-NEXT: blasStatus = hipblasScopy_64(blasHandle, n_64, &fx, incx_64, &fy, incy_64);
+  blasStatus = cublasScopy_64(blasHandle, n_64, &fx, incx_64, &fy, incy_64);
+  blasStatus = cublasScopy_v2_64(blasHandle, n_64, &fx, incx_64, &fy, incy_64);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasDcopy_v2_64(cublasHandle_t handle, int64_t n, const double* x, int64_t incx, double* y, int64_t incy);
+  // HIP: HIPBLAS_EXPORT hipblasStatus_t hipblasDcopy_64(hipblasHandle_t handle, int64_t n, const double* x, int64_t incx, double* y, int64_t incy);
+  // CHECK: blasStatus = hipblasDcopy_64(blasHandle, n_64, &dx, incx_64, &dy, incy_64);
+  // CHECK-NEXT: blasStatus = hipblasDcopy_64(blasHandle, n_64, &dx, incx_64, &dy, incy_64);
+  blasStatus = cublasDcopy_64(blasHandle, n_64, &dx, incx_64, &dy, incy_64);
+  blasStatus = cublasDcopy_v2_64(blasHandle, n_64, &dx, incx_64, &dy, incy_64);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasCcopy_v2_64(cublasHandle_t handle, int64_t n, const cuComplex* x, int64_t incx, cuComplex* y, int64_t incy);
+  // HIP: HIPBLAS_EXPORT hipblasStatus_t hipblasCcopy_v2_64(hipblasHandle_t handle, int64_t n, const hipComplex* x, int64_t incx, hipComplex* y, int64_t incy);
+  // CHECK: blasStatus = hipblasCcopy_v2_64(blasHandle, n_64, &complexx, incx_64, &complexy, incy_64);
+  // CHECK-NEXT: blasStatus = hipblasCcopy_v2_64(blasHandle, n_64, &complexx, incx_64, &complexy, incy_64);
+  blasStatus = cublasCcopy_64(blasHandle, n_64, &complexx, incx_64, &complexy, incy_64);
+  blasStatus = cublasCcopy_v2_64(blasHandle, n_64, &complexx, incx_64, &complexy, incy_64);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasZcopy_v2_64(cublasHandle_t handle, int64_t n, const cuDoubleComplex* x, int64_t incx, cuDoubleComplex* y, int64_t incy);
+  // HIP: HIPBLAS_EXPORT hipblasStatus_t hipblasZcopy_v2_64(hipblasHandle_t handle, int64_t n, const hipDoubleComplex* x, int64_t incx, hipDoubleComplex* y, int64_t incy);
+  // CHECK: blasStatus = hipblasZcopy_v2_64(blasHandle, n_64, &dcomplexx, incx_64, &dcomplexy, incy_64);
+  // CHECK-NEXT: blasStatus = hipblasZcopy_v2_64(blasHandle, n_64, &dcomplexx, incx_64, &dcomplexy, incy_64);
+  blasStatus = cublasZcopy_64(blasHandle, n_64, &dcomplexx, incx_64, &dcomplexy, incy_64);
+  blasStatus = cublasZcopy_v2_64(blasHandle, n_64, &dcomplexx, incx_64, &dcomplexy, incy_64);
 #endif
 
   return 0;

--- a/tests/unit_tests/synthetic/libraries/cublas2rocblas_v2.cu
+++ b/tests/unit_tests/synthetic/libraries/cublas2rocblas_v2.cu
@@ -2035,6 +2035,34 @@ int main() {
   // CHECK-NEXT: blasStatus = rocblas_zaxpy_64(blasHandle, n_64, &dcomplexa, &dcomplexx, incx_64, &dcomplexy, incy_64);
   blasStatus = cublasZaxpy_64(blasHandle, n_64, &dcomplexa, &dcomplexx, incx_64, &dcomplexy, incy_64);
   blasStatus = cublasZaxpy_v2_64(blasHandle, n_64, &dcomplexa, &dcomplexx, incx_64, &dcomplexy, incy_64);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasScopy_v2_64(cublasHandle_t handle, int64_t n, const float* x, int64_t incx, float* y, int64_t incy);
+  // ROC: ROCBLAS_EXPORT rocblas_status rocblas_scopy_64(rocblas_handle handle, int64_t n, const float* x, int64_t incx, float* y, int64_t incy);
+  // CHECK: blasStatus = rocblas_scopy_64(blasHandle, n_64, &fx, incx_64, &fy, incy_64);
+  // CHECK-NEXT: blasStatus = rocblas_scopy_64(blasHandle, n_64, &fx, incx_64, &fy, incy_64);
+  blasStatus = cublasScopy_64(blasHandle, n_64, &fx, incx_64, &fy, incy_64);
+  blasStatus = cublasScopy_v2_64(blasHandle, n_64, &fx, incx_64, &fy, incy_64);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasDcopy_v2_64(cublasHandle_t handle, int64_t n, const double* x, int64_t incx, double* y, int64_t incy);
+  // ROC: ROCBLAS_EXPORT rocblas_status rocblas_dcopy_64(rocblas_handle handle, int64_t n, const double* x, int64_t incx, double* y, int64_t incy);
+  // CHECK: blasStatus = rocblas_dcopy_64(blasHandle, n_64, &dx, incx_64, &dy, incy_64);
+  // CHECK-NEXT: blasStatus = rocblas_dcopy_64(blasHandle, n_64, &dx, incx_64, &dy, incy_64);
+  blasStatus = cublasDcopy_64(blasHandle, n_64, &dx, incx_64, &dy, incy_64);
+  blasStatus = cublasDcopy_v2_64(blasHandle, n_64, &dx, incx_64, &dy, incy_64);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasCcopy_v2_64(cublasHandle_t handle, int64_t n, const cuComplex* x, int64_t incx, cuComplex* y, int64_t incy);
+  // ROC: ROCBLAS_EXPORT rocblas_status rocblas_ccopy_64(rocblas_handle handle, int64_t n, const rocblas_float_complex* x, int64_t incx, rocblas_float_complex* y, int64_t incy);
+  // CHECK: blasStatus = rocblas_ccopy_64(blasHandle, n_64, &complexx, incx_64, &complexy, incy_64);
+  // CHECK-NEXT: blasStatus = rocblas_ccopy_64(blasHandle, n_64, &complexx, incx_64, &complexy, incy_64);
+  blasStatus = cublasCcopy_64(blasHandle, n_64, &complexx, incx_64, &complexy, incy_64);
+  blasStatus = cublasCcopy_v2_64(blasHandle, n_64, &complexx, incx_64, &complexy, incy_64);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasZcopy_v2_64(cublasHandle_t handle, int64_t n, const cuDoubleComplex* x, int64_t incx, cuDoubleComplex* y, int64_t incy);
+  // ROC: ROCBLAS_EXPORT rocblas_status rocblas_zcopy_64(rocblas_handle handle, int64_t n, const rocblas_double_complex* x, int64_t incx, rocblas_double_complex* y, int64_t incy);
+  // CHECK: blasStatus = rocblas_zcopy_64(blasHandle, n_64, &dcomplexx, incx_64, &dcomplexy, incy_64);
+  // CHECK-NEXT: blasStatus = rocblas_zcopy_64(blasHandle, n_64, &dcomplexx, incx_64, &dcomplexy, incy_64);
+  blasStatus = cublasZcopy_64(blasHandle, n_64, &dcomplexx, incx_64, &dcomplexy, incy_64);
+  blasStatus = cublasZcopy_v2_64(blasHandle, n_64, &dcomplexx, incx_64, &dcomplexy, incy_64);
 #endif
 
   return 0;


### PR DESCRIPTION
+ Updated `BLAS` synthetic tests, the regenerated hipify-perl, and `BLAS` `CUDA2HIP` documentation
