### PR TITLE
[HIPIFY][BLAS][6.2.0] cuBLAS support - Step 6 - 64-bit functions

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -3824,11 +3824,15 @@ sub simpleSubstitutions {
     subst("cublasCgetriBatched", "hipblasCgetriBatched_v2", "library");
     subst("cublasCgetrsBatched", "hipblasCgetrsBatched_v2", "library");
     subst("cublasChbmv", "hipblasChbmv_v2", "library");
+    subst("cublasChbmv_64", "hipblasChbmv_v2_64", "library");
     subst("cublasChbmv_v2", "hipblasChbmv_v2", "library");
+    subst("cublasChbmv_v2_64", "hipblasChbmv_v2_64", "library");
     subst("cublasChemm", "hipblasChemm_v2", "library");
     subst("cublasChemm_v2", "hipblasChemm_v2", "library");
     subst("cublasChemv", "hipblasChemv_v2", "library");
+    subst("cublasChemv_64", "hipblasChemv_v2_64", "library");
     subst("cublasChemv_v2", "hipblasChemv_v2", "library");
+    subst("cublasChemv_v2_64", "hipblasChemv_v2_64", "library");
     subst("cublasCher", "hipblasCher_v2", "library");
     subst("cublasCher2", "hipblasCher2_v2", "library");
     subst("cublasCher2_v2", "hipblasCher2_v2", "library");
@@ -4251,11 +4255,15 @@ sub simpleSubstitutions {
     subst("cublasZgetriBatched", "hipblasZgetriBatched_v2", "library");
     subst("cublasZgetrsBatched", "hipblasZgetrsBatched_v2", "library");
     subst("cublasZhbmv", "hipblasZhbmv_v2", "library");
+    subst("cublasZhbmv_64", "hipblasZhbmv_v2_64", "library");
     subst("cublasZhbmv_v2", "hipblasZhbmv_v2", "library");
+    subst("cublasZhbmv_v2_64", "hipblasZhbmv_v2_64", "library");
     subst("cublasZhemm", "hipblasZhemm_v2", "library");
     subst("cublasZhemm_v2", "hipblasZhemm_v2", "library");
     subst("cublasZhemv", "hipblasZhemv_v2", "library");
+    subst("cublasZhemv_64", "hipblasZhemv_v2_64", "library");
     subst("cublasZhemv_v2", "hipblasZhemv_v2", "library");
+    subst("cublasZhemv_v2_64", "hipblasZhemv_v2_64", "library");
     subst("cublasZher", "hipblasZher_v2", "library");
     subst("cublasZher2", "hipblasZher2_v2", "library");
     subst("cublasZher2_v2", "hipblasZher2_v2", "library");
@@ -11403,12 +11411,8 @@ sub warnHipOnlyUnsupportedFunctions {
         "cublasZher2k_64",
         "cublasZher2_v2_64",
         "cublasZher2_64",
-        "cublasZhemv_v2_64",
-        "cublasZhemv_64",
         "cublasZhemm_v2_64",
         "cublasZhemm_64",
-        "cublasZhbmv_v2_64",
-        "cublasZhbmv_64",
         "cublasZgemm_v2_64",
         "cublasZgemm_64",
         "cublasZgemmStridedBatched_64",
@@ -11679,12 +11683,8 @@ sub warnHipOnlyUnsupportedFunctions {
         "cublasCher2k_64",
         "cublasCher2_v2_64",
         "cublasCher2_64",
-        "cublasChemv_v2_64",
-        "cublasChemv_64",
         "cublasChemm_v2_64",
         "cublasChemm_64",
-        "cublasChbmv_v2_64",
-        "cublasChbmv_64",
         "cublasCgemm_v2_64",
         "cublasCgemm_64",
         "cublasCgemmStridedBatched_64",

--- a/docs/tables/CUBLAS_API_supported_by_HIP.md
+++ b/docs/tables/CUBLAS_API_supported_by_HIP.md
@@ -739,13 +739,13 @@
 |`cublasCgeru_v2`| | | | |`hipblasCgeru_v2`|6.0.0| | | | |
 |`cublasCgeru_v2_64`|12.0| | | |`hipblasCgeru_v2_64`|6.2.0| | | |6.2.0|
 |`cublasChbmv`| | | | |`hipblasChbmv_v2`|6.0.0| | | | |
-|`cublasChbmv_64`|12.0| | | | | | | | | |
+|`cublasChbmv_64`|12.0| | | |`hipblasChbmv_v2_64`|6.2.0| | | |6.2.0|
 |`cublasChbmv_v2`| | | | |`hipblasChbmv_v2`|6.0.0| | | | |
-|`cublasChbmv_v2_64`|12.0| | | | | | | | | |
+|`cublasChbmv_v2_64`|12.0| | | |`hipblasChbmv_v2_64`|6.2.0| | | |6.2.0|
 |`cublasChemv`| | | | |`hipblasChemv_v2`|6.0.0| | | | |
-|`cublasChemv_64`|12.0| | | | | | | | | |
+|`cublasChemv_64`|12.0| | | |`hipblasChemv_v2_64`|6.2.0| | | |6.2.0|
 |`cublasChemv_v2`| | | | |`hipblasChemv_v2`|6.0.0| | | | |
-|`cublasChemv_v2_64`|12.0| | | | | | | | | |
+|`cublasChemv_v2_64`|12.0| | | |`hipblasChemv_v2_64`|6.2.0| | | |6.2.0|
 |`cublasCher`| | | | |`hipblasCher_v2`|6.0.0| | | | |
 |`cublasCher2`| | | | |`hipblasCher2_v2`|6.0.0| | | | |
 |`cublasCher2_64`|12.0| | | | | | | | | |
@@ -947,13 +947,13 @@
 |`cublasZgeru_v2`| | | | |`hipblasZgeru_v2`|6.0.0| | | | |
 |`cublasZgeru_v2_64`|12.0| | | |`hipblasZgeru_v2_64`|6.2.0| | | |6.2.0|
 |`cublasZhbmv`| | | | |`hipblasZhbmv_v2`|6.0.0| | | | |
-|`cublasZhbmv_64`|12.0| | | | | | | | | |
+|`cublasZhbmv_64`|12.0| | | |`hipblasZhbmv_v2_64`|6.2.0| | | |6.2.0|
 |`cublasZhbmv_v2`| | | | |`hipblasZhbmv_v2`|6.0.0| | | | |
-|`cublasZhbmv_v2_64`|12.0| | | | | | | | | |
+|`cublasZhbmv_v2_64`|12.0| | | |`hipblasZhbmv_v2_64`|6.2.0| | | |6.2.0|
 |`cublasZhemv`| | | | |`hipblasZhemv_v2`|6.0.0| | | | |
-|`cublasZhemv_64`|12.0| | | | | | | | | |
+|`cublasZhemv_64`|12.0| | | |`hipblasZhemv_v2_64`|6.2.0| | | |6.2.0|
 |`cublasZhemv_v2`| | | | |`hipblasZhemv_v2`|6.0.0| | | | |
-|`cublasZhemv_v2_64`|12.0| | | | | | | | | |
+|`cublasZhemv_v2_64`|12.0| | | |`hipblasZhemv_v2_64`|6.2.0| | | |6.2.0|
 |`cublasZher`| | | | |`hipblasZher_v2`|6.0.0| | | | |
 |`cublasZher2`| | | | |`hipblasZher2_v2`|6.0.0| | | | |
 |`cublasZher2_64`|12.0| | | | | | | | | |

--- a/docs/tables/CUBLAS_API_supported_by_HIP_and_ROC.md
+++ b/docs/tables/CUBLAS_API_supported_by_HIP_and_ROC.md
@@ -739,13 +739,13 @@
 |`cublasCgeru_v2`| | | | |`hipblasCgeru_v2`|6.0.0| | | | |`rocblas_cgeru`|3.5.0| | | | |
 |`cublasCgeru_v2_64`|12.0| | | |`hipblasCgeru_v2_64`|6.2.0| | | |6.2.0| | | | | | |
 |`cublasChbmv`| | | | |`hipblasChbmv_v2`|6.0.0| | | | |`rocblas_chbmv`|3.5.0| | | | |
-|`cublasChbmv_64`|12.0| | | | | | | | | | | | | | | |
+|`cublasChbmv_64`|12.0| | | |`hipblasChbmv_v2_64`|6.2.0| | | |6.2.0| | | | | | |
 |`cublasChbmv_v2`| | | | |`hipblasChbmv_v2`|6.0.0| | | | |`rocblas_chbmv`|3.5.0| | | | |
-|`cublasChbmv_v2_64`|12.0| | | | | | | | | | | | | | | |
+|`cublasChbmv_v2_64`|12.0| | | |`hipblasChbmv_v2_64`|6.2.0| | | |6.2.0| | | | | | |
 |`cublasChemv`| | | | |`hipblasChemv_v2`|6.0.0| | | | |`rocblas_chemv`|1.5.0| | | | |
-|`cublasChemv_64`|12.0| | | | | | | | | | | | | | | |
+|`cublasChemv_64`|12.0| | | |`hipblasChemv_v2_64`|6.2.0| | | |6.2.0| | | | | | |
 |`cublasChemv_v2`| | | | |`hipblasChemv_v2`|6.0.0| | | | |`rocblas_chemv`|1.5.0| | | | |
-|`cublasChemv_v2_64`|12.0| | | | | | | | | | | | | | | |
+|`cublasChemv_v2_64`|12.0| | | |`hipblasChemv_v2_64`|6.2.0| | | |6.2.0| | | | | | |
 |`cublasCher`| | | | |`hipblasCher_v2`|6.0.0| | | | |`rocblas_cher`|3.5.0| | | | |
 |`cublasCher2`| | | | |`hipblasCher2_v2`|6.0.0| | | | |`rocblas_cher2`|3.5.0| | | | |
 |`cublasCher2_64`|12.0| | | | | | | | | | | | | | | |
@@ -947,13 +947,13 @@
 |`cublasZgeru_v2`| | | | |`hipblasZgeru_v2`|6.0.0| | | | |`rocblas_zgeru`|3.5.0| | | | |
 |`cublasZgeru_v2_64`|12.0| | | |`hipblasZgeru_v2_64`|6.2.0| | | |6.2.0| | | | | | |
 |`cublasZhbmv`| | | | |`hipblasZhbmv_v2`|6.0.0| | | | |`rocblas_zhbmv`|3.5.0| | | | |
-|`cublasZhbmv_64`|12.0| | | | | | | | | | | | | | | |
+|`cublasZhbmv_64`|12.0| | | |`hipblasZhbmv_v2_64`|6.2.0| | | |6.2.0| | | | | | |
 |`cublasZhbmv_v2`| | | | |`hipblasZhbmv_v2`|6.0.0| | | | |`rocblas_zhbmv`|3.5.0| | | | |
-|`cublasZhbmv_v2_64`|12.0| | | | | | | | | | | | | | | |
+|`cublasZhbmv_v2_64`|12.0| | | |`hipblasZhbmv_v2_64`|6.2.0| | | |6.2.0| | | | | | |
 |`cublasZhemv`| | | | |`hipblasZhemv_v2`|6.0.0| | | | |`rocblas_zhemv`|1.5.0| | | | |
-|`cublasZhemv_64`|12.0| | | | | | | | | | | | | | | |
+|`cublasZhemv_64`|12.0| | | |`hipblasZhemv_v2_64`|6.2.0| | | |6.2.0| | | | | | |
 |`cublasZhemv_v2`| | | | |`hipblasZhemv_v2`|6.0.0| | | | |`rocblas_zhemv`|1.5.0| | | | |
-|`cublasZhemv_v2_64`|12.0| | | | | | | | | | | | | | | |
+|`cublasZhemv_v2_64`|12.0| | | |`hipblasZhemv_v2_64`|6.2.0| | | |6.2.0| | | | | | |
 |`cublasZher`| | | | |`hipblasZher_v2`|6.0.0| | | | |`rocblas_zher`|3.5.0| | | | |
 |`cublasZher2`| | | | |`hipblasZher2_v2`|6.0.0| | | | |`rocblas_zher2`|3.5.0| | | | |
 |`cublasZher2_64`|12.0| | | | | | | | | | | | | | | |

--- a/src/CUDA2HIP_BLAS_API_functions.cpp
+++ b/src/CUDA2HIP_BLAS_API_functions.cpp
@@ -310,9 +310,9 @@ const std::map<llvm::StringRef, hipCounter> CUDA_BLAS_FUNCTION_MAP {
   {"cublasZsymv",                                          {"hipblasZsymv_v2",                                           "rocblas_zsymv",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, HIP_SUPPORTED_V2_ONLY}},
   {"cublasZsymv_64",                                       {"hipblasZsymv_64",                                           "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, UNSUPPORTED}},
   {"cublasChemv",                                          {"hipblasChemv_v2",                                           "rocblas_chemv",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, HIP_SUPPORTED_V2_ONLY}},
-  {"cublasChemv_64",                                       {"hipblasChemv_64",                                           "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, UNSUPPORTED}},
+  {"cublasChemv_64",                                       {"hipblasChemv_v2_64",                                        "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
   {"cublasZhemv",                                          {"hipblasZhemv_v2",                                           "rocblas_zhemv",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, HIP_SUPPORTED_V2_ONLY}},
-  {"cublasZhemv_64",                                       {"hipblasZhemv_64",                                           "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, UNSUPPORTED}},
+  {"cublasZhemv_64",                                       {"hipblasZhemv_v2_64",                                        "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
 
   // SBMV/HBMV
   {"cublasSsbmv",                                          {"hipblasSsbmv",                                              "rocblas_ssbmv",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, HIP_SUPPORTED_V2_ONLY}},
@@ -320,9 +320,9 @@ const std::map<llvm::StringRef, hipCounter> CUDA_BLAS_FUNCTION_MAP {
   {"cublasDsbmv",                                          {"hipblasDsbmv",                                              "rocblas_dsbmv",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, HIP_SUPPORTED_V2_ONLY}},
   {"cublasDsbmv_64",                                       {"hipblasDsbmv_64",                                           "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, UNSUPPORTED}},
   {"cublasChbmv",                                          {"hipblasChbmv_v2",                                           "rocblas_chbmv",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, HIP_SUPPORTED_V2_ONLY}},
-  {"cublasChbmv_64",                                       {"hipblasChbmv_64",                                           "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, UNSUPPORTED}},
+  {"cublasChbmv_64",                                       {"hipblasChbmv_v2_64",                                        "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
   {"cublasZhbmv",                                          {"hipblasZhbmv_v2",                                           "rocblas_zhbmv",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, HIP_SUPPORTED_V2_ONLY}},
-  {"cublasZhbmv_64",                                       {"hipblasZhbmv_64",                                           "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, UNSUPPORTED}},
+  {"cublasZhbmv_64",                                       {"hipblasZhbmv_v2_64",                                        "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
 
   // SPMV/HPMV
   {"cublasSspmv",                                          {"hipblasSspmv",                                              "rocblas_sspmv",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, HIP_SUPPORTED_V2_ONLY}},
@@ -728,9 +728,9 @@ const std::map<llvm::StringRef, hipCounter> CUDA_BLAS_FUNCTION_MAP {
   {"cublasZsymv_v2",                                       {"hipblasZsymv_v2",                                           "rocblas_zsymv",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
   {"cublasZsymv_v2_64",                                    {"hipblasZsymv_64",                                           "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, UNSUPPORTED}},
   {"cublasChemv_v2",                                       {"hipblasChemv_v2",                                           "rocblas_chemv",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
-  {"cublasChemv_v2_64",                                    {"hipblasChemv_64",                                           "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, UNSUPPORTED}},
+  {"cublasChemv_v2_64",                                    {"hipblasChemv_v2_64",                                        "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
   {"cublasZhemv_v2",                                       {"hipblasZhemv_v2",                                           "rocblas_zhemv",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
-  {"cublasZhemv_v2_64",                                    {"hipblasZhemv_64",                                           "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, UNSUPPORTED}},
+  {"cublasZhemv_v2_64",                                    {"hipblasZhemv_v2_64",                                        "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
 
   // SBMV/HBMV
   {"cublasSsbmv_v2",                                       {"hipblasSsbmv",                                              "rocblas_ssbmv",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
@@ -738,9 +738,9 @@ const std::map<llvm::StringRef, hipCounter> CUDA_BLAS_FUNCTION_MAP {
   {"cublasDsbmv_v2",                                       {"hipblasDsbmv",                                              "rocblas_dsbmv",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
   {"cublasDsbmv_v2_64",                                    {"hipblasDsbmv_64",                                           "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, UNSUPPORTED}},
   {"cublasChbmv_v2",                                       {"hipblasChbmv_v2",                                           "rocblas_chbmv",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
-  {"cublasChbmv_v2_64",                                    {"hipblasChbmv_64",                                           "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, UNSUPPORTED}},
+  {"cublasChbmv_v2_64",                                    {"hipblasChbmv_v2_64",                                        "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
   {"cublasZhbmv_v2",                                       {"hipblasZhbmv_v2",                                           "rocblas_zhbmv",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
-  {"cublasZhbmv_v2_64",                                    {"hipblasZhbmv_64",                                           "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, UNSUPPORTED}},
+  {"cublasZhbmv_v2_64",                                    {"hipblasZhbmv_v2_64",                                        "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
 
   // SPMV/HPMV
   {"cublasSspmv_v2",                                       {"hipblasSspmv",                                              "rocblas_sspmv",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
@@ -2080,6 +2080,10 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_BLAS_FUNCTION_VER_MAP {
   {"hipblasCgerc_v2_64",                                   {HIP_6020, HIP_0,    HIP_0,  HIP_LATEST}},
   {"hipblasZgeru_v2_64",                                   {HIP_6020, HIP_0,    HIP_0,  HIP_LATEST}},
   {"hipblasZgerc_v2_64",                                   {HIP_6020, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipblasChbmv_v2_64",                                   {HIP_6020, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipblasZhbmv_v2_64",                                   {HIP_6020, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipblasChemv_v2_64",                                   {HIP_6020, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipblasZhemv_v2_64",                                   {HIP_6020, HIP_0,    HIP_0,  HIP_LATEST}},
 
   {"rocblas_status_to_string",                             {HIP_3050, HIP_0,    HIP_0   }},
   {"rocblas_sscal",                                        {HIP_1050, HIP_0,    HIP_0   }},

--- a/tests/unit_tests/synthetic/libraries/cublas2hipblas_v2.cu
+++ b/tests/unit_tests/synthetic/libraries/cublas2hipblas_v2.cu
@@ -162,6 +162,7 @@ int main() {
   int incy = 0;
   int64_t incy_64 = 0;
   int k = 0;
+  int64_t k_64 = 0;
   int kl = 0;
   int64_t kl_64 = 0;
   int ku = 0;
@@ -2375,6 +2376,34 @@ int main() {
   // CHECK-NEXT: blasStatus = hipblasZgerc_v2_64(blasHandle, m_64, n_64, &dcomplexa, &dcomplexx, incx_64, &dcomplexy, incy_64, &dcomplexA, lda_64);
   blasStatus = cublasZgerc_64(blasHandle, m_64, n_64, &dcomplexa, &dcomplexx, incx_64, &dcomplexy, incy_64, &dcomplexA, lda_64);
   blasStatus = cublasZgerc_v2_64(blasHandle, m_64, n_64, &dcomplexa, &dcomplexx, incx_64, &dcomplexy, incy_64, &dcomplexA, lda_64);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasChbmv_v2_64(cublasHandle_t handle, cublasFillMode_t uplo, int64_t n, int64_t k, const cuComplex* alpha, const cuComplex* A, int64_t lda, const cuComplex* x, int64_t incx, const cuComplex* beta, cuComplex* y, int64_t incy);
+  // HIP: HIPBLAS_EXPORT hipblasStatus_t hipblasChbmv_v2_64(hipblasHandle_t handle, hipblasFillMode_t uplo, int64_t n, int64_t k, const hipComplex* alpha, const hipComplex* AP, int64_t lda, const hipComplex* x, int64_t incx, const hipComplex* beta, hipComplex* y, int64_t incy);
+  // CHECK: blasStatus = hipblasChbmv_v2_64(blasHandle, blasFillMode, n_64, k_64, &complexa, &complexA, lda_64, &complexx, incx_64, &complexb, &complexy, incy_64);
+  // CHECK-NEXT: blasStatus = hipblasChbmv_v2_64(blasHandle, blasFillMode, n_64, k_64, &complexa, &complexA, lda_64, &complexx, incx_64, &complexb, &complexy, incy_64);
+  blasStatus = cublasChbmv_64(blasHandle, blasFillMode, n_64, k_64, &complexa, &complexA, lda_64, &complexx, incx_64, &complexb, &complexy, incy_64);
+  blasStatus = cublasChbmv_v2_64(blasHandle, blasFillMode, n_64, k_64, &complexa, &complexA, lda_64, &complexx, incx_64, &complexb, &complexy, incy_64);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasZhbmv_v2_64(cublasHandle_t handle, cublasFillMode_t uplo, int64_t n, int64_t k, const cuDoubleComplex* alpha, const cuDoubleComplex* A, int64_t lda, const cuDoubleComplex* x, int64_t incx, const cuDoubleComplex* beta, cuDoubleComplex* y, int64_t incy);
+  // HIP: HIPBLAS_EXPORT hipblasStatus_t hipblasZhbmv_v2_64(hipblasHandle_t handle, hipblasFillMode_t uplo, int64_t n, int64_t k, const hipDoubleComplex* alpha, const hipDoubleComplex* AP, int64_t lda, const hipDoubleComplex* x, int64_t incx, const hipDoubleComplex* beta, hipDoubleComplex* y, int64_t incy);
+  // CHECK: blasStatus = hipblasZhbmv_v2_64(blasHandle, blasFillMode, n_64, k_64, &dcomplexa, &dcomplexA, lda_64, &dcomplexx, incx_64, &dcomplexb, &dcomplexy, incy_64);
+  // CHECK-NEXT: blasStatus = hipblasZhbmv_v2_64(blasHandle, blasFillMode, n_64, k_64, &dcomplexa, &dcomplexA, lda_64, &dcomplexx, incx_64, &dcomplexb, &dcomplexy, incy_64);
+  blasStatus = cublasZhbmv_64(blasHandle, blasFillMode, n_64, k_64, &dcomplexa, &dcomplexA, lda_64, &dcomplexx, incx_64, &dcomplexb, &dcomplexy, incy_64);
+  blasStatus = cublasZhbmv_v2_64(blasHandle, blasFillMode, n_64, k_64, &dcomplexa, &dcomplexA, lda_64, &dcomplexx, incx_64, &dcomplexb, &dcomplexy, incy_64);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasChemv_v2_64(cublasHandle_t handle, cublasFillMode_t uplo, int64_t n, const cuComplex* alpha, const cuComplex* A, int64_t lda, const cuComplex* x, int64_t incx, const cuComplex* beta, cuComplex* y, int64_t incy);
+  // HIP: HIPBLAS_EXPORT hipblasStatus_t hipblasChemv_v2_64(hipblasHandle_t handle, hipblasFillMode_t uplo, int64_t n, const hipComplex* alpha, const hipComplex* AP, int64_t lda, const hipComplex* x, int64_t incx, const hipComplex* beta, hipComplex* y, int64_t incy);
+  // CHECK: blasStatus = hipblasChemv_v2_64(blasHandle, blasFillMode, n_64, &complexa, &complexA, lda_64, &complexx, incx_64, &complexb, &complexy, incy_64);
+  // CHECK-NEXT: blasStatus = hipblasChemv_v2_64(blasHandle, blasFillMode, n_64, &complexa, &complexA, lda_64, &complexx, incx_64, &complexb, &complexy, incy_64);
+  blasStatus = cublasChemv_64(blasHandle, blasFillMode, n_64, &complexa, &complexA, lda_64, &complexx, incx_64, &complexb, &complexy, incy_64);
+  blasStatus = cublasChemv_v2_64(blasHandle, blasFillMode, n_64, &complexa, &complexA, lda_64, &complexx, incx_64, &complexb, &complexy, incy_64);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasZhemv_v2_64(cublasHandle_t handle, cublasFillMode_t uplo, int64_t n, const cuDoubleComplex* alpha, const cuDoubleComplex* A, int64_t lda, const cuDoubleComplex* x, int64_t incx, const cuDoubleComplex* beta, cuDoubleComplex* y, int64_t incy);
+  // HIP: HIPBLAS_EXPORT hipblasStatus_t hipblasZhemv_v2_64(hipblasHandle_t handle, hipblasFillMode_t uplo, int64_t n, const hipDoubleComplex* alpha, const hipDoubleComplex* AP, int64_t lda, const hipDoubleComplex* x, int64_t incx, const hipDoubleComplex* beta, hipDoubleComplex* y, int64_t incy);
+  // CHECK: blasStatus = hipblasZhemv_v2_64(blasHandle, blasFillMode, n_64, &dcomplexa, &dcomplexA, lda_64, &dcomplexx, incx_64, &dcomplexb, &dcomplexy, incy_64);
+  // CHECK-NEXT: blasStatus = hipblasZhemv_v2_64(blasHandle, blasFillMode, n_64, &dcomplexa, &dcomplexA, lda_64, &dcomplexx, incx_64, &dcomplexb, &dcomplexy, incy_64);
+  blasStatus = cublasZhemv_64(blasHandle, blasFillMode, n_64, &dcomplexa, &dcomplexA, lda_64, &dcomplexx, incx_64, &dcomplexb, &dcomplexy, incy_64);
+  blasStatus = cublasZhemv_v2_64(blasHandle, blasFillMode, n_64, &dcomplexa, &dcomplexA, lda_64, &dcomplexx, incx_64, &dcomplexb, &dcomplexy, incy_64);
 #endif
 
   return 0;


### PR DESCRIPTION
+ Updated synthetic tests, the regenerated `hipify-perl`, and `BLAS` `CUDA2HIP` documentation
