### PR TITLE
[HIPIFY] Deprecate CUDA Driver's Primary Context Management API in HIP

### DIFF
--- a/docs/tables/CUDA_Driver_API_functions_supported_by_HIP.md
+++ b/docs/tables/CUDA_Driver_API_functions_supported_by_HIP.md
@@ -1455,14 +1455,14 @@
 
 |**CUDA**|**A**|**D**|**C**|**R**|**HIP**|**A**|**D**|**C**|**R**|**E**|
 |:--|:-:|:-:|:-:|:-:|:--|:-:|:-:|:-:|:-:|:-:|
-|`cuDevicePrimaryCtxGetState`| | | | |`hipDevicePrimaryCtxGetState`|1.9.0| | | | |
-|`cuDevicePrimaryCtxRelease`| | | | |`hipDevicePrimaryCtxRelease`|1.9.0| | | | |
-|`cuDevicePrimaryCtxRelease_v2`|11.0| | | |`hipDevicePrimaryCtxRelease`|1.9.0| | | | |
-|`cuDevicePrimaryCtxReset`| | | | |`hipDevicePrimaryCtxReset`|1.9.0| | | | |
-|`cuDevicePrimaryCtxReset_v2`|11.0| | | |`hipDevicePrimaryCtxReset`|1.9.0| | | | |
-|`cuDevicePrimaryCtxRetain`| | | | |`hipDevicePrimaryCtxRetain`|1.9.0| | | | |
-|`cuDevicePrimaryCtxSetFlags`| | | | |`hipDevicePrimaryCtxSetFlags`|1.9.0| | | | |
-|`cuDevicePrimaryCtxSetFlags_v2`|11.0| | | |`hipDevicePrimaryCtxSetFlags`|1.9.0| | | | |
+|`cuDevicePrimaryCtxGetState`| | | | |`hipDevicePrimaryCtxGetState`|1.9.0|6.1.0| | | |
+|`cuDevicePrimaryCtxRelease`| | | | |`hipDevicePrimaryCtxRelease`|1.9.0|6.1.0| | | |
+|`cuDevicePrimaryCtxRelease_v2`|11.0| | | |`hipDevicePrimaryCtxRelease`|1.9.0|6.1.0| | | |
+|`cuDevicePrimaryCtxReset`| | | | |`hipDevicePrimaryCtxReset`|1.9.0|6.1.0| | | |
+|`cuDevicePrimaryCtxReset_v2`|11.0| | | |`hipDevicePrimaryCtxReset`|1.9.0|6.1.0| | | |
+|`cuDevicePrimaryCtxRetain`| | | | |`hipDevicePrimaryCtxRetain`|1.9.0|6.1.0| | | |
+|`cuDevicePrimaryCtxSetFlags`| | | | |`hipDevicePrimaryCtxSetFlags`|1.9.0|6.1.0| | | |
+|`cuDevicePrimaryCtxSetFlags_v2`|11.0| | | |`hipDevicePrimaryCtxSetFlags`|1.9.0|6.1.0| | | |
 
 ## **8. Context Management**
 

