### PR TITLE
[HIPIFY][HIP][6.2.0] Revise HIP APIs - Step 3 - Post 6.2 APIs removal

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -1426,13 +1426,10 @@ my %experimental_funcs = (
     "cudaLaunchAttributeCooperative" => "6.2.0",
     "cudaLaunchAttributeAccessPolicyWindow" => "6.2.0",
     "cudaKernelNodeAttributePriority" => "6.2.0",
-    "cudaGraphNodeSetParams" => "6.2.0",
     "cudaGraphKernelNodePortProgrammatic" => "6.2.0",
     "cudaGraphKernelNodePortLaunchCompletion" => "6.2.0",
     "cudaGraphKernelNodePortDefault" => "6.2.0",
     "cudaGraphInstantiateWithParams" => "6.2.0",
-    "cudaGraphExecNodeSetParams" => "6.2.0",
-    "cudaGraphExecGetFlags" => "6.2.0",
     "cudaGraphEdgeData_st" => "6.2.0",
     "cudaGraphEdgeData" => "6.2.0",
     "cudaGraphDependencyType_enum" => "6.2.0",
@@ -1615,15 +1612,8 @@ my %experimental_funcs = (
     "cuMemcpyAtoD" => "6.2.0",
     "cuMemcpyAtoA_v2" => "6.2.0",
     "cuMemcpyAtoA" => "6.2.0",
-    "cuGraphNodeSetParams" => "6.2.0",
-    "cuGraphMemcpyNodeSetParams" => "6.2.0",
-    "cuGraphMemcpyNodeGetParams" => "6.2.0",
     "cuGraphInstantiateWithParams" => "6.2.0",
-    "cuGraphExecNodeSetParams" => "6.2.0",
-    "cuGraphExecMemcpyNodeSetParams" => "6.2.0",
-    "cuGraphExecGetFlags" => "6.2.0",
     "cuGraphAddNode" => "6.2.0",
-    "cuGraphAddMemFreeNode" => "6.2.0",
     "cuGetProcAddress" => "6.2.0",
     "CUlaunchAttributeValue_union" => "6.2.0",
     "CUlaunchAttributeValue" => "6.2.0",
@@ -1809,20 +1799,10 @@ sub experimentalSubstitutions {
     subst("cudaMemcpy2DArrayToArray", "hipMemcpy2DArrayToArray", "memory");
     subst("cuStreamBeginCaptureToGraph", "hipStreamBeginCaptureToGraph", "stream");
     subst("cudaStreamBeginCaptureToGraph", "hipStreamBeginCaptureToGraph", "stream");
-    subst("cuGraphAddMemFreeNode", "hipDrvGraphAddMemFreeNode", "graph");
     subst("cuGraphAddNode", "hipGraphAddNode", "graph");
-    subst("cuGraphExecGetFlags", "hipGraphExecGetFlags", "graph");
-    subst("cuGraphExecMemcpyNodeSetParams", "hipDrvGraphExecMemcpyNodeSetParams", "graph");
-    subst("cuGraphExecNodeSetParams", "hipGraphExecNodeSetParams", "graph");
     subst("cuGraphInstantiateWithParams", "hipGraphInstantiateWithParams", "graph");
-    subst("cuGraphMemcpyNodeGetParams", "hipDrvGraphMemcpyNodeGetParams", "graph");
-    subst("cuGraphMemcpyNodeSetParams", "hipDrvGraphMemcpyNodeSetParams", "graph");
-    subst("cuGraphNodeSetParams", "hipGraphNodeSetParams", "graph");
     subst("cudaGraphAddNode", "hipGraphAddNode", "graph");
-    subst("cudaGraphExecGetFlags", "hipGraphExecGetFlags", "graph");
-    subst("cudaGraphExecNodeSetParams", "hipGraphExecNodeSetParams", "graph");
     subst("cudaGraphInstantiateWithParams", "hipGraphInstantiateWithParams", "graph");
-    subst("cudaGraphNodeSetParams", "hipGraphNodeSetParams", "graph");
     subst("cuGetProcAddress", "hipGetProcAddress", "driver_entry_point");
     subst("cudaGetDriverEntryPoint", "hipGetProcAddress", "driver_entry_point");
     subst("cudaGetFuncBySymbol", "hipGetFuncBySymbol", "driver_interact");
@@ -9580,6 +9560,7 @@ sub warnUnsupportedFunctions {
         "cudaGraphicsCubeFaceNegativeX",
         "cudaGraphicsCubeFace",
         "cudaGraphRemoveDependencies_v2",
+        "cudaGraphNodeSetParams",
         "cudaGraphNodeGetDependentNodes_v2",
         "cudaGraphNodeGetDependencies_v2",
         "cudaGraphKernelNodeUpdate",
@@ -9592,6 +9573,8 @@ sub warnUnsupportedFunctions {
         "cudaGraphExecUpdateResultInfo_st",
         "cudaGraphExecUpdateResultInfo",
         "cudaGraphExecUpdateErrorAttributesChanged",
+        "cudaGraphExecNodeSetParams",
+        "cudaGraphExecGetFlags",
         "cudaGraphDeviceNode_t",
         "cudaGraphDebugDotFlagsConditionalNodeParams",
         "cudaGraphConditionalNodeType",
@@ -10071,11 +10054,18 @@ sub warnUnsupportedFunctions {
         "cuGraphicsD3D11RegisterResource",
         "cuGraphicsD3D10RegisterResource",
         "cuGraphRemoveDependencies_v2",
+        "cuGraphNodeSetParams",
         "cuGraphNodeGetDependentNodes_v2",
         "cuGraphNodeGetDependencies_v2",
+        "cuGraphMemcpyNodeSetParams",
+        "cuGraphMemcpyNodeGetParams",
         "cuGraphGetEdges_v2",
+        "cuGraphExecNodeSetParams",
+        "cuGraphExecMemcpyNodeSetParams",
+        "cuGraphExecGetFlags",
         "cuGraphConditionalHandleCreate",
         "cuGraphAddNode_v2",
+        "cuGraphAddMemFreeNode",
         "cuGraphAddDependencies_v2",
         "cuGLUnregisterBufferObject",
         "cuGLUnmapBufferObjectAsync",

--- a/docs/tables/CUDA_Driver_API_functions_supported_by_HIP.md
+++ b/docs/tables/CUDA_Driver_API_functions_supported_by_HIP.md
@@ -1900,7 +1900,7 @@
 |`cuGraphAddHostNode`|10.0| | | |`hipGraphAddHostNode`|5.0.0| | | | |
 |`cuGraphAddKernelNode`|10.0| | | |`hipGraphAddKernelNode`|4.3.0| | | | |
 |`cuGraphAddMemAllocNode`|11.4| | | |`hipGraphAddMemAllocNode`|5.5.0| | | | |
-|`cuGraphAddMemFreeNode`|11.4| | | |`hipDrvGraphAddMemFreeNode`|6.2.0| | | |6.2.0|
+|`cuGraphAddMemFreeNode`|11.4| | | | | | | | | |
 |`cuGraphAddMemcpyNode`|10.0| | | |`hipDrvGraphAddMemcpyNode`|6.0.0| | | | |
 |`cuGraphAddMemsetNode`|10.0| | | |`hipDrvGraphAddMemsetNode`|6.1.0| | | | |
 |`cuGraphAddNode`|12.2| | | |`hipGraphAddNode`|6.2.0| | | |6.2.0|
@@ -1925,11 +1925,11 @@
 |`cuGraphExecEventWaitNodeSetEvent`|11.1| | | |`hipGraphExecEventWaitNodeSetEvent`|5.0.0| | | | |
 |`cuGraphExecExternalSemaphoresSignalNodeSetParams`|11.2| | | |`hipGraphExecExternalSemaphoresSignalNodeSetParams`|5.7.0| | | | |
 |`cuGraphExecExternalSemaphoresWaitNodeSetParams`|11.2| | | |`hipGraphExecExternalSemaphoresWaitNodeSetParams`|5.7.0| | | | |
-|`cuGraphExecGetFlags`|12.0| | | |`hipGraphExecGetFlags`|6.2.0| | | |6.2.0|
+|`cuGraphExecGetFlags`|12.0| | | | | | | | | |
 |`cuGraphExecHostNodeSetParams`|10.2| | | |`hipGraphExecHostNodeSetParams`|5.0.0| | | | |
 |`cuGraphExecKernelNodeSetParams`|10.1| | | |`hipGraphExecKernelNodeSetParams`|4.5.0| | | | |
-|`cuGraphExecMemcpyNodeSetParams`|10.2| | | |`hipDrvGraphExecMemcpyNodeSetParams`|6.2.0| | | |6.2.0|
-|`cuGraphExecNodeSetParams`|12.2| | | |`hipGraphExecNodeSetParams`|6.2.0| | | |6.2.0|
+|`cuGraphExecMemcpyNodeSetParams`|10.2| | | | | | | | | |
+|`cuGraphExecNodeSetParams`|12.2| | | | | | | | | |
 |`cuGraphExecUpdate`|10.2| | | |`hipGraphExecUpdate`|5.0.0| | | | |
 |`cuGraphExternalSemaphoresSignalNodeGetParams`|11.2| | | |`hipGraphExternalSemaphoresSignalNodeGetParams`|5.7.0| | | | |
 |`cuGraphExternalSemaphoresSignalNodeSetParams`|11.2| | | |`hipGraphExternalSemaphoresSignalNodeSetParams`|5.7.0| | | | |
@@ -1953,8 +1953,8 @@
 |`cuGraphLaunch`|10.0| | | |`hipGraphLaunch`|4.3.0| | | | |
 |`cuGraphMemAllocNodeGetParams`|11.4| | | |`hipGraphMemAllocNodeGetParams`|5.5.0| | | | |
 |`cuGraphMemFreeNodeGetParams`|11.4| | | |`hipGraphMemFreeNodeGetParams`|5.5.0| | | | |
-|`cuGraphMemcpyNodeGetParams`|10.0| | | |`hipDrvGraphMemcpyNodeGetParams`|6.2.0| | | |6.2.0|
-|`cuGraphMemcpyNodeSetParams`|10.0| | | |`hipDrvGraphMemcpyNodeSetParams`|6.2.0| | | |6.2.0|
+|`cuGraphMemcpyNodeGetParams`|10.0| | | | | | | | | |
+|`cuGraphMemcpyNodeSetParams`|10.0| | | | | | | | | |
 |`cuGraphMemsetNodeGetParams`|10.0| | | |`hipGraphMemsetNodeGetParams`|4.5.0| | | | |
 |`cuGraphMemsetNodeSetParams`|10.0| | | |`hipGraphMemsetNodeSetParams`|4.5.0| | | | |
 |`cuGraphNodeFindInClone`|10.0| | | |`hipGraphNodeFindInClone`|5.0.0| | | | |
@@ -1965,7 +1965,7 @@
 |`cuGraphNodeGetEnabled`|11.6| | | |`hipGraphNodeGetEnabled`|5.5.0| | | | |
 |`cuGraphNodeGetType`|10.0| | | |`hipGraphNodeGetType`|5.0.0| | | | |
 |`cuGraphNodeSetEnabled`|11.6| | | |`hipGraphNodeSetEnabled`|5.5.0| | | | |
-|`cuGraphNodeSetParams`|12.2| | | |`hipGraphNodeSetParams`|6.2.0| | | |6.2.0|
+|`cuGraphNodeSetParams`|12.2| | | | | | | | | |
 |`cuGraphReleaseUserObject`|11.3| | | |`hipGraphReleaseUserObject`|5.3.0| | | | |
 |`cuGraphRemoveDependencies`|10.0| | | |`hipGraphRemoveDependencies`|5.0.0| | | | |
 |`cuGraphRemoveDependencies_v2`|12.3| | | | | | | | | |

--- a/docs/tables/CUDA_Runtime_API_functions_supported_by_HIP.md
+++ b/docs/tables/CUDA_Runtime_API_functions_supported_by_HIP.md
@@ -464,7 +464,7 @@
 |`cudaGraphExecEventWaitNodeSetEvent`|11.1| | | |`hipGraphExecEventWaitNodeSetEvent`|5.0.0| | | | |
 |`cudaGraphExecExternalSemaphoresSignalNodeSetParams`|11.2| | | |`hipGraphExecExternalSemaphoresSignalNodeSetParams`|5.7.0| | | | |
 |`cudaGraphExecExternalSemaphoresWaitNodeSetParams`|11.2| | | |`hipGraphExecExternalSemaphoresWaitNodeSetParams`|5.7.0| | | | |
-|`cudaGraphExecGetFlags`|12.0| | | |`hipGraphExecGetFlags`|6.2.0| | | |6.2.0|
+|`cudaGraphExecGetFlags`|12.0| | | | | | | | | |
 |`cudaGraphExecHostNodeSetParams`|11.0| | | |`hipGraphExecHostNodeSetParams`|5.0.0| | | | |
 |`cudaGraphExecKernelNodeSetParams`|11.0| | | |`hipGraphExecKernelNodeSetParams`|4.5.0| | | | |
 |`cudaGraphExecMemcpyNodeSetParams`|11.0| | | |`hipGraphExecMemcpyNodeSetParams`|5.0.0| | | | |
@@ -472,7 +472,7 @@
 |`cudaGraphExecMemcpyNodeSetParamsFromSymbol`|11.1| | | |`hipGraphExecMemcpyNodeSetParamsFromSymbol`|5.0.0| | | | |
 |`cudaGraphExecMemcpyNodeSetParamsToSymbol`|11.1| | | |`hipGraphExecMemcpyNodeSetParamsToSymbol`|5.0.0| | | | |
 |`cudaGraphExecMemsetNodeSetParams`|11.0| | | |`hipGraphExecMemsetNodeSetParams`|5.0.0| | | | |
-|`cudaGraphExecNodeSetParams`|12.2| | | |`hipGraphExecNodeSetParams`|6.2.0| | | |6.2.0|
+|`cudaGraphExecNodeSetParams`|12.2| | | | | | | | | |
 |`cudaGraphExecUpdate`|11.0| | | |`hipGraphExecUpdate`|5.0.0| | | | |
 |`cudaGraphExternalSemaphoresSignalNodeGetParams`|11.2| | | |`hipGraphExternalSemaphoresSignalNodeGetParams`|5.7.0| | | | |
 |`cudaGraphExternalSemaphoresSignalNodeSetParams`|11.2| | | |`hipGraphExternalSemaphoresSignalNodeSetParams`|5.7.0| | | | |
@@ -510,7 +510,7 @@
 |`cudaGraphNodeGetEnabled`|11.6| | | |`hipGraphNodeGetEnabled`|5.5.0| | | | |
 |`cudaGraphNodeGetType`|11.0| | | |`hipGraphNodeGetType`|5.0.0| | | | |
 |`cudaGraphNodeSetEnabled`|11.6| | | |`hipGraphNodeSetEnabled`|5.5.0| | | | |
-|`cudaGraphNodeSetParams`|12.2| | | |`hipGraphNodeSetParams`|6.2.0| | | |6.2.0|
+|`cudaGraphNodeSetParams`|12.2| | | | | | | | | |
 |`cudaGraphReleaseUserObject`|11.3| | | |`hipGraphReleaseUserObject`|5.3.0| | | | |
 |`cudaGraphRemoveDependencies`|11.0| | | |`hipGraphRemoveDependencies`|5.0.0| | | | |
 |`cudaGraphRemoveDependencies_v2`|12.3| | | | | | | | | |

--- a/src/CUDA2HIP_Driver_API_functions.cpp
+++ b/src/CUDA2HIP_Driver_API_functions.cpp
@@ -710,9 +710,9 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_FUNCTION_MAP {
   // cudaGraphLaunch
   {"cuGraphLaunch",                                               {"hipGraphLaunch",                                              "", CONV_GRAPH, API_DRIVER, SEC::GRAPH}},
   // NOTE: cudaGraphMemcpyNodeGetParams has a different signature
-  {"cuGraphMemcpyNodeGetParams",                                  {"hipDrvGraphMemcpyNodeGetParams",                              "", CONV_GRAPH, API_DRIVER, SEC::GRAPH, HIP_EXPERIMENTAL}},
+  {"cuGraphMemcpyNodeGetParams",                                  {"hipDrvGraphMemcpyNodeGetParams",                              "", CONV_GRAPH, API_DRIVER, SEC::GRAPH, HIP_UNSUPPORTED}},
   // NOTE: cudaGraphMemcpyNodeSetParams has a different signature
-  {"cuGraphMemcpyNodeSetParams",                                  {"hipDrvGraphMemcpyNodeSetParams",                              "", CONV_GRAPH, API_DRIVER, SEC::GRAPH, HIP_EXPERIMENTAL}},
+  {"cuGraphMemcpyNodeSetParams",                                  {"hipDrvGraphMemcpyNodeSetParams",                              "", CONV_GRAPH, API_DRIVER, SEC::GRAPH, HIP_UNSUPPORTED}},
   // cudaGraphMemsetNodeGetParams
   {"cuGraphMemsetNodeGetParams",                                  {"hipGraphMemsetNodeGetParams",                                 "", CONV_GRAPH, API_DRIVER, SEC::GRAPH}},
   // cudaGraphMemsetNodeSetParams
@@ -738,7 +738,7 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_FUNCTION_MAP {
   // cudaGraphRemoveDependencies_v2
   {"cuGraphRemoveDependencies_v2",                                {"hipGraphRemoveDependencies_v2",                               "", CONV_GRAPH, API_DRIVER, SEC::GRAPH, HIP_UNSUPPORTED}},
   // no analogue
-  {"cuGraphExecMemcpyNodeSetParams",                              {"hipDrvGraphExecMemcpyNodeSetParams",                          "", CONV_GRAPH, API_DRIVER, SEC::GRAPH, HIP_EXPERIMENTAL}},
+  {"cuGraphExecMemcpyNodeSetParams",                              {"hipDrvGraphExecMemcpyNodeSetParams",                          "", CONV_GRAPH, API_DRIVER, SEC::GRAPH, HIP_UNSUPPORTED}},
   // cudaGraphExecHostNodeSetParams
   {"cuGraphExecHostNodeSetParams",                                {"hipGraphExecHostNodeSetParams",                               "", CONV_GRAPH, API_DRIVER, SEC::GRAPH}},
   // TODO: take into account the new signature since 12.0
@@ -795,7 +795,7 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_FUNCTION_MAP {
   // cudaGraphMemAllocNodeGetParams
   {"cuGraphMemAllocNodeGetParams",                                {"hipGraphMemAllocNodeGetParams",                               "", CONV_GRAPH, API_DRIVER, SEC::GRAPH}},
   // no analogue
-  {"cuGraphAddMemFreeNode",                                       {"hipDrvGraphAddMemFreeNode",                                   "", CONV_GRAPH, API_DRIVER, SEC::GRAPH, HIP_EXPERIMENTAL}},
+  {"cuGraphAddMemFreeNode",                                       {"hipDrvGraphAddMemFreeNode",                                   "", CONV_GRAPH, API_DRIVER, SEC::GRAPH, HIP_UNSUPPORTED}},
   // cudaGraphMemFreeNodeGetParams
   {"cuGraphMemFreeNodeGetParams",                                 {"hipGraphMemFreeNodeGetParams",                                "", CONV_GRAPH, API_DRIVER, SEC::GRAPH}},
   // cudaDeviceGraphMemTrim
@@ -817,15 +817,15 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_FUNCTION_MAP {
   // cudaGraphInstantiateWithParams
   {"cuGraphInstantiateWithParams",                                {"hipGraphInstantiateWithParams",                               "", CONV_GRAPH, API_DRIVER, SEC::GRAPH, HIP_EXPERIMENTAL}},
   // cudaGraphExecGetFlags
-  {"cuGraphExecGetFlags",                                         {"hipGraphExecGetFlags",                                        "", CONV_GRAPH, API_DRIVER, SEC::GRAPH, HIP_EXPERIMENTAL}},
+  {"cuGraphExecGetFlags",                                         {"hipGraphExecGetFlags",                                        "", CONV_GRAPH, API_DRIVER, SEC::GRAPH, HIP_UNSUPPORTED}},
   // cudaGraphAddNode
   {"cuGraphAddNode",                                              {"hipGraphAddNode",                                             "", CONV_GRAPH, API_DRIVER, SEC::GRAPH, HIP_EXPERIMENTAL}},
   // cudaGraphAddNode_v2
   {"cuGraphAddNode_v2",                                           {"hipGraphAddNode_v2",                                          "", CONV_GRAPH, API_DRIVER, SEC::GRAPH, HIP_UNSUPPORTED}},
   // cudaGraphNodeSetParams
-  {"cuGraphNodeSetParams",                                        {"hipGraphNodeSetParams",                                       "", CONV_GRAPH, API_DRIVER, SEC::GRAPH, HIP_EXPERIMENTAL}},
+  {"cuGraphNodeSetParams",                                        {"hipGraphNodeSetParams",                                       "", CONV_GRAPH, API_DRIVER, SEC::GRAPH, HIP_UNSUPPORTED}},
   // cudaGraphExecNodeSetParams
-  {"cuGraphExecNodeSetParams",                                    {"hipGraphExecNodeSetParams",                                   "", CONV_GRAPH, API_DRIVER, SEC::GRAPH, HIP_EXPERIMENTAL}},
+  {"cuGraphExecNodeSetParams",                                    {"hipGraphExecNodeSetParams",                                   "", CONV_GRAPH, API_DRIVER, SEC::GRAPH, HIP_UNSUPPORTED}},
   // cudaGraphConditionalHandleCreate
   {"cuGraphConditionalHandleCreate",                              {"hipGraphConditionalHandleCreate",                             "", CONV_GRAPH, API_DRIVER, SEC::GRAPH, HIP_UNSUPPORTED}},
 
@@ -1651,11 +1651,7 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_DRIVER_FUNCTION_VER_MAP {
   {"hipArrayGetDescriptor",                                       {HIP_5060, HIP_0,    HIP_0   }},
   {"hipArray3DGetDescriptor",                                     {HIP_5060, HIP_0,    HIP_0   }},
   {"hipDrvGraphAddMemcpyNode",                                    {HIP_6000, HIP_0,    HIP_0   }},
-  {"hipDrvGraphMemcpyNodeGetParams",                              {HIP_6020, HIP_0,    HIP_0,  HIP_LATEST}},
-  {"hipDrvGraphMemcpyNodeSetParams",                              {HIP_6020, HIP_0,    HIP_0,  HIP_LATEST}},
   {"hipDrvGraphAddMemsetNode",                                    {HIP_6010, HIP_0,    HIP_0   }},
-  {"hipDrvGraphAddMemFreeNode",                                   {HIP_6020, HIP_0,    HIP_0,  HIP_LATEST}},
-  {"hipDrvGraphExecMemcpyNodeSetParams",                          {HIP_6020, HIP_0,    HIP_0,  HIP_LATEST}},
   {"hipTexRefGetBorderColor",                                     {HIP_6010, HIP_6010, HIP_0   }},
   {"hipMemcpyAtoD",                                               {HIP_6020, HIP_0,    HIP_0,  HIP_LATEST}},
   {"hipMemcpyDtoA",                                               {HIP_6020, HIP_0,    HIP_0,  HIP_LATEST}},

--- a/src/CUDA2HIP_Runtime_API_functions.cpp
+++ b/src/CUDA2HIP_Runtime_API_functions.cpp
@@ -863,15 +863,15 @@ const std::map<llvm::StringRef, hipCounter> CUDA_RUNTIME_FUNCTION_MAP {
   // cuGraphInstantiateWithParams
   {"cudaGraphInstantiateWithParams",                          {"hipGraphInstantiateWithParams",                          "", CONV_GRAPH, API_RUNTIME, SEC::GRAPH, HIP_EXPERIMENTAL}},
   // cuGraphExecGetFlags
-  {"cudaGraphExecGetFlags",                                   {"hipGraphExecGetFlags",                                   "", CONV_GRAPH, API_RUNTIME, SEC::GRAPH, HIP_EXPERIMENTAL}},
+  {"cudaGraphExecGetFlags",                                   {"hipGraphExecGetFlags",                                   "", CONV_GRAPH, API_RUNTIME, SEC::GRAPH, HIP_UNSUPPORTED}},
   // cuGraphAddNode
   {"cudaGraphAddNode",                                        {"hipGraphAddNode",                                        "", CONV_GRAPH, API_RUNTIME, SEC::GRAPH, HIP_EXPERIMENTAL}},
   // cuGraphAddNode_v2
   {"cudaGraphAddNode_v2",                                     {"hipGraphAddNode_v2",                                     "", CONV_GRAPH, API_RUNTIME, SEC::GRAPH, HIP_UNSUPPORTED}},
   // cuGraphNodeSetParams
-  {"cudaGraphNodeSetParams",                                  {"hipGraphNodeSetParams",                                  "", CONV_GRAPH, API_RUNTIME, SEC::GRAPH, HIP_EXPERIMENTAL}},
+  {"cudaGraphNodeSetParams",                                  {"hipGraphNodeSetParams",                                  "", CONV_GRAPH, API_RUNTIME, SEC::GRAPH, HIP_UNSUPPORTED}},
   // cuGraphExecNodeSetParams
-  {"cudaGraphExecNodeSetParams",                              {"hipGraphExecNodeSetParams",                              "", CONV_GRAPH, API_RUNTIME, SEC::GRAPH, HIP_EXPERIMENTAL}},
+  {"cudaGraphExecNodeSetParams",                              {"hipGraphExecNodeSetParams",                              "", CONV_GRAPH, API_RUNTIME, SEC::GRAPH, HIP_UNSUPPORTED}},
   // cuGraphConditionalHandleCreate
   {"cudaGraphConditionalHandleCreate",                        {"hipGraphConditionalHandleCreate",                        "", CONV_GRAPH, API_RUNTIME, SEC::GRAPH, HIP_UNSUPPORTED}},
 
@@ -1429,9 +1429,6 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_RUNTIME_FUNCTION_VER_MAP {
   {"hipGraphExecExternalSemaphoresWaitNodeSetParams",         {HIP_5070, HIP_0,    HIP_0   }},
   {"hipGraphInstantiateWithParams",                           {HIP_6020, HIP_0,    HIP_0,  HIP_LATEST}},
   {"hipGraphAddNode",                                         {HIP_6020, HIP_0,    HIP_0,  HIP_LATEST}},
-  {"hipGraphExecGetFlags",                                    {HIP_6020, HIP_0,    HIP_0,  HIP_LATEST}},
-  {"hipGraphNodeSetParams",                                   {HIP_6020, HIP_0,    HIP_0,  HIP_LATEST}},
-  {"hipGraphExecNodeSetParams",                               {HIP_6020, HIP_0,    HIP_0,  HIP_LATEST}},
   {"hipGetProcAddress",                                       {HIP_6020, HIP_0,    HIP_0,  HIP_LATEST}},
   {"hipGetFuncBySymbol",                                      {HIP_6020, HIP_0,    HIP_0,  HIP_LATEST}},
   {"hipStreamBeginCaptureToGraph",                            {HIP_6020, HIP_0,    HIP_0,  HIP_LATEST}},

--- a/tests/unit_tests/synthetic/driver_functions.cu
+++ b/tests/unit_tests/synthetic/driver_functions.cu
@@ -1252,16 +1252,6 @@ int main() {
   // CHECK: result = hipGraphLaunch(graphExec, stream);
   result = cuGraphLaunch(graphExec, stream);
 
-  // CUDA: CUresult CUDAAPI cuGraphMemcpyNodeGetParams(CUgraphNode hNode, CUDA_MEMCPY3D *nodeParams);
-  // HIP: hipError_t hipDrvGraphMemcpyNodeGetParams(hipGraphNode_t node, hipMemcpy3DParms* pNodeParams);
-  // CHECK: result = hipDrvGraphMemcpyNodeGetParams(graphNode, &MEMCPY3D);
-  result = cuGraphMemcpyNodeGetParams(graphNode, &MEMCPY3D);
-
-  // CUDA: CUresult CUDAAPI cuGraphMemcpyNodeSetParams(CUgraphNode hNode, const CUDA_MEMCPY3D *nodeParams);
-  // HIP: hipError_t hipDrvGraphMemcpyNodeSetParams(hipGraphNode_t node, const hipMemcpy3DParms* pNodeParams);
-  // CHECK: result = hipDrvGraphMemcpyNodeSetParams(graphNode, &MEMCPY3D);
-  result = cuGraphMemcpyNodeSetParams(graphNode, &MEMCPY3D);
-
   // CUDA: CUresult CUDAAPI cuGraphMemsetNodeGetParams(CUgraphNode hNode, CUDA_MEMSET_NODE_PARAMS *nodeParams);
   // HIP: hipError_t hipGraphMemsetNodeGetParams(hipGraphNode_t node, hipMemsetParams* pNodeParams);
   // CHECK: result = hipGraphMemsetNodeGetParams(graphNode, &MEMSET_NODE_PARAMS);
@@ -1473,11 +1463,6 @@ int main() {
   // HIP: hipError_t hipMemUnmap(void* ptr, size_t size);
   // CHECK: result = hipMemUnmap(deviceptr, bytes);
   result = cuMemUnmap(deviceptr, bytes);
-
-  // CUDA: CUresult CUDAAPI cuGraphExecMemcpyNodeSetParams(CUgraphExec hGraphExec, CUgraphNode hNode, const CUDA_MEMCPY3D *copyParams, CUcontext ctx);
-  // HIP: hipError_t hipDrvGraphExecMemcpyNodeSetParams(hipGraphExec_t hGraphExec, hipGraphNode_t hNode, const HIP_MEMCPY3D* copyParams, hipCtx_t ctx);
-  // CHECK: result = hipDrvGraphExecMemcpyNodeSetParams(graphExec, graphNode, &MEMCPY3D, context);
-  result = cuGraphExecMemcpyNodeSetParams(graphExec, graphNode, &MEMCPY3D, context);
 #endif
 
 #if CUDA_VERSION >= 10020 && CUDA_VERSION < 12000
@@ -1815,11 +1800,6 @@ int main() {
   // CHECK: result = hipGraphMemAllocNodeGetParams(graphNode, &MEM_ALLOC_NODE_PARAMS);
   result = cuGraphMemAllocNodeGetParams(graphNode, &MEM_ALLOC_NODE_PARAMS);
 
-  // CUDA: CUresult CUDAAPI cuGraphAddMemFreeNode(CUgraphNode *phGraphNode, CUgraph hGraph, const CUgraphNode *dependencies, size_t numDependencies, CUdeviceptr dptr);
-  // HIP: hipError_t hipDrvGraphAddMemFreeNode(hipGraphNode_t* pGraphNode, hipGraph_t graph, const hipGraphNode_t* pDependencies, size_t numDependencies, void* dev_ptr);
-  // CHECK: result = hipDrvGraphAddMemFreeNode(&graphNode, graph, &graphNode2, bytes, deviceptr);
-  result = cuGraphAddMemFreeNode(&graphNode, graph, &graphNode2, bytes, deviceptr);
-
   // CUDA: CUresult CUDAAPI cuGraphMemFreeNodeGetParams(CUgraphNode hNode, CUdeviceptr *dptr_out);
   // HIP: hipError_t hipGraphMemFreeNodeGetParams(hipGraphNode_t node, void* dev_ptr);
   // CHECK: result = hipGraphMemFreeNodeGetParams(graphNode, &deviceptr);
@@ -1906,11 +1886,6 @@ int main() {
   // HIP: hipError_t hipGraphInstantiateWithParams(hipGraphExec_t* pGraphExec, hipGraph_t graph, hipGraphInstantiateParams *instantiateParams);
   // CHECK: result = hipGraphInstantiateWithParams(&graphExec, graph, &GRAPH_INSTANTIATE_PARAMS);
   result = cuGraphInstantiateWithParams(&graphExec, graph, &GRAPH_INSTANTIATE_PARAMS);
-
-  // CUDA: CUresult CUDAAPI cuGraphExecGetFlags(CUgraphExec hGraphExec, cuuint64_t *flags);
-  // HIP: hipError_t hipGraphExecGetFlags(hipGraphExec_t graphExec, unsigned long long* flags);
-  // CHECK: result = hipGraphExecGetFlags(graphExec, &ull);
-  result = cuGraphExecGetFlags(graphExec, &ull);
 #endif
 
 #if CUDA_VERSION >= 12020
@@ -1921,16 +1896,6 @@ int main() {
   // HIP: hipError_t hipGraphAddNode(hipGraphNode_t *pGraphNode, hipGraph_t graph, const hipGraphNode_t *pDependencies, size_t numDependencies, hipGraphNodeParams *nodeParams);
   // CHECK: result = hipGraphAddNode(&graphNode, graph, &graphNode2, bytes, &graphNodeParams);
   result = cuGraphAddNode(&graphNode, graph, &graphNode2, bytes, &graphNodeParams);
-
-  // CUDA: CUresult CUDAAPI cuGraphNodeSetParams(CUgraphNode hNode, CUgraphNodeParams *nodeParams);
-  // HIP: hipError_t hipGraphNodeSetParams(hipGraphNode_t node, hipGraphNodeParams *nodeParams);
-  // CHECK: result = hipGraphNodeSetParams(graphNode, &graphNodeParams);
-  result = cuGraphNodeSetParams(graphNode, &graphNodeParams);
-
-  // CUDA: CUresult CUDAAPI cuGraphExecNodeSetParams(CUgraphExec hGraphExec, CUgraphNode hNode, CUgraphNodeParams *nodeParams);
-  // HIP: hipError_t hipGraphExecNodeSetParams(hipGraphExec_t graphExec, hipGraphNode_t node, hipGraphNodeParams* nodeParams);
-  // CHECK: result = hipGraphExecNodeSetParams(graphExec, graphNode, &graphNodeParams);
-  result = cuGraphExecNodeSetParams(graphExec, graphNode, &graphNodeParams);
 #endif
 
 #if CUDA_VERSION >= 12030

--- a/tests/unit_tests/synthetic/runtime_functions.cu
+++ b/tests/unit_tests/synthetic/runtime_functions.cu
@@ -1606,13 +1606,6 @@ int main() {
   result = cudaUnbindTexture(texref);
 #endif
 
-#if CUDA_VERSION >= 12000
-  // CUDA: extern __host__ cudaError_t CUDARTAPI cudaGraphExecGetFlags(cudaGraphExec_t graphExec, unsigned long long *flags);
-  // HIP: hipError_t hipGraphExecGetFlags(hipGraphExec_t graphExec, unsigned long long* flags);
-  // CHECK: result = hipGraphExecGetFlags(GraphExec_t, &ull_2);
-  result = cudaGraphExecGetFlags(GraphExec_t, &ull_2);
-#endif
-
 #if CUDA_VERSION >= 12020
   // CHECK: hipGraphNodeParams *graphNodeParams = nullptr;
   cudaGraphNodeParams *graphNodeParams = nullptr;
@@ -1621,16 +1614,6 @@ int main() {
   // HIP: hipError_t hipGraphAddNode(hipGraphNode_t *pGraphNode, hipGraph_t graph, const hipGraphNode_t *pDependencies, size_t numDependencies, hipGraphNodeParams *nodeParams);
   // CHECK: result = hipGraphAddNode(&graphNode, Graph_t, &graphNode_2, bytes, graphNodeParams);
   result = cudaGraphAddNode(&graphNode, Graph_t, &graphNode_2, bytes, graphNodeParams);
-
-  // CUDA: extern __host__ cudaError_t CUDARTAPI cudaGraphNodeSetParams(cudaGraphNode_t node, struct cudaGraphNodeParams *nodeParams);
-  // HIP: hipError_t hipGraphNodeSetParams(hipGraphNode_t node, hipGraphNodeParams *nodeParams);
-  // CHECK: result = hipGraphNodeSetParams(graphNode, graphNodeParams);
-  result = cudaGraphNodeSetParams(graphNode, graphNodeParams);
-
-  // CUDA: extern __host__ cudaError_t CUDARTAPI cudaGraphExecNodeSetParams(cudaGraphExec_t graphExec, cudaGraphNode_t node, struct cudaGraphNodeParams *nodeParams);
-  // HIP: hipError_t hipGraphExecNodeSetParams(hipGraphExec_t graphExec, hipGraphNode_t node, hipGraphNodeParams* nodeParams);
-  // CHECK: result = hipGraphExecNodeSetParams(GraphExec_t, graphNode, graphNodeParams);
-  result = cudaGraphExecNodeSetParams(GraphExec_t, graphNode, graphNodeParams);
 #endif
 
 #if CUDA_VERSION >= 12030


### PR DESCRIPTION
+ Updated synthetic tests, the regenerated `hipify-perl`, and `CUDA2HIP` documentation
