### PR TITLE
[HIPIFY][doc] CUDA `12.5.0` is the latest supported release (LLVM 19.x)

### DIFF
--- a/docs/hipify-clang.rst
+++ b/docs/hipify-clang.rst
@@ -184,7 +184,7 @@ Dependencies
     - **Latest stable config**
     - **Latest stable config**
   * - `19.0.0 git <https://github.com/llvm/llvm-project>`_
-    - `12.4.1 <https://developer.nvidia.com/cuda-downloads>`_
+    - `12.5.0 <https://developer.nvidia.com/cuda-downloads>`_
     - ✅
     - ✅
 
@@ -822,7 +822,7 @@ Tested configurations:
     - ``3.29.3``
     - ``3.12.4``
   * - ``19.0.0git``
-    - ``7.0 - 12.4.1``
+    - ``7.0 - 12.5.0``
     - ``8.0.5  - 9.2.0``
     - ``2019.16.11.36, 2022.17.10.1``
     - ``3.29.3``


### PR DESCRIPTION
+ `CUDA 12.5.0` is supported by LLVM >= 19.0.0 but might work with the `hipify-clang` built against LLVM 17.x and 18.x
+ Tested on Windows 11 and Ubuntu 23.10
