### PR TITLE
[HIPIFY][BLAS][6.1][sync] Sync with `hipBLAS` and `rocBLAS` - Step 11 - SCAL 64bit

### DIFF
--- a/docs/tables/CUBLAS_API_supported_by_HIP.md
+++ b/docs/tables/CUBLAS_API_supported_by_HIP.md
@@ -226,17 +226,17 @@
 |`cublasCrotg`| | | | |`hipblasCrotg_v2`|6.0.0| | | | |
 |`cublasCrotg_v2`| | | | |`hipblasCrotg_v2`|6.0.0| | | | |
 |`cublasCscal`| | | | |`hipblasCscal_v2`|6.0.0| | | | |
-|`cublasCscal_64`|12.0| | | | | | | | | |
+|`cublasCscal_64`|12.0| | | |`hipblasCscal_v2_64`|6.1.0| | | | |
 |`cublasCscal_v2`| | | | |`hipblasCscal_v2`|6.0.0| | | | |
-|`cublasCscal_v2_64`|12.0| | | | | | | | | |
+|`cublasCscal_v2_64`|12.0| | | |`hipblasCscal_v2_64`|6.1.0| | | | |
 |`cublasCsrot`| | | | |`hipblasCsrot_v2`|6.0.0| | | | |
 |`cublasCsrot_64`|12.0| | | |`hipblasCsrot_v2_64`|6.1.0| | | | |
 |`cublasCsrot_v2`| | | | |`hipblasCsrot_v2`|6.0.0| | | | |
 |`cublasCsrot_v2_64`|12.0| | | |`hipblasCsrot_v2_64`|6.1.0| | | | |
 |`cublasCsscal`| | | | |`hipblasCsscal_v2`|6.0.0| | | | |
-|`cublasCsscal_64`|12.0| | | | | | | | | |
+|`cublasCsscal_64`|12.0| | | |`hipblasCsscal_v2_64`|6.1.0| | | | |
 |`cublasCsscal_v2`| | | | |`hipblasCsscal_v2`|6.0.0| | | | |
-|`cublasCsscal_v2_64`|12.0| | | | | | | | | |
+|`cublasCsscal_v2_64`|12.0| | | |`hipblasCsscal_v2_64`|6.1.0| | | | |
 |`cublasCswap`| | | | |`hipblasCswap_v2`|6.0.0| | | | |
 |`cublasCswap_64`|12.0| | | | | | | | | |
 |`cublasCswap_v2`| | | | |`hipblasCswap_v2`|6.0.0| | | | |
@@ -274,9 +274,9 @@
 |`cublasDrotmg`| | | | |`hipblasDrotmg`|3.0.0| | | | |
 |`cublasDrotmg_v2`| | | | |`hipblasDrotmg`|3.0.0| | | | |
 |`cublasDscal`| | | | |`hipblasDscal`|1.8.2| | | | |
-|`cublasDscal_64`|12.0| | | | | | | | | |
+|`cublasDscal_64`|12.0| | | |`hipblasDscal_64`|6.1.0| | | | |
 |`cublasDscal_v2`| | | | |`hipblasDscal`|1.8.2| | | | |
-|`cublasDscal_v2_64`|12.0| | | | | | | | | |
+|`cublasDscal_v2_64`|12.0| | | |`hipblasDscal_64`|6.1.0| | | | |
 |`cublasDswap`| | | | |`hipblasDswap`|3.0.0| | | | |
 |`cublasDswap_64`|12.0| | | | | | | | | |
 |`cublasDswap_v2`| | | | |`hipblasDswap`|3.0.0| | | | |
@@ -364,9 +364,9 @@
 |`cublasSrotmg`| | | | |`hipblasSrotmg`|3.0.0| | | | |
 |`cublasSrotmg_v2`| | | | |`hipblasSrotmg`|3.0.0| | | | |
 |`cublasSscal`| | | | |`hipblasSscal`|1.8.2| | | | |
-|`cublasSscal_64`|12.0| | | | | | | | | |
+|`cublasSscal_64`|12.0| | | |`hipblasSscal_64`|6.1.0| | | | |
 |`cublasSscal_v2`| | | | |`hipblasSscal`|1.8.2| | | | |
-|`cublasSscal_v2_64`|12.0| | | | | | | | | |
+|`cublasSscal_v2_64`|12.0| | | |`hipblasSscal_64`|6.1.0| | | | |
 |`cublasSswap`| | | | |`hipblasSswap`|3.0.0| | | | |
 |`cublasSswap_64`|12.0| | | | | | | | | |
 |`cublasSswap_v2`| | | | |`hipblasSswap`|3.0.0| | | | |
@@ -392,9 +392,9 @@
 |`cublasZdrot_v2`| | | | |`hipblasZdrot_v2`|6.0.0| | | | |
 |`cublasZdrot_v2_64`|12.0| | | |`hipblasZdrot_v2_64`|6.1.0| | | | |
 |`cublasZdscal`| | | | |`hipblasZdscal_v2`|6.0.0| | | | |
-|`cublasZdscal_64`|12.0| | | | | | | | | |
+|`cublasZdscal_64`|12.0| | | |`hipblasZdscal_v2_64`|6.1.0| | | | |
 |`cublasZdscal_v2`| | | | |`hipblasZdscal_v2`|6.0.0| | | | |
-|`cublasZdscal_v2_64`|12.0| | | | | | | | | |
+|`cublasZdscal_v2_64`|12.0| | | |`hipblasZdscal_v2_64`|6.1.0| | | | |
 |`cublasZrot`| | | | |`hipblasZrot_v2`|6.0.0| | | | |
 |`cublasZrot_64`|12.0| | | |`hipblasZrot_v2_64`|6.1.0| | | | |
 |`cublasZrot_v2`| | | | |`hipblasZrot_v2`|6.0.0| | | | |
