### PR TITLE
[HIPIFY][#1478][tests][fix] Split runtime tests based on CUDA version

### DIFF
--- a/tests/lit.cfg
+++ b/tests/lit.cfg
@@ -64,6 +64,7 @@ if config.cuda_version_major < 9:
     config.excludes.append('cub_01.cu')
     config.excludes.append('cub_02.cu')
     config.excludes.append('cub_03.cu')
+    config.excludes.append('runtime_functions_9000.cu')
 
 if config.cuda_version_major < 9 or (config.cuda_version_major == 9 and config.cuda_version_minor < 2):
     config.excludes.append('cusparse2rocsparse_9020.cu')

--- a/tests/unit_tests/synthetic/runtime_functions.cu
+++ b/tests/unit_tests/synthetic/runtime_functions.cu
@@ -862,16 +862,6 @@ int main() {
   // CHECK: hipLaunchParams LaunchParams;
   cudaLaunchParams LaunchParams;
 
-  // CUDA: extern __host__ __cudart_builtin__ cudaError_t CUDARTAPI cudaFuncSetAttribute(const void *func, enum cudaFuncAttribute attr, int value);
-  // HIP: hipError_t hipFuncSetAttribute(const void* func, hipFuncAttribute attr, int value);
-  // CHECK: result = hipFuncSetAttribute(reinterpret_cast<const void*>(func), FuncAttribute, intVal);
-  result = cudaFuncSetAttribute(func, FuncAttribute, intVal);
-
-  // CUDA: extern __host__ cudaError_t CUDARTAPI cudaLaunchCooperativeKernel(const void *func, dim3 gridDim, dim3 blockDim, void **args, size_t sharedMem, cudaStream_t stream);
-  // HIP: hipError_t hipLaunchCooperativeKernel(const void* f, dim3 gridDim, dim3 blockDimX, void** kernelParams, unsigned int sharedMemBytes, hipStream_t stream);
-  // CHECK: result = hipLaunchCooperativeKernel(reinterpret_cast<const void*>(func), gridDim, blockDim, &image, flags, stream);
-  result = cudaLaunchCooperativeKernel(func, gridDim, blockDim, &image, flags, stream);
-
   // CUDA: extern __CUDA_DEPRECATED __host__ cudaError_t CUDARTAPI cudaLaunchCooperativeKernelMultiDevice(struct cudaLaunchParams *launchParamsList, unsigned int numDevices, unsigned int flags __dv(0));
   // HIP: hipError_t hipLaunchCooperativeKernelMultiDevice(hipLaunchParams* launchParamsList, int numDevices, unsigned int flags);
   // CHECK: result = hipLaunchCooperativeKernelMultiDevice(&LaunchParams, intVal, flags);

--- a/tests/unit_tests/synthetic/runtime_functions_9000.cu
+++ b/tests/unit_tests/synthetic/runtime_functions_9000.cu
@@ -1,0 +1,40 @@
+// RUN: %run_test hipify "%s" "%t" %hipify_args 2 --skip-excluded-preprocessor-conditional-blocks --experimental %clang_args
+
+// CHECK: #include <hip/hip_runtime.h>
+#include <cuda_runtime.h>
+#include <string>
+#include <stdio.h>
+
+int main() {
+  printf("12.9000. CUDA Runtime API Functions synthetic test for CUDA >= 9000\n");
+
+  // CHECK: hipError_t result = hipSuccess;
+  cudaError result = cudaSuccess;
+
+  // CHECK: hipStream_t stream;
+  cudaStream_t stream;
+
+  int intVal = 0;
+  unsigned int flags = 0;
+  dim3 gridDim;
+  dim3 blockDim;
+  void* func = nullptr;
+  void* image = nullptr;
+
+#if CUDA_VERSION >= 9000
+  // CHECK: hipFuncAttribute FuncAttribute;
+  cudaFuncAttribute FuncAttribute;
+
+  // CUDA: extern __host__ __cudart_builtin__ cudaError_t CUDARTAPI cudaFuncSetAttribute(const void *func, enum cudaFuncAttribute attr, int value);
+  // HIP: hipError_t hipFuncSetAttribute(const void* func, hipFuncAttribute attr, int value);
+  // CHECK: result = hipFuncSetAttribute(reinterpret_cast<const void*>(func), FuncAttribute, intVal);
+  result = cudaFuncSetAttribute(func, FuncAttribute, intVal);
+
+  // CUDA: extern __host__ cudaError_t CUDARTAPI cudaLaunchCooperativeKernel(const void *func, dim3 gridDim, dim3 blockDim, void **args, size_t sharedMem, cudaStream_t stream);
+  // HIP: hipError_t hipLaunchCooperativeKernel(const void* f, dim3 gridDim, dim3 blockDimX, void** kernelParams, unsigned int sharedMemBytes, hipStream_t stream);
+  // CHECK: result = hipLaunchCooperativeKernel(reinterpret_cast<const void*>(func), gridDim, blockDim, &image, flags, stream);
+  result = cudaLaunchCooperativeKernel(func, gridDim, blockDim, &image, flags, stream);
+#endif
+
+  return 0;
+}


### PR DESCRIPTION
+ [Reason] Matchers do not work in negative preprocessor conditional blocks