### PR TITLE
[HIPIFY][SWDEV-446374][#72][#577][fix] Return `reinterpret_cast` for an explicit conversion between `pointer-to-function` and `pointer-to-object`

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -7051,6 +7051,22 @@ sub transformHostFunctions {
         $k += s/(?<!\/\/ CHECK: )($func)\s*\(([^,\)]+),([\s]*)([^,\)]+)(,\s*|\))/$func\($2,$3HIP_SYMBOL\($4\)$5/g;
     }
     foreach $func (
+        "hipFuncSetAttribute",
+        "hipFuncSetCacheConfig",
+        "hipFuncSetSharedMemConfig",
+        "hipLaunchCooperativeKernel",
+        "hipLaunchKernel"
+    )
+    {
+        $k += s/(?<!\/\/ CHECK: )($func)\s*\(([^,\)]+),/$func\(reinterpret_cast<const void*>\($2\),/g;
+    }
+    foreach $func (
+        "hipFuncGetAttributes"
+    )
+    {
+        $k += s/(?<!\/\/ CHECK: )($func)\s*\(([^,\)]+),([\s]*)([^,\)]+)(,\s*|\))/$func\($2,$3reinterpret_cast<const void*>\($4\)$5/g;
+    }
+    foreach $func (
         "hipGraphExecMemcpyNodeSetParamsToSymbol",
         "hipGraphMemcpyNodeSetParamsFromSymbol"
     )

--- a/src/HipifyAction.cpp
+++ b/src/HipifyAction.cpp
@@ -59,6 +59,12 @@ const std::string sCudaGetSymbolSize = "cudaGetSymbolSize";
 const std::string sCudaGetSymbolAddress = "cudaGetSymbolAddress";
 const std::string sCudaMemcpyFromSymbol = "cudaMemcpyFromSymbol";
 const std::string sCudaMemcpyFromSymbolAsync = "cudaMemcpyFromSymbolAsync";
+const std::string sCudaFuncSetCacheConfig = "cudaFuncSetCacheConfig";
+const std::string sCudaFuncSetSharedMemConfig = "cudaFuncSetSharedMemConfig";
+const std::string sCudaFuncGetAttributes = "cudaFuncGetAttributes";
+const std::string sCudaFuncSetAttribute = "cudaFuncSetAttribute";
+const std::string sCudaLaunchKernelStr = "cudaLaunchKernel";
+const std::string sCudaLaunchCooperativeKernel = "cudaLaunchCooperativeKernel";
 const std::string sCudaGraphAddMemcpyNodeToSymbol = "cudaGraphAddMemcpyNodeToSymbol";
 const std::string sCudaGraphAddMemcpyNodeFromSymbol = "cudaGraphAddMemcpyNodeFromSymbol";
 const std::string sCudaGraphMemcpyNodeSetParamsToSymbol = "cudaGraphMemcpyNodeSetParamsToSymbol";
