### PR TITLE
[HIPIFY][CUB][tests] Temporary disabling of `CUB` tests for `CUDA >= 12.6.x`

### DIFF
--- a/tests/lit.cfg
+++ b/tests/lit.cfg
@@ -144,6 +144,11 @@ if config.cuda_version_major >= 12:
     config.excludes.append('cusparse2rocsparse_before_12000.cu')
     clang_arguments += " -D_LIBCUDACXX_OBJECT_FORMAT_COFF"
 
+if config.cuda_version_major == 12 and config.cuda_version_minor >= 6:
+    config.excludes.append('cub_01.cu')
+    config.excludes.append('cub_02.cu')
+    config.excludes.append('cub_03.cu')
+
 if config.cudnn_version_major >= 9:
     config.excludes.append('cudnn2miopen_before_9000.cu')
 


### PR DESCRIPTION
**[Reason]** clang compilation error:

`CUDA/v12.6.0/include\cuda/std/__algorithm/min.h(49,1): error G65037BDE: expected ')'
    min(initializer_list<_Tp> __t, _Compare __comp)`

**[Note]** Even the latest trunk clang 20.0.0git doesn't fully support CUDA >= 12.5
