### PR TITLE
[HIPIFY][#936][BLASLT] `cublasLt` -> `hipblalLt` hipification support - Step 16

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -3879,6 +3879,10 @@ sub simpleSubstitutions {
     subst("cublasLtMatrixLayoutGetAttribute", "hipblasLtMatrixLayoutGetAttribute", "library");
     subst("cublasLtMatrixLayoutSetAttribute", "hipblasLtMatrixLayoutSetAttribute", "library");
     subst("cublasLtMatrixTransform", "hipblasLtMatrixTransform", "library");
+    subst("cublasLtMatrixTransformDescCreate", "hipblasLtMatrixTransformDescCreate", "library");
+    subst("cublasLtMatrixTransformDescDestroy", "hipblasLtMatrixTransformDescDestroy", "library");
+    subst("cublasLtMatrixTransformDescGetAttribute", "hipblasLtMatrixTransformDescGetAttribute", "library");
+    subst("cublasLtMatrixTransformDescSetAttribute", "hipblasLtMatrixTransformDescSetAttribute", "library");
     subst("cublasNrm2Ex", "hipblasNrm2Ex_v2", "library");
     subst("cublasRotEx", "hipblasRotEx_v2", "library");
     subst("cublasSasum", "hipblasSasum", "library");
@@ -5468,6 +5472,7 @@ sub simpleSubstitutions {
     subst("cublasLtMatrixLayoutOpaque_t", "hipblasLtMatrixLayoutOpaque_t", "type");
     subst("cublasLtMatrixLayoutStruct", "hipblasLtMatrixLayoutOpaque_t", "type");
     subst("cublasLtMatrixLayout_t", "hipblasLtMatrixLayout_t", "type");
+    subst("cublasLtMatrixTransformDescAttributes_t", "hipblasLtMatrixTransformDescAttributes_t", "type");
     subst("cublasLtMatrixTransformDescOpaque_t", "hipblasLtMatrixTransformDescOpaque_t", "type");
     subst("cublasLtMatrixTransformDesc_t", "hipblasLtMatrixTransformDesc_t", "type");
     subst("cublasLtPointerMode_t", "hipblasLtPointerMode_t", "type");
@@ -5756,6 +5761,10 @@ sub simpleSubstitutions {
     subst("CUBLASLT_MATRIX_LAYOUT_ROWS", "HIPBLASLT_MATRIX_LAYOUT_ROWS", "numeric_literal");
     subst("CUBLASLT_MATRIX_LAYOUT_STRIDED_BATCH_OFFSET", "HIPBLASLT_MATRIX_LAYOUT_STRIDED_BATCH_OFFSET", "numeric_literal");
     subst("CUBLASLT_MATRIX_LAYOUT_TYPE", "HIPBLASLT_MATRIX_LAYOUT_TYPE", "numeric_literal");
+    subst("CUBLASLT_MATRIX_TRANSFORM_DESC_POINTER_MODE", "HIPBLASLT_MATRIX_TRANSFORM_DESC_POINTER_MODE", "numeric_literal");
+    subst("CUBLASLT_MATRIX_TRANSFORM_DESC_SCALE_TYPE", "HIPBLASLT_MATRIX_TRANSFORM_DESC_SCALE_TYPE", "numeric_literal");
+    subst("CUBLASLT_MATRIX_TRANSFORM_DESC_TRANSA", "HIPBLASLT_MATRIX_TRANSFORM_DESC_TRANSA", "numeric_literal");
+    subst("CUBLASLT_MATRIX_TRANSFORM_DESC_TRANSB", "HIPBLASLT_MATRIX_TRANSFORM_DESC_TRANSB", "numeric_literal");
     subst("CUBLASLT_ORDER_COL", "HIPBLASLT_ORDER_COL", "numeric_literal");
     subst("CUBLASLT_ORDER_ROW", "HIPBLASLT_ORDER_ROW", "numeric_literal");
     subst("CUBLASLT_POINTER_MODE_ALPHA_DEVICE_VECTOR_BETA_HOST", "HIPBLASLT_POINTER_MODE_ALPHA_DEVICE_VECTOR_BETA_HOST", "numeric_literal");
@@ -11277,6 +11286,7 @@ sub warnHipOnlyUnsupportedFunctions {
         "cublasMigrateComputeType",
         "cublasLtPointerModeMask_t",
         "cublasLtNumericalImplFlags_t",
+        "cublasLtMatrixTransformDescInit",
         "cublasLtMatrixLayoutInit",
         "cublasLtMatmulTile_t",
         "cublasLtMatmulStages_t",
@@ -11901,6 +11911,12 @@ sub warnRocOnlyUnsupportedFunctions {
         "cublasLtPointerModeMask_t",
         "cublasLtOrder_t",
         "cublasLtNumericalImplFlags_t",
+        "cublasLtMatrixTransformDescSetAttribute",
+        "cublasLtMatrixTransformDescInit",
+        "cublasLtMatrixTransformDescGetAttribute",
+        "cublasLtMatrixTransformDescDestroy",
+        "cublasLtMatrixTransformDescCreate",
+        "cublasLtMatrixTransformDescAttributes_t",
         "cublasLtMatrixTransform",
         "cublasLtMatrixLayoutSetAttribute",
         "cublasLtMatrixLayoutInit",
@@ -12226,6 +12242,10 @@ sub warnRocOnlyUnsupportedFunctions {
         "CUBLASLT_NUMERICAL_IMPL_FLAGS_ACCUMULATOR_32I",
         "CUBLASLT_NUMERICAL_IMPL_FLAGS_ACCUMULATOR_32F",
         "CUBLASLT_NUMERICAL_IMPL_FLAGS_ACCUMULATOR_16F",
+        "CUBLASLT_MATRIX_TRANSFORM_DESC_TRANSB",
+        "CUBLASLT_MATRIX_TRANSFORM_DESC_TRANSA",
+        "CUBLASLT_MATRIX_TRANSFORM_DESC_SCALE_TYPE",
+        "CUBLASLT_MATRIX_TRANSFORM_DESC_POINTER_MODE",
         "CUBLASLT_MATRIX_LAYOUT_TYPE",
         "CUBLASLT_MATRIX_LAYOUT_STRIDED_BATCH_OFFSET",
         "CUBLASLT_MATRIX_LAYOUT_ROWS",

--- a/docs/tables/CUBLAS_API_supported_by_HIP.md
+++ b/docs/tables/CUBLAS_API_supported_by_HIP.md
@@ -314,6 +314,10 @@
 |`CUBLASLT_MATRIX_LAYOUT_ROWS`|10.1| | | |`HIPBLASLT_MATRIX_LAYOUT_ROWS`|6.0.0| | | | |
 |`CUBLASLT_MATRIX_LAYOUT_STRIDED_BATCH_OFFSET`|10.1| | | |`HIPBLASLT_MATRIX_LAYOUT_STRIDED_BATCH_OFFSET`|5.5.0| | | | |
 |`CUBLASLT_MATRIX_LAYOUT_TYPE`|10.1| | | |`HIPBLASLT_MATRIX_LAYOUT_TYPE`|6.0.0| | | | |
+|`CUBLASLT_MATRIX_TRANSFORM_DESC_POINTER_MODE`|10.1| | | |`HIPBLASLT_MATRIX_TRANSFORM_DESC_POINTER_MODE`|6.0.0| | | | |
+|`CUBLASLT_MATRIX_TRANSFORM_DESC_SCALE_TYPE`|10.1| | | |`HIPBLASLT_MATRIX_TRANSFORM_DESC_SCALE_TYPE`|6.0.0| | | | |
+|`CUBLASLT_MATRIX_TRANSFORM_DESC_TRANSA`|10.1| | | |`HIPBLASLT_MATRIX_TRANSFORM_DESC_TRANSA`|6.0.0| | | | |
+|`CUBLASLT_MATRIX_TRANSFORM_DESC_TRANSB`|10.1| | | |`HIPBLASLT_MATRIX_TRANSFORM_DESC_TRANSB`|6.0.0| | | | |
 |`CUBLASLT_NUMERICAL_IMPL_FLAGS_ACCUMULATOR_16F`|11.0| | | | | | | | | |
 |`CUBLASLT_NUMERICAL_IMPL_FLAGS_ACCUMULATOR_32F`|11.0| | | | | | | | | |
 |`CUBLASLT_NUMERICAL_IMPL_FLAGS_ACCUMULATOR_32I`|11.0| | | | | | | | | |
@@ -366,6 +370,7 @@
 |`cublasLtMatrixLayoutOpaque_t`|11.0| | | |`hipblasLtMatrixLayoutOpaque_t`| | | | | |
 |`cublasLtMatrixLayoutStruct`|10.1| | |10.2|`hipblasLtMatrixLayoutOpaque_t`| | | | | |
 |`cublasLtMatrixLayout_t`|10.1| | | |`hipblasLtMatrixLayout_t`| | | | | |
+|`cublasLtMatrixTransformDescAttributes_t`|10.1| | | |`hipblasLtMatrixTransformDescAttributes_t`|6.0.0| | | | |
 |`cublasLtMatrixTransformDescOpaque_t`|11.0| | | |`hipblasLtMatrixTransformDescOpaque_t`|6.0.0| | | | |
 |`cublasLtMatrixTransformDesc_t`|10.1| | | |`hipblasLtMatrixTransformDesc_t`|6.0.0| | | | |
 |`cublasLtNumericalImplFlags_t`|11.0| | | | | | | | | |
@@ -1269,6 +1274,11 @@
 |`cublasLtMatrixLayoutInit`|11.0| | | | | | | | | |
 |`cublasLtMatrixLayoutSetAttribute`|10.1| | | |`hipblasLtMatrixLayoutSetAttribute`|5.5.0| | | | |
 |`cublasLtMatrixTransform`|10.1| | | |`hipblasLtMatrixTransform`|6.0.0| | | | |
+|`cublasLtMatrixTransformDescCreate`|10.1| | | |`hipblasLtMatrixTransformDescCreate`|6.0.0| | | | |
+|`cublasLtMatrixTransformDescDestroy`|10.1| | | |`hipblasLtMatrixTransformDescDestroy`|6.0.0| | | | |
+|`cublasLtMatrixTransformDescGetAttribute`|10.1| | | |`hipblasLtMatrixTransformDescGetAttribute`|6.0.0| | | | |
+|`cublasLtMatrixTransformDescInit`|11.0| | | | | | | | | |
+|`cublasLtMatrixTransformDescSetAttribute`|10.1| | | |`hipblasLtMatrixTransformDescSetAttribute`|6.0.0| | | | |
 
 
 \*A - Added; D - Deprecated; C - Changed; R - Removed; E - Experimental

--- a/docs/tables/CUBLAS_API_supported_by_HIP_and_ROC.md
+++ b/docs/tables/CUBLAS_API_supported_by_HIP_and_ROC.md
@@ -314,6 +314,10 @@
 |`CUBLASLT_MATRIX_LAYOUT_ROWS`|10.1| | | |`HIPBLASLT_MATRIX_LAYOUT_ROWS`|6.0.0| | | | | | | | | | |
 |`CUBLASLT_MATRIX_LAYOUT_STRIDED_BATCH_OFFSET`|10.1| | | |`HIPBLASLT_MATRIX_LAYOUT_STRIDED_BATCH_OFFSET`|5.5.0| | | | | | | | | | |
 |`CUBLASLT_MATRIX_LAYOUT_TYPE`|10.1| | | |`HIPBLASLT_MATRIX_LAYOUT_TYPE`|6.0.0| | | | | | | | | | |
+|`CUBLASLT_MATRIX_TRANSFORM_DESC_POINTER_MODE`|10.1| | | |`HIPBLASLT_MATRIX_TRANSFORM_DESC_POINTER_MODE`|6.0.0| | | | | | | | | | |
+|`CUBLASLT_MATRIX_TRANSFORM_DESC_SCALE_TYPE`|10.1| | | |`HIPBLASLT_MATRIX_TRANSFORM_DESC_SCALE_TYPE`|6.0.0| | | | | | | | | | |
+|`CUBLASLT_MATRIX_TRANSFORM_DESC_TRANSA`|10.1| | | |`HIPBLASLT_MATRIX_TRANSFORM_DESC_TRANSA`|6.0.0| | | | | | | | | | |
+|`CUBLASLT_MATRIX_TRANSFORM_DESC_TRANSB`|10.1| | | |`HIPBLASLT_MATRIX_TRANSFORM_DESC_TRANSB`|6.0.0| | | | | | | | | | |
 |`CUBLASLT_NUMERICAL_IMPL_FLAGS_ACCUMULATOR_16F`|11.0| | | | | | | | | | | | | | | |
 |`CUBLASLT_NUMERICAL_IMPL_FLAGS_ACCUMULATOR_32F`|11.0| | | | | | | | | | | | | | | |
 |`CUBLASLT_NUMERICAL_IMPL_FLAGS_ACCUMULATOR_32I`|11.0| | | | | | | | | | | | | | | |
@@ -366,6 +370,7 @@
 |`cublasLtMatrixLayoutOpaque_t`|11.0| | | |`hipblasLtMatrixLayoutOpaque_t`| | | | | | | | | | | |
 |`cublasLtMatrixLayoutStruct`|10.1| | |10.2|`hipblasLtMatrixLayoutOpaque_t`| | | | | | | | | | | |
 |`cublasLtMatrixLayout_t`|10.1| | | |`hipblasLtMatrixLayout_t`| | | | | | | | | | | |
+|`cublasLtMatrixTransformDescAttributes_t`|10.1| | | |`hipblasLtMatrixTransformDescAttributes_t`|6.0.0| | | | | | | | | | |
 |`cublasLtMatrixTransformDescOpaque_t`|11.0| | | |`hipblasLtMatrixTransformDescOpaque_t`|6.0.0| | | | | | | | | | |
 |`cublasLtMatrixTransformDesc_t`|10.1| | | |`hipblasLtMatrixTransformDesc_t`|6.0.0| | | | | | | | | | |
 |`cublasLtNumericalImplFlags_t`|11.0| | | | | | | | | | | | | | | |
@@ -1269,6 +1274,11 @@
 |`cublasLtMatrixLayoutInit`|11.0| | | | | | | | | | | | | | | |
 |`cublasLtMatrixLayoutSetAttribute`|10.1| | | |`hipblasLtMatrixLayoutSetAttribute`|5.5.0| | | | | | | | | | |
 |`cublasLtMatrixTransform`|10.1| | | |`hipblasLtMatrixTransform`|6.0.0| | | | | | | | | | |
+|`cublasLtMatrixTransformDescCreate`|10.1| | | |`hipblasLtMatrixTransformDescCreate`|6.0.0| | | | | | | | | | |
+|`cublasLtMatrixTransformDescDestroy`|10.1| | | |`hipblasLtMatrixTransformDescDestroy`|6.0.0| | | | | | | | | | |
+|`cublasLtMatrixTransformDescGetAttribute`|10.1| | | |`hipblasLtMatrixTransformDescGetAttribute`|6.0.0| | | | | | | | | | |
+|`cublasLtMatrixTransformDescInit`|11.0| | | | | | | | | | | | | | | |
+|`cublasLtMatrixTransformDescSetAttribute`|10.1| | | |`hipblasLtMatrixTransformDescSetAttribute`|6.0.0| | | | | | | | | | |
 
 
 \*A - Added; D - Deprecated; C - Changed; R - Removed; E - Experimental

--- a/docs/tables/CUBLAS_API_supported_by_ROC.md
+++ b/docs/tables/CUBLAS_API_supported_by_ROC.md
@@ -314,6 +314,10 @@
 |`CUBLASLT_MATRIX_LAYOUT_ROWS`|10.1| | | | | | | | | |
 |`CUBLASLT_MATRIX_LAYOUT_STRIDED_BATCH_OFFSET`|10.1| | | | | | | | | |
 |`CUBLASLT_MATRIX_LAYOUT_TYPE`|10.1| | | | | | | | | |
+|`CUBLASLT_MATRIX_TRANSFORM_DESC_POINTER_MODE`|10.1| | | | | | | | | |
+|`CUBLASLT_MATRIX_TRANSFORM_DESC_SCALE_TYPE`|10.1| | | | | | | | | |
+|`CUBLASLT_MATRIX_TRANSFORM_DESC_TRANSA`|10.1| | | | | | | | | |
+|`CUBLASLT_MATRIX_TRANSFORM_DESC_TRANSB`|10.1| | | | | | | | | |
 |`CUBLASLT_NUMERICAL_IMPL_FLAGS_ACCUMULATOR_16F`|11.0| | | | | | | | | |
 |`CUBLASLT_NUMERICAL_IMPL_FLAGS_ACCUMULATOR_32F`|11.0| | | | | | | | | |
 |`CUBLASLT_NUMERICAL_IMPL_FLAGS_ACCUMULATOR_32I`|11.0| | | | | | | | | |
@@ -366,6 +370,7 @@
 |`cublasLtMatrixLayoutOpaque_t`|11.0| | | | | | | | | |
 |`cublasLtMatrixLayoutStruct`|10.1| | |10.2| | | | | | |
 |`cublasLtMatrixLayout_t`|10.1| | | | | | | | | |
+|`cublasLtMatrixTransformDescAttributes_t`|10.1| | | | | | | | | |
 |`cublasLtMatrixTransformDescOpaque_t`|11.0| | | | | | | | | |
 |`cublasLtMatrixTransformDesc_t`|10.1| | | | | | | | | |
 |`cublasLtNumericalImplFlags_t`|11.0| | | | | | | | | |
@@ -1269,6 +1274,11 @@
 |`cublasLtMatrixLayoutInit`|11.0| | | | | | | | | |
 |`cublasLtMatrixLayoutSetAttribute`|10.1| | | | | | | | | |
 |`cublasLtMatrixTransform`|10.1| | | | | | | | | |
+|`cublasLtMatrixTransformDescCreate`|10.1| | | | | | | | | |
+|`cublasLtMatrixTransformDescDestroy`|10.1| | | | | | | | | |
+|`cublasLtMatrixTransformDescGetAttribute`|10.1| | | | | | | | | |
+|`cublasLtMatrixTransformDescInit`|11.0| | | | | | | | | |
+|`cublasLtMatrixTransformDescSetAttribute`|10.1| | | | | | | | | |
 
 
 \*A - Added; D - Deprecated; C - Changed; R - Removed; E - Experimental

--- a/src/CUDA2HIP_BLAS_API_functions.cpp
+++ b/src/CUDA2HIP_BLAS_API_functions.cpp
@@ -1105,6 +1105,11 @@ const std::map<llvm::StringRef, hipCounter> CUDA_BLAS_FUNCTION_MAP {
   {"cublasLtMatmulDescDestroy",              {"hipblasLtMatmulDescDestroy",              "",                         CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LT, ROC_UNSUPPORTED}},
   {"cublasLtMatmulDescSetAttribute",         {"hipblasLtMatmulDescSetAttribute",         "",                         CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LT, ROC_UNSUPPORTED}},
   {"cublasLtMatmulDescGetAttribute",         {"hipblasLtMatmulDescGetAttribute",         "",                         CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LT, ROC_UNSUPPORTED}},
+  {"cublasLtMatrixTransformDescInit",        {"hipblasLtMatrixTransformDescInit",        "",                         CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LT, UNSUPPORTED}},
+  {"cublasLtMatrixTransformDescCreate",      {"hipblasLtMatrixTransformDescCreate",      "",                         CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LT, ROC_UNSUPPORTED}},
+  {"cublasLtMatrixTransformDescDestroy",     {"hipblasLtMatrixTransformDescDestroy",     "",                         CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LT, ROC_UNSUPPORTED}},
+  {"cublasLtMatrixTransformDescSetAttribute",{"hipblasLtMatrixTransformDescSetAttribute","",                         CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LT, ROC_UNSUPPORTED}},
+  {"cublasLtMatrixTransformDescGetAttribute",{"hipblasLtMatrixTransformDescGetAttribute","",                         CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LT, ROC_UNSUPPORTED}},
 };
 
 const std::map<llvm::StringRef, cudaAPIversions> CUDA_BLAS_FUNCTION_VER_MAP {
@@ -1577,6 +1582,11 @@ const std::map<llvm::StringRef, cudaAPIversions> CUDA_BLAS_FUNCTION_VER_MAP {
   {"cublasLtMatmulDescDestroy",                  {CUDA_101, CUDA_0,   CUDA_0   }},
   {"cublasLtMatmulDescSetAttribute",             {CUDA_101, CUDA_0,   CUDA_0   }},
   {"cublasLtMatmulDescGetAttribute",             {CUDA_101, CUDA_0,   CUDA_0   }},
+  {"cublasLtMatrixTransformDescInit",            {CUDA_110, CUDA_0,   CUDA_0   }}, // A: CUDA_VERSION 11001, CUBLAS_VERSION 11000, CUBLAS_VER_MAJOR 11 CUBLAS_VER_MINOR 0
+  {"cublasLtMatrixTransformDescCreate",          {CUDA_101, CUDA_0,   CUDA_0   }},
+  {"cublasLtMatrixTransformDescDestroy",         {CUDA_101, CUDA_0,   CUDA_0   }},
+  {"cublasLtMatrixTransformDescSetAttribute",    {CUDA_101, CUDA_0,   CUDA_0   }},
+  {"cublasLtMatrixTransformDescGetAttribute",    {CUDA_101, CUDA_0,   CUDA_0   }},
 };
 
 const std::map<llvm::StringRef, hipAPIversions> HIP_BLAS_FUNCTION_VER_MAP {
@@ -1991,6 +2001,10 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_BLAS_FUNCTION_VER_MAP {
   {"hipblasLtMatmulDescDestroy",                 {HIP_5050, HIP_0,    HIP_0   }},
   {"hipblasLtMatmulDescSetAttribute",            {HIP_5050, HIP_0,    HIP_0   }},
   {"hipblasLtMatmulDescGetAttribute",            {HIP_5050, HIP_0,    HIP_0   }},
+  {"hipblasLtMatrixTransformDescCreate",         {HIP_6000, HIP_0,    HIP_0   }},
+  {"hipblasLtMatrixTransformDescDestroy",        {HIP_6000, HIP_0,    HIP_0   }},
+  {"hipblasLtMatrixTransformDescSetAttribute",   {HIP_6000, HIP_0,    HIP_0   }},
+  {"hipblasLtMatrixTransformDescGetAttribute",   {HIP_6000, HIP_0,    HIP_0   }},
 
   {"rocblas_status_to_string",                   {HIP_3050, HIP_0,    HIP_0   }},
   {"rocblas_sscal",                              {HIP_1050, HIP_0,    HIP_0   }},

--- a/src/CUDA2HIP_BLAS_API_types.cpp
+++ b/src/CUDA2HIP_BLAS_API_types.cpp
@@ -417,6 +417,11 @@ const std::map<llvm::StringRef, hipCounter> CUDA_BLAS_TYPE_NAME_MAP {
   {"CUBLASLT_MATMUL_DESC_ATOMIC_SYNC_NUM_CHUNKS_D_COLS",             {"HIPBLASLT_MATMUL_DESC_ATOMIC_SYNC_NUM_CHUNKS_D_COLS",               "",                                                         CONV_NUMERIC_LITERAL, API_BLAS, SEC::BLAS_LT_DATA_TYPES, UNSUPPORTED}},
   {"CUBLASLT_MATMUL_DESC_ATOMIC_SYNC_IN_COUNTERS_POINTER",           {"HIPBLASLT_MATMUL_DESC_ATOMIC_SYNC_IN_COUNTERS_POINTER",             "",                                                         CONV_NUMERIC_LITERAL, API_BLAS, SEC::BLAS_LT_DATA_TYPES, UNSUPPORTED}},
   {"CUBLASLT_MATMUL_DESC_ATOMIC_SYNC_OUT_COUNTERS_POINTER",          {"HIPBLASLT_MATMUL_DESC_ATOMIC_SYNC_OUT_COUNTERS_POINTER",            "",                                                         CONV_NUMERIC_LITERAL, API_BLAS, SEC::BLAS_LT_DATA_TYPES, UNSUPPORTED}},
+  {"cublasLtMatrixTransformDescAttributes_t",                        {"hipblasLtMatrixTransformDescAttributes_t",                          "",                                                         CONV_TYPE, API_BLAS, SEC::BLAS_LT_DATA_TYPES, ROC_UNSUPPORTED}},
+  {"CUBLASLT_MATRIX_TRANSFORM_DESC_SCALE_TYPE",                      {"HIPBLASLT_MATRIX_TRANSFORM_DESC_SCALE_TYPE",                        "",                                                         CONV_NUMERIC_LITERAL, API_BLAS, SEC::BLAS_LT_DATA_TYPES, ROC_UNSUPPORTED}},
+  {"CUBLASLT_MATRIX_TRANSFORM_DESC_POINTER_MODE",                    {"HIPBLASLT_MATRIX_TRANSFORM_DESC_POINTER_MODE",                      "",                                                         CONV_NUMERIC_LITERAL, API_BLAS, SEC::BLAS_LT_DATA_TYPES, ROC_UNSUPPORTED}},
+  {"CUBLASLT_MATRIX_TRANSFORM_DESC_TRANSA",                          {"HIPBLASLT_MATRIX_TRANSFORM_DESC_TRANSA",                            "",                                                         CONV_NUMERIC_LITERAL, API_BLAS, SEC::BLAS_LT_DATA_TYPES, ROC_UNSUPPORTED}},
+  {"CUBLASLT_MATRIX_TRANSFORM_DESC_TRANSB",                          {"HIPBLASLT_MATRIX_TRANSFORM_DESC_TRANSB",                            "",                                                         CONV_NUMERIC_LITERAL, API_BLAS, SEC::BLAS_LT_DATA_TYPES, ROC_UNSUPPORTED}},
 };
 
 const std::map<llvm::StringRef, cudaAPIversions> CUDA_BLAS_TYPE_NAME_VER_MAP {
@@ -743,6 +748,11 @@ const std::map<llvm::StringRef, cudaAPIversions> CUDA_BLAS_TYPE_NAME_VER_MAP {
   {"CUBLASLT_MATMUL_DESC_ATOMIC_SYNC_NUM_CHUNKS_D_COLS",             {CUDA_122, CUDA_0,   CUDA_0  }}, // A: CUDA_VERSION 12022, CUBLAS_VERSION 120205, CUBLAS_VER_MAJOR 12 CUBLAS_VER_MINOR 2 CUBLAS_VER_PATCH 5
   {"CUBLASLT_MATMUL_DESC_ATOMIC_SYNC_IN_COUNTERS_POINTER",           {CUDA_122, CUDA_0,   CUDA_0  }}, // A: CUDA_VERSION 12022, CUBLAS_VERSION 120205, CUBLAS_VER_MAJOR 12 CUBLAS_VER_MINOR 2 CUBLAS_VER_PATCH 5
   {"CUBLASLT_MATMUL_DESC_ATOMIC_SYNC_OUT_COUNTERS_POINTER",          {CUDA_122, CUDA_0,   CUDA_0  }}, // A: CUDA_VERSION 12022, CUBLAS_VERSION 120205, CUBLAS_VER_MAJOR 12 CUBLAS_VER_MINOR 2 CUBLAS_VER_PATCH 5
+  {"cublasLtMatrixTransformDescAttributes_t",                        {CUDA_101, CUDA_0,   CUDA_0  }},
+  {"CUBLASLT_MATRIX_TRANSFORM_DESC_SCALE_TYPE",                      {CUDA_101, CUDA_0,   CUDA_0  }},
+  {"CUBLASLT_MATRIX_TRANSFORM_DESC_POINTER_MODE",                    {CUDA_101, CUDA_0,   CUDA_0  }},
+  {"CUBLASLT_MATRIX_TRANSFORM_DESC_TRANSA",                          {CUDA_101, CUDA_0,   CUDA_0  }},
+  {"CUBLASLT_MATRIX_TRANSFORM_DESC_TRANSB",                          {CUDA_101, CUDA_0,   CUDA_0  }},
 };
 
 const std::map<llvm::StringRef, hipAPIversions> HIP_BLAS_TYPE_NAME_VER_MAP {
@@ -869,6 +879,11 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_BLAS_TYPE_NAME_VER_MAP {
   {"HIPBLASLT_MATMUL_DESC_D_SCALE_POINTER",                          {HIP_5050, HIP_0,    HIP_0   }},
   {"HIPBLASLT_MATMUL_DESC_EPILOGUE_AUX_SCALE_POINTER",               {HIP_6000, HIP_0,    HIP_0   }},
   {"HIPBLASLT_MATMUL_DESC_BIAS_DATA_TYPE",                           {HIP_5050, HIP_0,    HIP_0   }},
+  {"hipblasLtMatrixTransformDescAttributes_t",                       {HIP_6000, HIP_0,    HIP_0   }},
+  {"HIPBLASLT_MATRIX_TRANSFORM_DESC_SCALE_TYPE",                     {HIP_6000, HIP_0,    HIP_0   }},
+  {"HIPBLASLT_MATRIX_TRANSFORM_DESC_POINTER_MODE",                   {HIP_6000, HIP_0,    HIP_0   }},
+  {"HIPBLASLT_MATRIX_TRANSFORM_DESC_TRANSA",                         {HIP_6000, HIP_0,    HIP_0   }},
+  {"HIPBLASLT_MATRIX_TRANSFORM_DESC_TRANSB",                         {HIP_6000, HIP_0,    HIP_0   }},
 
   {"rocblas_handle",                                                 {HIP_1050, HIP_0,    HIP_0   }},
   {"_rocblas_handle",                                                {HIP_1050, HIP_0,    HIP_0   }},

--- a/tests/unit_tests/synthetic/libraries/cublaslt2hipblaslt.cu
+++ b/tests/unit_tests/synthetic/libraries/cublaslt2hipblaslt.cu
@@ -94,6 +94,17 @@ int main() {
   cublasLtMatmulDescAttributes_t BLASLT_MATMUL_DESC_TRANSA = CUBLASLT_MATMUL_DESC_TRANSA;
   cublasLtMatmulDescAttributes_t BLASLT_MATMUL_DESC_TRANSB = CUBLASLT_MATMUL_DESC_TRANSB;
 
+  // CHECK: hipblasLtMatrixTransformDescAttributes_t blasLtMatrixTransformDescAttributes;
+  // CHECK-NEXT: hipblasLtMatrixTransformDescAttributes_t BLASLT_MATRIX_TRANSFORM_DESC_SCALE_TYPE = HIPBLASLT_MATRIX_TRANSFORM_DESC_SCALE_TYPE;
+  // CHECK-NEXT: hipblasLtMatrixTransformDescAttributes_t BLASLT_MATRIX_TRANSFORM_DESC_POINTER_MODE = HIPBLASLT_MATRIX_TRANSFORM_DESC_POINTER_MODE;
+  // CHECK-NEXT: hipblasLtMatrixTransformDescAttributes_t BLASLT_MATRIX_TRANSFORM_DESC_TRANSA = HIPBLASLT_MATRIX_TRANSFORM_DESC_TRANSA;
+  // CHECK-NEXT: hipblasLtMatrixTransformDescAttributes_t BLASLT_MATRIX_TRANSFORM_DESC_TRANSB = HIPBLASLT_MATRIX_TRANSFORM_DESC_TRANSB;
+  cublasLtMatrixTransformDescAttributes_t blasLtMatrixTransformDescAttributes;
+  cublasLtMatrixTransformDescAttributes_t BLASLT_MATRIX_TRANSFORM_DESC_SCALE_TYPE = CUBLASLT_MATRIX_TRANSFORM_DESC_SCALE_TYPE;
+  cublasLtMatrixTransformDescAttributes_t BLASLT_MATRIX_TRANSFORM_DESC_POINTER_MODE = CUBLASLT_MATRIX_TRANSFORM_DESC_POINTER_MODE;
+  cublasLtMatrixTransformDescAttributes_t BLASLT_MATRIX_TRANSFORM_DESC_TRANSA = CUBLASLT_MATRIX_TRANSFORM_DESC_TRANSA;
+  cublasLtMatrixTransformDescAttributes_t BLASLT_MATRIX_TRANSFORM_DESC_TRANSB = CUBLASLT_MATRIX_TRANSFORM_DESC_TRANSB;
+
   // CUDA: cublasStatus_t CUBLASWINAPI cublasLtCreate(cublasLtHandle_t* lightHandle);
   // HIP: HIPBLASLT_EXPORT hipblasStatus_t hipblasLtCreate(hipblasLtHandle_t* handle);
   // CHECK: status = hipblasLtCreate(&blasLtHandle);
@@ -148,6 +159,26 @@ int main() {
   // HIP: HIPBLASLT_EXPORT hipblasStatus_t hipblasLtMatmulDescGetAttribute(hipblasLtMatmulDesc_t matmulDesc, hipblasLtMatmulDescAttributes_t attr, void* buf, size_t sizeInBytes, size_t* sizeWritten);
   // CHECK: status = hipblasLtMatmulDescGetAttribute(blasLtMatmulDesc, blasLtMatmulDescAttributes, buf, workspaceSizeInBytes, &sizeWritten);
   status = cublasLtMatmulDescGetAttribute(blasLtMatmulDesc, blasLtMatmulDescAttributes, buf, workspaceSizeInBytes, &sizeWritten);
+
+  // CUDA: cublasStatus_t CUBLASWINAPI cublasLtMatrixTransformDescCreate(cublasLtMatrixTransformDesc_t* transformDesc, cudaDataType scaleType);
+  // HIP: HIPBLASLT_EXPORT hipblasStatus_t hipblasLtMatrixTransformDescCreate(hipblasLtMatrixTransformDesc_t* transformDesc, hipDataType scaleType);
+  // CHECK: status = hipblasLtMatrixTransformDescCreate(&blasLtMatrixTransformDesc, dataType);
+  status = cublasLtMatrixTransformDescCreate(&blasLtMatrixTransformDesc, dataType);
+
+  // CUDA: cublasStatus_t CUBLASWINAPI cublasLtMatrixTransformDescDestroy(cublasLtMatrixTransformDesc_t transformDesc);
+  // HIP: HIPBLASLT_EXPORT hipblasStatus_t hipblasLtMatrixTransformDescDestroy(hipblasLtMatrixTransformDesc_t transformDesc);
+  // CHECK: status = hipblasLtMatrixTransformDescDestroy(blasLtMatrixTransformDesc);
+  status = cublasLtMatrixTransformDescDestroy(blasLtMatrixTransformDesc);
+
+  // CUDA: cublasStatus_t CUBLASWINAPI cublasLtMatrixTransformDescSetAttribute(cublasLtMatrixTransformDesc_t transformDesc, cublasLtMatrixTransformDescAttributes_t attr, const void* buf, size_t sizeInBytes);
+  // HIP: HIPBLASLT_EXPORT hipblasStatus_t hipblasLtMatrixTransformDescSetAttribute( hipblasLtMatrixTransformDesc_t transformDesc, hipblasLtMatrixTransformDescAttributes_t attr, const void* buf, size_t sizeInBytes);
+  // CHECK: status = hipblasLtMatrixTransformDescSetAttribute(blasLtMatrixTransformDesc, blasLtMatrixTransformDescAttributes, buf, workspaceSizeInBytes);
+  status = cublasLtMatrixTransformDescSetAttribute(blasLtMatrixTransformDesc, blasLtMatrixTransformDescAttributes, buf, workspaceSizeInBytes);
+
+  // CUDA: cublasStatus_t CUBLASWINAPI cublasLtMatrixTransformDescGetAttribute(cublasLtMatrixTransformDesc_t transformDesc, cublasLtMatrixTransformDescAttributes_t attr, void* buf, size_t sizeInBytes, size_t* sizeWritten);
+  // HIP: HIPBLASLT_EXPORT hipblasStatus_t hipblasLtMatrixTransformDescGetAttribute(hipblasLtMatrixTransformDesc_t transformDesc, hipblasLtMatrixTransformDescAttributes_t attr, void* buf, size_t sizeInBytes, size_t* sizeWritten);
+  // CHECK: status = hipblasLtMatrixTransformDescGetAttribute(blasLtMatrixTransformDesc, blasLtMatrixTransformDescAttributes, buf, workspaceSizeInBytes, &sizeWritten);
+  status = cublasLtMatrixTransformDescGetAttribute(blasLtMatrixTransformDesc, blasLtMatrixTransformDescAttributes, buf, workspaceSizeInBytes, &sizeWritten);
 #endif
 
 #if CUBLAS_VERSION >= 10200


### PR DESCRIPTION
+ Updated synthetic tests, the regenerated `hipify-perl`, and `BLAS` `CUDA2HIP` documentation