@@ -402,9 +402,9 @@
 |`cublasZrotg`| | | | |`hipblasZrotg_v2`|6.0.0| | | | |
 |`cublasZrotg_v2`| | | | |`hipblasZrotg_v2`|6.0.0| | | | |
 |`cublasZscal`| | | | |`hipblasZscal_v2`|6.0.0| | | | |
-|`cublasZscal_64`|12.0| | | | | | | | | |
+|`cublasZscal_64`|12.0| | | |`hipblasZscal_v2_64`|6.1.0| | | | |
 |`cublasZscal_v2`| | | | |`hipblasZscal_v2`|6.0.0| | | | |
-|`cublasZscal_v2_64`|12.0| | | | | | | | | |
+|`cublasZscal_v2_64`|12.0| | | |`hipblasZscal_v2_64`|6.1.0| | | | |
 |`cublasZswap`| | | | |`hipblasZswap_v2`|6.0.0| | | | |
 |`cublasZswap_64`|12.0| | | | | | | | | |
 |`cublasZswap_v2`| | | | |`hipblasZswap_v2`|6.0.0| | | | |

--- a/docs/tables/CUBLAS_API_supported_by_HIP_and_ROC.md
+++ b/docs/tables/CUBLAS_API_supported_by_HIP_and_ROC.md
@@ -226,17 +226,17 @@
 |`cublasCrotg`| | | | |`hipblasCrotg_v2`|6.0.0| | | | |`rocblas_crotg`|3.5.0| | | | |
 |`cublasCrotg_v2`| | | | |`hipblasCrotg_v2`|6.0.0| | | | |`rocblas_crotg`|3.5.0| | | | |
 |`cublasCscal`| | | | |`hipblasCscal_v2`|6.0.0| | | | |`rocblas_cscal`|1.5.0| | | | |
-|`cublasCscal_64`|12.0| | | | | | | | | | | | | | | |
+|`cublasCscal_64`|12.0| | | |`hipblasCscal_v2_64`|6.1.0| | | | |`rocblas_cscal_64`|6.1.0| | | | |
 |`cublasCscal_v2`| | | | |`hipblasCscal_v2`|6.0.0| | | | |`rocblas_cscal`|1.5.0| | | | |
-|`cublasCscal_v2_64`|12.0| | | | | | | | | | | | | | | |
+|`cublasCscal_v2_64`|12.0| | | |`hipblasCscal_v2_64`|6.1.0| | | | |`rocblas_cscal_64`|6.1.0| | | | |
 |`cublasCsrot`| | | | |`hipblasCsrot_v2`|6.0.0| | | | |`rocblas_csrot`|3.5.0| | | | |
 |`cublasCsrot_64`|12.0| | | |`hipblasCsrot_v2_64`|6.1.0| | | | |`rocblas_csrot_64`|6.1.0| | | | |
 |`cublasCsrot_v2`| | | | |`hipblasCsrot_v2`|6.0.0| | | | |`rocblas_csrot`|3.5.0| | | | |
 |`cublasCsrot_v2_64`|12.0| | | |`hipblasCsrot_v2_64`|6.1.0| | | | |`rocblas_csrot_64`|6.1.0| | | | |
 |`cublasCsscal`| | | | |`hipblasCsscal_v2`|6.0.0| | | | |`rocblas_csscal`|3.5.0| | | | |
-|`cublasCsscal_64`|12.0| | | | | | | | | | | | | | | |
+|`cublasCsscal_64`|12.0| | | |`hipblasCsscal_v2_64`|6.1.0| | | | |`rocblas_csscal_64`|6.1.0| | | | |
 |`cublasCsscal_v2`| | | | |`hipblasCsscal_v2`|6.0.0| | | | |`rocblas_csscal`|3.5.0| | | | |
-|`cublasCsscal_v2_64`|12.0| | | | | | | | | | | | | | | |
+|`cublasCsscal_v2_64`|12.0| | | |`hipblasCsscal_v2_64`|6.1.0| | | | |`rocblas_csscal_64`|6.1.0| | | | |
 |`cublasCswap`| | | | |`hipblasCswap_v2`|6.0.0| | | | |`rocblas_cswap`|1.5.0| | | | |
 |`cublasCswap_64`|12.0| | | | | | | | | | | | | | | |
 |`cublasCswap_v2`| | | | |`hipblasCswap_v2`|6.0.0| | | | |`rocblas_cswap`|1.5.0| | | | |
@@ -274,9 +274,9 @@
 |`cublasDrotmg`| | | | |`hipblasDrotmg`|3.0.0| | | | |`rocblas_drotmg`|3.5.0| | | | |
 |`cublasDrotmg_v2`| | | | |`hipblasDrotmg`|3.0.0| | | | |`rocblas_drotmg`|3.5.0| | | | |
 |`cublasDscal`| | | | |`hipblasDscal`|1.8.2| | | | |`rocblas_dscal`|1.5.0| | | | |
-|`cublasDscal_64`|12.0| | | | | | | | | | | | | | | |
+|`cublasDscal_64`|12.0| | | |`hipblasDscal_64`|6.1.0| | | | |`rocblas_dscal_64`|6.1.0| | | | |
 |`cublasDscal_v2`| | | | |`hipblasDscal`|1.8.2| | | | |`rocblas_dscal`|1.5.0| | | | |
