### PR TITLE
[HIPIFY][BLAS][6.2.0] cuBLAS support - Step 5 - 64-bit functions

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -3813,9 +3813,13 @@ sub simpleSubstitutions {
     subst("cublasCgemv_v2", "hipblasCgemv_v2", "library");
     subst("cublasCgeqrfBatched", "hipblasCgeqrfBatched_v2", "library");
     subst("cublasCgerc", "hipblasCgerc_v2", "library");
+    subst("cublasCgerc_64", "hipblasCgerc_v2_64", "library");
     subst("cublasCgerc_v2", "hipblasCgerc_v2", "library");
+    subst("cublasCgerc_v2_64", "hipblasCgerc_v2_64", "library");
     subst("cublasCgeru", "hipblasCgeru_v2", "library");
+    subst("cublasCgeru_64", "hipblasCgeru_v2_64", "library");
     subst("cublasCgeru_v2", "hipblasCgeru_v2", "library");
+    subst("cublasCgeru_v2_64", "hipblasCgeru_v2_64", "library");
     subst("cublasCgetrfBatched", "hipblasCgetrfBatched_v2", "library");
     subst("cublasCgetriBatched", "hipblasCgetriBatched_v2", "library");
     subst("cublasCgetrsBatched", "hipblasCgetrsBatched_v2", "library");
@@ -3928,7 +3932,9 @@ sub simpleSubstitutions {
     subst("cublasDgemv_v2", "hipblasDgemv", "library");
     subst("cublasDgeqrfBatched", "hipblasDgeqrfBatched", "library");
     subst("cublasDger", "hipblasDger", "library");
+    subst("cublasDger_64", "hipblasDger_64", "library");
     subst("cublasDger_v2", "hipblasDger", "library");
+    subst("cublasDger_v2_64", "hipblasDger_64", "library");
     subst("cublasDgetrfBatched", "hipblasDgetrfBatched", "library");
     subst("cublasDgetriBatched", "hipblasDgetriBatched", "library");
     subst("cublasDgetrsBatched", "hipblasDgetrsBatched", "library");
@@ -4126,7 +4132,9 @@ sub simpleSubstitutions {
     subst("cublasSgemv_v2", "hipblasSgemv", "library");
     subst("cublasSgeqrfBatched", "hipblasSgeqrfBatched", "library");
     subst("cublasSger", "hipblasSger", "library");
+    subst("cublasSger_64", "hipblasSger_64", "library");
     subst("cublasSger_v2", "hipblasSger", "library");
+    subst("cublasSger_v2_64", "hipblasSger_64", "library");
     subst("cublasSgetrfBatched", "hipblasSgetrfBatched", "library");
     subst("cublasSgetriBatched", "hipblasSgetriBatched", "library");
     subst("cublasSgetrsBatched", "hipblasSgetrsBatched", "library");
@@ -4232,9 +4240,13 @@ sub simpleSubstitutions {
     subst("cublasZgemv_v2", "hipblasZgemv_v2", "library");
     subst("cublasZgeqrfBatched", "hipblasZgeqrfBatched_v2", "library");
     subst("cublasZgerc", "hipblasZgerc_v2", "library");
+    subst("cublasZgerc_64", "hipblasZgerc_v2_64", "library");
     subst("cublasZgerc_v2", "hipblasZgerc_v2", "library");
+    subst("cublasZgerc_v2_64", "hipblasZgerc_v2_64", "library");
     subst("cublasZgeru", "hipblasZgeru_v2", "library");
+    subst("cublasZgeru_64", "hipblasZgeru_v2_64", "library");
     subst("cublasZgeru_v2", "hipblasZgeru_v2", "library");
+    subst("cublasZgeru_v2_64", "hipblasZgeru_v2_64", "library");
     subst("cublasZgetrfBatched", "hipblasZgetrfBatched_v2", "library");
     subst("cublasZgetriBatched", "hipblasZgetriBatched_v2", "library");
     subst("cublasZgetrsBatched", "hipblasZgetrsBatched_v2", "library");
@@ -11397,10 +11409,6 @@ sub warnHipOnlyUnsupportedFunctions {
         "cublasZhemm_64",
         "cublasZhbmv_v2_64",
         "cublasZhbmv_64",
-        "cublasZgeru_v2_64",
-        "cublasZgeru_64",
-        "cublasZgerc_v2_64",
-        "cublasZgerc_64",
         "cublasZgemm_v2_64",
         "cublasZgemm_64",
         "cublasZgemmStridedBatched_64",
@@ -11463,8 +11471,6 @@ sub warnHipOnlyUnsupportedFunctions {
         "cublasSsbmv_64",
         "cublasSmatinvBatched",
         "cublasShutdown",
-        "cublasSger_v2_64",
-        "cublasSger_64",
         "cublasSgemm_v2_64",
         "cublasSgemm_64",
         "cublasSgemmStridedBatched_64",
@@ -11606,8 +11612,6 @@ sub warnHipOnlyUnsupportedFunctions {
         "cublasDotcEx_64",
         "cublasDotEx_64",
         "cublasDmatinvBatched",
-        "cublasDger_v2_64",
-        "cublasDger_64",
         "cublasDgemm_v2_64",
         "cublasDgemm_64",
         "cublasDgemmStridedBatched_64",
@@ -11681,10 +11685,6 @@ sub warnHipOnlyUnsupportedFunctions {
         "cublasChemm_64",
         "cublasChbmv_v2_64",
         "cublasChbmv_64",
-        "cublasCgeru_v2_64",
-        "cublasCgeru_64",
-        "cublasCgerc_v2_64",
-        "cublasCgerc_64",
         "cublasCgemm_v2_64",
         "cublasCgemm_64",
         "cublasCgemmStridedBatched_64",

--- a/docs/tables/CUBLAS_API_supported_by_HIP.md
+++ b/docs/tables/CUBLAS_API_supported_by_HIP.md
@@ -731,13 +731,13 @@
 |`cublasCgemv_v2`| | | | |`hipblasCgemv_v2`|6.0.0| | | | |
 |`cublasCgemv_v2_64`|12.0| | | |`hipblasCgemv_v2_64`|6.2.0| | | |6.2.0|
 |`cublasCgerc`| | | | |`hipblasCgerc_v2`|6.0.0| | | | |
-|`cublasCgerc_64`|12.0| | | | | | | | | |
+|`cublasCgerc_64`|12.0| | | |`hipblasCgerc_v2_64`|6.2.0| | | |6.2.0|
 |`cublasCgerc_v2`| | | | |`hipblasCgerc_v2`|6.0.0| | | | |
-|`cublasCgerc_v2_64`|12.0| | | | | | | | | |
+|`cublasCgerc_v2_64`|12.0| | | |`hipblasCgerc_v2_64`|6.2.0| | | |6.2.0|
 |`cublasCgeru`| | | | |`hipblasCgeru_v2`|6.0.0| | | | |
-|`cublasCgeru_64`|12.0| | | | | | | | | |
+|`cublasCgeru_64`|12.0| | | |`hipblasCgeru_v2_64`|6.2.0| | | |6.2.0|
 |`cublasCgeru_v2`| | | | |`hipblasCgeru_v2`|6.0.0| | | | |
-|`cublasCgeru_v2_64`|12.0| | | | | | | | | |
+|`cublasCgeru_v2_64`|12.0| | | |`hipblasCgeru_v2_64`|6.2.0| | | |6.2.0|
 |`cublasChbmv`| | | | |`hipblasChbmv_v2`|6.0.0| | | | |
 |`cublasChbmv_64`|12.0| | | | | | | | | |
 |`cublasChbmv_v2`| | | | |`hipblasChbmv_v2`|6.0.0| | | | |
@@ -811,9 +811,9 @@
 |`cublasDgemv_v2`| | | | |`hipblasDgemv`|1.8.2| | | | |
 |`cublasDgemv_v2_64`|12.0| | | |`hipblasDgemv_64`|6.2.0| | | |6.2.0|
 |`cublasDger`| | | | |`hipblasDger`|1.8.2| | | | |
-|`cublasDger_64`|12.0| | | | | | | | | |
+|`cublasDger_64`|12.0| | | |`hipblasDger_64`|6.2.0| | | |6.2.0|
 |`cublasDger_v2`| | | | |`hipblasDger`|1.8.2| | | | |
-|`cublasDger_v2_64`|12.0| | | | | | | | | |
+|`cublasDger_v2_64`|12.0| | | |`hipblasDger_64`|6.2.0| | | |6.2.0|
 |`cublasDsbmv`| | | | |`hipblasDsbmv`|3.5.0| | | | |
 |`cublasDsbmv_64`|12.0| | | | | | | | | |
 |`cublasDsbmv_v2`| | | | |`hipblasDsbmv`|3.5.0| | | | |
@@ -875,9 +875,9 @@
 |`cublasSgemv_v2`| | | | |`hipblasSgemv`|1.8.2| | | | |
 |`cublasSgemv_v2_64`|12.0| | | |`hipblasSgemv_64`|6.2.0| | | |6.2.0|
 |`cublasSger`| | | | |`hipblasSger`|1.8.2| | | | |
-|`cublasSger_64`|12.0| | | | | | | | | |
+|`cublasSger_64`|12.0| | | |`hipblasSger_64`|6.2.0| | | |6.2.0|
 |`cublasSger_v2`| | | | |`hipblasSger`|1.8.2| | | | |
-|`cublasSger_v2_64`|12.0| | | | | | | | | |
+|`cublasSger_v2_64`|12.0| | | |`hipblasSger_64`|6.2.0| | | |6.2.0|
 |`cublasSsbmv`| | | | |`hipblasSsbmv`|3.5.0| | | | |
 |`cublasSsbmv_64`|12.0| | | | | | | | | |
 |`cublasSsbmv_v2`| | | | |`hipblasSsbmv`|3.5.0| | | | |
@@ -939,13 +939,13 @@
 |`cublasZgemv_v2`| | | | |`hipblasZgemv_v2`|6.0.0| | | | |
 |`cublasZgemv_v2_64`|12.0| | | |`hipblasZgemv_v2_64`|6.2.0| | | |6.2.0|
 |`cublasZgerc`| | | | |`hipblasZgerc_v2`|6.0.0| | | | |
-|`cublasZgerc_64`|12.0| | | | | | | | | |
+|`cublasZgerc_64`|12.0| | | |`hipblasZgerc_v2_64`|6.2.0| | | |6.2.0|
 |`cublasZgerc_v2`| | | | |`hipblasZgerc_v2`|6.0.0| | | | |
-|`cublasZgerc_v2_64`|12.0| | | | | | | | | |
+|`cublasZgerc_v2_64`|12.0| | | |`hipblasZgerc_v2_64`|6.2.0| | | |6.2.0|
 |`cublasZgeru`| | | | |`hipblasZgeru_v2`|6.0.0| | | | |
-|`cublasZgeru_64`|12.0| | | | | | | | | |
+|`cublasZgeru_64`|12.0| | | |`hipblasZgeru_v2_64`|6.2.0| | | |6.2.0|
 |`cublasZgeru_v2`| | | | |`hipblasZgeru_v2`|6.0.0| | | | |
-|`cublasZgeru_v2_64`|12.0| | | | | | | | | |
+|`cublasZgeru_v2_64`|12.0| | | |`hipblasZgeru_v2_64`|6.2.0| | | |6.2.0|
 |`cublasZhbmv`| | | | |`hipblasZhbmv_v2`|6.0.0| | | | |
 |`cublasZhbmv_64`|12.0| | | | | | | | | |
 |`cublasZhbmv_v2`| | | | |`hipblasZhbmv_v2`|6.0.0| | | | |

--- a/docs/tables/CUBLAS_API_supported_by_HIP_and_ROC.md
+++ b/docs/tables/CUBLAS_API_supported_by_HIP_and_ROC.md
@@ -731,13 +731,13 @@
 |`cublasCgemv_v2`| | | | |`hipblasCgemv_v2`|6.0.0| | | | |`rocblas_cgemv`|1.5.0| | | | |
 |`cublasCgemv_v2_64`|12.0| | | |`hipblasCgemv_v2_64`|6.2.0| | | |6.2.0| | | | | | |
 |`cublasCgerc`| | | | |`hipblasCgerc_v2`|6.0.0| | | | |`rocblas_cgerc`|3.5.0| | | | |
-|`cublasCgerc_64`|12.0| | | | | | | | | | | | | | | |
+|`cublasCgerc_64`|12.0| | | |`hipblasCgerc_v2_64`|6.2.0| | | |6.2.0| | | | | | |
 |`cublasCgerc_v2`| | | | |`hipblasCgerc_v2`|6.0.0| | | | |`rocblas_cgerc`|3.5.0| | | | |
-|`cublasCgerc_v2_64`|12.0| | | | | | | | | | | | | | | |
+|`cublasCgerc_v2_64`|12.0| | | |`hipblasCgerc_v2_64`|6.2.0| | | |6.2.0| | | | | | |
 |`cublasCgeru`| | | | |`hipblasCgeru_v2`|6.0.0| | | | |`rocblas_cgeru`|3.5.0| | | | |
-|`cublasCgeru_64`|12.0| | | | | | | | | | | | | | | |
+|`cublasCgeru_64`|12.0| | | |`hipblasCgeru_v2_64`|6.2.0| | | |6.2.0| | | | | | |
 |`cublasCgeru_v2`| | | | |`hipblasCgeru_v2`|6.0.0| | | | |`rocblas_cgeru`|3.5.0| | | | |
-|`cublasCgeru_v2_64`|12.0| | | | | | | | | | | | | | | |
+|`cublasCgeru_v2_64`|12.0| | | |`hipblasCgeru_v2_64`|6.2.0| | | |6.2.0| | | | | | |
 |`cublasChbmv`| | | | |`hipblasChbmv_v2`|6.0.0| | | | |`rocblas_chbmv`|3.5.0| | | | |
 |`cublasChbmv_64`|12.0| | | | | | | | | | | | | | | |
 |`cublasChbmv_v2`| | | | |`hipblasChbmv_v2`|6.0.0| | | | |`rocblas_chbmv`|3.5.0| | | | |
@@ -811,9 +811,9 @@
 |`cublasDgemv_v2`| | | | |`hipblasDgemv`|1.8.2| | | | |`rocblas_dgemv`|1.5.0| | | | |
 |`cublasDgemv_v2_64`|12.0| | | |`hipblasDgemv_64`|6.2.0| | | |6.2.0| | | | | | |
 |`cublasDger`| | | | |`hipblasDger`|1.8.2| | | | |`rocblas_dger`|1.5.0| | | | |
-|`cublasDger_64`|12.0| | | | | | | | | | | | | | | |
+|`cublasDger_64`|12.0| | | |`hipblasDger_64`|6.2.0| | | |6.2.0| | | | | | |
 |`cublasDger_v2`| | | | |`hipblasDger`|1.8.2| | | | |`rocblas_dger`|1.5.0| | | | |
-|`cublasDger_v2_64`|12.0| | | | | | | | | | | | | | | |
+|`cublasDger_v2_64`|12.0| | | |`hipblasDger_64`|6.2.0| | | |6.2.0| | | | | | |
 |`cublasDsbmv`| | | | |`hipblasDsbmv`|3.5.0| | | | |`rocblas_dsbmv`|3.5.0| | | | |
 |`cublasDsbmv_64`|12.0| | | | | | | | | | | | | | | |
 |`cublasDsbmv_v2`| | | | |`hipblasDsbmv`|3.5.0| | | | |`rocblas_dsbmv`|3.5.0| | | | |
@@ -875,9 +875,9 @@
 |`cublasSgemv_v2`| | | | |`hipblasSgemv`|1.8.2| | | | |`rocblas_sgemv`|1.5.0| | | | |
 |`cublasSgemv_v2_64`|12.0| | | |`hipblasSgemv_64`|6.2.0| | | |6.2.0| | | | | | |
 |`cublasSger`| | | | |`hipblasSger`|1.8.2| | | | |`rocblas_sger`|1.5.0| | | | |
-|`cublasSger_64`|12.0| | | | | | | | | | | | | | | |
+|`cublasSger_64`|12.0| | | |`hipblasSger_64`|6.2.0| | | |6.2.0| | | | | | |
 |`cublasSger_v2`| | | | |`hipblasSger`|1.8.2| | | | |`rocblas_sger`|1.5.0| | | | |
-|`cublasSger_v2_64`|12.0| | | | | | | | | | | | | | | |
+|`cublasSger_v2_64`|12.0| | | |`hipblasSger_64`|6.2.0| | | |6.2.0| | | | | | |
 |`cublasSsbmv`| | | | |`hipblasSsbmv`|3.5.0| | | | |`rocblas_ssbmv`|3.5.0| | | | |
 |`cublasSsbmv_64`|12.0| | | | | | | | | | | | | | | |
 |`cublasSsbmv_v2`| | | | |`hipblasSsbmv`|3.5.0| | | | |`rocblas_ssbmv`|3.5.0| | | | |
@@ -939,13 +939,13 @@
 |`cublasZgemv_v2`| | | | |`hipblasZgemv_v2`|6.0.0| | | | |`rocblas_zgemv`|1.5.0| | | | |
 |`cublasZgemv_v2_64`|12.0| | | |`hipblasZgemv_v2_64`|6.2.0| | | |6.2.0| | | | | | |
 |`cublasZgerc`| | | | |`hipblasZgerc_v2`|6.0.0| | | | |`rocblas_zgerc`|3.5.0| | | | |
-|`cublasZgerc_64`|12.0| | | | | | | | | | | | | | | |
+|`cublasZgerc_64`|12.0| | | |`hipblasZgerc_v2_64`|6.2.0| | | |6.2.0| | | | | | |
 |`cublasZgerc_v2`| | | | |`hipblasZgerc_v2`|6.0.0| | | | |`rocblas_zgerc`|3.5.0| | | | |
-|`cublasZgerc_v2_64`|12.0| | | | | | | | | | | | | | | |
+|`cublasZgerc_v2_64`|12.0| | | |`hipblasZgerc_v2_64`|6.2.0| | | |6.2.0| | | | | | |
 |`cublasZgeru`| | | | |`hipblasZgeru_v2`|6.0.0| | | | |`rocblas_zgeru`|3.5.0| | | | |
-|`cublasZgeru_64`|12.0| | | | | | | | | | | | | | | |
+|`cublasZgeru_64`|12.0| | | |`hipblasZgeru_v2_64`|6.2.0| | | |6.2.0| | | | | | |
 |`cublasZgeru_v2`| | | | |`hipblasZgeru_v2`|6.0.0| | | | |`rocblas_zgeru`|3.5.0| | | | |
-|`cublasZgeru_v2_64`|12.0| | | | | | | | | | | | | | | |
+|`cublasZgeru_v2_64`|12.0| | | |`hipblasZgeru_v2_64`|6.2.0| | | |6.2.0| | | | | | |
 |`cublasZhbmv`| | | | |`hipblasZhbmv_v2`|6.0.0| | | | |`rocblas_zhbmv`|3.5.0| | | | |
 |`cublasZhbmv_64`|12.0| | | | | | | | | | | | | | | |
 |`cublasZhbmv_v2`| | | | |`hipblasZhbmv_v2`|6.0.0| | | | |`rocblas_zhbmv`|3.5.0| | | | |

--- a/src/CUDA2HIP_BLAS_API_functions.cpp
+++ b/src/CUDA2HIP_BLAS_API_functions.cpp
@@ -336,17 +336,17 @@ const std::map<llvm::StringRef, hipCounter> CUDA_BLAS_FUNCTION_MAP {
 
   // GER
   {"cublasSger",                                           {"hipblasSger",                                               "rocblas_sger",                                       CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, HIP_SUPPORTED_V2_ONLY}},
-  {"cublasSger_64",                                        {"hipblasSger_64",                                            "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, UNSUPPORTED}},
+  {"cublasSger_64",                                        {"hipblasSger_64",                                            "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
   {"cublasDger",                                           {"hipblasDger",                                               "rocblas_dger",                                       CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, HIP_SUPPORTED_V2_ONLY}},
-  {"cublasDger_64",                                        {"hipblasDger_64",                                            "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, UNSUPPORTED}},
+  {"cublasDger_64",                                        {"hipblasDger_64",                                            "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
   {"cublasCgeru",                                          {"hipblasCgeru_v2",                                           "rocblas_cgeru",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, HIP_SUPPORTED_V2_ONLY}},
-  {"cublasCgeru_64",                                       {"hipblasCgeru_64",                                           "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, UNSUPPORTED}},
+  {"cublasCgeru_64",                                       {"hipblasCgeru_v2_64",                                        "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
   {"cublasCgerc",                                          {"hipblasCgerc_v2",                                           "rocblas_cgerc",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, HIP_SUPPORTED_V2_ONLY}},
-  {"cublasCgerc_64",                                       {"hipblasCgerc_64",                                           "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, UNSUPPORTED}},
+  {"cublasCgerc_64",                                       {"hipblasCgerc_v2_64",                                        "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
   {"cublasZgeru",                                          {"hipblasZgeru_v2",                                           "rocblas_zgeru",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, HIP_SUPPORTED_V2_ONLY}},
-  {"cublasZgeru_64",                                       {"hipblasZgeru_64",                                           "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, UNSUPPORTED}},
+  {"cublasZgeru_64",                                       {"hipblasZgeru_v2_64",                                        "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
   {"cublasZgerc",                                          {"hipblasZgerc_v2",                                           "rocblas_zgerc",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, HIP_SUPPORTED_V2_ONLY}},
-  {"cublasZgerc_64",                                       {"hipblasZgerc_64",                                           "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, UNSUPPORTED}},
+  {"cublasZgerc_64",                                       {"hipblasZgerc_v2_64",                                        "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
 
   // SYR/HER
   {"cublasSsyr",                                           {"hipblasSsyr",                                               "rocblas_ssyr",                                       CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, HIP_SUPPORTED_V2_ONLY}},
@@ -754,17 +754,17 @@ const std::map<llvm::StringRef, hipCounter> CUDA_BLAS_FUNCTION_MAP {
 
   // GER
   {"cublasSger_v2",                                        {"hipblasSger",                                               "rocblas_sger",                                       CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
-  {"cublasSger_v2_64",                                     {"hipblasSger_64",                                            "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, UNSUPPORTED}},
+  {"cublasSger_v2_64",                                     {"hipblasSger_64",                                            "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
   {"cublasDger_v2",                                        {"hipblasDger",                                               "rocblas_dger",                                       CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
-  {"cublasDger_v2_64",                                     {"hipblasDger_64",                                            "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, UNSUPPORTED}},
+  {"cublasDger_v2_64",                                     {"hipblasDger_64",                                            "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
   {"cublasCgeru_v2",                                       {"hipblasCgeru_v2",                                           "rocblas_cgeru",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
-  {"cublasCgeru_v2_64",                                    {"hipblasCgeru_64",                                           "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, UNSUPPORTED}},
+  {"cublasCgeru_v2_64",                                    {"hipblasCgeru_v2_64",                                        "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
   {"cublasCgerc_v2",                                       {"hipblasCgerc_v2",                                           "rocblas_cgerc",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
-  {"cublasCgerc_v2_64",                                    {"hipblasCgerc_64",                                           "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, UNSUPPORTED}},
+  {"cublasCgerc_v2_64",                                    {"hipblasCgerc_v2_64",                                        "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
   {"cublasZgeru_v2",                                       {"hipblasZgeru_v2",                                           "rocblas_zgeru",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
-  {"cublasZgeru_v2_64",                                    {"hipblasZgeru_64",                                           "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, UNSUPPORTED}},
+  {"cublasZgeru_v2_64",                                    {"hipblasZgeru_v2_64",                                        "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
   {"cublasZgerc_v2",                                       {"hipblasZgerc_v2",                                           "rocblas_zgerc",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
-  {"cublasZgerc_v2_64",                                    {"hipblasZgerc_64",                                           "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, UNSUPPORTED}},
+  {"cublasZgerc_v2_64",                                    {"hipblasZgerc_v2_64",                                        "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
 
   // SYR/HER
   {"cublasSsyr_v2",                                        {"hipblasSsyr",                                               "rocblas_ssyr",                                       CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
@@ -2074,6 +2074,12 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_BLAS_FUNCTION_VER_MAP {
   {"hipblasDgemvStridedBatched_64",                        {HIP_6020, HIP_0,    HIP_0,  HIP_LATEST}},
   {"hipblasCgemvStridedBatched_v2_64",                     {HIP_6020, HIP_0,    HIP_0,  HIP_LATEST}},
   {"hipblasZgemvStridedBatched_v2_64",                     {HIP_6020, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipblasSger_64",                                       {HIP_6020, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipblasDger_64",                                       {HIP_6020, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipblasCgeru_v2_64",                                   {HIP_6020, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipblasCgerc_v2_64",                                   {HIP_6020, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipblasZgeru_v2_64",                                   {HIP_6020, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipblasZgerc_v2_64",                                   {HIP_6020, HIP_0,    HIP_0,  HIP_LATEST}},
 
   {"rocblas_status_to_string",                             {HIP_3050, HIP_0,    HIP_0   }},
   {"rocblas_sscal",                                        {HIP_1050, HIP_0,    HIP_0   }},

--- a/tests/unit_tests/synthetic/libraries/cublas2hipblas_v2.cu
+++ b/tests/unit_tests/synthetic/libraries/cublas2hipblas_v2.cu
@@ -2316,23 +2316,65 @@ int main() {
 
   // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasSgemvStridedBatched_64(cublasHandle_t handle, cublasOperation_t trans, int64_t m, int64_t n, const float* alpha, const float* A, int64_t lda, long long int strideA, const float* x, int64_t incx, long long int stridex, const float* beta, float* y, int64_t incy, long long int stridey, int64_t batchCount);
   // HIP: HIPBLAS_EXPORT hipblasStatus_t hipblasSgemvStridedBatched_64(hipblasHandle_t handle, hipblasOperation_t transA, int64_t m, int64_t n, const float* alpha, const float* AP, int64_t lda, hipblasStride strideA, const float* x, int64_t incx, hipblasStride stridex, const float* beta, float* y, int64_t incy, hipblasStride stridey, int64_t batchCount);
-  // CHECK: blasStatus = hipblasSgemvStridedBatched_64(blasHandle, blasOperation, m_64, n_64, &fa, &fA, lda, strideA, &fx, incx_64, strideX, &fb, &fy, incy_64, strideY, batchCount);
-  blasStatus = cublasSgemvStridedBatched_64(blasHandle, blasOperation, m_64, n_64, &fa, &fA, lda, strideA, &fx, incx_64, strideX, &fb, &fy, incy_64, strideY, batchCount);
+  // CHECK: blasStatus = hipblasSgemvStridedBatched_64(blasHandle, blasOperation, m_64, n_64, &fa, &fA, lda_64, strideA, &fx, incx_64, strideX, &fb, &fy, incy_64, strideY, batchCount);
+  blasStatus = cublasSgemvStridedBatched_64(blasHandle, blasOperation, m_64, n_64, &fa, &fA, lda_64, strideA, &fx, incx_64, strideX, &fb, &fy, incy_64, strideY, batchCount);
 
   // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasDgemvStridedBatched_64(cublasHandle_t handle, cublasOperation_t trans, int64_t m, int64_t n, const double* alpha, const double* A, int64_t lda, long long int strideA, const double* x, int64_t incx, long long int stridex, const double* beta, double* y, int64_t incy, long long int stridey, int64_t batchCount);
   // HIP: HIPBLAS_EXPORT hipblasStatus_t hipblasDgemvStridedBatched_64(hipblasHandle_t handle, hipblasOperation_t transA, int64_t m, int64_t n, const double* alpha, const double* AP, int64_t lda, hipblasStride strideA, const double* x, int64_t incx, hipblasStride stridex, const double* beta, double* y, int64_t incy, hipblasStride stridey, int64_t batchCount);
-  // CHECK: blasStatus = hipblasDgemvStridedBatched_64(blasHandle, blasOperation, m_64, n_64, &da, &dA, lda, strideA, &dx, incx_64, strideX, &db, &dy, incy_64, strideY, batchCount);
-  blasStatus = cublasDgemvStridedBatched_64(blasHandle, blasOperation, m_64, n_64, &da, &dA, lda, strideA, &dx, incx_64, strideX, &db, &dy, incy_64, strideY, batchCount);
+  // CHECK: blasStatus = hipblasDgemvStridedBatched_64(blasHandle, blasOperation, m_64, n_64, &da, &dA, lda_64, strideA, &dx, incx_64, strideX, &db, &dy, incy_64, strideY, batchCount);
+  blasStatus = cublasDgemvStridedBatched_64(blasHandle, blasOperation, m_64, n_64, &da, &dA, lda_64, strideA, &dx, incx_64, strideX, &db, &dy, incy_64, strideY, batchCount);
 
   // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasCgemvStridedBatched_64(cublasHandle_t handle, cublasOperation_t trans, int64_t m, int64_t n, const cuComplex* alpha, const cuComplex* A, int64_t lda, long long int strideA, const cuComplex* x, int64_t incx, long long int stridex, const cuComplex* beta, cuComplex* y, int64_t incy, long long int stridey, int64_t batchCount);
   // HIP: HIPBLAS_EXPORT hipblasStatus_t hipblasCgemvStridedBatched_v2_64(hipblasHandle_t handle, hipblasOperation_t transA, int64_t m, int64_t n,const hipComplex* alpha, const hipComplex* AP, int64_t lda,hipblasStride strideA, const hipComplex* x, int64_t incx, hipblasStride stridex, const hipComplex* beta, hipComplex* y, int64_t incy, hipblasStride stridey, int64_t batchCount);
-  // CHECK: blasStatus = hipblasCgemvStridedBatched_v2_64(blasHandle, blasOperation, m_64, n_64, &complexa, &complexA, lda, strideA, &complexx, incx_64, strideX, &complexb, &complexy, incy_64, strideY, batchCount);
-  blasStatus = cublasCgemvStridedBatched_64(blasHandle, blasOperation, m_64, n_64, &complexa, &complexA, lda, strideA, &complexx, incx_64, strideX, &complexb, &complexy, incy_64, strideY, batchCount);
+  // CHECK: blasStatus = hipblasCgemvStridedBatched_v2_64(blasHandle, blasOperation, m_64, n_64, &complexa, &complexA, lda_64, strideA, &complexx, incx_64, strideX, &complexb, &complexy, incy_64, strideY, batchCount);
+  blasStatus = cublasCgemvStridedBatched_64(blasHandle, blasOperation, m_64, n_64, &complexa, &complexA, lda_64, strideA, &complexx, incx_64, strideX, &complexb, &complexy, incy_64, strideY, batchCount);
 
   // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasZgemvStridedBatched_64(cublasHandle_t handle, cublasOperation_t trans, int64_t m, int64_t n, const cuDoubleComplex* alpha, const cuDoubleComplex* A, int64_t lda, long long int strideA, const cuDoubleComplex* x, int64_t incx, long long int stridex, const cuDoubleComplex* beta, cuDoubleComplex* y, int64_t incy, long long int stridey, int64_t batchCount);
   // HIP: HIPBLAS_EXPORT hipblasStatus_t hipblasZgemvStridedBatched_v2_64(hipblasHandle_t handle, hipblasOperation_t transA, int64_t m, int64_t n, const hipDoubleComplex* alpha, const hipDoubleComplex* AP, int64_t lda, hipblasStride strideA, const hipDoubleComplex* x, int64_t incx, hipblasStride stridex, const hipDoubleComplex* beta, hipDoubleComplex* y, int64_t incy, hipblasStride stridey, int64_t batchCount);
-  // CHECK: blasStatus = hipblasZgemvStridedBatched_v2_64(blasHandle, blasOperation, m_64, n_64, &dcomplexa, &dcomplexA, lda, strideA, &dcomplexx, incx_64, strideX, &dcomplexb, &dcomplexy, incy_64, strideY, batchCount);
-  blasStatus = cublasZgemvStridedBatched_64(blasHandle, blasOperation, m_64, n_64, &dcomplexa, &dcomplexA, lda, strideA, &dcomplexx, incx_64, strideX, &dcomplexb, &dcomplexy, incy_64, strideY, batchCount);
+  // CHECK: blasStatus = hipblasZgemvStridedBatched_v2_64(blasHandle, blasOperation, m_64, n_64, &dcomplexa, &dcomplexA, lda_64, strideA, &dcomplexx, incx_64, strideX, &dcomplexb, &dcomplexy, incy_64, strideY, batchCount);
+  blasStatus = cublasZgemvStridedBatched_64(blasHandle, blasOperation, m_64, n_64, &dcomplexa, &dcomplexA, lda_64, strideA, &dcomplexx, incx_64, strideX, &dcomplexb, &dcomplexy, incy_64, strideY, batchCount);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasSger_v2_64(cublasHandle_t handle, int64_t m, int64_t n, const float* alpha, const float* x, int64_t incx, const float* y, int64_t incy, float* A, int64_t lda);
+  // HIP: HIPBLAS_EXPORT hipblasStatus_t hipblasSger_64(hipblasHandle_t handle, int64_t m, int64_t n, const float* alpha, const float* x, int64_t incx, const float* y, int64_t incy, float* AP, int64_t lda);
+  // CHECK: blasStatus = hipblasSger_64(blasHandle, m_64, n_64, &fa, &fx, incx_64, &fy, incy_64, &fAP, lda_64);
+  // CHECK-NEXT: blasStatus = hipblasSger_64(blasHandle, m_64, n_64, &fa, &fx, incx_64, &fy, incy_64, &fAP, lda_64);
+  blasStatus = cublasSger_64(blasHandle, m_64, n_64, &fa, &fx, incx_64, &fy, incy_64, &fAP, lda_64);
+  blasStatus = cublasSger_v2_64(blasHandle, m_64, n_64, &fa, &fx, incx_64, &fy, incy_64, &fAP, lda_64);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasDger_v2_64(cublasHandle_t handle, int64_t m, int64_t n, const double* alpha, const double* x, int64_t incx, const double* y, int64_t incy, double* A, int64_t lda);
+  // HIP: HIPBLAS_EXPORT hipblasStatus_t hipblasDger_64(hipblasHandle_t handle, int64_t m, int64_t n, const double* alpha, const double* x, int64_t incx, const double* y, int64_t incy, double* AP, int64_t lda);
+  // CHECK: blasStatus = hipblasDger_64(blasHandle, m_64, n_64, &da, &dx, incx_64, &dy, incy_64, &dA, lda_64);
+  // CHECK-NEXT: blasStatus = hipblasDger_64(blasHandle, m_64, n_64, &da, &dx, incx_64, &dy, incy_64, &dA, lda_64);
+  blasStatus = cublasDger_64(blasHandle, m_64, n_64, &da, &dx, incx_64, &dy, incy_64, &dA, lda_64);
+  blasStatus = cublasDger_v2_64(blasHandle, m_64, n_64, &da, &dx, incx_64, &dy, incy_64, &dA, lda_64);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasCgeru_v2_64(cublasHandle_t handle, int64_t m, int64_t n, const cuComplex* alpha, const cuComplex* x, int64_t incx, const cuComplex* y, int64_t incy, cuComplex* A, int64_t lda);
+  // HIP: HIPBLAS_EXPORT hipblasStatus_t hipblasCgeru_v2_64(hipblasHandle_t handle, int64_t m, int64_t n, const hipComplex* alpha, const hipComplex* x, int64_t incx, const hipComplex* y, int64_t incy, hipComplex* AP, int64_t lda);
+  // CHECK: blasStatus = hipblasCgeru_v2_64(blasHandle, m_64, n_64, &complexa, &complexx, incx_64, &complexy, incy_64, &complexA, lda_64);
+  // CHECK-NEXT: blasStatus = hipblasCgeru_v2_64(blasHandle, m_64, n_64, &complexa, &complexx, incx_64, &complexy, incy_64, &complexA, lda_64);
+  blasStatus = cublasCgeru_64(blasHandle, m_64, n_64, &complexa, &complexx, incx_64, &complexy, incy_64, &complexA, lda_64);
+  blasStatus = cublasCgeru_v2_64(blasHandle, m_64, n_64, &complexa, &complexx, incx_64, &complexy, incy_64, &complexA, lda_64);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasCgerc_v2_64(cublasHandle_t handle, int64_t m, int64_t n, const cuComplex* alpha, const cuComplex* x, int64_t incx, const cuComplex* y, int64_t incy, cuComplex* A, int64_t lda);
+  // HIP: HIPBLAS_EXPORT hipblasStatus_t hipblasCgerc_v2_64(hipblasHandle_t handle, int64_t m, int64_t n, const hipComplex* alpha, const hipComplex* x, int64_t incx, const hipComplex* y, int64_t incy, hipComplex* AP, int64_t lda);
+  // CHECK: blasStatus = hipblasCgerc_v2_64(blasHandle, m_64, n_64, &complexa, &complexx, incx_64, &complexy, incy_64, &complexA, lda_64);
+  // CHECK-NEXT: blasStatus = hipblasCgerc_v2_64(blasHandle, m_64, n_64, &complexa, &complexx, incx_64, &complexy, incy_64, &complexA, lda_64);
+  blasStatus = cublasCgerc_64(blasHandle, m_64, n_64, &complexa, &complexx, incx_64, &complexy, incy_64, &complexA, lda_64);
+  blasStatus = cublasCgerc_v2_64(blasHandle, m_64, n_64, &complexa, &complexx, incx_64, &complexy, incy_64, &complexA, lda_64);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasZgeru_v2_64(cublasHandle_t handle, int64_t m, int64_t n, const cuDoubleComplex* alpha, const cuDoubleComplex* x, int64_t incx, const cuDoubleComplex* y, int64_t incy, cuDoubleComplex* A, int64_t lda);
+  // HIP: HIPBLAS_EXPORT hipblasStatus_t hipblasZgeru_v2_64(hipblasHandle_t handle, int64_t m, int64_t n, const hipDoubleComplex* alpha, const hipDoubleComplex* x, int64_t incx, const hipDoubleComplex* y, int64_t incy, hipDoubleComplex* AP, int64_t lda);
+  // CHECK: blasStatus = hipblasZgeru_v2_64(blasHandle, m_64, n_64, &dcomplexa, &dcomplexx, incx_64, &dcomplexy, incy_64, &dcomplexA, lda_64);
+  // CHECK-NEXT: blasStatus = hipblasZgeru_v2_64(blasHandle, m_64, n_64, &dcomplexa, &dcomplexx, incx_64, &dcomplexy, incy_64, &dcomplexA, lda_64);
+  blasStatus = cublasZgeru_64(blasHandle, m_64, n_64, &dcomplexa, &dcomplexx, incx_64, &dcomplexy, incy_64, &dcomplexA, lda_64);
+  blasStatus = cublasZgeru_v2_64(blasHandle, m_64, n_64, &dcomplexa, &dcomplexx, incx_64, &dcomplexy, incy_64, &dcomplexA, lda_64);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasZgerc_v2_64(cublasHandle_t handle, int64_t m, int64_t n, const cuDoubleComplex* alpha, const cuDoubleComplex* x, int64_t incx, const cuDoubleComplex* y, int64_t incy, cuDoubleComplex* A, int64_t lda);
+  // HIP: HIPBLAS_EXPORT hipblasStatus_t hipblasZgerc_v2_64(hipblasHandle_t handle, int64_t m, int64_t n, const hipDoubleComplex* alpha, const hipDoubleComplex* x, int64_t incx, const hipDoubleComplex* y, int64_t incy, hipDoubleComplex* AP, int64_t lda);
+  // CHECK: blasStatus = hipblasZgerc_v2_64(blasHandle, m_64, n_64, &dcomplexa, &dcomplexx, incx_64, &dcomplexy, incy_64, &dcomplexA, lda_64);
+  // CHECK-NEXT: blasStatus = hipblasZgerc_v2_64(blasHandle, m_64, n_64, &dcomplexa, &dcomplexx, incx_64, &dcomplexy, incy_64, &dcomplexA, lda_64);
+  blasStatus = cublasZgerc_64(blasHandle, m_64, n_64, &dcomplexa, &dcomplexx, incx_64, &dcomplexy, incy_64, &dcomplexA, lda_64);
+  blasStatus = cublasZgerc_v2_64(blasHandle, m_64, n_64, &dcomplexa, &dcomplexx, incx_64, &dcomplexy, incy_64, &dcomplexA, lda_64);
 #endif
 
   return 0;


### PR DESCRIPTION
+ Updated synthetic tests, the regenerated `hipify-perl`, and `BLAS` `CUDA2HIP` documentation
