### PR TITLE
[HIPIFY][BLAS][6.2.0] cuBLAS support - Step 7 - 64-bit functions

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -3835,10 +3835,14 @@ sub simpleSubstitutions {
     subst("cublasChemv_v2_64", "hipblasChemv_v2_64", "library");
     subst("cublasCher", "hipblasCher_v2", "library");
     subst("cublasCher2", "hipblasCher2_v2", "library");
+    subst("cublasCher2_64", "hipblasCher2_v2_64", "library");
     subst("cublasCher2_v2", "hipblasCher2_v2", "library");
+    subst("cublasCher2_v2_64", "hipblasCher2_v2_64", "library");
     subst("cublasCher2k", "hipblasCher2k_v2", "library");
     subst("cublasCher2k_v2", "hipblasCher2k_v2", "library");
+    subst("cublasCher_64", "hipblasCher_v2_64", "library");
     subst("cublasCher_v2", "hipblasCher_v2", "library");
+    subst("cublasCher_v2_64", "hipblasCher_v2_64", "library");
     subst("cublasCherk", "hipblasCherk_v2", "library");
     subst("cublasCherk_v2", "hipblasCherk_v2", "library");
     subst("cublasCherkx", "hipblasCherkx_v2", "library");
@@ -4266,10 +4270,14 @@ sub simpleSubstitutions {
     subst("cublasZhemv_v2_64", "hipblasZhemv_v2_64", "library");
     subst("cublasZher", "hipblasZher_v2", "library");
     subst("cublasZher2", "hipblasZher2_v2", "library");
+    subst("cublasZher2_64", "hipblasZher2_v2_64", "library");
     subst("cublasZher2_v2", "hipblasZher2_v2", "library");
+    subst("cublasZher2_v2_64", "hipblasZher2_v2_64", "library");
     subst("cublasZher2k", "hipblasZher2k_v2", "library");
     subst("cublasZher2k_v2", "hipblasZher2k_v2", "library");
+    subst("cublasZher_64", "hipblasZher_v2_64", "library");
     subst("cublasZher_v2", "hipblasZher_v2", "library");
+    subst("cublasZher_v2_64", "hipblasZher_v2_64", "library");
     subst("cublasZherk", "hipblasZherk_v2", "library");
     subst("cublasZherk_v2", "hipblasZherk_v2", "library");
     subst("cublasZherkx", "hipblasZherkx_v2", "library");
@@ -11422,12 +11430,8 @@ sub warnHipOnlyUnsupportedFunctions {
         "cublasZherkx_64",
         "cublasZherk_v2_64",
         "cublasZherk_64",
-        "cublasZher_v2_64",
-        "cublasZher_64",
         "cublasZher2k_v2_64",
         "cublasZher2k_64",
-        "cublasZher2_v2_64",
-        "cublasZher2_64",
         "cublasZhemm_v2_64",
         "cublasZhemm_64",
         "cublasZgemm_v2_64",
@@ -11694,12 +11698,8 @@ sub warnHipOnlyUnsupportedFunctions {
         "cublasCherkEx",
         "cublasCherk3mEx_64",
         "cublasCherk3mEx",
-        "cublasCher_v2_64",
-        "cublasCher_64",
         "cublasCher2k_v2_64",
         "cublasCher2k_64",
-        "cublasCher2_v2_64",
-        "cublasCher2_64",
         "cublasChemm_v2_64",
         "cublasChemm_64",
         "cublasCgemm_v2_64",

--- a/docs/tables/CUBLAS_API_supported_by_HIP.md
+++ b/docs/tables/CUBLAS_API_supported_by_HIP.md
@@ -748,12 +748,12 @@
 |`cublasChemv_v2_64`|12.0| | | |`hipblasChemv_v2_64`|6.2.0| | | |6.2.0|
 |`cublasCher`| | | | |`hipblasCher_v2`|6.0.0| | | | |
 |`cublasCher2`| | | | |`hipblasCher2_v2`|6.0.0| | | | |
-|`cublasCher2_64`|12.0| | | | | | | | | |
+|`cublasCher2_64`|12.0| | | |`hipblasCher2_v2_64`|6.2.0| | | |6.2.0|
 |`cublasCher2_v2`| | | | |`hipblasCher2_v2`|6.0.0| | | | |
-|`cublasCher2_v2_64`|12.0| | | | | | | | | |
-|`cublasCher_64`|12.0| | | | | | | | | |
+|`cublasCher2_v2_64`|12.0| | | |`hipblasCher2_v2_64`|6.2.0| | | |6.2.0|
+|`cublasCher_64`|12.0| | | |`hipblasCher_v2_64`|6.2.0| | | |6.2.0|
 |`cublasCher_v2`| | | | |`hipblasCher_v2`|6.0.0| | | | |
-|`cublasCher_v2_64`|12.0| | | | | | | | | |
+|`cublasCher_v2_64`|12.0| | | |`hipblasCher_v2_64`|6.2.0| | | |6.2.0|
 |`cublasChpmv`| | | | |`hipblasChpmv_v2`|6.0.0| | | | |
 |`cublasChpmv_64`|12.0| | | | | | | | | |
 |`cublasChpmv_v2`| | | | |`hipblasChpmv_v2`|6.0.0| | | | |
@@ -956,12 +956,12 @@
 |`cublasZhemv_v2_64`|12.0| | | |`hipblasZhemv_v2_64`|6.2.0| | | |6.2.0|
 |`cublasZher`| | | | |`hipblasZher_v2`|6.0.0| | | | |
 |`cublasZher2`| | | | |`hipblasZher2_v2`|6.0.0| | | | |
-|`cublasZher2_64`|12.0| | | | | | | | | |
+|`cublasZher2_64`|12.0| | | |`hipblasZher2_v2_64`|6.2.0| | | |6.2.0|
 |`cublasZher2_v2`| | | | |`hipblasZher2_v2`|6.0.0| | | | |
-|`cublasZher2_v2_64`|12.0| | | | | | | | | |
-|`cublasZher_64`|12.0| | | | | | | | | |
+|`cublasZher2_v2_64`|12.0| | | |`hipblasZher2_v2_64`|6.2.0| | | |6.2.0|
+|`cublasZher_64`|12.0| | | |`hipblasZher_v2_64`|6.2.0| | | |6.2.0|
 |`cublasZher_v2`| | | | |`hipblasZher_v2`|6.0.0| | | | |
-|`cublasZher_v2_64`|12.0| | | | | | | | | |
+|`cublasZher_v2_64`|12.0| | | |`hipblasZher_v2_64`|6.2.0| | | |6.2.0|
 |`cublasZhpmv`| | | | |`hipblasZhpmv_v2`|6.0.0| | | | |
 |`cublasZhpmv_64`|12.0| | | | | | | | | |
 |`cublasZhpmv_v2`| | | | |`hipblasZhpmv_v2`|6.0.0| | | | |

--- a/docs/tables/CUBLAS_API_supported_by_HIP_and_ROC.md
+++ b/docs/tables/CUBLAS_API_supported_by_HIP_and_ROC.md
@@ -748,12 +748,12 @@
 |`cublasChemv_v2_64`|12.0| | | |`hipblasChemv_v2_64`|6.2.0| | | |6.2.0| | | | | | |
 |`cublasCher`| | | | |`hipblasCher_v2`|6.0.0| | | | |`rocblas_cher`|3.5.0| | | | |
 |`cublasCher2`| | | | |`hipblasCher2_v2`|6.0.0| | | | |`rocblas_cher2`|3.5.0| | | | |
-|`cublasCher2_64`|12.0| | | | | | | | | | | | | | | |
+|`cublasCher2_64`|12.0| | | |`hipblasCher2_v2_64`|6.2.0| | | |6.2.0| | | | | | |
 |`cublasCher2_v2`| | | | |`hipblasCher2_v2`|6.0.0| | | | |`rocblas_cher2`|3.5.0| | | | |
-|`cublasCher2_v2_64`|12.0| | | | | | | | | | | | | | | |
-|`cublasCher_64`|12.0| | | | | | | | | | | | | | | |
+|`cublasCher2_v2_64`|12.0| | | |`hipblasCher2_v2_64`|6.2.0| | | |6.2.0| | | | | | |
+|`cublasCher_64`|12.0| | | |`hipblasCher_v2_64`|6.2.0| | | |6.2.0| | | | | | |
 |`cublasCher_v2`| | | | |`hipblasCher_v2`|6.0.0| | | | |`rocblas_cher`|3.5.0| | | | |
-|`cublasCher_v2_64`|12.0| | | | | | | | | | | | | | | |
+|`cublasCher_v2_64`|12.0| | | |`hipblasCher_v2_64`|6.2.0| | | |6.2.0| | | | | | |
 |`cublasChpmv`| | | | |`hipblasChpmv_v2`|6.0.0| | | | |`rocblas_chpmv`|3.5.0| | | | |
 |`cublasChpmv_64`|12.0| | | | | | | | | | | | | | | |
 |`cublasChpmv_v2`| | | | |`hipblasChpmv_v2`|6.0.0| | | | |`rocblas_chpmv`|3.5.0| | | | |
@@ -956,12 +956,12 @@
 |`cublasZhemv_v2_64`|12.0| | | |`hipblasZhemv_v2_64`|6.2.0| | | |6.2.0| | | | | | |
 |`cublasZher`| | | | |`hipblasZher_v2`|6.0.0| | | | |`rocblas_zher`|3.5.0| | | | |
 |`cublasZher2`| | | | |`hipblasZher2_v2`|6.0.0| | | | |`rocblas_zher2`|3.5.0| | | | |
-|`cublasZher2_64`|12.0| | | | | | | | | | | | | | | |
+|`cublasZher2_64`|12.0| | | |`hipblasZher2_v2_64`|6.2.0| | | |6.2.0| | | | | | |
 |`cublasZher2_v2`| | | | |`hipblasZher2_v2`|6.0.0| | | | |`rocblas_zher2`|3.5.0| | | | |
-|`cublasZher2_v2_64`|12.0| | | | | | | | | | | | | | | |
-|`cublasZher_64`|12.0| | | | | | | | | | | | | | | |
+|`cublasZher2_v2_64`|12.0| | | |`hipblasZher2_v2_64`|6.2.0| | | |6.2.0| | | | | | |
+|`cublasZher_64`|12.0| | | |`hipblasZher_v2_64`|6.2.0| | | |6.2.0| | | | | | |
 |`cublasZher_v2`| | | | |`hipblasZher_v2`|6.0.0| | | | |`rocblas_zher`|3.5.0| | | | |
-|`cublasZher_v2_64`|12.0| | | | | | | | | | | | | | | |
+|`cublasZher_v2_64`|12.0| | | |`hipblasZher_v2_64`|6.2.0| | | |6.2.0| | | | | | |
 |`cublasZhpmv`| | | | |`hipblasZhpmv_v2`|6.0.0| | | | |`rocblas_zhpmv`|3.5.0| | | | |
 |`cublasZhpmv_64`|12.0| | | | | | | | | | | | | | | |
 |`cublasZhpmv_v2`| | | | |`hipblasZhpmv_v2`|6.0.0| | | | |`rocblas_zhpmv`|3.5.0| | | | |

--- a/src/CUDA2HIP_BLAS_API_functions.cpp
+++ b/src/CUDA2HIP_BLAS_API_functions.cpp
@@ -358,9 +358,9 @@ const std::map<llvm::StringRef, hipCounter> CUDA_BLAS_FUNCTION_MAP {
   {"cublasZsyr",                                           {"hipblasZsyr_v2",                                            "rocblas_zsyr",                                       CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, HIP_SUPPORTED_V2_ONLY}},
   {"cublasZsyr_64",                                        {"hipblasZsyr_64",                                            "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, UNSUPPORTED}},
   {"cublasCher",                                           {"hipblasCher_v2",                                            "rocblas_cher",                                       CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, HIP_SUPPORTED_V2_ONLY}},
-  {"cublasCher_64",                                        {"hipblasCher_64",                                            "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, UNSUPPORTED}},
+  {"cublasCher_64",                                        {"hipblasCher_v2_64",                                         "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
   {"cublasZher",                                           {"hipblasZher_v2",                                            "rocblas_zher",                                       CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, HIP_SUPPORTED_V2_ONLY}},
-  {"cublasZher_64",                                        {"hipblasZher_64",                                            "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, UNSUPPORTED}},
+  {"cublasZher_64",                                        {"hipblasZher_v2_64",                                         "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
 
   // SPR/HPR
   {"cublasSspr",                                           {"hipblasSspr",                                               "rocblas_sspr",                                       CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, HIP_SUPPORTED_V2_ONLY}},
@@ -382,9 +382,9 @@ const std::map<llvm::StringRef, hipCounter> CUDA_BLAS_FUNCTION_MAP {
   {"cublasZsyr2",                                          {"hipblasZsyr2_v2",                                           "rocblas_zsyr2",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, HIP_SUPPORTED_V2_ONLY}},
   {"cublasZsyr2_64",                                       {"hipblasZsyr2_64",                                           "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, UNSUPPORTED}},
   {"cublasCher2",                                          {"hipblasCher2_v2",                                           "rocblas_cher2",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, HIP_SUPPORTED_V2_ONLY}},
-  {"cublasCher2_64",                                       {"hipblasCher2_64",                                           "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, UNSUPPORTED}},
+  {"cublasCher2_64",                                       {"hipblasCher2_v2_64",                                        "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
   {"cublasZher2",                                          {"hipblasZher2_v2",                                           "rocblas_zher2",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, HIP_SUPPORTED_V2_ONLY}},
-  {"cublasZher2_64",                                       {"hipblasZher2_64",                                           "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, UNSUPPORTED}},
+  {"cublasZher2_64",                                       {"hipblasZher2_v2_64",                                        "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
 
   // SPR2/HPR2
   {"cublasSspr2",                                          {"hipblasSspr2",                                              "rocblas_sspr2",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, HIP_SUPPORTED_V2_ONLY}},
@@ -776,9 +776,9 @@ const std::map<llvm::StringRef, hipCounter> CUDA_BLAS_FUNCTION_MAP {
   {"cublasZsyr_v2",                                        {"hipblasZsyr_v2",                                            "rocblas_zsyr",                                       CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
   {"cublasZsyr_v2_64",                                     {"hipblasZsyr_64",                                            "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, UNSUPPORTED}},
   {"cublasCher_v2",                                        {"hipblasCher_v2",                                            "rocblas_cher",                                       CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
-  {"cublasCher_v2_64",                                     {"hipblasCher_64",                                            "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, UNSUPPORTED}},
+  {"cublasCher_v2_64",                                     {"hipblasCher_v2_64",                                         "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
   {"cublasZher_v2",                                        {"hipblasZher_v2",                                            "rocblas_zher",                                       CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
-  {"cublasZher_v2_64",                                     {"hipblasZher_64",                                            "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, UNSUPPORTED}},
+  {"cublasZher_v2_64",                                     {"hipblasZher_v2_64",                                         "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
 
   // SPR/HPR
   {"cublasSspr_v2",                                        {"hipblasSspr",                                               "rocblas_sspr",                                       CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
@@ -800,9 +800,9 @@ const std::map<llvm::StringRef, hipCounter> CUDA_BLAS_FUNCTION_MAP {
   {"cublasZsyr2_v2",                                       {"hipblasZsyr2_v2",                                           "rocblas_zsyr2",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
   {"cublasZsyr2_v2_64",                                    {"hipblasZsyr2_64",                                           "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, UNSUPPORTED}},
   {"cublasCher2_v2",                                       {"hipblasCher2_v2",                                           "rocblas_cher2",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
-  {"cublasCher2_v2_64",                                    {"hipblasCher2_64",                                           "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, UNSUPPORTED}},
+  {"cublasCher2_v2_64",                                    {"hipblasCher2_v2_64",                                        "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
   {"cublasZher2_v2",                                       {"hipblasZher2_v2",                                           "rocblas_zher2",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
-  {"cublasZher2_v2_64",                                    {"hipblasZher2_64",                                           "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, UNSUPPORTED}},
+  {"cublasZher2_v2_64",                                    {"hipblasZher2_v2_64",                                        "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
 
   // SPR2/HPR2
   {"cublasSspr2_v2",                                       {"hipblasSspr2",                                              "rocblas_sspr2",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
@@ -2084,6 +2084,10 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_BLAS_FUNCTION_VER_MAP {
   {"hipblasZhbmv_v2_64",                                   {HIP_6020, HIP_0,    HIP_0,  HIP_LATEST}},
   {"hipblasChemv_v2_64",                                   {HIP_6020, HIP_0,    HIP_0,  HIP_LATEST}},
   {"hipblasZhemv_v2_64",                                   {HIP_6020, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipblasCher_v2_64",                                    {HIP_6020, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipblasZher_v2_64",                                    {HIP_6020, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipblasCher2_v2_64",                                   {HIP_6020, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipblasZher2_v2_64",                                   {HIP_6020, HIP_0,    HIP_0,  HIP_LATEST}},
 
   {"rocblas_status_to_string",                             {HIP_3050, HIP_0,    HIP_0   }},
   {"rocblas_sscal",                                        {HIP_1050, HIP_0,    HIP_0   }},

--- a/tests/unit_tests/synthetic/libraries/cublas2hipblas_v2.cu
+++ b/tests/unit_tests/synthetic/libraries/cublas2hipblas_v2.cu
@@ -2404,6 +2404,34 @@ int main() {
   // CHECK-NEXT: blasStatus = hipblasZhemv_v2_64(blasHandle, blasFillMode, n_64, &dcomplexa, &dcomplexA, lda_64, &dcomplexx, incx_64, &dcomplexb, &dcomplexy, incy_64);
   blasStatus = cublasZhemv_64(blasHandle, blasFillMode, n_64, &dcomplexa, &dcomplexA, lda_64, &dcomplexx, incx_64, &dcomplexb, &dcomplexy, incy_64);
   blasStatus = cublasZhemv_v2_64(blasHandle, blasFillMode, n_64, &dcomplexa, &dcomplexA, lda_64, &dcomplexx, incx_64, &dcomplexb, &dcomplexy, incy_64);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasCher_v2_64(cublasHandle_t handle, cublasFillMode_t uplo, int64_t n, const float* alpha, const cuComplex* x, int64_t incx, cuComplex* A, int64_t lda);
+  // HIP: HIPBLAS_EXPORT hipblasStatus_t hipblasCher_v2_64(hipblasHandle_t handle, hipblasFillMode_t uplo, int64_t n, const float* alpha, const hipComplex* x, int64_t incx, hipComplex* AP, int64_t lda);
+  // CHECK: blasStatus = hipblasCher_v2_64(blasHandle, blasFillMode, n_64, &fa, &complexx, incx_64, &complexA, lda_64);
+  // CHECK-NEXT: blasStatus = hipblasCher_v2_64(blasHandle, blasFillMode, n_64, &fa, &complexx, incx_64, &complexA, lda_64);
+  blasStatus = cublasCher_64(blasHandle, blasFillMode, n_64, &fa, &complexx, incx_64, &complexA, lda_64);
+  blasStatus = cublasCher_v2_64(blasHandle, blasFillMode, n_64, &fa, &complexx, incx_64, &complexA, lda_64);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasZher_v2_64(cublasHandle_t handle, cublasFillMode_t uplo, int64_t n, const double* alpha, const cuDoubleComplex* x, int64_t incx, cuDoubleComplex* A, int64_t lda);
+  // HIP: HIPBLAS_EXPORT hipblasStatus_t hipblasZher_v2_64(hipblasHandle_t handle, hipblasFillMode_t uplo, int64_t n, const double* alpha, const hipDoubleComplex* x, int64_t incx, hipDoubleComplex* AP, int64_t lda);
+  // CHECK: blasStatus = hipblasZher_v2_64(blasHandle, blasFillMode, n_64, &da, &dcomplexx, incx_64, &dcomplexA, lda_64);
+  // CHECK-NEXT: blasStatus = hipblasZher_v2_64(blasHandle, blasFillMode, n_64, &da, &dcomplexx, incx_64, &dcomplexA, lda_64);
+  blasStatus = cublasZher_64(blasHandle, blasFillMode, n_64, &da, &dcomplexx, incx_64, &dcomplexA, lda_64);
+  blasStatus = cublasZher_v2_64(blasHandle, blasFillMode, n_64, &da, &dcomplexx, incx_64, &dcomplexA, lda_64);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasCher2_v2_64(cublasHandle_t handle, cublasFillMode_t uplo, int64_t n, const cuComplex* alpha, const cuComplex* x, int64_t incx, const cuComplex* y, int64_t incy, cuComplex* A, int64_t lda);
+  // HIP: HIPBLAS_EXPORT hipblasStatus_t hipblasCher2_v2_64(hipblasHandle_t handle, hipblasFillMode_t uplo, int64_t n, const hipComplex* alpha, const hipComplex* x, int64_t incx, const hipComplex* y, int64_t incy, hipComplex* AP, int64_t lda);
+  // CHECK: blasStatus = hipblasCher2_v2_64(blasHandle, blasFillMode, n_64, &complexa, &complexx, incx_64, &complexy, incy_64, &complexA, lda_64);
+  // CHECK-NEXT: blasStatus = hipblasCher2_v2_64(blasHandle, blasFillMode, n_64, &complexa, &complexx, incx_64, &complexy, incy_64, &complexA, lda_64);
+  blasStatus = cublasCher2_64(blasHandle, blasFillMode, n_64, &complexa, &complexx, incx_64, &complexy, incy_64, &complexA, lda_64);
+  blasStatus = cublasCher2_v2_64(blasHandle, blasFillMode, n_64, &complexa, &complexx, incx_64, &complexy, incy_64, &complexA, lda_64);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasZher2_v2_64(cublasHandle_t handle, cublasFillMode_t uplo, int64_t n, const cuDoubleComplex* alpha, const cuDoubleComplex* x, int64_t incx, const cuDoubleComplex* y, int64_t incy, cuDoubleComplex* A, int64_t lda);
+  // HIP: HIPBLAS_EXPORT hipblasStatus_t hipblasZher2_v2_64(hipblasHandle_t handle, hipblasFillMode_t uplo, int64_t n, const hipDoubleComplex* alpha, const hipDoubleComplex* x, int64_t incx, const hipDoubleComplex* y, int64_t incy, hipDoubleComplex* AP, int64_t lda);
+  // CHECK: blasStatus = hipblasZher2_v2_64(blasHandle, blasFillMode, n_64, &dcomplexa, &dcomplexx, incx_64, &dcomplexy, incy_64, &dcomplexA, lda_64);
+  // CHECK-NEXT: blasStatus = hipblasZher2_v2_64(blasHandle, blasFillMode, n_64, &dcomplexa, &dcomplexx, incx_64, &dcomplexy, incy_64, &dcomplexA, lda_64);
+  blasStatus = cublasZher2_64(blasHandle, blasFillMode, n_64, &dcomplexa, &dcomplexx, incx_64, &dcomplexy, incy_64, &dcomplexA, lda_64);
+  blasStatus = cublasZher2_v2_64(blasHandle, blasFillMode, n_64, &dcomplexa, &dcomplexx, incx_64, &dcomplexy, incy_64, &dcomplexA, lda_64);
 #endif
 
   return 0;


### PR DESCRIPTION
+ Updated synthetic tests, the regenerated `hipify-perl`, and `BLAS` `CUDA2HIP` documentation