### PR TITLE
[HIPIFY][HIP][fix] Fix for `hipTexRefGetArray` and `hipTexRefGetBorderColor`

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -3487,6 +3487,7 @@ sub simpleSubstitutions {
     subst("cuTexRefGetAddressMode", "hipTexRefGetAddressMode", "texture");
     subst("cuTexRefGetAddress_v2", "hipTexRefGetAddress", "texture");
     subst("cuTexRefGetArray", "hipTexRefGetArray", "texture");
+    subst("cuTexRefGetBorderColor", "hipTexRefGetBorderColor", "texture");
     subst("cuTexRefGetFilterMode", "hipTexRefGetFilterMode", "texture");
     subst("cuTexRefGetFlags", "hipTexRefGetFlags", "texture");
     subst("cuTexRefGetFormat", "hipTexRefGetFormat", "texture");
@@ -9301,7 +9302,6 @@ sub warnUnsupportedFunctions {
         "cuWGLGetDevice",
         "cuVDPAUGetDevice",
         "cuVDPAUCtxCreate",
-        "cuTexRefGetBorderColor",
         "cuTexRefDestroy",
         "cuTexRefCreate",
         "cuTensorMapReplaceAddress",

--- a/docs/tables/CUDA_Driver_API_functions_supported_by_HIP.md
+++ b/docs/tables/CUDA_Driver_API_functions_supported_by_HIP.md
@@ -1953,8 +1953,8 @@
 |`cuTexRefGetAddress`| |11.0| | |`hipTexRefGetAddress`|3.0.0|4.3.0| | | |
 |`cuTexRefGetAddressMode`| |11.0| | |`hipTexRefGetAddressMode`|3.0.0|4.3.0| | | |
 |`cuTexRefGetAddress_v2`| |11.0| | |`hipTexRefGetAddress`|3.0.0|4.3.0| | | |
-|`cuTexRefGetArray`| |11.0| | |`hipTexRefGetArray`|3.0.0| | |4.2.0| |
-|`cuTexRefGetBorderColor`|8.0|11.0| | | | | | | | |
+|`cuTexRefGetArray`| |11.0| | |`hipTexRefGetArray`|3.0.0|6.1.0| | | |
+|`cuTexRefGetBorderColor`|8.0|11.0| | |`hipTexRefGetBorderColor`|6.1.0|6.1.0| | | |
 |`cuTexRefGetFilterMode`| |11.0| | |`hipTexRefGetFilterMode`|3.5.0|4.3.0| | | |
 |`cuTexRefGetFlags`| |11.0| | |`hipTexRefGetFlags`|3.5.0|4.3.0| | | |
 |`cuTexRefGetFormat`| |11.0| | |`hipTexRefGetFormat`|3.5.0|4.3.0| | | |

--- a/src/CUDA2HIP_Driver_API_functions.cpp
+++ b/src/CUDA2HIP_Driver_API_functions.cpp
@@ -843,8 +843,8 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_FUNCTION_MAP {
   {"cuTexRefGetAddress",                                          {"hipTexRefGetAddress",                                         "", CONV_TEXTURE, API_DRIVER, SEC::TEXTURE_DEPRECATED, DEPRECATED}},
   {"cuTexRefGetAddress_v2",                                       {"hipTexRefGetAddress",                                         "", CONV_TEXTURE, API_DRIVER, SEC::TEXTURE_DEPRECATED, DEPRECATED}},
   {"cuTexRefGetAddressMode",                                      {"hipTexRefGetAddressMode",                                     "", CONV_TEXTURE, API_DRIVER, SEC::TEXTURE_DEPRECATED, DEPRECATED}},
-  {"cuTexRefGetArray",                                            {"hipTexRefGetArray",                                           "", CONV_TEXTURE, API_DRIVER, SEC::TEXTURE_DEPRECATED, CUDA_DEPRECATED | HIP_REMOVED}},
-  {"cuTexRefGetBorderColor",                                      {"hipTexRefGetBorderColor",                                     "", CONV_TEXTURE, API_DRIVER, SEC::TEXTURE_DEPRECATED, CUDA_DEPRECATED | HIP_UNSUPPORTED}},
+  {"cuTexRefGetArray",                                            {"hipTexRefGetArray",                                           "", CONV_TEXTURE, API_DRIVER, SEC::TEXTURE_DEPRECATED, CUDA_DEPRECATED | HIP_DEPRECATED}},
+  {"cuTexRefGetBorderColor",                                      {"hipTexRefGetBorderColor",                                     "", CONV_TEXTURE, API_DRIVER, SEC::TEXTURE_DEPRECATED, CUDA_DEPRECATED | HIP_DEPRECATED}},
   {"cuTexRefGetFilterMode",                                       {"hipTexRefGetFilterMode",                                      "", CONV_TEXTURE, API_DRIVER, SEC::TEXTURE_DEPRECATED, DEPRECATED}},
   {"cuTexRefGetFlags",                                            {"hipTexRefGetFlags",                                           "", CONV_TEXTURE, API_DRIVER, SEC::TEXTURE_DEPRECATED, DEPRECATED}},
   {"cuTexRefGetFormat",                                           {"hipTexRefGetFormat",                                          "", CONV_TEXTURE, API_DRIVER, SEC::TEXTURE_DEPRECATED, DEPRECATED}},
@@ -1558,7 +1558,7 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_DRIVER_FUNCTION_VER_MAP {
   {"hipModuleOccupancyMaxPotentialBlockSizeWithFlags",            {HIP_3050, HIP_0,    HIP_0   }},
   {"hipTexRefGetAddress",                                         {HIP_3000, HIP_4030, HIP_0   }},
   {"hipTexRefGetAddressMode",                                     {HIP_3000, HIP_4030, HIP_0   }},
-  {"hipTexRefGetArray",                                           {HIP_3000, HIP_0,    HIP_4020}},
+  {"hipTexRefGetArray",                                           {HIP_3000, HIP_6010, HIP_0   }},
   {"hipTexRefGetFilterMode",                                      {HIP_3050, HIP_4030, HIP_0   }},
   {"hipTexRefGetFlags",                                           {HIP_3050, HIP_4030, HIP_0   }},
   {"hipTexRefGetFormat",                                          {HIP_3050, HIP_4030, HIP_0   }},
@@ -1643,6 +1643,7 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_DRIVER_FUNCTION_VER_MAP {
   {"hipDrvGraphAddMemFreeNode",                                   {HIP_6010, HIP_0,    HIP_0   }},
   {"hipDrvGraphExecMemcpyNodeSetParams",                          {HIP_6010, HIP_0,    HIP_0   }},
   {"hipDrvGraphExecMemsetNodeSetParams",                          {HIP_6010, HIP_0,    HIP_0   }},
+  {"hipTexRefGetBorderColor",                                     {HIP_6010, HIP_6010, HIP_0   }},
 };
 
 const std::map<unsigned int, llvm::StringRef> CUDA_DRIVER_API_SECTION_MAP {

--- a/tests/unit_tests/synthetic/driver_functions.cu
+++ b/tests/unit_tests/synthetic/driver_functions.cu
@@ -27,8 +27,9 @@ int main() {
   void* image = nullptr;
   std::string name = "str";
   uint32_t u_value = 0;
-  float ms = 0;
-  float ms_2 = 0;
+  float ms = 0.0f;
+  float ms_2 = 0.0f;
+  float fBorderColor = 0.0f;
   int* value = 0;
   int* value_2 = 0;
   GLuint gl_uint = 0;
@@ -973,6 +974,11 @@ int main() {
   // CHECK: result = hipPointerSetAttribute(image, pointer_attribute, deviceptr);
   result = cuPointerSetAttribute(image, pointer_attribute, deviceptr);
 
+  // CUDA: __CUDA_DEPRECATED CUresult CUDAAPI cuTexRefGetArray(CUarray *phArray, CUtexref hTexRef);
+  // HIP: DEPRECATED(DEPRECATED_MSG) hipError_t hipTexRefGetArray(hipArray_t* pArray, const textureReference* texRef);
+  // CHECK: result = hipTexRefGetArray(&array_, texref);
+  result = cuTexRefGetArray(&array_, texref);
+
 #if CUDA_VERSION >= 8000
   // CHECK: hipMemRangeAttribute MemoryRangeAttribute;
   // CHECK-NEXT: hipMemoryAdvise MemoryAdvise;
@@ -1011,8 +1017,13 @@ int main() {
 
   // CUDA: __CUDA_DEPRECATED CUresult CUDAAPI cuTexRefSetBorderColor(CUtexref hTexRef, float *pBorderColor);
   // HIP: DEPRECATED(DEPRECATED_MSG) hipError_t hipTexRefSetBorderColor(textureReference* texRef, float* pBorderColor);
-  // CHECK: result = hipTexRefSetBorderColor(texref, &ms);
-  result = cuTexRefSetBorderColor(texref, &ms);
+  // CHECK: result = hipTexRefSetBorderColor(texref, &fBorderColor);
+  result = cuTexRefSetBorderColor(texref, &fBorderColor);
+
+  // CUDA: __CUDA_DEPRECATED CUresult CUDAAPI cuTexRefGetBorderColor(float *pBorderColor, CUtexref hTexRef);
+  // HIP: DEPRECATED(DEPRECATED_MSG) hipError_t hipTexRefGetBorderColor(float* pBorderColor, const textureReference* texRef);
+  // CHECK: result = hipTexRefGetBorderColor(&fBorderColor, texref);
+  result = cuTexRefGetBorderColor(&fBorderColor, texref);
 
   // CHECK: hipDeviceP2PAttr deviceP2PAttribute;
   CUdevice_P2PAttribute deviceP2PAttribute;


### PR DESCRIPTION
+ `hipTexRefGetArray`, being deleted in HIP 4.2.0, reappeared in HIP 6.1.0 as deprecated
+ `hipTexRefGetBorderColor` appeared in HIP 6.1.0 as deprecated
+ Updated synthetic tests, `hipify-perl`, and `CUDA2HIP` documentation accordingly
