### PR TITLE
[HIPIFY][doc][6.1.0] `CHANGELOG.md` update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,13 +14,10 @@ Documentation for HIPIFY is available at
 * Full `rocSPARSE` support
 * New options:
   * `--amap` to hipify as much as possible, ignoring `--default-preprocessor` behavior
-  * `--clang-resource-directory` to specify the clang resource path - the path to the parent folder for the `include` folder that
-    contains `__clang_cuda_runtime_wrapper.h` and other header files used during the hipification process
 
 ### Fixes
 
 * Code blocks skipped by the Preprocessor are not hipified anymore under the `--default-preprocessor` option
-* Clang resource files used during hipification are now searchable and also can be specified by the `--clang-resource-directory` option
 
 ## HIPIFY for ROCm 6.0.2
 


### PR DESCRIPTION
+ `clang-resource-directory` related functionality has moved to the upcoming `6.1.1`
