### PR TITLE
[HIPIFY][BLAS][6.1][sync] Sync with `hipBLAS` and `rocBLAS` - Step 10 - ROTM 64bit

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -1925,7 +1925,9 @@ sub rocSubstitutions {
     subst("cublasDrotg", "rocblas_drotg", "library");
     subst("cublasDrotg_v2", "rocblas_drotg", "library");
     subst("cublasDrotm", "rocblas_drotm", "library");
+    subst("cublasDrotm_64", "rocblas_drotm_64", "library");
     subst("cublasDrotm_v2", "rocblas_drotm", "library");
+    subst("cublasDrotm_v2_64", "rocblas_drotm_64", "library");
     subst("cublasDrotmg", "rocblas_drotmg", "library");
     subst("cublasDrotmg_v2", "rocblas_drotmg", "library");
     subst("cublasDsbmv", "rocblas_dsbmv", "library");
@@ -2092,7 +2094,9 @@ sub rocSubstitutions {
     subst("cublasSrotg", "rocblas_srotg", "library");
     subst("cublasSrotg_v2", "rocblas_srotg", "library");
     subst("cublasSrotm", "rocblas_srotm", "library");
+    subst("cublasSrotm_64", "rocblas_srotm_64", "library");
     subst("cublasSrotm_v2", "rocblas_srotm", "library");
+    subst("cublasSrotm_v2_64", "rocblas_srotm_64", "library");
     subst("cublasSrotmg", "rocblas_srotmg", "library");
     subst("cublasSrotmg_v2", "rocblas_srotmg", "library");
     subst("cublasSsbmv", "rocblas_ssbmv", "library");
@@ -3925,7 +3929,9 @@ sub simpleSubstitutions {
     subst("cublasDrotg", "hipblasDrotg", "library");
     subst("cublasDrotg_v2", "hipblasDrotg", "library");
     subst("cublasDrotm", "hipblasDrotm", "library");
+    subst("cublasDrotm_64", "hipblasDrotm_64", "library");
     subst("cublasDrotm_v2", "hipblasDrotm", "library");
+    subst("cublasDrotm_v2_64", "hipblasDrotm_64", "library");
     subst("cublasDrotmg", "hipblasDrotmg", "library");
     subst("cublasDrotmg_v2", "hipblasDrotmg", "library");
     subst("cublasDsbmv", "hipblasDsbmv", "library");
@@ -4091,7 +4097,9 @@ sub simpleSubstitutions {
     subst("cublasSrotg", "hipblasSrotg", "library");
     subst("cublasSrotg_v2", "hipblasSrotg", "library");
     subst("cublasSrotm", "hipblasSrotm", "library");
+    subst("cublasSrotm_64", "hipblasSrotm_64", "library");
     subst("cublasSrotm_v2", "hipblasSrotm", "library");
+    subst("cublasSrotm_v2_64", "hipblasSrotm_64", "library");
     subst("cublasSrotmg", "hipblasSrotmg", "library");
     subst("cublasSrotmg_v2", "hipblasSrotmg", "library");
     subst("cublasSsbmv", "hipblasSsbmv", "library");
@@ -10928,8 +10936,6 @@ sub warnHipOnlyUnsupportedFunctions {
         "cublasSscal_64",
         "cublasSsbmv_v2_64",
         "cublasSsbmv_64",
-        "cublasSrotm_v2_64",
-        "cublasSrotm_64",
         "cublasSmatinvBatched",
         "cublasShutdown",
         "cublasSger_v2_64",
@@ -11044,8 +11050,6 @@ sub warnHipOnlyUnsupportedFunctions {
         "cublasDscal_64",
         "cublasDsbmv_v2_64",
         "cublasDsbmv_64",
-        "cublasDrotm_v2_64",
-        "cublasDrotm_64",
         "cublasDotcEx_64",
         "cublasDotEx_64",
         "cublasDmatinvBatched",
@@ -11373,8 +11377,6 @@ sub warnRocOnlyUnsupportedFunctions {
         "cublasSscal_64",
         "cublasSsbmv_v2_64",
         "cublasSsbmv_64",
-        "cublasSrotm_v2_64",
-        "cublasSrotm_64",
         "cublasSmatinvBatched",
         "cublasShutdown",
         "cublasSgetrsBatched",
@@ -11488,8 +11490,6 @@ sub warnRocOnlyUnsupportedFunctions {
         "cublasDscal_64",
         "cublasDsbmv_v2_64",
         "cublasDsbmv_64",
-        "cublasDrotm_v2_64",
-        "cublasDrotm_64",
         "cublasDotcEx_64",
         "cublasDotEx_64",
         "cublasDmatinvBatched",

--- a/docs/tables/CUBLAS_API_supported_by_HIP.md
+++ b/docs/tables/CUBLAS_API_supported_by_HIP.md
@@ -268,9 +268,9 @@
 |`cublasDrotg`| | | | |`hipblasDrotg`|3.0.0| | | | |
 |`cublasDrotg_v2`| | | | |`hipblasDrotg`|3.0.0| | | | |
 |`cublasDrotm`| | | | |`hipblasDrotm`|3.0.0| | | | |
-|`cublasDrotm_64`|12.0| | | | | | | | | |
+|`cublasDrotm_64`|12.0| | | |`hipblasDrotm_64`|6.1.0| | | | |
 |`cublasDrotm_v2`| | | | |`hipblasDrotm`|3.0.0| | | | |
-|`cublasDrotm_v2_64`|12.0| | | | | | | | | |
+|`cublasDrotm_v2_64`|12.0| | | |`hipblasDrotm_64`|6.1.0| | | | |
 |`cublasDrotmg`| | | | |`hipblasDrotmg`|3.0.0| | | | |
 |`cublasDrotmg_v2`| | | | |`hipblasDrotmg`|3.0.0| | | | |
 |`cublasDscal`| | | | |`hipblasDscal`|1.8.2| | | | |
@@ -358,9 +358,9 @@
 |`cublasSrotg`| | | | |`hipblasSrotg`|3.0.0| | | | |
 |`cublasSrotg_v2`| | | | |`hipblasSrotg`|3.0.0| | | | |
 |`cublasSrotm`| | | | |`hipblasSrotm`|3.0.0| | | | |
-|`cublasSrotm_64`|12.0| | | | | | | | | |
+|`cublasSrotm_64`|12.0| | | |`hipblasSrotm_64`|6.1.0| | | | |
 |`cublasSrotm_v2`| | | | |`hipblasSrotm`|3.0.0| | | | |
-|`cublasSrotm_v2_64`|12.0| | | | | | | | | |
+|`cublasSrotm_v2_64`|12.0| | | |`hipblasSrotm_64`|6.1.0| | | | |
 |`cublasSrotmg`| | | | |`hipblasSrotmg`|3.0.0| | | | |
 |`cublasSrotmg_v2`| | | | |`hipblasSrotmg`|3.0.0| | | | |
 |`cublasSscal`| | | | |`hipblasSscal`|1.8.2| | | | |

--- a/docs/tables/CUBLAS_API_supported_by_HIP_and_ROC.md
+++ b/docs/tables/CUBLAS_API_supported_by_HIP_and_ROC.md
@@ -268,9 +268,9 @@
 |`cublasDrotg`| | | | |`hipblasDrotg`|3.0.0| | | | |`rocblas_drotg`|3.5.0| | | | |
 |`cublasDrotg_v2`| | | | |`hipblasDrotg`|3.0.0| | | | |`rocblas_drotg`|3.5.0| | | | |
 |`cublasDrotm`| | | | |`hipblasDrotm`|3.0.0| | | | |`rocblas_drotm`|3.5.0| | | | |
-|`cublasDrotm_64`|12.0| | | | | | | | | | | | | | | |
+|`cublasDrotm_64`|12.0| | | |`hipblasDrotm_64`|6.1.0| | | | |`rocblas_drotm_64`|6.1.0| | | | |
 |`cublasDrotm_v2`| | | | |`hipblasDrotm`|3.0.0| | | | |`rocblas_drotm`|3.5.0| | | | |
-|`cublasDrotm_v2_64`|12.0| | | | | | | | | | | | | | | |
+|`cublasDrotm_v2_64`|12.0| | | |`hipblasDrotm_64`|6.1.0| | | | |`rocblas_drotm_64`|6.1.0| | | | |
 |`cublasDrotmg`| | | | |`hipblasDrotmg`|3.0.0| | | | |`rocblas_drotmg`|3.5.0| | | | |
 |`cublasDrotmg_v2`| | | | |`hipblasDrotmg`|3.0.0| | | | |`rocblas_drotmg`|3.5.0| | | | |
 |`cublasDscal`| | | | |`hipblasDscal`|1.8.2| | | | |`rocblas_dscal`|1.5.0| | | | |
@@ -358,9 +358,9 @@
 |`cublasSrotg`| | | | |`hipblasSrotg`|3.0.0| | | | |`rocblas_srotg`|3.5.0| | | | |
 |`cublasSrotg_v2`| | | | |`hipblasSrotg`|3.0.0| | | | |`rocblas_srotg`|3.5.0| | | | |
 |`cublasSrotm`| | | | |`hipblasSrotm`|3.0.0| | | | |`rocblas_srotm`|3.5.0| | | | |
-|`cublasSrotm_64`|12.0| | | | | | | | | | | | | | | |
+|`cublasSrotm_64`|12.0| | | |`hipblasSrotm_64`|6.1.0| | | | |`rocblas_srotm_64`|6.1.0| | | | |
 |`cublasSrotm_v2`| | | | |`hipblasSrotm`|3.0.0| | | | |`rocblas_srotm`|3.5.0| | | | |
-|`cublasSrotm_v2_64`|12.0| | | | | | | | | | | | | | | |
+|`cublasSrotm_v2_64`|12.0| | | |`hipblasSrotm_64`|6.1.0| | | | |`rocblas_srotm_64`|6.1.0| | | | |
 |`cublasSrotmg`| | | | |`hipblasSrotmg`|3.0.0| | | | |`rocblas_srotmg`|3.5.0| | | | |
 |`cublasSrotmg_v2`| | | | |`hipblasSrotmg`|3.0.0| | | | |`rocblas_srotmg`|3.5.0| | | | |
 |`cublasSscal`| | | | |`hipblasSscal`|1.8.2| | | | |`rocblas_sscal`|1.5.0| | | | |

--- a/docs/tables/CUBLAS_API_supported_by_ROC.md
+++ b/docs/tables/CUBLAS_API_supported_by_ROC.md
@@ -268,9 +268,9 @@
 |`cublasDrotg`| | | | |`rocblas_drotg`|3.5.0| | | | |
 |`cublasDrotg_v2`| | | | |`rocblas_drotg`|3.5.0| | | | |
 |`cublasDrotm`| | | | |`rocblas_drotm`|3.5.0| | | | |
-|`cublasDrotm_64`|12.0| | | | | | | | | |
+|`cublasDrotm_64`|12.0| | | |`rocblas_drotm_64`|6.1.0| | | | |
 |`cublasDrotm_v2`| | | | |`rocblas_drotm`|3.5.0| | | | |
-|`cublasDrotm_v2_64`|12.0| | | | | | | | | |
+|`cublasDrotm_v2_64`|12.0| | | |`rocblas_drotm_64`|6.1.0| | | | |
 |`cublasDrotmg`| | | | |`rocblas_drotmg`|3.5.0| | | | |
 |`cublasDrotmg_v2`| | | | |`rocblas_drotmg`|3.5.0| | | | |
 |`cublasDscal`| | | | |`rocblas_dscal`|1.5.0| | | | |
@@ -358,9 +358,9 @@
 |`cublasSrotg`| | | | |`rocblas_srotg`|3.5.0| | | | |
 |`cublasSrotg_v2`| | | | |`rocblas_srotg`|3.5.0| | | | |
 |`cublasSrotm`| | | | |`rocblas_srotm`|3.5.0| | | | |
-|`cublasSrotm_64`|12.0| | | | | | | | | |
+|`cublasSrotm_64`|12.0| | | |`rocblas_srotm_64`|6.1.0| | | | |
 |`cublasSrotm_v2`| | | | |`rocblas_srotm`|3.5.0| | | | |
-|`cublasSrotm_v2_64`|12.0| | | | | | | | | |
+|`cublasSrotm_v2_64`|12.0| | | |`rocblas_srotm_64`|6.1.0| | | | |
 |`cublasSrotmg`| | | | |`rocblas_srotmg`|3.5.0| | | | |
 |`cublasSrotmg_v2`| | | | |`rocblas_srotmg`|3.5.0| | | | |
 |`cublasSscal`| | | | |`rocblas_sscal`|1.5.0| | | | |

--- a/src/CUDA2HIP_BLAS_API_functions.cpp
+++ b/src/CUDA2HIP_BLAS_API_functions.cpp
@@ -210,9 +210,9 @@ const std::map<llvm::StringRef, hipCounter> CUDA_BLAS_FUNCTION_MAP {
 
   // ROTM
   {"cublasSrotm",                    {"hipblasSrotm",                    "rocblas_srotm",                            CONV_LIB_FUNC, API_BLAS, 5, HIP_SUPPORTED_V2_ONLY}},
-  {"cublasSrotm_64",                 {"hipblasSrotm_64",                 "",                                         CONV_LIB_FUNC, API_BLAS, 5, UNSUPPORTED}},
+  {"cublasSrotm_64",                 {"hipblasSrotm_64",                 "rocblas_srotm_64",                         CONV_LIB_FUNC, API_BLAS, 5}},
   {"cublasDrotm",                    {"hipblasDrotm",                    "rocblas_drotm",                            CONV_LIB_FUNC, API_BLAS, 5, HIP_SUPPORTED_V2_ONLY}},
-  {"cublasDrotm_64",                 {"hipblasDrotm_64",                 "",                                         CONV_LIB_FUNC, API_BLAS, 5, UNSUPPORTED}},
+  {"cublasDrotm_64",                 {"hipblasDrotm_64",                 "rocblas_drotm_64",                         CONV_LIB_FUNC, API_BLAS, 5}},
 
   // ROTMG
   {"cublasSrotmg",                   {"hipblasSrotmg",                   "rocblas_srotmg",                           CONV_LIB_FUNC, API_BLAS, 5, HIP_SUPPORTED_V2_ONLY}},
@@ -1063,9 +1063,9 @@ const std::map<llvm::StringRef, hipCounter> CUDA_BLAS_FUNCTION_MAP {
   {"cublasRotmEx",                   {"hipblasRotmEx",                   "",                                         CONV_LIB_FUNC, API_BLAS, 8, UNSUPPORTED}},
   {"cublasRotmEx_64",                {"hipblasRotmEx_64",                "",                                         CONV_LIB_FUNC, API_BLAS, 8, UNSUPPORTED}},
   {"cublasSrotm_v2",                 {"hipblasSrotm",                    "rocblas_srotm",                            CONV_LIB_FUNC, API_BLAS, 5}},
-  {"cublasSrotm_v2_64",              {"hipblasSrotm_64",                 "",                                         CONV_LIB_FUNC, API_BLAS, 5, UNSUPPORTED}},
+  {"cublasSrotm_v2_64",              {"hipblasSrotm_64",                 "rocblas_srotm_64",                         CONV_LIB_FUNC, API_BLAS, 5}},
   {"cublasDrotm_v2",                 {"hipblasDrotm",                    "rocblas_drotm",                            CONV_LIB_FUNC, API_BLAS, 5}},
-  {"cublasDrotm_v2_64",              {"hipblasDrotm_64",                 "",                                         CONV_LIB_FUNC, API_BLAS, 5, UNSUPPORTED}},
+  {"cublasDrotm_v2_64",              {"hipblasDrotm_64",                 "rocblas_drotm_64",                         CONV_LIB_FUNC, API_BLAS, 5}},
 
   // ROTMG
   {"cublasRotmgEx",                  {"hipblasRotmgEx",                  "",                                         CONV_LIB_FUNC, API_BLAS, 8, UNSUPPORTED}},
@@ -1907,6 +1907,8 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_BLAS_FUNCTION_VER_MAP {
   {"hipblasCsrot_v2_64",                         {HIP_6010, HIP_0,    HIP_0,  }},
   {"hipblasZrot_v2_64",                          {HIP_6010, HIP_0,    HIP_0,  }},
   {"hipblasZdrot_v2_64",                         {HIP_6010, HIP_0,    HIP_0,  }},
+  {"hipblasSrotm_64",                            {HIP_6010, HIP_0,    HIP_0,  }},
+  {"hipblasDrotm_64",                            {HIP_6010, HIP_0,    HIP_0,  }},
 
   {"rocblas_status_to_string",                   {HIP_3050, HIP_0,    HIP_0   }},
   {"rocblas_sscal",                              {HIP_1050, HIP_0,    HIP_0   }},
@@ -2179,6 +2181,8 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_BLAS_FUNCTION_VER_MAP {
   {"rocblas_csrot_64",                           {HIP_6010, HIP_0,    HIP_0,  }},
   {"rocblas_zrot_64",                            {HIP_6010, HIP_0,    HIP_0,  }},
   {"rocblas_zdrot_64",                           {HIP_6010, HIP_0,    HIP_0,  }},
+  {"rocblas_srotm_64",                           {HIP_6010, HIP_0,    HIP_0,  }},
+  {"rocblas_drotm_64",                           {HIP_6010, HIP_0,    HIP_0,  }},
 };
 
 const std::map<llvm::StringRef, hipAPIChangedVersions> HIP_BLAS_FUNCTION_CHANGED_VER_MAP {

--- a/tests/unit_tests/synthetic/libraries/cublas2hipblas_v2.cu
+++ b/tests/unit_tests/synthetic/libraries/cublas2hipblas_v2.cu
@@ -221,6 +221,7 @@ int main() {
   float fd1 = 0;
   float fd2 = 0;
   float fresult = 0;
+  float fparam = 0;
 
   float** fAarray = 0;
   const float** const fAarray_const = const_cast<const float**>(fAarray);
@@ -243,6 +244,7 @@ int main() {
   double dd1 = 0;
   double dd2 = 0;
   double dresult = 0;
+  double dparam = 0;
 
   double** dAarray = 0;
   const double** const dAarray_const = const_cast<const double**>(dAarray);
@@ -2090,6 +2092,20 @@ int main() {
   // CHECK-NEXT: blasStatus = hipblasZdrot_v2_64(blasHandle, n_64, &dcomplexx, incx_64, &dcomplexy, incy_64, &dc, &ds);
   blasStatus = cublasZdrot_64(blasHandle, n_64, &dcomplexx, incx_64, &dcomplexy, incy_64, &dc, &ds);
   blasStatus = cublasZdrot_v2_64(blasHandle, n_64, &dcomplexx, incx_64, &dcomplexy, incy_64, &dc, &ds);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasSrotm_v2_64(cublasHandle_t handle, int64_t n, float* x, int64_t incx, float* y, int64_t incy, const float* param);
+  // HIP: HIPBLAS_EXPORT hipblasStatus_t hipblasSrotm_64(hipblasHandle_t handle, int64_t n, float* x, int64_t incx, float* y, int64_t incy, const float* param);
+  // CHECK: blasStatus = hipblasSrotm_64(blasHandle, n_64, &fx, incx_64, &fy, incy_64, &fparam);
+  // CHECK-NEXT: blasStatus = hipblasSrotm_64(blasHandle, n_64, &fx, incx_64, &fy, incy_64, &fparam);
+  blasStatus = cublasSrotm_64(blasHandle, n_64, &fx, incx_64, &fy, incy_64, &fparam);
+  blasStatus = cublasSrotm_v2_64(blasHandle, n_64, &fx, incx_64, &fy, incy_64, &fparam);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasDrotm_v2_64(cublasHandle_t handle, int64_t n, double* x, int64_t incx, double* y, int64_t incy, const double* param);
+  // HIP: HIPBLAS_EXPORT hipblasStatus_t hipblasDrotm_64(hipblasHandle_t handle, int64_t n, double* x, int64_t incx, double* y, int64_t incy, const double* param);
+  // CHECK: blasStatus = hipblasDrotm_64(blasHandle, n_64, &dx, incx_64, &dy, incy_64, &dparam);
+  // CHECK-NEXT: blasStatus = hipblasDrotm_64(blasHandle, n_64, &dx, incx_64, &dy, incy_64, &dparam);
+  blasStatus = cublasDrotm_64(blasHandle, n_64, &dx, incx_64, &dy, incy_64, &dparam);
+  blasStatus = cublasDrotm_v2_64(blasHandle, n_64, &dx, incx_64, &dy, incy_64, &dparam);
 #endif
 
   return 0;

--- a/tests/unit_tests/synthetic/libraries/cublas2rocblas_v2.cu
+++ b/tests/unit_tests/synthetic/libraries/cublas2rocblas_v2.cu
@@ -241,6 +241,7 @@ int main() {
   float fd1 = 0;
   float fd2 = 0;
   float fresult = 0;
+  float fparam = 0;
 
   float** fAarray = 0;
   const float** const fAarray_const = const_cast<const float**>(fAarray);
@@ -263,6 +264,7 @@ int main() {
   double dd1 = 0;
   double dd2 = 0;
   double dresult = 0;
+  double dparam = 0;
 
   double** dAarray = 0;
   const double** const dAarray_const = const_cast<const double**>(dAarray);
@@ -2175,6 +2177,20 @@ int main() {
   // CHECK-NEXT: blasStatus = rocblas_zdrot_64(blasHandle, n_64, &dcomplexx, incx_64, &dcomplexy, incy_64, &dc, &ds);
   blasStatus = cublasZdrot_64(blasHandle, n_64, &dcomplexx, incx_64, &dcomplexy, incy_64, &dc, &ds);
   blasStatus = cublasZdrot_v2_64(blasHandle, n_64, &dcomplexx, incx_64, &dcomplexy, incy_64, &dc, &ds);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasSrotm_v2_64(cublasHandle_t handle, int64_t n, float* x, int64_t incx, float* y, int64_t incy, const float* param);
+  // ROC: ROCBLAS_EXPORT rocblas_status rocblas_srotm_64(rocblas_handle handle, int64_t n, float* x, int64_t incx, float* y, int64_t incy, const float* param);
+  // CHECK: blasStatus = rocblas_srotm_64(blasHandle, n_64, &fx, incx_64, &fy, incy_64, &fparam);
+  // CHECK-NEXT: blasStatus = rocblas_srotm_64(blasHandle, n_64, &fx, incx_64, &fy, incy_64, &fparam);
+  blasStatus = cublasSrotm_64(blasHandle, n_64, &fx, incx_64, &fy, incy_64, &fparam);
+  blasStatus = cublasSrotm_v2_64(blasHandle, n_64, &fx, incx_64, &fy, incy_64, &fparam);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasDrotm_v2_64(cublasHandle_t handle, int64_t n, double* x, int64_t incx, double* y, int64_t incy, const double* param);
+  // ROC: ROCBLAS_EXPORT rocblas_status rocblas_drotm_64(rocblas_handle handle, int64_t n, double* x, int64_t incx, double* y, int64_t incy, const double* param);
+  // CHECK: blasStatus = rocblas_drotm_64(blasHandle, n_64, &dx, incx_64, &dy, incy_64, &dparam);
+  // CHECK-NEXT: blasStatus = rocblas_drotm_64(blasHandle, n_64, &dx, incx_64, &dy, incy_64, &dparam);
+  blasStatus = cublasDrotm_64(blasHandle, n_64, &dx, incx_64, &dy, incy_64, &dparam);
+  blasStatus = cublasDrotm_v2_64(blasHandle, n_64, &dx, incx_64, &dy, incy_64, &dparam);
 #endif
 
   return 0;


### PR DESCRIPTION
+ Updated `BLAS` synthetic tests, the regenerated hipify-perl, and `BLAS` `CUDA2HIP` documentation
