### PR TITLE
[HIPIFY][feature] Implemented multiple (HIP API and ROC API) transformations for a single CUDA API description

### DIFF
--- a/src/CUDA2HIP_Perl.cpp
+++ b/src/CUDA2HIP_Perl.cpp
@@ -487,8 +487,9 @@ namespace perl {
     set<string> ReinterpretFunctions1;
     set<string> RemoveArgFunctions3;
     for (auto f : FuncArgCasts) {
-      auto castStruct = f.second;
-      for (auto c : castStruct.castMap) {
+      auto castStructs = f.second;
+      for (auto cc : castStructs) {
+        for (auto c : cc.castMap) {
         switch (c.first) {
           case 0:
             switch (c.second.castType) {
@@ -531,6 +532,7 @@ namespace perl {
             break;
           default: break;
         }
+      }
       }
     }
     set<string>& funcSet = DeviceSymbolFunctions0;

--- a/src/CUDA2HIP_Scripting.h
+++ b/src/CUDA2HIP_Scripting.h
@@ -82,7 +82,7 @@ namespace hipify {
 }
 
 extern std::string getCastType(hipify::CastTypes c);
-extern std::map<std::string, hipify::ArgCastStruct> FuncArgCasts;
+extern std::map<std::string, std::vector<hipify::ArgCastStruct>> FuncArgCasts;
 
 extern std::map<std::string, hipify::FuncOverloadsStruct> FuncOverloads;
 

--- a/src/HipifyAction.cpp
+++ b/src/HipifyAction.cpp
@@ -269,1458 +269,1783 @@ std::map<std::string, hipify::FuncOverloadsStruct> FuncOverloads {
   },
 };
 
-std::map<std::string, ArgCastStruct> FuncArgCasts {
+std::map<std::string, std::vector<ArgCastStruct>> FuncArgCasts {
   {sCudaMallocHost,
     {
       {
-        {2, {e_add_const_argument, cw_None, "hipHostMallocDefault"}}
+        {
+          {2, {e_add_const_argument, cw_None, "hipHostMallocDefault"}}
+        }
       }
     }
   },
   {sCudaMemcpyToSymbol,
     {
       {
-        {0, {e_HIP_SYMBOL, cw_None}}
+        {
+          {0, {e_HIP_SYMBOL, cw_None}}
+        }
       }
     }
   },
   {sCudaMemcpyToSymbolAsync,
     {
       {
-        {0, {e_HIP_SYMBOL, cw_None}}
+        {
+          {0, {e_HIP_SYMBOL, cw_None}}
+        }
       }
     }
   },
   {sCudaGetSymbolSize,
     {
       {
-        {1, {e_HIP_SYMBOL, cw_None}}
+        {
+          {1, {e_HIP_SYMBOL, cw_None}}
+        }
       }
     }
   },
   {sCudaGetSymbolAddress,
     {
       {
-        {1, {e_HIP_SYMBOL, cw_None}}
+        {
+          {1, {e_HIP_SYMBOL, cw_None}}
+        }
       }
     }
   },
   {sCudaMemcpyFromSymbol,
     {
       {
-        {1, {e_HIP_SYMBOL, cw_None}}
+        {
+          {1, {e_HIP_SYMBOL, cw_None}}
+        }
       }
     }
   },
   {sCudaMemcpyFromSymbolAsync,
     {
       {
-        {1, {e_HIP_SYMBOL, cw_None}}
+        {
+          {1, {e_HIP_SYMBOL, cw_None}}
+        }
       }
     }
   },
   {sCudaGraphAddMemcpyNodeToSymbol,
     {
       {
-        {4, {e_HIP_SYMBOL, cw_None}}
+        {
+          {4, {e_HIP_SYMBOL, cw_None}}
+        }
       }
     }
   },
   {sCudaGraphAddMemcpyNodeFromSymbol,
     {
       {
-        {5, {e_HIP_SYMBOL, cw_None}}
+        {
+          {5, {e_HIP_SYMBOL, cw_None}}
+        }
       }
     }
   },
   {sCudaGraphMemcpyNodeSetParamsToSymbol,
     {
       {
-        {1, {e_HIP_SYMBOL, cw_None}}
+        {
+          {1, {e_HIP_SYMBOL, cw_None}}
+        }
       }
     }
   },
   {sCudaGraphMemcpyNodeSetParamsFromSymbol,
     {
       {
-        {2, {e_HIP_SYMBOL, cw_None}}
+        {
+          {2, {e_HIP_SYMBOL, cw_None}}
+        }
       }
     }
   },
   {sCudaGraphExecMemcpyNodeSetParamsToSymbol,
     {
       {
-        {2, {e_HIP_SYMBOL, cw_None}}
+        {
+          {2, {e_HIP_SYMBOL, cw_None}}
+        }
       }
     }
   },
   {sCudaGraphExecMemcpyNodeSetParamsFromSymbol,
     {
       {
-        {3, {e_HIP_SYMBOL, cw_None}}
+        {
+          {3, {e_HIP_SYMBOL, cw_None}}
+        }
       }
     }
   },
   {sCudaGetTextureReference,
     {
       {
-        {1, {e_HIP_SYMBOL, cw_None}}
+        {
+          {1, {e_HIP_SYMBOL, cw_None}}
+        }
       }
     }
   },
   {sCuOccupancyMaxPotentialBlockSize,
     {
       {
-        {3, {e_remove_argument, cw_DataLoss}}
+        {
+          {3, {e_remove_argument, cw_DataLoss}}
+        }
       }
     }
   },
   {sCuOccupancyMaxPotentialBlockSizeWithFlags,
     {
       {
-        {3, {e_remove_argument, cw_DataLoss}}
+        {
+          {3, {e_remove_argument, cw_DataLoss}}
+        }
       }
     }
   },
   {sCudnnGetConvolutionForwardWorkspaceSize,
     {
       {
-        {1, {e_move_argument, cw_None, "", 2}},
-        {2, {e_move_argument, cw_None, "", 1}},
-        {5, {e_remove_argument, cw_None}}
-      },
-      true,
-      true
+        {
+          {1, {e_move_argument, cw_None, "", 2}},
+          {2, {e_move_argument, cw_None, "", 1}},
+          {5, {e_remove_argument, cw_None}}
+        },
+        true,
+        true
+      }
     }
   },
   {sCudnnGetConvolutionBackwardDataWorkspaceSize,
     {
       {
-        {1, {e_move_argument, cw_None, "", 2}},
-        {2, {e_move_argument, cw_None, "", 1}},
-        {5, {e_remove_argument, cw_None}}
-      },
-      true,
-      true
+        {
+          {1, {e_move_argument, cw_None, "", 2}},
+          {2, {e_move_argument, cw_None, "", 1}},
+          {5, {e_remove_argument, cw_None}}
+        },
+        true,
+        true
+      }
     }
   },
   {sCudnnFindConvolutionForwardAlgorithmEx,
     {
       {
-        {13, {e_add_const_argument, cw_None, "true"}}
-      },
-      true,
-      true
+        {
+          {13, {e_add_const_argument, cw_None, "true"}}
+        },
+        true,
+        true
+      }
     }
   },
   {sCudnnSetPooling2dDescriptor,
     {
       {
-        {2, {e_remove_argument, cw_None}}
-      },
-      true,
-      true
+        {
+          {2, {e_remove_argument, cw_None}}
+        },
+        true,
+        true
+      }
     }
   },
   {sCudnnGetPooling2dDescriptor,
     {
       {
-        {2, {e_remove_argument, cw_None}}
-      },
-      true,
-      true
+        {
+          {2, {e_remove_argument, cw_None}}
+        },
+        true,
+        true
+      }
     }
   },
   {sCudnnSetPoolingNdDescriptor,
     {
       {
-        {2, {e_remove_argument, cw_None}}
-      },
-      true,
-      true
+        {
+          {2, {e_remove_argument, cw_None}}
+        },
+        true,
+        true
+      }
     }
   },
   {sCudnnGetPoolingNdDescriptor,
     {
       {
-        {3, {e_remove_argument, cw_None}}
-      },
-      true,
-      true
+        {
+          {3, {e_remove_argument, cw_None}}
+        },
+        true,
+        true
+      }
     }
   },
   {sCudnnSetLRNDescriptor,
     {
       {
-        {1, {e_add_const_argument, cw_None, "miopenLRNCrossChannel"}}
-      },
-      true,
-      true
+        {
+          {1, {e_add_const_argument, cw_None, "miopenLRNCrossChannel"}}
+        },
+        true,
+        true
+      }
     }
   },
   {sCudnnGetRNNDescriptor_v6,
     {
       {
-        {0, {e_remove_argument, cw_None}}
-      },
-      true,
-      true
+        {
+          {0, {e_remove_argument, cw_None}}
+        },
+        true,
+        true
+      }
     }
   },
   {sCudnnSetRNNDescriptor_v6,
     {
       {
-        {0, {e_remove_argument, cw_None}}
-      },
-      true,
-      true
+        {
+          {0, {e_remove_argument, cw_None}}
+        },
+        true,
+        true
+      }
     }
   },
   {sCudnnSoftmaxForward,
     {
       {
-        {1, {e_move_argument, cw_None, "", 9, 2}},
-      },
-      true,
-      true
+        {
+          {1, {e_move_argument, cw_None, "", 9, 2}},
+        },
+        true,
+        true
+      }
     }
   },
   {sCudnnSoftmaxBackward,
     {
       {
-        {1, {e_move_argument, cw_None, "", 11, 2}},
-      },
-      true,
-      true
+        {
+          {1, {e_move_argument, cw_None, "", 11, 2}},
+        },
+        true,
+        true
+      }
     }
   },
   {sCudnnConvolutionForward,
     {
       {
-        {8, {e_move_argument, cw_None, "", 13, 2}},
-      },
-      true,
-      true
+        {
+          {8, {e_move_argument, cw_None, "", 13, 2}},
+        },
+        true,
+        true
+      }
     }
   },
   {sCudnnConvolutionBackwardData,
     {
       {
-        {2, {e_move_argument, cw_None, "", 4, 2}},
-        {4, {e_move_argument, cw_None, "", 2, 2}},
-        {8, {e_move_argument, cw_None, "", 13, 2}},
-      },
-      true,
-      true
+        {
+          {2, {e_move_argument, cw_None, "", 4, 2}},
+          {4, {e_move_argument, cw_None, "", 2, 2}},
+          {8, {e_move_argument, cw_None, "", 13, 2}},
+        },
+        true,
+        true
+      }
     }
   },
   {sCudnnRNNBackwardWeights,
     {
       {
-        {9, {e_move_argument, cw_None, "", 11, 2}},
-        {11, {e_move_argument, cw_None, "", 9, 2}},
-      },
-      true,
-      true
+        {
+          {9, {e_move_argument, cw_None, "", 11, 2}},
+          {11, {e_move_argument, cw_None, "", 9, 2}},
+        },
+        true,
+        true
+      }
     }
   },
   {sCusparseZgpsvInterleavedBatch,
     {
       {
-        {9, {e_add_var_argument, cw_None, "", 10}}
-      },
-      true,
-      false
+        {
+          {9, {e_add_var_argument, cw_None, "", 10}}
+        },
+        true,
+        false
+      }
     }
   },
   {sCusparseCgpsvInterleavedBatch,
     {
       {
-        {9, {e_add_var_argument, cw_None, "", 10}}
-      },
-      true,
-      false
+        {
+          {9, {e_add_var_argument, cw_None, "", 10}}
+        },
+        true,
+        false
+      }
     }
   },
   {sCusparseDgpsvInterleavedBatch,
     {
       {
-        {9, {e_add_var_argument, cw_None, "", 10}}
-      },
-      true,
-      false
+        {
+          {9, {e_add_var_argument, cw_None, "", 10}}
+        },
+        true,
+        false
+      }
     }
   },
   {sCusparseSgpsvInterleavedBatch,
     {
       {
-        {9, {e_add_var_argument, cw_None, "", 10}}
-      },
-      true,
-      false
+        {
+          {9, {e_add_var_argument, cw_None, "", 10}}
+        },
+        true,
+        false
+      }
     }
   },
   {sCusparseZgpsvInterleavedBatch_bufferSizeExt,
     {
       {
-        {9, {e_add_var_argument, cw_None, "", 10}}
-      },
-      true,
-      false
+        {
+          {9, {e_add_var_argument, cw_None, "", 10}}
+        },
+        true,
+        false
+      }
     }
   },
   {sCusparseCgpsvInterleavedBatch_bufferSizeExt,
     {
       {
-        {9, {e_add_var_argument, cw_None, "", 10}}
-      },
-      true,
-      false
+        {
+          {9, {e_add_var_argument, cw_None, "", 10}}
+        },
+        true,
+        false
+      }
     }
   },
   {sCusparseDgpsvInterleavedBatch_bufferSizeExt,
     {
       {
-        {9, {e_add_var_argument, cw_None, "", 10}}
-      },
-      true,
-      false
+        {
+          {9, {e_add_var_argument, cw_None, "", 10}}
+        },
+        true,
+        false
+      }
     }
   },
   {sCusparseSgpsvInterleavedBatch_bufferSizeExt,
     {
       {
-        {9, {e_add_var_argument, cw_None, "", 10}}
-      },
-      true,
-      false
+        {
+          {9, {e_add_var_argument, cw_None, "", 10}}
+        },
+        true,
+        false
+      }
     }
   },
   {sCusparseZgtsvInterleavedBatch,
     {
       {
-        {7, {e_add_var_argument, cw_None, "", 8}}
-      },
-      true,
-      false
+        {
+          {7, {e_add_var_argument, cw_None, "", 8}}
+        },
+        true,
+        false
+      }
     }
   },
   {sCusparseCgtsvInterleavedBatch,
     {
       {
-        {7, {e_add_var_argument, cw_None, "", 8}}
-      },
-      true,
-      false
+        {
+          {7, {e_add_var_argument, cw_None, "", 8}}
+        },
+        true,
+        false
+      }
     }
   },
   {sCusparseDgtsvInterleavedBatch,
     {
       {
-        {7, {e_add_var_argument, cw_None, "", 8}}
-      },
-      true,
-      false
+        {
+          {7, {e_add_var_argument, cw_None, "", 8}}
+        },
+        true,
+        false
+      }
     }
   },
   {sCusparseSgtsvInterleavedBatch,
     {
       {
-        {7, {e_add_var_argument, cw_None, "", 8}}
-      },
-      true,
-      false
+        {
+          {7, {e_add_var_argument, cw_None, "", 8}}
+        },
+        true,
+        false
+      }
     }
   },
   {sCusparseZgtsvInterleavedBatch_bufferSizeExt,
     {
       {
-        {7, {e_add_var_argument, cw_None, "", 8}}
-      },
-      true,
-      false
+        {
+          {7, {e_add_var_argument, cw_None, "", 8}}
+        },
+        true,
+        false
+      }
     }
   },
   {sCusparseCgtsvInterleavedBatch_bufferSizeExt,
     {
       {
-        {7, {e_add_var_argument, cw_None, "", 8}}
-      },
-      true,
-      false
+        {
+          {7, {e_add_var_argument, cw_None, "", 8}}
+        },
+        true,
+        false
+      }
     }
   },
   {sCusparseDgtsvInterleavedBatch_bufferSizeExt,
     {
       {
-        {7, {e_add_var_argument, cw_None, "", 8}}
-      },
-      true,
-      false
+        {
+          {7, {e_add_var_argument, cw_None, "", 8}}
+        },
+        true,
+        false
+      }
     }
   },
   {sCusparseSgtsvInterleavedBatch_bufferSizeExt,
     {
       {
-        {7, {e_add_var_argument, cw_None, "", 8}}
-      },
-      true,
-      false
+        {
+          {7, {e_add_var_argument, cw_None, "", 8}}
+        },
+        true,
+        false
+      }
     }
   },
   {sCusparseZcsrilu02,
     {
       {
-        {8, {e_replace_argument_with_const, cw_None, "rocsparse_solve_policy_auto"}}
-      },
-      true,
-      false
+        {
+          {8, {e_replace_argument_with_const, cw_None, "rocsparse_solve_policy_auto"}}
+        },
+        true,
+        false
+      }
     }
   },
   {sCusparseCcsrilu02,
     {
       {
-        {8, {e_replace_argument_with_const, cw_None, "rocsparse_solve_policy_auto"}}
-      },
-      true,
-      false
+        {
+          {8, {e_replace_argument_with_const, cw_None, "rocsparse_solve_policy_auto"}}
+        },
+        true,
+        false
+      }
     }
   },
   {sCusparseDcsrilu02,
     {
       {
-        {8, {e_replace_argument_with_const, cw_None, "rocsparse_solve_policy_auto"}}
-      },
-      true,
-      false
+        {
+          {8, {e_replace_argument_with_const, cw_None, "rocsparse_solve_policy_auto"}}
+        },
+        true,
+        false
+      }
     }
   },
   {sCusparseScsrilu02,
     {
       {
-        {8, {e_replace_argument_with_const, cw_None, "rocsparse_solve_policy_auto"}}
-      },
-      true,
-      false
+        {
+          {8, {e_replace_argument_with_const, cw_None, "rocsparse_solve_policy_auto"}}
+        },
+        true,
+        false
+      }
     }
   },
   {sCusparseZcsrilu02_analysis,
     {
       {
-        {8, {e_replace_argument_with_const, cw_None, "rocsparse_analysis_policy_force"}},
-        {9, {e_add_const_argument, cw_None, "rocsparse_solve_policy_auto"}}
-      },
-      true,
-      false
+        {
+          {8, {e_replace_argument_with_const, cw_None, "rocsparse_analysis_policy_force"}},
+          {9, {e_add_const_argument, cw_None, "rocsparse_solve_policy_auto"}}
+        },
+        true,
+        false
+      }
     }
   },
   {sCusparseCcsrilu02_analysis,
     {
       {
-        {8, {e_replace_argument_with_const, cw_None, "rocsparse_analysis_policy_force"}},
-        {9, {e_add_const_argument, cw_None, "rocsparse_solve_policy_auto"}}
-      },
-      true,
-      false
+        {
+          {8, {e_replace_argument_with_const, cw_None, "rocsparse_analysis_policy_force"}},
+          {9, {e_add_const_argument, cw_None, "rocsparse_solve_policy_auto"}}
+        },
+        true,
+        false
+      }
     }
   },
   {sCusparseDcsrilu02_analysis,
     {
       {
-        {8, {e_replace_argument_with_const, cw_None, "rocsparse_analysis_policy_force"}},
-        {9, {e_add_const_argument, cw_None, "rocsparse_solve_policy_auto"}}
-      },
-      true,
-      false
+        {
+          {8, {e_replace_argument_with_const, cw_None, "rocsparse_analysis_policy_force"}},
+          {9, {e_add_const_argument, cw_None, "rocsparse_solve_policy_auto"}}
+        },
+        true,
+        false
+      }
     }
   },
   {sCusparseScsrilu02_analysis,
     {
       {
-        {8, {e_replace_argument_with_const, cw_None, "rocsparse_analysis_policy_force"}},
-        {9, {e_add_const_argument, cw_None, "rocsparse_solve_policy_auto"}}
-      },
-      true,
-      false
+        {
+          {8, {e_replace_argument_with_const, cw_None, "rocsparse_analysis_policy_force"}},
+          {9, {e_add_const_argument, cw_None, "rocsparse_solve_policy_auto"}}
+        },
+        true,
+        false
+      }
     }
   },
   {sCusparseZcsric02_analysis,
     {
       {
-        {8, {e_replace_argument_with_const, cw_None, "rocsparse_analysis_policy_force"}},
-        {9, {e_add_const_argument, cw_None, "rocsparse_solve_policy_auto"}}
-      },
-      true,
-      false
+        {
+          {8, {e_replace_argument_with_const, cw_None, "rocsparse_analysis_policy_force"}},
+          {9, {e_add_const_argument, cw_None, "rocsparse_solve_policy_auto"}}
+        },
+        true,
+        false
+      }
     }
   },
   {sCusparseCcsric02_analysis,
     {
       {
-        {8, {e_replace_argument_with_const, cw_None, "rocsparse_analysis_policy_force"}},
-        {9, {e_add_const_argument, cw_None, "rocsparse_solve_policy_auto"}}
-      },
-      true,
-      false
+        {
+          {8, {e_replace_argument_with_const, cw_None, "rocsparse_analysis_policy_force"}},
+          {9, {e_add_const_argument, cw_None, "rocsparse_solve_policy_auto"}}
+        },
+        true,
+        false
+      }
     }
   },
   {sCusparseDcsric02_analysis,
     {
       {
-        {8, {e_replace_argument_with_const, cw_None, "rocsparse_analysis_policy_force"}},
-        {9, {e_add_const_argument, cw_None, "rocsparse_solve_policy_auto"}}
-      },
-      true,
-      false
+        {
+          {8, {e_replace_argument_with_const, cw_None, "rocsparse_analysis_policy_force"}},
+          {9, {e_add_const_argument, cw_None, "rocsparse_solve_policy_auto"}}
+        },
+        true,
+        false
+      }
     }
   },
   {sCusparseScsric02_analysis,
     {
       {
-        {8, {e_replace_argument_with_const, cw_None, "rocsparse_analysis_policy_force"}},
-        {9, {e_add_const_argument, cw_None, "rocsparse_solve_policy_auto"}}
-      },
-      true,
-      false
+        {
+          {8, {e_replace_argument_with_const, cw_None, "rocsparse_analysis_policy_force"}},
+          {9, {e_add_const_argument, cw_None, "rocsparse_solve_policy_auto"}}
+        },
+        true,
+        false
+      }
     }
   },
   {sCusparseZcsric02_bufferSize,
     {
       {
-        {8, {e_reinterpret_cast_size_t, cw_None}}
-      },
-      true,
-      false
+        {
+          {8, {e_reinterpret_cast_size_t, cw_None}}
+        },
+        true,
+        false
+      }
     }
   },
   {sCusparseCcsric02_bufferSize,
     {
       {
-        {8, {e_reinterpret_cast_size_t, cw_None}}
-      },
-      true,
-      false
+        {
+          {8, {e_reinterpret_cast_size_t, cw_None}}
+        },
+        true,
+        false
+      }
     }
   },
   {sCusparseDcsric02_bufferSize,
     {
       {
-        {8, {e_reinterpret_cast_size_t, cw_None}}
-      },
-      true,
-      false
+        {
+          {8, {e_reinterpret_cast_size_t, cw_None}}
+        },
+        true,
+        false
+      }
     }
   },
   {sCusparseScsric02_bufferSize,
     {
       {
-        {8, {e_reinterpret_cast_size_t, cw_None}}
-      },
-      true,
-      false
+        {
+          {8, {e_reinterpret_cast_size_t, cw_None}}
+        },
+        true,
+        false
+      }
     }
   },
   {sCusparseZbsrilu02,
     {
       {
-        {10, {e_replace_argument_with_const, cw_None, "rocsparse_solve_policy_auto"}}
-      },
-      true,
-      false
+        {
+          {10, {e_replace_argument_with_const, cw_None, "rocsparse_solve_policy_auto"}}
+        },
+        true,
+        false
+      }
     }
   },
   {sCusparseCbsrilu02,
     {
       {
-        {10, {e_replace_argument_with_const, cw_None, "rocsparse_solve_policy_auto"}}
-      },
-      true,
-      false
+        {
+          {10, {e_replace_argument_with_const, cw_None, "rocsparse_solve_policy_auto"}}
+        },
+        true,
+        false
+      }
     }
   },
   {sCusparseDbsrilu02,
     {
       {
-        {10, {e_replace_argument_with_const, cw_None, "rocsparse_solve_policy_auto"}}
-      },
-      true,
-      false
+        {
+          {10, {e_replace_argument_with_const, cw_None, "rocsparse_solve_policy_auto"}}
+        },
+        true,
+        false
+      }
     }
   },
   {sCusparseSbsrilu02,
     {
       {
-        {10, {e_replace_argument_with_const, cw_None, "rocsparse_solve_policy_auto"}}
-      },
-      true,
-      false
+        {
+          {10, {e_replace_argument_with_const, cw_None, "rocsparse_solve_policy_auto"}}
+        },
+        true,
+        false
+      }
     }
   },
   {sCusparseZbsrilu02_analysis,
     {
       {
-        {10, {e_replace_argument_with_const, cw_None, "rocsparse_analysis_policy_force"}},
-        {11, {e_add_const_argument, cw_None, "rocsparse_solve_policy_auto"}}
-      },
-      true,
-      false
+        {
+          {10, {e_replace_argument_with_const, cw_None, "rocsparse_analysis_policy_force"}},
+          {11, {e_add_const_argument, cw_None, "rocsparse_solve_policy_auto"}}
+        },
+        true,
+        false
+      }
     }
   },
   {sCusparseCbsrilu02_analysis,
     {
       {
-        {10, {e_replace_argument_with_const, cw_None, "rocsparse_analysis_policy_force"}},
-        {11, {e_add_const_argument, cw_None, "rocsparse_solve_policy_auto"}}
-      },
-      true,
-      false
+        {
+          {10, {e_replace_argument_with_const, cw_None, "rocsparse_analysis_policy_force"}},
+          {11, {e_add_const_argument, cw_None, "rocsparse_solve_policy_auto"}}
+        },
+        true,
+        false
+      }
     }
   },
   {sCusparseDbsrilu02_analysis,
     {
       {
-        {10, {e_replace_argument_with_const, cw_None, "rocsparse_analysis_policy_force"}},
-        {11, {e_add_const_argument, cw_None, "rocsparse_solve_policy_auto"}}
-      },
-      true,
-      false
+        {
+          {10, {e_replace_argument_with_const, cw_None, "rocsparse_analysis_policy_force"}},
+          {11, {e_add_const_argument, cw_None, "rocsparse_solve_policy_auto"}}
+        },
+        true,
+        false
+      }
     }
   },
   {sCusparseSbsrilu02_analysis,
     {
       {
-        {10, {e_replace_argument_with_const, cw_None, "rocsparse_analysis_policy_force"}},
-        {11, {e_add_const_argument, cw_None, "rocsparse_solve_policy_auto"}}
-      },
-      true,
-      false
+        {
+          {10, {e_replace_argument_with_const, cw_None, "rocsparse_analysis_policy_force"}},
+          {11, {e_add_const_argument, cw_None, "rocsparse_solve_policy_auto"}}
+        },
+        true,
+        false
+      }
     }
   },
   {sCusparseZbsric02,
     {
       {
-        {10, {e_replace_argument_with_const, cw_None, "rocsparse_solve_policy_auto"}}
-      },
-      true,
-      false
+        {
+          {10, {e_replace_argument_with_const, cw_None, "rocsparse_solve_policy_auto"}}
+        },
+        true,
+        false
+      }
     }
   },
   {sCusparseCbsric02,
     {
       {
-        {10, {e_replace_argument_with_const, cw_None, "rocsparse_solve_policy_auto"}}
-      },
-      true,
-      false
+        {
+          {10, {e_replace_argument_with_const, cw_None, "rocsparse_solve_policy_auto"}}
+        },
+        true,
+        false
+      }
     }
   },
   {sCusparseDbsric02,
     {
       {
-        {10, {e_replace_argument_with_const, cw_None, "rocsparse_solve_policy_auto"}}
-      },
-      true,
-      false
+        {
+          {10, {e_replace_argument_with_const, cw_None, "rocsparse_solve_policy_auto"}}
+        },
+        true,
+        false
+      }
     }
   },
   {sCusparseSbsric02,
     {
       {
-        {10, {e_replace_argument_with_const, cw_None, "rocsparse_solve_policy_auto"}}
-      },
-      true,
-      false
+        {
+          {10, {e_replace_argument_with_const, cw_None, "rocsparse_solve_policy_auto"}}
+        },
+        true,
+        false
+      }
     }
   },
   {sCusparseZbsric02_analysis,
     {
       {
-        {10, {e_replace_argument_with_const, cw_None, "rocsparse_analysis_policy_force"}},
-        {11, {e_add_const_argument, cw_None, "rocsparse_solve_policy_auto"}}
-      },
-      true,
-      false
+        {
+          {10, {e_replace_argument_with_const, cw_None, "rocsparse_analysis_policy_force"}},
+          {11, {e_add_const_argument, cw_None, "rocsparse_solve_policy_auto"}}
+        },
+        true,
+        false
+      }
     }
   },
   {sCusparseCbsric02_analysis,
     {
       {
-        {10, {e_replace_argument_with_const, cw_None, "rocsparse_analysis_policy_force"}},
-        {11, {e_add_const_argument, cw_None, "rocsparse_solve_policy_auto"}}
-      },
-      true,
-      false
+        {
+          {10, {e_replace_argument_with_const, cw_None, "rocsparse_analysis_policy_force"}},
+          {11, {e_add_const_argument, cw_None, "rocsparse_solve_policy_auto"}}
+        },
+        true,
+        false
+      }
     }
   },
   {sCusparseDbsric02_analysis,
     {
       {
-        {10, {e_replace_argument_with_const, cw_None, "rocsparse_analysis_policy_force"}},
-        {11, {e_add_const_argument, cw_None, "rocsparse_solve_policy_auto"}}
-      },
-      true,
-      false
+        {
+          {10, {e_replace_argument_with_const, cw_None, "rocsparse_analysis_policy_force"}},
+          {11, {e_add_const_argument, cw_None, "rocsparse_solve_policy_auto"}}
+        },
+        true,
+        false
+      }
     }
   },
   {sCusparseSbsric02_analysis,
     {
       {
-        {10, {e_replace_argument_with_const, cw_None, "rocsparse_analysis_policy_force"}},
-        {11, {e_add_const_argument, cw_None, "rocsparse_solve_policy_auto"}}
-      },
-      true,
-      false
+        {
+          {10, {e_replace_argument_with_const, cw_None, "rocsparse_analysis_policy_force"}},
+          {11, {e_add_const_argument, cw_None, "rocsparse_solve_policy_auto"}}
+        },
+        true,
+        false
+      }
     }
   },
   {sCusparseZbsric02_bufferSize,
     {
       {
-        {10, {e_reinterpret_cast_size_t, cw_None}}
-      },
-      true,
-      false
+        {
+          {10, {e_reinterpret_cast_size_t, cw_None}}
+        },
+        true,
+        false
+      }
     }
   },
   {sCusparseCbsric02_bufferSize,
     {
       {
-        {10, {e_reinterpret_cast_size_t, cw_None}}
-      },
-      true,
-      false
+        {
+          {10, {e_reinterpret_cast_size_t, cw_None}}
+        },
+        true,
+        false
+      }
     }
   },
   {sCusparseDbsric02_bufferSize,
     {
       {
-        {10, {e_reinterpret_cast_size_t, cw_None}}
-      },
-      true,
-      false
+        {
+          {10, {e_reinterpret_cast_size_t, cw_None}}
+        },
+        true,
+        false
+      }
     }
   },
   {sCusparseSbsric02_bufferSize,
     {
       {
-        {10, {e_reinterpret_cast_size_t, cw_None}}
-      },
-      true,
-      false
+        {
+          {10, {e_reinterpret_cast_size_t, cw_None}}
+        },
+        true,
+        false
+      }
     }
   },
   {sCusparseZbsrsm2_bufferSize,
     {
       {
-        {13, {e_reinterpret_cast_size_t, cw_None}}
-      },
-      true,
-      false
+        {
+          {13, {e_reinterpret_cast_size_t, cw_None}}
+        },
+        true,
+        false
+      }
     }
   },
   {sCusparseCbsrsm2_bufferSize,
     {
       {
-        {13, {e_reinterpret_cast_size_t, cw_None}}
-      },
-      true,
-      false
+        {
+          {13, {e_reinterpret_cast_size_t, cw_None}}
+        },
+        true,
+        false
+      }
     }
   },
   {sCusparseDbsrsm2_bufferSize,
     {
       {
-        {13, {e_reinterpret_cast_size_t, cw_None}}
-      },
-      true,
-      false
+        {
+          {13, {e_reinterpret_cast_size_t, cw_None}}
+        },
+        true,
+        false
+      }
     }
   },
   {sCusparseSbsrsm2_bufferSize,
     {
       {
-        {13, {e_reinterpret_cast_size_t, cw_None}}
-      },
-      true,
-      false
+        {
+          {13, {e_reinterpret_cast_size_t, cw_None}}
+        },
+        true,
+        false
+      }
     }
   },
   {sCusparseZcsrsm2_solve,
     {
       {
-        {15, {e_replace_argument_with_const, cw_None, "rocsparse_solve_policy_auto"}}
-      },
-      true,
-      false
+        {
+          {15, {e_replace_argument_with_const, cw_None, "rocsparse_solve_policy_auto"}}
+        },
+        true,
+        false
+      }
     }
   },
   {sCusparseCcsrsm2_solve,
     {
       {
-        {15, {e_replace_argument_with_const, cw_None, "rocsparse_solve_policy_auto"}}
-      },
-      true,
-      false
+        {
+          {15, {e_replace_argument_with_const, cw_None, "rocsparse_solve_policy_auto"}}
+        },
+        true,
+        false
+      }
     }
   },
   {sCusparseDcsrsm2_solve,
     {
       {
-        {15, {e_replace_argument_with_const, cw_None, "rocsparse_solve_policy_auto"}}
-      },
-      true,
-      false
+        {
+          {15, {e_replace_argument_with_const, cw_None, "rocsparse_solve_policy_auto"}}
+        },
+        true,
+        false
+      }
     }
   },
   {sCusparseScsrsm2_solve,
     {
       {
-        {15, {e_replace_argument_with_const, cw_None, "rocsparse_solve_policy_auto"}}
-      },
-      true,
-      false
+        {
+          {15, {e_replace_argument_with_const, cw_None, "rocsparse_solve_policy_auto"}}
+        },
+        true,
+        false
+      }
     }
   },
   {sCusparseZcsrsm2_analysis,
     {
       {
-        {15, {e_replace_argument_with_const, cw_None, "rocsparse_analysis_policy_force"}},
-        {16, {e_add_const_argument, cw_None, "rocsparse_solve_policy_auto"}}
-      },
-      true,
-      false
+        {
+          {15, {e_replace_argument_with_const, cw_None, "rocsparse_analysis_policy_force"}},
+          {16, {e_add_const_argument, cw_None, "rocsparse_solve_policy_auto"}}
+        },
+        true,
+        false
+      }
     }
   },
   {sCusparseCcsrsm2_analysis,
     {
       {
-        {15, {e_replace_argument_with_const, cw_None, "rocsparse_analysis_policy_force"}},
-        {16, {e_add_const_argument, cw_None, "rocsparse_solve_policy_auto"}}
-      },
-      true,
-      false
+        {
+          {15, {e_replace_argument_with_const, cw_None, "rocsparse_analysis_policy_force"}},
+          {16, {e_add_const_argument, cw_None, "rocsparse_solve_policy_auto"}}
+        },
+        true,
+        false
+      }
     }
   },
   {sCusparseDcsrsm2_analysis,
     {
       {
-        {15, {e_replace_argument_with_const, cw_None, "rocsparse_analysis_policy_force"}},
-        {16, {e_add_const_argument, cw_None, "rocsparse_solve_policy_auto"}}
-      },
-      true,
-      false
+        {
+          {15, {e_replace_argument_with_const, cw_None, "rocsparse_analysis_policy_force"}},
+          {16, {e_add_const_argument, cw_None, "rocsparse_solve_policy_auto"}}
+        },
+        true,
+        false
+      }
     }
   },
   {sCusparseScsrsm2_analysis,
     {
       {
-        {15, {e_replace_argument_with_const, cw_None, "rocsparse_analysis_policy_force"}},
-        {16, {e_add_const_argument, cw_None, "rocsparse_solve_policy_auto"}}
-      },
-      true,
-      false
+        {
+          {15, {e_replace_argument_with_const, cw_None, "rocsparse_analysis_policy_force"}},
+          {16, {e_add_const_argument, cw_None, "rocsparse_solve_policy_auto"}}
+        },
+        true,
+        false
+      }
     }
   },
   {sCusparseScsrsm2_bufferSizeExt,
     {
       {
-        {15, {e_replace_argument_with_const, cw_None, "rocsparse_solve_policy_auto"}}
-      },
-      true,
-      false
+        {
+          {15, {e_replace_argument_with_const, cw_None, "rocsparse_solve_policy_auto"}}
+        },
+        true,
+        false
+      }
     }
   },
   {sCusparseDcsrsm2_bufferSizeExt,
     {
       {
-        {15, {e_replace_argument_with_const, cw_None, "rocsparse_solve_policy_auto"}}
-      },
-      true,
-      false
+        {
+          {15, {e_replace_argument_with_const, cw_None, "rocsparse_solve_policy_auto"}}
+        },
+        true,
+        false
+      }
     }
   },
   {sCusparseCcsrsm2_bufferSizeExt,
     {
       {
-        {15, {e_replace_argument_with_const, cw_None, "rocsparse_solve_policy_auto"}}
-      },
-      true,
-      false
+        {
+          {15, {e_replace_argument_with_const, cw_None, "rocsparse_solve_policy_auto"}}
+        },
+        true,
+        false
+      }
     }
   },
   {sCusparseZcsrsm2_bufferSizeExt,
     {
       {
-        {15, {e_replace_argument_with_const, cw_None, "rocsparse_solve_policy_auto"}}
-      },
-      true,
-      false
+        {
+          {15, {e_replace_argument_with_const, cw_None, "rocsparse_solve_policy_auto"}}
+        },
+        true,
+        false
+      }
     }
   },
   {sCusparseZgemvi_bufferSize,
     {
       {
-        {5, {e_reinterpret_cast_size_t, cw_None}}
-      },
-      true,
-      false
+        {
+          {5, {e_reinterpret_cast_size_t, cw_None}}
+        },
+        true,
+        false
+      }
     }
   },
   {sCusparseCgemvi_bufferSize,
     {
       {
-        {5, {e_reinterpret_cast_size_t, cw_None}}
-      },
-      true,
-      false
+        {
+          {5, {e_reinterpret_cast_size_t, cw_None}}
+        },
+        true,
+        false
+      }
     }
   },
   {sCusparseDgemvi_bufferSize,
     {
       {
-        {5, {e_reinterpret_cast_size_t, cw_None}}
-      },
-      true,
-      false
+        {
+          {5, {e_reinterpret_cast_size_t, cw_None}}
+        },
+        true,
+        false
+      }
     }
   },
   {sCusparseSgemvi_bufferSize,
     {
       {
-        {5, {e_reinterpret_cast_size_t, cw_None}}
-      },
-      true,
-      false
+        {
+          {5, {e_reinterpret_cast_size_t, cw_None}}
+        },
+        true,
+        false
+      }
     }
   },
   {sCusparseZcsrsv2_solve,
     {
       {
-        {12, {e_replace_argument_with_const, cw_None, "rocsparse_solve_policy_auto"}}
-      },
-      true,
-      false
+        {
+          {12, {e_replace_argument_with_const, cw_None, "rocsparse_solve_policy_auto"}}
+        },
+        true,
+        false
+      }
     }
   },
   {sCusparseCcsrsv2_solve,
     {
       {
-        {12, {e_replace_argument_with_const, cw_None, "rocsparse_solve_policy_auto"}}
-      },
-      true,
-      false
+        {
+          {12, {e_replace_argument_with_const, cw_None, "rocsparse_solve_policy_auto"}}
+        },
+        true,
+        false
+      }
     }
   },
   {sCusparseDcsrsv2_solve,
     {
       {
-        {12, {e_replace_argument_with_const, cw_None, "rocsparse_solve_policy_auto"}}
-      },
-      true,
-      false
+        {
+          {12, {e_replace_argument_with_const, cw_None, "rocsparse_solve_policy_auto"}}
+        },
+        true,
+        false
+      }
     }
   },
   {sCusparseScsrsv2_solve,
     {
       {
-        {12, {e_replace_argument_with_const, cw_None, "rocsparse_solve_policy_auto"}}
-      },
-      true,
-      false
+        {
+          {12, {e_replace_argument_with_const, cw_None, "rocsparse_solve_policy_auto"}}
+        },
+        true,
+        false
+      }
     }
   },
   {sCusparseZcsrsv2_analysis,
     {
       {
-        {9, {e_replace_argument_with_const, cw_None, "rocsparse_analysis_policy_force"}},
-        {10, {e_add_const_argument, cw_None, "rocsparse_solve_policy_auto"}}
-      },
-      true,
-      false
+        {
+          {9, {e_replace_argument_with_const, cw_None, "rocsparse_analysis_policy_force"}},
+          {10, {e_add_const_argument, cw_None, "rocsparse_solve_policy_auto"}}
+        },
+        true,
+        false
+      }
     }
   },
   {sCusparseCcsrsv2_analysis,
     {
       {
-        {9, {e_replace_argument_with_const, cw_None, "rocsparse_analysis_policy_force"}},
-        {10, {e_add_const_argument, cw_None, "rocsparse_solve_policy_auto"}}
-      },
-      true,
-      false
+        {
+          {9, {e_replace_argument_with_const, cw_None, "rocsparse_analysis_policy_force"}},
+          {10, {e_add_const_argument, cw_None, "rocsparse_solve_policy_auto"}}
+        },
+        true,
+        false
+      }
     }
   },
   {sCusparseDcsrsv2_analysis,
     {
       {
-        {9, {e_replace_argument_with_const, cw_None, "rocsparse_analysis_policy_force"}},
-        {10, {e_add_const_argument, cw_None, "rocsparse_solve_policy_auto"}}
-      },
-      true,
-      false
+        {
+          {9, {e_replace_argument_with_const, cw_None, "rocsparse_analysis_policy_force"}},
+          {10, {e_add_const_argument, cw_None, "rocsparse_solve_policy_auto"}}
+        },
+        true,
+        false
+      }
     }
   },
   {sCusparseScsrsv2_analysis,
     {
       {
-        {9, {e_replace_argument_with_const, cw_None, "rocsparse_analysis_policy_force"}},
-        {10, {e_add_const_argument, cw_None, "rocsparse_solve_policy_auto"}}
-      },
-      true,
-      false
+        {
+          {9, {e_replace_argument_with_const, cw_None, "rocsparse_analysis_policy_force"}},
+          {10, {e_add_const_argument, cw_None, "rocsparse_solve_policy_auto"}}
+        },
+        true,
+        false
+      }
     }
   },
   {sCusparseZcsrmv,
     {
       {
-        {10, {e_add_const_argument, cw_None, "nullptr"}}
-      },
-      true,
-      false
+        {
+          {10, {e_add_const_argument, cw_None, "nullptr"}}
+        },
+        true,
+        false
+      }
     }
   },
   {sCusparseCcsrmv,
     {
       {
-        {10, {e_add_const_argument, cw_None, "nullptr"}}
-      },
-      true,
-      false
+        {
+          {10, {e_add_const_argument, cw_None, "nullptr"}}
+        },
+        true,
+        false
+      }
     }
   },
   {sCusparseDcsrmv,
     {
       {
-        {10, {e_add_const_argument, cw_None, "nullptr"}}
-      },
-      true,
-      false
+        {
+          {10, {e_add_const_argument, cw_None, "nullptr"}}
+        },
+        true,
+        false
+      }
     }
   },
   {sCusparseScsrmv,
     {
       {
-        {10, {e_add_const_argument, cw_None, "nullptr"}}
-      },
-      true,
-      false
+        {
+          {10, {e_add_const_argument, cw_None, "nullptr"}}
+        },
+        true,
+        false
+      }
     }
   },
   {sCusparseZbsrsv2_solve,
     {
       {
-        {14, {e_replace_argument_with_const, cw_None, "rocsparse_solve_policy_auto"}}
-      },
-      true,
-      false
+        {
+          {14, {e_replace_argument_with_const, cw_None, "rocsparse_solve_policy_auto"}}
+        },
+        true,
+        false
+      }
     }
   },
   {sCusparseCbsrsv2_solve,
     {
       {
-        {14, {e_replace_argument_with_const, cw_None, "rocsparse_solve_policy_auto"}}
-      },
-      true,
-      false
+        {
+          {14, {e_replace_argument_with_const, cw_None, "rocsparse_solve_policy_auto"}}
+        },
+        true,
+        false
+      }
     }
   },
   {sCusparseDbsrsv2_solve,
     {
       {
-        {14, {e_replace_argument_with_const, cw_None, "rocsparse_solve_policy_auto"}}
-      },
-      true,
-      false
+        {
+          {14, {e_replace_argument_with_const, cw_None, "rocsparse_solve_policy_auto"}}
+        },
+        true,
+        false
+      }
     }
   },
   {sCusparseSbsrsv2_solve,
     {
       {
-        {14, {e_replace_argument_with_const, cw_None, "rocsparse_solve_policy_auto"}}
-      },
-      true,
-      false
+        {
+          {14, {e_replace_argument_with_const, cw_None, "rocsparse_solve_policy_auto"}}
+        },
+        true,
+        false
+      }
     }
   },
   {sCusparseZbsrsv2_analysis,
     {
       {
-        {11, {e_replace_argument_with_const, cw_None, "rocsparse_analysis_policy_force"}},
-        {12, {e_add_const_argument, cw_None, "rocsparse_solve_policy_auto"}}
-      },
-      true,
-      false
+        {
+          {11, {e_replace_argument_with_const, cw_None, "rocsparse_analysis_policy_force"}},
+          {12, {e_add_const_argument, cw_None, "rocsparse_solve_policy_auto"}}
+        },
+        true,
+        false
+      }
     }
   },
   {sCusparseCbsrsv2_analysis,
     {
       {
-        {11, {e_replace_argument_with_const, cw_None, "rocsparse_analysis_policy_force"}},
-        {12, {e_add_const_argument, cw_None, "rocsparse_solve_policy_auto"}}
-      },
-      true,
-      false
+        {
+          {11, {e_replace_argument_with_const, cw_None, "rocsparse_analysis_policy_force"}},
+          {12, {e_add_const_argument, cw_None, "rocsparse_solve_policy_auto"}}
+        },
+        true,
+        false
+      }
     }
   },
   {sCusparseDbsrsv2_analysis,
     {
       {
-        {11, {e_replace_argument_with_const, cw_None, "rocsparse_analysis_policy_force"}},
-        {12, {e_add_const_argument, cw_None, "rocsparse_solve_policy_auto"}}
-      },
-      true,
-      false
+        {
+          {11, {e_replace_argument_with_const, cw_None, "rocsparse_analysis_policy_force"}},
+          {12, {e_add_const_argument, cw_None, "rocsparse_solve_policy_auto"}}
+        },
+        true,
+        false
+      }
     }
   },
   {sCusparseSbsrsv2_analysis,
     {
       {
-        {11, {e_replace_argument_with_const, cw_None, "rocsparse_analysis_policy_force"}},
-        {12, {e_add_const_argument, cw_None, "rocsparse_solve_policy_auto"}}
-      },
-      true,
-      false
+        {
+          {11, {e_replace_argument_with_const, cw_None, "rocsparse_analysis_policy_force"}},
+          {12, {e_add_const_argument, cw_None, "rocsparse_solve_policy_auto"}}
+        },
+        true,
+        false
+      }
     }
   },
   {sCusparseZcsrmm,
     {
       {
-        {2, {e_add_const_argument, cw_None, "rocsparse_operation_none"}}
-      },
-      true,
-      false
+        {
+          {2, {e_add_const_argument, cw_None, "rocsparse_operation_none"}}
+        },
+        true,
+        false
+      }
     }
   },
   {sCusparseCcsrmm,
     {
       {
-        {2, {e_add_const_argument, cw_None, "rocsparse_operation_none"}}
-      },
-      true,
-      false
+        {
+          {2, {e_add_const_argument, cw_None, "rocsparse_operation_none"}}
+        },
+        true,
+        false
+      }
     }
   },
   {sCusparseDcsrmm,
     {
       {
-        {2, {e_add_const_argument, cw_None, "rocsparse_operation_none"}}
-      },
-      true,
-      false
+        {
+          {2, {e_add_const_argument, cw_None, "rocsparse_operation_none"}}
+        },
+        true,
+        false
+      }
     }
   },
   {sCusparseScsrmm,
     {
       {
-        {2, {e_add_const_argument, cw_None, "rocsparse_operation_none"}}
-      },
-      true,
-      false
+        {
+          {2, {e_add_const_argument, cw_None, "rocsparse_operation_none"}}
+        },
+        true,
+        false
+      }
     }
   },
   {sCusparseZcsrgeam2,
     {
       {
-        {19, {e_remove_argument, cw_None}}
-      },
-      true,
-      false
+        {
+          {19, {e_remove_argument, cw_None}}
+        },
+        true,
+        false
+      }
     }
   },
   {sCusparseCcsrgeam2,
     {
       {
-        {19, {e_remove_argument, cw_None}}
-      },
-      true,
-      false
+        {
+          {19, {e_remove_argument, cw_None}}
+        },
+        true,
+        false
+      }
     }
   },
   {sCusparseDcsrgeam2,
     {
       {
-        {19, {e_remove_argument, cw_None}}
-      },
-      true,
-      false
+        {
+          {19, {e_remove_argument, cw_None}}
+        },
+        true,
+        false
+      }
     }
   },
   {sCusparseScsrgeam2,
     {
       {
-        {19, {e_remove_argument, cw_None}}
-      },
-      true,
-      false
+        {
+          {19, {e_remove_argument, cw_None}}
+        },
+        true,
+        false
+      }
     }
   },
   {sCusparseZbsrsv2_bufferSize,
     {
       {
-        {11, {e_reinterpret_cast_size_t, cw_None}}
-      },
-      true,
-      false
+        {
+          {11, {e_reinterpret_cast_size_t, cw_None}}
+        },
+        true,
+        false
+      }
     }
   },
   {sCusparseCbsrsv2_bufferSize,
     {
       {
-        {11, {e_reinterpret_cast_size_t, cw_None}}
-      },
-      true,
-      false
+        {
+          {11, {e_reinterpret_cast_size_t, cw_None}}
+        },
+        true,
+        false
+      }
     }
   },
   {sCusparseDbsrsv2_bufferSize,
     {
       {
-        {11, {e_reinterpret_cast_size_t, cw_None}}
-      },
-      true,
-      false
+        {
+          {11, {e_reinterpret_cast_size_t, cw_None}}
+        },
+        true,
+        false
+      }
     }
   },
   {sCusparseSbsrsv2_bufferSize,
     {
       {
-        {11, {e_reinterpret_cast_size_t, cw_None}}
-      },
-      true,
-      false
+        {
+          {11, {e_reinterpret_cast_size_t, cw_None}}
+        },
+        true,
+        false
+      }
     }
   },
   {sCusparseZcsrsv2_bufferSize,
     {
       {
-        {9, {e_reinterpret_cast_size_t, cw_None}}
-      },
-      true,
-      false
+        {
+          {9, {e_reinterpret_cast_size_t, cw_None}}
+        },
+        true,
+        false
+      }
     }
   },
   {sCusparseCcsrsv2_bufferSize,
     {
       {
-        {9, {e_reinterpret_cast_size_t, cw_None}}
-      },
-      true,
-      false
+        {
+          {9, {e_reinterpret_cast_size_t, cw_None}}
+        },
+        true,
+        false
+      }
     }
   },
   {sCusparseDcsrsv2_bufferSize,
     {
       {
-        {9, {e_reinterpret_cast_size_t, cw_None}}
-      },
-      true,
-      false
+        {
+          {9, {e_reinterpret_cast_size_t, cw_None}}
+        },
+        true,
+        false
+      }
     }
   },
   {sCusparseScsrsv2_bufferSize,
     {
       {
-        {9, {e_reinterpret_cast_size_t, cw_None}}
-      },
-      true,
-      false
+        {
+          {9, {e_reinterpret_cast_size_t, cw_None}}
+        },
+        true,
+        false
+      }
     }
   },
   {sCusparseZcsrgemm2,
     {
       {
-        {1, {e_add_const_argument, cw_None, "rocsparse_operation_none, rocsparse_operation_none"}}
-      },
-      true,
-      false
+        {
+          {1, {e_add_const_argument, cw_None, "rocsparse_operation_none, rocsparse_operation_none"}}
+        },
+        true,
+        false
+      }
     }
   },
   {sCusparseCcsrgemm2,
     {
       {
-        {1, {e_add_const_argument, cw_None, "rocsparse_operation_none, rocsparse_operation_none"}}
-      },
-      true,
-      false
+        {
+          {1, {e_add_const_argument, cw_None, "rocsparse_operation_none, rocsparse_operation_none"}}
+        },
+        true,
+        false
+      }
     }
   },
   {sCusparseDcsrgemm2,
     {
       {
-        {1, {e_add_const_argument, cw_None, "rocsparse_operation_none, rocsparse_operation_none"}}
-      },
-      true,
-      false
+        {
+          {1, {e_add_const_argument, cw_None, "rocsparse_operation_none, rocsparse_operation_none"}}
+        },
+        true,
+        false
+      }
     }
   },
   {sCusparseScsrgemm2,
     {
       {
-        {1, {e_add_const_argument, cw_None, "rocsparse_operation_none, rocsparse_operation_none"}}
-      },
-      true,
-      false
+        {
+          {1, {e_add_const_argument, cw_None, "rocsparse_operation_none, rocsparse_operation_none"}}
+        },
+        true,
+        false
+      }
     }
   },
   {sCusparseZcsrilu02_bufferSize,
     {
       {
-        {8, {e_reinterpret_cast_size_t, cw_None}}
-      },
-      true,
-      false
+        {
+          {8, {e_reinterpret_cast_size_t, cw_None}}
+        },
+        true,
+        false
+      }
     }
   },
   {sCusparseCcsrilu02_bufferSize,
     {
       {
-        {8, {e_reinterpret_cast_size_t, cw_None}}
-      },
-      true,
-      false
+        {
+          {8, {e_reinterpret_cast_size_t, cw_None}}
+        },
+        true,
+        false
+      }
     }
   },
   {sCusparseDcsrilu02_bufferSize,
     {
       {
-        {8, {e_reinterpret_cast_size_t, cw_None}}
-      },
-      true,
-      false
+        {
+          {8, {e_reinterpret_cast_size_t, cw_None}}
+        },
+        true,
+        false
+      }
     }
   },
   {sCusparseScsrilu02_bufferSize,
     {
       {
-        {8, {e_reinterpret_cast_size_t, cw_None}}
-      },
-      true,
-      false
+        {
+          {8, {e_reinterpret_cast_size_t, cw_None}}
+        },
+        true,
+        false
+      }
     }
   },
   {sCusparseZbsrilu02_bufferSize,
     {
       {
-        {10, {e_reinterpret_cast_size_t, cw_None}}
-      },
-      true,
-      false
+        {
+          {10, {e_reinterpret_cast_size_t, cw_None}}
+        },
+        true,
+        false
+      }
     }
   },
   {sCusparseCbsrilu02_bufferSize,
     {
       {
-        {10, {e_reinterpret_cast_size_t, cw_None}}
-      },
-      true,
-      false
+        {
+          {10, {e_reinterpret_cast_size_t, cw_None}}
+        },
+        true,
+        false
+      }
     }
   },
   {sCusparseDbsrilu02_bufferSize,
     {
       {
-        {10, {e_reinterpret_cast_size_t, cw_None}}
-      },
-      true,
-      false
+        {
+          {10, {e_reinterpret_cast_size_t, cw_None}}
+        },
+        true,
+        false
+      }
     }
   },
   {sCusparseSbsrilu02_bufferSize,
     {
       {
-        {10, {e_reinterpret_cast_size_t, cw_None}}
-      },
-      true,
-      false
+        {
+          {10, {e_reinterpret_cast_size_t, cw_None}}
+        },
+        true,
+        false
+      }
     }
   },
   {sCusparseCsr2cscEx2_bufferSize,
     {
       {
-        {4, {e_remove_argument, cw_None}},
-        {7, {e_remove_argument, cw_None}},
-        {8, {e_remove_argument, cw_None}},
-        {9, {e_remove_argument, cw_None}},
-        {10, {e_remove_argument, cw_None}},
-        {12, {e_remove_argument, cw_None}},
-        {13, {e_remove_argument, cw_None}}
-      },
-      true,
-      false
+        {
+          {4, {e_remove_argument, cw_None}},
+          {7, {e_remove_argument, cw_None}},
+          {8, {e_remove_argument, cw_None}},
+          {9, {e_remove_argument, cw_None}},
+          {10, {e_remove_argument, cw_None}},
+          {12, {e_remove_argument, cw_None}},
+          {13, {e_remove_argument, cw_None}}
+        },
+        true,
+        false
+      }
     }
   },
   {sCusparseSparseToDense,
     {
       {
-        {4, {e_add_const_argument, cw_None, "nullptr"}}
-      },
-      true,
-      false
+        {
+          {4, {e_add_const_argument, cw_None, "nullptr"}}
+        },
+        true,
+        false
+      }
     }
   },
   {sCusparseSparseToDense_bufferSize,
     {
       {
-        {5, {e_add_const_argument, cw_None, "nullptr"}}
-      },
-      true,
-      false
+        {
+          {5, {e_add_const_argument, cw_None, "nullptr"}}
+        },
+        true,
+        false
+      }
     }
   },
   {sCusparseDenseToSparse_bufferSize,
     {
       {
-        {5, {e_add_const_argument, cw_None, "nullptr"}}
-      },
-      true,
-      false
+        {
+          {5, {e_add_const_argument, cw_None, "nullptr"}}
+        },
+        true,
+        false
+      }
     }
   },
   {sCusparseDenseToSparse_analysis,
     {
       {
-        {4, {e_add_const_argument, cw_None, "nullptr"}}
-      },
-      true,
-      false
+        {
+          {4, {e_add_const_argument, cw_None, "nullptr"}}
+        },
+        true,
+        false
+      }
     }
   },
   {sCusparseSpMM_bufferSize,
     {
       {
-        {10, {e_add_const_argument, cw_None, "rocsparse_spmm_stage_compute"}},
-        {12, {e_add_const_argument, cw_None, "nullptr"}}
-      },
-      true,
-      false
+        {
+          {10, {e_add_const_argument, cw_None, "rocsparse_spmm_stage_compute"}},
+          {12, {e_add_const_argument, cw_None, "nullptr"}}
+        },
+        true,
+        false
+      }
     }
   },
   {sCusparseSpSM_analysis,
     {
       {
-        {9, {e_replace_argument_with_const, cw_None, "rocsparse_spsm_stage_compute"}},
-        {10, {e_add_const_argument, cw_None, "nullptr"}}
-      },
-      true,
-      false
+        {
+          {9, {e_replace_argument_with_const, cw_None, "rocsparse_spsm_stage_compute"}},
+          {10, {e_add_const_argument, cw_None, "nullptr"}}
+        },
+        true,
+        false
+      }
     }
   },
   {sCusparseSpSM_solve,
     {
       {
-        {9, {e_replace_argument_with_const, cw_None, "rocsparse_spsm_stage_compute"}},
-        {10, {e_add_const_argument, cw_None, "nullptr"}},
-        {11, {e_add_const_argument, cw_None, "nullptr"}},
+        {
+          {9, {e_replace_argument_with_const, cw_None, "rocsparse_spsm_stage_compute"}},
+          {10, {e_add_const_argument, cw_None, "nullptr"}},
+          {11, {e_add_const_argument, cw_None, "nullptr"}},
+        },
+        true,
+        false
       },
-      true,
-      false
+      {
+        {
+          {10, {e_add_const_argument, cw_None, "nullptr"}}
+        }
+      }
     }
   },
   {sCusparseXcsrgeam2Nnz,
     {
       {
-        {14, {e_remove_argument, cw_None}}
-      },
-      true,
-      false
+        {
+          {14, {e_remove_argument, cw_None}}
+        },
+        true,
+        false
+      }
     }
   },
 };
