### PR TITLE
[HIPIFY][BLAS][6.1][sync] Sync with `hipBLAS` and `rocBLAS` - Step 9 - ROT 64bit

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -1837,13 +1837,17 @@ sub rocSubstitutions {
     subst("cublasCreate", "rocblas_create_handle", "library");
     subst("cublasCreate_v2", "rocblas_create_handle", "library");
     subst("cublasCrot", "rocblas_crot", "library");
+    subst("cublasCrot_64", "rocblas_crot_64", "library");
     subst("cublasCrot_v2", "rocblas_crot", "library");
+    subst("cublasCrot_v2_64", "rocblas_crot_64", "library");
     subst("cublasCrotg", "rocblas_crotg", "library");
     subst("cublasCrotg_v2", "rocblas_crotg", "library");
     subst("cublasCscal", "rocblas_cscal", "library");
     subst("cublasCscal_v2", "rocblas_cscal", "library");
     subst("cublasCsrot", "rocblas_csrot", "library");
+    subst("cublasCsrot_64", "rocblas_csrot_64", "library");
     subst("cublasCsrot_v2", "rocblas_csrot", "library");
+    subst("cublasCsrot_v2_64", "rocblas_csrot_64", "library");
     subst("cublasCsscal", "rocblas_csscal", "library");
     subst("cublasCsscal_v2", "rocblas_csscal", "library");
     subst("cublasCswap", "rocblas_cswap", "library");
@@ -1915,7 +1919,9 @@ sub rocSubstitutions {
     subst("cublasDotEx", "rocblas_dot_ex", "library");
     subst("cublasDotcEx", "rocblas_dotc_ex", "library");
     subst("cublasDrot", "rocblas_drot", "library");
+    subst("cublasDrot_64", "rocblas_drot_64", "library");
     subst("cublasDrot_v2", "rocblas_drot", "library");
+    subst("cublasDrot_v2_64", "rocblas_drot_64", "library");
     subst("cublasDrotg", "rocblas_drotg", "library");
     subst("cublasDrotg_v2", "rocblas_drotg", "library");
     subst("cublasDrotm", "rocblas_drotm", "library");
@@ -2080,7 +2086,9 @@ sub rocSubstitutions {
     subst("cublasSnrm2_v2", "rocblas_snrm2", "library");
     subst("cublasSnrm2_v2_64", "rocblas_snrm2_64", "library");
     subst("cublasSrot", "rocblas_srot", "library");
+    subst("cublasSrot_64", "rocblas_srot_64", "library");
     subst("cublasSrot_v2", "rocblas_srot", "library");
+    subst("cublasSrot_v2_64", "rocblas_srot_64", "library");
     subst("cublasSrotg", "rocblas_srotg", "library");
     subst("cublasSrotg_v2", "rocblas_srotg", "library");
     subst("cublasSrotm", "rocblas_srotm", "library");
@@ -2151,7 +2159,9 @@ sub rocSubstitutions {
     subst("cublasZdotu_v2", "rocblas_zdotu", "library");
     subst("cublasZdotu_v2_64", "rocblas_zdotu_64", "library");
     subst("cublasZdrot", "rocblas_zdrot", "library");
+    subst("cublasZdrot_64", "rocblas_zdrot_64", "library");
     subst("cublasZdrot_v2", "rocblas_zdrot", "library");
+    subst("cublasZdrot_v2_64", "rocblas_zdrot_64", "library");
     subst("cublasZdscal", "rocblas_zdscal", "library");
     subst("cublasZdscal_v2", "rocblas_zdscal", "library");
     subst("cublasZgbmv", "rocblas_zgbmv", "library");
@@ -2191,7 +2201,9 @@ sub rocSubstitutions {
     subst("cublasZhpr2_v2", "rocblas_zhpr2", "library");
     subst("cublasZhpr_v2", "rocblas_zhpr", "library");
     subst("cublasZrot", "rocblas_zrot", "library");
+    subst("cublasZrot_64", "rocblas_zrot_64", "library");
     subst("cublasZrot_v2", "rocblas_zrot", "library");
+    subst("cublasZrot_v2_64", "rocblas_zrot_64", "library");
     subst("cublasZrotg", "rocblas_zrotg", "library");
     subst("cublasZrotg_v2", "rocblas_zrotg", "library");
     subst("cublasZscal", "rocblas_zscal", "library");
@@ -3820,13 +3832,17 @@ sub simpleSubstitutions {
     subst("cublasCreate", "hipblasCreate", "library");
     subst("cublasCreate_v2", "hipblasCreate", "library");
     subst("cublasCrot", "hipblasCrot_v2", "library");
+    subst("cublasCrot_64", "hipblasCrot_v2_64", "library");
     subst("cublasCrot_v2", "hipblasCrot_v2", "library");
+    subst("cublasCrot_v2_64", "hipblasCrot_v2_64", "library");
     subst("cublasCrotg", "hipblasCrotg_v2", "library");
     subst("cublasCrotg_v2", "hipblasCrotg_v2", "library");
     subst("cublasCscal", "hipblasCscal_v2", "library");
     subst("cublasCscal_v2", "hipblasCscal_v2", "library");
     subst("cublasCsrot", "hipblasCsrot_v2", "library");
+    subst("cublasCsrot_64", "hipblasCsrot_v2_64", "library");
     subst("cublasCsrot_v2", "hipblasCsrot_v2", "library");
+    subst("cublasCsrot_v2_64", "hipblasCsrot_v2_64", "library");
     subst("cublasCsscal", "hipblasCsscal_v2", "library");
     subst("cublasCsscal_v2", "hipblasCsscal_v2", "library");
     subst("cublasCswap", "hipblasCswap_v2", "library");
@@ -3903,7 +3919,9 @@ sub simpleSubstitutions {
     subst("cublasDotEx", "hipblasDotEx_v2", "library");
     subst("cublasDotcEx", "hipblasDotcEx_v2", "library");
     subst("cublasDrot", "hipblasDrot", "library");
+    subst("cublasDrot_64", "hipblasDrot_64", "library");
     subst("cublasDrot_v2", "hipblasDrot", "library");
+    subst("cublasDrot_v2_64", "hipblasDrot_64", "library");
     subst("cublasDrotg", "hipblasDrotg", "library");
     subst("cublasDrotg_v2", "hipblasDrotg", "library");
     subst("cublasDrotm", "hipblasDrotm", "library");
@@ -4067,7 +4085,9 @@ sub simpleSubstitutions {
     subst("cublasSnrm2_v2", "hipblasSnrm2", "library");
     subst("cublasSnrm2_v2_64", "hipblasSnrm2_64", "library");
     subst("cublasSrot", "hipblasSrot", "library");
+    subst("cublasSrot_64", "hipblasSrot_64", "library");
     subst("cublasSrot_v2", "hipblasSrot", "library");
+    subst("cublasSrot_v2_64", "hipblasSrot_64", "library");
     subst("cublasSrotg", "hipblasSrotg", "library");
     subst("cublasSrotg_v2", "hipblasSrotg", "library");
     subst("cublasSrotm", "hipblasSrotm", "library");
@@ -4134,7 +4154,9 @@ sub simpleSubstitutions {
     subst("cublasZdotu_v2", "hipblasZdotu_v2", "library");
     subst("cublasZdotu_v2_64", "hipblasZdotu_v2_64", "library");
     subst("cublasZdrot", "hipblasZdrot_v2", "library");
+    subst("cublasZdrot_64", "hipblasZdrot_v2_64", "library");
     subst("cublasZdrot_v2", "hipblasZdrot_v2", "library");
+    subst("cublasZdrot_v2_64", "hipblasZdrot_v2_64", "library");
     subst("cublasZdscal", "hipblasZdscal_v2", "library");
     subst("cublasZdscal_v2", "hipblasZdscal_v2", "library");
     subst("cublasZgbmv", "hipblasZgbmv_v2", "library");
@@ -4179,7 +4201,9 @@ sub simpleSubstitutions {
     subst("cublasZhpr2_v2", "hipblasZhpr2_v2", "library");
     subst("cublasZhpr_v2", "hipblasZhpr_v2", "library");
     subst("cublasZrot", "hipblasZrot_v2", "library");
+    subst("cublasZrot_64", "hipblasZrot_v2_64", "library");
     subst("cublasZrot_v2", "hipblasZrot_v2", "library");
+    subst("cublasZrot_v2_64", "hipblasZrot_v2_64", "library");
     subst("cublasZrotg", "hipblasZrotg_v2", "library");
     subst("cublasZrotg_v2", "hipblasZrotg_v2", "library");
     subst("cublasZscal", "hipblasZscal_v2", "library");
@@ -10806,8 +10830,6 @@ sub warnHipOnlyUnsupportedFunctions {
         "cublasZswap_64",
         "cublasZscal_v2_64",
         "cublasZscal_64",
-        "cublasZrot_v2_64",
-        "cublasZrot_64",
         "cublasZmatinvBatched",
         "cublasZhpr_v2_64",
         "cublasZhpr_64",
@@ -10849,8 +10871,6 @@ sub warnHipOnlyUnsupportedFunctions {
         "cublasZgbmv_64",
         "cublasZdscal_v2_64",
         "cublasZdscal_64",
-        "cublasZdrot_v2_64",
-        "cublasZdrot_64",
         "cublasZdgmm_64",
         "cublasXerbla",
         "cublasUint8gemmBias",
@@ -10910,8 +10930,6 @@ sub warnHipOnlyUnsupportedFunctions {
         "cublasSsbmv_64",
         "cublasSrotm_v2_64",
         "cublasSrotm_64",
-        "cublasSrot_v2_64",
-        "cublasSrot_64",
         "cublasSmatinvBatched",
         "cublasShutdown",
         "cublasSger_v2_64",
@@ -11028,8 +11046,6 @@ sub warnHipOnlyUnsupportedFunctions {
         "cublasDsbmv_64",
         "cublasDrotm_v2_64",
         "cublasDrotm_64",
-        "cublasDrot_v2_64",
-        "cublasDrot_64",
         "cublasDotcEx_64",
         "cublasDotEx_64",
         "cublasDmatinvBatched",
@@ -11089,12 +11105,8 @@ sub warnHipOnlyUnsupportedFunctions {
         "cublasCswap_64",
         "cublasCsscal_v2_64",
         "cublasCsscal_64",
-        "cublasCsrot_v2_64",
-        "cublasCsrot_64",
         "cublasCscal_v2_64",
         "cublasCscal_64",
-        "cublasCrot_v2_64",
-        "cublasCrot_64",
         "cublasCopyEx_64",
         "cublasCopyEx",
         "cublasContext",
@@ -11262,8 +11274,6 @@ sub warnRocOnlyUnsupportedFunctions {
         "cublasZswap_64",
         "cublasZscal_v2_64",
         "cublasZscal_64",
-        "cublasZrot_v2_64",
-        "cublasZrot_64",
         "cublasZmatinvBatched",
         "cublasZhpr_v2_64",
         "cublasZhpr_64",
@@ -11310,8 +11320,6 @@ sub warnRocOnlyUnsupportedFunctions {
         "cublasZgbmv_64",
         "cublasZdscal_v2_64",
         "cublasZdscal_64",
-        "cublasZdrot_v2_64",
-        "cublasZdrot_64",
         "cublasZdgmm_64",
         "cublasXerbla",
         "cublasUint8gemmBias",
@@ -11367,8 +11375,6 @@ sub warnRocOnlyUnsupportedFunctions {
         "cublasSsbmv_64",
         "cublasSrotm_v2_64",
         "cublasSrotm_64",
-        "cublasSrot_v2_64",
-        "cublasSrot_64",
         "cublasSmatinvBatched",
         "cublasShutdown",
         "cublasSgetrsBatched",
@@ -11484,8 +11490,6 @@ sub warnRocOnlyUnsupportedFunctions {
         "cublasDsbmv_64",
         "cublasDrotm_v2_64",
         "cublasDrotm_64",
-        "cublasDrot_v2_64",
-        "cublasDrot_64",
         "cublasDotcEx_64",
         "cublasDotEx_64",
         "cublasDmatinvBatched",
@@ -11550,12 +11554,8 @@ sub warnRocOnlyUnsupportedFunctions {
         "cublasCswap_64",
         "cublasCsscal_v2_64",
         "cublasCsscal_64",
-        "cublasCsrot_v2_64",
-        "cublasCsrot_64",
         "cublasCscal_v2_64",
         "cublasCscal_64",
-        "cublasCrot_v2_64",
-        "cublasCrot_64",
         "cublasCopyEx_64",
         "cublasCopyEx",
         "cublasCmatinvBatched",

--- a/docs/tables/CUBLAS_API_supported_by_HIP.md
+++ b/docs/tables/CUBLAS_API_supported_by_HIP.md
@@ -220,9 +220,9 @@
 |`cublasCdotu_v2`| | | | |`hipblasCdotu_v2`|6.0.0| | | | |
 |`cublasCdotu_v2_64`|12.0| | | |`hipblasCdotu_v2_64`|6.1.0| | | | |
 |`cublasCrot`| | | | |`hipblasCrot_v2`|6.0.0| | | | |
-|`cublasCrot_64`|12.0| | | | | | | | | |
+|`cublasCrot_64`|12.0| | | |`hipblasCrot_v2_64`|6.1.0| | | | |
 |`cublasCrot_v2`| | | | |`hipblasCrot_v2`|6.0.0| | | | |
-|`cublasCrot_v2_64`|12.0| | | | | | | | | |
+|`cublasCrot_v2_64`|12.0| | | |`hipblasCrot_v2_64`|6.1.0| | | | |
 |`cublasCrotg`| | | | |`hipblasCrotg_v2`|6.0.0| | | | |
 |`cublasCrotg_v2`| | | | |`hipblasCrotg_v2`|6.0.0| | | | |
 |`cublasCscal`| | | | |`hipblasCscal_v2`|6.0.0| | | | |
@@ -230,9 +230,9 @@
 |`cublasCscal_v2`| | | | |`hipblasCscal_v2`|6.0.0| | | | |
 |`cublasCscal_v2_64`|12.0| | | | | | | | | |
 |`cublasCsrot`| | | | |`hipblasCsrot_v2`|6.0.0| | | | |
-|`cublasCsrot_64`|12.0| | | | | | | | | |
+|`cublasCsrot_64`|12.0| | | |`hipblasCsrot_v2_64`|6.1.0| | | | |
 |`cublasCsrot_v2`| | | | |`hipblasCsrot_v2`|6.0.0| | | | |
-|`cublasCsrot_v2_64`|12.0| | | | | | | | | |
+|`cublasCsrot_v2_64`|12.0| | | |`hipblasCsrot_v2_64`|6.1.0| | | | |
 |`cublasCsscal`| | | | |`hipblasCsscal_v2`|6.0.0| | | | |
 |`cublasCsscal_64`|12.0| | | | | | | | | |
 |`cublasCsscal_v2`| | | | |`hipblasCsscal_v2`|6.0.0| | | | |
@@ -262,9 +262,9 @@
 |`cublasDnrm2_v2`| | | | |`hipblasDnrm2`|1.8.2| | | | |
 |`cublasDnrm2_v2_64`|12.0| | | |`hipblasDnrm2_64`|6.1.0| | | | |
 |`cublasDrot`| | | | |`hipblasDrot`|3.0.0| | | | |
-|`cublasDrot_64`|12.0| | | | | | | | | |
+|`cublasDrot_64`|12.0| | | |`hipblasDrot_64`|6.1.0| | | | |
 |`cublasDrot_v2`| | | | |`hipblasDrot`|3.0.0| | | | |
-|`cublasDrot_v2_64`|12.0| | | | | | | | | |
+|`cublasDrot_v2_64`|12.0| | | |`hipblasDrot_64`|6.1.0| | | | |
 |`cublasDrotg`| | | | |`hipblasDrotg`|3.0.0| | | | |
 |`cublasDrotg_v2`| | | | |`hipblasDrotg`|3.0.0| | | | |
 |`cublasDrotm`| | | | |`hipblasDrotm`|3.0.0| | | | |
@@ -352,9 +352,9 @@
 |`cublasSnrm2_v2`| | | | |`hipblasSnrm2`|1.8.2| | | | |
 |`cublasSnrm2_v2_64`|12.0| | | |`hipblasSnrm2_64`|6.1.0| | | | |
 |`cublasSrot`| | | | |`hipblasSrot`|3.0.0| | | | |
-|`cublasSrot_64`|12.0| | | | | | | | | |
+|`cublasSrot_64`|12.0| | | |`hipblasSrot_64`|6.1.0| | | | |
 |`cublasSrot_v2`| | | | |`hipblasSrot`|3.0.0| | | | |
-|`cublasSrot_v2_64`|12.0| | | | | | | | | |
+|`cublasSrot_v2_64`|12.0| | | |`hipblasSrot_64`|6.1.0| | | | |
 |`cublasSrotg`| | | | |`hipblasSrotg`|3.0.0| | | | |
 |`cublasSrotg_v2`| | | | |`hipblasSrotg`|3.0.0| | | | |
 |`cublasSrotm`| | | | |`hipblasSrotm`|3.0.0| | | | |
@@ -388,17 +388,17 @@
 |`cublasZdotu_v2`| | | | |`hipblasZdotu_v2`|6.0.0| | | | |
 |`cublasZdotu_v2_64`|12.0| | | |`hipblasZdotu_v2_64`|6.1.0| | | | |
 |`cublasZdrot`| | | | |`hipblasZdrot_v2`|6.0.0| | | | |
-|`cublasZdrot_64`|12.0| | | | | | | | | |
+|`cublasZdrot_64`|12.0| | | |`hipblasZdrot_v2_64`|6.1.0| | | | |
 |`cublasZdrot_v2`| | | | |`hipblasZdrot_v2`|6.0.0| | | | |
-|`cublasZdrot_v2_64`|12.0| | | | | | | | | |
+|`cublasZdrot_v2_64`|12.0| | | |`hipblasZdrot_v2_64`|6.1.0| | | | |
 |`cublasZdscal`| | | | |`hipblasZdscal_v2`|6.0.0| | | | |
 |`cublasZdscal_64`|12.0| | | | | | | | | |
 |`cublasZdscal_v2`| | | | |`hipblasZdscal_v2`|6.0.0| | | | |
 |`cublasZdscal_v2_64`|12.0| | | | | | | | | |
 |`cublasZrot`| | | | |`hipblasZrot_v2`|6.0.0| | | | |
-|`cublasZrot_64`|12.0| | | | | | | | | |
+|`cublasZrot_64`|12.0| | | |`hipblasZrot_v2_64`|6.1.0| | | | |
 |`cublasZrot_v2`| | | | |`hipblasZrot_v2`|6.0.0| | | | |
-|`cublasZrot_v2_64`|12.0| | | | | | | | | |
+|`cublasZrot_v2_64`|12.0| | | |`hipblasZrot_v2_64`|6.1.0| | | | |
 |`cublasZrotg`| | | | |`hipblasZrotg_v2`|6.0.0| | | | |
 |`cublasZrotg_v2`| | | | |`hipblasZrotg_v2`|6.0.0| | | | |
 |`cublasZscal`| | | | |`hipblasZscal_v2`|6.0.0| | | | |

--- a/docs/tables/CUBLAS_API_supported_by_HIP_and_ROC.md
+++ b/docs/tables/CUBLAS_API_supported_by_HIP_and_ROC.md
@@ -220,9 +220,9 @@
 |`cublasCdotu_v2`| | | | |`hipblasCdotu_v2`|6.0.0| | | | |`rocblas_cdotu`|1.5.0| | | | |
 |`cublasCdotu_v2_64`|12.0| | | |`hipblasCdotu_v2_64`|6.1.0| | | | |`rocblas_cdotu_64`|6.1.0| | | | |
 |`cublasCrot`| | | | |`hipblasCrot_v2`|6.0.0| | | | |`rocblas_crot`|3.5.0| | | | |
-|`cublasCrot_64`|12.0| | | | | | | | | | | | | | | |
+|`cublasCrot_64`|12.0| | | |`hipblasCrot_v2_64`|6.1.0| | | | |`rocblas_crot_64`|6.1.0| | | | |
 |`cublasCrot_v2`| | | | |`hipblasCrot_v2`|6.0.0| | | | |`rocblas_crot`|3.5.0| | | | |
-|`cublasCrot_v2_64`|12.0| | | | | | | | | | | | | | | |
+|`cublasCrot_v2_64`|12.0| | | |`hipblasCrot_v2_64`|6.1.0| | | | |`rocblas_crot_64`|6.1.0| | | | |
 |`cublasCrotg`| | | | |`hipblasCrotg_v2`|6.0.0| | | | |`rocblas_crotg`|3.5.0| | | | |
 |`cublasCrotg_v2`| | | | |`hipblasCrotg_v2`|6.0.0| | | | |`rocblas_crotg`|3.5.0| | | | |
 |`cublasCscal`| | | | |`hipblasCscal_v2`|6.0.0| | | | |`rocblas_cscal`|1.5.0| | | | |
@@ -230,9 +230,9 @@
 |`cublasCscal_v2`| | | | |`hipblasCscal_v2`|6.0.0| | | | |`rocblas_cscal`|1.5.0| | | | |
 |`cublasCscal_v2_64`|12.0| | | | | | | | | | | | | | | |
 |`cublasCsrot`| | | | |`hipblasCsrot_v2`|6.0.0| | | | |`rocblas_csrot`|3.5.0| | | | |
-|`cublasCsrot_64`|12.0| | | | | | | | | | | | | | | |
+|`cublasCsrot_64`|12.0| | | |`hipblasCsrot_v2_64`|6.1.0| | | | |`rocblas_csrot_64`|6.1.0| | | | |
 |`cublasCsrot_v2`| | | | |`hipblasCsrot_v2`|6.0.0| | | | |`rocblas_csrot`|3.5.0| | | | |
-|`cublasCsrot_v2_64`|12.0| | | | | | | | | | | | | | | |
+|`cublasCsrot_v2_64`|12.0| | | |`hipblasCsrot_v2_64`|6.1.0| | | | |`rocblas_csrot_64`|6.1.0| | | | |
 |`cublasCsscal`| | | | |`hipblasCsscal_v2`|6.0.0| | | | |`rocblas_csscal`|3.5.0| | | | |
 |`cublasCsscal_64`|12.0| | | | | | | | | | | | | | | |
 |`cublasCsscal_v2`| | | | |`hipblasCsscal_v2`|6.0.0| | | | |`rocblas_csscal`|3.5.0| | | | |
@@ -262,9 +262,9 @@
 |`cublasDnrm2_v2`| | | | |`hipblasDnrm2`|1.8.2| | | | |`rocblas_dnrm2`|1.5.0| | | | |
 |`cublasDnrm2_v2_64`|12.0| | | |`hipblasDnrm2_64`|6.1.0| | | | |`rocblas_dnrm2_64`|6.1.0| | | | |
 |`cublasDrot`| | | | |`hipblasDrot`|3.0.0| | | | |`rocblas_drot`|3.5.0| | | | |
-|`cublasDrot_64`|12.0| | | | | | | | | | | | | | | |
+|`cublasDrot_64`|12.0| | | |`hipblasDrot_64`|6.1.0| | | | |`rocblas_drot_64`|6.1.0| | | | |
 |`cublasDrot_v2`| | | | |`hipblasDrot`|3.0.0| | | | |`rocblas_drot`|3.5.0| | | | |
-|`cublasDrot_v2_64`|12.0| | | | | | | | | | | | | | | |
+|`cublasDrot_v2_64`|12.0| | | |`hipblasDrot_64`|6.1.0| | | | |`rocblas_drot_64`|6.1.0| | | | |
 |`cublasDrotg`| | | | |`hipblasDrotg`|3.0.0| | | | |`rocblas_drotg`|3.5.0| | | | |
 |`cublasDrotg_v2`| | | | |`hipblasDrotg`|3.0.0| | | | |`rocblas_drotg`|3.5.0| | | | |
 |`cublasDrotm`| | | | |`hipblasDrotm`|3.0.0| | | | |`rocblas_drotm`|3.5.0| | | | |
@@ -352,9 +352,9 @@
 |`cublasSnrm2_v2`| | | | |`hipblasSnrm2`|1.8.2| | | | |`rocblas_snrm2`|1.5.0| | | | |
 |`cublasSnrm2_v2_64`|12.0| | | |`hipblasSnrm2_64`|6.1.0| | | | |`rocblas_snrm2_64`|6.1.0| | | | |
 |`cublasSrot`| | | | |`hipblasSrot`|3.0.0| | | | |`rocblas_srot`|3.5.0| | | | |
-|`cublasSrot_64`|12.0| | | | | | | | | | | | | | | |
+|`cublasSrot_64`|12.0| | | |`hipblasSrot_64`|6.1.0| | | | |`rocblas_srot_64`|6.1.0| | | | |
 |`cublasSrot_v2`| | | | |`hipblasSrot`|3.0.0| | | | |`rocblas_srot`|3.5.0| | | | |
-|`cublasSrot_v2_64`|12.0| | | | | | | | | | | | | | | |
+|`cublasSrot_v2_64`|12.0| | | |`hipblasSrot_64`|6.1.0| | | | |`rocblas_srot_64`|6.1.0| | | | |
 |`cublasSrotg`| | | | |`hipblasSrotg`|3.0.0| | | | |`rocblas_srotg`|3.5.0| | | | |
 |`cublasSrotg_v2`| | | | |`hipblasSrotg`|3.0.0| | | | |`rocblas_srotg`|3.5.0| | | | |
 |`cublasSrotm`| | | | |`hipblasSrotm`|3.0.0| | | | |`rocblas_srotm`|3.5.0| | | | |
@@ -388,17 +388,17 @@
 |`cublasZdotu_v2`| | | | |`hipblasZdotu_v2`|6.0.0| | | | |`rocblas_zdotu`|1.5.0| | | | |
 |`cublasZdotu_v2_64`|12.0| | | |`hipblasZdotu_v2_64`|6.1.0| | | | |`rocblas_zdotu_64`|6.1.0| | | | |
 |`cublasZdrot`| | | | |`hipblasZdrot_v2`|6.0.0| | | | |`rocblas_zdrot`|3.5.0| | | | |
-|`cublasZdrot_64`|12.0| | | | | | | | | | | | | | | |
+|`cublasZdrot_64`|12.0| | | |`hipblasZdrot_v2_64`|6.1.0| | | | |`rocblas_zdrot_64`|6.1.0| | | | |
 |`cublasZdrot_v2`| | | | |`hipblasZdrot_v2`|6.0.0| | | | |`rocblas_zdrot`|3.5.0| | | | |
-|`cublasZdrot_v2_64`|12.0| | | | | | | | | | | | | | | |
+|`cublasZdrot_v2_64`|12.0| | | |`hipblasZdrot_v2_64`|6.1.0| | | | |`rocblas_zdrot_64`|6.1.0| | | | |
 |`cublasZdscal`| | | | |`hipblasZdscal_v2`|6.0.0| | | | |`rocblas_zdscal`|3.5.0| | | | |
 |`cublasZdscal_64`|12.0| | | | | | | | | | | | | | | |
 |`cublasZdscal_v2`| | | | |`hipblasZdscal_v2`|6.0.0| | | | |`rocblas_zdscal`|3.5.0| | | | |
 |`cublasZdscal_v2_64`|12.0| | | | | | | | | | | | | | | |
 |`cublasZrot`| | | | |`hipblasZrot_v2`|6.0.0| | | | |`rocblas_zrot`|3.5.0| | | | |
-|`cublasZrot_64`|12.0| | | | | | | | | | | | | | | |
+|`cublasZrot_64`|12.0| | | |`hipblasZrot_v2_64`|6.1.0| | | | |`rocblas_zrot_64`|6.1.0| | | | |
 |`cublasZrot_v2`| | | | |`hipblasZrot_v2`|6.0.0| | | | |`rocblas_zrot`|3.5.0| | | | |
-|`cublasZrot_v2_64`|12.0| | | | | | | | | | | | | | | |
+|`cublasZrot_v2_64`|12.0| | | |`hipblasZrot_v2_64`|6.1.0| | | | |`rocblas_zrot_64`|6.1.0| | | | |
 |`cublasZrotg`| | | | |`hipblasZrotg_v2`|6.0.0| | | | |`rocblas_zrotg`|3.5.0| | | | |
 |`cublasZrotg_v2`| | | | |`hipblasZrotg_v2`|6.0.0| | | | |`rocblas_zrotg`|3.5.0| | | | |
 |`cublasZscal`| | | | |`hipblasZscal_v2`|6.0.0| | | | |`rocblas_zscal`|1.5.0| | | | |

--- a/docs/tables/CUBLAS_API_supported_by_ROC.md
+++ b/docs/tables/CUBLAS_API_supported_by_ROC.md
@@ -220,9 +220,9 @@
 |`cublasCdotu_v2`| | | | |`rocblas_cdotu`|1.5.0| | | | |
 |`cublasCdotu_v2_64`|12.0| | | |`rocblas_cdotu_64`|6.1.0| | | | |
 |`cublasCrot`| | | | |`rocblas_crot`|3.5.0| | | | |
-|`cublasCrot_64`|12.0| | | | | | | | | |
+|`cublasCrot_64`|12.0| | | |`rocblas_crot_64`|6.1.0| | | | |
 |`cublasCrot_v2`| | | | |`rocblas_crot`|3.5.0| | | | |
-|`cublasCrot_v2_64`|12.0| | | | | | | | | |
+|`cublasCrot_v2_64`|12.0| | | |`rocblas_crot_64`|6.1.0| | | | |
 |`cublasCrotg`| | | | |`rocblas_crotg`|3.5.0| | | | |
 |`cublasCrotg_v2`| | | | |`rocblas_crotg`|3.5.0| | | | |
 |`cublasCscal`| | | | |`rocblas_cscal`|1.5.0| | | | |
@@ -230,9 +230,9 @@
 |`cublasCscal_v2`| | | | |`rocblas_cscal`|1.5.0| | | | |
 |`cublasCscal_v2_64`|12.0| | | | | | | | | |
 |`cublasCsrot`| | | | |`rocblas_csrot`|3.5.0| | | | |
-|`cublasCsrot_64`|12.0| | | | | | | | | |
+|`cublasCsrot_64`|12.0| | | |`rocblas_csrot_64`|6.1.0| | | | |
 |`cublasCsrot_v2`| | | | |`rocblas_csrot`|3.5.0| | | | |
-|`cublasCsrot_v2_64`|12.0| | | | | | | | | |
+|`cublasCsrot_v2_64`|12.0| | | |`rocblas_csrot_64`|6.1.0| | | | |
 |`cublasCsscal`| | | | |`rocblas_csscal`|3.5.0| | | | |
 |`cublasCsscal_64`|12.0| | | | | | | | | |
 |`cublasCsscal_v2`| | | | |`rocblas_csscal`|3.5.0| | | | |
@@ -262,9 +262,9 @@
 |`cublasDnrm2_v2`| | | | |`rocblas_dnrm2`|1.5.0| | | | |
 |`cublasDnrm2_v2_64`|12.0| | | |`rocblas_dnrm2_64`|6.1.0| | | | |
 |`cublasDrot`| | | | |`rocblas_drot`|3.5.0| | | | |
-|`cublasDrot_64`|12.0| | | | | | | | | |
+|`cublasDrot_64`|12.0| | | |`rocblas_drot_64`|6.1.0| | | | |
 |`cublasDrot_v2`| | | | |`rocblas_drot`|3.5.0| | | | |
-|`cublasDrot_v2_64`|12.0| | | | | | | | | |
+|`cublasDrot_v2_64`|12.0| | | |`rocblas_drot_64`|6.1.0| | | | |
 |`cublasDrotg`| | | | |`rocblas_drotg`|3.5.0| | | | |
 |`cublasDrotg_v2`| | | | |`rocblas_drotg`|3.5.0| | | | |
 |`cublasDrotm`| | | | |`rocblas_drotm`|3.5.0| | | | |
@@ -352,9 +352,9 @@
 |`cublasSnrm2_v2`| | | | |`rocblas_snrm2`|1.5.0| | | | |
 |`cublasSnrm2_v2_64`|12.0| | | |`rocblas_snrm2_64`|6.1.0| | | | |
 |`cublasSrot`| | | | |`rocblas_srot`|3.5.0| | | | |
-|`cublasSrot_64`|12.0| | | | | | | | | |
+|`cublasSrot_64`|12.0| | | |`rocblas_srot_64`|6.1.0| | | | |
 |`cublasSrot_v2`| | | | |`rocblas_srot`|3.5.0| | | | |
-|`cublasSrot_v2_64`|12.0| | | | | | | | | |
+|`cublasSrot_v2_64`|12.0| | | |`rocblas_srot_64`|6.1.0| | | | |
 |`cublasSrotg`| | | | |`rocblas_srotg`|3.5.0| | | | |
 |`cublasSrotg_v2`| | | | |`rocblas_srotg`|3.5.0| | | | |
 |`cublasSrotm`| | | | |`rocblas_srotm`|3.5.0| | | | |
@@ -388,17 +388,17 @@
 |`cublasZdotu_v2`| | | | |`rocblas_zdotu`|1.5.0| | | | |
 |`cublasZdotu_v2_64`|12.0| | | |`rocblas_zdotu_64`|6.1.0| | | | |
 |`cublasZdrot`| | | | |`rocblas_zdrot`|3.5.0| | | | |
-|`cublasZdrot_64`|12.0| | | | | | | | | |
+|`cublasZdrot_64`|12.0| | | |`rocblas_zdrot_64`|6.1.0| | | | |
 |`cublasZdrot_v2`| | | | |`rocblas_zdrot`|3.5.0| | | | |
-|`cublasZdrot_v2_64`|12.0| | | | | | | | | |
+|`cublasZdrot_v2_64`|12.0| | | |`rocblas_zdrot_64`|6.1.0| | | | |
 |`cublasZdscal`| | | | |`rocblas_zdscal`|3.5.0| | | | |
 |`cublasZdscal_64`|12.0| | | | | | | | | |
 |`cublasZdscal_v2`| | | | |`rocblas_zdscal`|3.5.0| | | | |
 |`cublasZdscal_v2_64`|12.0| | | | | | | | | |
 |`cublasZrot`| | | | |`rocblas_zrot`|3.5.0| | | | |
-|`cublasZrot_64`|12.0| | | | | | | | | |
+|`cublasZrot_64`|12.0| | | |`rocblas_zrot_64`|6.1.0| | | | |
 |`cublasZrot_v2`| | | | |`rocblas_zrot`|3.5.0| | | | |
-|`cublasZrot_v2_64`|12.0| | | | | | | | | |
+|`cublasZrot_v2_64`|12.0| | | |`rocblas_zrot_64`|6.1.0| | | | |
 |`cublasZrotg`| | | | |`rocblas_zrotg`|3.5.0| | | | |
 |`cublasZrotg_v2`| | | | |`rocblas_zrotg`|3.5.0| | | | |
 |`cublasZscal`| | | | |`rocblas_zscal`|1.5.0| | | | |

--- a/src/CUDA2HIP_BLAS_API_functions.cpp
+++ b/src/CUDA2HIP_BLAS_API_functions.cpp
@@ -190,17 +190,17 @@ const std::map<llvm::StringRef, hipCounter> CUDA_BLAS_FUNCTION_MAP {
 
   // ROT
   {"cublasSrot",                     {"hipblasSrot",                     "rocblas_srot",                             CONV_LIB_FUNC, API_BLAS, 5, HIP_SUPPORTED_V2_ONLY}},
-  {"cublasSrot_64",                  {"hipblasSrot_64",                  "",                                         CONV_LIB_FUNC, API_BLAS, 5, UNSUPPORTED}},
+  {"cublasSrot_64",                  {"hipblasSrot_64",                  "rocblas_srot_64",                          CONV_LIB_FUNC, API_BLAS, 5}},
   {"cublasDrot",                     {"hipblasDrot",                     "rocblas_drot",                             CONV_LIB_FUNC, API_BLAS, 5, HIP_SUPPORTED_V2_ONLY}},
-  {"cublasDrot_64",                  {"hipblasDrot_64",                  "",                                         CONV_LIB_FUNC, API_BLAS, 5, UNSUPPORTED}},
+  {"cublasDrot_64",                  {"hipblasDrot_64",                  "rocblas_drot_64",                          CONV_LIB_FUNC, API_BLAS, 5}},
   {"cublasCrot",                     {"hipblasCrot_v2",                  "rocblas_crot",                             CONV_LIB_FUNC, API_BLAS, 5, HIP_SUPPORTED_V2_ONLY}},
-  {"cublasCrot_64",                  {"hipblasCrot_64",                  "",                                         CONV_LIB_FUNC, API_BLAS, 5, UNSUPPORTED}},
+  {"cublasCrot_64",                  {"hipblasCrot_v2_64",               "rocblas_crot_64",                          CONV_LIB_FUNC, API_BLAS, 5}},
   {"cublasCsrot",                    {"hipblasCsrot_v2",                 "rocblas_csrot",                            CONV_LIB_FUNC, API_BLAS, 5, HIP_SUPPORTED_V2_ONLY}},
-  {"cublasCsrot_64",                 {"hipblasCsrot_64",                 "",                                         CONV_LIB_FUNC, API_BLAS, 5, UNSUPPORTED}},
+  {"cublasCsrot_64",                 {"hipblasCsrot_v2_64",              "rocblas_csrot_64",                         CONV_LIB_FUNC, API_BLAS, 5}},
   {"cublasZrot",                     {"hipblasZrot_v2",                  "rocblas_zrot",                             CONV_LIB_FUNC, API_BLAS, 5, HIP_SUPPORTED_V2_ONLY}},
-  {"cublasZrot_64",                  {"hipblasZrot_64",                  "",                                         CONV_LIB_FUNC, API_BLAS, 5, UNSUPPORTED}},
+  {"cublasZrot_64",                  {"hipblasZrot_v2_64",               "rocblas_zrot_64",                          CONV_LIB_FUNC, API_BLAS, 5}},
   {"cublasZdrot",                    {"hipblasZdrot_v2",                 "rocblas_zdrot",                            CONV_LIB_FUNC, API_BLAS, 5, HIP_SUPPORTED_V2_ONLY}},
-  {"cublasZdrot_64",                 {"hipblasZdrot_64",                 "",                                         CONV_LIB_FUNC, API_BLAS, 5, UNSUPPORTED}},
+  {"cublasZdrot_64",                 {"hipblasZdrot_v2_64",              "rocblas_zdrot_64",                         CONV_LIB_FUNC, API_BLAS, 5}},
 
   // ROTG
   {"cublasSrotg",                    {"hipblasSrotg",                    "rocblas_srotg",                            CONV_LIB_FUNC, API_BLAS, 5, HIP_SUPPORTED_V2_ONLY}},
@@ -1040,17 +1040,17 @@ const std::map<llvm::StringRef, hipCounter> CUDA_BLAS_FUNCTION_MAP {
   {"cublasRotEx",                    {"hipblasRotEx_v2",                 "rocblas_rot_ex",                           CONV_LIB_FUNC, API_BLAS, 8}},
   {"cublasRotEx_64",                 {"hipblasRotEx_64",                 "",                                         CONV_LIB_FUNC, API_BLAS, 8, UNSUPPORTED}},
   {"cublasSrot_v2",                  {"hipblasSrot",                     "rocblas_srot",                             CONV_LIB_FUNC, API_BLAS, 5}},
-  {"cublasSrot_v2_64",               {"hipblasSrot_64",                  "",                                         CONV_LIB_FUNC, API_BLAS, 5, UNSUPPORTED}},
+  {"cublasSrot_v2_64",               {"hipblasSrot_64",                  "rocblas_srot_64",                          CONV_LIB_FUNC, API_BLAS, 5}},
   {"cublasDrot_v2",                  {"hipblasDrot",                     "rocblas_drot",                             CONV_LIB_FUNC, API_BLAS, 5}},
-  {"cublasDrot_v2_64",               {"hipblasDrot_64",                  "",                                         CONV_LIB_FUNC, API_BLAS, 5, UNSUPPORTED}},
+  {"cublasDrot_v2_64",               {"hipblasDrot_64",                  "rocblas_drot_64",                          CONV_LIB_FUNC, API_BLAS, 5}},
   {"cublasCrot_v2",                  {"hipblasCrot_v2",                  "rocblas_crot",                             CONV_LIB_FUNC, API_BLAS, 5}},
-  {"cublasCrot_v2_64",               {"hipblasCrot_64",                  "",                                         CONV_LIB_FUNC, API_BLAS, 5, UNSUPPORTED}},
+  {"cublasCrot_v2_64",               {"hipblasCrot_v2_64",               "rocblas_crot_64",                          CONV_LIB_FUNC, API_BLAS, 5}},
   {"cublasCsrot_v2",                 {"hipblasCsrot_v2",                 "rocblas_csrot",                            CONV_LIB_FUNC, API_BLAS, 5}},
-  {"cublasCsrot_v2_64",              {"hipblasCsrot_64",                 "",                                         CONV_LIB_FUNC, API_BLAS, 5, UNSUPPORTED}},
+  {"cublasCsrot_v2_64",              {"hipblasCsrot_v2_64",              "rocblas_csrot_64",                         CONV_LIB_FUNC, API_BLAS, 5}},
   {"cublasZrot_v2",                  {"hipblasZrot_v2",                  "rocblas_zrot",                             CONV_LIB_FUNC, API_BLAS, 5}},
-  {"cublasZrot_v2_64",               {"hipblasZrot_64",                  "",                                         CONV_LIB_FUNC, API_BLAS, 5, UNSUPPORTED}},
+  {"cublasZrot_v2_64",               {"hipblasZrot_v2_64",               "rocblas_zrot_64",                          CONV_LIB_FUNC, API_BLAS, 5}},
   {"cublasZdrot_v2",                 {"hipblasZdrot_v2",                 "rocblas_zdrot",                            CONV_LIB_FUNC, API_BLAS, 5}},
-  {"cublasZdrot_v2_64",              {"hipblasZdrot_64",                 "",                                         CONV_LIB_FUNC, API_BLAS, 5, UNSUPPORTED}},
+  {"cublasZdrot_v2_64",              {"hipblasZdrot_v2_64",              "rocblas_zdrot_64",                         CONV_LIB_FUNC, API_BLAS, 5}},
 
   // ROTG
   {"cublasRotgEx",                   {"hipblasRotgEx",                   "",                                         CONV_LIB_FUNC, API_BLAS, 8, UNSUPPORTED}},
@@ -1901,6 +1901,12 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_BLAS_FUNCTION_VER_MAP {
   {"hipblasDnrm2_64",                            {HIP_6010, HIP_0,    HIP_0,  }},
   {"hipblasScnrm2_v2_64",                        {HIP_6010, HIP_0,    HIP_0,  }},
   {"hipblasDznrm2_v2_64",                        {HIP_6010, HIP_0,    HIP_0,  }},
+  {"hipblasSrot_64",                             {HIP_6010, HIP_0,    HIP_0,  }},
+  {"hipblasDrot_64",                             {HIP_6010, HIP_0,    HIP_0,  }},
+  {"hipblasCrot_v2_64",                          {HIP_6010, HIP_0,    HIP_0,  }},
+  {"hipblasCsrot_v2_64",                         {HIP_6010, HIP_0,    HIP_0,  }},
+  {"hipblasZrot_v2_64",                          {HIP_6010, HIP_0,    HIP_0,  }},
+  {"hipblasZdrot_v2_64",                         {HIP_6010, HIP_0,    HIP_0,  }},
 
   {"rocblas_status_to_string",                   {HIP_3050, HIP_0,    HIP_0   }},
   {"rocblas_sscal",                              {HIP_1050, HIP_0,    HIP_0   }},
@@ -2167,6 +2173,12 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_BLAS_FUNCTION_VER_MAP {
   {"rocblas_dnrm2_64",                           {HIP_6010, HIP_0,    HIP_0,  }},
   {"rocblas_scnrm2_64",                          {HIP_6010, HIP_0,    HIP_0,  }},
   {"rocblas_dznrm2_64",                          {HIP_6010, HIP_0,    HIP_0,  }},
+  {"rocblas_srot_64",                            {HIP_6010, HIP_0,    HIP_0,  }},
+  {"rocblas_drot_64",                            {HIP_6010, HIP_0,    HIP_0,  }},
+  {"rocblas_crot_64",                            {HIP_6010, HIP_0,    HIP_0,  }},
+  {"rocblas_csrot_64",                           {HIP_6010, HIP_0,    HIP_0,  }},
+  {"rocblas_zrot_64",                            {HIP_6010, HIP_0,    HIP_0,  }},
+  {"rocblas_zdrot_64",                           {HIP_6010, HIP_0,    HIP_0,  }},
 };
 
 const std::map<llvm::StringRef, hipAPIChangedVersions> HIP_BLAS_FUNCTION_CHANGED_VER_MAP {

--- a/tests/unit_tests/synthetic/libraries/cublas2hipblas_v2.cu
+++ b/tests/unit_tests/synthetic/libraries/cublas2hipblas_v2.cu
@@ -2048,6 +2048,48 @@ int main() {
   // CHECK-NEXT: blasStatus = hipblasDznrm2_v2_64(blasHandle, n_64, &dcomplexx, incx_64, &dresult);
   blasStatus = cublasDznrm2_64(blasHandle, n_64, &dcomplexx, incx_64, &dresult);
   blasStatus = cublasDznrm2_v2_64(blasHandle, n_64, &dcomplexx, incx_64, &dresult);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasSrot_v2_64(cublasHandle_t handle, int64_t n, float* x, int64_t incx, float* y, int64_t incy, const float* c, const float* s);
+  // HIP: HIPBLAS_EXPORT hipblasStatus_t hipblasSrot_64(hipblasHandle_t handle, int64_t n,float* x, int64_t incx, float* y, int64_t incy, const float* c, const float* s);
+  // CHECK: blasStatus = hipblasSrot_64(blasHandle, n_64, &fx, incx_64, &fy, incy_64, &fc, &fs);
+  // CHECK-NEXT: blasStatus = hipblasSrot_64(blasHandle, n_64, &fx, incx_64, &fy, incy_64, &fc, &fs);
+  blasStatus = cublasSrot_64(blasHandle, n_64, &fx, incx_64, &fy, incy_64, &fc, &fs);
+  blasStatus = cublasSrot_v2_64(blasHandle, n_64, &fx, incx_64, &fy, incy_64, &fc, &fs);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasDrot_v2_64(cublasHandle_t handle, int64_t n, double* x, int64_t incx, double* y, int64_t incy, const double* c, const double* s);
+  // HIP: HIPBLAS_EXPORT hipblasStatus_t hipblasDrot_64(hipblasHandle_t handle, int64_t n, double* x, int64_t incx, double* y, int64_t incy, const double* c, const double* s);
+  // CHECK: blasStatus = hipblasDrot_64(blasHandle, n_64, &dx, incx_64, &dy, incy_64, &dc, &ds);
+  // CHECK-NEXT: blasStatus = hipblasDrot_64(blasHandle, n_64, &dx, incx_64, &dy, incy_64, &dc, &ds);
+  blasStatus = cublasDrot_64(blasHandle, n_64, &dx, incx_64, &dy, incy_64, &dc, &ds);
+  blasStatus = cublasDrot_v2_64(blasHandle, n_64, &dx, incx_64, &dy, incy_64, &dc, &ds);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasCrot_v2_64(cublasHandle_t handle, int64_t n, cuComplex* x, int64_t incx, cuComplex* y, int64_t incy, const float* c, const cuComplex* s);
+  // HIP: HIPBLAS_EXPORT hipblasStatus_t hipblasCrot_v2_64(hipblasHandle_t handle, int64_t n, hipComplex* x, int64_t incx, hipComplex* y, int64_t incy, const float* c, const hipComplex* s);
+  // CHECK: blasStatus = hipblasCrot_v2_64(blasHandle, n_64, &complexx, incx_64, &complexy, incy_64, &fc, &complexs);
+  // CHECK-NEXT: blasStatus = hipblasCrot_v2_64(blasHandle, n_64, &complexx, incx_64, &complexy, incy_64, &fc, &complexs);
+  blasStatus = cublasCrot_64(blasHandle, n_64, &complexx, incx_64, &complexy, incy_64, &fc, &complexs);
+  blasStatus = cublasCrot_v2_64(blasHandle, n_64, &complexx, incx_64, &complexy, incy_64, &fc, &complexs);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasCsrot_v2_64(cublasHandle_t handle, int64_t n, cuComplex* x, int64_t incx, cuComplex* y, int64_t incy, const float* c, const float* s);
+  // HIP: HIPBLAS_EXPORT hipblasStatus_t hipblasCsrot_v2_64(hipblasHandle_t handle, int64_t n, hipComplex* x, int64_t incx, hipComplex* y, int64_t incy, const float* c, const float* s);
+  // CHECK: blasStatus = hipblasCsrot_v2_64(blasHandle, n_64, &complexx, incx_64, &complexy, incy_64, &fc, &fs);
+  // CHECK-NEXT: blasStatus = hipblasCsrot_v2_64(blasHandle, n_64, &complexx, incx_64, &complexy, incy_64, &fc, &fs);
+  blasStatus = cublasCsrot_64(blasHandle, n_64, &complexx, incx_64, &complexy, incy_64, &fc, &fs);
+  blasStatus = cublasCsrot_v2_64(blasHandle, n_64, &complexx, incx_64, &complexy, incy_64, &fc, &fs);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasZrot_v2_64(cublasHandle_t handle, int64_t n, cuDoubleComplex* x, int64_t incx, cuDoubleComplex* y, int64_t incy, const double* c, const cuDoubleComplex* s);
+  // HIP: HIPBLAS_EXPORT hipblasStatus_t hipblasZrot_v2_64(hipblasHandle_t handle, int64_t n, hipDoubleComplex* x, int64_t incx, hipDoubleComplex* y, int64_t incy, const double* c, const hipDoubleComplex* s);
+  // CHECK: blasStatus = hipblasZrot_v2_64(blasHandle, n_64, &dcomplexx, incx_64, &dcomplexy, incy_64, &dc, &dcomplexs);
+  // CHECK-NEXT: blasStatus = hipblasZrot_v2_64(blasHandle, n_64, &dcomplexx, incx_64, &dcomplexy, incy_64, &dc, &dcomplexs);
+  blasStatus = cublasZrot_64(blasHandle, n_64, &dcomplexx, incx_64, &dcomplexy, incy_64, &dc, &dcomplexs);
+  blasStatus = cublasZrot_v2_64(blasHandle, n_64, &dcomplexx, incx_64, &dcomplexy, incy_64, &dc, &dcomplexs);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasZdrot_v2_64(cublasHandle_t handle, int64_t n, cuDoubleComplex* x, int64_t incx, cuDoubleComplex* y, int64_t incy, const double* c, const double* s);
+  // HIP: HIPBLAS_EXPORT hipblasStatus_t hipblasZdrot_v2_64(hipblasHandle_t handle, int64_t n, hipDoubleComplex* x, int64_t incx, hipDoubleComplex* y, int64_t incy, const double* c, const double* s);
+  // CHECK: blasStatus = hipblasZdrot_v2_64(blasHandle, n_64, &dcomplexx, incx_64, &dcomplexy, incy_64, &dc, &ds);
+  // CHECK-NEXT: blasStatus = hipblasZdrot_v2_64(blasHandle, n_64, &dcomplexx, incx_64, &dcomplexy, incy_64, &dc, &ds);
+  blasStatus = cublasZdrot_64(blasHandle, n_64, &dcomplexx, incx_64, &dcomplexy, incy_64, &dc, &ds);
+  blasStatus = cublasZdrot_v2_64(blasHandle, n_64, &dcomplexx, incx_64, &dcomplexy, incy_64, &dc, &ds);
 #endif
 
   return 0;

--- a/tests/unit_tests/synthetic/libraries/cublas2rocblas_v2.cu
+++ b/tests/unit_tests/synthetic/libraries/cublas2rocblas_v2.cu
@@ -2133,6 +2133,48 @@ int main() {
   // CHECK-NEXT: blasStatus = rocblas_dznrm2_64(blasHandle, n_64, &dcomplexx, incx_64, &dresult);
   blasStatus = cublasDznrm2_64(blasHandle, n_64, &dcomplexx, incx_64, &dresult);
   blasStatus = cublasDznrm2_v2_64(blasHandle, n_64, &dcomplexx, incx_64, &dresult);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasSrot_v2_64(cublasHandle_t handle, int64_t n, float* x, int64_t incx, float* y, int64_t incy, const float* c, const float* s);
+  // ROC: ROCBLAS_EXPORT rocblas_status rocblas_srot_64(rocblas_handle handle, int64_t n, float* x, int64_t incx, float* y, int64_t incy, const float* c, const float* s);
+  // CHECK: blasStatus = rocblas_srot_64(blasHandle, n_64, &fx, incx_64, &fy, incy_64, &fc, &fs);
+  // CHECK-NEXT: blasStatus = rocblas_srot_64(blasHandle, n_64, &fx, incx_64, &fy, incy_64, &fc, &fs);
+  blasStatus = cublasSrot_64(blasHandle, n_64, &fx, incx_64, &fy, incy_64, &fc, &fs);
+  blasStatus = cublasSrot_v2_64(blasHandle, n_64, &fx, incx_64, &fy, incy_64, &fc, &fs);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasDrot_v2_64(cublasHandle_t handle, int64_t n, double* x, int64_t incx, double* y, int64_t incy, const double* c, const double* s);
+  // ROC: ROCBLAS_EXPORT rocblas_status rocblas_drot_64(rocblas_handle handle, int64_t n, double* x, int64_t incx, double* y, int64_t incy, const double* c, const double* s);
+  // CHECK: blasStatus = rocblas_drot_64(blasHandle, n_64, &dx, incx_64, &dy, incy_64, &dc, &ds);
+  // CHECK-NEXT: blasStatus = rocblas_drot_64(blasHandle, n_64, &dx, incx_64, &dy, incy_64, &dc, &ds);
+  blasStatus = cublasDrot_64(blasHandle, n_64, &dx, incx_64, &dy, incy_64, &dc, &ds);
+  blasStatus = cublasDrot_v2_64(blasHandle, n_64, &dx, incx_64, &dy, incy_64, &dc, &ds);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasCrot_v2_64(cublasHandle_t handle, int64_t n, cuComplex* x, int64_t incx, cuComplex* y, int64_t incy, const float* c, const cuComplex* s);
+  // ROC: ROCBLAS_EXPORT rocblas_status rocblas_crot_64(rocblas_handle handle, int64_t n, rocblas_float_complex* x, int64_t incx, rocblas_float_complex* y, int64_t incy, const float* c, const rocblas_float_complex* s);
+  // CHECK: blasStatus = rocblas_crot_64(blasHandle, n_64, &complexx, incx_64, &complexy, incy_64, &fc, &complexs);
+  // CHECK-NEXT: blasStatus = rocblas_crot_64(blasHandle, n_64, &complexx, incx_64, &complexy, incy_64, &fc, &complexs);
+  blasStatus = cublasCrot_64(blasHandle, n_64, &complexx, incx_64, &complexy, incy_64, &fc, &complexs);
+  blasStatus = cublasCrot_v2_64(blasHandle, n_64, &complexx, incx_64, &complexy, incy_64, &fc, &complexs);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasCsrot_v2_64(cublasHandle_t handle, int64_t n, cuComplex* x, int64_t incx, cuComplex* y, int64_t incy, const float* c, const float* s);
+  // ROC: ROCBLAS_EXPORT rocblas_status rocblas_csrot_64(rocblas_handle handle, int64_t n, rocblas_float_complex* x, int64_t incx, rocblas_float_complex* y, int64_t incy, const float* c, const float* s);
+  // CHECK: blasStatus = rocblas_csrot_64(blasHandle, n_64, &complexx, incx_64, &complexy, incy_64, &fc, &fs);
+  // CHECK-NEXT: blasStatus = rocblas_csrot_64(blasHandle, n_64, &complexx, incx_64, &complexy, incy_64, &fc, &fs);
+  blasStatus = cublasCsrot_64(blasHandle, n_64, &complexx, incx_64, &complexy, incy_64, &fc, &fs);
+  blasStatus = cublasCsrot_v2_64(blasHandle, n_64, &complexx, incx_64, &complexy, incy_64, &fc, &fs);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasZrot_v2_64(cublasHandle_t handle, int64_t n, cuDoubleComplex* x, int64_t incx, cuDoubleComplex* y, int64_t incy, const double* c, const cuDoubleComplex* s);
+  // ROC: ROCBLAS_EXPORT rocblas_status rocblas_zrot_64(rocblas_handle handle, int64_t n, rocblas_double_complex* x, int64_t incx, rocblas_double_complex* y, int64_t incy, const double* c, const rocblas_double_complex* s);
+  // CHECK: blasStatus = rocblas_zrot_64(blasHandle, n_64, &dcomplexx, incx_64, &dcomplexy, incy_64, &dc, &dcomplexs);
+  // CHECK-NEXT: blasStatus = rocblas_zrot_64(blasHandle, n_64, &dcomplexx, incx_64, &dcomplexy, incy_64, &dc, &dcomplexs);
+  blasStatus = cublasZrot_64(blasHandle, n_64, &dcomplexx, incx_64, &dcomplexy, incy_64, &dc, &dcomplexs);
+  blasStatus = cublasZrot_v2_64(blasHandle, n_64, &dcomplexx, incx_64, &dcomplexy, incy_64, &dc, &dcomplexs);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasZdrot_v2_64(cublasHandle_t handle, int64_t n, cuDoubleComplex* x, int64_t incx, cuDoubleComplex* y, int64_t incy, const double* c, const double* s);
+  // ROC: ROCBLAS_EXPORT rocblas_status rocblas_zdrot_64(rocblas_handle handle, int64_t n, rocblas_double_complex* x, int64_t incx, rocblas_double_complex* y, int64_t incy, const double* c, const double* s);
+  // CHECK: blasStatus = rocblas_zdrot_64(blasHandle, n_64, &dcomplexx, incx_64, &dcomplexy, incy_64, &dc, &ds);
+  // CHECK-NEXT: blasStatus = rocblas_zdrot_64(blasHandle, n_64, &dcomplexx, incx_64, &dcomplexy, incy_64, &dc, &ds);
+  blasStatus = cublasZdrot_64(blasHandle, n_64, &dcomplexx, incx_64, &dcomplexy, incy_64, &dc, &ds);
+  blasStatus = cublasZdrot_v2_64(blasHandle, n_64, &dcomplexx, incx_64, &dcomplexy, incy_64, &dc, &ds);
 #endif
 
   return 0;


### PR DESCRIPTION
+ Updated `BLAS` synthetic tests, the regenerated hipify-perl, and `BLAS` `CUDA2HIP` documentation