-|`cublasDscal_v2_64`|12.0| | | | | | | | | | | | | | | |
+|`cublasDscal_v2_64`|12.0| | | |`hipblasDscal_64`|6.1.0| | | | |`rocblas_dscal_64`|6.1.0| | | | |
 |`cublasDswap`| | | | |`hipblasDswap`|3.0.0| | | | |`rocblas_dswap`|1.5.0| | | | |
 |`cublasDswap_64`|12.0| | | | | | | | | | | | | | | |
 |`cublasDswap_v2`| | | | |`hipblasDswap`|3.0.0| | | | |`rocblas_dswap`|1.5.0| | | | |
@@ -364,9 +364,9 @@
 |`cublasSrotmg`| | | | |`hipblasSrotmg`|3.0.0| | | | |`rocblas_srotmg`|3.5.0| | | | |
 |`cublasSrotmg_v2`| | | | |`hipblasSrotmg`|3.0.0| | | | |`rocblas_srotmg`|3.5.0| | | | |
 |`cublasSscal`| | | | |`hipblasSscal`|1.8.2| | | | |`rocblas_sscal`|1.5.0| | | | |
-|`cublasSscal_64`|12.0| | | | | | | | | | | | | | | |
+|`cublasSscal_64`|12.0| | | |`hipblasSscal_64`|6.1.0| | | | |`rocblas_sscal_64`|6.1.0| | | | |
 |`cublasSscal_v2`| | | | |`hipblasSscal`|1.8.2| | | | |`rocblas_sscal`|1.5.0| | | | |
-|`cublasSscal_v2_64`|12.0| | | | | | | | | | | | | | | |
+|`cublasSscal_v2_64`|12.0| | | |`hipblasSscal_64`|6.1.0| | | | |`rocblas_sscal_64`|6.1.0| | | | |
 |`cublasSswap`| | | | |`hipblasSswap`|3.0.0| | | | |`rocblas_sswap`|1.5.0| | | | |
 |`cublasSswap_64`|12.0| | | | | | | | | | | | | | | |
 |`cublasSswap_v2`| | | | |`hipblasSswap`|3.0.0| | | | |`rocblas_sswap`|1.5.0| | | | |
@@ -392,9 +392,9 @@
 |`cublasZdrot_v2`| | | | |`hipblasZdrot_v2`|6.0.0| | | | |`rocblas_zdrot`|3.5.0| | | | |
 |`cublasZdrot_v2_64`|12.0| | | |`hipblasZdrot_v2_64`|6.1.0| | | | |`rocblas_zdrot_64`|6.1.0| | | | |
 |`cublasZdscal`| | | | |`hipblasZdscal_v2`|6.0.0| | | | |`rocblas_zdscal`|3.5.0| | | | |
-|`cublasZdscal_64`|12.0| | | | | | | | | | | | | | | |
+|`cublasZdscal_64`|12.0| | | |`hipblasZdscal_v2_64`|6.1.0| | | | |`rocblas_zdscal_64`|6.1.0| | | | |
 |`cublasZdscal_v2`| | | | |`hipblasZdscal_v2`|6.0.0| | | | |`rocblas_zdscal`|3.5.0| | | | |
-|`cublasZdscal_v2_64`|12.0| | | | | | | | | | | | | | | |
+|`cublasZdscal_v2_64`|12.0| | | |`hipblasZdscal_v2_64`|6.1.0| | | | |`rocblas_zdscal_64`|6.1.0| | | | |
 |`cublasZrot`| | | | |`hipblasZrot_v2`|6.0.0| | | | |`rocblas_zrot`|3.5.0| | | | |
 |`cublasZrot_64`|12.0| | | |`hipblasZrot_v2_64`|6.1.0| | | | |`rocblas_zrot_64`|6.1.0| | | | |
 |`cublasZrot_v2`| | | | |`hipblasZrot_v2`|6.0.0| | | | |`rocblas_zrot`|3.5.0| | | | |
@@ -402,9 +402,9 @@
 |`cublasZrotg`| | | | |`hipblasZrotg_v2`|6.0.0| | | | |`rocblas_zrotg`|3.5.0| | | | |
 |`cublasZrotg_v2`| | | | |`hipblasZrotg_v2`|6.0.0| | | | |`rocblas_zrotg`|3.5.0| | | | |
 |`cublasZscal`| | | | |`hipblasZscal_v2`|6.0.0| | | | |`rocblas_zscal`|1.5.0| | | | |
-|`cublasZscal_64`|12.0| | | | | | | | | | | | | | | |
+|`cublasZscal_64`|12.0| | | |`hipblasZscal_v2_64`|6.1.0| | | | |`rocblas_zscal_64`|6.1.0| | | | |
 |`cublasZscal_v2`| | | | |`hipblasZscal_v2`|6.0.0| | | | |`rocblas_zscal`|1.5.0| | | | |
-|`cublasZscal_v2_64`|12.0| | | | | | | | | | | | | | | |
+|`cublasZscal_v2_64`|12.0| | | |`hipblasZscal_v2_64`|6.1.0| | | | |`rocblas_zscal_64`|6.1.0| | | | |
 |`cublasZswap`| | | | |`hipblasZswap_v2`|6.0.0| | | | |`rocblas_zswap`|1.5.0| | | | |
 |`cublasZswap_64`|12.0| | | | | | | | | | | | | | | |
 |`cublasZswap_v2`| | | | |`hipblasZswap_v2`|6.0.0| | | | |`rocblas_zswap`|1.5.0| | | | |

--- a/docs/tables/CUBLAS_API_supported_by_ROC.md
+++ b/docs/tables/CUBLAS_API_supported_by_ROC.md
@@ -226,17 +226,17 @@
 |`cublasCrotg`| | | | |`rocblas_crotg`|3.5.0| | | | |
 |`cublasCrotg_v2`| | | | |`rocblas_crotg`|3.5.0| | | | |
 |`cublasCscal`| | | | |`rocblas_cscal`|1.5.0| | | | |
