### PR TITLE
[HIPIFY][tests][#1534][CUB][clang][fix] Restore building and testing of CUB - Step 3

### DIFF
--- a/tests/lit.cfg
+++ b/tests/lit.cfg
@@ -139,11 +139,9 @@ if config.cuda_version_major >= 12:
     config.excludes.append('cuSPARSE_11.cu')
     config.excludes.append('cublas_0_based_indexing.cu')
     config.excludes.append('cublas_0_based_indexing_rocblas.cu')
-    config.excludes.append('cub_01.cu')
-    config.excludes.append('cub_02.cu')
-    config.excludes.append('cub_03.cu')
     config.excludes.append('cusparse2rocsparse_9020_12000.cu')
     config.excludes.append('cusparse2rocsparse_before_12000.cu')
+    clang_arguments += " -D_LIBCUDACXX_OBJECT_FORMAT_COFF"
 
 if config.cudnn_version_major >= 9:
     config.excludes.append('cudnn2miopen_before_9000.cu')


### PR DESCRIPTION
+ Step 3 - Fix for compilation errors related to the requested alignment, which must be 8192 bytes or smaller
+ Finally, enabled CUB tests for `CUDA > 12.0`
+ [ToDo] To learn how to set additional clang options not for all tests but for particular ones
