### PR TITLE
[HIPIFY][fix] Fixed `HIP_MEMSET_NODE_PARAMS` and `hipGetProcAddress`

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -3545,8 +3545,6 @@ sub simpleSubstitutions {
     subst("cudaGraphicsSubResourceGetMappedArray", "hipGraphicsSubResourceGetMappedArray", "graphics");
     subst("cudaGraphicsUnmapResources", "hipGraphicsUnmapResources", "graphics");
     subst("cudaGraphicsUnregisterResource", "hipGraphicsUnregisterResource", "graphics");
-    subst("cuGetProcAddress", "hipGetProcAddress", "driver_entry_point");
-    subst("cudaGetDriverEntryPoint", "hipGetProcAddress", "driver_entry_point");
     subst("cuProfilerStart", "hipProfilerStart", "profiler");
     subst("cuProfilerStop", "hipProfilerStop", "profiler");
     subst("cudaProfilerStart", "hipProfilerStart", "profiler");
@@ -5207,9 +5205,9 @@ sub simpleSubstitutions {
     subst("CUDA_MEMCPY3D_v2", "HIP_MEMCPY3D", "type");
     subst("CUDA_MEMCPY_NODE_PARAMS", "hipMemcpyNodeParams", "type");
     subst("CUDA_MEMCPY_NODE_PARAMS_st", "hipMemcpyNodeParams", "type");
-    subst("CUDA_MEMSET_NODE_PARAMS", "hipMemsetParams", "type");
-    subst("CUDA_MEMSET_NODE_PARAMS_st", "hipMemsetParams", "type");
-    subst("CUDA_MEMSET_NODE_PARAMS_v1", "hipMemsetParams", "type");
+    subst("CUDA_MEMSET_NODE_PARAMS", "HIP_MEMSET_NODE_PARAMS", "type");
+    subst("CUDA_MEMSET_NODE_PARAMS_st", "HIP_MEMSET_NODE_PARAMS", "type");
+    subst("CUDA_MEMSET_NODE_PARAMS_v1", "HIP_MEMSET_NODE_PARAMS", "type");
     subst("CUDA_MEM_ALLOC_NODE_PARAMS", "hipMemAllocNodeParams", "type");
     subst("CUDA_MEM_ALLOC_NODE_PARAMS_st", "hipMemAllocNodeParams", "type");
     subst("CUDA_MEM_ALLOC_NODE_PARAMS_v1", "hipMemAllocNodeParams", "type");
@@ -8938,6 +8936,7 @@ sub warnUnsupportedFunctions {
         "cudaGetKernel",
         "cudaGetFuncBySymbol",
         "cudaGetDriverEntryPointFlags",
+        "cudaGetDriverEntryPoint",
         "cudaGLUnregisterBufferObject",
         "cudaGLUnmapBufferObjectAsync",
         "cudaGLUnmapBufferObject",
@@ -9416,6 +9415,7 @@ sub warnUnsupportedFunctions {
         "cuGraphConditionalHandleCreate",
         "cuGraphAddNode_v2",
         "cuGraphAddDependencies_v2",
+        "cuGetProcAddress",
         "cuGLUnregisterBufferObject",
         "cuGLUnmapBufferObjectAsync",
         "cuGLUnmapBufferObject",

--- a/docs/tables/CUDA_Driver_API_functions_supported_by_HIP.md
+++ b/docs/tables/CUDA_Driver_API_functions_supported_by_HIP.md
@@ -211,9 +211,9 @@
 |`CUDA_MEMCPY3D_v2`|11.3| | | |`HIP_MEMCPY3D`|3.2.0| | | | |
 |`CUDA_MEMCPY_NODE_PARAMS`|12.2| | | |`hipMemcpyNodeParams`|6.1.0| | | | |
 |`CUDA_MEMCPY_NODE_PARAMS_st`|12.2| | | |`hipMemcpyNodeParams`|6.1.0| | | | |
-|`CUDA_MEMSET_NODE_PARAMS`|10.0| | | |`hipMemsetParams`|4.3.0| | | | |
-|`CUDA_MEMSET_NODE_PARAMS_st`|10.0| | | |`hipMemsetParams`|4.3.0| | | | |
-|`CUDA_MEMSET_NODE_PARAMS_v1`|11.3| | | |`hipMemsetParams`|4.3.0| | | | |
+|`CUDA_MEMSET_NODE_PARAMS`|10.0| | | |`HIP_MEMSET_NODE_PARAMS`|6.1.0| | | | |
+|`CUDA_MEMSET_NODE_PARAMS_st`|10.0| | | |`HIP_MEMSET_NODE_PARAMS`|6.1.0| | | | |
+|`CUDA_MEMSET_NODE_PARAMS_v1`|11.3| | | |`HIP_MEMSET_NODE_PARAMS`|6.1.0| | | | |
 |`CUDA_MEMSET_NODE_PARAMS_v2`|12.2| | | | | | | | | |
 |`CUDA_MEMSET_NODE_PARAMS_v2_st`|12.2| | | | | | | | | |
 |`CUDA_MEM_ALLOC_NODE_PARAMS`|11.4| | | |`hipMemAllocNodeParams`|5.5.0| | | | |
@@ -2040,7 +2040,7 @@
 
 |**CUDA**|**A**|**D**|**C**|**R**|**HIP**|**A**|**D**|**C**|**R**|**E**|
 |:--|:-:|:-:|:-:|:-:|:--|:-:|:-:|:-:|:-:|:-:|
-|`cuGetProcAddress`|11.3| | | |`hipGetProcAddress`|6.1.0| | | | |
+|`cuGetProcAddress`|11.3| | | | | | | | | |
 
 ## **34. Coredump Attributes Control API**
 

--- a/docs/tables/CUDA_Runtime_API_functions_supported_by_HIP.md
+++ b/docs/tables/CUDA_Runtime_API_functions_supported_by_HIP.md
@@ -514,7 +514,7 @@
 
 |**CUDA**|**A**|**D**|**C**|**R**|**HIP**|**A**|**D**|**C**|**R**|**E**|
 |:--|:-:|:-:|:-:|:-:|:--|:-:|:-:|:-:|:-:|:-:|
-|`cudaGetDriverEntryPoint`|11.3| | | |`hipGetProcAddress`|6.1.0| | | | |
+|`cudaGetDriverEntryPoint`|11.3| | | | | | | | | |
 
 ## **30. C++ API Routines**
 

--- a/src/CUDA2HIP_Driver_API_functions.cpp
+++ b/src/CUDA2HIP_Driver_API_functions.cpp
@@ -945,7 +945,7 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_FUNCTION_MAP {
 
   // 33. Driver Entry Point Access
   // cudaGetDriverEntryPoint
-  {"cuGetProcAddress",                                            {"hipGetProcAddress",                                           "", CONV_DRIVER_ENTRY_POINT, API_DRIVER, SEC::DRIVER_ENTRY_POINT}},
+  {"cuGetProcAddress",                                            {"hipGetProcAddress",                                           "", CONV_DRIVER_ENTRY_POINT, API_DRIVER, SEC::DRIVER_ENTRY_POINT, HIP_UNSUPPORTED}},
 
   // 34. Coredump Attributes Control API
   //
@@ -1637,7 +1637,6 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_DRIVER_FUNCTION_VER_MAP {
   {"hipArrayGetDescriptor",                                       {HIP_5060, HIP_0,    HIP_0   }},
   {"hipArray3DGetDescriptor",                                     {HIP_5060, HIP_0,    HIP_0   }},
   {"hipDrvGraphAddMemcpyNode",                                    {HIP_6000, HIP_0,    HIP_0   }},
-  {"hipGetProcAddress",                                           {HIP_6010, HIP_0,    HIP_0   }},
   {"hipDrvGraphMemcpyNodeGetParams",                              {HIP_6010, HIP_0,    HIP_0   }},
   {"hipDrvGraphMemcpyNodeSetParams",                              {HIP_6010, HIP_0,    HIP_0   }},
   {"hipDrvGraphAddMemsetNode",                                    {HIP_6010, HIP_0,    HIP_0   }},

--- a/src/CUDA2HIP_Driver_API_types.cpp
+++ b/src/CUDA2HIP_Driver_API_types.cpp
@@ -110,16 +110,16 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_TYPE_NAME_MAP {
   {"CUDA_MEMCPY3D_PEER",                                               {"hip_Memcpy3D_Peer",                                        "", CONV_TYPE, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
   {"CUDA_MEMCPY3D_PEER_v1",                                            {"hip_Memcpy3D_Peer",                                        "", CONV_TYPE, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
 
-  {"CUDA_MEMCPY_NODE_PARAMS_st",                                       {"hipMemcpyNodeParams",                                        "", CONV_TYPE, API_DRIVER, SEC::DATA_TYPES}},
+  {"CUDA_MEMCPY_NODE_PARAMS_st",                                       {"hipMemcpyNodeParams",                                      "", CONV_TYPE, API_DRIVER, SEC::DATA_TYPES}},
   // cudaMemcpyNodeParams
-  {"CUDA_MEMCPY_NODE_PARAMS",                                          {"hipMemcpyNodeParams",                                        "", CONV_TYPE, API_DRIVER, SEC::DATA_TYPES}},
+  {"CUDA_MEMCPY_NODE_PARAMS",                                          {"hipMemcpyNodeParams",                                      "", CONV_TYPE, API_DRIVER, SEC::DATA_TYPES}},
 
-  {"CUDA_MEMSET_NODE_PARAMS_st",                                       {"hipMemsetParams",                                          "", CONV_TYPE, API_DRIVER, SEC::DATA_TYPES}},
-  // cudaMemsetParams
-  {"CUDA_MEMSET_NODE_PARAMS",                                          {"hipMemsetParams",                                          "", CONV_TYPE, API_DRIVER, SEC::DATA_TYPES}},
-  {"CUDA_MEMSET_NODE_PARAMS_v1",                                       {"hipMemsetParams",                                          "", CONV_TYPE, API_DRIVER, SEC::DATA_TYPES}},
+  {"CUDA_MEMSET_NODE_PARAMS_st",                                       {"HIP_MEMSET_NODE_PARAMS",                                   "", CONV_TYPE, API_DRIVER, SEC::DATA_TYPES}},
+  //
+  {"CUDA_MEMSET_NODE_PARAMS",                                          {"HIP_MEMSET_NODE_PARAMS",                                   "", CONV_TYPE, API_DRIVER, SEC::DATA_TYPES}},
+  {"CUDA_MEMSET_NODE_PARAMS_v1",                                       {"HIP_MEMSET_NODE_PARAMS",                                   "", CONV_TYPE, API_DRIVER, SEC::DATA_TYPES}},
   {"CUDA_MEMSET_NODE_PARAMS_v2_st",                                    {"hipMemsetParams_v2",                                       "", CONV_TYPE, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
-  // cudaMemsetParamsV2
+  //
   {"CUDA_MEMSET_NODE_PARAMS_v2",                                       {"hipMemsetParams_v2",                                       "", CONV_TYPE, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
 
   {"CUDA_POINTER_ATTRIBUTE_P2P_TOKENS_st",                             {"HIP_POINTER_ATTRIBUTE_P2P_TOKENS",                         "", CONV_TYPE, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
@@ -4182,4 +4182,5 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_DRIVER_TYPE_NAME_VER_MAP {
   {"HIP_GET_PROC_ADDRESS_SUCCESS",                                     {HIP_6010, HIP_0,    HIP_0   }},
   {"HIP_GET_PROC_ADDRESS_SYMBOL_NOT_FOUND",                            {HIP_6010, HIP_0,    HIP_0   }},
   {"HIP_GET_PROC_ADDRESS_VERSION_NOT_SUFFICIENT",                      {HIP_6010, HIP_0,    HIP_0   }},
+  {"HIP_MEMSET_NODE_PARAMS",                                           {HIP_6010, HIP_0,    HIP_0   }},
 };

--- a/src/CUDA2HIP_Runtime_API_functions.cpp
+++ b/src/CUDA2HIP_Runtime_API_functions.cpp
@@ -873,7 +873,7 @@ const std::map<llvm::StringRef, hipCounter> CUDA_RUNTIME_FUNCTION_MAP {
 
   // 29. Driver Entry Point Access
   // cuGetProcAddress
-  {"cudaGetDriverEntryPoint",                                 {"hipGetProcAddress",                                      "", CONV_DRIVER_ENTRY_POINT, API_RUNTIME, SEC::DRIVER_ENTRY_POINT}},
+  {"cudaGetDriverEntryPoint",                                 {"hipGetProcAddress",                                      "", CONV_DRIVER_ENTRY_POINT, API_RUNTIME, SEC::DRIVER_ENTRY_POINT, HIP_UNSUPPORTED}},
 
   // 30. C++ API Routines
   {"cudaGetKernel",                                           {"hipGetKernel",                                           "", CONV_CPP, API_RUNTIME, SEC::CPP, HIP_UNSUPPORTED}},

--- a/src/CUDA2HIP_Runtime_API_types.cpp
+++ b/src/CUDA2HIP_Runtime_API_types.cpp
@@ -99,9 +99,9 @@ const std::map<llvm::StringRef, hipCounter> CUDA_RUNTIME_TYPE_NAME_MAP {
   // no analogue
   {"cudaMemcpy3DPeerParms",                                            {"hipMemcpy3DPeerParms",                                     "", CONV_TYPE, API_RUNTIME, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
 
-  // CUDA_MEMSET_NODE_PARAMS
+  //
   {"cudaMemsetParams",                                                 {"hipMemsetParams",                                          "", CONV_TYPE, API_RUNTIME, SEC::DATA_TYPES}},
-  // CUDA_MEMSET_NODE_PARAMS_v2
+  //
   {"cudaMemsetParamsV2",                                               {"hipMemsetParams_v2",                                       "", CONV_TYPE, API_RUNTIME, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
 
   // no analogue

--- a/tests/unit_tests/synthetic/driver_functions.cu
+++ b/tests/unit_tests/synthetic/driver_functions.cu
@@ -1055,7 +1055,7 @@ int main() {
   // CHECK-NEXT: hipGraphNode_t graphNode, graphNode2;
   // CHECK-NEXT: const hipGraphNode_t *pGraphNode = nullptr;
   // CHECK-NEXT: hipKernelNodeParams KERNEL_NODE_PARAMS;
-  // CHECK-NEXT: hipMemsetParams MEMSET_NODE_PARAMS;
+  // CHECK-NEXT: HIP_MEMSET_NODE_PARAMS MEMSET_NODE_PARAMS;
   // CHECK-NEXT: hipGraphExec_t graphExec;
   // CHECK-NEXT: hipExternalMemory_t externalMemory;
   // CHECK-NEXT: hipExternalSemaphore_t externalSemaphore;
@@ -1703,6 +1703,11 @@ int main() {
   result = cuGraphReleaseUserObject(graph, userObject, count);
 
   // CUDA: CUresult CUDAAPI cuGraphDebugDotPrint(CUgraph hGraph, const char *path, unsigned int flags);
+  // HIP: hipError_t hipGraphDebugDotPrint(hipGraph_t graph, const char* path, unsigned int flags);
+  // CHECK: result = hipGraphDebugDotPrint(graph, name.c_str(), flags);
+  result = cuGraphDebugDotPrint(graph, name.c_str(), flags);
+
+  // CUDA: CUresult CUDAAPI cuGetProcAddress(const char *symbol, void **pfn, int cudaVersion, cuuint64_t flags, CUdriverProcAddressQueryResult *symbolStatus);
   // HIP: hipError_t hipGraphDebugDotPrint(hipGraph_t graph, const char* path, unsigned int flags);
   // CHECK: result = hipGraphDebugDotPrint(graph, name.c_str(), flags);
   result = cuGraphDebugDotPrint(graph, name.c_str(), flags);

--- a/tests/unit_tests/synthetic/driver_typedefs.cu
+++ b/tests/unit_tests/synthetic/driver_typedefs.cu
@@ -30,6 +30,11 @@ int main() {
 #if CUDA_VERSION >= 10000
   // CHECK: hipHostFn_t hostFn;
   CUhostFn hostFn;
+
+  // CHECK: HIP_MEMSET_NODE_PARAMS MEMSET_NODE_PARAMS_st;
+  // CHECK-NEXT: HIP_MEMSET_NODE_PARAMS MEMSET_NODE_PARAMS;
+  CUDA_MEMSET_NODE_PARAMS_st MEMSET_NODE_PARAMS_st;
+  CUDA_MEMSET_NODE_PARAMS MEMSET_NODE_PARAMS;
 #endif
 
 #if CUDA_VERSION >= 11000
@@ -52,6 +57,9 @@ int main() {
 
   // CHECK: hipMemGenericAllocationHandle_t memGenericAllocationHandle_v1;
   CUmemGenericAllocationHandle_v1 memGenericAllocationHandle_v1;
+
+  // CHECK: HIP_MEMSET_NODE_PARAMS MEMSET_NODE_PARAMS_v1;
+  CUDA_MEMSET_NODE_PARAMS_v1 MEMSET_NODE_PARAMS_v1;
 #endif
 
   return 0;


### PR DESCRIPTION
+ Driver's `CUDA_MEMSET_NODE_PARAMS` has analogue `HIP_MEMSET_NODE_PARAMS`, not `hipMemsetParams`, which is dedicated to Runtime APIs only
+ `hipGetProcAddress` is not implemented yet
+ Updated tests, the regenerated `hipify-perl`, and `CUDA2HIP` docs accordingly