-|`cublasCscal_64`|12.0| | | | | | | | | |
+|`cublasCscal_64`|12.0| | | |`rocblas_cscal_64`|6.1.0| | | | |
 |`cublasCscal_v2`| | | | |`rocblas_cscal`|1.5.0| | | | |
-|`cublasCscal_v2_64`|12.0| | | | | | | | | |
+|`cublasCscal_v2_64`|12.0| | | |`rocblas_cscal_64`|6.1.0| | | | |
 |`cublasCsrot`| | | | |`rocblas_csrot`|3.5.0| | | | |
 |`cublasCsrot_64`|12.0| | | |`rocblas_csrot_64`|6.1.0| | | | |
 |`cublasCsrot_v2`| | | | |`rocblas_csrot`|3.5.0| | | | |
 |`cublasCsrot_v2_64`|12.0| | | |`rocblas_csrot_64`|6.1.0| | | | |
 |`cublasCsscal`| | | | |`rocblas_csscal`|3.5.0| | | | |
-|`cublasCsscal_64`|12.0| | | | | | | | | |
+|`cublasCsscal_64`|12.0| | | |`rocblas_csscal_64`|6.1.0| | | | |
 |`cublasCsscal_v2`| | | | |`rocblas_csscal`|3.5.0| | | | |
-|`cublasCsscal_v2_64`|12.0| | | | | | | | | |
+|`cublasCsscal_v2_64`|12.0| | | |`rocblas_csscal_64`|6.1.0| | | | |
 |`cublasCswap`| | | | |`rocblas_cswap`|1.5.0| | | | |
 |`cublasCswap_64`|12.0| | | | | | | | | |
 |`cublasCswap_v2`| | | | |`rocblas_cswap`|1.5.0| | | | |
@@ -274,9 +274,9 @@
 |`cublasDrotmg`| | | | |`rocblas_drotmg`|3.5.0| | | | |
 |`cublasDrotmg_v2`| | | | |`rocblas_drotmg`|3.5.0| | | | |
 |`cublasDscal`| | | | |`rocblas_dscal`|1.5.0| | | | |
-|`cublasDscal_64`|12.0| | | | | | | | | |
+|`cublasDscal_64`|12.0| | | |`rocblas_dscal_64`|6.1.0| | | | |
 |`cublasDscal_v2`| | | | |`rocblas_dscal`|1.5.0| | | | |
-|`cublasDscal_v2_64`|12.0| | | | | | | | | |
+|`cublasDscal_v2_64`|12.0| | | |`rocblas_dscal_64`|6.1.0| | | | |
 |`cublasDswap`| | | | |`rocblas_dswap`|1.5.0| | | | |
 |`cublasDswap_64`|12.0| | | | | | | | | |
 |`cublasDswap_v2`| | | | |`rocblas_dswap`|1.5.0| | | | |
@@ -364,9 +364,9 @@
 |`cublasSrotmg`| | | | |`rocblas_srotmg`|3.5.0| | | | |
 |`cublasSrotmg_v2`| | | | |`rocblas_srotmg`|3.5.0| | | | |
 |`cublasSscal`| | | | |`rocblas_sscal`|1.5.0| | | | |
-|`cublasSscal_64`|12.0| | | | | | | | | |
+|`cublasSscal_64`|12.0| | | |`rocblas_sscal_64`|6.1.0| | | | |
 |`cublasSscal_v2`| | | | |`rocblas_sscal`|1.5.0| | | | |
-|`cublasSscal_v2_64`|12.0| | | | | | | | | |
+|`cublasSscal_v2_64`|12.0| | | |`rocblas_sscal_64`|6.1.0| | | | |
 |`cublasSswap`| | | | |`rocblas_sswap`|1.5.0| | | | |
 |`cublasSswap_64`|12.0| | | | | | | | | |
 |`cublasSswap_v2`| | | | |`rocblas_sswap`|1.5.0| | | | |
@@ -392,9 +392,9 @@
 |`cublasZdrot_v2`| | | | |`rocblas_zdrot`|3.5.0| | | | |
 |`cublasZdrot_v2_64`|12.0| | | |`rocblas_zdrot_64`|6.1.0| | | | |
 |`cublasZdscal`| | | | |`rocblas_zdscal`|3.5.0| | | | |
-|`cublasZdscal_64`|12.0| | | | | | | | | |
+|`cublasZdscal_64`|12.0| | | |`rocblas_zdscal_64`|6.1.0| | | | |
 |`cublasZdscal_v2`| | | | |`rocblas_zdscal`|3.5.0| | | | |
-|`cublasZdscal_v2_64`|12.0| | | | | | | | | |
+|`cublasZdscal_v2_64`|12.0| | | |`rocblas_zdscal_64`|6.1.0| | | | |
 |`cublasZrot`| | | | |`rocblas_zrot`|3.5.0| | | | |
 |`cublasZrot_64`|12.0| | | |`rocblas_zrot_64`|6.1.0| | | | |
 |`cublasZrot_v2`| | | | |`rocblas_zrot`|3.5.0| | | | |
@@ -402,9 +402,9 @@
 |`cublasZrotg`| | | | |`rocblas_zrotg`|3.5.0| | | | |
 |`cublasZrotg_v2`| | | | |`rocblas_zrotg`|3.5.0| | | | |
 |`cublasZscal`| | | | |`rocblas_zscal`|1.5.0| | | | |
