### PR TITLE
[HIPIFY][doc] CUDA `12.4.1` is the latest supported release (LLVM 19.x)

### DIFF
--- a/docs/hipify-clang.rst
+++ b/docs/hipify-clang.rst
@@ -177,7 +177,7 @@ Dependencies
     - **LATEST STABLE CONFIG**
     - **LATEST STABLE CONFIG**
   * - `19.0.0 git <https://github.com/llvm/llvm-project>`_
-    - `12.4.0 <https://developer.nvidia.com/cuda-downloads>`_
+    - `12.4.1 <https://developer.nvidia.com/cuda-downloads>`_
     - \+
     - \+
 


### PR DESCRIPTION
+ There are no HIPIFY-related changes since CUDA 12.4.0
+ CUDA 12.4.1 is supported by LLVM >= 19.0.0, but might work with the `hipify-clang` built against LLVM 17.x and 18.x
+ Updated the `README.md` accordingly
+ Tested on Windows 11 and Ubuntu 23.10