--- a/src/CUDA2HIP_Driver_API_functions.cpp
+++ b/src/CUDA2HIP_Driver_API_functions.cpp
@@ -85,14 +85,14 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_FUNCTION_MAP {
 
   // 7. Primary Context Management
   // no analogues
-  {"cuDevicePrimaryCtxGetState",                                  {"hipDevicePrimaryCtxGetState",                                 "", CONV_CONTEXT, API_DRIVER, SEC::PRIMARY_CONTEXT}},
-  {"cuDevicePrimaryCtxRelease",                                   {"hipDevicePrimaryCtxRelease",                                  "", CONV_CONTEXT, API_DRIVER, SEC::PRIMARY_CONTEXT}},
-  {"cuDevicePrimaryCtxRelease_v2",                                {"hipDevicePrimaryCtxRelease",                                  "", CONV_CONTEXT, API_DRIVER, SEC::PRIMARY_CONTEXT}},
-  {"cuDevicePrimaryCtxReset",                                     {"hipDevicePrimaryCtxReset",                                    "", CONV_CONTEXT, API_DRIVER, SEC::PRIMARY_CONTEXT}},
-  {"cuDevicePrimaryCtxReset_v2",                                  {"hipDevicePrimaryCtxReset",                                    "", CONV_CONTEXT, API_DRIVER, SEC::PRIMARY_CONTEXT}},
-  {"cuDevicePrimaryCtxRetain",                                    {"hipDevicePrimaryCtxRetain",                                   "", CONV_CONTEXT, API_DRIVER, SEC::PRIMARY_CONTEXT}},
-  {"cuDevicePrimaryCtxSetFlags",                                  {"hipDevicePrimaryCtxSetFlags",                                 "", CONV_CONTEXT, API_DRIVER, SEC::PRIMARY_CONTEXT}},
-  {"cuDevicePrimaryCtxSetFlags_v2",                               {"hipDevicePrimaryCtxSetFlags",                                 "", CONV_CONTEXT, API_DRIVER, SEC::PRIMARY_CONTEXT}},
+  {"cuDevicePrimaryCtxGetState",                                  {"hipDevicePrimaryCtxGetState",                                 "", CONV_CONTEXT, API_DRIVER, SEC::PRIMARY_CONTEXT, HIP_DEPRECATED}},
+  {"cuDevicePrimaryCtxRelease",                                   {"hipDevicePrimaryCtxRelease",                                  "", CONV_CONTEXT, API_DRIVER, SEC::PRIMARY_CONTEXT, HIP_DEPRECATED}},
+  {"cuDevicePrimaryCtxRelease_v2",                                {"hipDevicePrimaryCtxRelease",                                  "", CONV_CONTEXT, API_DRIVER, SEC::PRIMARY_CONTEXT, HIP_DEPRECATED}},
+  {"cuDevicePrimaryCtxReset",                                     {"hipDevicePrimaryCtxReset",                                    "", CONV_CONTEXT, API_DRIVER, SEC::PRIMARY_CONTEXT, HIP_DEPRECATED}},
+  {"cuDevicePrimaryCtxReset_v2",                                  {"hipDevicePrimaryCtxReset",                                    "", CONV_CONTEXT, API_DRIVER, SEC::PRIMARY_CONTEXT, HIP_DEPRECATED}},
+  {"cuDevicePrimaryCtxRetain",                                    {"hipDevicePrimaryCtxRetain",                                   "", CONV_CONTEXT, API_DRIVER, SEC::PRIMARY_CONTEXT, HIP_DEPRECATED}},
+  {"cuDevicePrimaryCtxSetFlags",                                  {"hipDevicePrimaryCtxSetFlags",                                 "", CONV_CONTEXT, API_DRIVER, SEC::PRIMARY_CONTEXT, HIP_DEPRECATED}},
+  {"cuDevicePrimaryCtxSetFlags_v2",                               {"hipDevicePrimaryCtxSetFlags",                                 "", CONV_CONTEXT, API_DRIVER, SEC::PRIMARY_CONTEXT, HIP_DEPRECATED}},
 
   // 8. Context Management
   // no analogues, except a few
@@ -1497,11 +1497,11 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_DRIVER_FUNCTION_VER_MAP {
   {"hipDeviceGetName",                                            {HIP_1060, HIP_0,    HIP_0   }},
   {"hipDeviceTotalMem",                                           {HIP_1060, HIP_0,    HIP_0   }},
   {"hipDeviceComputeCapability",                                  {HIP_1060, HIP_0,    HIP_0   }},
-  {"hipDevicePrimaryCtxGetState",                                 {HIP_1090, HIP_0,    HIP_0   }},
-  {"hipDevicePrimaryCtxRelease",                                  {HIP_1090, HIP_0,    HIP_0   }},
-  {"hipDevicePrimaryCtxReset",                                    {HIP_1090, HIP_0,    HIP_0   }},
-  {"hipDevicePrimaryCtxRetain",                                   {HIP_1090, HIP_0,    HIP_0   }},
-  {"hipDevicePrimaryCtxSetFlags",                                 {HIP_1090, HIP_0,    HIP_0   }},
+  {"hipDevicePrimaryCtxGetState",                                 {HIP_1090, HIP_6010, HIP_0   }},
+  {"hipDevicePrimaryCtxRelease",                                  {HIP_1090, HIP_6010, HIP_0   }},
+  {"hipDevicePrimaryCtxReset",                                    {HIP_1090, HIP_6010, HIP_0   }},
+  {"hipDevicePrimaryCtxRetain",                                   {HIP_1090, HIP_6010, HIP_0   }},
+  {"hipDevicePrimaryCtxSetFlags",                                 {HIP_1090, HIP_6010, HIP_0   }},
   {"hipCtxCreate",                                                {HIP_1060, HIP_1090, HIP_0   }},
   {"hipCtxDestroy",                                               {HIP_1060, HIP_1090, HIP_0   }},
   {"hipCtxGetApiVersion",                                         {HIP_1090, HIP_1090, HIP_0   }},


### PR DESCRIPTION
+ Updated `CUDA2HIP` documentation accordingly