-|`cublasZscal_64`|12.0| | | | | | | | | |
+|`cublasZscal_64`|12.0| | | |`rocblas_zscal_64`|6.1.0| | | | |
 |`cublasZscal_v2`| | | | |`rocblas_zscal`|1.5.0| | | | |
-|`cublasZscal_v2_64`|12.0| | | | | | | | | |
+|`cublasZscal_v2_64`|12.0| | | |`rocblas_zscal_64`|6.1.0| | | | |
 |`cublasZswap`| | | | |`rocblas_zswap`|1.5.0| | | | |
 |`cublasZswap_64`|12.0| | | | | | | | | |
 |`cublasZswap_v2`| | | | |`rocblas_zswap`|1.5.0| | | | |

--- a/src/CUDA2HIP_BLAS_API_functions.cpp
+++ b/src/CUDA2HIP_BLAS_API_functions.cpp
@@ -116,17 +116,17 @@ const std::map<llvm::StringRef, hipCounter> CUDA_BLAS_FUNCTION_MAP {
   // SCAL
   // SCAL functions' signatures differ from _v2 ones, hipblas and rocblas SCAL functions have mapping to SCAL_v2 functions only
   {"cublasSscal",                    {"hipblasSscal",                    "rocblas_sscal",                            CONV_LIB_FUNC, API_BLAS, 5, HIP_SUPPORTED_V2_ONLY}},
-  {"cublasSscal_64",                 {"hipblasSscal_64",                 "",                                         CONV_LIB_FUNC, API_BLAS, 5, UNSUPPORTED}},
+  {"cublasSscal_64",                 {"hipblasSscal_64",                 "rocblas_sscal_64",                         CONV_LIB_FUNC, API_BLAS, 5}},
   {"cublasDscal",                    {"hipblasDscal",                    "rocblas_dscal",                            CONV_LIB_FUNC, API_BLAS, 5, HIP_SUPPORTED_V2_ONLY}},
-  {"cublasDscal_64",                 {"hipblasDscal_64",                 "",                                         CONV_LIB_FUNC, API_BLAS, 5, UNSUPPORTED}},
+  {"cublasDscal_64",                 {"hipblasDscal_64",                 "rocblas_dscal_64",                         CONV_LIB_FUNC, API_BLAS, 5}},
   {"cublasCscal",                    {"hipblasCscal_v2",                 "rocblas_cscal",                            CONV_LIB_FUNC, API_BLAS, 5, HIP_SUPPORTED_V2_ONLY}},
-  {"cublasCscal_64",                 {"hipblasCscal_64",                 "",                                         CONV_LIB_FUNC, API_BLAS, 5, UNSUPPORTED}},
+  {"cublasCscal_64",                 {"hipblasCscal_v2_64",              "rocblas_cscal_64",                         CONV_LIB_FUNC, API_BLAS, 5}},
   {"cublasCsscal",                   {"hipblasCsscal_v2",                "rocblas_csscal",                           CONV_LIB_FUNC, API_BLAS, 5, HIP_SUPPORTED_V2_ONLY}},
-  {"cublasCsscal_64",                {"hipblasCsscal_64",                "",                                         CONV_LIB_FUNC, API_BLAS, 5, UNSUPPORTED}},
+  {"cublasCsscal_64",                {"hipblasCsscal_v2_64",             "rocblas_csscal_64",                        CONV_LIB_FUNC, API_BLAS, 5}},
   {"cublasZscal",                    {"hipblasZscal_v2",                 "rocblas_zscal",                            CONV_LIB_FUNC, API_BLAS, 5, HIP_SUPPORTED_V2_ONLY}},
-  {"cublasZscal_64",                 {"hipblasZscal_64",                 "",                                         CONV_LIB_FUNC, API_BLAS, 5, UNSUPPORTED}},
+  {"cublasZscal_64",                 {"hipblasZscal_v2_64",              "rocblas_zscal_64",                         CONV_LIB_FUNC, API_BLAS, 5}},
   {"cublasZdscal",                   {"hipblasZdscal_v2",                "rocblas_zdscal",                           CONV_LIB_FUNC, API_BLAS, 5, HIP_SUPPORTED_V2_ONLY}},
-  {"cublasZdscal_64",                {"hipblasZdscal_64",                "",                                         CONV_LIB_FUNC, API_BLAS, 5, UNSUPPORTED}},
+  {"cublasZdscal_64",                {"hipblasZdscal_v2_64",             "rocblas_zdscal_64",                        CONV_LIB_FUNC, API_BLAS, 5}},
 
   // AXPY
   {"cublasSaxpy",                    {"hipblasSaxpy",                    "rocblas_saxpy",                            CONV_LIB_FUNC, API_BLAS, 5, HIP_SUPPORTED_V2_ONLY}},
@@ -952,17 +952,17 @@ const std::map<llvm::StringRef, hipCounter> CUDA_BLAS_FUNCTION_MAP {
   {"cublasScalEx",                   {"hipblasScalEx_v2",                "rocblas_scal_ex",                          CONV_LIB_FUNC, API_BLAS, 8}},
   {"cublasScalEx_64",                {"hipblasScalEx_64",                "",                                         CONV_LIB_FUNC, API_BLAS, 8, UNSUPPORTED}},
   {"cublasSscal_v2",                 {"hipblasSscal",                    "rocblas_sscal",                            CONV_LIB_FUNC, API_BLAS, 5}},
-  {"cublasSscal_v2_64",              {"hipblasSscal_64",                 "",                                         CONV_LIB_FUNC, API_BLAS, 5, UNSUPPORTED}},
+  {"cublasSscal_v2_64",              {"hipblasSscal_64",                 "rocblas_sscal_64",                         CONV_LIB_FUNC, API_BLAS, 5}},
   {"cublasDscal_v2",                 {"hipblasDscal",                    "rocblas_dscal",                            CONV_LIB_FUNC, API_BLAS, 5}},
-  {"cublasDscal_v2_64",              {"hipblasDscal_64",                 "",                                         CONV_LIB_FUNC, API_BLAS, 5, UNSUPPORTED}},
+  {"cublasDscal_v2_64",              {"hipblasDscal_64",                 "rocblas_dscal_64",                         CONV_LIB_FUNC, API_BLAS, 5}},
   {"cublasCscal_v2",                 {"hipblasCscal_v2",                 "rocblas_cscal",                            CONV_LIB_FUNC, API_BLAS, 5}},
-  {"cublasCscal_v2_64",              {"hipblasCscal_64",                 "",                                         CONV_LIB_FUNC, API_BLAS, 5, UNSUPPORTED}},
+  {"cublasCscal_v2_64",              {"hipblasCscal_v2_64",              "rocblas_cscal_64",                         CONV_LIB_FUNC, API_BLAS, 5}},
   {"cublasCsscal_v2",                {"hipblasCsscal_v2",                "rocblas_csscal",                           CONV_LIB_FUNC, API_BLAS, 5}},
-  {"cublasCsscal_v2_64",             {"hipblasCsscal_64",                "",                                         CONV_LIB_FUNC, API_BLAS, 5, UNSUPPORTED}},
+  {"cublasCsscal_v2_64",             {"hipblasCsscal_v2_64",             "rocblas_csscal_64",                        CONV_LIB_FUNC, API_BLAS, 5}},
   {"cublasZscal_v2",                 {"hipblasZscal_v2",                 "rocblas_zscal",                            CONV_LIB_FUNC, API_BLAS, 5}},
-  {"cublasZscal_v2_64",              {"hipblasZscal_64",                 "",                                         CONV_LIB_FUNC, API_BLAS, 5, UNSUPPORTED}},
+  {"cublasZscal_v2_64",              {"hipblasZscal_v2_64",              "rocblas_zscal_64",                         CONV_LIB_FUNC, API_BLAS, 5}},
   {"cublasZdscal_v2",                {"hipblasZdscal_v2",                "rocblas_zdscal",                           CONV_LIB_FUNC, API_BLAS, 5}},
-  {"cublasZdscal_v2_64",             {"hipblasZdscal_64",                "",                                         CONV_LIB_FUNC, API_BLAS, 5, UNSUPPORTED}},
+  {"cublasZdscal_v2_64",             {"hipblasZdscal_v2_64",             "rocblas_zdscal_64",                        CONV_LIB_FUNC, API_BLAS, 5}},
 
   // AXPY
   {"cublasAxpyEx",                   {"hipblasAxpyEx_v2",                "rocblas_axpy_ex",                          CONV_LIB_FUNC, API_BLAS, 8}},
@@ -1909,6 +1909,12 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_BLAS_FUNCTION_VER_MAP {
   {"hipblasZdrot_v2_64",                         {HIP_6010, HIP_0,    HIP_0,  }},
   {"hipblasSrotm_64",                            {HIP_6010, HIP_0,    HIP_0,  }},
   {"hipblasDrotm_64",                            {HIP_6010, HIP_0,    HIP_0,  }},
+  {"hipblasSscal_64",                            {HIP_6010, HIP_0,    HIP_0,  }},
+  {"hipblasDscal_64",                            {HIP_6010, HIP_0,    HIP_0,  }},
+  {"hipblasCscal_v2_64",                         {HIP_6010, HIP_0,    HIP_0,  }},
+  {"hipblasCsscal_v2_64",                        {HIP_6010, HIP_0,    HIP_0,  }},
+  {"hipblasZscal_v2_64",                         {HIP_6010, HIP_0,    HIP_0,  }},
+  {"hipblasZdscal_v2_64",                        {HIP_6010, HIP_0,    HIP_0,  }},
 
   {"rocblas_status_to_string",                   {HIP_3050, HIP_0,    HIP_0   }},
   {"rocblas_sscal",                              {HIP_1050, HIP_0,    HIP_0   }},
@@ -2183,6 +2189,12 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_BLAS_FUNCTION_VER_MAP {
   {"rocblas_zdrot_64",                           {HIP_6010, HIP_0,    HIP_0,  }},
   {"rocblas_srotm_64",                           {HIP_6010, HIP_0,    HIP_0,  }},
   {"rocblas_drotm_64",                           {HIP_6010, HIP_0,    HIP_0,  }},
+  {"rocblas_sscal_64",                           {HIP_6010, HIP_0,    HIP_0,  }},
+  {"rocblas_dscal_64",                           {HIP_6010, HIP_0,    HIP_0,  }},
+  {"rocblas_cscal_64",                           {HIP_6010, HIP_0,    HIP_0,  }},
+  {"rocblas_csscal_64",                          {HIP_6010, HIP_0,    HIP_0,  }},
+  {"rocblas_zscal_64",                           {HIP_6010, HIP_0,    HIP_0,  }},
+  {"rocblas_zdscal_64",                          {HIP_6010, HIP_0,    HIP_0,  }},
 };
 
 const std::map<llvm::StringRef, hipAPIChangedVersions> HIP_BLAS_FUNCTION_CHANGED_VER_MAP {

--- a/tests/unit_tests/synthetic/libraries/cublas2hipblas_v2.cu
+++ b/tests/unit_tests/synthetic/libraries/cublas2hipblas_v2.cu
@@ -2106,6 +2106,48 @@ int main() {
   // CHECK-NEXT: blasStatus = hipblasDrotm_64(blasHandle, n_64, &dx, incx_64, &dy, incy_64, &dparam);
   blasStatus = cublasDrotm_64(blasHandle, n_64, &dx, incx_64, &dy, incy_64, &dparam);
   blasStatus = cublasDrotm_v2_64(blasHandle, n_64, &dx, incx_64, &dy, incy_64, &dparam);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasSscal_v2_64(cublasHandle_t handle, int64_t n, const float* alpha, float* x, int64_t incx);
+  // HIP: HIPBLAS_EXPORT hipblasStatus_t hipblasSscal_64(hipblasHandle_t handle, int64_t n, const float* alpha, float* x, int64_t incx);
+  // CHECK: blasStatus = hipblasSscal_64(blasHandle, n_64, &fa, &fx, incx_64);
+  // CHECK-NEXT: blasStatus = hipblasSscal_64(blasHandle, n_64, &fa, &fx, incx_64);
+  blasStatus = cublasSscal_64(blasHandle, n_64, &fa, &fx, incx_64);
+  blasStatus = cublasSscal_v2_64(blasHandle, n_64, &fa, &fx, incx_64);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasDscal_v2_64(cublasHandle_t handle, int64_t n, const double* alpha, double* x, int64_t incx);
+  // HIP: HIPBLAS_EXPORT hipblasStatus_t hipblasDscal_64(hipblasHandle_t handle, int64_t n, const double* alpha, double* x, int64_t incx);
+  // CHECK: blasStatus = hipblasDscal_64(blasHandle, n_64, &da, &dx, incx_64);
+  // CHECK-NEXT: blasStatus = hipblasDscal_64(blasHandle, n_64, &da, &dx, incx_64);
+  blasStatus = cublasDscal_64(blasHandle, n_64, &da, &dx, incx_64);
+  blasStatus = cublasDscal_v2_64(blasHandle, n_64, &da, &dx, incx_64);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasCscal_v2_64(cublasHandle_t handle, int64_t n, const cuComplex* alpha, cuComplex* x, int64_t incx);
+  // HIP: HIPBLAS_EXPORT hipblasStatus_t hipblasCscal_v2_64(hipblasHandle_t handle, int64_t n, const hipComplex* alpha, hipComplex* x, int64_t incx);
+  // CHECK: blasStatus = hipblasCscal_v2_64(blasHandle, n_64, &complexa, &complexx, incx_64);
+  // CHECK-NEXT: blasStatus = hipblasCscal_v2_64(blasHandle, n_64, &complexa, &complexx, incx_64);
+  blasStatus = cublasCscal_64(blasHandle, n_64, &complexa, &complexx, incx_64);
+  blasStatus = cublasCscal_v2_64(blasHandle, n_64, &complexa, &complexx, incx_64);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasCsscal_v2_64(cublasHandle_t handle, int64_t n, const float* alpha, cuComplex* x, int64_t incx);
+  // HIP: HIPBLAS_EXPORT hipblasStatus_t hipblasCsscal_v2_64(hipblasHandle_t handle, int64_t n, const float* alpha, hipComplex* x, int64_t incx);
+  // CHECK: blasStatus = hipblasCsscal_v2_64(blasHandle, n_64, &fa, &complexx, incx_64);
+  // CHECK-NEXT: blasStatus = hipblasCsscal_v2_64(blasHandle, n_64, &fa, &complexx, incx_64);
+  blasStatus = cublasCsscal_64(blasHandle, n_64, &fa, &complexx, incx_64);
+  blasStatus = cublasCsscal_v2_64(blasHandle, n_64, &fa, &complexx, incx_64);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasZscal_v2_64(cublasHandle_t handle, int64_t n, const cuDoubleComplex* alpha, cuDoubleComplex* x, int64_t incx);
+  // HIP: HIPBLAS_EXPORT hipblasStatus_t hipblasZscal_v2_64(hipblasHandle_t handle, int64_t n, const hipDoubleComplex* alpha, hipDoubleComplex* x, int64_t incx);
+  // CHECK: blasStatus = hipblasZscal_v2_64(blasHandle, n_64, &dcomplexa, &dcomplexx, incx_64);
+  // CHECK-NEXT: blasStatus = hipblasZscal_v2_64(blasHandle, n_64, &dcomplexa, &dcomplexx, incx_64);
+  blasStatus = cublasZscal_64(blasHandle, n_64, &dcomplexa, &dcomplexx, incx_64);
+  blasStatus = cublasZscal_v2_64(blasHandle, n_64, &dcomplexa, &dcomplexx, incx_64);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasZdscal_v2_64(cublasHandle_t handle, int64_t n, const double* alpha, cuDoubleComplex* x, int64_t incx);
+  // HIP: HIPBLAS_EXPORT hipblasStatus_t hipblasZdscal_v2_64(hipblasHandle_t handle, int64_t n, const double* alpha, hipDoubleComplex* x, int64_t incx);
+  // CHECK: blasStatus = hipblasZdscal_v2_64(blasHandle, n_64, &da, &dcomplexx, incx_64);
+  // CHECK-NEXT: blasStatus = hipblasZdscal_v2_64(blasHandle, n_64, &da, &dcomplexx, incx_64);
+  blasStatus = cublasZdscal_64(blasHandle, n_64, &da, &dcomplexx, incx_64);
+  blasStatus = cublasZdscal_v2_64(blasHandle, n_64, &da, &dcomplexx, incx_64);
 #endif
 
   return 0;

--- a/tests/unit_tests/synthetic/libraries/cublas2rocblas_v2.cu
+++ b/tests/unit_tests/synthetic/libraries/cublas2rocblas_v2.cu
@@ -2191,6 +2191,48 @@ int main() {
   // CHECK-NEXT: blasStatus = rocblas_drotm_64(blasHandle, n_64, &dx, incx_64, &dy, incy_64, &dparam);
   blasStatus = cublasDrotm_64(blasHandle, n_64, &dx, incx_64, &dy, incy_64, &dparam);
   blasStatus = cublasDrotm_v2_64(blasHandle, n_64, &dx, incx_64, &dy, incy_64, &dparam);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasSscal_v2_64(cublasHandle_t handle, int64_t n, const float* alpha, float* x, int64_t incx);
+  // ROC: ROCBLAS_EXPORT rocblas_status rocblas_sscal_64(rocblas_handle handle, int64_t n, const float* alpha, float* x, int64_t incx);
+  // CHECK: blasStatus = rocblas_sscal_64(blasHandle, n_64, &fa, &fx, incx_64);
+  // CHECK-NEXT: blasStatus = rocblas_sscal_64(blasHandle, n_64, &fa, &fx, incx_64);
+  blasStatus = cublasSscal_64(blasHandle, n_64, &fa, &fx, incx_64);
+  blasStatus = cublasSscal_v2_64(blasHandle, n_64, &fa, &fx, incx_64);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasDscal_v2_64(cublasHandle_t handle, int64_t n, const double* alpha, double* x, int64_t incx);
+  // ROC: ROCBLAS_EXPORT rocblas_status rocblas_dscal_64(rocblas_handle handle, int64_t n, const double* alpha, double* x, int64_t incx);
+  // CHECK: blasStatus = rocblas_dscal_64(blasHandle, n_64, &da, &dx, incx_64);
+  // CHECK-NEXT: blasStatus = rocblas_dscal_64(blasHandle, n_64, &da, &dx, incx_64);
+  blasStatus = cublasDscal_64(blasHandle, n_64, &da, &dx, incx_64);
+  blasStatus = cublasDscal_v2_64(blasHandle, n_64, &da, &dx, incx_64);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasCscal_v2_64(cublasHandle_t handle, int64_t n, const cuComplex* alpha, cuComplex* x, int64_t incx);
+  // ROC: ROCBLAS_EXPORT rocblas_status rocblas_cscal_64(rocblas_handle handle, int64_t n, const rocblas_float_complex* alpha, rocblas_float_complex* x, int64_t incx);
+  // CHECK: blasStatus = rocblas_cscal_64(blasHandle, n_64, &complexa, &complexx, incx_64);
+  // CHECK-NEXT: blasStatus = rocblas_cscal_64(blasHandle, n_64, &complexa, &complexx, incx_64);
+  blasStatus = cublasCscal_64(blasHandle, n_64, &complexa, &complexx, incx_64);
+  blasStatus = cublasCscal_v2_64(blasHandle, n_64, &complexa, &complexx, incx_64);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasCsscal_v2_64(cublasHandle_t handle, int64_t n, const float* alpha, cuComplex* x, int64_t incx);
+  // ROC: ROCBLAS_EXPORT rocblas_status rocblas_csscal_64(rocblas_handle handle, int64_t n, const float* alpha, rocblas_float_complex* x, int64_t incx);
+  // CHECK: blasStatus = rocblas_csscal_64(blasHandle, n_64, &fa, &complexx, incx_64);
+  // CHECK-NEXT: blasStatus = rocblas_csscal_64(blasHandle, n_64, &fa, &complexx, incx_64);
+  blasStatus = cublasCsscal_64(blasHandle, n_64, &fa, &complexx, incx_64);
+  blasStatus = cublasCsscal_v2_64(blasHandle, n_64, &fa, &complexx, incx_64);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasZscal_v2_64(cublasHandle_t handle, int64_t n, const cuDoubleComplex* alpha, cuDoubleComplex* x, int64_t incx);
+  // ROC: ROCBLAS_EXPORT rocblas_status rocblas_zscal_64(rocblas_handle handle, int64_t n, const rocblas_double_complex* alpha, rocblas_double_complex* x, int64_t incx);
+  // CHECK: blasStatus = rocblas_zscal_64(blasHandle, n_64, &dcomplexa, &dcomplexx, incx_64);
+  // CHECK-NEXT: blasStatus = rocblas_zscal_64(blasHandle, n_64, &dcomplexa, &dcomplexx, incx_64);
+  blasStatus = cublasZscal_64(blasHandle, n_64, &dcomplexa, &dcomplexx, incx_64);
+  blasStatus = cublasZscal_v2_64(blasHandle, n_64, &dcomplexa, &dcomplexx, incx_64);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasZdscal_v2_64(cublasHandle_t handle, int64_t n, const double* alpha, cuDoubleComplex* x, int64_t incx);
+  // ROC: ROCBLAS_EXPORT rocblas_status rocblas_zdscal_64(rocblas_handle handle, int64_t n, const double* alpha, rocblas_double_complex* x, int64_t incx);
+  // CHECK: blasStatus = rocblas_zdscal_64(blasHandle, n_64, &da, &dcomplexx, incx_64);
+  // CHECK-NEXT: blasStatus = rocblas_zdscal_64(blasHandle, n_64, &da, &dcomplexx, incx_64);
+  blasStatus = cublasZdscal_64(blasHandle, n_64, &da, &dcomplexx, incx_64);
+  blasStatus = cublasZdscal_v2_64(blasHandle, n_64, &da, &dcomplexx, incx_64);
 #endif
 
   return 0;


### PR DESCRIPTION
+ Updated `BLAS` synthetic tests, the regenerated hipify-perl, and `BLAS` `CUDA2HIP` documentation
