### PR TITLE
[HIPIFY][BLAS][6.2.0] cuBLAS support - Step 3 - 64-bit functions

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -1446,18 +1446,22 @@ my %experimental_funcs = (
     "cudaDriverEntryPointQueryResult" => "6.2.0",
     "cublasZgemv_v2_64" => "6.2.0",
     "cublasZgemv_64" => "6.2.0",
+    "cublasZgemvBatched_64" => "6.2.0",
     "cublasZgbmv_v2_64" => "6.2.0",
     "cublasZgbmv_64" => "6.2.0",
     "cublasSgemv_v2_64" => "6.2.0",
     "cublasSgemv_64" => "6.2.0",
+    "cublasSgemvBatched_64" => "6.2.0",
     "cublasSgbmv_v2_64" => "6.2.0",
     "cublasSgbmv_64" => "6.2.0",
     "cublasDgemv_v2_64" => "6.2.0",
     "cublasDgemv_64" => "6.2.0",
+    "cublasDgemvBatched_64" => "6.2.0",
     "cublasDgbmv_v2_64" => "6.2.0",
     "cublasDgbmv_64" => "6.2.0",
     "cublasCgemv_v2_64" => "6.2.0",
     "cublasCgemv_64" => "6.2.0",
+    "cublasCgemvBatched_64" => "6.2.0",
     "cublasCgbmv_v2_64" => "6.2.0",
     "cublasCgbmv_64" => "6.2.0",
     "cuStreamBeginCaptureToGraph" => "6.2.0",
@@ -1662,18 +1666,22 @@ sub experimentalSubstitutions {
     subst("cudaGetFuncBySymbol", "hipGetFuncBySymbol", "driver_interact");
     subst("cublasCgbmv_64", "hipblasCgbmv_64", "library");
     subst("cublasCgbmv_v2_64", "hipblasCgbmv_v2_64", "library");
+    subst("cublasCgemvBatched_64", "hipblasCgemvBatched_v2_64", "library");
     subst("cublasCgemv_64", "hipblasCgemv_64", "library");
     subst("cublasCgemv_v2_64", "hipblasCgemv_v2_64", "library");
     subst("cublasDgbmv_64", "hipblasDgbmv_64", "library");
     subst("cublasDgbmv_v2_64", "hipblasDgbmv_64", "library");
+    subst("cublasDgemvBatched_64", "hipblasDgemvBatched_64", "library");
     subst("cublasDgemv_64", "hipblasDgemv_64", "library");
     subst("cublasDgemv_v2_64", "hipblasDgemv_64", "library");
     subst("cublasSgbmv_64", "hipblasSgbmv_64", "library");
     subst("cublasSgbmv_v2_64", "hipblasSgbmv_64", "library");
+    subst("cublasSgemvBatched_64", "hipblasSgemvBatched_64", "library");
     subst("cublasSgemv_64", "hipblasSgemv_64", "library");
     subst("cublasSgemv_v2_64", "hipblasSgemv_64", "library");
     subst("cublasZgbmv_64", "hipblasZgbmv_64", "library");
     subst("cublasZgbmv_v2_64", "hipblasZgbmv_v2_64", "library");
+    subst("cublasZgemvBatched_64", "hipblasZgemvBatched_v2_64", "library");
     subst("cublasZgemv_64", "hipblasZgemv_64", "library");
     subst("cublasZgemv_v2_64", "hipblasZgemv_v2_64", "library");
     subst("curandSetGeneratorOrdering", "hiprandSetGeneratorOrdering", "library");
@@ -11362,7 +11370,6 @@ sub warnHipOnlyUnsupportedFunctions {
         "cublasZgerc_v2_64",
         "cublasZgerc_64",
         "cublasZgemvStridedBatched_64",
-        "cublasZgemvBatched_64",
         "cublasZgemm_v2_64",
         "cublasZgemm_64",
         "cublasZgemmStridedBatched_64",
@@ -11429,7 +11436,6 @@ sub warnHipOnlyUnsupportedFunctions {
         "cublasSger_64",
         "cublasSgemvStridedBatched_64",
         "cublasSgemvStridedBatched",
-        "cublasSgemvBatched_64",
         "cublasSgemvBatched",
         "cublasSgemm_v2_64",
         "cublasSgemm_64",
@@ -11574,7 +11580,6 @@ sub warnHipOnlyUnsupportedFunctions {
         "cublasDger_64",
         "cublasDgemvStridedBatched_64",
         "cublasDgemvStridedBatched",
-        "cublasDgemvBatched_64",
         "cublasDgemvBatched",
         "cublasDgemm_v2_64",
         "cublasDgemm_64",
@@ -11654,7 +11659,6 @@ sub warnHipOnlyUnsupportedFunctions {
         "cublasCgerc_v2_64",
         "cublasCgerc_64",
         "cublasCgemvStridedBatched_64",
-        "cublasCgemvBatched_64",
         "cublasCgemm_v2_64",
         "cublasCgemm_64",
         "cublasCgemmStridedBatched_64",

--- a/docs/tables/CUBLAS_API_supported_by_HIP.md
+++ b/docs/tables/CUBLAS_API_supported_by_HIP.md
@@ -1032,7 +1032,7 @@
 |`cublasCgemm_v2`| | | | |`hipblasCgemm_v2`|6.0.0| | | | |
 |`cublasCgemm_v2_64`|12.0| | | | | | | | | |
 |`cublasCgemvBatched`|11.6| | | |`hipblasCgemvBatched_v2`|6.0.0| | | | |
-|`cublasCgemvBatched_64`|12.0| | | | | | | | | |
+|`cublasCgemvBatched_64`|12.0| | | |`hipblasCgemvBatched_v2_64`|6.2.0| | | |6.2.0|
 |`cublasCgemvStridedBatched`|11.6| | | |`hipblasCgemvStridedBatched_v2`|6.0.0| | | | |
 |`cublasCgemvStridedBatched_64`|12.0| | | | | | | | | |
 |`cublasChemm`| | | | |`hipblasChemm_v2`|6.0.0| | | | |
@@ -1082,7 +1082,7 @@
 |`cublasDgemm_v2`| | | | |`hipblasDgemm`|1.8.2| | | | |
 |`cublasDgemm_v2_64`|12.0| | | | | | | | | |
 |`cublasDgemvBatched`|11.6| | | | | | | | | |
-|`cublasDgemvBatched_64`|12.0| | | | | | | | | |
+|`cublasDgemvBatched_64`|12.0| | | |`hipblasDgemvBatched_64`|6.2.0| | | |6.2.0|
 |`cublasDgemvStridedBatched`|11.6| | | | | | | | | |
 |`cublasDgemvStridedBatched_64`|12.0| | | | | | | | | |
 |`cublasDsymm`| | | | |`hipblasDsymm`|3.6.0| | | | |
@@ -1132,7 +1132,7 @@
 |`cublasSgemm_v2`| | | | |`hipblasSgemm`|1.8.2| | | | |
 |`cublasSgemm_v2_64`|12.0| | | | | | | | | |
 |`cublasSgemvBatched`|11.6| | | | | | | | | |
-|`cublasSgemvBatched_64`|12.0| | | | | | | | | |
+|`cublasSgemvBatched_64`|12.0| | | |`hipblasSgemvBatched_64`|6.2.0| | | |6.2.0|
 |`cublasSgemvStridedBatched`|11.6| | | | | | | | | |
 |`cublasSgemvStridedBatched_64`|12.0| | | | | | | | | |
 |`cublasSsymm`| | | | |`hipblasSsymm`|3.6.0| | | | |
@@ -1176,7 +1176,7 @@
 |`cublasZgemm_v2`| | | | |`hipblasZgemm_v2`|6.0.0| | | | |
 |`cublasZgemm_v2_64`|12.0| | | | | | | | | |
 |`cublasZgemvBatched`|11.6| | | |`hipblasZgemvBatched_v2`|6.0.0| | | | |
-|`cublasZgemvBatched_64`|12.0| | | | | | | | | |
+|`cublasZgemvBatched_64`|12.0| | | |`hipblasZgemvBatched_v2_64`|6.2.0| | | |6.2.0|
 |`cublasZgemvStridedBatched`|11.6| | | |`hipblasZgemvStridedBatched_v2`|6.0.0| | | | |
 |`cublasZgemvStridedBatched_64`|12.0| | | | | | | | | |
 |`cublasZhemm`| | | | |`hipblasZhemm_v2`|6.0.0| | | | |

--- a/docs/tables/CUBLAS_API_supported_by_HIP_and_ROC.md
+++ b/docs/tables/CUBLAS_API_supported_by_HIP_and_ROC.md
@@ -1032,7 +1032,7 @@
 |`cublasCgemm_v2`| | | | |`hipblasCgemm_v2`|6.0.0| | | | |`rocblas_cgemm`|1.5.0| | | | |
 |`cublasCgemm_v2_64`|12.0| | | | | | | | | | | | | | | |
 |`cublasCgemvBatched`|11.6| | | |`hipblasCgemvBatched_v2`|6.0.0| | | | |`rocblas_cgemv_batched`|3.5.0| | | | |
-|`cublasCgemvBatched_64`|12.0| | | | | | | | | | | | | | | |
+|`cublasCgemvBatched_64`|12.0| | | |`hipblasCgemvBatched_v2_64`|6.2.0| | | |6.2.0| | | | | | |
 |`cublasCgemvStridedBatched`|11.6| | | |`hipblasCgemvStridedBatched_v2`|6.0.0| | | | |`rocblas_cgemv_strided_batched`|3.5.0| | | | |
 |`cublasCgemvStridedBatched_64`|12.0| | | | | | | | | | | | | | | |
 |`cublasChemm`| | | | |`hipblasChemm_v2`|6.0.0| | | | |`rocblas_chemm`|3.5.0| | | | |
@@ -1082,7 +1082,7 @@
 |`cublasDgemm_v2`| | | | |`hipblasDgemm`|1.8.2| | | | |`rocblas_dgemm`|1.5.0| | | | |
 |`cublasDgemm_v2_64`|12.0| | | | | | | | | | | | | | | |
 |`cublasDgemvBatched`|11.6| | | | | | | | | | | | | | | |
-|`cublasDgemvBatched_64`|12.0| | | | | | | | | | | | | | | |
+|`cublasDgemvBatched_64`|12.0| | | |`hipblasDgemvBatched_64`|6.2.0| | | |6.2.0| | | | | | |
 |`cublasDgemvStridedBatched`|11.6| | | | | | | | | | | | | | | |
 |`cublasDgemvStridedBatched_64`|12.0| | | | | | | | | | | | | | | |
 |`cublasDsymm`| | | | |`hipblasDsymm`|3.6.0| | | | |`rocblas_dsymm`|3.5.0| | | | |
@@ -1132,7 +1132,7 @@
 |`cublasSgemm_v2`| | | | |`hipblasSgemm`|1.8.2| | | | |`rocblas_sgemm`|1.5.0| | | | |
 |`cublasSgemm_v2_64`|12.0| | | | | | | | | | | | | | | |
 |`cublasSgemvBatched`|11.6| | | | | | | | | | | | | | | |
-|`cublasSgemvBatched_64`|12.0| | | | | | | | | | | | | | | |
+|`cublasSgemvBatched_64`|12.0| | | |`hipblasSgemvBatched_64`|6.2.0| | | |6.2.0| | | | | | |
 |`cublasSgemvStridedBatched`|11.6| | | | | | | | | | | | | | | |
 |`cublasSgemvStridedBatched_64`|12.0| | | | | | | | | | | | | | | |
 |`cublasSsymm`| | | | |`hipblasSsymm`|3.6.0| | | | |`rocblas_ssymm`|3.5.0| | | | |
@@ -1176,7 +1176,7 @@
 |`cublasZgemm_v2`| | | | |`hipblasZgemm_v2`|6.0.0| | | | |`rocblas_zgemm`|1.5.0| | | | |
 |`cublasZgemm_v2_64`|12.0| | | | | | | | | | | | | | | |
 |`cublasZgemvBatched`|11.6| | | |`hipblasZgemvBatched_v2`|6.0.0| | | | |`rocblas_zgemv_batched`|3.5.0| | | | |
-|`cublasZgemvBatched_64`|12.0| | | | | | | | | | | | | | | |
+|`cublasZgemvBatched_64`|12.0| | | |`hipblasZgemvBatched_v2_64`|6.2.0| | | |6.2.0| | | | | | |
 |`cublasZgemvStridedBatched`|11.6| | | |`hipblasZgemvStridedBatched_v2`|6.0.0| | | | |`rocblas_zgemv_strided_batched`|3.5.0| | | | |
 |`cublasZgemvStridedBatched_64`|12.0| | | | | | | | | | | | | | | |
 |`cublasZhemm`| | | | |`hipblasZhemm_v2`|6.0.0| | | | |`rocblas_zhemm`|3.5.0| | | | |

--- a/src/CUDA2HIP_BLAS_API_functions.cpp
+++ b/src/CUDA2HIP_BLAS_API_functions.cpp
@@ -441,13 +441,13 @@ const std::map<llvm::StringRef, hipCounter> CUDA_BLAS_FUNCTION_MAP {
 
   // BATCH GEMV
   {"cublasSgemvBatched",                                   {"hipblasSgemvBatched",                                       "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3, UNSUPPORTED}},
-  {"cublasSgemvBatched_64",                                {"hipblasSgemvBatched_64",                                    "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3, UNSUPPORTED}},
+  {"cublasSgemvBatched_64",                                {"hipblasSgemvBatched_64",                                    "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
   {"cublasDgemvBatched",                                   {"hipblasDgemvBatched",                                       "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3, UNSUPPORTED}},
-  {"cublasDgemvBatched_64",                                {"hipblasDgemvBatched_64",                                    "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3, UNSUPPORTED}},
+  {"cublasDgemvBatched_64",                                {"hipblasDgemvBatched_64",                                    "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
   {"cublasCgemvBatched",                                   {"hipblasCgemvBatched_v2",                                    "rocblas_cgemv_batched",                              CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3}},
-  {"cublasCgemvBatched_64",                                {"hipblasCgemvBatched_64",                                    "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3, UNSUPPORTED}},
+  {"cublasCgemvBatched_64",                                {"hipblasCgemvBatched_v2_64",                                 "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
   {"cublasZgemvBatched",                                   {"hipblasZgemvBatched_v2",                                    "rocblas_zgemv_batched",                              CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3}},
-  {"cublasZgemvBatched_64",                                {"hipblasZgemvBatched_64",                                    "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3, UNSUPPORTED}},
+  {"cublasZgemvBatched_64",                                {"hipblasZgemvBatched_v2_64",                                 "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
   {"cublasHSHgemvBatched",                                 {"hipblasHSHgemvBatched",                                     "rocblas_hshgemv_batched",                            CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3, HIP_UNSUPPORTED}},
   {"cublasHSHgemvBatched_64",                              {"hipblasHSHgemvBatched_64",                                  "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3, UNSUPPORTED}},
   {"cublasHSSgemvBatched",                                 {"hipblasHSSgemvBatched",                                     "rocblas_hssgemv_batched",                            CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3, HIP_UNSUPPORTED}},
@@ -2058,6 +2058,10 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_BLAS_FUNCTION_VER_MAP {
   {"hipblasCgemv_v2_64",                                   {HIP_6020, HIP_0,    HIP_0,  HIP_LATEST}},
   {"hipblasZgemv_64",                                      {HIP_6020, HIP_0,    HIP_0,  HIP_LATEST}},
   {"hipblasZgemv_v2_64",                                   {HIP_6020, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipblasSgemvBatched_64",                               {HIP_6020, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipblasDgemvBatched_64",                               {HIP_6020, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipblasCgemvBatched_v2_64",                            {HIP_6020, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipblasZgemvBatched_v2_64",                            {HIP_6020, HIP_0,    HIP_0,  HIP_LATEST}},
 
   {"rocblas_status_to_string",                             {HIP_3050, HIP_0,    HIP_0   }},
   {"rocblas_sscal",                                        {HIP_1050, HIP_0,    HIP_0   }},

--- a/tests/unit_tests/synthetic/libraries/cublas2hipblas_v2.cu
+++ b/tests/unit_tests/synthetic/libraries/cublas2hipblas_v2.cu
@@ -167,6 +167,7 @@ int main() {
   int ku = 0;
   int64_t ku_64 = 0;
   int batchCount = 0;
+  int64_t batchCount_64 = 0;
   int P = 0;
   int info = 0;
   void* image = nullptr;
@@ -237,6 +238,10 @@ int main() {
   const float** const fAarray_const = const_cast<const float**>(fAarray);
   float** fBarray = nullptr;
   const float** const fBarray_const = const_cast<const float**>(fBarray);
+  float** fXarray = nullptr;
+  const float** const fXarray_const = const_cast<const float**>(fXarray);
+  float** fYarray = nullptr;
+  const float** const fYarray_const = const_cast<const float**>(fYarray);
   float** fCarray = nullptr;
   float** fTauarray = nullptr;
 
@@ -260,6 +265,10 @@ int main() {
   const double** const dAarray_const = const_cast<const double**>(dAarray);
   double** dBarray = nullptr;
   const double** const dBarray_const = const_cast<const double**>(dBarray);
+  double** dXarray = nullptr;
+  const double** const dXarray_const = const_cast<const double**>(dXarray);
+  double** dYarray = nullptr;
+  const double** const dYarray_const = const_cast<const double**>(dYarray);
   double** dCarray = nullptr;
   double** dTauarray = nullptr;
 
@@ -291,26 +300,42 @@ int main() {
   // CHECK: hipComplex** complexAarray = 0;
   // CHECK: const hipComplex** const complexAarray_const = const_cast<const hipComplex**>(complexAarray);
   // CHECK-NEXT: hipComplex** complexBarray = 0;
-  // CHECK: const hipComplex** const complexBarray_const = const_cast<const hipComplex**>(complexBarray);
+  // CHECK-NEXT: const hipComplex** const complexBarray_const = const_cast<const hipComplex**>(complexBarray);
+  // CHECK-NEXT: hipComplex** complexXarray = 0;
+  // CHECK-NEXT: const hipComplex** const complexXarray_const = const_cast<const hipComplex**>(complexXarray);
+  // CHECK-NEXT: hipComplex** complexYarray = 0;
+  // CHECK-NEXT: const hipComplex** const complexYarray_const = const_cast<const hipComplex**>(complexYarray);
   // CHECK-NEXT: hipComplex** complexCarray = 0;
   // CHECK-NEXT: hipComplex** complexTauarray = 0;
   cuComplex** complexAarray = 0;
   const cuComplex** const complexAarray_const = const_cast<const cuComplex**>(complexAarray);
   cuComplex** complexBarray = 0;
   const cuComplex** const complexBarray_const = const_cast<const cuComplex**>(complexBarray);
+  cuComplex** complexXarray = 0;
+  const cuComplex** const complexXarray_const = const_cast<const cuComplex**>(complexXarray);
+  cuComplex** complexYarray = 0;
+  const cuComplex** const complexYarray_const = const_cast<const cuComplex**>(complexYarray);
   cuComplex** complexCarray = 0;
   cuComplex** complexTauarray = 0;
 
   // CHECK: hipDoubleComplex** dcomplexAarray = 0;
   // CHECK: const hipDoubleComplex** const dcomplexAarray_const = const_cast<const hipDoubleComplex**>(dcomplexAarray);
   // CHECK-NEXT: hipDoubleComplex** dcomplexBarray = 0;
-  // CHECK: const hipDoubleComplex** const dcomplexBarray_const = const_cast<const hipDoubleComplex**>(dcomplexBarray);
+  // CHECK-NEXT: const hipDoubleComplex** const dcomplexBarray_const = const_cast<const hipDoubleComplex**>(dcomplexBarray);
+  // CHECK-NEXT: hipDoubleComplex** dcomplexXarray = 0;
+  // CHECK-NEXT: const hipDoubleComplex** const dcomplexXarray_const = const_cast<const hipDoubleComplex**>(dcomplexXarray);
+  // CHECK-NEXT: hipDoubleComplex** dcomplexYarray = 0;
+  // CHECK-NEXT: const hipDoubleComplex** const dcomplexYarray_const = const_cast<const hipDoubleComplex**>(dcomplexYarray);
   // CHECK-NEXT: hipDoubleComplex** dcomplexCarray = 0;
   // CHECK-NEXT: hipDoubleComplex** dcomplexTauarray = 0;
   cuDoubleComplex** dcomplexAarray = 0;
   const cuDoubleComplex** const dcomplexAarray_const = const_cast<const cuDoubleComplex**>(dcomplexAarray);
   cuDoubleComplex** dcomplexBarray = 0;
   const cuDoubleComplex** const dcomplexBarray_const = const_cast<const cuDoubleComplex**>(dcomplexBarray);
+  cuDoubleComplex** dcomplexXarray = 0;
+  const cuDoubleComplex** const dcomplexXarray_const = const_cast<const cuDoubleComplex**>(dcomplexXarray);
+  cuDoubleComplex** dcomplexYarray = 0;
+  const cuDoubleComplex** const dcomplexYarray_const = const_cast<const cuDoubleComplex**>(dcomplexYarray);
   cuDoubleComplex** dcomplexCarray = 0;
   cuDoubleComplex** dcomplexTauarray = 0;
 
@@ -2244,6 +2269,26 @@ int main() {
   // CHECK-NEXT: blasStatus = hipblasZgemv_v2_64(blasHandle, blasOperation, m_64, n_64, &dcomplexa, &dcomplexA, lda_64, &dcomplexx, incx_64, &dcomplexb, &dcomplexy, incy_64);
   blasStatus = cublasZgemv_64(blasHandle, blasOperation, m_64, n_64, &dcomplexa, &dcomplexA, lda_64, &dcomplexx, incx_64, &dcomplexb, &dcomplexy, incy_64);
   blasStatus = cublasZgemv_v2_64(blasHandle, blasOperation, m_64, n_64, &dcomplexa, &dcomplexA, lda_64, &dcomplexx, incx_64, &dcomplexb, &dcomplexy, incy_64);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasSgemvBatched_64(cublasHandle_t handle, cublasOperation_t trans, int64_t m, int64_t n, const float* alpha, const float* const Aarray[], int64_t lda, const float* const xarray[], int64_t incx, const float* beta, float* const yarray[], int64_t incy, int64_t batchCount);
+  // HIP: HIPBLAS_EXPORT hipblasStatus_t hipblasSgemvBatched_64(hipblasHandle_t handle, hipblasOperation_t trans, int64_t m, int64_t n, const float* alpha, const float* const AP[], int64_t lda, const float* const x[], int64_t incx, const float* beta, float* const y[], int64_t incy, int64_t batchCount);
+  // CHECK: blasStatus = hipblasSgemvBatched_64(blasHandle, blasOperation, m_64, n_64, &fa, fAarray_const, lda_64, fXarray_const, incx_64, &fb, fYarray, incy_64, batchCount_64);
+  blasStatus = cublasSgemvBatched_64(blasHandle, blasOperation, m_64, n_64, &fa, fAarray_const, lda_64, fXarray_const, incx_64, &fb, fYarray, incy_64, batchCount_64);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasDgemvBatched_64(cublasHandle_t handle, cublasOperation_t trans, int64_t m, int64_t n, const double* alpha, const double* const Aarray[], int64_t lda, const double* const xarray[], int64_t incx, const double* beta, double* const yarray[], int64_t incy, int64_t batchCount);
+  // HIP: HIPBLAS_EXPORT hipblasStatus_t hipblasDgemvBatched_64(hipblasHandle_t handle, hipblasOperation_t trans, int64_t m, int64_t n, const double* alpha, const double* const AP[], int64_t lda, const double* const x[], int64_t incx, const double* beta, double* const y[], int64_t incy, int64_t batchCount);
+  // CHECK: blasStatus = hipblasDgemvBatched_64(blasHandle, blasOperation, m_64, n_64, &da, dAarray_const, lda_64, dXarray_const, incx_64, &db, dYarray, incy_64, batchCount_64);
+  blasStatus = cublasDgemvBatched_64(blasHandle, blasOperation, m_64, n_64, &da, dAarray_const, lda_64, dXarray_const, incx_64, &db, dYarray, incy_64, batchCount_64);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasCgemvBatched_64(cublasHandle_t handle, cublasOperation_t trans, int64_t m, int64_t n, const cuComplex* alpha, const cuComplex* const Aarray[], int64_t lda, const cuComplex* const xarray[], int64_t incx, const cuComplex* beta, cuComplex* const yarray[], int64_t incy, int64_t batchCount);
+  // HIP: HIPBLAS_EXPORT hipblasStatus_t hipblasCgemvBatched_v2_64(hipblasHandle_t handle, hipblasOperation_t trans, int64_t m, int64_t n, const hipComplex* alpha, const hipComplex* const AP[], int64_t lda, const hipComplex* const x[], int64_t incx, const hipComplex* beta, hipComplex* const y[], int64_t incy, int64_t batchCount);
+  // CHECK: blasStatus = hipblasCgemvBatched_v2_64(blasHandle, blasOperation, m_64, n_64, &complexa, complexAarray_const, lda_64, complexXarray_const, incx_64, &complexb, complexYarray, incy_64, batchCount_64);
+  blasStatus = cublasCgemvBatched_64(blasHandle, blasOperation, m_64, n_64, &complexa, complexAarray_const, lda_64, complexXarray_const, incx_64, &complexb, complexYarray, incy_64, batchCount_64);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasZgemvBatched_64(cublasHandle_t handle, cublasOperation_t trans, int64_t m, int64_t n, const cuDoubleComplex* alpha, const cuDoubleComplex* const Aarray[], int64_t lda, const cuDoubleComplex* const xarray[], int64_t incx, const cuDoubleComplex* beta, cuDoubleComplex* const yarray[], int64_t incy, int64_t batchCount);
+  // HIP: HIPBLAS_EXPORT hipblasStatus_t hipblasZgemvBatched_v2_64(hipblasHandle_t handle, hipblasOperation_t trans, int64_t m, int64_t n, const hipDoubleComplex* alpha, const hipDoubleComplex* const AP[], int64_t lda, const hipDoubleComplex* const x[], int64_t incx, const hipDoubleComplex* beta, hipDoubleComplex* const y[], int64_t incy, int64_t batchCount);
+  // CHECK: blasStatus = hipblasZgemvBatched_v2_64(blasHandle, blasOperation, m_64, n_64, &dcomplexa, dcomplexAarray_const, lda_64, dcomplexXarray_const, incx_64, &dcomplexb, dcomplexYarray, incy_64, batchCount_64);
+  blasStatus = cublasZgemvBatched_64(blasHandle, blasOperation, m_64, n_64, &dcomplexa, dcomplexAarray_const, lda_64, dcomplexXarray_const, incx_64, &dcomplexb, dcomplexYarray, incy_64, batchCount_64);
 #endif
 
   return 0;


### PR DESCRIPTION
+ Updated synthetic tests, the regenerated `hipify-perl`, and `BLAS` `CUDA2HIP` documentation