### PR TITLE
[HIPIFY][tests][Linux][fix] Use explicit GL include for CUDA_VERSION <= 9020

### DIFF
--- a/tests/unit_tests/synthetic/driver_enums.cu
+++ b/tests/unit_tests/synthetic/driver_enums.cu
@@ -6,6 +6,8 @@
 #if defined(_WIN32)
   #include "windows.h"
   #include <GL/glew.h>
+#elif CUDA_VERSION <= 9020
+  #include <GL/glew.h>
 #endif
 #include "cudaGL.h"
 

--- a/tests/unit_tests/synthetic/driver_functions.cu
+++ b/tests/unit_tests/synthetic/driver_functions.cu
@@ -7,6 +7,8 @@
 #if defined(_WIN32)
   #include "windows.h"
   #include <GL/glew.h>
+#elif CUDA_VERSION <= 9020
+  #include <GL/glew.h>
 #endif
 #include "cudaGL.h"
 #include "cudaProfiler.h"

--- a/tests/unit_tests/synthetic/driver_functions_internal.cu
+++ b/tests/unit_tests/synthetic/driver_functions_internal.cu
@@ -7,6 +7,8 @@
 #if defined(_WIN32)
   #include "windows.h"
   #include <GL/glew.h>
+#elif CUDA_VERSION <= 9020
+  #include <GL/glew.h>
 #endif
 #include "cudaGL.h"
 


### PR DESCRIPTION
+ Affects only GL tests
+ Either CUDA samples (where GL is shipped) or `freeglut3` should be installed
