### PR TITLE
[HIPIFY][BLAS][6.2.0] cuBLAS support - Step 19 - 64-bit functions - Revising

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -1444,21 +1444,53 @@ my %experimental_funcs = (
     "cudaDriverEntryPointSymbolNotFound" => "6.2.0",
     "cudaDriverEntryPointSuccess" => "6.2.0",
     "cudaDriverEntryPointQueryResult" => "6.2.0",
+    "cublasZtrmv_v2_64" => "6.2.0",
+    "cublasZtrmv_64" => "6.2.0",
+    "cublasZtpsv_v2_64" => "6.2.0",
+    "cublasZtpsv_64" => "6.2.0",
+    "cublasZtpmv_v2_64" => "6.2.0",
+    "cublasZtpmv_64" => "6.2.0",
+    "cublasZtbmv_v2_64" => "6.2.0",
+    "cublasZtbmv_64" => "6.2.0",
     "cublasZgemv_v2_64" => "6.2.0",
     "cublasZgemv_64" => "6.2.0",
     "cublasZgemvBatched_64" => "6.2.0",
     "cublasZgbmv_v2_64" => "6.2.0",
     "cublasZgbmv_64" => "6.2.0",
+    "cublasStrmv_v2_64" => "6.2.0",
+    "cublasStrmv_64" => "6.2.0",
+    "cublasStpsv_v2_64" => "6.2.0",
+    "cublasStpsv_64" => "6.2.0",
+    "cublasStpmv_v2_64" => "6.2.0",
+    "cublasStpmv_64" => "6.2.0",
+    "cublasStbmv_v2_64" => "6.2.0",
+    "cublasStbmv_64" => "6.2.0",
     "cublasSgemv_v2_64" => "6.2.0",
     "cublasSgemv_64" => "6.2.0",
     "cublasSgemvBatched_64" => "6.2.0",
     "cublasSgbmv_v2_64" => "6.2.0",
     "cublasSgbmv_64" => "6.2.0",
+    "cublasDtrmv_v2_64" => "6.2.0",
+    "cublasDtrmv_64" => "6.2.0",
+    "cublasDtpsv_v2_64" => "6.2.0",
+    "cublasDtpsv_64" => "6.2.0",
+    "cublasDtpmv_v2_64" => "6.2.0",
+    "cublasDtpmv_64" => "6.2.0",
+    "cublasDtbmv_v2_64" => "6.2.0",
+    "cublasDtbmv_64" => "6.2.0",
     "cublasDgemv_v2_64" => "6.2.0",
     "cublasDgemv_64" => "6.2.0",
     "cublasDgemvBatched_64" => "6.2.0",
     "cublasDgbmv_v2_64" => "6.2.0",
     "cublasDgbmv_64" => "6.2.0",
+    "cublasCtrmv_v2_64" => "6.2.0",
+    "cublasCtrmv_64" => "6.2.0",
+    "cublasCtpsv_v2_64" => "6.2.0",
+    "cublasCtpsv_64" => "6.2.0",
+    "cublasCtpmv_v2_64" => "6.2.0",
+    "cublasCtpmv_64" => "6.2.0",
+    "cublasCtbmv_v2_64" => "6.2.0",
+    "cublasCtbmv_64" => "6.2.0",
     "cublasCgemv_v2_64" => "6.2.0",
     "cublasCgemv_64" => "6.2.0",
     "cublasCgemvBatched_64" => "6.2.0",
@@ -1664,26 +1696,58 @@ sub experimentalSubstitutions {
     subst("cuGetProcAddress", "hipGetProcAddress", "driver_entry_point");
     subst("cudaGetDriverEntryPoint", "hipGetProcAddress", "driver_entry_point");
     subst("cudaGetFuncBySymbol", "hipGetFuncBySymbol", "driver_interact");
-    subst("cublasCgbmv_64", "hipblasCgbmv_64", "library");
+    subst("cublasCgbmv_64", "hipblasCgbmv_v2_64", "library");
     subst("cublasCgbmv_v2_64", "hipblasCgbmv_v2_64", "library");
     subst("cublasCgemvBatched_64", "hipblasCgemvBatched_v2_64", "library");
     subst("cublasCgemv_64", "hipblasCgemv_64", "library");
     subst("cublasCgemv_v2_64", "hipblasCgemv_v2_64", "library");
+    subst("cublasCtbmv_64", "hipblasCtbmv_v2_64", "library");
+    subst("cublasCtbmv_v2_64", "hipblasCtbmv_v2_64", "library");
+    subst("cublasCtpmv_64", "hipblasCtpmv_v2_64", "library");
+    subst("cublasCtpmv_v2_64", "hipblasCtpmv_v2_64", "library");
+    subst("cublasCtpsv_64", "hipblasCtpsv_v2_64", "library");
+    subst("cublasCtpsv_v2_64", "hipblasCtpsv_v2_64", "library");
+    subst("cublasCtrmv_64", "hipblasCtrmv_v2_64", "library");
+    subst("cublasCtrmv_v2_64", "hipblasCtrmv_v2_64", "library");
     subst("cublasDgbmv_64", "hipblasDgbmv_64", "library");
     subst("cublasDgbmv_v2_64", "hipblasDgbmv_64", "library");
     subst("cublasDgemvBatched_64", "hipblasDgemvBatched_64", "library");
     subst("cublasDgemv_64", "hipblasDgemv_64", "library");
     subst("cublasDgemv_v2_64", "hipblasDgemv_64", "library");
+    subst("cublasDtbmv_64", "hipblasDtbmv_64", "library");
+    subst("cublasDtbmv_v2_64", "hipblasDtbmv_64", "library");
+    subst("cublasDtpmv_64", "hipblasDtpmv_64", "library");
+    subst("cublasDtpmv_v2_64", "hipblasDtpmv_64", "library");
+    subst("cublasDtpsv_64", "hipblasDtpsv_64", "library");
+    subst("cublasDtpsv_v2_64", "hipblasDtpsv_64", "library");
+    subst("cublasDtrmv_64", "hipblasDtrmv_64", "library");
+    subst("cublasDtrmv_v2_64", "hipblasDtrmv_64", "library");
     subst("cublasSgbmv_64", "hipblasSgbmv_64", "library");
     subst("cublasSgbmv_v2_64", "hipblasSgbmv_64", "library");
     subst("cublasSgemvBatched_64", "hipblasSgemvBatched_64", "library");
     subst("cublasSgemv_64", "hipblasSgemv_64", "library");
     subst("cublasSgemv_v2_64", "hipblasSgemv_64", "library");
-    subst("cublasZgbmv_64", "hipblasZgbmv_64", "library");
+    subst("cublasStbmv_64", "hipblasStbmv_64", "library");
+    subst("cublasStbmv_v2_64", "hipblasStbmv_64", "library");
+    subst("cublasStpmv_64", "hipblasStpmv_64", "library");
+    subst("cublasStpmv_v2_64", "hipblasStpmv_64", "library");
+    subst("cublasStpsv_64", "hipblasStpsv_64", "library");
+    subst("cublasStpsv_v2_64", "hipblasStpsv_64", "library");
+    subst("cublasStrmv_64", "hipblasStrmv_64", "library");
+    subst("cublasStrmv_v2_64", "hipblasStrmv_64", "library");
+    subst("cublasZgbmv_64", "hipblasZgbmv_v2_64", "library");
     subst("cublasZgbmv_v2_64", "hipblasZgbmv_v2_64", "library");
     subst("cublasZgemvBatched_64", "hipblasZgemvBatched_v2_64", "library");
     subst("cublasZgemv_64", "hipblasZgemv_64", "library");
     subst("cublasZgemv_v2_64", "hipblasZgemv_v2_64", "library");
+    subst("cublasZtbmv_64", "hipblasZtbmv_v2_64", "library");
+    subst("cublasZtbmv_v2_64", "hipblasZtbmv_v2_64", "library");
+    subst("cublasZtpmv_64", "hipblasZtpmv_v2_64", "library");
+    subst("cublasZtpmv_v2_64", "hipblasZtpmv_v2_64", "library");
+    subst("cublasZtpsv_64", "hipblasZtpsv_v2_64", "library");
+    subst("cublasZtpsv_v2_64", "hipblasZtpsv_v2_64", "library");
+    subst("cublasZtrmv_64", "hipblasZtrmv_v2_64", "library");
+    subst("cublasZtrmv_v2_64", "hipblasZtrmv_v2_64", "library");
     subst("curandSetGeneratorOrdering", "hiprandSetGeneratorOrdering", "library");
     subst("cusolverDnCreateParams", "hipsolverDnCreateParams", "library");
     subst("cusolverDnDestroyParams", "hipsolverDnDestroyParams", "library");
@@ -3902,27 +3966,19 @@ sub simpleSubstitutions {
     subst("cublasCsyrk_v2", "hipblasCsyrk_v2", "library");
     subst("cublasCsyrkx", "hipblasCsyrkx_v2", "library");
     subst("cublasCtbmv", "hipblasCtbmv_v2", "library");
-    subst("cublasCtbmv_64", "hipblasCtbmv_v2_64", "library");
     subst("cublasCtbmv_v2", "hipblasCtbmv_v2", "library");
-    subst("cublasCtbmv_v2_64", "hipblasCtbmv_v2_64", "library");
     subst("cublasCtbsv", "hipblasCtbsv_v2", "library");
     subst("cublasCtbsv_64", "hipblasCtbsv_v2_64", "library");
     subst("cublasCtbsv_v2", "hipblasCtbsv_v2", "library");
     subst("cublasCtbsv_v2_64", "hipblasCtbsv_v2_64", "library");
     subst("cublasCtpmv", "hipblasCtpmv_v2", "library");
-    subst("cublasCtpmv_64", "hipblasCtpmv_v2_64", "library");
     subst("cublasCtpmv_v2", "hipblasCtpmv_v2", "library");
-    subst("cublasCtpmv_v2_64", "hipblasCtpmv_v2_64", "library");
     subst("cublasCtpsv", "hipblasCtpsv_v2", "library");
-    subst("cublasCtpsv_64", "hipblasCtpsv_v2_64", "library");
     subst("cublasCtpsv_v2", "hipblasCtpsv_v2", "library");
-    subst("cublasCtpsv_v2_64", "hipblasCtpsv_v2_64", "library");
     subst("cublasCtrmm", "hipblasCtrmm_v2", "library");
     subst("cublasCtrmm_v2", "hipblasCtrmm_v2", "library");
     subst("cublasCtrmv", "hipblasCtrmv_v2", "library");
-    subst("cublasCtrmv_64", "hipblasCtrmv_v2_64", "library");
     subst("cublasCtrmv_v2", "hipblasCtrmv_v2", "library");
-    subst("cublasCtrmv_v2_64", "hipblasCtrmv_v2_64", "library");
     subst("cublasCtrsm", "hipblasCtrsm_v2", "library");
     subst("cublasCtrsmBatched", "hipblasCtrsmBatched_v2", "library");
     subst("cublasCtrsm_v2", "hipblasCtrsm_v2", "library");
@@ -4030,27 +4086,19 @@ sub simpleSubstitutions {
     subst("cublasDsyrk_v2", "hipblasDsyrk", "library");
     subst("cublasDsyrkx", "hipblasDsyrkx", "library");
     subst("cublasDtbmv", "hipblasDtbmv", "library");
-    subst("cublasDtbmv_64", "hipblasDtbmv_64", "library");
     subst("cublasDtbmv_v2", "hipblasDtbmv", "library");
-    subst("cublasDtbmv_v2_64", "hipblasDtbmv_64", "library");
     subst("cublasDtbsv", "hipblasDtbsv", "library");
     subst("cublasDtbsv_64", "hipblasDtbsv_64", "library");
     subst("cublasDtbsv_v2", "hipblasDtbsv", "library");
     subst("cublasDtbsv_v2_64", "hipblasDtbsv_64", "library");
     subst("cublasDtpmv", "hipblasDtpmv", "library");
-    subst("cublasDtpmv_64", "hipblasDtpmv_64", "library");
     subst("cublasDtpmv_v2", "hipblasDtpmv", "library");
-    subst("cublasDtpmv_v2_64", "hipblasDtpmv_64", "library");
     subst("cublasDtpsv", "hipblasDtpsv", "library");
-    subst("cublasDtpsv_64", "hipblasDtpsv_64", "library");
     subst("cublasDtpsv_v2", "hipblasDtpsv", "library");
-    subst("cublasDtpsv_v2_64", "hipblasDtpsv_64", "library");
     subst("cublasDtrmm", "hipblasDtrmm", "library");
     subst("cublasDtrmm_v2", "hipblasDtrmm", "library");
     subst("cublasDtrmv", "hipblasDtrmv", "library");
-    subst("cublasDtrmv_64", "hipblasDtrmv_64", "library");
     subst("cublasDtrmv_v2", "hipblasDtrmv", "library");
-    subst("cublasDtrmv_v2_64", "hipblasDtrmv_64", "library");
     subst("cublasDtrsm", "hipblasDtrsm", "library");
     subst("cublasDtrsmBatched", "hipblasDtrsmBatched", "library");
     subst("cublasDtrsm_v2", "hipblasDtrsm", "library");
@@ -4252,27 +4300,19 @@ sub simpleSubstitutions {
     subst("cublasSsyrk_v2", "hipblasSsyrk", "library");
     subst("cublasSsyrkx", "hipblasSsyrkx", "library");
     subst("cublasStbmv", "hipblasStbmv", "library");
-    subst("cublasStbmv_64", "hipblasStbmv_64", "library");
     subst("cublasStbmv_v2", "hipblasStbmv", "library");
-    subst("cublasStbmv_v2_64", "hipblasStbmv_64", "library");
     subst("cublasStbsv", "hipblasStbsv", "library");
     subst("cublasStbsv_64", "hipblasStbsv_64", "library");
     subst("cublasStbsv_v2", "hipblasStbsv", "library");
     subst("cublasStbsv_v2_64", "hipblasStbsv_64", "library");
     subst("cublasStpmv", "hipblasStpmv", "library");
-    subst("cublasStpmv_64", "hipblasStpmv_64", "library");
     subst("cublasStpmv_v2", "hipblasStpmv", "library");
-    subst("cublasStpmv_v2_64", "hipblasStpmv_64", "library");
     subst("cublasStpsv", "hipblasStpsv", "library");
-    subst("cublasStpsv_64", "hipblasStpsv_64", "library");
     subst("cublasStpsv_v2", "hipblasStpsv", "library");
-    subst("cublasStpsv_v2_64", "hipblasStpsv_64", "library");
     subst("cublasStrmm", "hipblasStrmm", "library");
     subst("cublasStrmm_v2", "hipblasStrmm", "library");
     subst("cublasStrmv", "hipblasStrmv", "library");
-    subst("cublasStrmv_64", "hipblasStrmv_64", "library");
     subst("cublasStrmv_v2", "hipblasStrmv", "library");
-    subst("cublasStrmv_v2_64", "hipblasStrmv_64", "library");
     subst("cublasStrsm", "hipblasStrsm", "library");
     subst("cublasStrsmBatched", "hipblasStrsmBatched", "library");
     subst("cublasStrsm_v2", "hipblasStrsm", "library");
@@ -4397,27 +4437,19 @@ sub simpleSubstitutions {
     subst("cublasZsyrk_v2", "hipblasZsyrk_v2", "library");
     subst("cublasZsyrkx", "hipblasZsyrkx_v2", "library");
     subst("cublasZtbmv", "hipblasZtbmv_v2", "library");
-    subst("cublasZtbmv_64", "hipblasZtbmv_v2_64", "library");
     subst("cublasZtbmv_v2", "hipblasZtbmv_v2", "library");
-    subst("cublasZtbmv_v2_64", "hipblasZtbmv_v2_64", "library");
     subst("cublasZtbsv", "hipblasZtbsv_v2", "library");
     subst("cublasZtbsv_64", "hipblasZtbsv_v2_64", "library");
     subst("cublasZtbsv_v2", "hipblasZtbsv_v2", "library");
     subst("cublasZtbsv_v2_64", "hipblasZtbsv_v2_64", "library");
     subst("cublasZtpmv", "hipblasZtpmv_v2", "library");
-    subst("cublasZtpmv_64", "hipblasZtpmv_v2_64", "library");
     subst("cublasZtpmv_v2", "hipblasZtpmv_v2", "library");
-    subst("cublasZtpmv_v2_64", "hipblasZtpmv_v2_64", "library");
     subst("cublasZtpsv", "hipblasZtpsv_v2", "library");
-    subst("cublasZtpsv_64", "hipblasZtpsv_v2_64", "library");
     subst("cublasZtpsv_v2", "hipblasZtpsv_v2", "library");
-    subst("cublasZtpsv_v2_64", "hipblasZtpsv_v2_64", "library");
     subst("cublasZtrmm", "hipblasZtrmm_v2", "library");
     subst("cublasZtrmm_v2", "hipblasZtrmm_v2", "library");
     subst("cublasZtrmv", "hipblasZtrmv_v2", "library");
-    subst("cublasZtrmv_64", "hipblasZtrmv_v2_64", "library");
     subst("cublasZtrmv_v2", "hipblasZtrmv_v2", "library");
-    subst("cublasZtrmv_v2_64", "hipblasZtrmv_v2_64", "library");
     subst("cublasZtrsm", "hipblasZtrsm_v2", "library");
     subst("cublasZtrsmBatched", "hipblasZtrsmBatched_v2", "library");
     subst("cublasZtrsm_v2", "hipblasZtrsm_v2", "library");

--- a/docs/tables/CUBLAS_API_supported_by_HIP.md
+++ b/docs/tables/CUBLAS_API_supported_by_HIP.md
@@ -723,7 +723,7 @@
 |**CUDA**|**A**|**D**|**C**|**R**|**HIP**|**A**|**D**|**C**|**R**|**E**|
 |:--|:-:|:-:|:-:|:-:|:--|:-:|:-:|:-:|:-:|:-:|
 |`cublasCgbmv`| | | | |`hipblasCgbmv_v2`|6.0.0| | | | |
-|`cublasCgbmv_64`|12.0| | | |`hipblasCgbmv_64`|6.2.0| | | |6.2.0|
+|`cublasCgbmv_64`|12.0| | | |`hipblasCgbmv_v2_64`|6.2.0| | | |6.2.0|
 |`cublasCgbmv_v2`| | | | |`hipblasCgbmv_v2`|6.0.0| | | | |
 |`cublasCgbmv_v2_64`|12.0| | | |`hipblasCgbmv_v2_64`|6.2.0| | | |6.2.0|
 |`cublasCgemv`| | | | |`hipblasCgemv_v2`|6.0.0| | | | |
@@ -931,7 +931,7 @@
 |`cublasStrsv_v2`| | | | |`hipblasStrsv`|3.0.0| | | | |
 |`cublasStrsv_v2_64`|12.0| | | | | | | | | |
 |`cublasZgbmv`| | | | |`hipblasZgbmv_v2`|6.0.0| | | | |
-|`cublasZgbmv_64`|12.0| | | |`hipblasZgbmv_64`|6.2.0| | | |6.2.0|
+|`cublasZgbmv_64`|12.0| | | |`hipblasZgbmv_v2_64`|6.2.0| | | |6.2.0|
 |`cublasZgbmv_v2`| | | | |`hipblasZgbmv_v2`|6.0.0| | | | |
 |`cublasZgbmv_v2_64`|12.0| | | |`hipblasZgbmv_v2_64`|6.2.0| | | |6.2.0|
 |`cublasZgemv`| | | | |`hipblasZgemv_v2`|6.0.0| | | | |

--- a/docs/tables/CUBLAS_API_supported_by_HIP_and_ROC.md
+++ b/docs/tables/CUBLAS_API_supported_by_HIP_and_ROC.md
@@ -723,7 +723,7 @@
 |**CUDA**|**A**|**D**|**C**|**R**|**HIP**|**A**|**D**|**C**|**R**|**E**|**ROC**|**A**|**D**|**C**|**R**|**E**|
 |:--|:-:|:-:|:-:|:-:|:--|:-:|:-:|:-:|:-:|:-:|:--|:-:|:-:|:-:|:-:|:-:|
 |`cublasCgbmv`| | | | |`hipblasCgbmv_v2`|6.0.0| | | | |`rocblas_cgbmv`|3.5.0| | | | |
-|`cublasCgbmv_64`|12.0| | | |`hipblasCgbmv_64`|6.2.0| | | |6.2.0| | | | | | |
+|`cublasCgbmv_64`|12.0| | | |`hipblasCgbmv_v2_64`|6.2.0| | | |6.2.0| | | | | | |
 |`cublasCgbmv_v2`| | | | |`hipblasCgbmv_v2`|6.0.0| | | | |`rocblas_cgbmv`|3.5.0| | | | |
 |`cublasCgbmv_v2_64`|12.0| | | |`hipblasCgbmv_v2_64`|6.2.0| | | |6.2.0| | | | | | |
 |`cublasCgemv`| | | | |`hipblasCgemv_v2`|6.0.0| | | | |`rocblas_cgemv`|1.5.0| | | | |
@@ -931,7 +931,7 @@
 |`cublasStrsv_v2`| | | | |`hipblasStrsv`|3.0.0| | | | |`rocblas_strsv`|3.5.0| | | | |
 |`cublasStrsv_v2_64`|12.0| | | | | | | | | | | | | | | |
 |`cublasZgbmv`| | | | |`hipblasZgbmv_v2`|6.0.0| | | | |`rocblas_zgbmv`|3.5.0| | | | |
-|`cublasZgbmv_64`|12.0| | | |`hipblasZgbmv_64`|6.2.0| | | |6.2.0| | | | | | |
+|`cublasZgbmv_64`|12.0| | | |`hipblasZgbmv_v2_64`|6.2.0| | | |6.2.0| | | | | | |
 |`cublasZgbmv_v2`| | | | |`hipblasZgbmv_v2`|6.0.0| | | | |`rocblas_zgbmv`|3.5.0| | | | |
 |`cublasZgbmv_v2_64`|12.0| | | |`hipblasZgbmv_v2_64`|6.2.0| | | |6.2.0| | | | | | |
 |`cublasZgemv`| | | | |`hipblasZgemv_v2`|6.0.0| | | | |`rocblas_zgemv`|1.5.0| | | | |

--- a/src/CUDA2HIP_BLAS_API_functions.cpp
+++ b/src/CUDA2HIP_BLAS_API_functions.cpp
@@ -236,39 +236,39 @@ const std::map<llvm::StringRef, hipCounter> CUDA_BLAS_FUNCTION_MAP {
   {"cublasDgbmv",                                          {"hipblasDgbmv",                                              "rocblas_dgbmv",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, HIP_SUPPORTED_V2_ONLY}},
   {"cublasDgbmv_64",                                       {"hipblasDgbmv_64",                                           "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
   {"cublasCgbmv",                                          {"hipblasCgbmv_v2",                                           "rocblas_cgbmv",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, HIP_SUPPORTED_V2_ONLY}},
-  {"cublasCgbmv_64",                                       {"hipblasCgbmv_64",                                           "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
+  {"cublasCgbmv_64",                                       {"hipblasCgbmv_v2_64",                                        "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
   {"cublasZgbmv",                                          {"hipblasZgbmv_v2",                                           "rocblas_zgbmv",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, HIP_SUPPORTED_V2_ONLY}},
-  {"cublasZgbmv_64",                                       {"hipblasZgbmv_64",                                           "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
+  {"cublasZgbmv_64",                                       {"hipblasZgbmv_v2_64",                                        "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
 
   // TRMV
   {"cublasStrmv",                                          {"hipblasStrmv",                                              "rocblas_strmv",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, HIP_SUPPORTED_V2_ONLY}},
-  {"cublasStrmv_64",                                       {"hipblasStrmv_64",                                           "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
+  {"cublasStrmv_64",                                       {"hipblasStrmv_64",                                           "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
   {"cublasDtrmv",                                          {"hipblasDtrmv",                                              "rocblas_dtrmv",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, HIP_SUPPORTED_V2_ONLY}},
-  {"cublasDtrmv_64",                                       {"hipblasDtrmv_64",                                           "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
+  {"cublasDtrmv_64",                                       {"hipblasDtrmv_64",                                           "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
   {"cublasCtrmv",                                          {"hipblasCtrmv_v2",                                           "rocblas_ctrmv",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, HIP_SUPPORTED_V2_ONLY}},
-  {"cublasCtrmv_64",                                       {"hipblasCtrmv_v2_64",                                        "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
+  {"cublasCtrmv_64",                                       {"hipblasCtrmv_v2_64",                                        "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
   {"cublasZtrmv",                                          {"hipblasZtrmv_v2",                                           "rocblas_ztrmv",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, HIP_SUPPORTED_V2_ONLY}},
-  {"cublasZtrmv_64",                                       {"hipblasZtrmv_v2_64",                                        "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
+  {"cublasZtrmv_64",                                       {"hipblasZtrmv_v2_64",                                        "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
 
   // TBMV
   {"cublasStbmv",                                          {"hipblasStbmv",                                              "rocblas_stbmv",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, HIP_SUPPORTED_V2_ONLY}},
-  {"cublasStbmv_64",                                       {"hipblasStbmv_64",                                           "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
+  {"cublasStbmv_64",                                       {"hipblasStbmv_64",                                           "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
   {"cublasDtbmv",                                          {"hipblasDtbmv",                                              "rocblas_dtbmv",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, HIP_SUPPORTED_V2_ONLY}},
-  {"cublasDtbmv_64",                                       {"hipblasDtbmv_64",                                           "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
+  {"cublasDtbmv_64",                                       {"hipblasDtbmv_64",                                           "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
   {"cublasCtbmv",                                          {"hipblasCtbmv_v2",                                           "rocblas_ctbmv",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, HIP_SUPPORTED_V2_ONLY}},
-  {"cublasCtbmv_64",                                       {"hipblasCtbmv_v2_64",                                        "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
+  {"cublasCtbmv_64",                                       {"hipblasCtbmv_v2_64",                                        "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
   {"cublasZtbmv",                                          {"hipblasZtbmv_v2",                                           "rocblas_ztbmv",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, HIP_SUPPORTED_V2_ONLY}},
-  {"cublasZtbmv_64",                                       {"hipblasZtbmv_v2_64",                                        "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
+  {"cublasZtbmv_64",                                       {"hipblasZtbmv_v2_64",                                        "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
 
   // TPMV
   {"cublasStpmv",                                          {"hipblasStpmv",                                              "rocblas_stpmv",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, HIP_SUPPORTED_V2_ONLY}},
-  {"cublasStpmv_64",                                       {"hipblasStpmv_64",                                           "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
+  {"cublasStpmv_64",                                       {"hipblasStpmv_64",                                           "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
   {"cublasDtpmv",                                          {"hipblasDtpmv",                                              "rocblas_dtpmv",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, HIP_SUPPORTED_V2_ONLY}},
-  {"cublasDtpmv_64",                                       {"hipblasDtpmv_64",                                           "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
+  {"cublasDtpmv_64",                                       {"hipblasDtpmv_64",                                           "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
   {"cublasCtpmv",                                          {"hipblasCtpmv_v2",                                           "rocblas_ctpmv",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, HIP_SUPPORTED_V2_ONLY}},
-  {"cublasCtpmv_64",                                       {"hipblasCtpmv_v2_64",                                        "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
+  {"cublasCtpmv_64",                                       {"hipblasCtpmv_v2_64",                                        "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
   {"cublasZtpmv",                                          {"hipblasZtpmv_v2",                                           "rocblas_ztpmv",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, HIP_SUPPORTED_V2_ONLY}},
-  {"cublasZtpmv_64",                                       {"hipblasZtpmv_v2_64",                                        "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
+  {"cublasZtpmv_64",                                       {"hipblasZtpmv_v2_64",                                        "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
 
   // TRSV
   {"cublasStrsv",                                          {"hipblasStrsv",                                              "rocblas_strsv",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, HIP_SUPPORTED_V2_ONLY}},
@@ -282,13 +282,13 @@ const std::map<llvm::StringRef, hipCounter> CUDA_BLAS_FUNCTION_MAP {
 
   // TPSV
   {"cublasStpsv",                                          {"hipblasStpsv",                                              "rocblas_stpsv",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, HIP_SUPPORTED_V2_ONLY}},
-  {"cublasStpsv_64",                                       {"hipblasStpsv_64",                                           "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
+  {"cublasStpsv_64",                                       {"hipblasStpsv_64",                                           "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
   {"cublasDtpsv",                                          {"hipblasDtpsv",                                              "rocblas_dtpsv",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, HIP_SUPPORTED_V2_ONLY}},
-  {"cublasDtpsv_64",                                       {"hipblasDtpsv_64",                                           "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
+  {"cublasDtpsv_64",                                       {"hipblasDtpsv_64",                                           "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
   {"cublasCtpsv",                                          {"hipblasCtpsv_v2",                                           "rocblas_ctpsv",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, HIP_SUPPORTED_V2_ONLY}},
-  {"cublasCtpsv_64",                                       {"hipblasCtpsv_v2_64",                                        "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
+  {"cublasCtpsv_64",                                       {"hipblasCtpsv_v2_64",                                        "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
   {"cublasZtpsv",                                          {"hipblasZtpsv_v2",                                           "rocblas_ztpsv",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, HIP_SUPPORTED_V2_ONLY}},
-  {"cublasZtpsv_64",                                       {"hipblasZtpsv_v2_64",                                        "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
+  {"cublasZtpsv_64",                                       {"hipblasZtpsv_v2_64",                                        "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
 
   // TBSV
   {"cublasStbsv",                                          {"hipblasStbsv",                                              "rocblas_stbsv",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, HIP_SUPPORTED_V2_ONLY}},
@@ -660,33 +660,33 @@ const std::map<llvm::StringRef, hipCounter> CUDA_BLAS_FUNCTION_MAP {
 
   // TRMV
   {"cublasStrmv_v2",                                       {"hipblasStrmv",                                              "rocblas_strmv",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
-  {"cublasStrmv_v2_64",                                    {"hipblasStrmv_64",                                           "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
+  {"cublasStrmv_v2_64",                                    {"hipblasStrmv_64",                                           "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
   {"cublasDtrmv_v2",                                       {"hipblasDtrmv",                                              "rocblas_dtrmv",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
-  {"cublasDtrmv_v2_64",                                    {"hipblasDtrmv_64",                                           "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
+  {"cublasDtrmv_v2_64",                                    {"hipblasDtrmv_64",                                           "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
   {"cublasCtrmv_v2",                                       {"hipblasCtrmv_v2",                                           "rocblas_ctrmv",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
-  {"cublasCtrmv_v2_64",                                    {"hipblasCtrmv_v2_64",                                        "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
+  {"cublasCtrmv_v2_64",                                    {"hipblasCtrmv_v2_64",                                        "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
   {"cublasZtrmv_v2",                                       {"hipblasZtrmv_v2",                                           "rocblas_ztrmv",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
-  {"cublasZtrmv_v2_64",                                    {"hipblasZtrmv_v2_64",                                        "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
+  {"cublasZtrmv_v2_64",                                    {"hipblasZtrmv_v2_64",                                        "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
 
   // TBMV
   {"cublasStbmv_v2",                                       {"hipblasStbmv",                                              "rocblas_stbmv",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
-  {"cublasStbmv_v2_64",                                    {"hipblasStbmv_64",                                           "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
+  {"cublasStbmv_v2_64",                                    {"hipblasStbmv_64",                                           "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
   {"cublasDtbmv_v2",                                       {"hipblasDtbmv",                                              "rocblas_dtbmv",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
-  {"cublasDtbmv_v2_64",                                    {"hipblasDtbmv_64",                                           "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
+  {"cublasDtbmv_v2_64",                                    {"hipblasDtbmv_64",                                           "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
   {"cublasCtbmv_v2",                                       {"hipblasCtbmv_v2",                                           "rocblas_ctbmv",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
-  {"cublasCtbmv_v2_64",                                    {"hipblasCtbmv_v2_64",                                        "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
+  {"cublasCtbmv_v2_64",                                    {"hipblasCtbmv_v2_64",                                        "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
   {"cublasZtbmv_v2",                                       {"hipblasZtbmv_v2",                                           "rocblas_ztbmv",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
-  {"cublasZtbmv_v2_64",                                    {"hipblasZtbmv_v2_64",                                        "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
+  {"cublasZtbmv_v2_64",                                    {"hipblasZtbmv_v2_64",                                        "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
 
   // TPMV
   {"cublasStpmv_v2",                                       {"hipblasStpmv",                                              "rocblas_stpmv",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
-  {"cublasStpmv_v2_64",                                    {"hipblasStpmv_64",                                           "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
+  {"cublasStpmv_v2_64",                                    {"hipblasStpmv_64",                                           "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
   {"cublasDtpmv_v2",                                       {"hipblasDtpmv",                                              "rocblas_dtpmv",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
-  {"cublasDtpmv_v2_64",                                    {"hipblasDtpmv_64",                                           "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
+  {"cublasDtpmv_v2_64",                                    {"hipblasDtpmv_64",                                           "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
   {"cublasCtpmv_v2",                                       {"hipblasCtpmv_v2",                                           "rocblas_ctpmv",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
-  {"cublasCtpmv_v2_64",                                    {"hipblasCtpmv_v2_64",                                        "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
+  {"cublasCtpmv_v2_64",                                    {"hipblasCtpmv_v2_64",                                        "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
   {"cublasZtpmv_v2",                                       {"hipblasZtpmv_v2",                                           "rocblas_ztpmv",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
-  {"cublasZtpmv_v2_64",                                    {"hipblasZtpmv_v2_64",                                        "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
+  {"cublasZtpmv_v2_64",                                    {"hipblasZtpmv_v2_64",                                        "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
 
   // TRSV
   {"cublasStrsv_v2",                                       {"hipblasStrsv",                                              "rocblas_strsv",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
@@ -700,13 +700,13 @@ const std::map<llvm::StringRef, hipCounter> CUDA_BLAS_FUNCTION_MAP {
 
   // TPSV
   {"cublasStpsv_v2",                                       {"hipblasStpsv",                                              "rocblas_stpsv",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
-  {"cublasStpsv_v2_64",                                    {"hipblasStpsv_64",                                           "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
+  {"cublasStpsv_v2_64",                                    {"hipblasStpsv_64",                                           "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
   {"cublasDtpsv_v2",                                       {"hipblasDtpsv",                                              "rocblas_dtpsv",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
-  {"cublasDtpsv_v2_64",                                    {"hipblasDtpsv_64",                                           "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
+  {"cublasDtpsv_v2_64",                                    {"hipblasDtpsv_64",                                           "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
   {"cublasCtpsv_v2",                                       {"hipblasCtpsv_v2",                                           "rocblas_ctpsv",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
-  {"cublasCtpsv_v2_64",                                    {"hipblasCtpsv_v2_64",                                        "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
+  {"cublasCtpsv_v2_64",                                    {"hipblasCtpsv_v2_64",                                        "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
   {"cublasZtpsv_v2",                                       {"hipblasZtpsv_v2",                                           "rocblas_ztpsv",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
-  {"cublasZtpsv_v2_64",                                    {"hipblasZtpsv_v2_64",                                        "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
+  {"cublasZtpsv_v2_64",                                    {"hipblasZtpsv_v2_64",                                        "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
 
   // TBSV
   {"cublasStbsv_v2",                                       {"hipblasStbsv",                                              "rocblas_stbsv",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
@@ -2052,9 +2052,7 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_BLAS_FUNCTION_VER_MAP {
   {"hipblasLtMatmulAlgoGetHeuristic",                      {HIP_5050, HIP_0,    HIP_0   }},
   {"hipblasSgbmv_64",                                      {HIP_6020, HIP_0,    HIP_0,  HIP_LATEST}},
   {"hipblasDgbmv_64",                                      {HIP_6020, HIP_0,    HIP_0,  HIP_LATEST}},
-  {"hipblasCgbmv_64",                                      {HIP_6020, HIP_0,    HIP_0,  HIP_LATEST}},
   {"hipblasCgbmv_v2_64",                                   {HIP_6020, HIP_0,    HIP_0,  HIP_LATEST}},
-  {"hipblasZgbmv_64",                                      {HIP_6020, HIP_0,    HIP_0,  HIP_LATEST}},
   {"hipblasZgbmv_v2_64",                                   {HIP_6020, HIP_0,    HIP_0,  HIP_LATEST}},
   {"hipblasSgemv_64",                                      {HIP_6020, HIP_0,    HIP_0,  HIP_LATEST}},
   {"hipblasDgemv_64",                                      {HIP_6020, HIP_0,    HIP_0,  HIP_LATEST}},

--- a/tests/unit_tests/synthetic/libraries/cublas2hipblas_v2.cu
+++ b/tests/unit_tests/synthetic/libraries/cublas2hipblas_v2.cu
@@ -2252,15 +2252,15 @@ int main() {
   blasStatus = cublasDgbmv_v2_64(blasHandle, blasOperation, m_64, n_64, kl_64, ku_64, &da, &dA, lda_64, &dx, incx_64, &db, &dy, incy_64);
 
   // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasCgbmv_v2_64(cublasHandle_t handle, cublasOperation_t trans, int64_t m, int64_t n, int64_t kl, int64_t ku, const cuComplex* alpha, const cuComplex* A, int64_t lda, const cuComplex* x, int64_t incx, const cuComplex* beta, cuComplex* y, int64_t incy);
-  // HIP: HIPBLAS_EXPORT hipblasStatus_t hipblasCgbmv_64(hipblasHandle_t handle, hipblasOperation_t trans, int64_t m, int64_t n, int64_t kl, int64_t ku, const hipblasComplex* alpha, const hipblasComplex* AP, int64_t lda, const hipblasComplex* x, int64_t incx, const hipblasComplex* beta, hipblasComplex* y, int64_t incy);
-  // CHECK: blasStatus = hipblasCgbmv_64(blasHandle, blasOperation, m_64, n_64, kl_64, ku_64, &complexa, &complexA, lda_64, &complexx, incx_64, &complexb, &complexy, incy_64);
+  // HIP: HIPBLAS_EXPORT hipblasStatus_t hipblasCgbmv_v2_64(hipblasHandle_t handle, hipblasOperation_t trans, int64_t m, int64_t n, int64_t kl, int64_t ku, const hipComplex* alpha, const hipComplex* AP, int64_t lda, const hipComplex* x, int64_t incx, const hipComplex* beta, hipComplex* y, int64_t incy);
+  // CHECK: blasStatus = hipblasCgbmv_v2_64(blasHandle, blasOperation, m_64, n_64, kl_64, ku_64, &complexa, &complexA, lda_64, &complexx, incx_64, &complexb, &complexy, incy_64);
   // CHECK-NEXT: blasStatus = hipblasCgbmv_v2_64(blasHandle, blasOperation, m_64, n_64, kl_64, ku_64, &complexa, &complexA, lda_64, &complexx, incx_64, &complexb, &complexy, incy_64);
   blasStatus = cublasCgbmv_64(blasHandle, blasOperation, m_64, n_64, kl_64, ku_64, &complexa, &complexA, lda_64, &complexx, incx_64, &complexb, &complexy, incy_64);
   blasStatus = cublasCgbmv_v2_64(blasHandle, blasOperation, m_64, n_64, kl_64, ku_64, &complexa, &complexA, lda_64, &complexx, incx_64, &complexb, &complexy, incy_64);
 
   // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasZgbmv_v2_64(cublasHandle_t handle, cublasOperation_t trans, int64_t m, int64_t n, int64_t kl, int64_t ku, const cuDoubleComplex* alpha, const cuDoubleComplex* A, int64_t lda, const cuDoubleComplex* x, int64_t incx, const cuDoubleComplex* beta, cuDoubleComplex* y, int64_t incy);
-  // HIP: HIPBLAS_EXPORT hipblasStatus_t hipblasZgbmv_64(hipblasHandle_t handle, hipblasOperation_t trans, int64_t m, int64_t n, int64_t kl, int64_t ku, const hipblasDoubleComplex* alpha, const hipblasDoubleComplex* AP, int64_t lda, const hipblasDoubleComplex* x, int64_t incx, const hipblasDoubleComplex* beta, hipblasDoubleComplex* y, int64_t incy);
-  // CHECK: blasStatus = hipblasZgbmv_64(blasHandle, blasOperation, m_64, n_64, kl_64, ku_64, &dcomplexa, &dcomplexA, lda_64, &dcomplexx, incx_64, &dcomplexb, &dcomplexy, incy_64);
+  // HIP: HIPBLAS_EXPORT hipblasStatus_t hipblasZgbmv_v2_64(hipblasHandle_t handle, hipblasOperation_t trans, int64_t m, int64_t n, int64_t kl, int64_t ku, const hipDoubleComplex* alpha, const hipDoubleComplex* AP, int64_t lda, const hipDoubleComplex* x, int64_t incx, const hipDoubleComplex* beta, hipDoubleComplex* y, int64_t incy);
+  // CHECK: blasStatus = hipblasZgbmv_v2_64(blasHandle, blasOperation, m_64, n_64, kl_64, ku_64, &dcomplexa, &dcomplexA, lda_64, &dcomplexx, incx_64, &dcomplexb, &dcomplexy, incy_64);
   // CHECK-NEXT: blasStatus = hipblasZgbmv_v2_64(blasHandle, blasOperation, m_64, n_64, kl_64, ku_64, &dcomplexa, &dcomplexA, lda_64, &dcomplexx, incx_64, &dcomplexb, &dcomplexy, incy_64);
   blasStatus = cublasZgbmv_64(blasHandle, blasOperation, m_64, n_64, kl_64, ku_64, &dcomplexa, &dcomplexA, lda_64, &dcomplexx, incx_64, &dcomplexb, &dcomplexy, incy_64);
   blasStatus = cublasZgbmv_v2_64(blasHandle, blasOperation, m_64, n_64, kl_64, ku_64, &dcomplexa, &dcomplexA, lda_64, &dcomplexx, incx_64, &dcomplexb, &dcomplexy, incy_64);


### PR DESCRIPTION
+ Updated synthetic tests, the regenerated `hipify-perl`, and `BLAS` `CUDA2HIP` documentation
