### PR TITLE
[HIPIFY][tests][doc] Python 3.12.5 is supported

### DIFF
--- a/docs/hipify-clang.rst
+++ b/docs/hipify-clang.rst
@@ -646,7 +646,7 @@ Minimum build system requirements for the above configurations:
 
 Recommended build system requirements:
 
-* CMake 3.30.2, GNU C/C++ 13.2, Python 3.12.4.
+* CMake 3.30.2, GNU C/C++ 13.2, Python 3.12.5.
 
 Here's how to build ``hipify-clang`` with testing support on ``Ubuntu 23.10.01``:
 
@@ -690,7 +690,7 @@ The corresponding successful output is:
   --    - Binary path        : /usr/llvm/18.1.8/dist/bin
   -- Linker detection: GNU ld
   -- ---- The below configuring for hipify-clang testing only ----
-  -- Found Python: /usr/bin/python3.12 (found version "3.12.4") found components: Interpreter 
+  -- Found Python: /usr/bin/python3.12 (found version "3.12.5") found components: Interpreter 
   -- Found lit: /usr/local/bin/lit
   -- Found FileCheck: /GIT/LLVM/trunk/dist/FileCheck
   -- Initial CUDA to configure:
@@ -726,7 +726,7 @@ The corresponding successful output is:
   x86_64 - Platform architecture
   Linux 6.5.0-15-generic - Platform OS
   64 - hipify-clang binary bitness
-  64 - python 3.12.4 binary bitness
+  64 - python 3.12.5 binary bitness
   ===============================================================
   -- Testing: 106 tests, 12 threads --
   Testing Time: 6.91s
@@ -821,13 +821,13 @@ Tested configurations:
     - ``8.0.5  - 9.3.0``
     - ``2019.16.11.38, 2022.17.10.5``
     - ``3.30.0``
-    - ``3.12.4``
+    - ``3.12.5``
   * - ``19.0.0git``
     - ``7.0 - 12.5.1``
     - ``8.0.5  - 9.3.0``
     - ``2019.16.11.38, 2022.17.10.5``
     - ``3.30.0``
-    - ``3.12.4``
+    - ``3.12.5``
 
 :sup:`5` LLVM 14.x.x is the latest major release supporting Visual Studio 2017.
 
@@ -886,7 +886,7 @@ The corresponding successful output is:
   --    - LLVM Include path  : D:/LLVM/18.1.8/dist/include
   --    - Binary path        : D:/LLVM/18.1.8/dist/bin
   -- ---- The below configuring for hipify-clang testing only ----
-  -- Found Python: C:/Users/TT/AppData/Local/Programs/Python/Python312/python.exe (found version "3.12.4") found components: Interpreter
+  -- Found Python: C:/Users/TT/AppData/Local/Programs/Python/Python312/python.exe (found version "3.12.5") found components: Interpreter
   -- Found lit: C:/Users/TT/AppData/Local/Programs/Python/Python312/Scripts/lit.exe
   -- Found FileCheck: D:/LLVM/18.1.8/dist/bin/FileCheck.exe
   -- Initial CUDA to configure:


### PR DESCRIPTION
+ [IMP] In case of errors, similar to `ModuleNotFoundError: No module named 'setuptools'`, upgrade the `setuptools` package: `python -m pip install --upgrade pip setuptools`