### PR TITLE
[HIPIFY][#936][BLASLT] `cublasLt` -> `hipblalLt` hipification support - Step 15

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -3870,6 +3870,10 @@ sub simpleSubstitutions {
     subst("cublasLtCreate", "hipblasLtCreate", "library");
     subst("cublasLtDestroy", "hipblasLtDestroy", "library");
     subst("cublasLtMatmul", "hipblasLtMatmul", "library");
+    subst("cublasLtMatmulDescCreate", "hipblasLtMatmulDescCreate", "library");
+    subst("cublasLtMatmulDescDestroy", "hipblasLtMatmulDescDestroy", "library");
+    subst("cublasLtMatmulDescGetAttribute", "hipblasLtMatmulDescGetAttribute", "library");
+    subst("cublasLtMatmulDescSetAttribute", "hipblasLtMatmulDescSetAttribute", "library");
     subst("cublasLtMatrixLayoutCreate", "hipblasLtMatrixLayoutCreate", "library");
     subst("cublasLtMatrixLayoutDestroy", "hipblasLtMatrixLayoutDestroy", "library");
     subst("cublasLtMatrixLayoutGetAttribute", "hipblasLtMatrixLayoutGetAttribute", "library");
@@ -11277,6 +11281,7 @@ sub warnHipOnlyUnsupportedFunctions {
         "cublasLtMatmulTile_t",
         "cublasLtMatmulStages_t",
         "cublasLtMatmulInnerShape_t",
+        "cublasLtMatmulDescInit",
         "cublasLtHeuristicsCacheSetCapacity",
         "cublasLtHeuristicsCacheGetCapacity",
         "cublasLtGetVersion",
@@ -11906,6 +11911,11 @@ sub warnRocOnlyUnsupportedFunctions {
         "cublasLtMatmulTile_t",
         "cublasLtMatmulStages_t",
         "cublasLtMatmulInnerShape_t",
+        "cublasLtMatmulDescSetAttribute",
+        "cublasLtMatmulDescInit",
+        "cublasLtMatmulDescGetAttribute",
+        "cublasLtMatmulDescDestroy",
+        "cublasLtMatmulDescCreate",
         "cublasLtMatmulDescAttributes_t",
         "cublasLtMatmul",
         "cublasLtHeuristicsCacheSetCapacity",

--- a/docs/tables/CUBLAS_API_supported_by_HIP.md
+++ b/docs/tables/CUBLAS_API_supported_by_HIP.md
@@ -1258,6 +1258,11 @@
 |`cublasLtHeuristicsCacheGetCapacity`|11.8| | | | | | | | | |
 |`cublasLtHeuristicsCacheSetCapacity`|11.8| | | | | | | | | |
 |`cublasLtMatmul`|10.1| | | |`hipblasLtMatmul`|5.5.0| | | | |
+|`cublasLtMatmulDescCreate`|10.1| |11.0| |`hipblasLtMatmulDescCreate`|5.5.0| | | | |
+|`cublasLtMatmulDescDestroy`|10.1| | | |`hipblasLtMatmulDescDestroy`|5.5.0| | | | |
+|`cublasLtMatmulDescGetAttribute`|10.1| | | |`hipblasLtMatmulDescGetAttribute`|5.5.0| | | | |
+|`cublasLtMatmulDescInit`|11.0| | | | | | | | | |
+|`cublasLtMatmulDescSetAttribute`|10.1| | | |`hipblasLtMatmulDescSetAttribute`|5.5.0| | | | |
 |`cublasLtMatrixLayoutCreate`|10.1| | | |`hipblasLtMatrixLayoutCreate`|5.5.0| | | | |
 |`cublasLtMatrixLayoutDestroy`|10.1| | | |`hipblasLtMatrixLayoutDestroy`|5.5.0| | | | |
 |`cublasLtMatrixLayoutGetAttribute`|10.1| | | |`hipblasLtMatrixLayoutGetAttribute`|5.5.0| | | | |

--- a/docs/tables/CUBLAS_API_supported_by_HIP_and_ROC.md
+++ b/docs/tables/CUBLAS_API_supported_by_HIP_and_ROC.md
@@ -1258,6 +1258,11 @@
 |`cublasLtHeuristicsCacheGetCapacity`|11.8| | | | | | | | | | | | | | | |
 |`cublasLtHeuristicsCacheSetCapacity`|11.8| | | | | | | | | | | | | | | |
 |`cublasLtMatmul`|10.1| | | |`hipblasLtMatmul`|5.5.0| | | | | | | | | | |
+|`cublasLtMatmulDescCreate`|10.1| |11.0| |`hipblasLtMatmulDescCreate`|5.5.0| | | | | | | | | | |
+|`cublasLtMatmulDescDestroy`|10.1| | | |`hipblasLtMatmulDescDestroy`|5.5.0| | | | | | | | | | |
+|`cublasLtMatmulDescGetAttribute`|10.1| | | |`hipblasLtMatmulDescGetAttribute`|5.5.0| | | | | | | | | | |
+|`cublasLtMatmulDescInit`|11.0| | | | | | | | | | | | | | | |
+|`cublasLtMatmulDescSetAttribute`|10.1| | | |`hipblasLtMatmulDescSetAttribute`|5.5.0| | | | | | | | | | |
 |`cublasLtMatrixLayoutCreate`|10.1| | | |`hipblasLtMatrixLayoutCreate`|5.5.0| | | | | | | | | | |
 |`cublasLtMatrixLayoutDestroy`|10.1| | | |`hipblasLtMatrixLayoutDestroy`|5.5.0| | | | | | | | | | |
 |`cublasLtMatrixLayoutGetAttribute`|10.1| | | |`hipblasLtMatrixLayoutGetAttribute`|5.5.0| | | | | | | | | | |

--- a/docs/tables/CUBLAS_API_supported_by_ROC.md
+++ b/docs/tables/CUBLAS_API_supported_by_ROC.md
@@ -1258,6 +1258,11 @@
 |`cublasLtHeuristicsCacheGetCapacity`|11.8| | | | | | | | | |
 |`cublasLtHeuristicsCacheSetCapacity`|11.8| | | | | | | | | |
 |`cublasLtMatmul`|10.1| | | | | | | | | |
+|`cublasLtMatmulDescCreate`|10.1| |11.0| | | | | | | |
+|`cublasLtMatmulDescDestroy`|10.1| | | | | | | | | |
+|`cublasLtMatmulDescGetAttribute`|10.1| | | | | | | | | |
+|`cublasLtMatmulDescInit`|11.0| | | | | | | | | |
+|`cublasLtMatmulDescSetAttribute`|10.1| | | | | | | | | |
 |`cublasLtMatrixLayoutCreate`|10.1| | | | | | | | | |
 |`cublasLtMatrixLayoutDestroy`|10.1| | | | | | | | | |
 |`cublasLtMatrixLayoutGetAttribute`|10.1| | | | | | | | | |

--- a/src/CUDA2HIP.h
+++ b/src/CUDA2HIP.h
@@ -138,6 +138,7 @@ extern const std::map<llvm::StringRef, hipAPIversions> HIP_COMPLEX_FUNCTION_VER_
 extern const std::map<llvm::StringRef, hipAPIversions> HIP_BLAS_TYPE_NAME_VER_MAP;
 extern const std::map<llvm::StringRef, hipAPIversions> HIP_BLAS_FUNCTION_VER_MAP;
 extern const std::map<llvm::StringRef, hipAPIChangedVersions> HIP_BLAS_FUNCTION_CHANGED_VER_MAP;
+extern const std::map<llvm::StringRef, cudaAPIChangedVersions> CUDA_BLAS_FUNCTION_CHANGED_VER_MAP;
 extern const std::map<llvm::StringRef, hipAPIversions> HIP_RAND_TYPE_NAME_VER_MAP;
 extern const std::map<llvm::StringRef, hipAPIversions> HIP_RAND_FUNCTION_VER_MAP;
 extern const std::map<llvm::StringRef, hipAPIversions> HIP_DNN_TYPE_NAME_VER_MAP;

--- a/src/CUDA2HIP_BLAS_API_functions.cpp
+++ b/src/CUDA2HIP_BLAS_API_functions.cpp
@@ -1097,6 +1097,14 @@ const std::map<llvm::StringRef, hipCounter> CUDA_BLAS_FUNCTION_MAP {
   {"cublasLtMatrixLayoutDestroy",    {"hipblasLtMatrixLayoutDestroy",    "",                                         CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LT, ROC_UNSUPPORTED}},
   {"cublasLtMatrixLayoutSetAttribute",       {"hipblasLtMatrixLayoutSetAttribute",       "",                         CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LT, ROC_UNSUPPORTED}},
   {"cublasLtMatrixLayoutGetAttribute",       {"hipblasLtMatrixLayoutGetAttribute",       "",                         CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LT, ROC_UNSUPPORTED}},
+  {"cublasLtMatmulDescInit",                 {"hipblasLtMatmulDescInit",                 "",                         CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LT, UNSUPPORTED}},
+  // [hipBLASLt] TODO: Use hipblasComputeType_t instead of incompatible hipblasLtComputeType_t
+  // [HIPIFY] TODO: For CUDA < 11.0 throw an error cublasLtMatmulDescCreate is not supported by HIP, please use the newer version of cublasLtMatmulDescCreate (>=11.0)
+  // [Reason] The signature change in 11.0.1 from cublasLtMatmulDescCreate(cublasLtMatmulDesc_t *matmulDesc, cudaDataType computeType);
+  {"cublasLtMatmulDescCreate",               {"hipblasLtMatmulDescCreate",               "",                         CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LT, ROC_UNSUPPORTED}},
+  {"cublasLtMatmulDescDestroy",              {"hipblasLtMatmulDescDestroy",              "",                         CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LT, ROC_UNSUPPORTED}},
+  {"cublasLtMatmulDescSetAttribute",         {"hipblasLtMatmulDescSetAttribute",         "",                         CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LT, ROC_UNSUPPORTED}},
+  {"cublasLtMatmulDescGetAttribute",         {"hipblasLtMatmulDescGetAttribute",         "",                         CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LT, ROC_UNSUPPORTED}},
 };
 
 const std::map<llvm::StringRef, cudaAPIversions> CUDA_BLAS_FUNCTION_VER_MAP {
@@ -1564,6 +1572,11 @@ const std::map<llvm::StringRef, cudaAPIversions> CUDA_BLAS_FUNCTION_VER_MAP {
   {"cublasLtMatrixLayoutDestroy",                {CUDA_101, CUDA_0,   CUDA_0   }},
   {"cublasLtMatrixLayoutSetAttribute",           {CUDA_101, CUDA_0,   CUDA_0   }},
   {"cublasLtMatrixLayoutGetAttribute",           {CUDA_101, CUDA_0,   CUDA_0   }},
+  {"cublasLtMatmulDescInit",                     {CUDA_110, CUDA_0,   CUDA_0   }}, // A: CUDA_VERSION 11001, CUBLAS_VERSION 11000, CUBLAS_VER_MAJOR 11 CUBLAS_VER_MINOR 0
+  {"cublasLtMatmulDescCreate",                   {CUDA_101, CUDA_0,   CUDA_0   }},
+  {"cublasLtMatmulDescDestroy",                  {CUDA_101, CUDA_0,   CUDA_0   }},
+  {"cublasLtMatmulDescSetAttribute",             {CUDA_101, CUDA_0,   CUDA_0   }},
+  {"cublasLtMatmulDescGetAttribute",             {CUDA_101, CUDA_0,   CUDA_0   }},
 };
 
 const std::map<llvm::StringRef, hipAPIversions> HIP_BLAS_FUNCTION_VER_MAP {
@@ -1974,6 +1987,10 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_BLAS_FUNCTION_VER_MAP {
   {"hipblasLtMatrixLayoutDestroy",               {HIP_5050, HIP_0,    HIP_0   }},
   {"hipblasLtMatrixLayoutSetAttribute",          {HIP_5050, HIP_0,    HIP_0   }},
   {"hipblasLtMatrixLayoutGetAttribute",          {HIP_5050, HIP_0,    HIP_0   }},
+  {"hipblasLtMatmulDescCreate",                  {HIP_5050, HIP_0,    HIP_0   }},
+  {"hipblasLtMatmulDescDestroy",                 {HIP_5050, HIP_0,    HIP_0   }},
+  {"hipblasLtMatmulDescSetAttribute",            {HIP_5050, HIP_0,    HIP_0   }},
+  {"hipblasLtMatmulDescGetAttribute",            {HIP_5050, HIP_0,    HIP_0   }},
 
   {"rocblas_status_to_string",                   {HIP_3050, HIP_0,    HIP_0   }},
   {"rocblas_sscal",                              {HIP_1050, HIP_0,    HIP_0   }},
@@ -2275,6 +2292,10 @@ const std::map<llvm::StringRef, hipAPIChangedVersions> HIP_BLAS_FUNCTION_CHANGED
   {"rocblas_dtrmm",                              {HIP_6000}},
   {"rocblas_ctrmm",                              {HIP_6000}},
   {"rocblas_ztrmm",                              {HIP_6000}},
+};
+
+const std::map<llvm::StringRef, cudaAPIChangedVersions> CUDA_BLAS_FUNCTION_CHANGED_VER_MAP {
+  {"cublasLtMatmulDescCreate",                   {CUDA_110}},
 };
 
 const std::map<unsigned int, llvm::StringRef> CUDA_BLAS_API_SECTION_MAP {

--- a/src/CUDA2HIP_Doc.cpp
+++ b/src/CUDA2HIP_Doc.cpp
@@ -559,6 +559,7 @@ namespace doc {
       const versionMap &getFunctionVersions() const override { return CUDA_BLAS_FUNCTION_VER_MAP; }
       const hipVersionMap &getHipFunctionVersions() const override { return HIP_BLAS_FUNCTION_VER_MAP; }
       const hipChangedVersionMap &getHipChangedFunctionVersions() const override { return HIP_BLAS_FUNCTION_CHANGED_VER_MAP; }
+      const cudaChangedVersionMap &getCudaChangedFunctionVersions() const override { return CUDA_BLAS_FUNCTION_CHANGED_VER_MAP; }
       const versionMap &getTypeVersions() const override { return CUDA_BLAS_TYPE_NAME_VER_MAP; }
       const hipVersionMap &getHipTypeVersions() const override { return HIP_BLAS_TYPE_NAME_VER_MAP; }
       const string &getName() const override { return sCUBLAS; }

--- a/tests/unit_tests/synthetic/libraries/cublaslt2hipblaslt.cu
+++ b/tests/unit_tests/synthetic/libraries/cublaslt2hipblaslt.cu
@@ -133,6 +133,21 @@ int main() {
   // HIP: HIPBLASLT_EXPORT hipblasStatus_t hipblasLtMatrixLayoutGetAttribute(hipblasLtMatrixLayout_t matLayout, hipblasLtMatrixLayoutAttribute_t attr, void* buf, size_t sizeInBytes, size_t* sizeWritten);
   // CHECK: status = hipblasLtMatrixLayoutGetAttribute(blasLtMatrixLayout, blasLtMatrixLayoutAttribute, buf, workspaceSizeInBytes, &sizeWritten);
   status = cublasLtMatrixLayoutGetAttribute(blasLtMatrixLayout, blasLtMatrixLayoutAttribute, buf, workspaceSizeInBytes, &sizeWritten);
+
+  // CUDA: cublasStatus_t CUBLASWINAPI cublasLtMatmulDescDestroy(cublasLtMatmulDesc_t matmulDesc);
+  // HIP: HIPBLASLT_EXPORT hipblasStatus_t hipblasLtMatmulDescDestroy(const hipblasLtMatmulDesc_t matmulDesc);
+  // CHECK: status = hipblasLtMatmulDescDestroy(blasLtMatmulDesc);
+  status = cublasLtMatmulDescDestroy(blasLtMatmulDesc);
+
+  // CUDA: cublasStatus_t CUBLASWINAPI cublasLtMatmulDescSetAttribute(cublasLtMatmulDesc_t matmulDesc, cublasLtMatmulDescAttributes_t attr, const void* buf, size_t sizeInBytes);
+  // HIP: HIPBLASLT_EXPORT hipblasStatus_t hipblasLtMatmulDescSetAttribute(hipblasLtMatmulDesc_t matmulDesc, hipblasLtMatmulDescAttributes_t attr, const void* buf, size_t sizeInBytes);
+  // CHECK: status = hipblasLtMatmulDescSetAttribute(blasLtMatmulDesc, blasLtMatmulDescAttributes, buf, workspaceSizeInBytes);
+  status = cublasLtMatmulDescSetAttribute(blasLtMatmulDesc, blasLtMatmulDescAttributes, buf, workspaceSizeInBytes);
+
+  // CUDA: cublasStatus_t CUBLASWINAPI cublasLtMatmulDescGetAttribute(cublasLtMatmulDesc_t matmulDesc, cublasLtMatmulDescAttributes_t attr, void* buf, size_t sizeInBytes, size_t* sizeWritten);
+  // HIP: HIPBLASLT_EXPORT hipblasStatus_t hipblasLtMatmulDescGetAttribute(hipblasLtMatmulDesc_t matmulDesc, hipblasLtMatmulDescAttributes_t attr, void* buf, size_t sizeInBytes, size_t* sizeWritten);
+  // CHECK: status = hipblasLtMatmulDescGetAttribute(blasLtMatmulDesc, blasLtMatmulDescAttributes, buf, workspaceSizeInBytes, &sizeWritten);
+  status = cublasLtMatmulDescGetAttribute(blasLtMatmulDesc, blasLtMatmulDescAttributes, buf, workspaceSizeInBytes, &sizeWritten);
 #endif
 
 #if CUBLAS_VERSION >= 10200
@@ -147,6 +162,20 @@ int main() {
   // CHECK-NEXT: hipblasLtMatmulDescAttributes_t BLASLT_MATMUL_DESC_BIAS_POINTER = HIPBLASLT_MATMUL_DESC_BIAS_POINTER;
   cublasLtMatmulDescAttributes_t BLASLT_MATMUL_DESC_EPILOGUE = CUBLASLT_MATMUL_DESC_EPILOGUE;
   cublasLtMatmulDescAttributes_t BLASLT_MATMUL_DESC_BIAS_POINTER = CUBLASLT_MATMUL_DESC_BIAS_POINTER;
+#endif
+
+#if CUDA_VERSION >= 11000
+  // CHECK: hipblasComputeType_t blasComputeType;
+  cublasComputeType_t blasComputeType;
+
+  // [hipBLASLt] TODO: Use hipblasComputeType_t instead of incompatible hipblasLtComputeType_t
+  // [HIPIFY] TODO: For CUDA < 11.0 throw an error cublasLtMatmulDescCreate is not supported by HIP, please use the newer version of cublasLtMatmulDescCreate (>=11.0)
+  // [Reason] The signature change in 11.0.1 from cublasLtMatmulDescCreate(cublasLtMatmulDesc_t *matmulDesc, cudaDataType computeType);
+  // CUDA: cublasStatus_t CUBLASWINAPI cublasLtMatmulDescCreate(cublasLtMatmulDesc_t* matmulDesc, cublasComputeType_t computeType, cudaDataType_t scaleType);
+  // HIP: HIPBLASLT_EXPORT hipblasStatus_t hipblasLtMatmulDescCreate(hipblasLtMatmulDesc_t* matmulDesc, hipblasLtComputeType_t computeType, hipblasDatatype_t scaleType);
+  // CHECK: status = hipblasLtMatmulDescCreate(&blasLtMatmulDesc, blasComputeType, dataType);
+  status = cublasLtMatmulDescCreate(&blasLtMatmulDesc, blasComputeType, dataType);
+
 #endif
 
 #if CUDA_VERSION >= 11000 && CUBLAS_VERSION >= 11000


### PR DESCRIPTION
+ Updated synthetic tests, the regenerated `hipify-perl`, and `BLAS` `CUDA2HIP` documentation

[ToDo]
+ [hipBLASLt] Create a ticket to use `hipblasComputeType_t` instead of incompatible `hipblasLtComputeType_t`
+ For CUDA < 11.0 throw an error `cublasLtMatmulDescCreate` is not supported by HIP, please use the newer version of `cublasLtMatmulDescCreate` (>=11.0) 
[Reason] The signature change in 11.0.1 from `cublasLtMatmulDescCreate(cublasLtMatmulDesc_t *matmulDesc, cudaDataType computeType)`