### PR TITLE
[HIPIFY][BLAS][6.1][sync] Sync with `hipBLAS` and `rocBLAS` - Step 7 - DOT 64bit

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -1791,9 +1791,13 @@ sub rocSubstitutions {
     subst("cublasCcopy_v2_64", "rocblas_ccopy_64", "library");
     subst("cublasCdgmm", "rocblas_cdgmm", "library");
     subst("cublasCdotc", "rocblas_cdotc", "library");
+    subst("cublasCdotc_64", "rocblas_cdotc_64", "library");
     subst("cublasCdotc_v2", "rocblas_cdotc", "library");
+    subst("cublasCdotc_v2_64", "rocblas_cdotc_64", "library");
     subst("cublasCdotu", "rocblas_cdotu", "library");
+    subst("cublasCdotu_64", "rocblas_cdotu_64", "library");
     subst("cublasCdotu_v2", "rocblas_cdotu", "library");
+    subst("cublasCdotu_v2_64", "rocblas_cdotu_64", "library");
     subst("cublasCgbmv", "rocblas_cgbmv", "library");
     subst("cublasCgbmv_v2", "rocblas_cgbmv", "library");
     subst("cublasCgeam", "rocblas_cgeam", "library");
@@ -1888,7 +1892,9 @@ sub rocSubstitutions {
     subst("cublasDcopy_v2_64", "rocblas_dcopy_64", "library");
     subst("cublasDdgmm", "rocblas_ddgmm", "library");
     subst("cublasDdot", "rocblas_ddot", "library");
+    subst("cublasDdot_64", "rocblas_ddot_64", "library");
     subst("cublasDdot_v2", "rocblas_ddot", "library");
+    subst("cublasDdot_v2_64", "rocblas_ddot_64", "library");
     subst("cublasDestroy", "rocblas_destroy_handle", "library");
     subst("cublasDestroy_v2", "rocblas_destroy_handle", "library");
     subst("cublasDgbmv", "rocblas_dgbmv", "library");
@@ -2039,7 +2045,9 @@ sub rocSubstitutions {
     subst("cublasScopy_v2_64", "rocblas_scopy_64", "library");
     subst("cublasSdgmm", "rocblas_sdgmm", "library");
     subst("cublasSdot", "rocblas_sdot", "library");
+    subst("cublasSdot_64", "rocblas_sdot_64", "library");
     subst("cublasSdot_v2", "rocblas_sdot", "library");
+    subst("cublasSdot_v2_64", "rocblas_sdot_64", "library");
     subst("cublasSetAtomicsMode", "rocblas_set_atomics_mode", "library");
     subst("cublasSetMathMode", "rocblas_set_math_mode", "library");
     subst("cublasSetMatrix", "rocblas_set_matrix", "library");
@@ -2127,9 +2135,13 @@ sub rocSubstitutions {
     subst("cublasZcopy_v2_64", "rocblas_zcopy_64", "library");
     subst("cublasZdgmm", "rocblas_zdgmm", "library");
     subst("cublasZdotc", "rocblas_zdotc", "library");
+    subst("cublasZdotc_64", "rocblas_zdotc_64", "library");
     subst("cublasZdotc_v2", "rocblas_zdotc", "library");
+    subst("cublasZdotc_v2_64", "rocblas_zdotc_64", "library");
     subst("cublasZdotu", "rocblas_zdotu", "library");
+    subst("cublasZdotu_64", "rocblas_zdotu_64", "library");
     subst("cublasZdotu_v2", "rocblas_zdotu", "library");
+    subst("cublasZdotu_v2_64", "rocblas_zdotu_64", "library");
     subst("cublasZdrot", "rocblas_zdrot", "library");
     subst("cublasZdrot_v2", "rocblas_zdrot", "library");
     subst("cublasZdscal", "rocblas_zdscal", "library");
@@ -3749,9 +3761,13 @@ sub simpleSubstitutions {
     subst("cublasCcopy_v2_64", "hipblasCcopy_v2_64", "library");
     subst("cublasCdgmm", "hipblasCdgmm_v2", "library");
     subst("cublasCdotc", "hipblasCdotc_v2", "library");
+    subst("cublasCdotc_64", "hipblasCdotc_v2_64", "library");
     subst("cublasCdotc_v2", "hipblasCdotc_v2", "library");
+    subst("cublasCdotc_v2_64", "hipblasCdotc_v2_64", "library");
     subst("cublasCdotu", "hipblasCdotu_v2", "library");
+    subst("cublasCdotu_64", "hipblasCdotu_v2_64", "library");
     subst("cublasCdotu_v2", "hipblasCdotu_v2", "library");
+    subst("cublasCdotu_v2_64", "hipblasCdotu_v2_64", "library");
     subst("cublasCgbmv", "hipblasCgbmv_v2", "library");
     subst("cublasCgbmv_v2", "hipblasCgbmv_v2", "library");
     subst("cublasCgeam", "hipblasCgeam_v2", "library");
@@ -3851,7 +3867,9 @@ sub simpleSubstitutions {
     subst("cublasDcopy_v2_64", "hipblasDcopy_64", "library");
     subst("cublasDdgmm", "hipblasDdgmm", "library");
     subst("cublasDdot", "hipblasDdot", "library");
+    subst("cublasDdot_64", "hipblasDdot_64", "library");
     subst("cublasDdot_v2", "hipblasDdot", "library");
+    subst("cublasDdot_v2_64", "hipblasDdot_64", "library");
     subst("cublasDestroy", "hipblasDestroy", "library");
     subst("cublasDestroy_v2", "hipblasDestroy", "library");
     subst("cublasDgbmv", "hipblasDgbmv", "library");
@@ -4001,7 +4019,9 @@ sub simpleSubstitutions {
     subst("cublasScopy_v2_64", "hipblasScopy_64", "library");
     subst("cublasSdgmm", "hipblasSdgmm", "library");
     subst("cublasSdot", "hipblasSdot", "library");
+    subst("cublasSdot_64", "hipblasSdot_64", "library");
     subst("cublasSdot_v2", "hipblasSdot", "library");
+    subst("cublasSdot_v2_64", "hipblasSdot_64", "library");
     subst("cublasSetAtomicsMode", "hipblasSetAtomicsMode", "library");
     subst("cublasSetMathMode", "hipblasSetMathMode", "library");
     subst("cublasSetMatrix", "hipblasSetMatrix", "library");
@@ -4090,9 +4110,13 @@ sub simpleSubstitutions {
     subst("cublasZcopy_v2_64", "hipblasZcopy_v2_64", "library");
     subst("cublasZdgmm", "hipblasZdgmm_v2", "library");
     subst("cublasZdotc", "hipblasZdotc_v2", "library");
+    subst("cublasZdotc_64", "hipblasZdotc_v2_64", "library");
     subst("cublasZdotc_v2", "hipblasZdotc_v2", "library");
+    subst("cublasZdotc_v2_64", "hipblasZdotc_v2_64", "library");
     subst("cublasZdotu", "hipblasZdotu_v2", "library");
+    subst("cublasZdotu_64", "hipblasZdotu_v2_64", "library");
     subst("cublasZdotu_v2", "hipblasZdotu_v2", "library");
+    subst("cublasZdotu_v2_64", "hipblasZdotu_v2_64", "library");
     subst("cublasZdrot", "hipblasZdrot_v2", "library");
     subst("cublasZdrot_v2", "hipblasZdrot_v2", "library");
     subst("cublasZdscal", "hipblasZdscal_v2", "library");
@@ -10811,10 +10835,6 @@ sub warnHipOnlyUnsupportedFunctions {
         "cublasZdscal_64",
         "cublasZdrot_v2_64",
         "cublasZdrot_64",
-        "cublasZdotu_v2_64",
-        "cublasZdotu_64",
-        "cublasZdotc_v2_64",
-        "cublasZdotc_64",
         "cublasZdgmm_64",
         "cublasXerbla",
         "cublasUint8gemmBias",
@@ -10904,8 +10924,6 @@ sub warnHipOnlyUnsupportedFunctions {
         "cublasSetMatrixAsync_64",
         "cublasSetLoggerCallback",
         "cublasSetKernelStream",
-        "cublasSdot_v2_64",
-        "cublasSdot_64",
         "cublasSdgmm_64",
         "cublasScnrm2_v2_64",
         "cublasScnrm2_64",
@@ -11022,8 +11040,6 @@ sub warnHipOnlyUnsupportedFunctions {
         "cublasDgeam_64",
         "cublasDgbmv_v2_64",
         "cublasDgbmv_64",
-        "cublasDdot_v2_64",
-        "cublasDdot_64",
         "cublasDdgmm_64",
         "cublasCtrttp",
         "cublasCtrsv_v2_64",
@@ -11125,10 +11141,6 @@ sub warnHipOnlyUnsupportedFunctions {
         "cublasCgeam_64",
         "cublasCgbmv_v2_64",
         "cublasCgbmv_64",
-        "cublasCdotu_v2_64",
-        "cublasCdotu_64",
-        "cublasCdotc_v2_64",
-        "cublasCdotc_64",
         "cublasCdgmm_64",
         "cublasAxpyEx_64",
         "cublasAsumEx_64",
@@ -11292,10 +11304,6 @@ sub warnRocOnlyUnsupportedFunctions {
         "cublasZdscal_64",
         "cublasZdrot_v2_64",
         "cublasZdrot_64",
-        "cublasZdotu_v2_64",
-        "cublasZdotu_64",
-        "cublasZdotc_v2_64",
-        "cublasZdotc_64",
         "cublasZdgmm_64",
         "cublasXerbla",
         "cublasUint8gemmBias",
@@ -11386,8 +11394,6 @@ sub warnRocOnlyUnsupportedFunctions {
         "cublasSetMatrixAsync_64",
         "cublasSetLoggerCallback",
         "cublasSetKernelStream",
-        "cublasSdot_v2_64",
-        "cublasSdot_64",
         "cublasSdgmm_64",
         "cublasScnrm2_v2_64",
         "cublasScnrm2_64",
@@ -11503,8 +11509,6 @@ sub warnRocOnlyUnsupportedFunctions {
         "cublasDgeam_64",
         "cublasDgbmv_v2_64",
         "cublasDgbmv_64",
-        "cublasDdot_v2_64",
-        "cublasDdot_64",
         "cublasDdgmm_64",
         "cublasCtrttp",
         "cublasCtrsv_v2_64",
@@ -11610,10 +11614,6 @@ sub warnRocOnlyUnsupportedFunctions {
         "cublasCgeam_64",
         "cublasCgbmv_v2_64",
         "cublasCgbmv_64",
-        "cublasCdotu_v2_64",
-        "cublasCdotu_64",
-        "cublasCdotc_v2_64",
-        "cublasCdotc_64",
         "cublasCdgmm_64",
         "cublasAxpyEx_64",
         "cublasAsumEx_64",

--- a/docs/tables/CUBLAS_API_supported_by_HIP.md
+++ b/docs/tables/CUBLAS_API_supported_by_HIP.md
@@ -212,13 +212,13 @@
 |`cublasCcopy_v2`| | | | |`hipblasCcopy_v2`|6.0.0| | | | |
 |`cublasCcopy_v2_64`|12.0| | | |`hipblasCcopy_v2_64`|6.1.0| | | | |
 |`cublasCdotc`| | | | |`hipblasCdotc_v2`|6.0.0| | | | |
-|`cublasCdotc_64`|12.0| | | | | | | | | |
+|`cublasCdotc_64`|12.0| | | |`hipblasCdotc_v2_64`|6.1.0| | | | |
 |`cublasCdotc_v2`| | | | |`hipblasCdotc_v2`|6.0.0| | | | |
-|`cublasCdotc_v2_64`|12.0| | | | | | | | | |
+|`cublasCdotc_v2_64`|12.0| | | |`hipblasCdotc_v2_64`|6.1.0| | | | |
 |`cublasCdotu`| | | | |`hipblasCdotu_v2`|6.0.0| | | | |
-|`cublasCdotu_64`|12.0| | | | | | | | | |
+|`cublasCdotu_64`|12.0| | | |`hipblasCdotu_v2_64`|6.1.0| | | | |
 |`cublasCdotu_v2`| | | | |`hipblasCdotu_v2`|6.0.0| | | | |
-|`cublasCdotu_v2_64`|12.0| | | | | | | | | |
+|`cublasCdotu_v2_64`|12.0| | | |`hipblasCdotu_v2_64`|6.1.0| | | | |
 |`cublasCrot`| | | | |`hipblasCrot_v2`|6.0.0| | | | |
 |`cublasCrot_64`|12.0| | | | | | | | | |
 |`cublasCrot_v2`| | | | |`hipblasCrot_v2`|6.0.0| | | | |
@@ -254,9 +254,9 @@
 |`cublasDcopy_v2`| | | | |`hipblasDcopy`|1.8.2| | | | |
 |`cublasDcopy_v2_64`|12.0| | | |`hipblasDcopy_64`|6.1.0| | | | |
 |`cublasDdot`| | | | |`hipblasDdot`|3.0.0| | | | |
-|`cublasDdot_64`|12.0| | | | | | | | | |
+|`cublasDdot_64`|12.0| | | |`hipblasDdot_64`|6.1.0| | | | |
 |`cublasDdot_v2`| | | | |`hipblasDdot`|3.0.0| | | | |
-|`cublasDdot_v2_64`|12.0| | | | | | | | | |
+|`cublasDdot_v2_64`|12.0| | | |`hipblasDdot_64`|6.1.0| | | | |
 |`cublasDnrm2`| | | | |`hipblasDnrm2`|1.8.2| | | | |
 |`cublasDnrm2_64`|12.0| | | | | | | | | |
 |`cublasDnrm2_v2`| | | | |`hipblasDnrm2`|1.8.2| | | | |
@@ -344,9 +344,9 @@
 |`cublasScopy_v2`| | | | |`hipblasScopy`|1.8.2| | | | |
 |`cublasScopy_v2_64`|12.0| | | |`hipblasScopy_64`|6.1.0| | | | |
 |`cublasSdot`| | | | |`hipblasSdot`|3.0.0| | | | |
-|`cublasSdot_64`|12.0| | | | | | | | | |
+|`cublasSdot_64`|12.0| | | |`hipblasSdot_64`|6.1.0| | | | |
 |`cublasSdot_v2`| | | | |`hipblasSdot`|3.0.0| | | | |
-|`cublasSdot_v2_64`|12.0| | | | | | | | | |
+|`cublasSdot_v2_64`|12.0| | | |`hipblasSdot_64`|6.1.0| | | | |
 |`cublasSnrm2`| | | | |`hipblasSnrm2`|1.8.2| | | | |
 |`cublasSnrm2_64`|12.0| | | | | | | | | |
 |`cublasSnrm2_v2`| | | | |`hipblasSnrm2`|1.8.2| | | | |
@@ -380,13 +380,13 @@
 |`cublasZcopy_v2`| | | | |`hipblasZcopy_v2`|6.0.0| | | | |
 |`cublasZcopy_v2_64`|12.0| | | |`hipblasZcopy_v2_64`|6.1.0| | | | |
 |`cublasZdotc`| | | | |`hipblasZdotc_v2`|6.0.0| | | | |
-|`cublasZdotc_64`|12.0| | | | | | | | | |
+|`cublasZdotc_64`|12.0| | | |`hipblasZdotc_v2_64`|6.1.0| | | | |
 |`cublasZdotc_v2`| | | | |`hipblasZdotc_v2`|6.0.0| | | | |
-|`cublasZdotc_v2_64`|12.0| | | | | | | | | |
+|`cublasZdotc_v2_64`|12.0| | | |`hipblasZdotc_v2_64`|6.1.0| | | | |
 |`cublasZdotu`| | | | |`hipblasZdotu_v2`|6.0.0| | | | |
-|`cublasZdotu_64`|12.0| | | | | | | | | |
+|`cublasZdotu_64`|12.0| | | |`hipblasZdotu_v2_64`|6.1.0| | | | |
 |`cublasZdotu_v2`| | | | |`hipblasZdotu_v2`|6.0.0| | | | |
-|`cublasZdotu_v2_64`|12.0| | | | | | | | | |
+|`cublasZdotu_v2_64`|12.0| | | |`hipblasZdotu_v2_64`|6.1.0| | | | |
 |`cublasZdrot`| | | | |`hipblasZdrot_v2`|6.0.0| | | | |
 |`cublasZdrot_64`|12.0| | | | | | | | | |
 |`cublasZdrot_v2`| | | | |`hipblasZdrot_v2`|6.0.0| | | | |

--- a/docs/tables/CUBLAS_API_supported_by_HIP_and_ROC.md
+++ b/docs/tables/CUBLAS_API_supported_by_HIP_and_ROC.md
@@ -212,13 +212,13 @@
 |`cublasCcopy_v2`| | | | |`hipblasCcopy_v2`|6.0.0| | | | |`rocblas_ccopy`|1.5.0| | | | |
 |`cublasCcopy_v2_64`|12.0| | | |`hipblasCcopy_v2_64`|6.1.0| | | | |`rocblas_ccopy_64`|6.1.0| | | | |
 |`cublasCdotc`| | | | |`hipblasCdotc_v2`|6.0.0| | | | |`rocblas_cdotc`|3.5.0| | | | |
-|`cublasCdotc_64`|12.0| | | | | | | | | | | | | | | |
+|`cublasCdotc_64`|12.0| | | |`hipblasCdotc_v2_64`|6.1.0| | | | |`rocblas_cdotc_64`|6.1.0| | | | |
 |`cublasCdotc_v2`| | | | |`hipblasCdotc_v2`|6.0.0| | | | |`rocblas_cdotc`|3.5.0| | | | |
-|`cublasCdotc_v2_64`|12.0| | | | | | | | | | | | | | | |
+|`cublasCdotc_v2_64`|12.0| | | |`hipblasCdotc_v2_64`|6.1.0| | | | |`rocblas_cdotc_64`|6.1.0| | | | |
 |`cublasCdotu`| | | | |`hipblasCdotu_v2`|6.0.0| | | | |`rocblas_cdotu`|1.5.0| | | | |
-|`cublasCdotu_64`|12.0| | | | | | | | | | | | | | | |
+|`cublasCdotu_64`|12.0| | | |`hipblasCdotu_v2_64`|6.1.0| | | | |`rocblas_cdotu_64`|6.1.0| | | | |
 |`cublasCdotu_v2`| | | | |`hipblasCdotu_v2`|6.0.0| | | | |`rocblas_cdotu`|1.5.0| | | | |
-|`cublasCdotu_v2_64`|12.0| | | | | | | | | | | | | | | |
+|`cublasCdotu_v2_64`|12.0| | | |`hipblasCdotu_v2_64`|6.1.0| | | | |`rocblas_cdotu_64`|6.1.0| | | | |
 |`cublasCrot`| | | | |`hipblasCrot_v2`|6.0.0| | | | |`rocblas_crot`|3.5.0| | | | |
 |`cublasCrot_64`|12.0| | | | | | | | | | | | | | | |
 |`cublasCrot_v2`| | | | |`hipblasCrot_v2`|6.0.0| | | | |`rocblas_crot`|3.5.0| | | | |
@@ -254,9 +254,9 @@
 |`cublasDcopy_v2`| | | | |`hipblasDcopy`|1.8.2| | | | |`rocblas_dcopy`|1.5.0| | | | |
 |`cublasDcopy_v2_64`|12.0| | | |`hipblasDcopy_64`|6.1.0| | | | |`rocblas_dcopy_64`|6.1.0| | | | |
 |`cublasDdot`| | | | |`hipblasDdot`|3.0.0| | | | |`rocblas_ddot`|1.5.0| | | | |
-|`cublasDdot_64`|12.0| | | | | | | | | | | | | | | |
+|`cublasDdot_64`|12.0| | | |`hipblasDdot_64`|6.1.0| | | | |`rocblas_ddot_64`|6.1.0| | | | |
 |`cublasDdot_v2`| | | | |`hipblasDdot`|3.0.0| | | | |`rocblas_ddot`|1.5.0| | | | |
-|`cublasDdot_v2_64`|12.0| | | | | | | | | | | | | | | |
+|`cublasDdot_v2_64`|12.0| | | |`hipblasDdot_64`|6.1.0| | | | |`rocblas_ddot_64`|6.1.0| | | | |
 |`cublasDnrm2`| | | | |`hipblasDnrm2`|1.8.2| | | | |`rocblas_dnrm2`|1.5.0| | | | |
 |`cublasDnrm2_64`|12.0| | | | | | | | | | | | | | | |
 |`cublasDnrm2_v2`| | | | |`hipblasDnrm2`|1.8.2| | | | |`rocblas_dnrm2`|1.5.0| | | | |
@@ -344,9 +344,9 @@
 |`cublasScopy_v2`| | | | |`hipblasScopy`|1.8.2| | | | |`rocblas_scopy`|1.5.0| | | | |
 |`cublasScopy_v2_64`|12.0| | | |`hipblasScopy_64`|6.1.0| | | | |`rocblas_scopy_64`|6.1.0| | | | |
 |`cublasSdot`| | | | |`hipblasSdot`|3.0.0| | | | |`rocblas_sdot`|1.5.0| | | | |
-|`cublasSdot_64`|12.0| | | | | | | | | | | | | | | |
+|`cublasSdot_64`|12.0| | | |`hipblasSdot_64`|6.1.0| | | | |`rocblas_sdot_64`|6.1.0| | | | |
 |`cublasSdot_v2`| | | | |`hipblasSdot`|3.0.0| | | | |`rocblas_sdot`|1.5.0| | | | |
-|`cublasSdot_v2_64`|12.0| | | | | | | | | | | | | | | |
+|`cublasSdot_v2_64`|12.0| | | |`hipblasSdot_64`|6.1.0| | | | |`rocblas_sdot_64`|6.1.0| | | | |
 |`cublasSnrm2`| | | | |`hipblasSnrm2`|1.8.2| | | | |`rocblas_snrm2`|1.5.0| | | | |
 |`cublasSnrm2_64`|12.0| | | | | | | | | | | | | | | |
 |`cublasSnrm2_v2`| | | | |`hipblasSnrm2`|1.8.2| | | | |`rocblas_snrm2`|1.5.0| | | | |
@@ -380,13 +380,13 @@
 |`cublasZcopy_v2`| | | | |`hipblasZcopy_v2`|6.0.0| | | | |`rocblas_zcopy`|1.5.0| | | | |
 |`cublasZcopy_v2_64`|12.0| | | |`hipblasZcopy_v2_64`|6.1.0| | | | |`rocblas_zcopy_64`|6.1.0| | | | |
 |`cublasZdotc`| | | | |`hipblasZdotc_v2`|6.0.0| | | | |`rocblas_zdotc`|3.5.0| | | | |
-|`cublasZdotc_64`|12.0| | | | | | | | | | | | | | | |
+|`cublasZdotc_64`|12.0| | | |`hipblasZdotc_v2_64`|6.1.0| | | | |`rocblas_zdotc_64`|6.1.0| | | | |
 |`cublasZdotc_v2`| | | | |`hipblasZdotc_v2`|6.0.0| | | | |`rocblas_zdotc`|3.5.0| | | | |
-|`cublasZdotc_v2_64`|12.0| | | | | | | | | | | | | | | |
+|`cublasZdotc_v2_64`|12.0| | | |`hipblasZdotc_v2_64`|6.1.0| | | | |`rocblas_zdotc_64`|6.1.0| | | | |
 |`cublasZdotu`| | | | |`hipblasZdotu_v2`|6.0.0| | | | |`rocblas_zdotu`|1.5.0| | | | |
-|`cublasZdotu_64`|12.0| | | | | | | | | | | | | | | |
+|`cublasZdotu_64`|12.0| | | |`hipblasZdotu_v2_64`|6.1.0| | | | |`rocblas_zdotu_64`|6.1.0| | | | |
 |`cublasZdotu_v2`| | | | |`hipblasZdotu_v2`|6.0.0| | | | |`rocblas_zdotu`|1.5.0| | | | |
-|`cublasZdotu_v2_64`|12.0| | | | | | | | | | | | | | | |
+|`cublasZdotu_v2_64`|12.0| | | |`hipblasZdotu_v2_64`|6.1.0| | | | |`rocblas_zdotu_64`|6.1.0| | | | |
 |`cublasZdrot`| | | | |`hipblasZdrot_v2`|6.0.0| | | | |`rocblas_zdrot`|3.5.0| | | | |
 |`cublasZdrot_64`|12.0| | | | | | | | | | | | | | | |
 |`cublasZdrot_v2`| | | | |`hipblasZdrot_v2`|6.0.0| | | | |`rocblas_zdrot`|3.5.0| | | | |

--- a/docs/tables/CUBLAS_API_supported_by_ROC.md
+++ b/docs/tables/CUBLAS_API_supported_by_ROC.md
@@ -212,13 +212,13 @@
 |`cublasCcopy_v2`| | | | |`rocblas_ccopy`|1.5.0| | | | |
 |`cublasCcopy_v2_64`|12.0| | | |`rocblas_ccopy_64`|6.1.0| | | | |
 |`cublasCdotc`| | | | |`rocblas_cdotc`|3.5.0| | | | |
-|`cublasCdotc_64`|12.0| | | | | | | | | |
+|`cublasCdotc_64`|12.0| | | |`rocblas_cdotc_64`|6.1.0| | | | |
 |`cublasCdotc_v2`| | | | |`rocblas_cdotc`|3.5.0| | | | |
-|`cublasCdotc_v2_64`|12.0| | | | | | | | | |
+|`cublasCdotc_v2_64`|12.0| | | |`rocblas_cdotc_64`|6.1.0| | | | |
 |`cublasCdotu`| | | | |`rocblas_cdotu`|1.5.0| | | | |
-|`cublasCdotu_64`|12.0| | | | | | | | | |
+|`cublasCdotu_64`|12.0| | | |`rocblas_cdotu_64`|6.1.0| | | | |
 |`cublasCdotu_v2`| | | | |`rocblas_cdotu`|1.5.0| | | | |
-|`cublasCdotu_v2_64`|12.0| | | | | | | | | |
+|`cublasCdotu_v2_64`|12.0| | | |`rocblas_cdotu_64`|6.1.0| | | | |
 |`cublasCrot`| | | | |`rocblas_crot`|3.5.0| | | | |
 |`cublasCrot_64`|12.0| | | | | | | | | |
 |`cublasCrot_v2`| | | | |`rocblas_crot`|3.5.0| | | | |
@@ -254,9 +254,9 @@
 |`cublasDcopy_v2`| | | | |`rocblas_dcopy`|1.5.0| | | | |
 |`cublasDcopy_v2_64`|12.0| | | |`rocblas_dcopy_64`|6.1.0| | | | |
 |`cublasDdot`| | | | |`rocblas_ddot`|1.5.0| | | | |
-|`cublasDdot_64`|12.0| | | | | | | | | |
+|`cublasDdot_64`|12.0| | | |`rocblas_ddot_64`|6.1.0| | | | |
 |`cublasDdot_v2`| | | | |`rocblas_ddot`|1.5.0| | | | |
-|`cublasDdot_v2_64`|12.0| | | | | | | | | |
+|`cublasDdot_v2_64`|12.0| | | |`rocblas_ddot_64`|6.1.0| | | | |
 |`cublasDnrm2`| | | | |`rocblas_dnrm2`|1.5.0| | | | |
 |`cublasDnrm2_64`|12.0| | | | | | | | | |
 |`cublasDnrm2_v2`| | | | |`rocblas_dnrm2`|1.5.0| | | | |
@@ -344,9 +344,9 @@
 |`cublasScopy_v2`| | | | |`rocblas_scopy`|1.5.0| | | | |
 |`cublasScopy_v2_64`|12.0| | | |`rocblas_scopy_64`|6.1.0| | | | |
 |`cublasSdot`| | | | |`rocblas_sdot`|1.5.0| | | | |
-|`cublasSdot_64`|12.0| | | | | | | | | |
+|`cublasSdot_64`|12.0| | | |`rocblas_sdot_64`|6.1.0| | | | |
 |`cublasSdot_v2`| | | | |`rocblas_sdot`|1.5.0| | | | |
-|`cublasSdot_v2_64`|12.0| | | | | | | | | |
+|`cublasSdot_v2_64`|12.0| | | |`rocblas_sdot_64`|6.1.0| | | | |
 |`cublasSnrm2`| | | | |`rocblas_snrm2`|1.5.0| | | | |
 |`cublasSnrm2_64`|12.0| | | | | | | | | |
 |`cublasSnrm2_v2`| | | | |`rocblas_snrm2`|1.5.0| | | | |
@@ -380,13 +380,13 @@
 |`cublasZcopy_v2`| | | | |`rocblas_zcopy`|1.5.0| | | | |
 |`cublasZcopy_v2_64`|12.0| | | |`rocblas_zcopy_64`|6.1.0| | | | |
 |`cublasZdotc`| | | | |`rocblas_zdotc`|3.5.0| | | | |
-|`cublasZdotc_64`|12.0| | | | | | | | | |
+|`cublasZdotc_64`|12.0| | | |`rocblas_zdotc_64`|6.1.0| | | | |
 |`cublasZdotc_v2`| | | | |`rocblas_zdotc`|3.5.0| | | | |
-|`cublasZdotc_v2_64`|12.0| | | | | | | | | |
+|`cublasZdotc_v2_64`|12.0| | | |`rocblas_zdotc_64`|6.1.0| | | | |
 |`cublasZdotu`| | | | |`rocblas_zdotu`|1.5.0| | | | |
-|`cublasZdotu_64`|12.0| | | | | | | | | |
+|`cublasZdotu_64`|12.0| | | |`rocblas_zdotu_64`|6.1.0| | | | |
 |`cublasZdotu_v2`| | | | |`rocblas_zdotu`|1.5.0| | | | |
-|`cublasZdotu_v2_64`|12.0| | | | | | | | | |
+|`cublasZdotu_v2_64`|12.0| | | |`rocblas_zdotu_64`|6.1.0| | | | |
 |`cublasZdrot`| | | | |`rocblas_zdrot`|3.5.0| | | | |
 |`cublasZdrot_64`|12.0| | | | | | | | | |
 |`cublasZdrot_v2`| | | | |`rocblas_zdrot`|3.5.0| | | | |

--- a/src/CUDA2HIP_BLAS_API_functions.cpp
+++ b/src/CUDA2HIP_BLAS_API_functions.cpp
@@ -101,17 +101,17 @@ const std::map<llvm::StringRef, hipCounter> CUDA_BLAS_FUNCTION_MAP {
   // DOT
   // DOT functions' signatures differ from _v2 ones, hipblas and rocblas DOT functions have mapping to DOT_v2 functions only
   {"cublasSdot",                     {"hipblasSdot",                     "rocblas_sdot",                             CONV_LIB_FUNC, API_BLAS, 5, HIP_SUPPORTED_V2_ONLY}},
-  {"cublasSdot_64",                  {"hipblasSdot_64",                  "",                                         CONV_LIB_FUNC, API_BLAS, 5, UNSUPPORTED}},
+  {"cublasSdot_64",                  {"hipblasSdot_64",                  "rocblas_sdot_64",                          CONV_LIB_FUNC, API_BLAS, 5}},
   {"cublasDdot",                     {"hipblasDdot",                     "rocblas_ddot",                             CONV_LIB_FUNC, API_BLAS, 5, HIP_SUPPORTED_V2_ONLY}},
-  {"cublasDdot_64",                  {"hipblasDdot_64",                  "",                                         CONV_LIB_FUNC, API_BLAS, 5, UNSUPPORTED}},
+  {"cublasDdot_64",                  {"hipblasDdot_64",                  "rocblas_ddot_64",                          CONV_LIB_FUNC, API_BLAS, 5}},
   {"cublasCdotu",                    {"hipblasCdotu_v2",                 "rocblas_cdotu",                            CONV_LIB_FUNC, API_BLAS, 5, HIP_SUPPORTED_V2_ONLY}},
-  {"cublasCdotu_64",                 {"hipblasCdotu_64",                 "",                                         CONV_LIB_FUNC, API_BLAS, 5, UNSUPPORTED}},
+  {"cublasCdotu_64",                 {"hipblasCdotu_v2_64",              "rocblas_cdotu_64",                         CONV_LIB_FUNC, API_BLAS, 5}},
   {"cublasCdotc",                    {"hipblasCdotc_v2",                 "rocblas_cdotc",                            CONV_LIB_FUNC, API_BLAS, 5, HIP_SUPPORTED_V2_ONLY}},
-  {"cublasCdotc_64",                 {"hipblasCdotc_64",                 "",                                         CONV_LIB_FUNC, API_BLAS, 5, UNSUPPORTED}},
+  {"cublasCdotc_64",                 {"hipblasCdotc_v2_64",              "rocblas_cdotc_64",                         CONV_LIB_FUNC, API_BLAS, 5}},
   {"cublasZdotu",                    {"hipblasZdotu_v2",                 "rocblas_zdotu",                            CONV_LIB_FUNC, API_BLAS, 5, HIP_SUPPORTED_V2_ONLY}},
-  {"cublasZdotu_64",                 {"hipblasZdotu_64",                  "",                                        CONV_LIB_FUNC, API_BLAS, 5, UNSUPPORTED}},
+  {"cublasZdotu_64",                 {"hipblasZdotu_v2_64",              "rocblas_zdotu_64",                         CONV_LIB_FUNC, API_BLAS, 5}},
   {"cublasZdotc",                    {"hipblasZdotc_v2",                 "rocblas_zdotc",                            CONV_LIB_FUNC, API_BLAS, 5, HIP_SUPPORTED_V2_ONLY}},
-  {"cublasZdotc_64",                 {"hipblasZdotc_64",                  "",                                        CONV_LIB_FUNC, API_BLAS, 5, UNSUPPORTED}},
+  {"cublasZdotc_64",                 {"hipblasZdotc_v2_64",              "rocblas_zdotc_64",                         CONV_LIB_FUNC, API_BLAS, 5}},
 
   // SCAL
   // SCAL functions' signatures differ from _v2 ones, hipblas and rocblas SCAL functions have mapping to SCAL_v2 functions only
@@ -935,18 +935,18 @@ const std::map<llvm::StringRef, hipCounter> CUDA_BLAS_FUNCTION_MAP {
   {"cublasDotcEx_64",                {"hipblasDotcEx_64",                "",                                         CONV_LIB_FUNC, API_BLAS, 8, UNSUPPORTED}},
 
   {"cublasSdot_v2",                  {"hipblasSdot",                     "rocblas_sdot",                             CONV_LIB_FUNC, API_BLAS, 5}},
-  {"cublasSdot_v2_64",               {"hipblasSdot_64",                  "",                                         CONV_LIB_FUNC, API_BLAS, 5, UNSUPPORTED}},
+  {"cublasSdot_v2_64",               {"hipblasSdot_64",                  "rocblas_sdot_64",                          CONV_LIB_FUNC, API_BLAS, 5}},
   {"cublasDdot_v2",                  {"hipblasDdot",                     "rocblas_ddot",                             CONV_LIB_FUNC, API_BLAS, 5}},
-  {"cublasDdot_v2_64",               {"hipblasDdot_64",                  "",                                         CONV_LIB_FUNC, API_BLAS, 5, UNSUPPORTED}},
+  {"cublasDdot_v2_64",               {"hipblasDdot_64",                  "rocblas_ddot_64",                          CONV_LIB_FUNC, API_BLAS, 5}},
 
   {"cublasCdotu_v2",                 {"hipblasCdotu_v2",                 "rocblas_cdotu",                            CONV_LIB_FUNC, API_BLAS, 5}},
-  {"cublasCdotu_v2_64",              {"hipblasCdotu_64",                 "",                                         CONV_LIB_FUNC, API_BLAS, 5, UNSUPPORTED}},
+  {"cublasCdotu_v2_64",              {"hipblasCdotu_v2_64",              "rocblas_cdotu_64",                         CONV_LIB_FUNC, API_BLAS, 5}},
   {"cublasCdotc_v2",                 {"hipblasCdotc_v2",                 "rocblas_cdotc",                            CONV_LIB_FUNC, API_BLAS, 5}},
-  {"cublasCdotc_v2_64",              {"hipblasCdotc_64",                 "",                                         CONV_LIB_FUNC, API_BLAS, 5, UNSUPPORTED}},
+  {"cublasCdotc_v2_64",              {"hipblasCdotc_v2_64",              "rocblas_cdotc_64",                         CONV_LIB_FUNC, API_BLAS, 5}},
   {"cublasZdotu_v2",                 {"hipblasZdotu_v2",                 "rocblas_zdotu",                            CONV_LIB_FUNC, API_BLAS, 5}},
-  {"cublasZdotu_v2_64",              {"hipblasZdotu_64",                 "",                                         CONV_LIB_FUNC, API_BLAS, 5, UNSUPPORTED}},
+  {"cublasZdotu_v2_64",              {"hipblasZdotu_v2_64",              "rocblas_zdotu_64",                         CONV_LIB_FUNC, API_BLAS, 5}},
   {"cublasZdotc_v2",                 {"hipblasZdotc_v2",                 "rocblas_zdotc",                            CONV_LIB_FUNC, API_BLAS, 5}},
-  {"cublasZdotc_v2_64",              {"hipblasZdotc_64",                 "",                                         CONV_LIB_FUNC, API_BLAS, 5, UNSUPPORTED}},
+  {"cublasZdotc_v2_64",              {"hipblasZdotc_v2_64",              "rocblas_zdotc_64",                         CONV_LIB_FUNC, API_BLAS, 5}},
 
   // SCAL
   {"cublasScalEx",                   {"hipblasScalEx_v2",                "rocblas_scal_ex",                          CONV_LIB_FUNC, API_BLAS, 8}},
@@ -1891,6 +1891,12 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_BLAS_FUNCTION_VER_MAP {
   {"hipblasDcopy_64",                            {HIP_6010, HIP_0,    HIP_0,  }},
   {"hipblasCcopy_v2_64",                         {HIP_6010, HIP_0,    HIP_0,  }},
   {"hipblasZcopy_v2_64",                         {HIP_6010, HIP_0,    HIP_0,  }},
+  {"hipblasSdot_64",                             {HIP_6010, HIP_0,    HIP_0,  }},
+  {"hipblasDdot_64",                             {HIP_6010, HIP_0,    HIP_0,  }},
+  {"hipblasCdotc_v2_64",                         {HIP_6010, HIP_0,    HIP_0,  }},
+  {"hipblasCdotu_v2_64",                         {HIP_6010, HIP_0,    HIP_0,  }},
+  {"hipblasZdotc_v2_64",                         {HIP_6010, HIP_0,    HIP_0,  }},
+  {"hipblasZdotu_v2_64",                         {HIP_6010, HIP_0,    HIP_0,  }},
 
   {"rocblas_status_to_string",                   {HIP_3050, HIP_0,    HIP_0   }},
   {"rocblas_sscal",                              {HIP_1050, HIP_0,    HIP_0   }},
@@ -2147,6 +2153,12 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_BLAS_FUNCTION_VER_MAP {
   {"rocblas_dcopy_64",                           {HIP_6010, HIP_0,    HIP_0,  }},
   {"rocblas_ccopy_64",                           {HIP_6010, HIP_0,    HIP_0,  }},
   {"rocblas_zcopy_64",                           {HIP_6010, HIP_0,    HIP_0,  }},
+  {"rocblas_sdot_64",                            {HIP_6010, HIP_0,    HIP_0,  }},
+  {"rocblas_ddot_64",                            {HIP_6010, HIP_0,    HIP_0,  }},
+  {"rocblas_cdotc_64",                           {HIP_6010, HIP_0,    HIP_0,  }},
+  {"rocblas_cdotu_64",                           {HIP_6010, HIP_0,    HIP_0,  }},
+  {"rocblas_zdotc_64",                           {HIP_6010, HIP_0,    HIP_0,  }},
+  {"rocblas_zdotu_64",                           {HIP_6010, HIP_0,    HIP_0,  }},
 };
 
 const std::map<llvm::StringRef, hipAPIChangedVersions> HIP_BLAS_FUNCTION_CHANGED_VER_MAP {

--- a/tests/unit_tests/synthetic/libraries/cublas2hipblas_v2.cu
+++ b/tests/unit_tests/synthetic/libraries/cublas2hipblas_v2.cu
@@ -271,10 +271,10 @@ int main() {
   blasStatus = cublasDnrm2(blasHandle, n, &dx, incx, &dresult);
   blasStatus = cublasDnrm2_v2(blasHandle, n, &dx, incx, &dresult);
 
-  // CHECK: hipComplex complex, complexa, complexA, complexB, complexC, complexx, complexy, complexs, complexb;
-  cuComplex complex, complexa, complexA, complexB, complexC, complexx, complexy, complexs, complexb;
-  // CHECK: hipDoubleComplex dcomplex, dcomplexa, dcomplexA, dcomplexB, dcomplexC, dcomplexx, dcomplexy, dcomplexs, dcomplexb;
-  cuDoubleComplex dcomplex, dcomplexa, dcomplexA, dcomplexB, dcomplexC, dcomplexx, dcomplexy, dcomplexs, dcomplexb;
+  // CHECK: hipComplex complex, complexa, complexA, complexB, complexC, complexx, complexy, complexs, complexb, complexresult;
+  cuComplex complex, complexa, complexA, complexB, complexC, complexx, complexy, complexs, complexb, complexresult;
+  // CHECK: hipDoubleComplex dcomplex, dcomplexa, dcomplexA, dcomplexB, dcomplexC, dcomplexx, dcomplexy, dcomplexs, dcomplexb, dcomplexresult;
+  cuDoubleComplex dcomplex, dcomplexa, dcomplexA, dcomplexB, dcomplexC, dcomplexx, dcomplexy, dcomplexs, dcomplexb, dcomplexresult;
 
   // CHECK: hipComplex** complexAarray = 0;
   // CHECK: const hipComplex** const complexAarray_const = const_cast<const hipComplex**>(complexAarray);
@@ -1978,6 +1978,48 @@ int main() {
   // CHECK-NEXT: blasStatus = hipblasZcopy_v2_64(blasHandle, n_64, &dcomplexx, incx_64, &dcomplexy, incy_64);
   blasStatus = cublasZcopy_64(blasHandle, n_64, &dcomplexx, incx_64, &dcomplexy, incy_64);
   blasStatus = cublasZcopy_v2_64(blasHandle, n_64, &dcomplexx, incx_64, &dcomplexy, incy_64);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasSdot_v2_64(cublasHandle_t handle, int64_t n, const float* x, int64_t incx, const float* y, int64_t incy, float* result);
+  // HIP: HIPBLAS_EXPORT hipblasStatus_t hipblasSdot_64(hipblasHandle_t handle, int64_t n, const float* x, int64_t incx, const float* y, int64_t incy, float* result);
+  // CHECK: blasStatus = hipblasSdot_64(blasHandle, n_64, &fx, incx_64, &fy, incy_64, &fresult);
+  // CHECK-NEXT: blasStatus = hipblasSdot_64(blasHandle, n_64, &fx, incx_64, &fy, incy_64, &fresult);
+  blasStatus = cublasSdot_64(blasHandle, n_64, &fx, incx_64, &fy, incy_64, &fresult);
+  blasStatus = cublasSdot_v2_64(blasHandle, n_64, &fx, incx_64, &fy, incy_64, &fresult);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasDdot_v2_64(cublasHandle_t handle, int64_t n, const double* x, int64_t incx, const double* y, int64_t incy, double* result);
+  // HIP: HIPBLAS_EXPORT hipblasStatus_t hipblasDdot_64(hipblasHandle_t handle, int64_t n, const double* x, int64_t incx, const double* y, int64_t incy, double* result);
+  // CHECK: blasStatus = hipblasDdot_64(blasHandle, n_64, &dx, incx_64, &dy, incy_64, &dresult);
+  // CHECK-NEXT: blasStatus = hipblasDdot_64(blasHandle, n_64, &dx, incx_64, &dy, incy_64, &dresult);
+  blasStatus = cublasDdot_64(blasHandle, n_64, &dx, incx_64, &dy, incy_64, &dresult);
+  blasStatus = cublasDdot_v2_64(blasHandle, n_64, &dx, incx_64, &dy, incy_64, &dresult);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasCdotc_v2_64(cublasHandle_t handle, int64_t n, const cuComplex* x, int64_t incx, const cuComplex* y, int64_t incy, cuComplex* result);
+  // HIP: HIPBLAS_EXPORT hipblasStatus_t hipblasCdotc_v2_64(hipblasHandle_t handle, int64_t n, const hipComplex* x, int64_t incx, const hipComplex* y, int64_t incy, hipComplex* result);
+  // CHECK: blasStatus = hipblasCdotc_v2_64(blasHandle, n_64, &complexx, incx_64, &complexy, incy_64, &complexresult);
+  // CHECK-NEXT: blasStatus = hipblasCdotc_v2_64(blasHandle, n_64, &complexx, incx_64, &complexy, incy_64, &complexresult);
+  blasStatus = cublasCdotc_64(blasHandle, n_64, &complexx, incx_64, &complexy, incy_64, &complexresult);
+  blasStatus = cublasCdotc_v2_64(blasHandle, n_64, &complexx, incx_64, &complexy, incy_64, &complexresult);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasCdotu_v2_64(cublasHandle_t handle, int64_t n, const cuComplex* x, int64_t incx, const cuComplex* y, int64_t incy, cuComplex* result);
+  // HIP: HIPBLAS_EXPORT hipblasStatus_t hipblasCdotu_v2_64(hipblasHandle_t handle, int64_t n, const hipComplex* x, int64_t incx, const hipComplex* y, int64_t incy, hipComplex* result);
+  // CHECK: blasStatus = hipblasCdotu_v2_64(blasHandle, n_64, &complexx, incx_64, &complexy, incy_64, &complexresult);
+  // CHECK-NEXT: blasStatus = hipblasCdotu_v2_64(blasHandle, n_64, &complexx, incx_64, &complexy, incy_64, &complexresult);
+  blasStatus = cublasCdotu_64(blasHandle, n_64, &complexx, incx_64, &complexy, incy_64, &complexresult);
+  blasStatus = cublasCdotu_v2_64(blasHandle, n_64, &complexx, incx_64, &complexy, incy_64, &complexresult);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasZdotc_v2_64(cublasHandle_t handle, int64_t n, const cuDoubleComplex* x, int64_t incx, const cuDoubleComplex* y, int64_t incy, cuDoubleComplex* result);
+  // HIP: HIPBLAS_EXPORT hipblasStatus_t hipblasZdotc_v2_64(hipblasHandle_t handle, int64_t n, const hipDoubleComplex* x, int64_t incx, const hipDoubleComplex* y, int64_t incy, hipDoubleComplex* result);
+  // CHECK: blasStatus = hipblasZdotc_v2_64(blasHandle, n_64, &dcomplexx, incx_64, &dcomplexy, incy_64, &dcomplexresult);
+  // CHECK-NEXT: blasStatus = hipblasZdotc_v2_64(blasHandle, n_64, &dcomplexx, incx_64, &dcomplexy, incy_64, &dcomplexresult);
+  blasStatus = cublasZdotc_64(blasHandle, n_64, &dcomplexx, incx_64, &dcomplexy, incy_64, &dcomplexresult);
+  blasStatus = cublasZdotc_v2_64(blasHandle, n_64, &dcomplexx, incx_64, &dcomplexy, incy_64, &dcomplexresult);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasZdotu_v2_64(cublasHandle_t handle, int64_t n, const cuDoubleComplex* x, int64_t incx, const cuDoubleComplex* y, int64_t incy, cuDoubleComplex* result);
+  // HIP: HIPBLAS_EXPORT hipblasStatus_t hipblasZdotu_v2_64(hipblasHandle_t handle, int64_t n, const hipDoubleComplex* x, int64_t incx, const hipDoubleComplex* y, int64_t incy, hipDoubleComplex* result);
+  // CHECK: blasStatus = hipblasZdotu_v2_64(blasHandle, n_64, &dcomplexx, incx_64, &dcomplexy, incy_64, &dcomplexresult);
+  // CHECK-NEXT: blasStatus = hipblasZdotu_v2_64(blasHandle, n_64, &dcomplexx, incx_64, &dcomplexy, incy_64, &dcomplexresult);
+  blasStatus = cublasZdotu_64(blasHandle, n_64, &dcomplexx, incx_64, &dcomplexy, incy_64, &dcomplexresult);
+  blasStatus = cublasZdotu_v2_64(blasHandle, n_64, &dcomplexx, incx_64, &dcomplexy, incy_64, &dcomplexresult);
 #endif
 
   return 0;

--- a/tests/unit_tests/synthetic/libraries/cublas2rocblas_v2.cu
+++ b/tests/unit_tests/synthetic/libraries/cublas2rocblas_v2.cu
@@ -293,10 +293,10 @@ int main() {
   blasStatus = cublasDnrm2(blasHandle, n, &dx, incx, &dresult);
   blasStatus = cublasDnrm2_v2(blasHandle, n, &dx, incx, &dresult);
 
-  // CHECK: rocblas_float_complex complex, complexa, complexA, complexB, complexC, complexx, complexy, complexs, complexb;
-  cuComplex complex, complexa, complexA, complexB, complexC, complexx, complexy, complexs, complexb;
-  // CHECK: rocblas_double_complex dcomplex, dcomplexa, dcomplexA, dcomplexB, dcomplexC, dcomplexx, dcomplexy, dcomplexs, dcomplexb;
-  cuDoubleComplex dcomplex, dcomplexa, dcomplexA, dcomplexB, dcomplexC, dcomplexx, dcomplexy, dcomplexs, dcomplexb;
+  // CHECK: rocblas_float_complex complex, complexa, complexA, complexB, complexC, complexx, complexy, complexs, complexb, complexresult;
+  cuComplex complex, complexa, complexA, complexB, complexC, complexx, complexy, complexs, complexb, complexresult;
+  // CHECK: rocblas_double_complex dcomplex, dcomplexa, dcomplexA, dcomplexB, dcomplexC, dcomplexx, dcomplexy, dcomplexs, dcomplexb, dcomplexresult;
+  cuDoubleComplex dcomplex, dcomplexa, dcomplexA, dcomplexB, dcomplexC, dcomplexx, dcomplexy, dcomplexs, dcomplexb, dcomplexresult;
 
   // CHECK: rocblas_float_complex** complexAarray = 0;
   // CHECK: const rocblas_float_complex** const complexAarray_const = const_cast<const rocblas_float_complex**>(complexAarray);
@@ -2063,6 +2063,48 @@ int main() {
   // CHECK-NEXT: blasStatus = rocblas_zcopy_64(blasHandle, n_64, &dcomplexx, incx_64, &dcomplexy, incy_64);
   blasStatus = cublasZcopy_64(blasHandle, n_64, &dcomplexx, incx_64, &dcomplexy, incy_64);
   blasStatus = cublasZcopy_v2_64(blasHandle, n_64, &dcomplexx, incx_64, &dcomplexy, incy_64);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasSdot_v2_64(cublasHandle_t handle, int64_t n, const float* x, int64_t incx, const float* y, int64_t incy, float* result);
+  // ROC: ROCBLAS_EXPORT rocblas_status rocblas_sdot_64(rocblas_handle handle, int64_t n, const float* x, int64_t incx, const float* y, int64_t incy, float* result);
+  // CHECK: blasStatus = rocblas_sdot_64(blasHandle, n_64, &fx, incx_64, &fy, incy_64, &fresult);
+  // CHECK-NEXT: blasStatus = rocblas_sdot_64(blasHandle, n_64, &fx, incx_64, &fy, incy_64, &fresult);
+  blasStatus = cublasSdot_64(blasHandle, n_64, &fx, incx_64, &fy, incy_64, &fresult);
+  blasStatus = cublasSdot_v2_64(blasHandle, n_64, &fx, incx_64, &fy, incy_64, &fresult);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasDdot_v2_64(cublasHandle_t handle, int64_t n, const double* x, int64_t incx, const double* y, int64_t incy, double* result);
+  // ROC: ROCBLAS_EXPORT rocblas_status rocblas_ddot_64(rocblas_handle handle, int64_t n, const double* x, int64_t incx, const double* y, int64_t incy, double* result);
+  // CHECK: blasStatus = rocblas_ddot_64(blasHandle, n_64, &dx, incx_64, &dy, incy_64, &dresult);
+  // CHECK-NEXT: blasStatus = rocblas_ddot_64(blasHandle, n_64, &dx, incx_64, &dy, incy_64, &dresult);
+  blasStatus = cublasDdot_64(blasHandle, n_64, &dx, incx_64, &dy, incy_64, &dresult);
+  blasStatus = cublasDdot_v2_64(blasHandle, n_64, &dx, incx_64, &dy, incy_64, &dresult);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasCdotc_v2_64(cublasHandle_t handle, int64_t n, const cuComplex* x, int64_t incx, const cuComplex* y, int64_t incy, cuComplex* result);
+  // ROC: ROCBLAS_EXPORT rocblas_status rocblas_cdotc_64(rocblas_handle handle, int64_t n, const rocblas_float_complex* x, int64_t incx, const rocblas_float_complex* y, int64_t incy, rocblas_float_complex* result);
+  // CHECK: blasStatus = rocblas_cdotc_64(blasHandle, n_64, &complexx, incx_64, &complexy, incy_64, &complexresult);
+  // CHECK-NEXT: blasStatus = rocblas_cdotc_64(blasHandle, n_64, &complexx, incx_64, &complexy, incy_64, &complexresult);
+  blasStatus = cublasCdotc_64(blasHandle, n_64, &complexx, incx_64, &complexy, incy_64, &complexresult);
+  blasStatus = cublasCdotc_v2_64(blasHandle, n_64, &complexx, incx_64, &complexy, incy_64, &complexresult);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasCdotu_v2_64(cublasHandle_t handle, int64_t n, const cuComplex* x, int64_t incx, const cuComplex* y, int64_t incy, cuComplex* result);
+  // ROC: ROCBLAS_EXPORT rocblas_status rocblas_cdotu_64(rocblas_handle handle, int64_t n, const rocblas_float_complex* x, int64_t incx, const rocblas_float_complex* y, int64_t incy, rocblas_float_complex* result);
+  // CHECK: blasStatus = rocblas_cdotu_64(blasHandle, n_64, &complexx, incx_64, &complexy, incy_64, &complexresult);
+  // CHECK-NEXT: blasStatus = rocblas_cdotu_64(blasHandle, n_64, &complexx, incx_64, &complexy, incy_64, &complexresult);
+  blasStatus = cublasCdotu_64(blasHandle, n_64, &complexx, incx_64, &complexy, incy_64, &complexresult);
+  blasStatus = cublasCdotu_v2_64(blasHandle, n_64, &complexx, incx_64, &complexy, incy_64, &complexresult);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasZdotc_v2_64(cublasHandle_t handle, int64_t n, const cuDoubleComplex* x, int64_t incx, const cuDoubleComplex* y, int64_t incy, cuDoubleComplex* result);
+  // ROC: ROCBLAS_EXPORT rocblas_status rocblas_zdotc_64(rocblas_handle handle, int64_t n, const rocblas_double_complex* x, int64_t incx, const rocblas_double_complex* y, int64_t incy, rocblas_double_complex* result);
+  // CHECK: blasStatus = rocblas_zdotc_64(blasHandle, n_64, &dcomplexx, incx_64, &dcomplexy, incy_64, &dcomplexresult);
+  // CHECK-NEXT: blasStatus = rocblas_zdotc_64(blasHandle, n_64, &dcomplexx, incx_64, &dcomplexy, incy_64, &dcomplexresult);
+  blasStatus = cublasZdotc_64(blasHandle, n_64, &dcomplexx, incx_64, &dcomplexy, incy_64, &dcomplexresult);
+  blasStatus = cublasZdotc_v2_64(blasHandle, n_64, &dcomplexx, incx_64, &dcomplexy, incy_64, &dcomplexresult);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasZdotu_v2_64(cublasHandle_t handle, int64_t n, const cuDoubleComplex* x, int64_t incx, const cuDoubleComplex* y, int64_t incy, cuDoubleComplex* result);
+  // ROC: ROCBLAS_EXPORT rocblas_status rocblas_zdotu_64(rocblas_handle handle, int64_t n, const rocblas_double_complex* x, int64_t incx, const rocblas_double_complex* y, int64_t incy, rocblas_double_complex* result);
+  // CHECK: blasStatus = rocblas_zdotu_64(blasHandle, n_64, &dcomplexx, incx_64, &dcomplexy, incy_64, &dcomplexresult);
+  // CHECK-NEXT: blasStatus = rocblas_zdotu_64(blasHandle, n_64, &dcomplexx, incx_64, &dcomplexy, incy_64, &dcomplexresult);
+  blasStatus = cublasZdotu_64(blasHandle, n_64, &dcomplexx, incx_64, &dcomplexy, incy_64, &dcomplexresult);
+  blasStatus = cublasZdotu_v2_64(blasHandle, n_64, &dcomplexx, incx_64, &dcomplexy, incy_64, &dcomplexresult);
 #endif
 
   return 0;


### PR DESCRIPTION
+ Updated `BLAS` synthetic tests, the regenerated hipify-perl, and `BLAS` `CUDA2HIP` documentation
