### PR TITLE
[HIPIFY][rocBLAS][6.1][sync] Sync with `rocBLAS` - Step 14 - NRM2Ex, SCALEx, and ROTEx 64bit

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -1502,7 +1502,9 @@ sub rocSubstitutions {
     subst("cublasIzamin_v2", "rocblas_izamin", "library");
     subst("cublasIzamin_v2_64", "rocblas_izamin_64", "library");
     subst("cublasNrm2Ex", "rocblas_nrm2_ex", "library");
+    subst("cublasNrm2Ex_64", "rocblas_nrm2_ex_64", "library");
     subst("cublasRotEx", "rocblas_rot_ex", "library");
+    subst("cublasRotEx_64", "rocblas_rot_ex_64", "library");
     subst("cublasSasum", "rocblas_sasum", "library");
     subst("cublasSasum_64", "rocblas_sasum_64", "library");
     subst("cublasSasum_v2", "rocblas_sasum", "library");
@@ -1512,6 +1514,7 @@ sub rocSubstitutions {
     subst("cublasSaxpy_v2", "rocblas_saxpy", "library");
     subst("cublasSaxpy_v2_64", "rocblas_saxpy_64", "library");
     subst("cublasScalEx", "rocblas_scal_ex", "library");
+    subst("cublasScalEx_64", "rocblas_scal_ex_64", "library");
     subst("cublasScasum", "rocblas_scasum", "library");
     subst("cublasScasum_64", "rocblas_scasum_64", "library");
     subst("cublasScasum_v2", "rocblas_scasum", "library");
@@ -11150,13 +11153,10 @@ sub warnRocOnlyUnsupportedFunctions {
         "cublasSetLoggerCallback",
         "cublasSetKernelStream",
         "cublasSdgmm_64",
-        "cublasScalEx_64",
         "cublasRotmgEx",
         "cublasRotmEx_64",
         "cublasRotmEx",
         "cublasRotgEx",
-        "cublasRotEx_64",
-        "cublasNrm2Ex_64",
         "cublasMigrateComputeType",
         "cublasLoggerConfigure",
         "cublasLogCallback",

--- a/docs/tables/CUBLAS_API_supported_by_HIP_and_ROC.md
+++ b/docs/tables/CUBLAS_API_supported_by_HIP_and_ROC.md
@@ -322,7 +322,7 @@
 |`cublasIzamin_v2`| | | | |`hipblasIzamin_v2`|6.0.0| | | | |`rocblas_izamin`|3.5.0| | | | |
 |`cublasIzamin_v2_64`|12.0| | | |`hipblasIzamin_v2_64`|6.1.0| | | | |`rocblas_izamin_64`|6.1.0| | | | |
 |`cublasNrm2Ex`|8.0| | | |`hipblasNrm2Ex_v2`|6.0.0| | | | |`rocblas_nrm2_ex`|4.1.0| | | | |
-|`cublasNrm2Ex_64`|12.0| | | | | | | | | | | | | | | |
+|`cublasNrm2Ex_64`|12.0| | | | | | | | | |`rocblas_nrm2_ex_64`|6.1.0| | | | |
 |`cublasSasum`| | | | |`hipblasSasum`|1.8.2| | | | |`rocblas_sasum`|1.5.0| | | | |
 |`cublasSasum_64`|12.0| | | |`hipblasSasum_64`|6.1.0| | | | |`rocblas_sasum_64`|6.1.0| | | | |
 |`cublasSasum_v2`| | | | |`hipblasSasum`|1.8.2| | | | |`rocblas_sasum`|1.5.0| | | | |
@@ -967,13 +967,13 @@
 |`cublasIaminEx`|10.1| | | | | | | | | | | | | | | |
 |`cublasIaminEx_64`|12.0| | | | | | | | | | | | | | | |
 |`cublasRotEx`|10.1| | | |`hipblasRotEx_v2`|6.0.0| | | | |`rocblas_rot_ex`|4.1.0| | | | |
-|`cublasRotEx_64`|12.0| | | | | | | | | | | | | | | |
+|`cublasRotEx_64`|12.0| | | | | | | | | |`rocblas_rot_ex_64`|6.1.0| | | | |
 |`cublasRotgEx`|10.1| | | | | | | | | | | | | | | |
 |`cublasRotmEx`|10.1| | | | | | | | | | | | | | | |
 |`cublasRotmEx_64`|12.0| | | | | | | | | | | | | | | |
 |`cublasRotmgEx`|10.1| | | | | | | | | | | | | | | |
 |`cublasScalEx`|8.0| | | |`hipblasScalEx_v2`|6.0.0| | | | |`rocblas_scal_ex`|4.0.0| | | | |
-|`cublasScalEx_64`|12.0| | | | | | | | | | | | | | | |
+|`cublasScalEx_64`|12.0| | | | | | | | | |`rocblas_scal_ex_64`|6.1.0| | | | |
 |`cublasSdgmm`| | | | |`hipblasSdgmm`|3.6.0| | | | |`rocblas_sdgmm`|3.5.0| | | | |
 |`cublasSdgmm_64`|12.0| | | | | | | | | | | | | | | |
 |`cublasSgeam`| | | | |`hipblasSgeam`|1.8.2| | | | |`rocblas_sgeam`|1.6.4| | | | |

--- a/docs/tables/CUBLAS_API_supported_by_ROC.md
+++ b/docs/tables/CUBLAS_API_supported_by_ROC.md
@@ -322,7 +322,7 @@
 |`cublasIzamin_v2`| | | | |`rocblas_izamin`|3.5.0| | | | |
 |`cublasIzamin_v2_64`|12.0| | | |`rocblas_izamin_64`|6.1.0| | | | |
 |`cublasNrm2Ex`|8.0| | | |`rocblas_nrm2_ex`|4.1.0| | | | |
-|`cublasNrm2Ex_64`|12.0| | | | | | | | | |
+|`cublasNrm2Ex_64`|12.0| | | |`rocblas_nrm2_ex_64`|6.1.0| | | | |
 |`cublasSasum`| | | | |`rocblas_sasum`|1.5.0| | | | |
 |`cublasSasum_64`|12.0| | | |`rocblas_sasum_64`|6.1.0| | | | |
 |`cublasSasum_v2`| | | | |`rocblas_sasum`|1.5.0| | | | |
@@ -967,13 +967,13 @@
 |`cublasIaminEx`|10.1| | | | | | | | | |
 |`cublasIaminEx_64`|12.0| | | | | | | | | |
 |`cublasRotEx`|10.1| | | |`rocblas_rot_ex`|4.1.0| | | | |
-|`cublasRotEx_64`|12.0| | | | | | | | | |
+|`cublasRotEx_64`|12.0| | | |`rocblas_rot_ex_64`|6.1.0| | | | |
 |`cublasRotgEx`|10.1| | | | | | | | | |
 |`cublasRotmEx`|10.1| | | | | | | | | |
 |`cublasRotmEx_64`|12.0| | | | | | | | | |
 |`cublasRotmgEx`|10.1| | | | | | | | | |
 |`cublasScalEx`|8.0| | | |`rocblas_scal_ex`|4.0.0| | | | |
-|`cublasScalEx_64`|12.0| | | | | | | | | |
+|`cublasScalEx_64`|12.0| | | |`rocblas_scal_ex_64`|6.1.0| | | | |
 |`cublasSdgmm`| | | | |`rocblas_sdgmm`|3.5.0| | | | |
 |`cublasSdgmm_64`|12.0| | | | | | | | | |
 |`cublasSgeam`| | | | |`rocblas_sgeam`|1.6.4| | | | |

--- a/src/CUDA2HIP_BLAS_API_functions.cpp
+++ b/src/CUDA2HIP_BLAS_API_functions.cpp
@@ -96,7 +96,7 @@ const std::map<llvm::StringRef, hipCounter> CUDA_BLAS_FUNCTION_MAP {
   {"cublasDznrm2",                   {"hipblasDznrm2_v2",                "rocblas_dznrm2",                           CONV_LIB_FUNC, API_BLAS, 5, HIP_SUPPORTED_V2_ONLY}},
   {"cublasDznrm2_64",                {"hipblasDznrm2_v2_64",             "rocblas_dznrm2_64",                        CONV_LIB_FUNC, API_BLAS, 5}},
   {"cublasNrm2Ex",                   {"hipblasNrm2Ex_v2",                "rocblas_nrm2_ex",                          CONV_LIB_FUNC, API_BLAS, 5}},
-  {"cublasNrm2Ex_64",                {"hipblasNrm2Ex_64",                "",                                         CONV_LIB_FUNC, API_BLAS, 5, UNSUPPORTED}},
+  {"cublasNrm2Ex_64",                {"hipblasNrm2Ex_64",                "rocblas_nrm2_ex_64",                       CONV_LIB_FUNC, API_BLAS, 5, HIP_UNSUPPORTED}},
 
   // DOT
   // DOT functions' signatures differ from _v2 ones, hipblas and rocblas DOT functions have mapping to DOT_v2 functions only
@@ -950,7 +950,7 @@ const std::map<llvm::StringRef, hipCounter> CUDA_BLAS_FUNCTION_MAP {
 
   // SCAL
   {"cublasScalEx",                   {"hipblasScalEx_v2",                "rocblas_scal_ex",                          CONV_LIB_FUNC, API_BLAS, 8}},
-  {"cublasScalEx_64",                {"hipblasScalEx_64",                "",                                         CONV_LIB_FUNC, API_BLAS, 8, UNSUPPORTED}},
+  {"cublasScalEx_64",                {"hipblasScalEx_64",                "rocblas_scal_ex_64",                       CONV_LIB_FUNC, API_BLAS, 8, HIP_UNSUPPORTED}},
   {"cublasSscal_v2",                 {"hipblasSscal",                    "rocblas_sscal",                            CONV_LIB_FUNC, API_BLAS, 5}},
   {"cublasSscal_v2_64",              {"hipblasSscal_64",                 "rocblas_sscal_64",                         CONV_LIB_FUNC, API_BLAS, 5}},
   {"cublasDscal_v2",                 {"hipblasDscal",                    "rocblas_dscal",                            CONV_LIB_FUNC, API_BLAS, 5}},
@@ -1038,7 +1038,7 @@ const std::map<llvm::StringRef, hipCounter> CUDA_BLAS_FUNCTION_MAP {
 
   // ROT
   {"cublasRotEx",                    {"hipblasRotEx_v2",                 "rocblas_rot_ex",                           CONV_LIB_FUNC, API_BLAS, 8}},
-  {"cublasRotEx_64",                 {"hipblasRotEx_64",                 "",                                         CONV_LIB_FUNC, API_BLAS, 8, UNSUPPORTED}},
+  {"cublasRotEx_64",                 {"hipblasRotEx_64",                 "rocblas_rot_ex_64",                        CONV_LIB_FUNC, API_BLAS, 8, HIP_UNSUPPORTED}},
   {"cublasSrot_v2",                  {"hipblasSrot",                     "rocblas_srot",                             CONV_LIB_FUNC, API_BLAS, 5}},
   {"cublasSrot_v2_64",               {"hipblasSrot_64",                  "rocblas_srot_64",                          CONV_LIB_FUNC, API_BLAS, 5}},
   {"cublasDrot_v2",                  {"hipblasDrot",                     "rocblas_drot",                             CONV_LIB_FUNC, API_BLAS, 5}},
@@ -2206,6 +2206,9 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_BLAS_FUNCTION_VER_MAP {
   {"rocblas_axpy_ex_64",                         {HIP_6010, HIP_0,    HIP_0,  }},
   {"rocblas_dot_ex_64",                          {HIP_6010, HIP_0,    HIP_0,  }},
   {"rocblas_dotc_ex_64",                         {HIP_6010, HIP_0,    HIP_0,  }},
+  {"rocblas_nrm2_ex_64",                         {HIP_6010, HIP_0,    HIP_0,  }},
+  {"rocblas_rot_ex_64",                          {HIP_6010, HIP_0,    HIP_0,  }},
+  {"rocblas_scal_ex_64",                         {HIP_6010, HIP_0,    HIP_0,  }},
 };
 
 const std::map<llvm::StringRef, hipAPIChangedVersions> HIP_BLAS_FUNCTION_CHANGED_VER_MAP {

--- a/tests/unit_tests/synthetic/libraries/cublas2rocblas_v2.cu
+++ b/tests/unit_tests/synthetic/libraries/cublas2rocblas_v2.cu
@@ -165,6 +165,8 @@ int main() {
   void *image = nullptr;
   void *image_2 = nullptr;
   void *valpha = nullptr;
+  void *vc = nullptr;
+  void *vs = nullptr;
   void *vx = nullptr;
   void *vy = nullptr;
   void *vresult = nullptr;
@@ -1771,8 +1773,8 @@ int main() {
   cublasDataType_t R_32U = CUDA_R_32U;
   cublasDataType_t C_32U = CUDA_C_32U;
 
-  // CHECK: rocblas_datatype DataType_2, DataType_3, alpha_type, x_type, y_type, execution_type, result_type;
-  cudaDataType DataType_2, DataType_3, alpha_type, x_type, y_type, execution_type, result_type;
+  // CHECK: rocblas_datatype DataType_2, DataType_3, alpha_type, cs_type, x_type, y_type, execution_type, result_type;
+  cudaDataType DataType_2, DataType_3, alpha_type, cs_type, x_type, y_type, execution_type, result_type;
 
   // CHECK: rocblas_gemm_algo blasGemmAlgo;
   // CHECK-NEXT: rocblas_gemm_algo BLAS_GEMM_DFALT = rocblas_gemm_algo_standard;
@@ -2280,6 +2282,21 @@ int main() {
   // ROC: ROCBLAS_EXPORT rocblas_status rocblas_dotc_ex_64(rocblas_handle handle, int64_t n, const void* x, rocblas_datatype x_type, int64_t incx, const void* y, rocblas_datatype y_type, int64_t incy, void* result, rocblas_datatype result_type, rocblas_datatype execution_type);
   // CHECK: blasStatus = rocblas_dotc_ex_64(blasHandle, n_64, vx, x_type, incx_64, vy, y_type, incy_64, vresult, result_type, execution_type);
   blasStatus = cublasDotcEx_64(blasHandle, n_64, vx, x_type, incx_64, vy, y_type, incy_64, vresult, result_type, execution_type);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasNrm2Ex_64(cublasHandle_t handle, int64_t n, const void* x, cudaDataType xType, int64_t incx, void* result, cudaDataType resultType, cudaDataType executionType);
+  // ROC: ROCBLAS_EXPORT rocblas_status rocblas_nrm2_ex_64(rocblas_handle handle, int64_t n, const void* x, rocblas_datatype x_type, int64_t incx, void* results, rocblas_datatype result_type, rocblas_datatype execution_type);
+  // CHECK: blasStatus = rocblas_nrm2_ex_64(blasHandle, n_64, vx, x_type, incx_64, vresult, result_type, execution_type);
+  blasStatus = cublasNrm2Ex_64(blasHandle, n_64, vx, x_type, incx_64, vresult, result_type, execution_type);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasRotEx_64(cublasHandle_t handle, int64_t n, void* x, cudaDataType xType, int64_t incx, void* y, cudaDataType yType, int64_t incy, const void* c, const void* s, cudaDataType csType, cudaDataType executiontype);
+  // ROC: ROCBLAS_EXPORT rocblas_status rocblas_rot_ex_64(rocblas_handle handle, int64_t n, void* x, rocblas_datatype x_type, int64_t incx, void* y, rocblas_datatype y_type, int64_t incy, const void* c, const void* s, rocblas_datatype cs_type, rocblas_datatype execution_type);
+  // CHECK: blasStatus = rocblas_rot_ex_64(blasHandle, n_64, vx, x_type, incx_64, vy, y_type, incy_64, vc, vs, cs_type, execution_type);
+  blasStatus = cublasRotEx_64(blasHandle, n_64, vx, x_type, incx_64, vy, y_type, incy_64, vc, vs, cs_type, execution_type);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasScalEx_64(cublasHandle_t handle, int64_t n, const void* alpha, cudaDataType alphaType, void* x, cudaDataType xType, int64_t incx, cudaDataType executionType);
+  // ROC: ROCBLAS_EXPORT rocblas_status rocblas_scal_ex_64(rocblas_handle handle, int64_t n, const void* alpha, rocblas_datatype alpha_type, void* x, rocblas_datatype x_type, int64_t incx, rocblas_datatype execution_type);
+  // CHECK: blasStatus = rocblas_scal_ex_64(blasHandle, n_64, valpha, alpha_type, vx, x_type, incx_64, execution_type);
+  blasStatus = cublasScalEx_64(blasHandle, n_64, valpha, alpha_type, vx, x_type, incx_64, execution_type);
 #endif
 
   return 0;


### PR DESCRIPTION
+ Updated `rocBLAS` synthetic tests, the regenerated hipify-perl, and `BLAS` `CUDA2HIP` documentation
