### PR TITLE
[HIPIFY][BLAS][6.2.0] cuBLAS support - Step 10 - 64-bit functions

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -3979,11 +3979,15 @@ sub simpleSubstitutions {
     subst("cublasDscal_v2", "hipblasDscal", "library");
     subst("cublasDscal_v2_64", "hipblasDscal_64", "library");
     subst("cublasDspmv", "hipblasDspmv", "library");
+    subst("cublasDspmv_64", "hipblasDspmv_64", "library");
     subst("cublasDspmv_v2", "hipblasDspmv", "library");
+    subst("cublasDspmv_v2_64", "hipblasDspmv_64", "library");
     subst("cublasDspr", "hipblasDspr", "library");
     subst("cublasDspr2", "hipblasDspr2", "library");
     subst("cublasDspr2_v2", "hipblasDspr2", "library");
+    subst("cublasDspr_64", "hipblasDspr_64", "library");
     subst("cublasDspr_v2", "hipblasDspr", "library");
+    subst("cublasDspr_v2_64", "hipblasDspr_64", "library");
     subst("cublasDswap", "hipblasDswap", "library");
     subst("cublasDswap_64", "hipblasDswap_64", "library");
     subst("cublasDswap_v2", "hipblasDswap", "library");
@@ -4179,11 +4183,15 @@ sub simpleSubstitutions {
     subst("cublasSscal_v2", "hipblasSscal", "library");
     subst("cublasSscal_v2_64", "hipblasSscal_64", "library");
     subst("cublasSspmv", "hipblasSspmv", "library");
+    subst("cublasSspmv_64", "hipblasSspmv_64", "library");
     subst("cublasSspmv_v2", "hipblasSspmv", "library");
+    subst("cublasSspmv_v2_64", "hipblasSspmv_64", "library");
     subst("cublasSspr", "hipblasSspr", "library");
     subst("cublasSspr2", "hipblasSspr2", "library");
     subst("cublasSspr2_v2", "hipblasSspr2", "library");
+    subst("cublasSspr_64", "hipblasSspr_64", "library");
     subst("cublasSspr_v2", "hipblasSspr", "library");
+    subst("cublasSspr_v2_64", "hipblasSspr_64", "library");
     subst("cublasSswap", "hipblasSswap", "library");
     subst("cublasSswap_64", "hipblasSswap_64", "library");
     subst("cublasSswap_v2", "hipblasSswap", "library");
@@ -11556,12 +11564,8 @@ sub warnHipOnlyUnsupportedFunctions {
         "cublasSsymv_64",
         "cublasSsymm_v2_64",
         "cublasSsymm_64",
-        "cublasSspr_v2_64",
-        "cublasSspr_64",
         "cublasSspr2_v2_64",
         "cublasSspr2_64",
-        "cublasSspmv_v2_64",
-        "cublasSspmv_64",
         "cublasSmatinvBatched",
         "cublasShutdown",
         "cublasSgemm_v2_64",
@@ -11694,12 +11698,8 @@ sub warnHipOnlyUnsupportedFunctions {
         "cublasDsymv_64",
         "cublasDsymm_v2_64",
         "cublasDsymm_64",
-        "cublasDspr_v2_64",
-        "cublasDspr_64",
         "cublasDspr2_v2_64",
         "cublasDspr2_64",
-        "cublasDspmv_v2_64",
-        "cublasDspmv_64",
         "cublasDotcEx_64",
         "cublasDotEx_64",
         "cublasDmatinvBatched",

--- a/docs/tables/CUBLAS_API_supported_by_HIP.md
+++ b/docs/tables/CUBLAS_API_supported_by_HIP.md
@@ -819,17 +819,17 @@
 |`cublasDsbmv_v2`| | | | |`hipblasDsbmv`|3.5.0| | | | |
 |`cublasDsbmv_v2_64`|12.0| | | |`hipblasDsbmv_64`|6.2.0| | | |6.2.0|
 |`cublasDspmv`| | | | |`hipblasDspmv`|3.5.0| | | | |
-|`cublasDspmv_64`|12.0| | | | | | | | | |
+|`cublasDspmv_64`|12.0| | | |`hipblasDspmv_64`|6.2.0| | | |6.2.0|
 |`cublasDspmv_v2`| | | | |`hipblasDspmv`|3.5.0| | | | |
-|`cublasDspmv_v2_64`|12.0| | | | | | | | | |
+|`cublasDspmv_v2_64`|12.0| | | |`hipblasDspmv_64`|6.2.0| | | |6.2.0|
 |`cublasDspr`| | | | |`hipblasDspr`|3.5.0| | | | |
 |`cublasDspr2`| | | | |`hipblasDspr2`|3.5.0| | | | |
 |`cublasDspr2_64`|12.0| | | | | | | | | |
 |`cublasDspr2_v2`| | | | |`hipblasDspr2`|3.5.0| | | | |
 |`cublasDspr2_v2_64`|12.0| | | | | | | | | |
-|`cublasDspr_64`|12.0| | | | | | | | | |
+|`cublasDspr_64`|12.0| | | |`hipblasDspr_64`|6.2.0| | | |6.2.0|
 |`cublasDspr_v2`| | | | |`hipblasDspr`|3.5.0| | | | |
-|`cublasDspr_v2_64`|12.0| | | | | | | | | |
+|`cublasDspr_v2_64`|12.0| | | |`hipblasDspr_64`|6.2.0| | | |6.2.0|
 |`cublasDsymv`| | | | |`hipblasDsymv`|3.5.0| | | | |
 |`cublasDsymv_64`|12.0| | | | | | | | | |
 |`cublasDsymv_v2`| | | | |`hipblasDsymv`|3.5.0| | | | |
@@ -883,17 +883,17 @@
 |`cublasSsbmv_v2`| | | | |`hipblasSsbmv`|3.5.0| | | | |
 |`cublasSsbmv_v2_64`|12.0| | | |`hipblasSsbmv_64`|6.2.0| | | |6.2.0|
 |`cublasSspmv`| | | | |`hipblasSspmv`|3.5.0| | | | |
-|`cublasSspmv_64`|12.0| | | | | | | | | |
+|`cublasSspmv_64`|12.0| | | |`hipblasSspmv_64`|6.2.0| | | |6.2.0|
 |`cublasSspmv_v2`| | | | |`hipblasSspmv`|3.5.0| | | | |
-|`cublasSspmv_v2_64`|12.0| | | | | | | | | |
+|`cublasSspmv_v2_64`|12.0| | | |`hipblasSspmv_64`|6.2.0| | | |6.2.0|
 |`cublasSspr`| | | | |`hipblasSspr`|3.5.0| | | | |
 |`cublasSspr2`| | | | |`hipblasSspr2`|3.5.0| | | | |
 |`cublasSspr2_64`|12.0| | | | | | | | | |
 |`cublasSspr2_v2`| | | | |`hipblasSspr2`|3.5.0| | | | |
 |`cublasSspr2_v2_64`|12.0| | | | | | | | | |
-|`cublasSspr_64`|12.0| | | | | | | | | |
+|`cublasSspr_64`|12.0| | | |`hipblasSspr_64`|6.2.0| | | |6.2.0|
 |`cublasSspr_v2`| | | | |`hipblasSspr`|3.5.0| | | | |
-|`cublasSspr_v2_64`|12.0| | | | | | | | | |
+|`cublasSspr_v2_64`|12.0| | | |`hipblasSspr_64`|6.2.0| | | |6.2.0|
 |`cublasSsymv`| | | | |`hipblasSsymv`|3.5.0| | | | |
 |`cublasSsymv_64`|12.0| | | | | | | | | |
 |`cublasSsymv_v2`| | | | |`hipblasSsymv`|3.5.0| | | | |

--- a/docs/tables/CUBLAS_API_supported_by_HIP_and_ROC.md
+++ b/docs/tables/CUBLAS_API_supported_by_HIP_and_ROC.md
@@ -819,17 +819,17 @@
 |`cublasDsbmv_v2`| | | | |`hipblasDsbmv`|3.5.0| | | | |`rocblas_dsbmv`|3.5.0| | | | |
 |`cublasDsbmv_v2_64`|12.0| | | |`hipblasDsbmv_64`|6.2.0| | | |6.2.0| | | | | | |
 |`cublasDspmv`| | | | |`hipblasDspmv`|3.5.0| | | | |`rocblas_dspmv`|3.5.0| | | | |
-|`cublasDspmv_64`|12.0| | | | | | | | | | | | | | | |
+|`cublasDspmv_64`|12.0| | | |`hipblasDspmv_64`|6.2.0| | | |6.2.0| | | | | | |
 |`cublasDspmv_v2`| | | | |`hipblasDspmv`|3.5.0| | | | |`rocblas_dspmv`|3.5.0| | | | |
-|`cublasDspmv_v2_64`|12.0| | | | | | | | | | | | | | | |
+|`cublasDspmv_v2_64`|12.0| | | |`hipblasDspmv_64`|6.2.0| | | |6.2.0| | | | | | |
 |`cublasDspr`| | | | |`hipblasDspr`|3.5.0| | | | |`rocblas_dspr`|3.5.0| | | | |
 |`cublasDspr2`| | | | |`hipblasDspr2`|3.5.0| | | | |`rocblas_dspr2`|3.5.0| | | | |
 |`cublasDspr2_64`|12.0| | | | | | | | | | | | | | | |
 |`cublasDspr2_v2`| | | | |`hipblasDspr2`|3.5.0| | | | |`rocblas_dspr2`|3.5.0| | | | |
 |`cublasDspr2_v2_64`|12.0| | | | | | | | | | | | | | | |
-|`cublasDspr_64`|12.0| | | | | | | | | | | | | | | |
+|`cublasDspr_64`|12.0| | | |`hipblasDspr_64`|6.2.0| | | |6.2.0| | | | | | |
 |`cublasDspr_v2`| | | | |`hipblasDspr`|3.5.0| | | | |`rocblas_dspr`|3.5.0| | | | |
-|`cublasDspr_v2_64`|12.0| | | | | | | | | | | | | | | |
+|`cublasDspr_v2_64`|12.0| | | |`hipblasDspr_64`|6.2.0| | | |6.2.0| | | | | | |
 |`cublasDsymv`| | | | |`hipblasDsymv`|3.5.0| | | | |`rocblas_dsymv`|1.5.0| | | | |
 |`cublasDsymv_64`|12.0| | | | | | | | | | | | | | | |
 |`cublasDsymv_v2`| | | | |`hipblasDsymv`|3.5.0| | | | |`rocblas_dsymv`|1.5.0| | | | |
@@ -883,17 +883,17 @@
 |`cublasSsbmv_v2`| | | | |`hipblasSsbmv`|3.5.0| | | | |`rocblas_ssbmv`|3.5.0| | | | |
 |`cublasSsbmv_v2_64`|12.0| | | |`hipblasSsbmv_64`|6.2.0| | | |6.2.0| | | | | | |
 |`cublasSspmv`| | | | |`hipblasSspmv`|3.5.0| | | | |`rocblas_sspmv`|3.5.0| | | | |
-|`cublasSspmv_64`|12.0| | | | | | | | | | | | | | | |
+|`cublasSspmv_64`|12.0| | | |`hipblasSspmv_64`|6.2.0| | | |6.2.0| | | | | | |
 |`cublasSspmv_v2`| | | | |`hipblasSspmv`|3.5.0| | | | |`rocblas_sspmv`|3.5.0| | | | |
-|`cublasSspmv_v2_64`|12.0| | | | | | | | | | | | | | | |
+|`cublasSspmv_v2_64`|12.0| | | |`hipblasSspmv_64`|6.2.0| | | |6.2.0| | | | | | |
 |`cublasSspr`| | | | |`hipblasSspr`|3.5.0| | | | |`rocblas_sspr`|3.5.0| | | | |
 |`cublasSspr2`| | | | |`hipblasSspr2`|3.5.0| | | | |`rocblas_sspr2`|3.5.0| | | | |
 |`cublasSspr2_64`|12.0| | | | | | | | | | | | | | | |
 |`cublasSspr2_v2`| | | | |`hipblasSspr2`|3.5.0| | | | |`rocblas_sspr2`|3.5.0| | | | |
 |`cublasSspr2_v2_64`|12.0| | | | | | | | | | | | | | | |
-|`cublasSspr_64`|12.0| | | | | | | | | | | | | | | |
+|`cublasSspr_64`|12.0| | | |`hipblasSspr_64`|6.2.0| | | |6.2.0| | | | | | |
 |`cublasSspr_v2`| | | | |`hipblasSspr`|3.5.0| | | | |`rocblas_sspr`|3.5.0| | | | |
-|`cublasSspr_v2_64`|12.0| | | | | | | | | | | | | | | |
+|`cublasSspr_v2_64`|12.0| | | |`hipblasSspr_64`|6.2.0| | | |6.2.0| | | | | | |
 |`cublasSsymv`| | | | |`hipblasSsymv`|3.5.0| | | | |`rocblas_ssymv`|1.5.0| | | | |
 |`cublasSsymv_64`|12.0| | | | | | | | | | | | | | | |
 |`cublasSsymv_v2`| | | | |`hipblasSsymv`|3.5.0| | | | |`rocblas_ssymv`|1.5.0| | | | |

--- a/src/CUDA2HIP_BLAS_API_functions.cpp
+++ b/src/CUDA2HIP_BLAS_API_functions.cpp
@@ -326,9 +326,9 @@ const std::map<llvm::StringRef, hipCounter> CUDA_BLAS_FUNCTION_MAP {
 
   // SPMV/HPMV
   {"cublasSspmv",                                          {"hipblasSspmv",                                              "rocblas_sspmv",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, HIP_SUPPORTED_V2_ONLY}},
-  {"cublasSspmv_64",                                       {"hipblasSspmv_64",                                           "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, UNSUPPORTED}},
+  {"cublasSspmv_64",                                       {"hipblasSspmv_64",                                           "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
   {"cublasDspmv",                                          {"hipblasDspmv",                                              "rocblas_dspmv",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, HIP_SUPPORTED_V2_ONLY}},
-  {"cublasDspmv_64",                                       {"hipblasDspmv_64",                                           "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, UNSUPPORTED}},
+  {"cublasDspmv_64",                                       {"hipblasDspmv_64",                                           "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
   {"cublasChpmv",                                          {"hipblasChpmv_v2",                                           "rocblas_chpmv",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, HIP_SUPPORTED_V2_ONLY}},
   {"cublasChpmv_64",                                       {"hipblasChpmv_v2_64",                                        "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
   {"cublasZhpmv",                                          {"hipblasZhpmv_v2",                                           "rocblas_zhpmv",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, HIP_SUPPORTED_V2_ONLY}},
@@ -364,9 +364,9 @@ const std::map<llvm::StringRef, hipCounter> CUDA_BLAS_FUNCTION_MAP {
 
   // SPR/HPR
   {"cublasSspr",                                           {"hipblasSspr",                                               "rocblas_sspr",                                       CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, HIP_SUPPORTED_V2_ONLY}},
-  {"cublasSspr_64",                                        {"hipblasSspr_64",                                            "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, UNSUPPORTED}},
+  {"cublasSspr_64",                                        {"hipblasSspr_64",                                            "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
   {"cublasDspr",                                           {"hipblasDspr",                                               "rocblas_dspr",                                       CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, HIP_SUPPORTED_V2_ONLY}},
-  {"cublasDspr_64",                                        {"hipblasDspr_64",                                            "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, UNSUPPORTED}},
+  {"cublasDspr_64",                                        {"hipblasDspr_64",                                            "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
   {"cublasChpr",                                           {"hipblasChpr_v2",                                            "rocblas_chpr",                                       CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, HIP_SUPPORTED_V2_ONLY}},
   {"cublasChpr_64",                                        {"hipblasChpr_v2_64",                                         "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
   {"cublasZhpr",                                           {"hipblasZhpr_v2",                                            "rocblas_zhpr",                                       CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, HIP_SUPPORTED_V2_ONLY}},
@@ -744,9 +744,9 @@ const std::map<llvm::StringRef, hipCounter> CUDA_BLAS_FUNCTION_MAP {
 
   // SPMV/HPMV
   {"cublasSspmv_v2",                                       {"hipblasSspmv",                                              "rocblas_sspmv",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
-  {"cublasSspmv_v2_64",                                    {"hipblasSspmv_64",                                           "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, UNSUPPORTED}},
+  {"cublasSspmv_v2_64",                                    {"hipblasSspmv_64",                                           "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
   {"cublasDspmv_v2",                                       {"hipblasDspmv",                                              "rocblas_dspmv",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
-  {"cublasDspmv_v2_64",                                    {"hipblasDspmv_64",                                           "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, UNSUPPORTED}},
+  {"cublasDspmv_v2_64",                                    {"hipblasDspmv_64",                                           "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
   {"cublasChpmv_v2",                                       {"hipblasChpmv_v2",                                           "rocblas_chpmv",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
   {"cublasChpmv_v2_64",                                    {"hipblasChpmv_v2_64",                                        "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
   {"cublasZhpmv_v2",                                       {"hipblasZhpmv_v2",                                           "rocblas_zhpmv",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
@@ -782,9 +782,9 @@ const std::map<llvm::StringRef, hipCounter> CUDA_BLAS_FUNCTION_MAP {
 
   // SPR/HPR
   {"cublasSspr_v2",                                        {"hipblasSspr",                                               "rocblas_sspr",                                       CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
-  {"cublasSspr_v2_64",                                     {"hipblasSspr_64",                                            "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, UNSUPPORTED}},
+  {"cublasSspr_v2_64",                                     {"hipblasSspr_64",                                            "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
   {"cublasDspr_v2",                                        {"hipblasDspr",                                               "rocblas_dspr",                                       CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
-  {"cublasDspr_v2_64",                                     {"hipblasDspr_64",                                            "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, UNSUPPORTED}},
+  {"cublasDspr_v2_64",                                     {"hipblasDspr_64",                                            "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
   {"cublasChpr_v2",                                        {"hipblasChpr_v2",                                            "rocblas_chpr",                                       CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
   {"cublasChpr_v2_64",                                     {"hipblasChpr_v2_64",                                         "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
   {"cublasZhpr_v2",                                        {"hipblasZhpr_v2",                                            "rocblas_zhpr",                                       CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
@@ -2096,6 +2096,10 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_BLAS_FUNCTION_VER_MAP {
   {"hipblasZhpr2_v2_64",                                   {HIP_6020, HIP_0,    HIP_0,  HIP_LATEST}},
   {"hipblasSsbmv_64",                                      {HIP_6020, HIP_0,    HIP_0,  HIP_LATEST}},
   {"hipblasDsbmv_64",                                      {HIP_6020, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipblasSspmv_64",                                      {HIP_6020, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipblasDspmv_64",                                      {HIP_6020, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipblasSspr_64",                                       {HIP_6020, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipblasDspr_64",                                       {HIP_6020, HIP_0,    HIP_0,  HIP_LATEST}},
 
   {"rocblas_status_to_string",                             {HIP_3050, HIP_0,    HIP_0   }},
   {"rocblas_sscal",                                        {HIP_1050, HIP_0,    HIP_0   }},

--- a/tests/unit_tests/synthetic/libraries/cublas2hipblas_v2.cu
+++ b/tests/unit_tests/synthetic/libraries/cublas2hipblas_v2.cu
@@ -2488,6 +2488,34 @@ int main() {
   // CHECK-NEXT: blasStatus = hipblasDsbmv_64(blasHandle, blasFillMode, n_64, k_64, &da, &dA, lda_64, &dx, incx_64, &db, &dy, incy_64);
   blasStatus = cublasDsbmv_64(blasHandle, blasFillMode, n_64, k_64, &da, &dA, lda_64, &dx, incx_64, &db, &dy, incy_64);
   blasStatus = cublasDsbmv_v2_64(blasHandle, blasFillMode, n_64, k_64, &da, &dA, lda_64, &dx, incx_64, &db, &dy, incy_64);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasSspmv_v2_64(cublasHandle_t handle, cublasFillMode_t uplo, int64_t n, const float* alpha, const float* AP, const float* x, int64_t incx, const float* beta, float* y, int64_t incy);
+  // HIP: HIPBLAS_EXPORT hipblasStatus_t hipblasSspmv_64(hipblasHandle_t handle, hipblasFillMode_t uplo, int64_t n, const float* alpha, const float* AP, const float* x, int64_t incx, const float* beta, float* y, int64_t incy);
+  // CHECK: blasStatus = hipblasSspmv_64(blasHandle, blasFillMode, n_64, &fa, &fA, &fx, incx_64, &fb, &fy, incy_64);
+  // CHECK-NEXT: blasStatus = hipblasSspmv_64(blasHandle, blasFillMode, n_64, &fa, &fA, &fx, incx_64, &fb, &fy, incy_64);
+  blasStatus = cublasSspmv_64(blasHandle, blasFillMode, n_64, &fa, &fA, &fx, incx_64, &fb, &fy, incy_64);
+  blasStatus = cublasSspmv_v2_64(blasHandle, blasFillMode, n_64, &fa, &fA, &fx, incx_64, &fb, &fy, incy_64);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasDspmv_v2_64(cublasHandle_t handle, cublasFillMode_t uplo, int64_t n, const double* alpha, const double* AP, const double* x, int64_t incx, const double* beta, double* y, int64_t incy);
+  // HIP: HIPBLAS_EXPORT hipblasStatus_t hipblasDspmv_64(hipblasHandle_t handle, hipblasFillMode_t uplo, int64_t n, const double* alpha, const double* AP, const double* x, int64_t incx, const double* beta, double* y, int64_t incy);
+  // CHECK: blasStatus = hipblasDspmv_64(blasHandle, blasFillMode, n_64, &da, &dA, &dx, incx_64, &db, &dy, incy_64);
+  // CHECK-NEXT: blasStatus = hipblasDspmv_64(blasHandle, blasFillMode, n_64, &da, &dA, &dx, incx_64, &db, &dy, incy_64);
+  blasStatus = cublasDspmv_64(blasHandle, blasFillMode, n_64, &da, &dA, &dx, incx_64, &db, &dy, incy_64);
+  blasStatus = cublasDspmv_v2_64(blasHandle, blasFillMode, n_64, &da, &dA, &dx, incx_64, &db, &dy, incy_64);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasSspr_v2_64(cublasHandle_t handle, cublasFillMode_t uplo, int64_t n, const float* alpha, const float* x, int64_t incx, float* AP);
+  // HIP: HIPBLAS_EXPORT hipblasStatus_t hipblasSspr_64(hipblasHandle_t handle, hipblasFillMode_t uplo, int64_t n, const float* alpha, const float* x, int64_t incx, float* AP);
+  // CHECK: blasStatus = hipblasSspr_64(blasHandle, blasFillMode, n_64, &fa, &fx, incx_64, &fA);
+  // CHECK-NEXT: blasStatus = hipblasSspr_64(blasHandle, blasFillMode, n_64, &fa, &fx, incx_64, &fA);
+  blasStatus = cublasSspr_64(blasHandle, blasFillMode, n_64, &fa, &fx, incx_64, &fA);
+  blasStatus = cublasSspr_v2_64(blasHandle, blasFillMode, n_64, &fa, &fx, incx_64, &fA);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasDspr_v2_64(cublasHandle_t handle, cublasFillMode_t uplo, int64_t n, const double* alpha, const double* x, int64_t incx, double* AP);
+  // HIP: HIPBLAS_EXPORT hipblasStatus_t hipblasDspr_64(hipblasHandle_t handle, hipblasFillMode_t uplo, int64_t n, const double* alpha, const double* x, int64_t incx, double* AP);
+  // CHECK: blasStatus = hipblasDspr_64(blasHandle, blasFillMode, n_64, &da, &dx, incx_64, &dA);
+  // CHECK-NEXT: blasStatus = hipblasDspr_64(blasHandle, blasFillMode, n_64, &da, &dx, incx_64, &dA);
+  blasStatus = cublasDspr_64(blasHandle, blasFillMode, n_64, &da, &dx, incx_64, &dA);
+  blasStatus = cublasDspr_v2_64(blasHandle, blasFillMode, n_64, &da, &dx, incx_64, &dA);
 #endif
 
   return 0;


### PR DESCRIPTION
+ Updated synthetic tests, the regenerated `hipify-perl`, and `BLAS` `CUDA2HIP` documentation
