### PR TITLE
[HIPIFY][SPARSE][6.1][sync] Sync with `rocSPARSE` - New APIs

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -2237,6 +2237,7 @@ sub rocSubstitutions {
     subst("cusparseCreateMatDescr", "rocsparse_create_mat_descr", "library");
     subst("cusparseCreatePruneInfo", "rocsparse_create_mat_info", "library");
     subst("cusparseCreateSpVec", "rocsparse_create_spvec_descr", "library");
+    subst("cusparseCscGet", "rocsparse_csc_get", "library");
     subst("cusparseCscSetPointers", "rocsparse_csc_set_pointers", "library");
     subst("cusparseCsctr", "rocsparse_csctr", "library");
     subst("cusparseCsr2cscEx2_bufferSize", "rocsparse_csr2csc_buffer_size", "library");

--- a/docs/tables/CUSPARSE_API_supported_by_HIP_and_ROC.md
+++ b/docs/tables/CUSPARSE_API_supported_by_HIP_and_ROC.md
@@ -837,7 +837,7 @@
 |`cusparseCreateDnVec`|10.2| | | |`hipsparseCreateDnVec`|4.1.0| | | | |`rocsparse_create_dnvec_descr`|4.1.0| | | | |
 |`cusparseCreateSlicedEll`|12.1| | | | | | | | | | | | | | | |
 |`cusparseCreateSpVec`|10.2| | | |`hipsparseCreateSpVec`|4.1.0| | | | |`rocsparse_create_spvec_descr`|4.1.0| | | | |
-|`cusparseCscGet`|11.7| | | |`hipsparseCscGet`|6.1.0| | | |6.1.0| | | | | | |
+|`cusparseCscGet`|11.7| | | |`hipsparseCscGet`|6.1.0| | | |6.1.0|`rocsparse_csc_get`|6.1.0| | | |6.1.0|
 |`cusparseCscSetPointers`|11.1| | | |`hipsparseCscSetPointers`|4.2.0| | | | |`rocsparse_csc_set_pointers`|4.1.0| | | | |
 |`cusparseCsrGet`|10.2| | | |`hipsparseCsrGet`|4.1.0| | | | |`rocsparse_csr_get`|4.1.0| | | | |
 |`cusparseCsrSetPointers`|11.0| | | |`hipsparseCsrSetPointers`|4.1.0| | | | |`rocsparse_csr_set_pointers`|4.1.0| | | | |

--- a/docs/tables/CUSPARSE_API_supported_by_ROC.md
+++ b/docs/tables/CUSPARSE_API_supported_by_ROC.md
@@ -837,7 +837,7 @@
 |`cusparseCreateDnVec`|10.2| | | |`rocsparse_create_dnvec_descr`|4.1.0| | | | |
 |`cusparseCreateSlicedEll`|12.1| | | | | | | | | |
 |`cusparseCreateSpVec`|10.2| | | |`rocsparse_create_spvec_descr`|4.1.0| | | | |
-|`cusparseCscGet`|11.7| | | | | | | | | |
+|`cusparseCscGet`|11.7| | | |`rocsparse_csc_get`|6.1.0| | | |6.1.0|
 |`cusparseCscSetPointers`|11.1| | | |`rocsparse_csc_set_pointers`|4.1.0| | | | |
 |`cusparseCsrGet`|10.2| | | |`rocsparse_csr_get`|4.1.0| | | | |
 |`cusparseCsrSetPointers`|11.0| | | |`rocsparse_csr_set_pointers`|4.1.0| | | | |

--- a/src/CUDA2HIP_SPARSE_API_functions.cpp
+++ b/src/CUDA2HIP_SPARSE_API_functions.cpp
@@ -749,7 +749,7 @@ const std::map<llvm::StringRef, hipCounter> CUDA_SPARSE_FUNCTION_MAP {
   {"cusparseConstCsrGet",                               {"hipsparseConstCsrGet",                               "rocsparse_const_csr_get",                                          CONV_LIB_FUNC, API_SPARSE, 15}},
   {"cusparseCsrSetPointers",                            {"hipsparseCsrSetPointers",                            "rocsparse_csr_set_pointers",                                       CONV_LIB_FUNC, API_SPARSE, 15}},
   {"cusparseCscSetPointers",                            {"hipsparseCscSetPointers",                            "rocsparse_csc_set_pointers",                                       CONV_LIB_FUNC, API_SPARSE, 15}},
-  {"cusparseCscGet",                                    {"hipsparseCscGet",                                    "",                                                                 CONV_LIB_FUNC, API_SPARSE, 15, HIP_EXPERIMENTAL}},
+  {"cusparseCscGet",                                    {"hipsparseCscGet",                                    "rocsparse_csc_get",                                                CONV_LIB_FUNC, API_SPARSE, 15, HIP_EXPERIMENTAL}},
   {"cusparseConstCscGet",                               {"hipsparseConstCscGet",                               "rocsparse_const_csc_get",                                          CONV_LIB_FUNC, API_SPARSE, 15, HIP_EXPERIMENTAL}},
   {"cusparseCooSetPointers",                            {"hipsparseCooSetPointers",                            "rocsparse_coo_set_pointers",                                       CONV_LIB_FUNC, API_SPARSE, 15}},
   {"cusparseCsrSetStridedBatch",                        {"hipsparseCsrSetStridedBatch",                        "rocsparse_csr_set_strided_batch",                                  CONV_LIB_FUNC, API_SPARSE, 15}},
@@ -2432,6 +2432,7 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_SPARSE_FUNCTION_VER_MAP {
   {"rocsparse_spsm",                                     {HIP_4050, HIP_0,    HIP_0   }},
   {"rocsparse_spvv",                                     {HIP_4010, HIP_0,    HIP_0   }},
   {"rocsparse_spsv",                                     {HIP_4050, HIP_0,    HIP_0   }},
+  {"rocsparse_csc_get",                                  {HIP_6010, HIP_0,    HIP_0,  HIP_LATEST}},
 };
 
 const std::map<llvm::StringRef, cudaAPIChangedVersions> CUDA_SPARSE_FUNCTION_CHANGED_VER_MAP {

--- a/tests/unit_tests/synthetic/libraries/cusparse2rocsparse.cu
+++ b/tests/unit_tests/synthetic/libraries/cusparse2rocsparse.cu
@@ -1656,11 +1656,11 @@ int main() {
   status_t = cusparseDestroyPruneInfo(prune_info);
 #endif
 
-#if (CUDA_VERSION >= 10010 && CUDA_VERSION < 11000 && !defined(_WIN32)) || CUDA_VERSION >= 11000
+#if (CUDA_VERSION >= 10010 && CUSPARSE_VERSION >= 10200 && CUDA_VERSION < 11000 && !defined(_WIN32)) || CUDA_VERSION >= 11000
   // CHECK: _rocsparse_spmat_descr *spMatDescr = nullptr;
-  // CHECK-NEXT: rocsparse_spmat_descr spMatDescr_t, matC;
+  // CHECK-NEXT: rocsparse_spmat_descr spMatDescr_t, matC, spmatA, spmatB, spmatC;
   cusparseSpMatDescr *spMatDescr = nullptr;
-  cusparseSpMatDescr_t spMatDescr_t, matC;
+  cusparseSpMatDescr_t spMatDescr_t, matC, spmatA, spmatB, spmatC;
 
   // CHECK: _rocsparse_dnmat_descr *dnMatDescr = nullptr;
   // CHECK-NEXT: rocsparse_dnmat_descr dnMatDescr_t, matA, matB;
@@ -2131,6 +2131,13 @@ int main() {
   // CHECK-NEXT: rocsparse_spsm_alg SPSM_ALG_DEFAULT = rocsparse_spsm_alg_default;
   cusparseSpSMAlg_t spSMAlg_t;
   cusparseSpSMAlg_t SPSM_ALG_DEFAULT = CUSPARSE_SPSM_ALG_DEFAULT;
+#endif
+
+#if CUDA_VERSION >= 11070
+  // CUDA: cusparseStatus_t CUSPARSEAPI cusparseCscGet(cusparseSpMatDescr_t spMatDescr, int64_t* rows, int64_t* cols, int64_t* nnz, void** cscColOffsets, void** cscRowInd, void** cscValues, cusparseIndexType_t* cscColOffsetsType, cusparseIndexType_t* cscRowIndType, cusparseIndexBase_t* idxBase, cudaDataType* valueType);
+  // ROC: ROCSPARSE_EXPORT rocsparse_status rocsparse_csc_get(const rocsparse_spmat_descr descr, int64_t* rows, int64_t* cols, int64_t* nnz, void** csc_col_ptr, void** csc_row_ind, void** csc_val, rocsparse_indextype* col_ptr_type, rocsparse_indextype* row_ind_type, rocsparse_index_base* idx_base, rocsparse_datatype* data_type);
+  // CHECK: status_t = rocsparse_csc_get(spmatA, &rows, &cols, &nnz, &cscColOffsets, &cscRowInd, &cscValues, &cscColOffsetsType, &cscRowIndType, &indexBase_t, &dataType);
+  status_t = cusparseCscGet(spmatA, &rows, &cols, &nnz, &cscColOffsets, &cscRowInd, &cscValues, &cscColOffsetsType, &cscRowIndType, &indexBase_t, &dataType);
 #endif
 
 #if CUDA_VERSION < 12000


### PR DESCRIPTION
+ Updated `rocSPARSE` synthetic tests, the regenerated hipify-perl, and `SPARSE` `CUDA2HIP` documentation
