### PR TITLE
[HIPIFY][rocRAND][feature] Support for `cuRAND -> rocRAND` hipification - Step 3 - Data Types

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -3370,6 +3370,16 @@ sub rocSubstitutions {
     subst("CUDNN_STATUS_NOT_SUPPORTED", "miopenStatusUnsupportedOp", "numeric_literal");
     subst("CUDNN_STATUS_SUCCESS", "miopenStatusSuccess", "numeric_literal");
     subst("CUDNN_UNIDIRECTIONAL", "miopenRNNunidirection", "numeric_literal");
+    subst("CURAND_STATUS_ALLOCATION_FAILED", "ROCRAND_STATUS_ALLOCATION_FAILED", "numeric_literal");
+    subst("CURAND_STATUS_DOUBLE_PRECISION_REQUIRED", "ROCRAND_STATUS_DOUBLE_PRECISION_REQUIRED", "numeric_literal");
+    subst("CURAND_STATUS_INTERNAL_ERROR", "ROCRAND_STATUS_INTERNAL_ERROR", "numeric_literal");
+    subst("CURAND_STATUS_LAUNCH_FAILURE", "ROCRAND_STATUS_LAUNCH_FAILURE", "numeric_literal");
+    subst("CURAND_STATUS_LENGTH_NOT_MULTIPLE", "ROCRAND_STATUS_LENGTH_NOT_MULTIPLE", "numeric_literal");
+    subst("CURAND_STATUS_NOT_INITIALIZED", "ROCRAND_STATUS_NOT_CREATED", "numeric_literal");
+    subst("CURAND_STATUS_OUT_OF_RANGE", "ROCRAND_STATUS_OUT_OF_RANGE", "numeric_literal");
+    subst("CURAND_STATUS_SUCCESS", "ROCRAND_STATUS_SUCCESS", "numeric_literal");
+    subst("CURAND_STATUS_TYPE_ERROR", "ROCRAND_STATUS_TYPE_ERROR", "numeric_literal");
+    subst("CURAND_STATUS_VERSION_MISMATCH", "ROCRAND_STATUS_VERSION_MISMATCH", "numeric_literal");
     subst("CUSOLVER_EIG_MODE_NOVECTOR", "rocblas_evect_none", "numeric_literal");
     subst("CUSOLVER_EIG_MODE_VECTOR", "rocblas_evect_original", "numeric_literal");
     subst("CUSOLVER_EIG_RANGE_ALL", "rocblas_erange_all", "numeric_literal");

--- a/docs/tables/CURAND_API_supported_by_HIP_and_ROC.md
+++ b/docs/tables/CURAND_API_supported_by_HIP_and_ROC.md
@@ -40,19 +40,19 @@
 |`CURAND_RNG_TEST`| | | | |`HIPRAND_RNG_TEST`|1.5.0| | | | | | | | | | |
 |`CURAND_SCRAMBLED_DIRECTION_VECTORS_32_JOEKUO6`| | | | |`HIPRAND_SCRAMBLED_DIRECTION_VECTORS_32_JOEKUO6`|6.0.0| | | | | | | | | | |
 |`CURAND_SCRAMBLED_DIRECTION_VECTORS_64_JOEKUO6`| | | | |`HIPRAND_SCRAMBLED_DIRECTION_VECTORS_64_JOEKUO6`|6.0.0| | | | | | | | | | |
-|`CURAND_STATUS_ALLOCATION_FAILED`| | | | |`HIPRAND_STATUS_ALLOCATION_FAILED`|1.5.0| | | | | | | | | | |
+|`CURAND_STATUS_ALLOCATION_FAILED`| | | | |`HIPRAND_STATUS_ALLOCATION_FAILED`|1.5.0| | | | |`ROCRAND_STATUS_ALLOCATION_FAILED`|1.5.0| | | | |
 |`CURAND_STATUS_ARCH_MISMATCH`| | | | |`HIPRAND_STATUS_ARCH_MISMATCH`|1.5.0| | | | | | | | | | |
-|`CURAND_STATUS_DOUBLE_PRECISION_REQUIRED`| | | | |`HIPRAND_STATUS_DOUBLE_PRECISION_REQUIRED`|1.5.0| | | | | | | | | | |
+|`CURAND_STATUS_DOUBLE_PRECISION_REQUIRED`| | | | |`HIPRAND_STATUS_DOUBLE_PRECISION_REQUIRED`|1.5.0| | | | |`ROCRAND_STATUS_DOUBLE_PRECISION_REQUIRED`|1.5.0| | | | |
 |`CURAND_STATUS_INITIALIZATION_FAILED`| | | | |`HIPRAND_STATUS_INITIALIZATION_FAILED`|1.5.0| | | | | | | | | | |
-|`CURAND_STATUS_INTERNAL_ERROR`| | | | |`HIPRAND_STATUS_INTERNAL_ERROR`|1.5.0| | | | | | | | | | |
-|`CURAND_STATUS_LAUNCH_FAILURE`| | | | |`HIPRAND_STATUS_LAUNCH_FAILURE`|1.5.0| | | | | | | | | | |
-|`CURAND_STATUS_LENGTH_NOT_MULTIPLE`| | | | |`HIPRAND_STATUS_LENGTH_NOT_MULTIPLE`|1.5.0| | | | | | | | | | |
-|`CURAND_STATUS_NOT_INITIALIZED`| | | | |`HIPRAND_STATUS_NOT_INITIALIZED`|1.5.0| | | | | | | | | | |
-|`CURAND_STATUS_OUT_OF_RANGE`| | | | |`HIPRAND_STATUS_OUT_OF_RANGE`|1.5.0| | | | | | | | | | |
+|`CURAND_STATUS_INTERNAL_ERROR`| | | | |`HIPRAND_STATUS_INTERNAL_ERROR`|1.5.0| | | | |`ROCRAND_STATUS_INTERNAL_ERROR`|1.5.0| | | | |
+|`CURAND_STATUS_LAUNCH_FAILURE`| | | | |`HIPRAND_STATUS_LAUNCH_FAILURE`|1.5.0| | | | |`ROCRAND_STATUS_LAUNCH_FAILURE`|1.5.0| | | | |
+|`CURAND_STATUS_LENGTH_NOT_MULTIPLE`| | | | |`HIPRAND_STATUS_LENGTH_NOT_MULTIPLE`|1.5.0| | | | |`ROCRAND_STATUS_LENGTH_NOT_MULTIPLE`|1.5.0| | | | |
+|`CURAND_STATUS_NOT_INITIALIZED`| | | | |`HIPRAND_STATUS_NOT_INITIALIZED`|1.5.0| | | | |`ROCRAND_STATUS_NOT_CREATED`|1.5.0| | | | |
+|`CURAND_STATUS_OUT_OF_RANGE`| | | | |`HIPRAND_STATUS_OUT_OF_RANGE`|1.5.0| | | | |`ROCRAND_STATUS_OUT_OF_RANGE`|1.5.0| | | | |
 |`CURAND_STATUS_PREEXISTING_FAILURE`| | | | |`HIPRAND_STATUS_PREEXISTING_FAILURE`|1.5.0| | | | | | | | | | |
-|`CURAND_STATUS_SUCCESS`| | | | |`HIPRAND_STATUS_SUCCESS`|1.5.0| | | | | | | | | | |
-|`CURAND_STATUS_TYPE_ERROR`| | | | |`HIPRAND_STATUS_TYPE_ERROR`|1.5.0| | | | | | | | | | |
-|`CURAND_STATUS_VERSION_MISMATCH`| | | | |`HIPRAND_STATUS_VERSION_MISMATCH`|1.5.0| | | | | | | | | | |
+|`CURAND_STATUS_SUCCESS`| | | | |`HIPRAND_STATUS_SUCCESS`|1.5.0| | | | |`ROCRAND_STATUS_SUCCESS`|1.5.0| | | | |
+|`CURAND_STATUS_TYPE_ERROR`| | | | |`HIPRAND_STATUS_TYPE_ERROR`|1.5.0| | | | |`ROCRAND_STATUS_TYPE_ERROR`|1.5.0| | | | |
+|`CURAND_STATUS_VERSION_MISMATCH`| | | | |`HIPRAND_STATUS_VERSION_MISMATCH`|1.5.0| | | | |`ROCRAND_STATUS_VERSION_MISMATCH`|1.5.0| | | | |
 |`curandDirectionVectorSet`| | | | |`hiprandDirectionVectorSet_t`|6.0.0| | | | | | | | | | |
 |`curandDirectionVectorSet_t`| | | | |`hiprandDirectionVectorSet_t`|6.0.0| | | | | | | | | | |
 |`curandDirectionVectors32_t`| | | | |`hiprandDirectionVectors32_t`|1.5.0| | | | | | | | | | |
@@ -97,8 +97,8 @@
 |`curandStateXORWOW`| | | | |`hiprandStateXORWOW`|1.8.0| | | | | | | | | | |
 |`curandStateXORWOW_t`| | | | |`hiprandStateXORWOW_t`|1.5.0| | | | | | | | | | |
 |`curandState_t`| | | | |`hiprandState_t`|1.5.0| | | | | | | | | | |
-|`curandStatus`| | | | |`hiprandStatus`|1.5.0| | | | |`rocrand_status`|1.5.1| | | | |
-|`curandStatus_t`| | | | |`hiprandStatus_t`|1.5.0| | | | |`rocrand_status`|1.5.1| | | | |
+|`curandStatus`| | | | |`hiprandStatus`|1.5.0| | | | |`rocrand_status`|1.5.0| | | | |
+|`curandStatus_t`| | | | |`hiprandStatus_t`|1.5.0| | | | |`rocrand_status`|1.5.0| | | | |
 
 ## **2. Host API Functions**
 

--- a/docs/tables/CURAND_API_supported_by_ROC.md
+++ b/docs/tables/CURAND_API_supported_by_ROC.md
@@ -40,19 +40,19 @@
 |`CURAND_RNG_TEST`| | | | | | | | | | |
 |`CURAND_SCRAMBLED_DIRECTION_VECTORS_32_JOEKUO6`| | | | | | | | | | |
 |`CURAND_SCRAMBLED_DIRECTION_VECTORS_64_JOEKUO6`| | | | | | | | | | |
-|`CURAND_STATUS_ALLOCATION_FAILED`| | | | | | | | | | |
+|`CURAND_STATUS_ALLOCATION_FAILED`| | | | |`ROCRAND_STATUS_ALLOCATION_FAILED`|1.5.0| | | | |
 |`CURAND_STATUS_ARCH_MISMATCH`| | | | | | | | | | |
-|`CURAND_STATUS_DOUBLE_PRECISION_REQUIRED`| | | | | | | | | | |
+|`CURAND_STATUS_DOUBLE_PRECISION_REQUIRED`| | | | |`ROCRAND_STATUS_DOUBLE_PRECISION_REQUIRED`|1.5.0| | | | |
 |`CURAND_STATUS_INITIALIZATION_FAILED`| | | | | | | | | | |
-|`CURAND_STATUS_INTERNAL_ERROR`| | | | | | | | | | |
-|`CURAND_STATUS_LAUNCH_FAILURE`| | | | | | | | | | |
-|`CURAND_STATUS_LENGTH_NOT_MULTIPLE`| | | | | | | | | | |
-|`CURAND_STATUS_NOT_INITIALIZED`| | | | | | | | | | |
-|`CURAND_STATUS_OUT_OF_RANGE`| | | | | | | | | | |
+|`CURAND_STATUS_INTERNAL_ERROR`| | | | |`ROCRAND_STATUS_INTERNAL_ERROR`|1.5.0| | | | |
+|`CURAND_STATUS_LAUNCH_FAILURE`| | | | |`ROCRAND_STATUS_LAUNCH_FAILURE`|1.5.0| | | | |
+|`CURAND_STATUS_LENGTH_NOT_MULTIPLE`| | | | |`ROCRAND_STATUS_LENGTH_NOT_MULTIPLE`|1.5.0| | | | |
+|`CURAND_STATUS_NOT_INITIALIZED`| | | | |`ROCRAND_STATUS_NOT_CREATED`|1.5.0| | | | |
+|`CURAND_STATUS_OUT_OF_RANGE`| | | | |`ROCRAND_STATUS_OUT_OF_RANGE`|1.5.0| | | | |
 |`CURAND_STATUS_PREEXISTING_FAILURE`| | | | | | | | | | |
-|`CURAND_STATUS_SUCCESS`| | | | | | | | | | |
-|`CURAND_STATUS_TYPE_ERROR`| | | | | | | | | | |
-|`CURAND_STATUS_VERSION_MISMATCH`| | | | | | | | | | |
+|`CURAND_STATUS_SUCCESS`| | | | |`ROCRAND_STATUS_SUCCESS`|1.5.0| | | | |
+|`CURAND_STATUS_TYPE_ERROR`| | | | |`ROCRAND_STATUS_TYPE_ERROR`|1.5.0| | | | |
+|`CURAND_STATUS_VERSION_MISMATCH`| | | | |`ROCRAND_STATUS_VERSION_MISMATCH`|1.5.0| | | | |
 |`curandDirectionVectorSet`| | | | | | | | | | |
 |`curandDirectionVectorSet_t`| | | | | | | | | | |
 |`curandDirectionVectors32_t`| | | | | | | | | | |
@@ -97,8 +97,8 @@
 |`curandStateXORWOW`| | | | | | | | | | |
 |`curandStateXORWOW_t`| | | | | | | | | | |
 |`curandState_t`| | | | | | | | | | |
-|`curandStatus`| | | | |`rocrand_status`|1.5.1| | | | |
-|`curandStatus_t`| | | | |`rocrand_status`|1.5.1| | | | |
+|`curandStatus`| | | | |`rocrand_status`|1.5.0| | | | |
+|`curandStatus_t`| | | | |`rocrand_status`|1.5.0| | | | |
 
 ## **2. Host API Functions**
 

--- a/src/CUDA2HIP_RAND_API_types.cpp
+++ b/src/CUDA2HIP_RAND_API_types.cpp
@@ -25,8 +25,8 @@ THE SOFTWARE.
 // Map of all functions
 const std::map<llvm::StringRef, hipCounter> CUDA_RAND_TYPE_NAME_MAP {
   // RAND Host types
-  {"curandStatus",                                  {"hiprandStatus",                                  "rocrand_status",                                                  CONV_TYPE, API_RAND, 1}},
-  {"curandStatus_t",                                {"hiprandStatus_t",                                "rocrand_status",                                                  CONV_TYPE, API_RAND, 1}},
+  {"curandStatus",                                  {"hiprandStatus",                                  "rocrand_status",                                                 CONV_TYPE, API_RAND, 1}},
+  {"curandStatus_t",                                {"hiprandStatus_t",                                "rocrand_status",                                                 CONV_TYPE, API_RAND, 1}},
   {"curandRngType",                                 {"hiprandRngType_t",                               "", CONV_TYPE, API_RAND, 1}},
   {"curandRngType_t",                               {"hiprandRngType_t",                               "", CONV_TYPE, API_RAND, 1}},
   {"curandGenerator_st",                            {"hiprandGenerator_st",                            "", CONV_TYPE, API_RAND, 1}},
@@ -75,19 +75,19 @@ const std::map<llvm::StringRef, hipCounter> CUDA_RAND_TYPE_NAME_MAP {
   {"curandState_t",                                 {"hiprandState_t",                                 "", CONV_TYPE, API_RAND, 1}},
 
   // RAND function call status types (enum curandStatus)
-  {"CURAND_STATUS_SUCCESS",                         {"HIPRAND_STATUS_SUCCESS",                         "", CONV_NUMERIC_LITERAL, API_RAND, 1}},
-  {"CURAND_STATUS_VERSION_MISMATCH",                {"HIPRAND_STATUS_VERSION_MISMATCH",                "", CONV_NUMERIC_LITERAL, API_RAND, 1}},
-  {"CURAND_STATUS_NOT_INITIALIZED",                 {"HIPRAND_STATUS_NOT_INITIALIZED",                 "", CONV_NUMERIC_LITERAL, API_RAND, 1}},
-  {"CURAND_STATUS_ALLOCATION_FAILED",               {"HIPRAND_STATUS_ALLOCATION_FAILED",               "", CONV_NUMERIC_LITERAL, API_RAND, 1}},
-  {"CURAND_STATUS_TYPE_ERROR",                      {"HIPRAND_STATUS_TYPE_ERROR",                      "", CONV_NUMERIC_LITERAL, API_RAND, 1}},
-  {"CURAND_STATUS_OUT_OF_RANGE",                    {"HIPRAND_STATUS_OUT_OF_RANGE",                    "", CONV_NUMERIC_LITERAL, API_RAND, 1}},
-  {"CURAND_STATUS_LENGTH_NOT_MULTIPLE",             {"HIPRAND_STATUS_LENGTH_NOT_MULTIPLE",             "", CONV_NUMERIC_LITERAL, API_RAND, 1}},
-  {"CURAND_STATUS_DOUBLE_PRECISION_REQUIRED",       {"HIPRAND_STATUS_DOUBLE_PRECISION_REQUIRED",       "", CONV_NUMERIC_LITERAL, API_RAND, 1}},
-  {"CURAND_STATUS_LAUNCH_FAILURE",                  {"HIPRAND_STATUS_LAUNCH_FAILURE",                  "", CONV_NUMERIC_LITERAL, API_RAND, 1}},
-  {"CURAND_STATUS_PREEXISTING_FAILURE",             {"HIPRAND_STATUS_PREEXISTING_FAILURE",             "", CONV_NUMERIC_LITERAL, API_RAND, 1}},
-  {"CURAND_STATUS_INITIALIZATION_FAILED",           {"HIPRAND_STATUS_INITIALIZATION_FAILED",           "", CONV_NUMERIC_LITERAL, API_RAND, 1}},
-  {"CURAND_STATUS_ARCH_MISMATCH",                   {"HIPRAND_STATUS_ARCH_MISMATCH",                   "", CONV_NUMERIC_LITERAL, API_RAND, 1}},
-  {"CURAND_STATUS_INTERNAL_ERROR",                  {"HIPRAND_STATUS_INTERNAL_ERROR",                  "", CONV_NUMERIC_LITERAL, API_RAND, 1}},
+  {"CURAND_STATUS_SUCCESS",                         {"HIPRAND_STATUS_SUCCESS",                         "ROCRAND_STATUS_SUCCESS",                                         CONV_NUMERIC_LITERAL, API_RAND, 1}},
+  {"CURAND_STATUS_VERSION_MISMATCH",                {"HIPRAND_STATUS_VERSION_MISMATCH",                "ROCRAND_STATUS_VERSION_MISMATCH",                                CONV_NUMERIC_LITERAL, API_RAND, 1}},
+  {"CURAND_STATUS_NOT_INITIALIZED",                 {"HIPRAND_STATUS_NOT_INITIALIZED",                 "ROCRAND_STATUS_NOT_CREATED",                                     CONV_NUMERIC_LITERAL, API_RAND, 1}},
+  {"CURAND_STATUS_ALLOCATION_FAILED",               {"HIPRAND_STATUS_ALLOCATION_FAILED",               "ROCRAND_STATUS_ALLOCATION_FAILED",                               CONV_NUMERIC_LITERAL, API_RAND, 1}},
+  {"CURAND_STATUS_TYPE_ERROR",                      {"HIPRAND_STATUS_TYPE_ERROR",                      "ROCRAND_STATUS_TYPE_ERROR",                                      CONV_NUMERIC_LITERAL, API_RAND, 1}},
+  {"CURAND_STATUS_OUT_OF_RANGE",                    {"HIPRAND_STATUS_OUT_OF_RANGE",                    "ROCRAND_STATUS_OUT_OF_RANGE",                                    CONV_NUMERIC_LITERAL, API_RAND, 1}},
+  {"CURAND_STATUS_LENGTH_NOT_MULTIPLE",             {"HIPRAND_STATUS_LENGTH_NOT_MULTIPLE",             "ROCRAND_STATUS_LENGTH_NOT_MULTIPLE",                             CONV_NUMERIC_LITERAL, API_RAND, 1}},
+  {"CURAND_STATUS_DOUBLE_PRECISION_REQUIRED",       {"HIPRAND_STATUS_DOUBLE_PRECISION_REQUIRED",       "ROCRAND_STATUS_DOUBLE_PRECISION_REQUIRED",                       CONV_NUMERIC_LITERAL, API_RAND, 1}},
+  {"CURAND_STATUS_LAUNCH_FAILURE",                  {"HIPRAND_STATUS_LAUNCH_FAILURE",                  "ROCRAND_STATUS_LAUNCH_FAILURE",                                  CONV_NUMERIC_LITERAL, API_RAND, 1}},
+  {"CURAND_STATUS_PREEXISTING_FAILURE",             {"HIPRAND_STATUS_PREEXISTING_FAILURE",             "",                                                               CONV_NUMERIC_LITERAL, API_RAND, 1, ROC_UNSUPPORTED}},
+  {"CURAND_STATUS_INITIALIZATION_FAILED",           {"HIPRAND_STATUS_INITIALIZATION_FAILED",           "",                                                               CONV_NUMERIC_LITERAL, API_RAND, 1, ROC_UNSUPPORTED}},
+  {"CURAND_STATUS_ARCH_MISMATCH",                   {"HIPRAND_STATUS_ARCH_MISMATCH",                   "",                                                               CONV_NUMERIC_LITERAL, API_RAND, 1, ROC_UNSUPPORTED}},
+  {"CURAND_STATUS_INTERNAL_ERROR",                  {"HIPRAND_STATUS_INTERNAL_ERROR",                  "ROCRAND_STATUS_INTERNAL_ERROR",                                  CONV_NUMERIC_LITERAL, API_RAND, 1}},
 
   // RAND generator types (enum curandRngType)
   {"CURAND_RNG_TEST",                               {"HIPRAND_RNG_TEST",                               "", CONV_NUMERIC_LITERAL, API_RAND, 1}},
@@ -205,5 +205,15 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_RAND_TYPE_NAME_VER_MAP {
   {"hiprandStateSobol64",                           {HIP_6020, HIP_0,    HIP_0,  HIP_LATEST}},
   {"hiprandStateSobol64_t",                         {HIP_6020, HIP_0,    HIP_0,  HIP_LATEST}},
 
-  {"rocrand_status",                                {HIP_1051, HIP_0,    HIP_0   }},
+  {"rocrand_status",                                {HIP_1050, HIP_0,    HIP_0   }},
+  {"ROCRAND_STATUS_SUCCESS",                        {HIP_1050, HIP_0,    HIP_0   }},
+  {"ROCRAND_STATUS_VERSION_MISMATCH",               {HIP_1050, HIP_0,    HIP_0   }},
+  {"ROCRAND_STATUS_NOT_CREATED",                    {HIP_1050, HIP_0,    HIP_0   }},
+  {"ROCRAND_STATUS_ALLOCATION_FAILED",              {HIP_1050, HIP_0,    HIP_0   }},
+  {"ROCRAND_STATUS_TYPE_ERROR",                     {HIP_1050, HIP_0,    HIP_0   }},
+  {"ROCRAND_STATUS_OUT_OF_RANGE",                   {HIP_1050, HIP_0,    HIP_0   }},
+  {"ROCRAND_STATUS_LENGTH_NOT_MULTIPLE",            {HIP_1050, HIP_0,    HIP_0   }},
+  {"ROCRAND_STATUS_DOUBLE_PRECISION_REQUIRED",      {HIP_1050, HIP_0,    HIP_0   }},
+  {"ROCRAND_STATUS_LAUNCH_FAILURE",                 {HIP_1050, HIP_0,    HIP_0   }},
+  {"ROCRAND_STATUS_INTERNAL_ERROR",                 {HIP_1050, HIP_0,    HIP_0   }},
 };

--- a/tests/unit_tests/synthetic/libraries/curand2rocrand.cu
+++ b/tests/unit_tests/synthetic/libraries/curand2rocrand.cu
@@ -1,0 +1,39 @@
+// RUN: %run_test hipify "%s" "%t" %hipify_args 2 --experimental --roc %clang_args
+
+// CHECK: #include <hip/hip_runtime.h>
+#include <cuda_runtime.h>
+#include <stdio.h>
+// CHECK: #include "rocrand/rocrand.h"
+#include "curand.h"
+// CHECK-NOT: #include "rocrand/rocrand.h"
+
+int main() {
+  printf("21.1. cuRAND API to rocRAND API synthetic test\n");
+
+  // CHECK: rocrand_status randStatus;
+  // CHECK-NEXT: rocrand_status randStatus_t;
+  // CHECK-NEXT: rocrand_status STATUS_SUCCESS = ROCRAND_STATUS_SUCCESS;
+  // CHECK-NEXT: rocrand_status STATUS_VERSION_MISMATCH = ROCRAND_STATUS_VERSION_MISMATCH;
+  // CHECK-NEXT: rocrand_status STATUS_NOT_INITIALIZED = ROCRAND_STATUS_NOT_CREATED;
+  // CHECK-NEXT: rocrand_status STATUS_ALLOCATION_FAILED = ROCRAND_STATUS_ALLOCATION_FAILED;
+  // CHECK-NEXT: rocrand_status STATUS_TYPE_ERROR = ROCRAND_STATUS_TYPE_ERROR;
+  // CHECK-NEXT: rocrand_status STATUS_OUT_OF_RANGE = ROCRAND_STATUS_OUT_OF_RANGE;
+  // CHECK-NEXT: rocrand_status STATUS_LENGTH_NOT_MULTIPLE = ROCRAND_STATUS_LENGTH_NOT_MULTIPLE;
+  // CHECK-NEXT: rocrand_status STATUS_DOUBLE_PRECISION_REQUIRED = ROCRAND_STATUS_DOUBLE_PRECISION_REQUIRED;
+  // CHECK-NEXT: rocrand_status STATUS_LAUNCH_FAILURE = ROCRAND_STATUS_LAUNCH_FAILURE;
+  // CHECK-NEXT: rocrand_status STATUS_INTERNAL_ERROR = ROCRAND_STATUS_INTERNAL_ERROR;
+  curandStatus randStatus;
+  curandStatus_t randStatus_t;
+  curandStatus_t STATUS_SUCCESS = CURAND_STATUS_SUCCESS;
+  curandStatus_t STATUS_VERSION_MISMATCH = CURAND_STATUS_VERSION_MISMATCH;
+  curandStatus_t STATUS_NOT_INITIALIZED = CURAND_STATUS_NOT_INITIALIZED;
+  curandStatus_t STATUS_ALLOCATION_FAILED = CURAND_STATUS_ALLOCATION_FAILED;
+  curandStatus_t STATUS_TYPE_ERROR = CURAND_STATUS_TYPE_ERROR;
+  curandStatus_t STATUS_OUT_OF_RANGE = CURAND_STATUS_OUT_OF_RANGE;
+  curandStatus_t STATUS_LENGTH_NOT_MULTIPLE = CURAND_STATUS_LENGTH_NOT_MULTIPLE;
+  curandStatus_t STATUS_DOUBLE_PRECISION_REQUIRED = CURAND_STATUS_DOUBLE_PRECISION_REQUIRED;
+  curandStatus_t STATUS_LAUNCH_FAILURE = CURAND_STATUS_LAUNCH_FAILURE;
+  curandStatus_t STATUS_INTERNAL_ERROR = CURAND_STATUS_INTERNAL_ERROR;
+
+  return 0;
+}


### PR DESCRIPTION
+ Updated synthetic tests, the regenerated `hipify-perl`, and `RAND` `CUDA2HIP` documentation
