### PR TITLE
[HIPIFY][RAND][6.2.0] cuRAND support - Step 1

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -1407,6 +1407,15 @@ my %experimental_funcs = (
     "cusolverDnDestroyParams" => "6.2.0",
     "cusolverDnCreateParams" => "6.2.0",
     "cusolverAlgMode_t" => "6.2.0",
+    "curandStateSobol64_t" => "6.2.0",
+    "curandStateSobol64" => "6.2.0",
+    "curandStateScrambledSobol64_t" => "6.2.0",
+    "curandStateScrambledSobol64" => "6.2.0",
+    "curandStateScrambledSobol32_t" => "6.2.0",
+    "curandStateScrambledSobol32" => "6.2.0",
+    "curandSetGeneratorOrdering" => "6.2.0",
+    "curandOrdering_t" => "6.2.0",
+    "curandOrdering" => "6.2.0",
     "cublasZgbmv_v2_64" => "6.2.0",
     "cublasZgbmv_64" => "6.2.0",
     "cublasSgbmv_v2_64" => "6.2.0",
@@ -1418,6 +1427,12 @@ my %experimental_funcs = (
     "CUSOLVER_ALG_1" => "6.2.0",
     "CUSOLVER_ALG_0" => "6.2.0",
     "CUSOLVERDN_GETRF" => "6.2.0",
+    "CURAND_ORDERING_QUASI_DEFAULT" => "6.2.0",
+    "CURAND_ORDERING_PSEUDO_SEEDED" => "6.2.0",
+    "CURAND_ORDERING_PSEUDO_LEGACY" => "6.2.0",
+    "CURAND_ORDERING_PSEUDO_DYNAMIC" => "6.2.0",
+    "CURAND_ORDERING_PSEUDO_DEFAULT" => "6.2.0",
+    "CURAND_ORDERING_PSEUDO_BEST" => "6.2.0",
     "CUBLASLT_MATMUL_DESC_AMAX_D_POINTER" => "6.2.0"
 );
 
@@ -1564,16 +1579,31 @@ sub experimentalSubstitutions {
     subst("cublasSgbmv_v2_64", "hipblasSgbmv_64", "library");
     subst("cublasZgbmv_64", "hipblasZgbmv_64", "library");
     subst("cublasZgbmv_v2_64", "hipblasZgbmv_64", "library");
+    subst("curandSetGeneratorOrdering", "hiprandSetGeneratorOrdering", "library");
     subst("cusolverDnCreateParams", "hipsolverDnCreateParams", "library");
     subst("cusolverDnDestroyParams", "hipsolverDnDestroyParams", "library");
     subst("cusolverDnSetAdvOptions", "hipsolverDnSetAdvOptions", "library");
     subst("cusolverDnXgetrf", "hipsolverDnXgetrf", "library");
     subst("cusolverDnXgetrf_bufferSize", "hipsolverDnXgetrf_bufferSize", "library");
     subst("cusolverDnXgetrs", "hipsolverDnXgetrs", "library");
+    subst("curandOrdering", "hiprandOrdering", "type");
+    subst("curandOrdering_t", "hiprandOrdering_t", "type");
+    subst("curandStateScrambledSobol32", "hiprandStateScrambledSobol32", "type");
+    subst("curandStateScrambledSobol32_t", "hiprandStateScrambledSobol32_t", "type");
+    subst("curandStateScrambledSobol64", "hiprandStateScrambledSobol64", "type");
+    subst("curandStateScrambledSobol64_t", "hiprandStateScrambledSobol64_t", "type");
+    subst("curandStateSobol64", "hiprandStateSobol64", "type");
+    subst("curandStateSobol64_t", "hiprandStateSobol64_t", "type");
     subst("cusolverAlgMode_t", "hipsolverAlgMode_t", "type");
     subst("cusolverDnFunction_t", "hipsolverDnFunction_t", "type");
     subst("cusolverDnParams_t", "hipsolverDnParams_t", "type");
     subst("CUBLASLT_MATMUL_DESC_AMAX_D_POINTER", "HIPBLASLT_MATMUL_DESC_AMAX_D_POINTER", "numeric_literal");
+    subst("CURAND_ORDERING_PSEUDO_BEST", "HIPRAND_ORDERING_PSEUDO_BEST", "numeric_literal");
+    subst("CURAND_ORDERING_PSEUDO_DEFAULT", "HIPRAND_ORDERING_PSEUDO_DEFAULT", "numeric_literal");
+    subst("CURAND_ORDERING_PSEUDO_DYNAMIC", "HIPRAND_ORDERING_PSEUDO_DYNAMIC", "numeric_literal");
+    subst("CURAND_ORDERING_PSEUDO_LEGACY", "HIPRAND_ORDERING_PSEUDO_LEGACY", "numeric_literal");
+    subst("CURAND_ORDERING_PSEUDO_SEEDED", "HIPRAND_ORDERING_PSEUDO_SEEDED", "numeric_literal");
+    subst("CURAND_ORDERING_QUASI_DEFAULT", "HIPRAND_ORDERING_QUASI_DEFAULT", "numeric_literal");
     subst("CUSOLVERDN_GETRF", "HIPSOLVERDN_GETRF", "numeric_literal");
     subst("CUSOLVER_ALG_0", "HIPSOLVER_ALG_0", "numeric_literal");
     subst("CUSOLVER_ALG_1", "HIPSOLVER_ALG_1", "numeric_literal");
@@ -5700,7 +5730,7 @@ sub simpleSubstitutions {
     subst("curandStateXORWOW", "hiprandStateXORWOW", "type");
     subst("curandStateXORWOW_t", "hiprandStateXORWOW_t", "type");
     subst("curandState_t", "hiprandState_t", "type");
-    subst("curandStatus", "hiprandStatus_t", "type");
+    subst("curandStatus", "hiprandStatus", "type");
     subst("curandStatus_t", "hiprandStatus_t", "type");
     subst("cusolverDnHandle_t", "hipsolverHandle_t", "type");
     subst("cusolverEigMode_t", "hipsolverEigMode_t", "type");
@@ -8590,15 +8620,6 @@ sub warnUnsupportedFunctions {
         "curand_mtgp32_single_specific",
         "curand_mtgp32_single",
         "curand_Philox4x32_10",
-        "curandStateSobol64_t",
-        "curandStateSobol64",
-        "curandStateScrambledSobol64_t",
-        "curandStateScrambledSobol64",
-        "curandStateScrambledSobol32_t",
-        "curandStateScrambledSobol32",
-        "curandSetGeneratorOrdering",
-        "curandOrdering_t",
-        "curandOrdering",
         "curandMethod_t",
         "curandMethod",
         "curandHistogramM2_t",
@@ -10355,12 +10376,6 @@ sub warnUnsupportedFunctions {
         "CUSOLVERDN_POTRF",
         "CURAND_REJECTION",
         "CURAND_POISSON",
-        "CURAND_ORDERING_QUASI_DEFAULT",
-        "CURAND_ORDERING_PSEUDO_SEEDED",
-        "CURAND_ORDERING_PSEUDO_LEGACY",
-        "CURAND_ORDERING_PSEUDO_DYNAMIC",
-        "CURAND_ORDERING_PSEUDO_DEFAULT",
-        "CURAND_ORDERING_PSEUDO_BEST",
         "CURAND_M2",
         "CURAND_M1",
         "CURAND_KNUTH",

--- a/docs/tables/CURAND_API_supported_by_HIP.md
+++ b/docs/tables/CURAND_API_supported_by_HIP.md
@@ -18,12 +18,12 @@
 |`CURAND_KNUTH`| | | | | | | | | | |
 |`CURAND_M1`| | | | | | | | | | |
 |`CURAND_M2`| | | | | | | | | | |
-|`CURAND_ORDERING_PSEUDO_BEST`| | | | | | | | | | |
-|`CURAND_ORDERING_PSEUDO_DEFAULT`| | | | | | | | | | |
-|`CURAND_ORDERING_PSEUDO_DYNAMIC`|11.5| | | | | | | | | |
-|`CURAND_ORDERING_PSEUDO_LEGACY`|11.0| | | | | | | | | |
-|`CURAND_ORDERING_PSEUDO_SEEDED`| | | | | | | | | | |
-|`CURAND_ORDERING_QUASI_DEFAULT`| | | | | | | | | | |
+|`CURAND_ORDERING_PSEUDO_BEST`| | | | |`HIPRAND_ORDERING_PSEUDO_BEST`|6.2.0| | | |6.2.0|
+|`CURAND_ORDERING_PSEUDO_DEFAULT`| | | | |`HIPRAND_ORDERING_PSEUDO_DEFAULT`|6.2.0| | | |6.2.0|
+|`CURAND_ORDERING_PSEUDO_DYNAMIC`|11.5| | | |`HIPRAND_ORDERING_PSEUDO_DYNAMIC`|6.2.0| | | |6.2.0|
+|`CURAND_ORDERING_PSEUDO_LEGACY`|11.0| | | |`HIPRAND_ORDERING_PSEUDO_LEGACY`|6.2.0| | | |6.2.0|
+|`CURAND_ORDERING_PSEUDO_SEEDED`| | | | |`HIPRAND_ORDERING_PSEUDO_SEEDED`|6.2.0| | | |6.2.0|
+|`CURAND_ORDERING_QUASI_DEFAULT`| | | | |`HIPRAND_ORDERING_QUASI_DEFAULT`|6.2.0| | | |6.2.0|
 |`CURAND_POISSON`| | | | | | | | | | |
 |`CURAND_REJECTION`| | | | | | | | | | |
 |`CURAND_RNG_PSEUDO_DEFAULT`| | | | |`HIPRAND_RNG_PSEUDO_DEFAULT`|1.5.0| | | | |
@@ -75,8 +75,8 @@
 |`curandHistogramM2_t`| | | | | | | | | | |
 |`curandMethod`| | | | | | | | | | |
 |`curandMethod_t`| | | | | | | | | | |
-|`curandOrdering`| | | | | | | | | | |
-|`curandOrdering_t`| | | | | | | | | | |
+|`curandOrdering`| | | | |`hiprandOrdering`|6.2.0| | | |6.2.0|
+|`curandOrdering_t`| | | | |`hiprandOrdering_t`|6.2.0| | | |6.2.0|
 |`curandRngType`| | | | |`hiprandRngType_t`|1.5.0| | | | |
 |`curandRngType_t`| | | | |`hiprandRngType_t`|1.5.0| | | | |
 |`curandState`| | | | |`hiprandState`|1.8.0| | | | |
@@ -86,18 +86,18 @@
 |`curandStateMtgp32_t`| | | | |`hiprandStateMtgp32_t`|1.5.0| | | | |
 |`curandStatePhilox4_32_10`| | | | |`hiprandStatePhilox4_32_10`|1.8.0| | | | |
 |`curandStatePhilox4_32_10_t`| | | | |`hiprandStatePhilox4_32_10_t`|1.8.0| | | | |
-|`curandStateScrambledSobol32`| | | | | | | | | | |
-|`curandStateScrambledSobol32_t`| | | | | | | | | | |
-|`curandStateScrambledSobol64`| | | | | | | | | | |
-|`curandStateScrambledSobol64_t`| | | | | | | | | | |
+|`curandStateScrambledSobol32`| | | | |`hiprandStateScrambledSobol32`|6.2.0| | | |6.2.0|
+|`curandStateScrambledSobol32_t`| | | | |`hiprandStateScrambledSobol32_t`|6.2.0| | | |6.2.0|
+|`curandStateScrambledSobol64`| | | | |`hiprandStateScrambledSobol64`|6.2.0| | | |6.2.0|
+|`curandStateScrambledSobol64_t`| | | | |`hiprandStateScrambledSobol64_t`|6.2.0| | | |6.2.0|
 |`curandStateSobol32`| | | | |`hiprandStateSobol32`|1.8.0| | | | |
 |`curandStateSobol32_t`| | | | |`hiprandStateSobol32_t`|1.5.0| | | | |
-|`curandStateSobol64`| | | | | | | | | | |
-|`curandStateSobol64_t`| | | | | | | | | | |
+|`curandStateSobol64`| | | | |`hiprandStateSobol64`|6.2.0| | | |6.2.0|
+|`curandStateSobol64_t`| | | | |`hiprandStateSobol64_t`|6.2.0| | | |6.2.0|
 |`curandStateXORWOW`| | | | |`hiprandStateXORWOW`|1.8.0| | | | |
 |`curandStateXORWOW_t`| | | | |`hiprandStateXORWOW_t`|1.5.0| | | | |
 |`curandState_t`| | | | |`hiprandState_t`|1.5.0| | | | |
-|`curandStatus`| | | | |`hiprandStatus_t`|1.5.0| | | | |
+|`curandStatus`| | | | |`hiprandStatus`|1.5.0| | | | |
 |`curandStatus_t`| | | | |`hiprandStatus_t`|1.5.0| | | | |
 
 ## **2. Host API Functions**
@@ -128,7 +128,7 @@
 |`curandMakeMTGP32Constants`| | | | |`hiprandMakeMTGP32Constants`|1.5.0| | | | |
 |`curandMakeMTGP32KernelState`| | | | |`hiprandMakeMTGP32KernelState`|1.5.0| | | | |
 |`curandSetGeneratorOffset`| | | | |`hiprandSetGeneratorOffset`|1.5.0| | | | |
-|`curandSetGeneratorOrdering`| | | | | | | | | | |
+|`curandSetGeneratorOrdering`| | | | |`hiprandSetGeneratorOrdering`|6.2.0| | | |6.2.0|
 |`curandSetPseudoRandomGeneratorSeed`| | | | |`hiprandSetPseudoRandomGeneratorSeed`|1.5.0| | | | |
 |`curandSetQuasiRandomGeneratorDimensions`| | | | |`hiprandSetQuasiRandomGeneratorDimensions`|1.5.0| | | | |
 |`curandSetStream`| | | | |`hiprandSetStream`|1.5.0| | | | |

--- a/src/CUDA2HIP_RAND_API_functions.cpp
+++ b/src/CUDA2HIP_RAND_API_functions.cpp
@@ -47,7 +47,7 @@ const std::map<llvm::StringRef, hipCounter> CUDA_RAND_FUNCTION_MAP {
   {"curandGetScrambleConstants64",                  {"hiprandGetScrambleConstants64",                  "", CONV_LIB_FUNC, API_RAND, 2}},
   {"curandGetVersion",                              {"hiprandGetVersion",                              "", CONV_LIB_FUNC, API_RAND, 2}},
   {"curandSetGeneratorOffset",                      {"hiprandSetGeneratorOffset",                      "", CONV_LIB_FUNC, API_RAND, 2}},
-  {"curandSetGeneratorOrdering",                    {"hiprandSetGeneratorOrdering",                    "", CONV_LIB_FUNC, API_RAND, 2, HIP_UNSUPPORTED}},
+  {"curandSetGeneratorOrdering",                    {"hiprandSetGeneratorOrdering",                    "", CONV_LIB_FUNC, API_RAND, 2, HIP_EXPERIMENTAL}},
   {"curandSetPseudoRandomGeneratorSeed",            {"hiprandSetPseudoRandomGeneratorSeed",            "", CONV_LIB_FUNC, API_RAND, 2}},
   {"curandSetQuasiRandomGeneratorDimensions",       {"hiprandSetQuasiRandomGeneratorDimensions",       "", CONV_LIB_FUNC, API_RAND, 2}},
   {"curandSetStream",                               {"hiprandSetStream",                               "", CONV_LIB_FUNC, API_RAND, 2}},
@@ -140,6 +140,7 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_RAND_FUNCTION_VER_MAP {
   {"hiprandGetDirectionVectors64",                  {HIP_6000, HIP_0,    HIP_0   }},
   {"hiprandGetScrambleConstants32",                 {HIP_6000, HIP_0,    HIP_0   }},
   {"hiprandGetScrambleConstants64",                 {HIP_6000, HIP_0,    HIP_0   }},
+  {"hiprandSetGeneratorOrdering",                   {HIP_6020, HIP_0,    HIP_0,  HIP_LATEST}},
 };
 
 const std::map<unsigned int, llvm::StringRef> CUDA_RAND_API_SECTION_MAP {

--- a/src/CUDA2HIP_RAND_API_types.cpp
+++ b/src/CUDA2HIP_RAND_API_types.cpp
@@ -25,7 +25,7 @@ THE SOFTWARE.
 // Map of all functions
 const std::map<llvm::StringRef, hipCounter> CUDA_RAND_TYPE_NAME_MAP {
   // RAND Host types
-  {"curandStatus",                                  {"hiprandStatus_t",                                "", CONV_TYPE, API_RAND, 1}},
+  {"curandStatus",                                  {"hiprandStatus",                                  "", CONV_TYPE, API_RAND, 1}},
   {"curandStatus_t",                                {"hiprandStatus_t",                                "", CONV_TYPE, API_RAND, 1}},
   {"curandRngType",                                 {"hiprandRngType_t",                               "", CONV_TYPE, API_RAND, 1}},
   {"curandRngType_t",                               {"hiprandRngType_t",                               "", CONV_TYPE, API_RAND, 1}},
@@ -33,8 +33,8 @@ const std::map<llvm::StringRef, hipCounter> CUDA_RAND_TYPE_NAME_MAP {
   {"curandGenerator_t",                             {"hiprandGenerator_t",                             "", CONV_TYPE, API_RAND, 1}},
   {"curandDirectionVectorSet",                      {"hiprandDirectionVectorSet_t",                    "", CONV_TYPE, API_RAND, 1}},
   {"curandDirectionVectorSet_t",                    {"hiprandDirectionVectorSet_t",                    "", CONV_TYPE, API_RAND, 1}},
-  {"curandOrdering",                                {"hiprandOrdering_t",                              "", CONV_TYPE, API_RAND, 1, HIP_UNSUPPORTED}},
-  {"curandOrdering_t",                              {"hiprandOrdering_t",                              "", CONV_TYPE, API_RAND, 1, HIP_UNSUPPORTED}},
+  {"curandOrdering",                                {"hiprandOrdering",                                "", CONV_TYPE, API_RAND, 1, HIP_EXPERIMENTAL}},
+  {"curandOrdering_t",                              {"hiprandOrdering_t",                              "", CONV_TYPE, API_RAND, 1, HIP_EXPERIMENTAL}},
   {"curandDistribution_st",                         {"hiprandDistribution_st",                         "", CONV_TYPE, API_RAND, 1, HIP_UNSUPPORTED}},
   {"curandHistogramM2V_st",                         {"hiprandHistogramM2V_st",                         "", CONV_TYPE, API_RAND, 1, HIP_UNSUPPORTED}},
   {"curandDistribution_t",                          {"hiprandDistribution_t",                          "", CONV_TYPE, API_RAND, 1, HIP_UNSUPPORTED}},
@@ -57,12 +57,12 @@ const std::map<llvm::StringRef, hipCounter> CUDA_RAND_TYPE_NAME_MAP {
   // RAND types for Device functions
   {"curandStateMtgp32",                             {"hiprandStateMtgp32",                             "", CONV_TYPE, API_RAND, 1}},
   {"curandStateMtgp32_t",                           {"hiprandStateMtgp32_t",                           "", CONV_TYPE, API_RAND, 1}},
-  {"curandStateScrambledSobol64",                   {"hiprandStateScrambledSobol64",                   "", CONV_TYPE, API_RAND, 1, HIP_UNSUPPORTED}},
-  {"curandStateScrambledSobol64_t",                 {"hiprandStateScrambledSobol64_t",                 "", CONV_TYPE, API_RAND, 1, HIP_UNSUPPORTED}},
-  {"curandStateSobol64",                            {"hiprandStateSobol64",                            "", CONV_TYPE, API_RAND, 1, HIP_UNSUPPORTED}},
-  {"curandStateSobol64_t",                          {"hiprandStateSobol64_t",                          "", CONV_TYPE, API_RAND, 1, HIP_UNSUPPORTED}},
-  {"curandStateScrambledSobol32",                   {"hiprandStateScrambledSobol32",                   "", CONV_TYPE, API_RAND, 1, HIP_UNSUPPORTED}},
-  {"curandStateScrambledSobol32_t",                 {"hiprandStateScrambledSobol32_t",                 "", CONV_TYPE, API_RAND, 1, HIP_UNSUPPORTED}},
+  {"curandStateScrambledSobol64",                   {"hiprandStateScrambledSobol64",                   "", CONV_TYPE, API_RAND, 1, HIP_EXPERIMENTAL}},
+  {"curandStateScrambledSobol64_t",                 {"hiprandStateScrambledSobol64_t",                 "", CONV_TYPE, API_RAND, 1, HIP_EXPERIMENTAL}},
+  {"curandStateSobol64",                            {"hiprandStateSobol64",                            "", CONV_TYPE, API_RAND, 1, HIP_EXPERIMENTAL}},
+  {"curandStateSobol64_t",                          {"hiprandStateSobol64_t",                          "", CONV_TYPE, API_RAND, 1, HIP_EXPERIMENTAL}},
+  {"curandStateScrambledSobol32",                   {"hiprandStateScrambledSobol32",                   "", CONV_TYPE, API_RAND, 1, HIP_EXPERIMENTAL}},
+  {"curandStateScrambledSobol32_t",                 {"hiprandStateScrambledSobol32_t",                 "", CONV_TYPE, API_RAND, 1, HIP_EXPERIMENTAL}},
   {"curandStateSobol32",                            {"hiprandStateSobol32",                            "", CONV_TYPE, API_RAND, 1}},
   {"curandStateSobol32_t",                          {"hiprandStateSobol32_t",                          "", CONV_TYPE, API_RAND, 1}},
   {"curandStateMRG32k3a",                           {"hiprandStateMRG32k3a",                           "", CONV_TYPE, API_RAND, 1}},
@@ -104,12 +104,12 @@ const std::map<llvm::StringRef, hipCounter> CUDA_RAND_TYPE_NAME_MAP {
   {"CURAND_RNG_QUASI_SCRAMBLED_SOBOL64",            {"HIPRAND_RNG_QUASI_SCRAMBLED_SOBOL64",            "", CONV_NUMERIC_LITERAL, API_RAND, 1}},
 
   // RAND ordering of results in memory (enum curandOrdering)
-  {"CURAND_ORDERING_PSEUDO_BEST",                   {"HIPRAND_ORDERING_PSEUDO_BEST",                   "", CONV_NUMERIC_LITERAL, API_RAND, 1, HIP_UNSUPPORTED}},
-  {"CURAND_ORDERING_PSEUDO_DEFAULT",                {"HIPRAND_ORDERING_PSEUDO_DEFAULT",                "", CONV_NUMERIC_LITERAL, API_RAND, 1, HIP_UNSUPPORTED}},
-  {"CURAND_ORDERING_PSEUDO_SEEDED",                 {"HIPRAND_ORDERING_PSEUDO_SEEDED",                 "", CONV_NUMERIC_LITERAL, API_RAND, 1, HIP_UNSUPPORTED}},
-  {"CURAND_ORDERING_PSEUDO_LEGACY",                 {"HIPRAND_ORDERING_PSEUDO_LEGACY",                 "", CONV_NUMERIC_LITERAL, API_RAND, 1, HIP_UNSUPPORTED}},
-  {"CURAND_ORDERING_PSEUDO_DYNAMIC",                {"HIPRAND_ORDERING_PSEUDO_DYNAMIC",                "", CONV_NUMERIC_LITERAL, API_RAND, 1, HIP_UNSUPPORTED}},
-  {"CURAND_ORDERING_QUASI_DEFAULT",                 {"HIPRAND_ORDERING_QUASI_DEFAULT",                 "", CONV_NUMERIC_LITERAL, API_RAND, 1, HIP_UNSUPPORTED}},
+  {"CURAND_ORDERING_PSEUDO_BEST",                   {"HIPRAND_ORDERING_PSEUDO_BEST",                   "", CONV_NUMERIC_LITERAL, API_RAND, 1, HIP_EXPERIMENTAL}},
+  {"CURAND_ORDERING_PSEUDO_DEFAULT",                {"HIPRAND_ORDERING_PSEUDO_DEFAULT",                "", CONV_NUMERIC_LITERAL, API_RAND, 1, HIP_EXPERIMENTAL}},
+  {"CURAND_ORDERING_PSEUDO_SEEDED",                 {"HIPRAND_ORDERING_PSEUDO_SEEDED",                 "", CONV_NUMERIC_LITERAL, API_RAND, 1, HIP_EXPERIMENTAL}},
+  {"CURAND_ORDERING_PSEUDO_LEGACY",                 {"HIPRAND_ORDERING_PSEUDO_LEGACY",                 "", CONV_NUMERIC_LITERAL, API_RAND, 1, HIP_EXPERIMENTAL}},
+  {"CURAND_ORDERING_PSEUDO_DYNAMIC",                {"HIPRAND_ORDERING_PSEUDO_DYNAMIC",                "", CONV_NUMERIC_LITERAL, API_RAND, 1, HIP_EXPERIMENTAL}},
+  {"CURAND_ORDERING_QUASI_DEFAULT",                 {"HIPRAND_ORDERING_QUASI_DEFAULT",                 "", CONV_NUMERIC_LITERAL, API_RAND, 1, HIP_EXPERIMENTAL}},
 
   // RAND choice of direction vector set (enum curandDirectionVectorSet)
   {"CURAND_DIRECTION_VECTORS_32_JOEKUO6",           {"HIPRAND_DIRECTION_VECTORS_32_JOEKUO6",           "", CONV_NUMERIC_LITERAL, API_RAND, 1}},
@@ -135,11 +135,12 @@ const std::map<llvm::StringRef, hipCounter> CUDA_RAND_TYPE_NAME_MAP {
 };
 
 const std::map<llvm::StringRef, cudaAPIversions> CUDA_RAND_TYPE_NAME_VER_MAP {
-  {"CURAND_ORDERING_PSEUDO_LEGACY",                 {CUDA_110, CUDA_0,   CUDA_0  }},
-  {"CURAND_ORDERING_PSEUDO_DYNAMIC",                {CUDA_115, CUDA_0,   CUDA_0  }},
+  {"CURAND_ORDERING_PSEUDO_LEGACY",                 {CUDA_110, CUDA_0,   CUDA_0  }}, // A: CUDA_VERSION 11001, CURAND_VERSION 10200, CURAND_VER_MAJOR 10 CURAND_VER_MINOR 2 CURAND_VER_PATCH 0
+  {"CURAND_ORDERING_PSEUDO_DYNAMIC",                {CUDA_115, CUDA_0,   CUDA_0  }}, // A: CUDA_VERSION 11052, CURAND_VERSION 10207, CURAND_VER_MAJOR 10 CURAND_VER_MINOR 2 CURAND_VER_PATCH 7
 };
 
 const std::map<llvm::StringRef, hipAPIversions> HIP_RAND_TYPE_NAME_VER_MAP {
+  {"hiprandStatus",                                 {HIP_1050, HIP_0,    HIP_0   }},
   {"hiprandStatus_t",                               {HIP_1050, HIP_0,    HIP_0   }},
   {"hiprandRngType_t",                              {HIP_1050, HIP_0,    HIP_0   }},
   {"hiprandGenerator_st",                           {HIP_1050, HIP_0,    HIP_0   }},
@@ -189,4 +190,18 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_RAND_TYPE_NAME_VER_MAP {
   {"HIPRAND_SCRAMBLED_DIRECTION_VECTORS_32_JOEKUO6",{HIP_6000, HIP_0,    HIP_0   }},
   {"HIPRAND_DIRECTION_VECTORS_64_JOEKUO6",          {HIP_6000, HIP_0,    HIP_0   }},
   {"HIPRAND_SCRAMBLED_DIRECTION_VECTORS_64_JOEKUO6",{HIP_6000, HIP_0,    HIP_0   }},
+  {"hiprandOrdering",                               {HIP_6020, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hiprandOrdering_t",                             {HIP_6020, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"HIPRAND_ORDERING_PSEUDO_BEST",                  {HIP_6020, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"HIPRAND_ORDERING_PSEUDO_DEFAULT",               {HIP_6020, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"HIPRAND_ORDERING_PSEUDO_SEEDED",                {HIP_6020, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"HIPRAND_ORDERING_PSEUDO_LEGACY",                {HIP_6020, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"HIPRAND_ORDERING_PSEUDO_DYNAMIC",               {HIP_6020, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"HIPRAND_ORDERING_QUASI_DEFAULT",                {HIP_6020, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hiprandStateScrambledSobol32",                  {HIP_6020, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hiprandStateScrambledSobol32_t",                {HIP_6020, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hiprandStateScrambledSobol64",                  {HIP_6020, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hiprandStateScrambledSobol64_t",                {HIP_6020, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hiprandStateSobol64",                           {HIP_6020, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hiprandStateSobol64_t",                         {HIP_6020, HIP_0,    HIP_0,  HIP_LATEST}},
 };

--- a/tests/unit_tests/synthetic/libraries/curand2hiprand.cu
+++ b/tests/unit_tests/synthetic/libraries/curand2hiprand.cu
@@ -1,0 +1,75 @@
+// RUN: %run_test hipify "%s" "%t" %hipify_args 3 --amap --skip-excluded-preprocessor-conditional-blocks --experimental %clang_args -D__CUDA_API_VERSION_INTERNAL -ferror-limit=500
+
+// CHECK: #include <hip/hip_runtime.h>
+#include <cuda_runtime.h>
+#include <stdio.h>
+// CHECK: #include "hiprand/hiprand.h"
+// CHECK-NEXT: #include "hiprand/hiprand_kernel.h"
+#include "curand.h"
+#include "curand_kernel.h"
+// CHECK-NOT: #include "hiprand/hiprand.h"
+// CHECK-NOT: #include "hiprand/hiprand_kernel.h"
+
+#if defined(_WIN32) && CUDA_VERSION < 9000
+  typedef signed   __int64 int64_t;
+  typedef unsigned __int64 uint64_t;
+#endif
+
+int main() {
+  printf("21. cuRAND API to hipRAND API synthetic test\n");
+
+  // CHECK: hiprandOrdering randOrdering;
+  // CHECK-NEXT: hiprandOrdering_t randOrdering_t;
+  // CHECK-NEXT: hiprandOrdering_t RAND_ORDERING_PSEUDO_BEST = HIPRAND_ORDERING_PSEUDO_BEST;
+  // CHECK-NEXT: hiprandOrdering_t RAND_ORDERING_PSEUDO_DEFAULT = HIPRAND_ORDERING_PSEUDO_DEFAULT;
+  // CHECK-NEXT: hiprandOrdering_t RAND_ORDERING_PSEUDO_SEEDED = HIPRAND_ORDERING_PSEUDO_SEEDED;
+  // CHECK-NEXT: hiprandOrdering_t RAND_ORDERING_QUASI_DEFAULT = HIPRAND_ORDERING_QUASI_DEFAULT;
+  curandOrdering randOrdering;
+  curandOrdering_t randOrdering_t;
+  curandOrdering_t RAND_ORDERING_PSEUDO_BEST = CURAND_ORDERING_PSEUDO_BEST;
+  curandOrdering_t RAND_ORDERING_PSEUDO_DEFAULT = CURAND_ORDERING_PSEUDO_DEFAULT;
+  curandOrdering_t RAND_ORDERING_PSEUDO_SEEDED = CURAND_ORDERING_PSEUDO_SEEDED;
+  curandOrdering_t RAND_ORDERING_QUASI_DEFAULT = CURAND_ORDERING_QUASI_DEFAULT;
+
+  // CHECK: hiprandStatus randStatus;
+  // CHECK-NEXT: hiprandStatus_t status;
+  curandStatus randStatus;
+  curandStatus_t status;
+
+  // CHECK: hiprandGenerator_st *randGenerator_st = nullptr;
+  // CHECK-NEXT: hiprandGenerator_t randGenerator;
+  curandGenerator_st *randGenerator_st = nullptr;
+  curandGenerator_t randGenerator;
+
+  // CHECK: hiprandStateSobol64 randStateSobol64;
+  // CHECK-NEXT: hiprandStateSobol64_t randStateSobol64_t;
+  curandStateSobol64 randStateSobol64;
+  curandStateSobol64_t randStateSobol64_t;
+
+  // CHECK: hiprandStateScrambledSobol64 randStateScrambledSobol64;
+  // CHECK-NEXT: hiprandStateScrambledSobol64_t randStateScrambledSobol64_t;
+  curandStateScrambledSobol64 randStateScrambledSobol64;
+  curandStateScrambledSobol64_t randStateScrambledSobol64_t;
+
+  // CHECK: hiprandStateScrambledSobol32 randStateScrambledSobol32;
+  // CHECK-NEXT: hiprandStateScrambledSobol32_t randStateScrambledSobol32_t;
+  curandStateScrambledSobol32 randStateScrambledSobol32;
+  curandStateScrambledSobol32_t randStateScrambledSobol32_t;
+
+  // CUDA: curandStatus_t CURANDAPI curandSetGeneratorOrdering(curandGenerator_t generator, curandOrdering_t order);
+  // HIP: hiprandStatus_t HIPRANDAPI hiprandSetGeneratorOrdering(hiprandGenerator_t generator, hiprandOrdering_t order);
+  // CHECK: status = hiprandSetGeneratorOrdering(randGenerator, randOrdering_t);
+  status = curandSetGeneratorOrdering(randGenerator, randOrdering_t);
+
+#if CUDA_VERSION >= 11000 && CURAND_VERSION >= 10200
+  // CHECK: hiprandOrdering_t RAND_ORDERING_PSEUDO_LEGACY = HIPRAND_ORDERING_PSEUDO_LEGACY;
+  curandOrdering_t RAND_ORDERING_PSEUDO_LEGACY = CURAND_ORDERING_PSEUDO_LEGACY;
+#endif
+
+#if CUDA_VERSION >= 11050 && CURAND_VERSION >= 10207
+  // CHECK: hiprandOrdering_t RAND_ORDERING_PSEUDO_DYNAMIC = HIPRAND_ORDERING_PSEUDO_DYNAMIC;
+  curandOrdering_t RAND_ORDERING_PSEUDO_DYNAMIC = CURAND_ORDERING_PSEUDO_DYNAMIC;
+#endif
+
+  return 0;
+}


### PR DESCRIPTION
+ Updated the regenerated `hipify-perl`, and `BLAS` `CUDA2HIP` documentation
+ Added `RAND` synthetic tests

[ToDo] Cover the rest of `RAND` APIs and data types with synthetic tests