### PR TITLE
[HIPIFY][BLAS][6.2.0] cuBLAS support - Step 27 - All functions revising - final

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -1464,6 +1464,8 @@ my %experimental_funcs = (
     "cublasZsymv_64" => "6.2.0",
     "cublasZhpr_v2_64" => "6.2.0",
     "cublasZhpr_64" => "6.2.0",
+    "cublasZhpr2_v2_64" => "6.2.0",
+    "cublasZhpr2_64" => "6.2.0",
     "cublasZhpmv_v2_64" => "6.2.0",
     "cublasZhpmv_64" => "6.2.0",
     "cublasZher_v2_64" => "6.2.0",
@@ -1480,6 +1482,7 @@ my %experimental_funcs = (
     "cublasZgerc_64" => "6.2.0",
     "cublasZgemv_v2_64" => "6.2.0",
     "cublasZgemv_64" => "6.2.0",
+    "cublasZgemvStridedBatched_64" => "6.2.0",
     "cublasZgemvBatched_64" => "6.2.0",
     "cublasZgbmv_v2_64" => "6.2.0",
     "cublasZgbmv_64" => "6.2.0",
@@ -1503,6 +1506,8 @@ my %experimental_funcs = (
     "cublasSsymv_64" => "6.2.0",
     "cublasSspr_v2_64" => "6.2.0",
     "cublasSspr_64" => "6.2.0",
+    "cublasSspr2_v2_64" => "6.2.0",
+    "cublasSspr2_64" => "6.2.0",
     "cublasSspmv_v2_64" => "6.2.0",
     "cublasSspmv_64" => "6.2.0",
     "cublasSsbmv_v2_64" => "6.2.0",
@@ -1511,6 +1516,7 @@ my %experimental_funcs = (
     "cublasSger_64" => "6.2.0",
     "cublasSgemv_v2_64" => "6.2.0",
     "cublasSgemv_64" => "6.2.0",
+    "cublasSgemvStridedBatched_64" => "6.2.0",
     "cublasSgemvBatched_64" => "6.2.0",
     "cublasSgbmv_v2_64" => "6.2.0",
     "cublasSgbmv_64" => "6.2.0",
@@ -1537,6 +1543,8 @@ my %experimental_funcs = (
     "cublasDsymv_64" => "6.2.0",
     "cublasDspr_v2_64" => "6.2.0",
     "cublasDspr_64" => "6.2.0",
+    "cublasDspr2_v2_64" => "6.2.0",
+    "cublasDspr2_64" => "6.2.0",
     "cublasDspmv_v2_64" => "6.2.0",
     "cublasDspmv_64" => "6.2.0",
     "cublasDsbmv_v2_64" => "6.2.0",
@@ -1547,6 +1555,7 @@ my %experimental_funcs = (
     "cublasDger_64" => "6.2.0",
     "cublasDgemv_v2_64" => "6.2.0",
     "cublasDgemv_64" => "6.2.0",
+    "cublasDgemvStridedBatched_64" => "6.2.0",
     "cublasDgemvBatched_64" => "6.2.0",
     "cublasDgbmv_v2_64" => "6.2.0",
     "cublasDgbmv_64" => "6.2.0",
@@ -1570,6 +1579,8 @@ my %experimental_funcs = (
     "cublasCsymv_64" => "6.2.0",
     "cublasChpr_v2_64" => "6.2.0",
     "cublasChpr_64" => "6.2.0",
+    "cublasChpr2_v2_64" => "6.2.0",
+    "cublasChpr2_64" => "6.2.0",
     "cublasChpmv_v2_64" => "6.2.0",
     "cublasChpmv_64" => "6.2.0",
     "cublasCher_v2_64" => "6.2.0",
@@ -1586,6 +1597,7 @@ my %experimental_funcs = (
     "cublasCgerc_64" => "6.2.0",
     "cublasCgemv_v2_64" => "6.2.0",
     "cublasCgemv_64" => "6.2.0",
+    "cublasCgemvStridedBatched_64" => "6.2.0",
     "cublasCgemvBatched_64" => "6.2.0",
     "cublasCgbmv_v2_64" => "6.2.0",
     "cublasCgbmv_64" => "6.2.0",
@@ -1794,6 +1806,7 @@ sub experimentalSubstitutions {
     subst("cublasCgbmv_64", "hipblasCgbmv_v2_64", "library");
     subst("cublasCgbmv_v2_64", "hipblasCgbmv_v2_64", "library");
     subst("cublasCgemvBatched_64", "hipblasCgemvBatched_v2_64", "library");
+    subst("cublasCgemvStridedBatched_64", "hipblasCgemvStridedBatched_v2_64", "library");
     subst("cublasCgemv_64", "hipblasCgemv_v2_64", "library");
     subst("cublasCgemv_v2_64", "hipblasCgemv_v2_64", "library");
     subst("cublasCgerc_64", "hipblasCgerc_v2_64", "library");
@@ -1810,6 +1823,8 @@ sub experimentalSubstitutions {
     subst("cublasCher_v2_64", "hipblasCher_v2_64", "library");
     subst("cublasChpmv_64", "hipblasChpmv_v2_64", "library");
     subst("cublasChpmv_v2_64", "hipblasChpmv_v2_64", "library");
+    subst("cublasChpr2_64", "hipblasChpr2_v2_64", "library");
+    subst("cublasChpr2_v2_64", "hipblasChpr2_v2_64", "library");
     subst("cublasChpr_64", "hipblasChpr_v2_64", "library");
     subst("cublasChpr_v2_64", "hipblasChpr_v2_64", "library");
     subst("cublasCsymv_64", "hipblasCsymv_v2_64", "library");
@@ -1833,6 +1848,7 @@ sub experimentalSubstitutions {
     subst("cublasDgbmv_64", "hipblasDgbmv_64", "library");
     subst("cublasDgbmv_v2_64", "hipblasDgbmv_64", "library");
     subst("cublasDgemvBatched_64", "hipblasDgemvBatched_64", "library");
+    subst("cublasDgemvStridedBatched_64", "hipblasDgemvStridedBatched_64", "library");
     subst("cublasDgemv_64", "hipblasDgemv_64", "library");
     subst("cublasDgemv_v2_64", "hipblasDgemv_64", "library");
     subst("cublasDger_64", "hipblasDger_64", "library");
@@ -1843,6 +1859,8 @@ sub experimentalSubstitutions {
     subst("cublasDsbmv_v2_64", "hipblasDsbmv_64", "library");
     subst("cublasDspmv_64", "hipblasDspmv_64", "library");
     subst("cublasDspmv_v2_64", "hipblasDspmv_64", "library");
+    subst("cublasDspr2_64", "hipblasDspr2_64", "library");
+    subst("cublasDspr2_v2_64", "hipblasDspr2_64", "library");
     subst("cublasDspr_64", "hipblasDspr_64", "library");
     subst("cublasDspr_v2_64", "hipblasDspr_64", "library");
     subst("cublasDsymv_64", "hipblasDsymv_64", "library");
@@ -1869,6 +1887,7 @@ sub experimentalSubstitutions {
     subst("cublasSgbmv_64", "hipblasSgbmv_64", "library");
     subst("cublasSgbmv_v2_64", "hipblasSgbmv_64", "library");
     subst("cublasSgemvBatched_64", "hipblasSgemvBatched_64", "library");
+    subst("cublasSgemvStridedBatched_64", "hipblasSgemvStridedBatched_64", "library");
     subst("cublasSgemv_64", "hipblasSgemv_64", "library");
     subst("cublasSgemv_v2_64", "hipblasSgemv_64", "library");
     subst("cublasSger_64", "hipblasSger_64", "library");
@@ -1877,6 +1896,8 @@ sub experimentalSubstitutions {
     subst("cublasSsbmv_v2_64", "hipblasSsbmv_64", "library");
     subst("cublasSspmv_64", "hipblasSspmv_64", "library");
     subst("cublasSspmv_v2_64", "hipblasSspmv_64", "library");
+    subst("cublasSspr2_64", "hipblasSspr2_64", "library");
+    subst("cublasSspr2_v2_64", "hipblasSspr2_64", "library");
     subst("cublasSspr_64", "hipblasSspr_64", "library");
     subst("cublasSspr_v2_64", "hipblasSspr_64", "library");
     subst("cublasSsymv_64", "hipblasSsymv_64", "library");
@@ -1900,6 +1921,7 @@ sub experimentalSubstitutions {
     subst("cublasZgbmv_64", "hipblasZgbmv_v2_64", "library");
     subst("cublasZgbmv_v2_64", "hipblasZgbmv_v2_64", "library");
     subst("cublasZgemvBatched_64", "hipblasZgemvBatched_v2_64", "library");
+    subst("cublasZgemvStridedBatched_64", "hipblasZgemvStridedBatched_v2_64", "library");
     subst("cublasZgemv_64", "hipblasZgemv_v2_64", "library");
     subst("cublasZgemv_v2_64", "hipblasZgemv_v2_64", "library");
     subst("cublasZgerc_64", "hipblasZgerc_v2_64", "library");
@@ -1916,6 +1938,8 @@ sub experimentalSubstitutions {
     subst("cublasZher_v2_64", "hipblasZher_v2_64", "library");
     subst("cublasZhpmv_64", "hipblasZhpmv_v2_64", "library");
     subst("cublasZhpmv_v2_64", "hipblasZhpmv_v2_64", "library");
+    subst("cublasZhpr2_64", "hipblasZhpr2_v2_64", "library");
+    subst("cublasZhpr2_v2_64", "hipblasZhpr2_v2_64", "library");
     subst("cublasZhpr_64", "hipblasZhpr_v2_64", "library");
     subst("cublasZhpr_v2_64", "hipblasZhpr_v2_64", "library");
     subst("cublasZsymv_64", "hipblasZsymv_v2_64", "library");
@@ -4061,7 +4085,6 @@ sub simpleSubstitutions {
     subst("cublasCgemv", "hipblasCgemv_v2", "library");
     subst("cublasCgemvBatched", "hipblasCgemvBatched_v2", "library");
     subst("cublasCgemvStridedBatched", "hipblasCgemvStridedBatched_v2", "library");
-    subst("cublasCgemvStridedBatched_64", "hipblasCgemvStridedBatched_v2_64", "library");
     subst("cublasCgemv_v2", "hipblasCgemv_v2", "library");
     subst("cublasCgeqrfBatched", "hipblasCgeqrfBatched_v2", "library");
     subst("cublasCgerc", "hipblasCgerc_v2", "library");
@@ -4090,9 +4113,7 @@ sub simpleSubstitutions {
     subst("cublasChpmv_v2", "hipblasChpmv_v2", "library");
     subst("cublasChpr", "hipblasChpr_v2", "library");
     subst("cublasChpr2", "hipblasChpr2_v2", "library");
-    subst("cublasChpr2_64", "hipblasChpr2_v2_64", "library");
     subst("cublasChpr2_v2", "hipblasChpr2_v2", "library");
-    subst("cublasChpr2_v2_64", "hipblasChpr2_v2_64", "library");
     subst("cublasChpr_v2", "hipblasChpr_v2", "library");
     subst("cublasCreate", "hipblasCreate", "library");
     subst("cublasCreate_v2", "hipblasCreate", "library");
@@ -4178,7 +4199,6 @@ sub simpleSubstitutions {
     subst("cublasDgemv", "hipblasDgemv", "library");
     subst("cublasDgemvBatched", "hipblasDgemvBatched", "library");
     subst("cublasDgemvStridedBatched", "hipblasDgemvStridedBatched", "library");
-    subst("cublasDgemvStridedBatched_64", "hipblasDgemvStridedBatched_64", "library");
     subst("cublasDgemv_v2", "hipblasDgemv", "library");
     subst("cublasDgeqrfBatched", "hipblasDgeqrfBatched", "library");
     subst("cublasDger", "hipblasDger", "library");
@@ -4214,9 +4234,7 @@ sub simpleSubstitutions {
     subst("cublasDspmv_v2", "hipblasDspmv", "library");
     subst("cublasDspr", "hipblasDspr", "library");
     subst("cublasDspr2", "hipblasDspr2", "library");
-    subst("cublasDspr2_64", "hipblasDspr2_64", "library");
     subst("cublasDspr2_v2", "hipblasDspr2", "library");
-    subst("cublasDspr2_v2_64", "hipblasDspr2_64", "library");
     subst("cublasDspr_v2", "hipblasDspr", "library");
     subst("cublasDswap", "hipblasDswap", "library");
     subst("cublasDswap_64", "hipblasDswap_64", "library");
@@ -4378,7 +4396,6 @@ sub simpleSubstitutions {
     subst("cublasSgemv", "hipblasSgemv", "library");
     subst("cublasSgemvBatched", "hipblasSgemvBatched", "library");
     subst("cublasSgemvStridedBatched", "hipblasSgemvStridedBatched", "library");
-    subst("cublasSgemvStridedBatched_64", "hipblasSgemvStridedBatched_64", "library");
     subst("cublasSgemv_v2", "hipblasSgemv", "library");
     subst("cublasSgeqrfBatched", "hipblasSgeqrfBatched", "library");
     subst("cublasSger", "hipblasSger", "library");
@@ -4412,9 +4429,7 @@ sub simpleSubstitutions {
     subst("cublasSspmv_v2", "hipblasSspmv", "library");
     subst("cublasSspr", "hipblasSspr", "library");
     subst("cublasSspr2", "hipblasSspr2", "library");
-    subst("cublasSspr2_64", "hipblasSspr2_64", "library");
     subst("cublasSspr2_v2", "hipblasSspr2", "library");
-    subst("cublasSspr2_v2_64", "hipblasSspr2_64", "library");
     subst("cublasSspr_v2", "hipblasSspr", "library");
     subst("cublasSswap", "hipblasSswap", "library");
     subst("cublasSswap_64", "hipblasSswap_64", "library");
@@ -4486,7 +4501,6 @@ sub simpleSubstitutions {
     subst("cublasZgemv", "hipblasZgemv_v2", "library");
     subst("cublasZgemvBatched", "hipblasZgemvBatched_v2", "library");
     subst("cublasZgemvStridedBatched", "hipblasZgemvStridedBatched_v2", "library");
-    subst("cublasZgemvStridedBatched_64", "hipblasZgemvStridedBatched_v2_64", "library");
     subst("cublasZgemv_v2", "hipblasZgemv_v2", "library");
     subst("cublasZgeqrfBatched", "hipblasZgeqrfBatched_v2", "library");
     subst("cublasZgerc", "hipblasZgerc_v2", "library");
@@ -4515,9 +4529,7 @@ sub simpleSubstitutions {
     subst("cublasZhpmv_v2", "hipblasZhpmv_v2", "library");
     subst("cublasZhpr", "hipblasZhpr_v2", "library");
     subst("cublasZhpr2", "hipblasZhpr2_v2", "library");
-    subst("cublasZhpr2_64", "hipblasZhpr2_v2_64", "library");
     subst("cublasZhpr2_v2", "hipblasZhpr2_v2", "library");
-    subst("cublasZhpr2_v2_64", "hipblasZhpr2_v2_64", "library");
     subst("cublasZhpr_v2", "hipblasZhpr_v2", "library");
     subst("cublasZrot", "hipblasZrot_v2", "library");
     subst("cublasZrot_64", "hipblasZrot_v2_64", "library");

--- a/src/CUDA2HIP_BLAS_API_functions.cpp
+++ b/src/CUDA2HIP_BLAS_API_functions.cpp
@@ -388,13 +388,13 @@ const std::map<llvm::StringRef, hipCounter> CUDA_BLAS_FUNCTION_MAP {
 
   // SPR2/HPR2
   {"cublasSspr2",                                          {"hipblasSspr2",                                              "rocblas_sspr2",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, HIP_SUPPORTED_V2_ONLY}},
-  {"cublasSspr2_64",                                       {"hipblasSspr2_64",                                           "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
+  {"cublasSspr2_64",                                       {"hipblasSspr2_64",                                           "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
   {"cublasDspr2",                                          {"hipblasDspr2",                                              "rocblas_dspr2",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, HIP_SUPPORTED_V2_ONLY}},
-  {"cublasDspr2_64",                                       {"hipblasDspr2_64",                                           "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
+  {"cublasDspr2_64",                                       {"hipblasDspr2_64",                                           "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
   {"cublasChpr2",                                          {"hipblasChpr2_v2",                                           "rocblas_chpr2",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, HIP_SUPPORTED_V2_ONLY}},
-  {"cublasChpr2_64",                                       {"hipblasChpr2_v2_64",                                        "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
+  {"cublasChpr2_64",                                       {"hipblasChpr2_v2_64",                                        "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
   {"cublasZhpr2",                                          {"hipblasZhpr2_v2",                                           "rocblas_zhpr2",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, HIP_SUPPORTED_V2_ONLY}},
-  {"cublasZhpr2_64",                                       {"hipblasZhpr2_v2_64",                                        "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
+  {"cublasZhpr2_64",                                       {"hipblasZhpr2_v2_64",                                        "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
 
   // Blas3 (v1) Routines
   // GEMM
@@ -459,13 +459,13 @@ const std::map<llvm::StringRef, hipCounter> CUDA_BLAS_FUNCTION_MAP {
   {"cublasTSSgemvBatched",                                 {"hipblasTSSgemvBatched",                                     "rocblas_tssgemv_batched",                            CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3, HIP_UNSUPPORTED}},
   {"cublasTSSgemvBatched_64",                              {"hipblasTSSgemvBatched_64",                                  "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3, UNSUPPORTED}},
   {"cublasSgemvStridedBatched",                            {"hipblasSgemvStridedBatched",                                "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3, ROC_UNSUPPORTED}},
-  {"cublasSgemvStridedBatched_64",                         {"hipblasSgemvStridedBatched_64",                             "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3, ROC_UNSUPPORTED}},
+  {"cublasSgemvStridedBatched_64",                         {"hipblasSgemvStridedBatched_64",                             "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
   {"cublasDgemvStridedBatched",                            {"hipblasDgemvStridedBatched",                                "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3, ROC_UNSUPPORTED}},
-  {"cublasDgemvStridedBatched_64",                         {"hipblasDgemvStridedBatched_64",                             "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3, ROC_UNSUPPORTED}},
+  {"cublasDgemvStridedBatched_64",                         {"hipblasDgemvStridedBatched_64",                             "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
   {"cublasCgemvStridedBatched",                            {"hipblasCgemvStridedBatched_v2",                             "rocblas_cgemv_strided_batched",                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3}},
-  {"cublasCgemvStridedBatched_64",                         {"hipblasCgemvStridedBatched_v2_64",                          "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3, ROC_UNSUPPORTED}},
+  {"cublasCgemvStridedBatched_64",                         {"hipblasCgemvStridedBatched_v2_64",                          "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
   {"cublasZgemvStridedBatched",                            {"hipblasZgemvStridedBatched_v2",                             "rocblas_zgemv_strided_batched",                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3}},
-  {"cublasZgemvStridedBatched_64",                         {"hipblasZgemvStridedBatched_v2_64",                          "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3, ROC_UNSUPPORTED}},
+  {"cublasZgemvStridedBatched_64",                         {"hipblasZgemvStridedBatched_v2_64",                          "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
   {"cublasHSHgemvStridedBatched",                          {"hipblasHSHgemvStridedBatched",                              "rocblas_hshgemv_strided_batched",                    CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3, HIP_UNSUPPORTED}},
   {"cublasHSHgemvStridedBatched_64",                       {"hipblasHSHgemvStridedBatched_64",                           "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3, UNSUPPORTED}},
   {"cublasHSSgemvStridedBatched",                          {"hipblasHSSgemvStridedBatched",                              "rocblas_hssgemv_strided_batched",                    CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3, HIP_UNSUPPORTED}},
@@ -806,13 +806,13 @@ const std::map<llvm::StringRef, hipCounter> CUDA_BLAS_FUNCTION_MAP {
 
   // SPR2/HPR2
   {"cublasSspr2_v2",                                       {"hipblasSspr2",                                              "rocblas_sspr2",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
-  {"cublasSspr2_v2_64",                                    {"hipblasSspr2_64",                                           "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
+  {"cublasSspr2_v2_64",                                    {"hipblasSspr2_64",                                           "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
   {"cublasDspr2_v2",                                       {"hipblasDspr2",                                              "rocblas_dspr2",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
-  {"cublasDspr2_v2_64",                                    {"hipblasDspr2_64",                                           "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
+  {"cublasDspr2_v2_64",                                    {"hipblasDspr2_64",                                           "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
   {"cublasChpr2_v2",                                       {"hipblasChpr2_v2",                                           "rocblas_chpr2",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
-  {"cublasChpr2_v2_64",                                    {"hipblasChpr2_v2_64",                                        "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
+  {"cublasChpr2_v2_64",                                    {"hipblasChpr2_v2_64",                                        "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
   {"cublasZhpr2_v2",                                       {"hipblasZhpr2_v2",                                           "rocblas_zhpr2",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
-  {"cublasZhpr2_v2_64",                                    {"hipblasZhpr2_v2_64",                                        "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
+  {"cublasZhpr2_v2_64",                                    {"hipblasZhpr2_v2_64",                                        "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED | HIP_EXPERIMENTAL}},
 
   // Blas3 (v2) Routines
   // GEMM
@@ -1715,8 +1715,6 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_BLAS_FUNCTION_VER_MAP {
   {"hipblasHgemmStridedBatched",                           {HIP_3000, HIP_0,    HIP_0   }},
   {"hipblasSsyrk",                                         {HIP_3050, HIP_0,    HIP_0   }},
   {"hipblasDsyrk",                                         {HIP_3050, HIP_0,    HIP_0   }},
-  {"hipblasCherk",                                         {HIP_3050, HIP_0,    HIP_0   }},
-  {"hipblasZherk",                                         {HIP_3050, HIP_0,    HIP_0   }},
   {"hipblasSsyr2k",                                        {HIP_3050, HIP_0,    HIP_0   }},
   {"hipblasDsyr2k",                                        {HIP_3050, HIP_0,    HIP_0   }},
   {"hipblasSsyrkx",                                        {HIP_3050, HIP_0,    HIP_0   }},
@@ -1725,7 +1723,6 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_BLAS_FUNCTION_VER_MAP {
   {"hipblasDsymm",                                         {HIP_3060, HIP_0,    HIP_0   }},
   {"hipblasStrsm",                                         {HIP_1082, HIP_0,    HIP_0   }},
   {"hipblasDtrsm",                                         {HIP_1082, HIP_0,    HIP_0   }},
-  {"hipblasZtrsm",                                         {HIP_3050, HIP_0,    HIP_0   }},
   {"hipblasStrmm",                                         {HIP_3020, HIP_0,    HIP_0   }},
   {"hipblasDtrmm",                                         {HIP_3020, HIP_0,    HIP_0   }},
   {"hipblasSgeam",                                         {HIP_1082, HIP_0,    HIP_0   }},


### PR DESCRIPTION
+ Remove v1 versions of those functions, for which only v2 versions are used in hipification
+ Mark the rest of `HIP_EXPERIMENTAL` functions
