### PR TITLE
[HIPIFY][fix] Header device_launch_parameters present in CUDA should be skipped

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -5635,6 +5635,7 @@ sub simpleSubstitutions {
     subst("cublas.h", "hipblas.h", "include_cuda_main_header");
     subst("cuda.h", "hip\/hip_runtime.h", "include_cuda_main_header");
     subst("cuda_runtime.h", "hip\/hip_runtime.h", "include_cuda_main_header");
+    subst("device_launch_parameters.h", "", "include");
     subst("cudnn.h", "hipDNN.h", "include_cuda_main_header");
     subst("cufft.h", "hipfft\/hipfft.h", "include_cuda_main_header");
     subst("curand.h", "hiprand\/hiprand.h", "include_cuda_main_header");

--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -5625,6 +5625,7 @@ sub simpleSubstitutions {
     subst("curand_precalc.h", "hiprand\/hiprand_kernel.h", "include");
     subst("curand_uniform.h", "hiprand\/hiprand_kernel.h", "include");
     subst("device_functions.h", "hip\/device_functions.h", "include");
+    subst("device_launch_parameters.h", "", "include");
     subst("driver_types.h", "hip\/driver_types.h", "include");
     subst("library_types.h", "hip\/library_types.h", "include");
     subst("math_constants.h", "hip\/hip_math_constants.h", "include");
@@ -5635,7 +5636,6 @@ sub simpleSubstitutions {
     subst("cublas.h", "hipblas.h", "include_cuda_main_header");
     subst("cuda.h", "hip\/hip_runtime.h", "include_cuda_main_header");
     subst("cuda_runtime.h", "hip\/hip_runtime.h", "include_cuda_main_header");
-    subst("device_launch_parameters.h", "", "include");
     subst("cudnn.h", "hipDNN.h", "include_cuda_main_header");
     subst("cufft.h", "hipfft\/hipfft.h", "include_cuda_main_header");
     subst("curand.h", "hiprand\/hiprand.h", "include_cuda_main_header");

--- a/src/CUDA2HIP.cpp
+++ b/src/CUDA2HIP.cpp
@@ -27,6 +27,7 @@ const std::map <llvm::StringRef, hipCounter> CUDA_INCLUDE_MAP {
   // CUDA includes
   {"cuda.h",                                                {"hip/hip_runtime.h",                                     "", CONV_INCLUDE_CUDA_MAIN_H,    API_DRIVER, 0}},
   {"cuda_runtime.h",                                        {"hip/hip_runtime.h",                                     "", CONV_INCLUDE_CUDA_MAIN_H,    API_RUNTIME, 0}},
+  {"device_launch_parameters.h",                            {"",                                                      "", CONV_INCLUDE,                API_RUNTIME, 0}},
   {"cuda_runtime_api.h",                                    {"hip/hip_runtime_api.h",                                 "", CONV_INCLUDE,                API_RUNTIME, 0}},
   {"channel_descriptor.h",                                  {"hip/channel_descriptor.h",                              "", CONV_INCLUDE,                API_RUNTIME, 0}},
   {"device_functions.h",                                    {"hip/device_functions.h",                                "", CONV_INCLUDE,                API_RUNTIME, 0}},


### PR DESCRIPTION
Initially mentioned by https://github.com/ROCm/HIP/issues/3568

the header device_launch_parameters.h is not present in HIP, it should be consumed when its encountered during hipify process.