### PR TITLE
[HIPIFY][#674][rocSPARSE][feature] rocSPARSE support - Step 109 - `cusparseSpVV` -> `rocsparse_spvv`

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -2287,6 +2287,7 @@ sub rocSubstitutions {
     subst("cusparseSpMatSetValues", "rocsparse_spmat_set_values", "library");
     subst("cusparseSpSM_analysis", "rocsparse_spsm", "library");
     subst("cusparseSpSM_solve", "rocsparse_spsm", "library");
+    subst("cusparseSpVV", "rocsparse_spvv", "library");
     subst("cusparseSpVV_bufferSize", "rocsparse_spvv", "library");
     subst("cusparseSpVecGet", "rocsparse_spvec_get", "library");
     subst("cusparseSpVecGetIndexBase", "rocsparse_spvec_get_index_base", "library");

--- a/docs/tables/CUSPARSE_API_supported_by_HIP_and_ROC.md
+++ b/docs/tables/CUSPARSE_API_supported_by_HIP_and_ROC.md
@@ -904,7 +904,7 @@
 |`cusparseSpSV_destroyDescr`|11.3| | | |`hipsparseSpSV_destroyDescr`|4.5.0| | | | | | | | | | |
 |`cusparseSpSV_solve`|11.3| |12.0| |`hipsparseSpSV_solve`|4.5.0| |6.0.0| | | | | | | | |
 |`cusparseSpSV_updateMatrix`|12.1| | | | | | | | | | | | | | | |
-|`cusparseSpVV`|10.1| |12.0| |`hipsparseSpVV`|4.1.0| |6.0.0| | | | | | | | |
+|`cusparseSpVV`|10.1| |12.0| |`hipsparseSpVV`|4.1.0| |6.0.0| | |`rocsparse_spvv`|4.1.0| |6.0.0| | |
 |`cusparseSpVV_bufferSize`|10.1| |12.0| |`hipsparseSpVV_bufferSize`|4.1.0| |6.0.0| | |`rocsparse_spvv`|4.1.0| |6.0.0| | |
 |`cusparseSpVecGet`|10.2| | | |`hipsparseSpVecGet`|4.1.0| | | | |`rocsparse_spvec_get`|4.1.0| | | | |
 |`cusparseSpVecGetIndexBase`|10.2| |12.0| |`hipsparseSpVecGetIndexBase`|4.1.0| |6.0.0| | |`rocsparse_spvec_get_index_base`|4.1.0| |6.0.0| | |

--- a/docs/tables/CUSPARSE_API_supported_by_ROC.md
+++ b/docs/tables/CUSPARSE_API_supported_by_ROC.md
@@ -904,7 +904,7 @@
 |`cusparseSpSV_destroyDescr`|11.3| | | | | | | | | |
 |`cusparseSpSV_solve`|11.3| |12.0| | | | | | | |
 |`cusparseSpSV_updateMatrix`|12.1| | | | | | | | | |
-|`cusparseSpVV`|10.1| |12.0| | | | | | | |
+|`cusparseSpVV`|10.1| |12.0| |`rocsparse_spvv`|4.1.0| |6.0.0| | |
 |`cusparseSpVV_bufferSize`|10.1| |12.0| |`rocsparse_spvv`|4.1.0| |6.0.0| | |
 |`cusparseSpVecGet`|10.2| | | |`rocsparse_spvec_get`|4.1.0| | | | |
 |`cusparseSpVecGetIndexBase`|10.2| |12.0| |`rocsparse_spvec_get_index_base`|4.1.0| |6.0.0| | |

--- a/src/CUDA2HIP_SPARSE_API_functions.cpp
+++ b/src/CUDA2HIP_SPARSE_API_functions.cpp
@@ -853,8 +853,7 @@ const std::map<llvm::StringRef, hipCounter> CUDA_SPARSE_FUNCTION_MAP {
   {"cusparseConstrainedGeMM_bufferSize",                {"hipsparseConstrainedGeMM_bufferSize",                "",                                                                 CONV_LIB_FUNC, API_SPARSE, 15, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED}},
 
   // Sparse Vector * Vector Operations
-  // NOTE: rocsparse_spvv has one additional argument: size_t* buffer_size, thus cusparseSpVV is still ROC_UNSUPPORTED
-  {"cusparseSpVV",                                      {"hipsparseSpVV",                                      "",                                                                 CONV_LIB_FUNC, API_SPARSE, 15, ROC_UNSUPPORTED}},
+  {"cusparseSpVV",                                      {"hipsparseSpVV",                                      "rocsparse_spvv",                                                   CONV_LIB_FUNC, API_SPARSE, 15}},
   {"cusparseSpVV_bufferSize",                           {"hipsparseSpVV_bufferSize",                           "rocsparse_spvv",                                                   CONV_LIB_FUNC, API_SPARSE, 15}},
 
   {"cusparseAxpby",                                     {"hipsparseAxpby",                                     "rocsparse_axpby",                                                  CONV_LIB_FUNC, API_SPARSE, 15}},

--- a/src/HipifyAction.cpp
+++ b/src/HipifyAction.cpp
@@ -214,6 +214,7 @@ const std::string sCusparseSpSM_solve = "cusparseSpSM_solve";
 const std::string sCusparseXcsrgeam2Nnz = "cusparseXcsrgeam2Nnz";
 const std::string sCudaMallocHost = "cudaMallocHost";
 const std::string sCusparseSpMM = "cusparseSpMM";
+const std::string sCusparseSpVV = "cusparseSpVV";
 const std::string sCusparseSpVV_bufferSize = "cusparseSpVV_bufferSize";
 const std::string sCusparseSpMV = "cusparseSpMV";
 const std::string sCusparseSpMV_bufferSize = "cusparseSpMV_bufferSize";
@@ -2074,6 +2075,17 @@ std::map<std::string, std::vector<ArgCastStruct>> FuncArgCasts {
       }
     }
   },
+  {sCusparseSpVV,
+    {
+      {
+        {
+          {6, {e_add_const_argument, cw_None, "nullptr"}}
+        },
+        true,
+        false
+      }
+    }
+  },
   {sCusparseSpMV_bufferSize,
     {
       {
@@ -2955,12 +2967,13 @@ std::unique_ptr<clang::ASTConsumer> HipifyAction::CreateASTConsumer(clang::Compi
             sCusparseSparseToDense_bufferSize,
             sCusparseDenseToSparse_bufferSize,
             sCusparseDenseToSparse_analysis,
+            sCusparseSpMM,
             sCusparseSpMM_bufferSize,
             sCusparseSpSM_analysis,
             sCusparseSpSM_solve,
             sCusparseXcsrgeam2Nnz,
             sCudaMallocHost,
-            sCusparseSpMM,
+            sCusparseSpVV,
             sCusparseSpVV_bufferSize,
             sCusparseSpMV,
             sCusparseSpMV_bufferSize

--- a/tests/unit_tests/synthetic/libraries/cusparse2rocsparse_12000.cu
+++ b/tests/unit_tests/synthetic/libraries/cusparse2rocsparse_12000.cu
@@ -183,6 +183,11 @@ int main() {
   // CHECK: status_t = rocsparse_spmm(handle_t, opA, opB, alpha, constSpMatDescr, constDnMatDescr, beta, dnmatC, dataType, spMMAlg_t, rocsparse_spmm_stage_compute, nullptr, tempBuffer);
   status_t = cusparseSpMM(handle_t, opA, opB, alpha, constSpMatDescr, constDnMatDescr, beta, dnmatC, dataType, spMMAlg_t, tempBuffer);
 
+  // CUDA: cusparseStatus_t CUSPARSEAPI cusparseSpVV(cusparseHandle_t handle, cusparseOperation_t opX, cusparseConstSpVecDescr_t vecX, cusparseConstDnVecDescr_t vecY, void* result, cudaDataType computeType, void* externalBuffer);
+  // ROC: ROCSPARSE_EXPORT rocsparse_status rocsparse_spvv(rocsparse_handle handle, rocsparse_operation trans, rocsparse_const_spvec_descr x, rocsparse_const_dnvec_descr y, void* result, rocsparse_datatype compute_type, size_t* buffer_size, void* temp_buffer);
+  // CHECK: status_t = rocsparse_spvv(handle_t, opX, constSpVecDescr, constDnVecDescr, result, dataType, nullptr, tempBuffer);
+  status_t = cusparseSpVV(handle_t, opX, constSpVecDescr, constDnVecDescr, result, dataType, tempBuffer);
+
   // CUDA: cusparseStatus_t CUSPARSEAPI cusparseSpVV_bufferSize(cusparseHandle_t handle, cusparseOperation_t opX, cusparseConstSpVecDescr_t vecX, cusparseConstDnVecDescr_t vecY, const void* result, cudaDataType computeType, size_t* bufferSize);
   // ROC: ROCSPARSE_EXPORT rocsparse_status rocsparse_spvv(rocsparse_handle handle, rocsparse_operation trans, rocsparse_const_spvec_descr x, rocsparse_const_dnvec_descr y, void* result, rocsparse_datatype compute_type, size_t* buffer_size, void* temp_buffer);
   // CHECK: status_t = rocsparse_spvv(handle_t, opX, constSpVecDescr, constDnVecDescr, result, dataType, &bufferSize, nullptr);


### PR DESCRIPTION
+ Updated `SPARSE` synthetic tests, the regenerated hipify-perl, and `SPARSE` `CUDA2HIP` documentation
