### PR TITLE
[HIPIFY][tests][fix] Fix for the header test failed on CUDA 7.0.0

### DIFF
--- a/tests/lit.cfg
+++ b/tests/lit.cfg
@@ -50,6 +50,7 @@ if config.cuda_version_major == 7 and config.cuda_version_minor == 0:
     config.excludes.append('cudnn_convolution_forward.cu')
     config.excludes.append('cusparse2rocsparse_7050.cu')
     config.excludes.append('headers_test_12_SOLVER_7050.cu')
+    config.excludes.append('headers_test_09_fp16_7050.cu')
 
 if config.cuda_version_major < 8:
     config.excludes.append('cuSPARSE_02.cu')

--- a/tests/unit_tests/headers/headers_test_09_fp16_7050.cu
+++ b/tests/unit_tests/headers/headers_test_09_fp16_7050.cu
@@ -1,0 +1,14 @@
+// RUN: %run_test hipify "%s" "%t" %hipify_args 2 --default-preprocessor --roc %clang_args
+
+// CHECK: #include <hip/hip_runtime.h>
+#include <cuda.h>
+// CHECK-NOT: #include <hip/hip_runtime.h>
+#include <memory>
+
+#include <cuda_runtime.h>
+// CHECK-NOT: #include <hip/hip_runtime.h>
+
+#if CUDA_VERSION >= 7050
+// CHECK: #include "hip/hip_fp16.h"
+#include "cuda_fp16.h"
+#endif

--- a/tests/unit_tests/headers/headers_test_09_rocrand.cu
+++ b/tests/unit_tests/headers/headers_test_09_rocrand.cu
@@ -11,7 +11,6 @@
 // CHECK: #include "hip/device_functions.h"
 // CHECK: #include "hip/driver_types.h"
 // CHECK: #include "hip/hip_complex.h"
-// CHECK: #include "hip/hip_fp16.h"
 // CHECK: #include "hip/hip_texture_types.h"
 // CHECK: #include "hip/hip_vector_types.h"
 
@@ -76,7 +75,6 @@
 #include "device_functions.h"
 #include "driver_types.h"
 #include "cuComplex.h"
-#include "cuda_fp16.h"
 #include "cuda_texture_types.h"
 #include "vector_types.h"
 


### PR DESCRIPTION
[Reason] `cuda_fp16.h` appeared only in CUDA `7.5.0`