### PR TITLE
[HIPIFY][#1439][fix] Switched the matcher `cudaOverloadedHostFuncCall` to using `getWriteRange`

### DIFF
--- a/src/HipifyAction.cpp
+++ b/src/HipifyAction.cpp
@@ -2734,15 +2734,13 @@ bool HipifyAction::cudaOverloadedHostFuncCall(const mat::MatchFinder::MatchResul
     auto overrideInfo = itNumArgs->second;
     auto counter = overrideInfo.counter;
     // check if SUPPORTED
-    auto* SM = Result.SourceManager;
-    clang::SourceLocation s;
     switch (overrideInfo.overloadType) {
       case ot_arguments_number:
       default:
       {
-        s = call->getBeginLoc();
-        ct::Replacement Rep(*SM, s, name.size(), counter.hipName.str());
-        clang::FullSourceLoc fullSL(s, *SM);
+        clang::SourceRange replacementRange = getWriteRange(*Result.SourceManager, { call->getBeginLoc(), call->getEndLoc() });
+        ct::Replacement Rep(*Result.SourceManager, replacementRange.getBegin(), name.size(), counter.hipName.str());
+        clang::FullSourceLoc fullSL(replacementRange.getBegin(), *Result.SourceManager);
         insertReplacement(Rep, fullSL);
         break;
       }


### PR DESCRIPTION
**[Synopsis]**
+ In the provided [graphMemoryFootprint.cu](https://github.com/ROCm/HIPIFY/files/15050706/graphMemoryFootprint.cu.zip), the entire source code is not hipified due to the following line:

```c++
checkCudaErrors(cudaGraphInstantiate(graphExec, graph, NULL, NULL, 0));
```
+ Clang itself provided only one diagnostic: `Skipped some replacements,` but all the replacements were skipped, in fact.
+ Without the wrapping`checkCudaErrors` macro, the hipification works correctly.

**[Solution]**
+ Take into account possible macro expansions by starting to use the function `getWriteRange`, in which possible macro expansions have already been handled.

**[ToDo]**
+ Revise all the rest matchers and switch them to using `getWriteRange` AMAP.
+ Try to provide more detailed diagnostics for matchers.