@@ -277,6 +283,60 @@ std::map<std::string, hipify::FuncOverloadsStruct> FuncOverloads {
 };
 
 std::map<std::string, std::vector<ArgCastStruct>> FuncArgCasts {
+  {sCudaFuncSetCacheConfig,
+    {
+      {
+        {
+          {0, {e_reinterpret_cast, cw_None}}
+        }
+      }
+    }
+  },
+  {sCudaFuncSetSharedMemConfig,
+    {
+      {
+        {
+          {0, {e_reinterpret_cast, cw_None}}
+        }
+      }
+    }
+  },
+  {sCudaFuncGetAttributes,
+    {
+      {
+        {
+          {1, {e_reinterpret_cast, cw_None}}
+        }
+      }
+    }
+  },
+  {sCudaFuncSetAttribute,
+    {
+      {
+        {
+          {0, {e_reinterpret_cast, cw_None}}
+        }
+      }
+    }
+  },
+  {sCudaLaunchKernelStr,
+    {
+      {
+        {
+          {0, {e_reinterpret_cast, cw_None}}
+        }
+      }
+    }
+  },
+  {sCudaLaunchCooperativeKernel,
+    {
+      {
+        {
+          {0, {e_reinterpret_cast, cw_None}}
+        }
+      }
+    }
+  },
   {sCudaMallocHost,
     {
       {
@@ -2835,6 +2895,12 @@ std::unique_ptr<clang::ASTConsumer> HipifyAction::CreateASTConsumer(clang::Compi
       mat::callee(
         mat::functionDecl(
           mat::hasAnyName(
+            sCudaFuncSetCacheConfig,
+            sCudaFuncSetSharedMemConfig,
+            sCudaFuncGetAttributes,
+            sCudaFuncSetAttribute,
+            sCudaLaunchKernelStr,
+            sCudaLaunchCooperativeKernel,
             sCudaGetSymbolAddress,
             sCudaGetSymbolSize,
             sCudaMemcpyFromSymbol,

--- a/tests/unit_tests/casts/reinterpret_cast.cu
+++ b/tests/unit_tests/casts/reinterpret_cast.cu
@@ -367,11 +367,11 @@ int main() {
   // CHECK: hipFuncCache_t cacheConfig;
   cudaFuncCache cacheConfig;
   void* func;
-  // CHECK: hipFuncSetCacheConfig(func, cacheConfig);
+  // CHECK: hipFuncSetCacheConfig(reinterpret_cast<const void*>(func), cacheConfig);
   cudaFuncSetCacheConfig(func, cacheConfig);
   // CHECK: hipFuncAttributes attr{};
   cudaFuncAttributes attr{};
-  // CHECK: auto r = hipFuncGetAttributes(&attr, &fn);
+  // CHECK: auto r = hipFuncGetAttributes(&attr, reinterpret_cast<const void*>(&fn));
   auto r = cudaFuncGetAttributes(&attr, &fn);
   // CHECK: if (r != hipSuccess || attr.maxThreadsPerBlock == 0) {
   if (r != cudaSuccess || attr.maxThreadsPerBlock == 0) {

--- a/tests/unit_tests/synthetic/runtime_functions.cu
+++ b/tests/unit_tests/synthetic/runtime_functions.cu
@@ -370,22 +370,22 @@ int main() {
 
   // CUDA: extern __host__ __cudart_builtin__ cudaError_t CUDARTAPI cudaFuncGetAttributes(struct cudaFuncAttributes *attr, const void *func);
   // HIP: hipError_t hipFuncGetAttributes(struct hipFuncAttributes* attr, const void* func);
-  // CHECK: result = hipFuncGetAttributes(&FuncAttributes, func);
+  // CHECK: result = hipFuncGetAttributes(&FuncAttributes, reinterpret_cast<const void*>(func));
   result = cudaFuncGetAttributes(&FuncAttributes, func);
 
   // CUDA: extern __host__ cudaError_t CUDARTAPI cudaFuncSetCacheConfig(const void *func, enum cudaFuncCache cacheConfig);
   // HIP: hipError_t hipFuncSetCacheConfig(const void* func, hipFuncCache_t config);
-  // CHECK: result = hipFuncSetCacheConfig(func, FuncCache);
+  // CHECK: result = hipFuncSetCacheConfig(reinterpret_cast<const void*>(func), FuncCache);
   result = cudaFuncSetCacheConfig(func, FuncCache);
 
   // CUDA: extern __host__ cudaError_t CUDARTAPI cudaFuncSetSharedMemConfig(const void *func, enum cudaSharedMemConfig config);
   // HIP: hipError_t hipFuncSetSharedMemConfig(const void* func, hipSharedMemConfig config);
-  // CHECK: result = hipFuncSetSharedMemConfig(func, SharedMemConfig);
+  // CHECK: result = hipFuncSetSharedMemConfig(reinterpret_cast<const void*>(func), SharedMemConfig);
   result = cudaFuncSetSharedMemConfig(func, SharedMemConfig);
 
   // CUDA: extern __host__ cudaError_t CUDARTAPI cudaLaunchKernel(const void *func, dim3 gridDim, dim3 blockDim, void **args, size_t sharedMem, cudaStream_t stream);
   // HIP: hipError_t hipLaunchKernel(const void* function_address, dim3 numBlocks, dim3 dimBlocks, void** args, size_t sharedMemBytes __dparm(0), hipStream_t stream __dparm(0));
-  // CHECK: result = hipLaunchKernel(func, gridDim, blockDim, &image, bytes, stream);
+  // CHECK: result = hipLaunchKernel(reinterpret_cast<const void*>(func), gridDim, blockDim, &image, bytes, stream);
   result = cudaLaunchKernel(func, gridDim, blockDim, &image, bytes, stream);
 
   // CUDA: extern __host__ __cudart_builtin__ cudaError_t CUDARTAPI cudaOccupancyMaxActiveBlocksPerMultiprocessor(int *numBlocks, const void *func, int blockSize, size_t dynamicSMemSize);
@@ -864,12 +864,12 @@ int main() {
 
   // CUDA: extern __host__ __cudart_builtin__ cudaError_t CUDARTAPI cudaFuncSetAttribute(const void *func, enum cudaFuncAttribute attr, int value);
   // HIP: hipError_t hipFuncSetAttribute(const void* func, hipFuncAttribute attr, int value);
-  // CHECK: result = hipFuncSetAttribute(func, FuncAttribute, intVal);
+  // CHECK: result = hipFuncSetAttribute(reinterpret_cast<const void*>(func), FuncAttribute, intVal);
   result = cudaFuncSetAttribute(func, FuncAttribute, intVal);
 
   // CUDA: extern __host__ cudaError_t CUDARTAPI cudaLaunchCooperativeKernel(const void *func, dim3 gridDim, dim3 blockDim, void **args, size_t sharedMem, cudaStream_t stream);
   // HIP: hipError_t hipLaunchCooperativeKernel(const void* f, dim3 gridDim, dim3 blockDimX, void** kernelParams, unsigned int sharedMemBytes, hipStream_t stream);
-  // CHECK: result = hipLaunchCooperativeKernel(func, gridDim, blockDim, &image, flags, stream);
+  // CHECK: result = hipLaunchCooperativeKernel(reinterpret_cast<const void*>(func), gridDim, blockDim, &image, flags, stream);
   result = cudaLaunchCooperativeKernel(func, gridDim, blockDim, &image, flags, stream);
 
   // CUDA: extern __CUDA_DEPRECATED __host__ cudaError_t CUDARTAPI cudaLaunchCooperativeKernelMultiDevice(struct cudaLaunchParams *launchParamsList, unsigned int numDevices, unsigned int flags __dv(0));


### PR DESCRIPTION
**[Reasons]**
+ An implicit `pointer-to-function` to `pointer-to-object` conversion supported by `nvcc` (`Windows` and `Linux`); that is why the following kernel function might be passed to the function as an argument without explicit casting:

```cpp
__global__ void myKernel() {}
int main() {
  cudaFuncSetCacheConfig(myKernel,cudaFuncCachePreferEqual);
  return 0;
}
```

+ An implicit `pointer-to-function` to `pointer-to-object` conversion supported by `clang`, but on `Windows` only; the following warning is generated:
```cpp
warning: implicit conversion between pointer-to-function and pointer-to-object is a Microsoft extension [-Wmicrosoft-cast]
   11 |          hipFuncSetCacheConfig(myKernel,hipFuncCachePreferEqual);
      |                                ^~~~~~~~
```
+ On `Linux` through the GCC toolchain, `clang` reports an error:
```cpp
GIT/HIPIFY/build/cudaFuncSetCacheConfig.hip:11:10: error: no matching function for call to 'hipFuncSetCacheConfig'
   11 |          hipFuncSetCacheConfig(myKernel,hipFuncCachePreferEqual);
      |          ^~~~~~~~~~~~~~~~~~~~~
/ROCM/hip/hip_runtime_api.h:2155:12: note: candidate function not viable: no known conversion from 'void ()' to 'const void *' for 1st argument
 2155 | hipError_t hipFuncSetCacheConfig(const void* func, hipFuncCache_t config);
      |            ^                     ~~~~~~~~~~~~~~~~
 ```
**[Solution]**
+ Return `reinterpret_cast` for explicit conversion between `pointer-to-function` and `pointer-to-object` for the `Func` APIs unconditionally despite the OS.

**[Misc]**
+ It would be great to have the same behaviour in `clang` as `nvcc` because functions' signatures are identical, but it can be solved only in clang when targeting CUDA/HIP.

```cpp
extern __host__ cudaError_t CUDARTAPI cudaFuncSetCacheConfig(const void *func, enum cudaFuncCache cacheConfig);

hipError_t hipFuncSetCacheConfig(const void* func, hipFuncCache_t config);
```

**[Affected APIs]**

`cudaFuncGetAttributes` -> `hipFuncGetAttributes`
`cudaFuncSetAttribute` -> `hipFuncSetAttribute`
`cudaFuncSetCacheConfig` -> `hipFuncSetCacheConfig`
`cudaFuncSetSharedMemConfig` -> `hipFuncSetSharedMemConfig`
`cudaLaunchKernel` -> `hipLaunchKernel`
`cudaLaunchCooperativeKernel` -> `hipLaunchCooperativeKernel`

**[ToDo]**
+ Do not apply cast if it already takes place (revise all the casting patterns in HIPIFY matchers)