### PR TITLE
[HIPIFY][SOLVER] Sync with CUDA 12.4.0 - Step 9 - cuSOLVER

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -8328,6 +8328,8 @@ sub warnUnsupportedFunctions {
         "cusolverDnXpotrs",
         "cusolverDnXpotrf_bufferSize",
         "cusolverDnXpotrf",
+        "cusolverDnXlarft_bufferSize",
+        "cusolverDnXlarft",
         "cusolverDnXgetrs",
         "cusolverDnXgetrf_bufferSize",
         "cusolverDnXgetrf",

--- a/docs/tables/CUSOLVER_API_supported_by_HIP.md
+++ b/docs/tables/CUSOLVER_API_supported_by_HIP.md
@@ -442,6 +442,8 @@
 |`cusolverDnXgetrf`|11.1| | | | | | | | | |
 |`cusolverDnXgetrf_bufferSize`|11.1| | | | | | | | | |
 |`cusolverDnXgetrs`|11.1| | | | | | | | | |
+|`cusolverDnXlarft`|12.4| | | | | | | | | |
+|`cusolverDnXlarft_bufferSize`|12.4| | | | | | | | | |
 |`cusolverDnXpotrf`|11.1| | | | | | | | | |
 |`cusolverDnXpotrf_bufferSize`|11.1| | | | | | | | | |
 |`cusolverDnXpotrs`|11.1| | | | | | | | | |

--- a/docs/tables/CUSOLVER_API_supported_by_HIP_and_ROC.md
+++ b/docs/tables/CUSOLVER_API_supported_by_HIP_and_ROC.md
@@ -442,6 +442,8 @@
 |`cusolverDnXgetrf`|11.1| | | | | | | | | | | | | | | |
 |`cusolverDnXgetrf_bufferSize`|11.1| | | | | | | | | | | | | | | |
 |`cusolverDnXgetrs`|11.1| | | | | | | | | | | | | | | |
+|`cusolverDnXlarft`|12.4| | | | | | | | | | | | | | | |
+|`cusolverDnXlarft_bufferSize`|12.4| | | | | | | | | | | | | | | |
 |`cusolverDnXpotrf`|11.1| | | | | | | | | | | | | | | |
 |`cusolverDnXpotrf_bufferSize`|11.1| | | | | | | | | | | | | | | |
 |`cusolverDnXpotrs`|11.1| | | | | | | | | | | | | | | |

--- a/docs/tables/CUSOLVER_API_supported_by_ROC.md
+++ b/docs/tables/CUSOLVER_API_supported_by_ROC.md
@@ -442,6 +442,8 @@
 |`cusolverDnXgetrf`|11.1| | | | | | | | | |
 |`cusolverDnXgetrf_bufferSize`|11.1| | | | | | | | | |
 |`cusolverDnXgetrs`|11.1| | | | | | | | | |
+|`cusolverDnXlarft`|12.4| | | | | | | | | |
+|`cusolverDnXlarft_bufferSize`|12.4| | | | | | | | | |
 |`cusolverDnXpotrf`|11.1| | | | | | | | | |
 |`cusolverDnXpotrf_bufferSize`|11.1| | | | | | | | | |
 |`cusolverDnXpotrs`|11.1| | | | | | | | | |

--- a/src/CUDA2HIP_SOLVER_API_functions.cpp
+++ b/src/CUDA2HIP_SOLVER_API_functions.cpp
@@ -467,6 +467,8 @@ const std::map<llvm::StringRef, hipCounter> CUDA_SOLVER_FUNCTION_MAP {
   {"cusolverDnXgesvdp",                                  {"hipsolverDnXgesvdp",                                    "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
   {"cusolverDnXgesvdr_bufferSize",                       {"hipsolverDnXgesvdr_bufferSize",                         "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
   {"cusolverDnXgesvdr",                                  {"hipsolverDnXgesvdr",                                    "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
+  {"cusolverDnXlarft_bufferSize",                        {"hipsolverDnXlarft_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
+  {"cusolverDnXlarft",                                   {"hipsolverDnXlarft",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
   {"cusolverDnLoggerSetCallback",                        {"hipsolverDnLoggerSetCallback",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
   {"cusolverDnLoggerSetFile",                            {"hipsolverDnLoggerSetFile",                              "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
   {"cusolverDnLoggerOpenFile",                           {"hipsolverDnLoggerOpenFile",                             "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
@@ -1157,6 +1159,8 @@ const std::map<llvm::StringRef, cudaAPIversions> CUDA_SOLVER_FUNCTION_VER_MAP {
   {"cusolverSpDcsrcholDiag",                             {CUDA_101, CUDA_0,   CUDA_0  }}, // CUSOLVER_VERSION 10200
   {"cusolverSpCcsrcholDiag",                             {CUDA_101, CUDA_0,   CUDA_0  }}, // CUSOLVER_VERSION 10200
   {"cusolverSpZcsrcholDiag",                             {CUDA_101, CUDA_0,   CUDA_0  }}, // CUSOLVER_VERSION 10200
+  {"cusolverDnXlarft",                                   {CUDA_124, CUDA_0,   CUDA_0  }},
+  {"cusolverDnXlarft_bufferSize",                        {CUDA_124, CUDA_0,   CUDA_0  }},
 };
 
 const std::map<llvm::StringRef, hipAPIversions> HIP_SOLVER_FUNCTION_VER_MAP {


### PR DESCRIPTION
+ Updated the regenerated `hipify-perl` and `SOLVER` `CUDA2HIP` docs accordingly
