### PR TITLE
[HIPIFY][#936][BLASLT] `cublasLt` -> `hipblalLt` hipification support - Step 3

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -5448,6 +5448,9 @@ sub simpleSubstitutions {
     subst("cublasGemmAlgo_t", "hipblasGemmAlgo_t", "type");
     subst("cublasHandle_t", "hipblasHandle_t", "type");
     subst("cublasLtHandle_t", "hipblasLtHandle_t", "type");
+    subst("cublasLtMatrixLayoutOpaque_t", "hipblasLtMatrixLayoutOpaque_t", "type");
+    subst("cublasLtMatrixLayoutStruct", "hipblasLtMatrixLayoutOpaque_t", "type");
+    subst("cublasLtMatrixLayout_t", "hipblasLtMatrixLayout_t", "type");
     subst("cublasMath_t", "hipblasMath_t", "type");
     subst("cublasOperation_t", "hipblasOperation_t", "type");
     subst("cublasPointerMode_t", "hipblasPointerMode_t", "type");
@@ -11216,6 +11219,7 @@ sub warnHipOnlyUnsupportedFunctions {
         "cublasLtGetStatusName",
         "cublasLtGetProperty",
         "cublasLtGetCudartVersion",
+        "cublasLtDisableCpuInstructionsSetMask",
         "cublasLtContext",
         "cublasLoggerConfigure",
         "cublasLogCallback",
@@ -11651,6 +11655,7 @@ sub warnRocOnlyUnsupportedFunctions {
         "cublasLtGetStatusName",
         "cublasLtGetProperty",
         "cublasLtGetCudartVersion",
+        "cublasLtDisableCpuInstructionsSetMask",
         "cublasLoggerConfigure",
         "cublasLogCallback",
         "cublasIaminEx_64",

--- a/docs/tables/CUBLAS_API_supported_by_HIP.md
+++ b/docs/tables/CUBLAS_API_supported_by_HIP.md
@@ -148,6 +148,9 @@
 |:--|:-:|:-:|:-:|:-:|:--|:-:|:-:|:-:|:-:|:-:|
 |`cublasLtContext`|10.1| | | | | | | | | |
 |`cublasLtHandle_t`|10.1| | | |`hipblasLtHandle_t`|5.5.0| | | | |
+|`cublasLtMatrixLayoutOpaque_t`|11.0| | | |`hipblasLtMatrixLayoutOpaque_t`| | | | | |
+|`cublasLtMatrixLayoutStruct`|10.1| | |10.2|`hipblasLtMatrixLayoutOpaque_t`| | | | | |
+|`cublasLtMatrixLayout_t`|10.1| | | |`hipblasLtMatrixLayout_t`| | | | | |
 
 ## **4. CUBLAS Helper Function Reference**
 
@@ -1025,6 +1028,7 @@
 |:--|:-:|:-:|:-:|:-:|:--|:-:|:-:|:-:|:-:|:-:|
 |`cublasLtCreate`|10.1| | | |`hipblasLtCreate`|5.5.0| | | | |
 |`cublasLtDestroy`|10.1| | | |`hipblasLtDestroy`|5.5.0| | | | |
+|`cublasLtDisableCpuInstructionsSetMask`|12.1| | | | | | | | | |
 |`cublasLtGetCudartVersion`|10.1| | | | | | | | | |
 |`cublasLtGetProperty`|10.1| | | | | | | | | |
 |`cublasLtGetStatusName`|11.4| | | | | | | | | |

--- a/docs/tables/CUBLAS_API_supported_by_HIP_and_ROC.md
+++ b/docs/tables/CUBLAS_API_supported_by_HIP_and_ROC.md
@@ -148,6 +148,9 @@
 |:--|:-:|:-:|:-:|:-:|:--|:-:|:-:|:-:|:-:|:-:|:--|:-:|:-:|:-:|:-:|:-:|
 |`cublasLtContext`|10.1| | | | | | | | | | | | | | | |
 |`cublasLtHandle_t`|10.1| | | |`hipblasLtHandle_t`|5.5.0| | | | | | | | | | |
+|`cublasLtMatrixLayoutOpaque_t`|11.0| | | |`hipblasLtMatrixLayoutOpaque_t`| | | | | | | | | | | |
+|`cublasLtMatrixLayoutStruct`|10.1| | |10.2|`hipblasLtMatrixLayoutOpaque_t`| | | | | | | | | | | |
+|`cublasLtMatrixLayout_t`|10.1| | | |`hipblasLtMatrixLayout_t`| | | | | | | | | | | |
 
 ## **4. CUBLAS Helper Function Reference**
 
@@ -1025,6 +1028,7 @@
 |:--|:-:|:-:|:-:|:-:|:--|:-:|:-:|:-:|:-:|:-:|:--|:-:|:-:|:-:|:-:|:-:|
 |`cublasLtCreate`|10.1| | | |`hipblasLtCreate`|5.5.0| | | | | | | | | | |
 |`cublasLtDestroy`|10.1| | | |`hipblasLtDestroy`|5.5.0| | | | | | | | | | |
+|`cublasLtDisableCpuInstructionsSetMask`|12.1| | | | | | | | | | | | | | | |
 |`cublasLtGetCudartVersion`|10.1| | | | | | | | | | | | | | | |
 |`cublasLtGetProperty`|10.1| | | | | | | | | | | | | | | |
 |`cublasLtGetStatusName`|11.4| | | | | | | | | | | | | | | |

--- a/docs/tables/CUBLAS_API_supported_by_ROC.md
+++ b/docs/tables/CUBLAS_API_supported_by_ROC.md
@@ -148,6 +148,9 @@
 |:--|:-:|:-:|:-:|:-:|:--|:-:|:-:|:-:|:-:|:-:|
 |`cublasLtContext`|10.1| | | | | | | | | |
 |`cublasLtHandle_t`|10.1| | | | | | | | | |
+|`cublasLtMatrixLayoutOpaque_t`|11.0| | | | | | | | | |
+|`cublasLtMatrixLayoutStruct`|10.1| | |10.2| | | | | | |
+|`cublasLtMatrixLayout_t`|10.1| | | | | | | | | |
 
 ## **4. CUBLAS Helper Function Reference**
 
@@ -1025,6 +1028,7 @@
 |:--|:-:|:-:|:-:|:-:|:--|:-:|:-:|:-:|:-:|:-:|
 |`cublasLtCreate`|10.1| | | | | | | | | |
 |`cublasLtDestroy`|10.1| | | | | | | | | |
+|`cublasLtDisableCpuInstructionsSetMask`|12.1| | | | | | | | | |
 |`cublasLtGetCudartVersion`|10.1| | | | | | | | | |
 |`cublasLtGetProperty`|10.1| | | | | | | | | |
 |`cublasLtGetStatusName`|11.4| | | | | | | | | |

--- a/src/CUDA2HIP_BLAS_API_functions.cpp
+++ b/src/CUDA2HIP_BLAS_API_functions.cpp
@@ -1087,8 +1087,9 @@ const std::map<llvm::StringRef, hipCounter> CUDA_BLAS_FUNCTION_MAP {
   {"cublasLtGetVersion",             {"hipblasLtGetVersion",             "",                                         CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LT, UNSUPPORTED}},
   {"cublasLtGetCudartVersion",       {"hipblasLtGetCudartVersion",       "",                                         CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LT, UNSUPPORTED}},
   {"cublasLtGetProperty",            {"hipblasLtGetProperty",            "",                                         CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LT, UNSUPPORTED}},
-  {"cublasLtHeuristicsCacheGetCapacity",  {"hipblasLtHeuristicsCacheGetCapacity",            "",                     CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LT, UNSUPPORTED}},
-  {"cublasLtHeuristicsCacheSetCapacity",  {"hipblasLtHeuristicsCacheSetCapacity",            "",                     CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LT, UNSUPPORTED}},
+  {"cublasLtHeuristicsCacheGetCapacity",     {"hipblasLtHeuristicsCacheGetCapacity",     "",                         CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LT, UNSUPPORTED}},
+  {"cublasLtHeuristicsCacheSetCapacity",     {"hipblasLtHeuristicsCacheSetCapacity",     "",                         CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LT, UNSUPPORTED}},
+  {"cublasLtDisableCpuInstructionsSetMask",  {"hipblasLtDisableCpuInstructionsSetMask",  "",                         CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LT, UNSUPPORTED}},
 };
 
 const std::map<llvm::StringRef, cudaAPIversions> CUDA_BLAS_FUNCTION_VER_MAP {
@@ -1541,13 +1542,14 @@ const std::map<llvm::StringRef, cudaAPIversions> CUDA_BLAS_FUNCTION_VER_MAP {
   {"cublasDgemmGroupedBatched_64",               {CUDA_124, CUDA_0,   CUDA_0   }},
   {"cublasLtCreate",                             {CUDA_101, CUDA_0,   CUDA_0   }},
   {"cublasLtDestroy",                            {CUDA_101, CUDA_0,   CUDA_0   }},
-  {"cublasLtGetStatusName",                      {CUDA_114, CUDA_0,   CUDA_0   }}, // A: CUDA_VERSION 11042, CUBLAS_VERSION 11061, CUBLAS_VER_MAJOR 11 CUBLAS_VER_MINOR 6
-  {"cublasLtGetStatusString",                    {CUDA_114, CUDA_0,   CUDA_0   }}, // A: CUDA_VERSION 11042, CUBLAS_VERSION 11061, CUBLAS_VER_MAJOR 11 CUBLAS_VER_MINOR 6
+  {"cublasLtGetStatusName",                      {CUDA_114, CUDA_0,   CUDA_0   }}, // A: CUDA_VERSION 11042, CUBLAS_VERSION 110601, CUBLAS_VER_MAJOR 11 CUBLAS_VER_MINOR 6
+  {"cublasLtGetStatusString",                    {CUDA_114, CUDA_0,   CUDA_0   }}, // A: CUDA_VERSION 11042, CUBLAS_VERSION 110601, CUBLAS_VER_MAJOR 11 CUBLAS_VER_MINOR 6
   {"cublasLtGetVersion",                         {CUDA_101, CUDA_0,   CUDA_0   }},
   {"cublasLtGetCudartVersion",                   {CUDA_101, CUDA_0,   CUDA_0   }},
   {"cublasLtGetProperty",                        {CUDA_101, CUDA_0,   CUDA_0   }},
   {"cublasLtHeuristicsCacheGetCapacity",         {CUDA_118, CUDA_0,   CUDA_0   }},
   {"cublasLtHeuristicsCacheSetCapacity",         {CUDA_118, CUDA_0,   CUDA_0   }},
+  {"cublasLtDisableCpuInstructionsSetMask",      {CUDA_121, CUDA_0,   CUDA_0   }}, // A: CUDA_VERSION 12011, CUBLAS_VERSION 120103, CUBLAS_VER_MAJOR 12 CUBLAS_VER_MINOR 3
 };
 
 const std::map<llvm::StringRef, hipAPIversions> HIP_BLAS_FUNCTION_VER_MAP {

--- a/src/CUDA2HIP_BLAS_API_types.cpp
+++ b/src/CUDA2HIP_BLAS_API_types.cpp
@@ -189,6 +189,11 @@ const std::map<llvm::StringRef, hipCounter> CUDA_BLAS_TYPE_NAME_MAP {
   {"cublasLtHandle_t",                                 {"hipblasLtHandle_t",                                 "",                                      CONV_TYPE, API_BLAS, SEC::BLAS_LT_DATA_TYPES}},
   // TODO: dereferencing: typedef struct cublasLtContext *cublasLtHandle_t;
   {"cublasLtContext",                                  {"hipblasLtContext",                                  "",                                      CONV_TYPE, API_BLAS, SEC::BLAS_LT_DATA_TYPES, HIP_UNSUPPORTED}},
+  // NOTE: hipblasLtMatrixLayoutOpaque_t contains uint64_t data[4], whereas cublasLtMatrixLayoutOpaque_t contains uint64_t data[8]
+  {"cublasLtMatrixLayoutOpaque_t",                     {"hipblasLtMatrixLayoutOpaque_t",                     "",                                      CONV_TYPE, API_BLAS, SEC::BLAS_LT_DATA_TYPES}},
+  // NOTE: cublasLtMatrixLayoutStruct is the former name for cublasLtMatrixLayoutOpaque_t, that has been alive for 10.1.0 <= CUDA <= 10.2.0
+  {"cublasLtMatrixLayoutStruct",                       {"hipblasLtMatrixLayoutOpaque_t",                     "",                                      CONV_TYPE, API_BLAS, SEC::BLAS_LT_DATA_TYPES}},
+  {"cublasLtMatrixLayout_t",                           {"hipblasLtMatrixLayout_t",                           "",                                      CONV_TYPE, API_BLAS, SEC::BLAS_LT_DATA_TYPES}},
 
 };
 
@@ -292,6 +297,9 @@ const std::map<llvm::StringRef, cudaAPIversions> CUDA_BLAS_TYPE_NAME_VER_MAP {
   {"CUDA_R_8F_E5M2",                                   {CUDA_118, CUDA_0,   CUDA_0  }},
   {"cublasLtHandle_t",                                 {CUDA_101, CUDA_0,   CUDA_0  }},
   {"cublasLtContext",                                  {CUDA_101, CUDA_0,   CUDA_0  }},
+  {"cublasLtMatrixLayoutOpaque_t",                     {CUDA_110, CUDA_0,   CUDA_0  }}, // A: CUDA_VERSION 11001, CUBLAS_VERSION 11000, CUBLAS_VER_MAJOR 11 CUBLAS_VER_MINOR 0
+  {"cublasLtMatrixLayoutStruct",                       {CUDA_101, CUDA_0,   CUDA_102}},
+  {"cublasLtMatrixLayout_t",                           {CUDA_101, CUDA_0,   CUDA_0  }},
 };
 
 const std::map<llvm::StringRef, hipAPIversions> HIP_BLAS_TYPE_NAME_VER_MAP {

--- a/tests/lit.cfg
+++ b/tests/lit.cfg
@@ -83,6 +83,13 @@ if config.cuda_version_major < 10 or (config.cuda_version_major == 10 and config
 if config.cuda_version_major < 10 or (config.cuda_version_major == 10 and config.cuda_version_minor < 1) or config.cuda_version_major >= 12:
     config.excludes.append('cusparse2rocsparse_10010_12000.cu')
 
+if config.cuda_version_major < 10 or (config.cuda_version_major == 10 and config.cuda_version_minor < 1):
+    config.excludes.append('cublaslt2hipblaslt.cu')
+    config.excludes.append('cublaslt2hipblaslt_10010_10020.cu')
+
+if not (config.cuda_version_major == 10 and (config.cuda_version_minor == 1 and config.cuda_version_minor == 2)):
+    config.excludes.append('cublaslt2hipblaslt_10010_10020.cu')
+
 if config.cuda_version_major < 11 and sys.platform in ['win32']:
     config.excludes.append('cusparse2rocsparse_10010_12000.cu')
 

--- a/tests/unit_tests/synthetic/libraries/cublaslt2hipblaslt.cu
+++ b/tests/unit_tests/synthetic/libraries/cublaslt2hipblaslt.cu
@@ -30,5 +30,10 @@ int main() {
   status = cublasLtDestroy(blasLtHandle);
 #endif
 
+#if CUDA_VERSION >= 11000 && CUBLAS_VERSION >= 11000
+  // CHECK: hipblasLtMatrixLayoutOpaque_t blasLtMatrixLayoutOpaque;
+  cublasLtMatrixLayoutOpaque_t blasLtMatrixLayoutOpaque;
+#endif
+
   return 0;
 }

--- a/tests/unit_tests/synthetic/libraries/cublaslt2hipblaslt_10010_10020.cu
+++ b/tests/unit_tests/synthetic/libraries/cublaslt2hipblaslt_10010_10020.cu
@@ -1,0 +1,19 @@
+// RUN: %run_test hipify "%s" "%t" %hipify_args 3 --amap --skip-excluded-preprocessor-conditional-blocks --experimental %clang_args -D__CUDA_API_VERSION_INTERNAL -ferror-limit=500
+
+// CHECK: #include <hip/hip_runtime.h>
+#include <cuda_runtime.h>
+#include <stdio.h>
+// CHECK: #include "hipblaslt.h"
+#include "cublasLt.h"
+// CHECK-NOT: #include "hipblaslt.h"
+
+int main() {
+  printf("20.1. cuBLASLt API to hipBLASLt API synthetic test\n");
+
+#if CUDA_VERSION >= 10010 && CUDA_VERSION <= 10020
+  // CHECK: hipblasLtMatrixLayoutOpaque_t blasLtMatrixLayoutOpaque;
+  cublasLtMatrixLayoutStruct blasLtMatrixLayoutOpaque;
+#endif
+
+  return 0;
+}


### PR DESCRIPTION
+ Provided additional CUDA version-dependent tests
+ Updated the tests, test harness, regenerated `hipify-perl`, and `BLAS` `CUDA2HIP` documentation