@@ -2175,126 +2500,128 @@ bool HipifyAction::cudaHostFuncCall(const mat::MatchFinder::MatchResult &Result)
     std::string sName = funcDcl->getDeclName().getAsString();
     auto it = FuncArgCasts.find(sName);
     if (it == FuncArgCasts.end()) return false;
-    auto castStruct = it->second;
-    if (castStruct.isToMIOpen != TranslateToMIOpen || castStruct.isToRoc != TranslateToRoc) return false;
-    clang::LangOptions DefaultLangOptions;
-    for (auto c : castStruct.castMap) {
-      size_t length = 0;
-      unsigned int argNum = c.first;
-      clang::SmallString<40> XStr;
-      llvm::raw_svector_ostream OS(XStr);
-      auto *SM = Result.SourceManager;
-      clang::SourceRange sr, replacementRange;
-      clang::SourceLocation s, e;
-      if (argNum < call->getNumArgs()) {
-        sr = call->getArg(argNum)->getSourceRange();
-        replacementRange = getWriteRange(*SM, { sr.getBegin(), sr.getEnd() });
-        s = replacementRange.getBegin();
-        e = replacementRange.getEnd();
-      } else {
-        s = e = call->getEndLoc();
-      }
-      switch (c.second.castType) {
-        case e_remove_argument:
-        {
-          OS << "";
-          if (argNum < call->getNumArgs() - 1) {
-            e = call->getArg(argNum + 1)->getBeginLoc();
-          }
-          else {
-            e = call->getEndLoc();
-            if (call->getNumArgs() > 1) {
-              auto prevComma = clang::Lexer::findNextToken(call->getArg(argNum - 1)->getSourceRange().getEnd(), *SM, DefaultLangOptions);
-              if (!prevComma)
-                s = call->getEndLoc();
-              s = prevComma->getLocation();
-            }
-          }
-          length = SM->getCharacterData(e) - SM->getCharacterData(s);
-          break;
-        }
-        case e_move_argument:
-        {
-          std::string sArg;
-          clang::SmallString<40> dst_XStr;
-          llvm::raw_svector_ostream dst_OS(dst_XStr);
-          if (c.second.numberToMoveOrCopy > 1) {
-            if ((argNum + c.second.numberToMoveOrCopy - 1) >= call->getNumArgs())
-              continue;
-            sr = call->getArg(argNum + c.second.numberToMoveOrCopy - 1)->getSourceRange();
-            sr.setBegin(call->getArg(argNum)->getBeginLoc());
-          }
-          sArg = readSourceText(*SM, sr).str();
-          if (c.second.moveOrCopyTo < call->getNumArgs())
-            dst_OS << sArg << ", ";
-          else
-            dst_OS << ", " << sArg;
-          clang::SourceLocation dst_s;
-          if (c.second.moveOrCopyTo < call->getNumArgs())
-            dst_s = call->getArg(c.second.moveOrCopyTo)->getBeginLoc();
-          else
-            dst_s = call->getEndLoc();
-          ct::Replacement dst_Rep(*SM, dst_s, 0, dst_OS.str());
-          clang::FullSourceLoc dst_fullSL(dst_s, *SM);
-          insertReplacement(dst_Rep, dst_fullSL);
-          OS << "";
-          if (argNum < call->getNumArgs())
-            e = call->getArg(argNum + c.second.numberToMoveOrCopy)->getBeginLoc();
-          else
-            e = call->getEndLoc();
-          length = SM->getCharacterData(e) - SM->getCharacterData(s);
-          break;
-        }
-        case e_add_const_argument:
-        {
-          if (argNum < call->getNumArgs())
-            OS << c.second.constValToAddOrReplace << ", ";
-          else
-            OS << ", " << c.second.constValToAddOrReplace;
-          break;
-        }
-        case e_add_var_argument:
-        {
-          if (argNum >= call->getNumArgs())
-            continue;
+    auto castStructs = it->second;
+    for (auto cc : castStructs) {
+      if (cc.isToMIOpen != TranslateToMIOpen || cc.isToRoc != TranslateToRoc) continue;
+      clang::LangOptions DefaultLangOptions;
+      for (auto c : cc.castMap) {
+        size_t length = 0;
+        unsigned int argNum = c.first;
+        clang::SmallString<40> XStr;
+        llvm::raw_svector_ostream OS(XStr);
+        auto *SM = Result.SourceManager;
+        clang::SourceRange sr, replacementRange;
+        clang::SourceLocation s, e;
+        if (argNum < call->getNumArgs()) {
           sr = call->getArg(argNum)->getSourceRange();
-          sr.setBegin(call->getArg(argNum)->getBeginLoc());
-          std::string sArg = readSourceText(*SM, sr).str();
-          if (c.second.moveOrCopyTo < call->getNumArgs()) {
-            OS << sArg << ", ";
-            s = call->getArg(c.second.moveOrCopyTo)->getBeginLoc();
-          }
-          else {
-            OS << ", " << sArg;
-            s = call->getEndLoc();
-          }
-          break;
+          replacementRange = getWriteRange(*SM, { sr.getBegin(), sr.getEnd() });
+          s = replacementRange.getBegin();
+          e = replacementRange.getEnd();
+        } else {
+          s = e = call->getEndLoc();
         }
-        case e_replace_argument_with_const:
-        {
-          if (argNum >= call->getNumArgs())
+        switch (c.second.castType) {
+          case e_remove_argument:
+          {
+            OS << "";
+            if (argNum < call->getNumArgs() - 1) {
+              e = call->getArg(argNum + 1)->getBeginLoc();
+            }
+            else {
+              e = call->getEndLoc();
+              if (call->getNumArgs() > 1) {
+                auto prevComma = clang::Lexer::findNextToken(call->getArg(argNum - 1)->getSourceRange().getEnd(), *SM, DefaultLangOptions);
+                if (!prevComma)
+                  s = call->getEndLoc();
+                s = prevComma->getLocation();
+              }
+            }
+            length = SM->getCharacterData(e) - SM->getCharacterData(s);
             break;
-          OS << c.second.constValToAddOrReplace;
-          length = SM->getCharacterData(clang::Lexer::getLocForEndOfToken(e, 0, *SM, DefaultLangOptions)) - SM->getCharacterData(s);
-          break;
+          }
+          case e_move_argument:
+          {
+            std::string sArg;
+            clang::SmallString<40> dst_XStr;
+            llvm::raw_svector_ostream dst_OS(dst_XStr);
+            if (c.second.numberToMoveOrCopy > 1) {
+              if ((argNum + c.second.numberToMoveOrCopy - 1) >= call->getNumArgs())
+                continue;
+              sr = call->getArg(argNum + c.second.numberToMoveOrCopy - 1)->getSourceRange();
+              sr.setBegin(call->getArg(argNum)->getBeginLoc());
+            }
+            sArg = readSourceText(*SM, sr).str();
+            if (c.second.moveOrCopyTo < call->getNumArgs())
+              dst_OS << sArg << ", ";
+            else
+              dst_OS << ", " << sArg;
+            clang::SourceLocation dst_s;
+            if (c.second.moveOrCopyTo < call->getNumArgs())
+              dst_s = call->getArg(c.second.moveOrCopyTo)->getBeginLoc();
+            else
+              dst_s = call->getEndLoc();
+            ct::Replacement dst_Rep(*SM, dst_s, 0, dst_OS.str());
+            clang::FullSourceLoc dst_fullSL(dst_s, *SM);
+            insertReplacement(dst_Rep, dst_fullSL);
+            OS << "";
+            if (argNum < call->getNumArgs())
+              e = call->getArg(argNum + c.second.numberToMoveOrCopy)->getBeginLoc();
+            else
+              e = call->getEndLoc();
+            length = SM->getCharacterData(e) - SM->getCharacterData(s);
+            break;
+          }
+          case e_add_const_argument:
+          {
+            if (argNum < call->getNumArgs())
+              OS << c.second.constValToAddOrReplace << ", ";
+            else
+              OS << ", " << c.second.constValToAddOrReplace;
+            break;
+          }
+          case e_add_var_argument:
+          {
+            if (argNum >= call->getNumArgs())
+              continue;
+            sr = call->getArg(argNum)->getSourceRange();
+            sr.setBegin(call->getArg(argNum)->getBeginLoc());
+            std::string sArg = readSourceText(*SM, sr).str();
+            if (c.second.moveOrCopyTo < call->getNumArgs()) {
+              OS << sArg << ", ";
+              s = call->getArg(c.second.moveOrCopyTo)->getBeginLoc();
+            }
+            else {
+              OS << ", " << sArg;
+              s = call->getEndLoc();
+            }
+            break;
+          }
+          case e_replace_argument_with_const:
+          {
+            if (argNum >= call->getNumArgs())
+              break;
+            OS << c.second.constValToAddOrReplace;
+            length = SM->getCharacterData(clang::Lexer::getLocForEndOfToken(e, 0, *SM, DefaultLangOptions)) - SM->getCharacterData(s);
+            break;
+          }
+          default:
+            OS << getCastType(c.second.castType) << "(" << readSourceText(*SM, sr) << ")";
+            length = SM->getCharacterData(clang::Lexer::getLocForEndOfToken(e, 0, *SM, DefaultLangOptions)) - SM->getCharacterData(s);
+            break;
         }
-        default:
-          OS << getCastType(c.second.castType) << "(" << readSourceText(*SM, sr) << ")";
-          length = SM->getCharacterData(clang::Lexer::getLocForEndOfToken(e, 0, *SM, DefaultLangOptions)) - SM->getCharacterData(s);
-          break;
-      }
-      ct::Replacement Rep(*SM, s, length, OS.str());
-      clang::FullSourceLoc fullSL(s, *SM);
-      insertReplacement(Rep, fullSL);
-      switch (c.second.castWarn) {
-        case cw_DataLoss: {
-          clang::DiagnosticsEngine &DE = getCompilerInstance().getDiagnostics();
-          const auto ID = DE.getCustomDiagID(clang::DiagnosticsEngine::Warning, "Possible data loss in %0 argument of '%1'.");
-          DE.Report(fullSL, ID) << argNum+1 << sName;
-          break;
+        ct::Replacement Rep(*SM, s, length, OS.str());
+        clang::FullSourceLoc fullSL(s, *SM);
+        insertReplacement(Rep, fullSL);
+        switch (c.second.castWarn) {
+          case cw_DataLoss: {
+            clang::DiagnosticsEngine &DE = getCompilerInstance().getDiagnostics();
+            const auto ID = DE.getCustomDiagID(clang::DiagnosticsEngine::Warning, "Possible data loss in %0 argument of '%1'.");
+            DE.Report(fullSL, ID) << argNum+1 << sName;
+            break;
+          }
+          case cw_None:
+          default: break;
         }
-        case cw_None:
-        default: break;
       }
     }
     return true;

--- a/tests/lit.cfg
+++ b/tests/lit.cfg
@@ -95,6 +95,7 @@ if config.cuda_version_major < 11 or (config.cuda_version_major == 11 and config
 # [NOTE] Both CUDA 11.3.0 CUDA 11.3.1 have the same CUDA_VERSION 11030, and we can't distinguish them, thus exclude the below tests from both 11.3.0 and 11.3.1
 if config.cuda_version_major < 11 or (config.cuda_version_major == 11 and config.cuda_version_minor <= 3) or config.cuda_version_major >= 12:
     config.excludes.append('cusparse2rocsparse_11030_12000.cu')
+    config.excludes.append('cusparse2hipsparse_11030_12000.cu')
 
 if config.cuda_version_major <= 10:
     config.excludes.append('headers_test_12_SOLVER_10010.cu')
@@ -119,6 +120,7 @@ if config.cuda_version_major < 12:
     config.excludes.append('headers_test_09_12000.cu')
     config.excludes.append('runtime_functions_12000.cu')
     config.excludes.append('cusparse2rocsparse_12000.cu')
+    config.excludes.append('cusparse2hipsparse_12000.cu')
 
 if config.cuda_version_major >= 12:
     config.excludes.append('headers_test_06.cu')

--- a/tests/unit_tests/synthetic/libraries/cusparse2hipsparse.cu
+++ b/tests/unit_tests/synthetic/libraries/cusparse2hipsparse.cu
@@ -2772,12 +2772,6 @@ int main() {
   // HIP: HIPSPARSE_EXPORT hipsparseStatus_t hipsparseSpSM_analysis(hipsparseHandle_t handle, hipsparseOperation_t opA, hipsparseOperation_t opB, const void* alpha, const hipsparseSpMatDescr_t matA, const hipsparseDnMatDescr_t matB, const hipsparseDnMatDescr_t matC, hipDataType computeType, hipsparseSpSMAlg_t alg, hipsparseSpSMDescr_t spsmDescr, void* externalBuffer);
   // CHECK: status_t = hipsparseSpSM_analysis(handle_t, opA, opB, alpha, spmatA, dnmatB, dnmatC, dataType, spSMAlg_t, spSMDescr, tempBuffer);
   status_t = cusparseSpSM_analysis(handle_t, opA, opB, alpha, spmatA, dnmatB, dnmatC, dataType, spSMAlg_t, spSMDescr, tempBuffer);
-
-  // TODO: hipsparseSpSM_solve has an additional argument void* externalBuffer - might be added as nullptr
-  // CUDA: cusparseStatus_t CUSPARSEAPI cusparseSpSM_solve(cusparseHandle_t handle, cusparseOperation_t opA, cusparseOperation_t opB, const void* alpha, cusparseSpMatDescr_t matA, cusparseDnMatDescr_t matB, cusparseDnMatDescr_t matC, cudaDataType computeType, cusparseSpSMAlg_t alg, cusparseSpSMDescr_t spsmDescr);
-  // HIP: HIPSPARSE_EXPORT hipsparseStatus_t hipsparseSpSM_solve(hipsparseHandle_t handle, hipsparseOperation_t opA, hipsparseOperation_t opB, const void* alpha, const hipsparseSpMatDescr_t matA, const hipsparseDnMatDescr_t matB, const hipsparseDnMatDescr_t matC, hipDataType computeType, hipsparseSpSMAlg_t alg, hipsparseSpSMDescr_t spsmDescr, void* externalBuffer);
-  // CHECK: status_t = hipsparseSpSM_solve(handle_t, opA, opB, alpha, spmatA, dnmatB, dnmatC, dataType, spSMAlg_t, spSMDescr);
-  status_t = cusparseSpSM_solve(handle_t, opA, opB, alpha, spmatA, dnmatB, dnmatC, dataType, spSMAlg_t, spSMDescr);
 #endif
 #endif
 
@@ -3354,11 +3348,6 @@ int main() {
   // HIP: HIPSPARSE_EXPORT hipsparseStatus_t hipsparseSpSM_analysis(hipsparseHandle_t handle, hipsparseOperation_t opA, hipsparseOperation_t opB, const void* alpha, hipsparseConstSpMatDescr_t matA, hipsparseConstDnMatDescr_t matB, const hipsparseDnMatDescr_t matC, hipDataType computeType, hipsparseSpSMAlg_t alg, hipsparseSpSMDescr_t spsmDescr, void* externalBuffer);
   // CHECK: status_t = hipsparseSpSM_analysis(handle_t, opA, opB, alpha, constSpMatDescr, constDnMatDescrB, dnmatC, dataType, spSMAlg_t, spSMDescr, tempBuffer);
   status_t = cusparseSpSM_analysis(handle_t, opA, opB, alpha, constSpMatDescr, constDnMatDescrB, dnmatC, dataType, spSMAlg_t, spSMDescr, tempBuffer);
-
-  // CUDA: cusparseStatus_t CUSPARSEAPI cusparseSpSM_solve(cusparseHandle_t handle, cusparseOperation_t opA, cusparseOperation_t opB, const void* alpha, cusparseConstSpMatDescr_t matA, cusparseConstDnMatDescr_t matB, cusparseDnMatDescr_t matC, cudaDataType computeType, cusparseSpSMAlg_t alg, cusparseSpSMDescr_t spsmDescr);
-  // HIP: HIPSPARSE_EXPORT hipsparseStatus_t hipsparseSpSM_solve(hipsparseHandle_t handle, hipsparseOperation_t opA, hipsparseOperation_t opB, const void* alpha, hipsparseConstSpMatDescr_t matA, hipsparseConstDnMatDescr_t matB, const hipsparseDnMatDescr_t matC, hipDataType computeType, hipsparseSpSMAlg_t alg, hipsparseSpSMDescr_t spsmDescr, void* externalBuffer);
-  // CHECK: status_t = hipsparseSpSM_solve(handle_t, opA, opB, alpha, constSpMatDescr, constDnMatDescrB, dnmatC, dataType, spSMAlg_t, spSMDescr);
-  status_t = cusparseSpSM_solve(handle_t, opA, opB, alpha, constSpMatDescr, constDnMatDescrB, dnmatC, dataType, spSMAlg_t, spSMDescr);
 
   // CUDA: cusparseStatus_t CUSPARSEAPI cusparseConstDnVecGetValues(cusparseConstDnVecDescr_t dnVecDescr, const void** values);
   // HIP: HIPSPARSE_EXPORT hipsparseStatus_t hipsparseConstDnVecGetValues(hipsparseConstDnVecDescr_t dnVecDescr, const void** values);

--- a/tests/unit_tests/synthetic/libraries/cusparse2hipsparse_11030_12000.cu
+++ b/tests/unit_tests/synthetic/libraries/cusparse2hipsparse_11030_12000.cu
@@ -1,0 +1,112 @@
+// RUN: %run_test hipify "%s" "%t" %hipify_args 3 --skip-excluded-preprocessor-conditional-blocks --experimental --use-hip-data-types %clang_args -ferror-limit=500
+
+// CHECK: #include <hip/hip_runtime.h>
+#include <cuda_runtime.h>
+// CHECK: #include "hip/hip_complex.h"
+#include "cuComplex.h"
+#include <stdio.h>
+// CHECK: #include "hipsparse.h"
+#include "cusparse.h"
+// CHECK-NOT: #include "hipsparse.h"
+
+#if defined(_WIN32) && CUDA_VERSION < 9000
+  typedef signed   __int64 int64_t;
+  typedef unsigned __int64 uint64_t;
+#endif
+
+int main() {
+  printf("17.1. cuSPARSE API to hipSPARSE API synthetic test\n");
+
+  // CHECK: hipsparseStatus_t status_t;
+  cusparseStatus_t status_t;
+
+  // CHECK: hipsparseHandle_t handle_t;
+  cusparseHandle_t handle_t;
+
+  // CHECK: hipsparseMatDescr_t matDescr_t, matDescr_t_2, matDescr_A, matDescr_B, matDescr_C, matDescr_D;
+  cusparseMatDescr_t matDescr_t, matDescr_t_2, matDescr_A, matDescr_B, matDescr_C, matDescr_D;
+
+  // CHECK: hipsparseOperation_t opA, opB, opX;
+  cusparseOperation_t opA, opB, opX;
+
+  // CHECK: hipsparseSolvePolicy_t solvePolicy_t;
+  cusparseSolvePolicy_t solvePolicy_t;
+
+  int m = 0;
+  int n = 0;
+  int k = 0;
+  int innz = 0;
+  int nnza = 0;
+  int nnzb = 0;
+  int nnzc = 0;
+  int nnzd = 0;
+  int csrRowPtrA = 0;
+  int csrRowPtrB = 0;
+  int csrRowPtrC = 0;
+  int csrRowPtrD = 0;
+  int csrColIndA = 0;
+  int csrColIndB = 0;
+  int csrColIndC = 0;
+  int csrColIndD = 0;
+  int bufferSizeInBytes = 0;
+  size_t bufferSize = 0;
+  double dA = 0.f;
+  double dB = 0.f;
+  double dAlpha = 0.f;
+  double dF = 0.f;
+  double dX = 0.f;
+  double dcsrSortedValA = 0.f;
+  double dcsrSortedValB = 0.f;
+  double dcsrSortedValC = 0.f;
+  double dcsrSortedValD = 0.f;
+  float fAlpha = 0.f;
+  float fA = 0.f;
+  float fB = 0.f;
+  float fF = 0.f;
+  float fX = 0.f;
+  float csrSortedValA = 0.f;
+  float csrSortedValB = 0.f;
+  float csrSortedValC = 0.f;
+  float csrSortedValD = 0.f;
+  void *alpha = nullptr;
+  void *pBuffer = nullptr;
+  void *tempBuffer = nullptr;
+
+  // CHECK: hipDoubleComplex dcomplex, dcomplexA, dcomplexAlpha, dcomplexB, dcomplexBeta, dcomplexC, dcomplexF, dcomplexX, dcomplexY, dComplexbsrSortedValA, dComplexbsrSortedValC, dComplexcsrSortedValA, dComplexcsrSortedValB, dComplexcsrSortedValC, dComplexcsrSortedValD, dcomplextol, dComplexbsrSortedVal, dComplexbscVal, dComplexcscSortedVal, dcomplexds, dcomplexdl, dcomplexd, dcomplexdu, dcomplexdw, dcomplexx, dcomplex_boost_val;
+  cuDoubleComplex dcomplex, dcomplexA, dcomplexAlpha, dcomplexB, dcomplexBeta, dcomplexC, dcomplexF, dcomplexX, dcomplexY, dComplexbsrSortedValA, dComplexbsrSortedValC, dComplexcsrSortedValA, dComplexcsrSortedValB, dComplexcsrSortedValC, dComplexcsrSortedValD, dcomplextol, dComplexbsrSortedVal, dComplexbscVal, dComplexcscSortedVal, dcomplexds, dcomplexdl, dcomplexd, dcomplexdu, dcomplexdw, dcomplexx, dcomplex_boost_val;
+
+  // CHECK: hipComplex complex, complexA, complexAlpha, complexB, complexBeta, complexC, complexF, complexX, complexY, complexbsrValA, complexbsrSortedValC, complexcsrSortedValA, complexcsrSortedValB, complexcsrSortedValC, complexcsrSortedValD, complextol, complexbsrSortedVal, complexbscVal, complexcscSortedVal, complexds, complexdl, complexd, complexdu, complexdw, complexx, complex_boost_val;
+  cuComplex complex, complexA, complexAlpha, complexB, complexBeta, complexC, complexF, complexX, complexY, complexbsrValA, complexbsrSortedValC, complexcsrSortedValA, complexcsrSortedValB, complexcsrSortedValC, complexcsrSortedValD, complextol, complexbsrSortedVal, complexbscVal, complexcscSortedVal, complexds, complexdl, complexd, complexdu, complexdw, complexx, complex_boost_val;
+
+#if CUDA_VERSION >= 8000
+  // CHECK: hipDataType dataType_t;
+  // CHECK-NEXT: hipDataType dataType;
+  cudaDataType_t dataType_t;
+  cudaDataType dataType;
+#endif
+
+#if (CUDA_VERSION >= 10010 && CUDA_VERSION < 11000 && !defined(_WIN32)) || CUDA_VERSION >= 11000
+  // CHECK: hipsparseSpMatDescr_t spMatDescr_t, spmatA, spmatB, spmatC;
+  cusparseSpMatDescr_t spMatDescr_t, spmatA, spmatB, spmatC;
+
+  // CHECK: hipsparseDnMatDescr_t dnMatDescr_t, dnmatA, dnmatB, dnmatC;
+  cusparseDnMatDescr_t dnMatDescr_t, dnmatA, dnmatB, dnmatC;
+#endif
+
+#if CUDA_VERSION >= 11030 && CUSPARSE_VERSION >= 11600
+  // CHECK: hipsparseSpSMAlg_t spSMAlg_t;
+  cusparseSpSMAlg_t spSMAlg_t;
+
+  // CHECK: hipsparseSpSMDescr_t spSMDescr;
+  cusparseSpSMDescr_t spSMDescr;
+
+#if CUDA_VERSION < 12000
+  // CUDA: cusparseStatus_t CUSPARSEAPI cusparseSpSM_solve(cusparseHandle_t handle, cusparseOperation_t opA, cusparseOperation_t opB, const void* alpha, cusparseSpMatDescr_t matA, cusparseDnMatDescr_t matB, cusparseDnMatDescr_t matC, cudaDataType computeType, cusparseSpSMAlg_t alg, cusparseSpSMDescr_t spsmDescr);
+  // HIP: HIPSPARSE_EXPORT hipsparseStatus_t hipsparseSpSM_solve(hipsparseHandle_t handle, hipsparseOperation_t opA, hipsparseOperation_t opB, const void* alpha, const hipsparseSpMatDescr_t matA, const hipsparseDnMatDescr_t matB, const hipsparseDnMatDescr_t matC, hipDataType computeType, hipsparseSpSMAlg_t alg, hipsparseSpSMDescr_t spsmDescr, void* externalBuffer);
+  // CHECK: status_t = hipsparseSpSM_solve(handle_t, opA, opB, alpha, spmatA, dnmatB, dnmatC, dataType, spSMAlg_t, spSMDescr, nullptr);
+  status_t = cusparseSpSM_solve(handle_t, opA, opB, alpha, spmatA, dnmatB, dnmatC, dataType, spSMAlg_t, spSMDescr);
+#endif
+#endif
+
+  return 0;
+}

--- a/tests/unit_tests/synthetic/libraries/cusparse2hipsparse_12000.cu
+++ b/tests/unit_tests/synthetic/libraries/cusparse2hipsparse_12000.cu
@@ -1,0 +1,131 @@
+// RUN: %run_test hipify "%s" "%t" %hipify_args 3 --skip-excluded-preprocessor-conditional-blocks --experimental --use-hip-data-types %clang_args -ferror-limit=500
+
+// CHECK: #include <hip/hip_runtime.h>
+#include <cuda_runtime.h>
+// CHECK: #include "hip/hip_complex.h"
+#include "cuComplex.h"
+#include <stdio.h>
+// CHECK: #include "hipsparse.h"
+#include "cusparse.h"
+// CHECK-NOT: #include "hipsparse.h"
+
+#if defined(_WIN32) && CUDA_VERSION < 9000
+  typedef signed   __int64 int64_t;
+  typedef unsigned __int64 uint64_t;
+#endif
+
+int main() {
+  printf("17.1. cuSPARSE API to hipSPARSE API synthetic test\n");
+
+  // CHECK: hipsparseStatus_t status_t;
+  cusparseStatus_t status_t;
+
+  // CHECK: hipsparseHandle_t handle_t;
+  cusparseHandle_t handle_t;
+
+  // CHECK: hipsparseMatDescr_t matDescr_t, matDescr_t_2, matDescr_A, matDescr_B, matDescr_C, matDescr_D;
+  cusparseMatDescr_t matDescr_t, matDescr_t_2, matDescr_A, matDescr_B, matDescr_C, matDescr_D;
+
+  // CHECK: hipsparseOperation_t opA, opB, opX;
+  cusparseOperation_t opA, opB, opX;
+
+  // CHECK: hipsparseSolvePolicy_t solvePolicy_t;
+  cusparseSolvePolicy_t solvePolicy_t;
+
+  int m = 0;
+  int n = 0;
+  int k = 0;
+  int innz = 0;
+  int nnza = 0;
+  int nnzb = 0;
+  int nnzc = 0;
+  int nnzd = 0;
+  int csrRowPtrA = 0;
+  int csrRowPtrB = 0;
+  int csrRowPtrC = 0;
+  int csrRowPtrD = 0;
+  int csrColIndA = 0;
+  int csrColIndB = 0;
+  int csrColIndC = 0;
+  int csrColIndD = 0;
+  int bufferSizeInBytes = 0;
+  size_t bufferSize = 0;
+  double dA = 0.f;
+  double dB = 0.f;
+  double dAlpha = 0.f;
+  double dF = 0.f;
+  double dX = 0.f;
+  double dcsrSortedValA = 0.f;
+  double dcsrSortedValB = 0.f;
+  double dcsrSortedValC = 0.f;
+  double dcsrSortedValD = 0.f;
+  float fAlpha = 0.f;
+  float fA = 0.f;
+  float fB = 0.f;
+  float fF = 0.f;
+  float fX = 0.f;
+  float csrSortedValA = 0.f;
+  float csrSortedValB = 0.f;
+  float csrSortedValC = 0.f;
+  float csrSortedValD = 0.f;
+  void *alpha = nullptr;
+  void *pBuffer = nullptr;
+  void *tempBuffer = nullptr;
+
+  // CHECK: hipDoubleComplex dcomplex, dcomplexA, dcomplexAlpha, dcomplexB, dcomplexBeta, dcomplexC, dcomplexF, dcomplexX, dcomplexY, dComplexbsrSortedValA, dComplexbsrSortedValC, dComplexcsrSortedValA, dComplexcsrSortedValB, dComplexcsrSortedValC, dComplexcsrSortedValD, dcomplextol, dComplexbsrSortedVal, dComplexbscVal, dComplexcscSortedVal, dcomplexds, dcomplexdl, dcomplexd, dcomplexdu, dcomplexdw, dcomplexx, dcomplex_boost_val;
+  cuDoubleComplex dcomplex, dcomplexA, dcomplexAlpha, dcomplexB, dcomplexBeta, dcomplexC, dcomplexF, dcomplexX, dcomplexY, dComplexbsrSortedValA, dComplexbsrSortedValC, dComplexcsrSortedValA, dComplexcsrSortedValB, dComplexcsrSortedValC, dComplexcsrSortedValD, dcomplextol, dComplexbsrSortedVal, dComplexbscVal, dComplexcscSortedVal, dcomplexds, dcomplexdl, dcomplexd, dcomplexdu, dcomplexdw, dcomplexx, dcomplex_boost_val;
+
+  // CHECK: hipComplex complex, complexA, complexAlpha, complexB, complexBeta, complexC, complexF, complexX, complexY, complexbsrValA, complexbsrSortedValC, complexcsrSortedValA, complexcsrSortedValB, complexcsrSortedValC, complexcsrSortedValD, complextol, complexbsrSortedVal, complexbscVal, complexcscSortedVal, complexds, complexdl, complexd, complexdu, complexdw, complexx, complex_boost_val;
+  cuComplex complex, complexA, complexAlpha, complexB, complexBeta, complexC, complexF, complexX, complexY, complexbsrValA, complexbsrSortedValC, complexcsrSortedValA, complexcsrSortedValB, complexcsrSortedValC, complexcsrSortedValD, complextol, complexbsrSortedVal, complexbscVal, complexcscSortedVal, complexds, complexdl, complexd, complexdu, complexdw, complexx, complex_boost_val;
+
+#if CUDA_VERSION >= 8000
+  // CHECK: hipDataType dataType_t;
+  // CHECK-NEXT: hipDataType dataType;
+  cudaDataType_t dataType_t;
+  cudaDataType dataType;
+#endif
+
+#if (CUDA_VERSION >= 10010 && CUDA_VERSION < 11000 && !defined(_WIN32)) || CUDA_VERSION >= 11000
+  // CHECK: hipsparseSpMatDescr_t spMatDescr_t, spmatA, spmatB, spmatC;
+  cusparseSpMatDescr_t spMatDescr_t, spmatA, spmatB, spmatC;
+
+  // CHECK: hipsparseDnMatDescr_t dnMatDescr_t, dnmatA, dnmatB, dnmatC;
+  cusparseDnMatDescr_t dnMatDescr_t, dnmatA, dnmatB, dnmatC;
+#endif
+
+#if CUDA_VERSION >= 11030 && CUSPARSE_VERSION >= 11600
+  // CHECK: hipsparseSpSMAlg_t spSMAlg_t;
+  cusparseSpSMAlg_t spSMAlg_t;
+
+  // CHECK: hipsparseSpSMDescr_t spSMDescr;
+  cusparseSpSMDescr_t spSMDescr;
+#endif
+
+#if CUDA_VERSION >= 12000
+  // CHECK: hipsparseCsr2CscAlg_t CSR2CSC_ALG_DEFAULT = HIPSPARSE_CSR2CSC_ALG_DEFAULT;
+  cusparseCsr2CscAlg_t CSR2CSC_ALG_DEFAULT = CUSPARSE_CSR2CSC_ALG_DEFAULT;
+
+  // CHECK: hipsparseConstSpVecDescr_t constSpVecDescr = nullptr;
+  cusparseConstSpVecDescr_t constSpVecDescr = nullptr;
+
+  // CHECK: hipsparseConstSpMatDescr_t constSpMatDescr = nullptr;
+  // CHECK-NEXT: hipsparseConstSpMatDescr_t constSpMatDescrB = nullptr;
+  cusparseConstSpMatDescr_t constSpMatDescr = nullptr;
+  cusparseConstSpMatDescr_t constSpMatDescrB = nullptr;
+
+  // CHECK: hipsparseConstDnVecDescr_t constDnVecDescr = nullptr;
+  cusparseConstDnVecDescr_t constDnVecDescr = nullptr;
+
+  // CHECK: hipsparseConstDnMatDescr_t constDnMatDescr = nullptr;
+  // CHECK-NEXT: hipsparseConstDnMatDescr_t constDnMatDescrB = nullptr;
+  cusparseConstDnMatDescr_t constDnMatDescr = nullptr;
+  cusparseConstDnMatDescr_t constDnMatDescrB = nullptr;
+
+  // CUDA: cusparseStatus_t CUSPARSEAPI cusparseSpSM_solve(cusparseHandle_t handle, cusparseOperation_t opA, cusparseOperation_t opB, const void* alpha, cusparseConstSpMatDescr_t matA, cusparseConstDnMatDescr_t matB, cusparseDnMatDescr_t matC, cudaDataType computeType, cusparseSpSMAlg_t alg, cusparseSpSMDescr_t spsmDescr);
+  // HIP: HIPSPARSE_EXPORT hipsparseStatus_t hipsparseSpSM_solve(hipsparseHandle_t handle, hipsparseOperation_t opA, hipsparseOperation_t opB, const void* alpha, hipsparseConstSpMatDescr_t matA, hipsparseConstDnMatDescr_t matB, const hipsparseDnMatDescr_t matC, hipDataType computeType, hipsparseSpSMAlg_t alg, hipsparseSpSMDescr_t spsmDescr, void* externalBuffer);
+  // CHECK: status_t = hipsparseSpSM_solve(handle_t, opA, opB, alpha, constSpMatDescr, constDnMatDescrB, dnmatC, dataType, spSMAlg_t, spSMDescr, nullptr);
+  status_t = cusparseSpSM_solve(handle_t, opA, opB, alpha, constSpMatDescr, constDnMatDescrB, dnmatC, dataType, spSMAlg_t, spSMDescr);
+#endif
+
+  return 0;
+}


### PR DESCRIPTION
+ For instance, `cusparseSpSM_solve`, translated to `rocsparse_spsm` or `hipsparseSpSM_solve`; both need different function signature transformations, which can be described now in a single CUDA API transformation description
+ Added the corresponding `SPARSE` synthetic tests
