### PR TITLE
[HIPIFY][BLAS][6.2.0] cuBLAS support - Step 26 - 64-bit functions

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -1514,6 +1514,9 @@ my %experimental_funcs = (
     "cublasSgemvBatched_64" => "6.2.0",
     "cublasSgbmv_v2_64" => "6.2.0",
     "cublasSgbmv_64" => "6.2.0",
+    "cublasScalEx_64" => "6.2.0",
+    "cublasRotEx_64" => "6.2.0",
+    "cublasNrm2Ex_64" => "6.2.0",
     "cublasDtrsv_v2_64" => "6.2.0",
     "cublasDtrsv_64" => "6.2.0",
     "cublasDtrmv_v2_64" => "6.2.0",
@@ -1860,6 +1863,9 @@ sub experimentalSubstitutions {
     subst("cublasDtrmv_v2_64", "hipblasDtrmv_64", "library");
     subst("cublasDtrsv_64", "hipblasDtrsv_64", "library");
     subst("cublasDtrsv_v2_64", "hipblasDtrsv_64", "library");
+    subst("cublasNrm2Ex_64", "hipblasNrm2Ex_v2_64", "library");
+    subst("cublasRotEx_64", "hipblasRotEx_v2_64", "library");
+    subst("cublasScalEx_64", "hipblasScalEx_v2_64", "library");
     subst("cublasSgbmv_64", "hipblasSgbmv_64", "library");
     subst("cublasSgbmv_v2_64", "hipblasSgbmv_64", "library");
     subst("cublasSgemvBatched_64", "hipblasSgemvBatched_64", "library");
@@ -11750,13 +11756,10 @@ sub warnHipOnlyUnsupportedFunctions {
         "cublasSetLoggerCallback",
         "cublasSetKernelStream",
         "cublasSdgmm_64",
-        "cublasScalEx_64",
         "cublasRotmgEx",
         "cublasRotmEx_64",
         "cublasRotmEx",
         "cublasRotgEx",
-        "cublasRotEx_64",
-        "cublasNrm2Ex_64",
         "cublasMigrateComputeType",
         "cublasLtReductionScheme_t",
         "cublasLtPointerModeMask_t",

--- a/docs/tables/CUBLAS_API_supported_by_HIP.md
+++ b/docs/tables/CUBLAS_API_supported_by_HIP.md
@@ -630,7 +630,7 @@
 |`cublasIzamin_v2`| | | | |`hipblasIzamin_v2`|6.0.0| | | | |
 |`cublasIzamin_v2_64`|12.0| | | |`hipblasIzamin_v2_64`|6.1.0| | | | |
 |`cublasNrm2Ex`|8.0| | | |`hipblasNrm2Ex_v2`|6.0.0| | | | |
-|`cublasNrm2Ex_64`|12.0| | | | | | | | | |
+|`cublasNrm2Ex_64`|12.0| | | |`hipblasNrm2Ex_v2_64`|6.2.0| | | |6.2.0|
 |`cublasSasum`| | | | |`hipblasSasum`|1.8.2| | | | |
 |`cublasSasum_64`|12.0| | | |`hipblasSasum_64`|6.1.0| | | | |
 |`cublasSasum_v2`| | | | |`hipblasSasum`|1.8.2| | | | |
@@ -1281,13 +1281,13 @@
 |`cublasIaminEx`|10.1| | | | | | | | | |
 |`cublasIaminEx_64`|12.0| | | | | | | | | |
 |`cublasRotEx`|10.1| | | |`hipblasRotEx_v2`|6.0.0| | | | |
-|`cublasRotEx_64`|12.0| | | | | | | | | |
+|`cublasRotEx_64`|12.0| | | |`hipblasRotEx_v2_64`|6.2.0| | | |6.2.0|
 |`cublasRotgEx`|10.1| | | | | | | | | |
 |`cublasRotmEx`|10.1| | | | | | | | | |
 |`cublasRotmEx_64`|12.0| | | | | | | | | |
 |`cublasRotmgEx`|10.1| | | | | | | | | |
 |`cublasScalEx`|8.0| | | |`hipblasScalEx_v2`|6.0.0| | | | |
-|`cublasScalEx_64`|12.0| | | | | | | | | |
+|`cublasScalEx_64`|12.0| | | |`hipblasScalEx_v2_64`|6.2.0| | | |6.2.0|
 |`cublasSdgmm`| | | | |`hipblasSdgmm`|3.6.0| | | | |
 |`cublasSdgmm_64`|12.0| | | | | | | | | |
 |`cublasSgeam`| | | | |`hipblasSgeam`|1.8.2| | | | |

--- a/docs/tables/CUBLAS_API_supported_by_HIP_and_ROC.md
+++ b/docs/tables/CUBLAS_API_supported_by_HIP_and_ROC.md
@@ -630,7 +630,7 @@
 |`cublasIzamin_v2`| | | | |`hipblasIzamin_v2`|6.0.0| | | | |`rocblas_izamin`|3.5.0| | | | |
 |`cublasIzamin_v2_64`|12.0| | | |`hipblasIzamin_v2_64`|6.1.0| | | | |`rocblas_izamin_64`|6.1.0| | | | |
 |`cublasNrm2Ex`|8.0| | | |`hipblasNrm2Ex_v2`|6.0.0| | | | |`rocblas_nrm2_ex`|4.1.0| | | | |
-|`cublasNrm2Ex_64`|12.0| | | | | | | | | |`rocblas_nrm2_ex_64`|6.1.0| | | | |
+|`cublasNrm2Ex_64`|12.0| | | |`hipblasNrm2Ex_v2_64`|6.2.0| | | |6.2.0|`rocblas_nrm2_ex_64`|6.1.0| | | | |
 |`cublasSasum`| | | | |`hipblasSasum`|1.8.2| | | | |`rocblas_sasum`|1.5.0| | | | |
 |`cublasSasum_64`|12.0| | | |`hipblasSasum_64`|6.1.0| | | | |`rocblas_sasum_64`|6.1.0| | | | |
 |`cublasSasum_v2`| | | | |`hipblasSasum`|1.8.2| | | | |`rocblas_sasum`|1.5.0| | | | |
@@ -1281,13 +1281,13 @@
 |`cublasIaminEx`|10.1| | | | | | | | | | | | | | | |
 |`cublasIaminEx_64`|12.0| | | | | | | | | | | | | | | |
 |`cublasRotEx`|10.1| | | |`hipblasRotEx_v2`|6.0.0| | | | |`rocblas_rot_ex`|4.1.0| | | | |
-|`cublasRotEx_64`|12.0| | | | | | | | | |`rocblas_rot_ex_64`|6.1.0| | | | |
+|`cublasRotEx_64`|12.0| | | |`hipblasRotEx_v2_64`|6.2.0| | | |6.2.0|`rocblas_rot_ex_64`|6.1.0| | | | |
 |`cublasRotgEx`|10.1| | | | | | | | | | | | | | | |
 |`cublasRotmEx`|10.1| | | | | | | | | | | | | | | |
 |`cublasRotmEx_64`|12.0| | | | | | | | | | | | | | | |
 |`cublasRotmgEx`|10.1| | | | | | | | | | | | | | | |
 |`cublasScalEx`|8.0| | | |`hipblasScalEx_v2`|6.0.0| | | | |`rocblas_scal_ex`|4.0.0| | | | |
-|`cublasScalEx_64`|12.0| | | | | | | | | |`rocblas_scal_ex_64`|6.1.0| | | | |
+|`cublasScalEx_64`|12.0| | | |`hipblasScalEx_v2_64`|6.2.0| | | |6.2.0|`rocblas_scal_ex_64`|6.1.0| | | | |
 |`cublasSdgmm`| | | | |`hipblasSdgmm`|3.6.0| | | | |`rocblas_sdgmm`|3.5.0| | | | |
 |`cublasSdgmm_64`|12.0| | | | | | | | | | | | | | | |
 |`cublasSgeam`| | | | |`hipblasSgeam`|1.8.2| | | | |`rocblas_sgeam`|1.6.4| | | | |

--- a/src/CUDA2HIP_BLAS_API_functions.cpp
+++ b/src/CUDA2HIP_BLAS_API_functions.cpp
@@ -98,7 +98,7 @@ const std::map<llvm::StringRef, hipCounter> CUDA_BLAS_FUNCTION_MAP {
   {"cublasDznrm2",                                         {"hipblasDznrm2_v2",                                          "rocblas_dznrm2",                                     CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_1, HIP_SUPPORTED_V2_ONLY}},
   {"cublasDznrm2_64",                                      {"hipblasDznrm2_v2_64",                                       "rocblas_dznrm2_64",                                  CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_1}},
   {"cublasNrm2Ex",                                         {"hipblasNrm2Ex_v2",                                          "rocblas_nrm2_ex",                                    CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_1}},
-  {"cublasNrm2Ex_64",                                      {"hipblasNrm2Ex_64",                                          "rocblas_nrm2_ex_64",                                 CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_1, HIP_UNSUPPORTED}},
+  {"cublasNrm2Ex_64",                                      {"hipblasNrm2Ex_v2_64",                                       "rocblas_nrm2_ex_64",                                 CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_1, HIP_EXPERIMENTAL}},
 
   // DOT
   // DOT functions' signatures differ from _v2 ones, hipblas and rocblas DOT functions have mapping to DOT_v2 functions only
@@ -958,7 +958,7 @@ const std::map<llvm::StringRef, hipCounter> CUDA_BLAS_FUNCTION_MAP {
 
   // SCAL
   {"cublasScalEx",                                         {"hipblasScalEx_v2",                                          "rocblas_scal_ex",                                    CONV_LIB_FUNC, API_BLAS, SEC::BLAS_EXT}},
-  {"cublasScalEx_64",                                      {"hipblasScalEx_64",                                          "rocblas_scal_ex_64",                                 CONV_LIB_FUNC, API_BLAS, SEC::BLAS_EXT, HIP_UNSUPPORTED}},
+  {"cublasScalEx_64",                                      {"hipblasScalEx_v2_64",                                       "rocblas_scal_ex_64",                                 CONV_LIB_FUNC, API_BLAS, SEC::BLAS_EXT, HIP_EXPERIMENTAL}},
   {"cublasSscal_v2",                                       {"hipblasSscal",                                              "rocblas_sscal",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_1}},
   {"cublasSscal_v2_64",                                    {"hipblasSscal_64",                                           "rocblas_sscal_64",                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_1}},
   {"cublasDscal_v2",                                       {"hipblasDscal",                                              "rocblas_dscal",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_1}},
@@ -1046,7 +1046,7 @@ const std::map<llvm::StringRef, hipCounter> CUDA_BLAS_FUNCTION_MAP {
 
   // ROT
   {"cublasRotEx",                                          {"hipblasRotEx_v2",                                           "rocblas_rot_ex",                                     CONV_LIB_FUNC, API_BLAS, SEC::BLAS_EXT}},
-  {"cublasRotEx_64",                                       {"hipblasRotEx_64",                                           "rocblas_rot_ex_64",                                  CONV_LIB_FUNC, API_BLAS, SEC::BLAS_EXT, HIP_UNSUPPORTED}},
+  {"cublasRotEx_64",                                       {"hipblasRotEx_v2_64",                                        "rocblas_rot_ex_64",                                  CONV_LIB_FUNC, API_BLAS, SEC::BLAS_EXT, HIP_EXPERIMENTAL}},
   {"cublasSrot_v2",                                        {"hipblasSrot",                                               "rocblas_srot",                                       CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_1}},
   {"cublasSrot_v2_64",                                     {"hipblasSrot_64",                                            "rocblas_srot_64",                                    CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_1}},
   {"cublasDrot_v2",                                        {"hipblasDrot",                                               "rocblas_drot",                                       CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_1}},
@@ -1742,8 +1742,6 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_BLAS_FUNCTION_VER_MAP {
   {"hipblasDgeqrfBatched",                                 {HIP_3050, HIP_0,    HIP_0   }},
   {"hipblasSdgmm",                                         {HIP_3060, HIP_0,    HIP_0   }},
   {"hipblasDdgmm",                                         {HIP_3060, HIP_0,    HIP_0   }},
-  {"hipblasRotEx",                                         {HIP_4010, HIP_0,    HIP_0   }},
-  {"hipblasScalEx",                                        {HIP_4010, HIP_0,    HIP_0   }},
   {"hipblasIcamax_v2",                                     {HIP_6000, HIP_0,    HIP_0   }},
   {"hipblasIzamax_v2",                                     {HIP_6000, HIP_0,    HIP_0   }},
   {"hipblasIcamin_v2",                                     {HIP_6000, HIP_0,    HIP_0   }},
@@ -2025,6 +2023,9 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_BLAS_FUNCTION_VER_MAP {
   {"hipblasAxpyEx_v2_64",                                  {HIP_6020, HIP_0,    HIP_0,  HIP_LATEST}},
   {"hipblasDotEx_v2_64",                                   {HIP_6020, HIP_0,    HIP_0,  HIP_LATEST}},
   {"hipblasDotcEx_v2_64",                                  {HIP_6020, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipblasNrm2Ex_v2_64",                                  {HIP_6020, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipblasRotEx_v2_64",                                   {HIP_6020, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipblasScalEx_v2_64",                                  {HIP_6020, HIP_0,    HIP_0,  HIP_LATEST}},
 
   {"rocblas_status_to_string",                             {HIP_3050, HIP_0,    HIP_0   }},
   {"rocblas_sscal",                                        {HIP_1050, HIP_0,    HIP_0   }},

--- a/tests/unit_tests/synthetic/libraries/cublas2hipblas_v2.cu
+++ b/tests/unit_tests/synthetic/libraries/cublas2hipblas_v2.cu
@@ -2795,6 +2795,21 @@ int main() {
   // HIP: HIPBLAS_EXPORT hipblasStatus_t hipblasDotcEx_v2_64(hipblasHandle_t handle, int64_t n, const void* x, hipDataType xType, int64_t incx, const void* y, hipDataType yType, int64_t incy, void* result, hipDataType resultType, hipDataType executionType);
   // CHECK: blasStatus = hipblasDotcEx_v2_64(blasHandle, n_64, xptr, Xtype, incx_64, yptr, Ytype, incy_64, image, DataType, Executiontype);
   blasStatus = cublasDotcEx_64(blasHandle, n_64, xptr, Xtype, incx_64, yptr, Ytype, incy_64, image, DataType, Executiontype);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasNrm2Ex_64(cublasHandle_t handle, int64_t n, const void* x, cudaDataType xType, int64_t incx, void* result, cudaDataType resultType, cudaDataType executionType);
+  // HIP: HIPBLAS_EXPORT hipblasStatus_t hipblasNrm2Ex_v2_64(hipblasHandle_t handle, int64_t n, const void* x, hipDataType xType, int64_t incx, void* result, hipDataType resultType, hipDataType executionType);
+  // CHECK: blasStatus = hipblasNrm2Ex_v2_64(blasHandle, n_64, xptr, Xtype, incx_64, image, DataType, Executiontype);
+  blasStatus = cublasNrm2Ex_64(blasHandle, n_64, xptr, Xtype, incx_64, image, DataType, Executiontype);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasRotEx_64(cublasHandle_t handle, int64_t n, void* x, cudaDataType xType, int64_t incx, void* y, cudaDataType yType, int64_t incy, const void* c, const void* s, cudaDataType csType, cudaDataType executiontype);
+  // HIP: HIPBLAS_EXPORT hipblasStatus_t hipblasRotEx_v2_64(hipblasHandle_t handle, int64_t n, void* x, hipDataType xType, int64_t incx, void* y, hipDataType yType, int64_t incy, const void* c, const void* s, hipDataType csType, hipDataType executionType);
+  // CHECK: blasStatus = hipblasRotEx_v2_64(blasHandle, n_64, xptr, Xtype, incx_64, yptr, Ytype, incy_64, cptr, sptr, CStype, Executiontype);
+  blasStatus = cublasRotEx_64(blasHandle, n_64, xptr, Xtype, incx_64, yptr, Ytype, incy_64, cptr, sptr, CStype, Executiontype);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasScalEx_64(cublasHandle_t handle, int64_t n, const void* alpha, cudaDataType alphaType, void* x, cudaDataType xType, int64_t incx, cudaDataType executionType);
+  // HIP: HIPBLAS_EXPORT hipblasStatus_t hipblasScalEx_v2_64(hipblasHandle_t handle, int64_t n, const void* alpha, hipDataType alphaType, void* x, hipDataType xType, int64_t incx, hipDataType executionType);
+  // CHECK: blasStatus = hipblasScalEx_v2_64(blasHandle, n_64, aptr, Atype, xptr, Xtype, incx_64, Executiontype);
+  blasStatus = cublasScalEx_64(blasHandle, n_64, aptr, Atype, xptr, Xtype, incx_64, Executiontype);
 #endif
 
   return 0;


### PR DESCRIPTION
+ Updated synthetic tests, the regenerated `hipify-perl`, and `BLAS` `CUDA2HIP` documentation