### PR TITLE
[HIPIFY][doc] CUDA `12.4.0` is the latest supported release (LLVM 19.x)

### DIFF
--- a/docs/hipify-clang.rst
+++ b/docs/hipify-clang.rst
@@ -177,7 +177,7 @@ Dependencies
     - **LATEST STABLE CONFIG**
     - **LATEST STABLE CONFIG**
   * - `19.0.0 git <https://github.com/llvm/llvm-project>`_
-    - `12.3.2 <https://developer.nvidia.com/cuda-downloads>`_
+    - `12.4.0 <https://developer.nvidia.com/cuda-downloads>`_
     - \+
     - \+
 


### PR DESCRIPTION
+ CUDA 12.4.0 is supported by LLVM >= 19.0.0, might work with LLVM 17.x and 18.x
+ Updated the `README.md` accordingly
+ Tested on Windows 11 and Ubuntu 23.10