### PR TITLE
[HIPIFY][#936][BLASLT] `cublasLt` -> `hipblalLt` hipification support - Step 11

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -3869,6 +3869,8 @@ sub simpleSubstitutions {
     subst("cublasIzamin_v2_64", "hipblasIzamin_v2_64", "library");
     subst("cublasLtCreate", "hipblasLtCreate", "library");
     subst("cublasLtDestroy", "hipblasLtDestroy", "library");
+    subst("cublasLtMatmul", "hipblasLtMatmul", "library");
+    subst("cublasLtMatrixTransform", "hipblasLtMatrixTransform", "library");
     subst("cublasNrm2Ex", "hipblasNrm2Ex_v2", "library");
     subst("cublasRotEx", "hipblasRotEx_v2", "library");
     subst("cublasSasum", "hipblasSasum", "library");
@@ -6900,6 +6902,8 @@ sub simpleSubstitutions {
     subst("cudaSuccess", "hipSuccess", "numeric_literal");
     subst("cudaUserObjectNoDestructorSync", "hipUserObjectNoDestructorSync", "numeric_literal");
     subst("cusolver_int_t", "int", "numeric_literal");
+    subst("CUBLASLT_ORDER_COL", "HIPBLASLT_ORDER_COL", "define");
+    subst("CUBLASLT_ORDER_ROW", "HIPBLASLT_ORDER_ROW", "define");
     subst("CUB_MAX", "CUB_MAX", "define");
     subst("CUB_MIN", "CUB_MIN", "define");
     subst("CUB_NAMESPACE_BEGIN", "BEGIN_HIPCUB_NAMESPACE", "define");
@@ -6940,6 +6944,7 @@ sub simpleSubstitutions {
     subst("_CubLog", "_HipcubLog", "define");
     subst("__CUB_ALIGN_BYTES", "__HIPCUB_ALIGN_BYTES", "define");
     subst("__CUDACC__", "__HIPCC__", "define");
+    subst("cublasLtOrder_t", "hipblasLtOrder_t", "define");
     subst("cudaArrayCubemap", "hipArrayCubemap", "define");
     subst("cudaArrayDefault", "hipArrayDefault", "define");
     subst("cudaArrayLayered", "hipArrayLayered", "define");
@@ -11509,6 +11514,9 @@ sub warnHipOnlyUnsupportedFunctions {
         "CUBLASLT_POINTER_MODE_MASK_ALPHA_DEVICE_VECTOR_BETA_HOST",
         "CUBLASLT_POINTER_MODE_DEVICE_VECTOR",
         "CUBLASLT_POINTER_MODE_ALPHA_DEVICE_VECTOR_BETA_ZERO",
+        "CUBLASLT_ORDER_COL4_4R2_8C",
+        "CUBLASLT_ORDER_COL32_2R_4R4",
+        "CUBLASLT_ORDER_COL32",
         "CUBLASLT_NUMERICAL_IMPL_FLAGS_TENSOR_OP_MASK",
         "CUBLASLT_NUMERICAL_IMPL_FLAGS_OP_TYPE_MASK",
         "CUBLASLT_NUMERICAL_IMPL_FLAGS_OP_INPUT_TYPE_MASK",
@@ -11842,10 +11850,13 @@ sub warnRocOnlyUnsupportedFunctions {
         "cublasMigrateComputeType",
         "cublasLtPointerMode_t",
         "cublasLtPointerModeMask_t",
+        "cublasLtOrder_t",
         "cublasLtNumericalImplFlags_t",
+        "cublasLtMatrixTransform",
         "cublasLtMatmulTile_t",
         "cublasLtMatmulStages_t",
         "cublasLtMatmulInnerShape_t",
+        "cublasLtMatmul",
         "cublasLtHeuristicsCacheSetCapacity",
         "cublasLtHeuristicsCacheGetCapacity",
         "cublasLtGetVersion",
@@ -12128,6 +12139,11 @@ sub warnRocOnlyUnsupportedFunctions {
         "CUBLASLT_POINTER_MODE_DEVICE_VECTOR",
         "CUBLASLT_POINTER_MODE_DEVICE",
         "CUBLASLT_POINTER_MODE_ALPHA_DEVICE_VECTOR_BETA_ZERO",
+        "CUBLASLT_ORDER_ROW",
+        "CUBLASLT_ORDER_COL4_4R2_8C",
+        "CUBLASLT_ORDER_COL32_2R_4R4",
+        "CUBLASLT_ORDER_COL32",
+        "CUBLASLT_ORDER_COL",
         "CUBLASLT_NUMERICAL_IMPL_FLAGS_TENSOR_OP_MASK",
         "CUBLASLT_NUMERICAL_IMPL_FLAGS_OP_TYPE_MASK",
         "CUBLASLT_NUMERICAL_IMPL_FLAGS_OP_INPUT_TYPE_MASK",

--- a/docs/tables/CUBLAS_API_supported_by_HIP.md
+++ b/docs/tables/CUBLAS_API_supported_by_HIP.md
@@ -298,6 +298,11 @@
 |`CUBLASLT_NUMERICAL_IMPL_FLAGS_OP_INPUT_TYPE_MASK`|11.0| | | | | | | | | |
 |`CUBLASLT_NUMERICAL_IMPL_FLAGS_OP_TYPE_MASK`|11.0| | | | | | | | | |
 |`CUBLASLT_NUMERICAL_IMPL_FLAGS_TENSOR_OP_MASK`|11.0| | | | | | | | | |
+|`CUBLASLT_ORDER_COL`|10.1| | | |`HIPBLASLT_ORDER_COL`|6.0.0| | | | |
+|`CUBLASLT_ORDER_COL32`|10.1| | | | | | | | | |
+|`CUBLASLT_ORDER_COL32_2R_4R4`|11.0| | | | | | | | | |
+|`CUBLASLT_ORDER_COL4_4R2_8C`|10.1| | | | | | | | | |
+|`CUBLASLT_ORDER_ROW`|10.1| | | |`HIPBLASLT_ORDER_ROW`|6.0.0| | | | |
 |`CUBLASLT_POINTER_MODE_ALPHA_DEVICE_VECTOR_BETA_HOST`|11.4| | | |`HIPBLASLT_POINTER_MODE_ALPHA_DEVICE_VECTOR_BETA_HOST`|6.0.0| | | | |
 |`CUBLASLT_POINTER_MODE_ALPHA_DEVICE_VECTOR_BETA_ZERO`|10.1| | | | | | | | | |
 |`CUBLASLT_POINTER_MODE_DEVICE`| | | | |`HIPBLASLT_POINTER_MODE_DEVICE`|6.1.0| | | | |
@@ -325,6 +330,7 @@
 |`cublasLtMatrixTransformDescOpaque_t`|11.0| | | |`hipblasLtMatrixTransformDescOpaque_t`|6.0.0| | | | |
 |`cublasLtMatrixTransformDesc_t`|10.1| | | |`hipblasLtMatrixTransformDesc_t`|6.0.0| | | | |
 |`cublasLtNumericalImplFlags_t`|11.0| | | | | | | | | |
+|`cublasLtOrder_t`|10.1| | | |`hipblasLtOrder_t`|6.0.0| | | | |
 |`cublasLtPointerModeMask_t`|10.1| | | | | | | | | |
 |`cublasLtPointerMode_t`|10.1| | | |`hipblasLtPointerMode_t`|6.0.0| | | | |
 
@@ -1212,6 +1218,8 @@
 |`cublasLtGetVersion`|10.1| | | | | | | | | |
 |`cublasLtHeuristicsCacheGetCapacity`|11.8| | | | | | | | | |
 |`cublasLtHeuristicsCacheSetCapacity`|11.8| | | | | | | | | |
+|`cublasLtMatmul`|10.1| | | |`hipblasLtMatmul`|5.5.0| | | | |
+|`cublasLtMatrixTransform`|10.1| | | |`hipblasLtMatrixTransform`|6.0.0| | | | |
 
 
 \*A - Added; D - Deprecated; C - Changed; R - Removed; E - Experimental

--- a/docs/tables/CUBLAS_API_supported_by_HIP_and_ROC.md
+++ b/docs/tables/CUBLAS_API_supported_by_HIP_and_ROC.md
@@ -298,6 +298,11 @@
 |`CUBLASLT_NUMERICAL_IMPL_FLAGS_OP_INPUT_TYPE_MASK`|11.0| | | | | | | | | | | | | | | |
 |`CUBLASLT_NUMERICAL_IMPL_FLAGS_OP_TYPE_MASK`|11.0| | | | | | | | | | | | | | | |
 |`CUBLASLT_NUMERICAL_IMPL_FLAGS_TENSOR_OP_MASK`|11.0| | | | | | | | | | | | | | | |
+|`CUBLASLT_ORDER_COL`|10.1| | | |`HIPBLASLT_ORDER_COL`|6.0.0| | | | | | | | | | |
+|`CUBLASLT_ORDER_COL32`|10.1| | | | | | | | | | | | | | | |
+|`CUBLASLT_ORDER_COL32_2R_4R4`|11.0| | | | | | | | | | | | | | | |
+|`CUBLASLT_ORDER_COL4_4R2_8C`|10.1| | | | | | | | | | | | | | | |
+|`CUBLASLT_ORDER_ROW`|10.1| | | |`HIPBLASLT_ORDER_ROW`|6.0.0| | | | | | | | | | |
 |`CUBLASLT_POINTER_MODE_ALPHA_DEVICE_VECTOR_BETA_HOST`|11.4| | | |`HIPBLASLT_POINTER_MODE_ALPHA_DEVICE_VECTOR_BETA_HOST`|6.0.0| | | | | | | | | | |
 |`CUBLASLT_POINTER_MODE_ALPHA_DEVICE_VECTOR_BETA_ZERO`|10.1| | | | | | | | | | | | | | | |
 |`CUBLASLT_POINTER_MODE_DEVICE`| | | | |`HIPBLASLT_POINTER_MODE_DEVICE`|6.1.0| | | | | | | | | | |
@@ -325,6 +330,7 @@
 |`cublasLtMatrixTransformDescOpaque_t`|11.0| | | |`hipblasLtMatrixTransformDescOpaque_t`|6.0.0| | | | | | | | | | |
 |`cublasLtMatrixTransformDesc_t`|10.1| | | |`hipblasLtMatrixTransformDesc_t`|6.0.0| | | | | | | | | | |
 |`cublasLtNumericalImplFlags_t`|11.0| | | | | | | | | | | | | | | |
+|`cublasLtOrder_t`|10.1| | | |`hipblasLtOrder_t`|6.0.0| | | | | | | | | | |
 |`cublasLtPointerModeMask_t`|10.1| | | | | | | | | | | | | | | |
 |`cublasLtPointerMode_t`|10.1| | | |`hipblasLtPointerMode_t`|6.0.0| | | | | | | | | | |
 
@@ -1212,6 +1218,8 @@
 |`cublasLtGetVersion`|10.1| | | | | | | | | | | | | | | |
 |`cublasLtHeuristicsCacheGetCapacity`|11.8| | | | | | | | | | | | | | | |
 |`cublasLtHeuristicsCacheSetCapacity`|11.8| | | | | | | | | | | | | | | |
+|`cublasLtMatmul`|10.1| | | |`hipblasLtMatmul`|5.5.0| | | | | | | | | | |
+|`cublasLtMatrixTransform`|10.1| | | |`hipblasLtMatrixTransform`|6.0.0| | | | | | | | | | |
 
 
 \*A - Added; D - Deprecated; C - Changed; R - Removed; E - Experimental

--- a/docs/tables/CUBLAS_API_supported_by_ROC.md
+++ b/docs/tables/CUBLAS_API_supported_by_ROC.md
@@ -298,6 +298,11 @@
 |`CUBLASLT_NUMERICAL_IMPL_FLAGS_OP_INPUT_TYPE_MASK`|11.0| | | | | | | | | |
 |`CUBLASLT_NUMERICAL_IMPL_FLAGS_OP_TYPE_MASK`|11.0| | | | | | | | | |
 |`CUBLASLT_NUMERICAL_IMPL_FLAGS_TENSOR_OP_MASK`|11.0| | | | | | | | | |
+|`CUBLASLT_ORDER_COL`|10.1| | | | | | | | | |
+|`CUBLASLT_ORDER_COL32`|10.1| | | | | | | | | |
+|`CUBLASLT_ORDER_COL32_2R_4R4`|11.0| | | | | | | | | |
+|`CUBLASLT_ORDER_COL4_4R2_8C`|10.1| | | | | | | | | |
+|`CUBLASLT_ORDER_ROW`|10.1| | | | | | | | | |
 |`CUBLASLT_POINTER_MODE_ALPHA_DEVICE_VECTOR_BETA_HOST`|11.4| | | | | | | | | |
 |`CUBLASLT_POINTER_MODE_ALPHA_DEVICE_VECTOR_BETA_ZERO`|10.1| | | | | | | | | |
 |`CUBLASLT_POINTER_MODE_DEVICE`| | | | | | | | | | |
@@ -325,6 +330,7 @@
 |`cublasLtMatrixTransformDescOpaque_t`|11.0| | | | | | | | | |
 |`cublasLtMatrixTransformDesc_t`|10.1| | | | | | | | | |
 |`cublasLtNumericalImplFlags_t`|11.0| | | | | | | | | |
+|`cublasLtOrder_t`|10.1| | | | | | | | | |
 |`cublasLtPointerModeMask_t`|10.1| | | | | | | | | |
 |`cublasLtPointerMode_t`|10.1| | | | | | | | | |
 
@@ -1212,6 +1218,8 @@
 |`cublasLtGetVersion`|10.1| | | | | | | | | |
 |`cublasLtHeuristicsCacheGetCapacity`|11.8| | | | | | | | | |
 |`cublasLtHeuristicsCacheSetCapacity`|11.8| | | | | | | | | |
+|`cublasLtMatmul`|10.1| | | | | | | | | |
+|`cublasLtMatrixTransform`|10.1| | | | | | | | | |
 
 
 \*A - Added; D - Deprecated; C - Changed; R - Removed; E - Experimental

--- a/src/CUDA2HIP_BLAS_API_functions.cpp
+++ b/src/CUDA2HIP_BLAS_API_functions.cpp
@@ -1090,6 +1090,8 @@ const std::map<llvm::StringRef, hipCounter> CUDA_BLAS_FUNCTION_MAP {
   {"cublasLtHeuristicsCacheGetCapacity",     {"hipblasLtHeuristicsCacheGetCapacity",     "",                         CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LT, UNSUPPORTED}},
   {"cublasLtHeuristicsCacheSetCapacity",     {"hipblasLtHeuristicsCacheSetCapacity",     "",                         CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LT, UNSUPPORTED}},
   {"cublasLtDisableCpuInstructionsSetMask",  {"hipblasLtDisableCpuInstructionsSetMask",  "",                         CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LT, UNSUPPORTED}},
+  {"cublasLtMatmul",                 {"hipblasLtMatmul",                 "",                                         CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LT, ROC_UNSUPPORTED}},
+  {"cublasLtMatrixTransform",        {"hipblasLtMatrixTransform",        "",                                         CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LT, ROC_UNSUPPORTED}},
 };
 
 const std::map<llvm::StringRef, cudaAPIversions> CUDA_BLAS_FUNCTION_VER_MAP {
@@ -1550,6 +1552,8 @@ const std::map<llvm::StringRef, cudaAPIversions> CUDA_BLAS_FUNCTION_VER_MAP {
   {"cublasLtHeuristicsCacheGetCapacity",         {CUDA_118, CUDA_0,   CUDA_0   }},
   {"cublasLtHeuristicsCacheSetCapacity",         {CUDA_118, CUDA_0,   CUDA_0   }},
   {"cublasLtDisableCpuInstructionsSetMask",      {CUDA_121, CUDA_0,   CUDA_0   }}, // A: CUDA_VERSION 12011, CUBLAS_VERSION 120103, CUBLAS_VER_MAJOR 12 CUBLAS_VER_MINOR 3
+  {"cublasLtMatmul",                             {CUDA_101, CUDA_0,   CUDA_0   }},
+  {"cublasLtMatrixTransform",                    {CUDA_101, CUDA_0,   CUDA_0   }},
 };
 
 const std::map<llvm::StringRef, hipAPIversions> HIP_BLAS_FUNCTION_VER_MAP {
@@ -1954,6 +1958,8 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_BLAS_FUNCTION_VER_MAP {
   {"hipblasZswap_v2_64",                         {HIP_6010, HIP_0,    HIP_0   }},
   {"hipblasLtCreate",                            {HIP_5050, HIP_0,    HIP_0   }},
   {"hipblasLtDestroy",                           {HIP_5050, HIP_0,    HIP_0   }},
+  {"hipblasLtMatmul",                            {HIP_5050, HIP_0,    HIP_0   }},
+  {"hipblasLtMatrixTransform",                   {HIP_6000, HIP_0,    HIP_0   }},
 
   {"rocblas_status_to_string",                   {HIP_3050, HIP_0,    HIP_0   }},
   {"rocblas_sscal",                              {HIP_1050, HIP_0,    HIP_0   }},

--- a/src/CUDA2HIP_BLAS_API_types.cpp
+++ b/src/CUDA2HIP_BLAS_API_types.cpp
@@ -372,6 +372,12 @@ const std::map<llvm::StringRef, hipCounter> CUDA_BLAS_TYPE_NAME_MAP {
   {"CUBLASLT_NUMERICAL_IMPL_FLAGS_OP_INPUT_TYPE_MASK", {"HIPBLASLT_NUMERICAL_IMPL_FLAGS_OP_INPUT_TYPE_MASK", "",                                      CONV_DEFINE, API_BLAS, SEC::BLAS_LT_DATA_TYPES, UNSUPPORTED}},
   {"CUBLASLT_NUMERICAL_IMPL_FLAGS_GAUSSIAN",           {"HIPBLASLT_NUMERICAL_IMPL_FLAGS_GAUSSIAN",           "",                                      CONV_DEFINE, API_BLAS, SEC::BLAS_LT_DATA_TYPES, UNSUPPORTED}},
   {"cublasLtNumericalImplFlags_t",                     {"hipblasLtNumericalImplFlags_t",                     "",                                      CONV_DEFINE, API_BLAS, SEC::BLAS_LT_DATA_TYPES, UNSUPPORTED}},
+  {"cublasLtOrder_t",                                  {"hipblasLtOrder_t",                                  "",                                      CONV_DEFINE, API_BLAS, SEC::BLAS_LT_DATA_TYPES, ROC_UNSUPPORTED}},
+  {"CUBLASLT_ORDER_COL",                               {"HIPBLASLT_ORDER_COL",                               "",                                      CONV_DEFINE, API_BLAS, SEC::BLAS_LT_DATA_TYPES, ROC_UNSUPPORTED}},
+  {"CUBLASLT_ORDER_ROW",                               {"HIPBLASLT_ORDER_ROW",                               "",                                      CONV_DEFINE, API_BLAS, SEC::BLAS_LT_DATA_TYPES, ROC_UNSUPPORTED}},
+  {"CUBLASLT_ORDER_COL32",                             {"HIPBLASLT_ORDER_COL32",                             "",                                      CONV_DEFINE, API_BLAS, SEC::BLAS_LT_DATA_TYPES, UNSUPPORTED}},
+  {"CUBLASLT_ORDER_COL4_4R2_8C",                       {"HIPBLASLT_ORDER_COL4_4R2_8C",                       "",                                      CONV_DEFINE, API_BLAS, SEC::BLAS_LT_DATA_TYPES, UNSUPPORTED}},
+  {"CUBLASLT_ORDER_COL32_2R_4R4",                      {"HIPBLASLT_ORDER_COL32_2R_4R4",                      "",                                      CONV_DEFINE, API_BLAS, SEC::BLAS_LT_DATA_TYPES, UNSUPPORTED}},
 };
 
 const std::map<llvm::StringRef, cudaAPIversions> CUDA_BLAS_TYPE_NAME_VER_MAP {
@@ -652,6 +658,12 @@ const std::map<llvm::StringRef, cudaAPIversions> CUDA_BLAS_TYPE_NAME_VER_MAP {
   {"CUBLASLT_NUMERICAL_IMPL_FLAGS_OP_INPUT_TYPE_MASK", {CUDA_110, CUDA_0,   CUDA_0  }}, // A: CUDA_VERSION 11001, CUBLAS_VERSION 11000, CUBLAS_VER_MAJOR 11 CUBLAS_VER_MINOR 0
   {"CUBLASLT_NUMERICAL_IMPL_FLAGS_GAUSSIAN",           {CUDA_110, CUDA_0,   CUDA_0  }}, // A: CUDA_VERSION 11001, CUBLAS_VERSION 11000, CUBLAS_VER_MAJOR 11 CUBLAS_VER_MINOR 0
   {"cublasLtNumericalImplFlags_t",                     {CUDA_110, CUDA_0,   CUDA_0  }}, // A: CUDA_VERSION 11001, CUBLAS_VERSION 11000, CUBLAS_VER_MAJOR 11 CUBLAS_VER_MINOR 0
+  {"cublasLtOrder_t",                                  {CUDA_101, CUDA_0,   CUDA_0  }},
+  {"CUBLASLT_ORDER_COL",                               {CUDA_101, CUDA_0,   CUDA_0  }},
+  {"CUBLASLT_ORDER_ROW",                               {CUDA_101, CUDA_0,   CUDA_0  }},
+  {"CUBLASLT_ORDER_COL32",                             {CUDA_101, CUDA_0,   CUDA_0  }},
+  {"CUBLASLT_ORDER_COL4_4R2_8C",                       {CUDA_101, CUDA_0,   CUDA_0  }},
+  {"CUBLASLT_ORDER_COL32_2R_4R4",                      {CUDA_110, CUDA_0,   CUDA_0  }}, // A: CUDA_VERSION 11001, CUBLAS_VERSION 11000, CUBLAS_VER_MAJOR 11 CUBLAS_VER_MINOR 0
 };
 
 const std::map<llvm::StringRef, hipAPIversions> HIP_BLAS_TYPE_NAME_VER_MAP {
@@ -752,6 +764,9 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_BLAS_TYPE_NAME_VER_MAP {
   {"HIPBLASLT_POINTER_MODE_HOST",                      {HIP_6000, HIP_0,    HIP_0   }},
   {"HIPBLASLT_POINTER_MODE_DEVICE",                    {HIP_6010, HIP_0,    HIP_0   }},
   {"HIPBLASLT_POINTER_MODE_ALPHA_DEVICE_VECTOR_BETA_HOST",  {HIP_6000, HIP_0,    HIP_0   }},
+  {"hipblasLtOrder_t",                                 {HIP_6000, HIP_0,    HIP_0   }},
+  {"HIPBLASLT_ORDER_COL",                              {HIP_6000, HIP_0,    HIP_0   }},
+  {"HIPBLASLT_ORDER_ROW",                              {HIP_6000, HIP_0,    HIP_0   }},
 
   {"rocblas_handle",                                   {HIP_1050, HIP_0,    HIP_0   }},
   {"_rocblas_handle",                                  {HIP_1050, HIP_0,    HIP_0   }},

--- a/tests/unit_tests/synthetic/libraries/cublaslt2hipblaslt.cu
+++ b/tests/unit_tests/synthetic/libraries/cublaslt2hipblaslt.cu
@@ -16,7 +16,19 @@ int main() {
   // CHECK: hipblasStatus_t status;
   cublasStatus_t status;
 
+  // CHECK: hipStream_t stream;
+  cudaStream_t stream;
+
+  void *A = nullptr;
+  void *B = nullptr;
+  void *C = nullptr;
+  void *D = nullptr;
+  void *alpha = nullptr;
+  void *beta = nullptr;
+  void *workspace = nullptr;
   const char *const_ch = nullptr;
+
+  size_t workspaceSizeInBytes = 0;
 
 #if CUDA_VERSION >= 10010
   // CHECK: hipblasLtMatmulAlgo_t blasLtMatmulAlgo;
@@ -31,6 +43,16 @@ int main() {
   // CHECK: hipblasLtMatmulPreference_t blasLtMatmulPreference;
   cublasLtMatmulPreference_t blasLtMatmulPreference;
 
+  // CHECK: hipblasLtMatrixLayout_t blasLtMatrixLayout, Adesc, Bdesc, Cdesc, Ddesc;
+  cublasLtMatrixLayout_t blasLtMatrixLayout, Adesc, Bdesc, Cdesc, Ddesc;
+
+  // CHECK: hipblasLtOrder_t blasLtOrder;
+  // CHECK-NEXT: hipblasLtOrder_t BLASLT_ORDER_COL = HIPBLASLT_ORDER_COL;
+  // CHECK-NEXT: hipblasLtOrder_t BLASLT_ORDER_ROW = HIPBLASLT_ORDER_ROW;
+  cublasLtOrder_t blasLtOrder;
+  cublasLtOrder_t BLASLT_ORDER_COL = CUBLASLT_ORDER_COL;
+  cublasLtOrder_t BLASLT_ORDER_ROW = CUBLASLT_ORDER_ROW;
+
   // CUDA: cublasStatus_t CUBLASWINAPI cublasLtCreate(cublasLtHandle_t* lightHandle);
   // HIP: HIPBLASLT_EXPORT hipblasStatus_t hipblasLtCreate(hipblasLtHandle_t* handle);
   // CHECK: status = hipblasLtCreate(&blasLtHandle);
@@ -41,6 +63,17 @@ int main() {
   // CHECK: status = hipblasLtDestroy(blasLtHandle);
   status = cublasLtDestroy(blasLtHandle);
 
+  // CUDA: cublasStatus_t CUBLASWINAPI cublasLtMatmul(cublasLtHandle_t lightHandle, cublasLtMatmulDesc_t computeDesc, const void* alpha, const void* A, cublasLtMatrixLayout_t Adesc, const void* B, cublasLtMatrixLayout_t Bdesc, const void* beta, const void* C, cublasLtMatrixLayout_t Cdesc, void* D, cublasLtMatrixLayout_t Ddesc, const cublasLtMatmulAlgo_t* algo, void* workspace, size_t workspaceSizeInBytes, cudaStream_t stream);
+  // HIP: HIPBLASLT_EXPORT hipblasStatus_t hipblasLtMatmul(hipblasLtHandle_t handle, hipblasLtMatmulDesc_t matmulDesc, const void* alpha, const void* A, hipblasLtMatrixLayout_t Adesc, const void* B, hipblasLtMatrixLayout_t Bdesc, const void* beta, const void* C, hipblasLtMatrixLayout_t Cdesc, void* D, hipblasLtMatrixLayout_t Ddesc, const hipblasLtMatmulAlgo_t* algo, void* workspace, size_t workspaceSizeInBytes, hipStream_t stream);
+  // CHECK: status = hipblasLtMatmul(blasLtHandle, blasLtMatmulDesc, alpha, A, Adesc, B, Bdesc, beta, C, Cdesc, D, Ddesc, &blasLtMatmulAlgo, workspace, workspaceSizeInBytes, stream);
+  status = cublasLtMatmul(blasLtHandle, blasLtMatmulDesc, alpha, A, Adesc, B, Bdesc, beta, C, Cdesc, D, Ddesc, &blasLtMatmulAlgo, workspace, workspaceSizeInBytes, stream);
+
+  // CUDA: cublasStatus_t CUBLASWINAPI cublasLtMatrixTransform(cublasLtHandle_t lightHandle, cublasLtMatrixTransformDesc_t transformDesc, const void* alpha, const void* A, cublasLtMatrixLayout_t Adesc, const void* beta, const void* B, cublasLtMatrixLayout_t Bdesc, void* C, cublasLtMatrixLayout_t Cdesc, cudaStream_t stream);
+  // HIP: HIPBLASLT_EXPORT hipblasStatus_t hipblasLtMatrixTransform(hipblasLtHandle_t lightHandle, hipblasLtMatrixTransformDesc_t transformDesc, const void* alpha, const void* A, hipblasLtMatrixLayout_t Adesc, const void* beta, const void* B, hipblasLtMatrixLayout_t Bdesc, void* C, hipblasLtMatrixLayout_t Cdesc, hipStream_t stream);
+  // CHECK: status = hipblasLtMatrixTransform(blasLtHandle, blasLtMatrixTransformDesc, alpha, A, Adesc, beta, B, Bdesc, C, Cdesc, stream);
+  status = cublasLtMatrixTransform(blasLtHandle, blasLtMatrixTransformDesc, alpha, A, Adesc, beta, B, Bdesc, C, Cdesc, stream);
+#endif
+
 #if CUBLAS_VERSION >= 10200
   // CHECK: hipblasLtPointerMode_t blasLtPointerMode;
   // CHECK-NEXT: hipblasLtPointerMode_t BLASLT_POINTER_MODE_HOST = HIPBLASLT_POINTER_MODE_HOST;
@@ -48,7 +81,6 @@ int main() {
   cublasLtPointerMode_t blasLtPointerMode;
   cublasLtPointerMode_t BLASLT_POINTER_MODE_HOST = CUBLASLT_POINTER_MODE_HOST;
   cublasLtPointerMode_t BLASLT_POINTER_MODE_DEVICE = CUBLASLT_POINTER_MODE_DEVICE;
-#endif
 #endif
 
 #if CUDA_VERSION >= 11000 && CUBLAS_VERSION >= 11000


### PR DESCRIPTION
+ Updated synthetic tests, the regenerated `hipify-perl`, and `BLAS` `CUDA2HIP` documentation
