### PR TITLE
[HIPIFY][tests][#1534][CUB][clang][fix] Restore building and testing of CUB - Step 1

### DIFF
--- a/tests/lit.cfg
+++ b/tests/lit.cfg
@@ -155,6 +155,9 @@ if config.llvm_version_major < 10:
     config.excludes.append('pp_if_else_conditionals_LLVM_10.cu')
     config.excludes.append('pp_if_else_conditionals_01_LLVM_10.cu')
 
+if config.llvm_version_major > 18:
+    clang_arguments += " -Wno-missing-template-arg-list-after-template-kw"
+
 # name: The name of this test suite.
 config.name = 'hipify'
 


### PR DESCRIPTION
+ Step 1 - Fix for compilation errors related to the expected template argument list
+ [ToDo] To learn how to set additional clang options not for all tests but for particular ones
