### PR TITLE
[HIPIFY][tests][lit] Introduced `LIT_ARGS` to pass options to `LIT` from `CMake`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -333,16 +333,20 @@ if(HIPIFY_CLANG_TESTS OR HIPIFY_CLANG_TESTS_ONLY)
     ${CMAKE_CURRENT_BINARY_DIR}/tests/lit.site.cfg
     @ONLY)
 
+  if(NOT LIT_ARGS)
+    set(LIT_ARGS -v)
+  endif()
+
   if(HIPIFY_CLANG_TESTS_ONLY)
     add_lit_testsuite(test-hipify "Running HIPIFY regression tests"
       ${CMAKE_CURRENT_LIST_DIR}/tests
       PARAMS site_config=${CMAKE_CURRENT_BINARY_DIR}/tests/lit.site.cfg
-      ARGS -v)
+      ARGS ${LIT_ARGS})
   else()
     add_lit_testsuite(test-hipify "Running HIPIFY regression tests"
       ${CMAKE_CURRENT_LIST_DIR}/tests
       PARAMS site_config=${CMAKE_CURRENT_BINARY_DIR}/tests/lit.site.cfg
-      ARGS -v
+      ARGS ${LIT_ARGS}
       DEPENDS hipify-clang)
   endif()
 


### PR DESCRIPTION
+ For example: `cmake ... -DLIT_ARGS="-a --show-unsupported"`
+ If `LIT_ARGS` is not set, `-v` is used as a lit option by default (as it was before)
+ lit options: https://llvm.org/docs/CommandGuide/lit.html
