### PR TITLE
[HIPIFY][SWDEV-480722][hiRAND][fix] Add missing support for `curandDirectionVectors64_t` -> `hiprandDirectionVectors64_t`

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -6248,6 +6248,7 @@ sub simpleSubstitutions {
     subst("curandDirectionVectorSet", "hiprandDirectionVectorSet_t", "type");
     subst("curandDirectionVectorSet_t", "hiprandDirectionVectorSet_t", "type");
     subst("curandDirectionVectors32_t", "hiprandDirectionVectors32_t", "type");
+    subst("curandDirectionVectors64_t", "hiprandDirectionVectors64_t", "type");
     subst("curandDiscreteDistribution_st", "hiprandDiscreteDistribution_st", "type");
     subst("curandDiscreteDistribution_t", "hiprandDiscreteDistribution_t", "type");
     subst("curandGenerator_st", "hiprandGenerator_st", "type");
@@ -9263,7 +9264,6 @@ sub warnUnsupportedFunctions {
         "curandDistributionShift_st",
         "curandDistributionM2Shift_t",
         "curandDistributionM2Shift_st",
-        "curandDirectionVectors64_t",
         "cufftXtWorkAreaPolicy_t",
         "cufftXtWorkAreaPolicy",
         "cufftXtSubFormat_t",

--- a/docs/tables/CURAND_API_supported_by_HIP.md
+++ b/docs/tables/CURAND_API_supported_by_HIP.md
@@ -56,7 +56,7 @@
 |`curandDirectionVectorSet`| | | | |`hiprandDirectionVectorSet_t`|6.0.0| | | | |
 |`curandDirectionVectorSet_t`| | | | |`hiprandDirectionVectorSet_t`|6.0.0| | | | |
 |`curandDirectionVectors32_t`| | | | |`hiprandDirectionVectors32_t`|1.5.0| | | | |
-|`curandDirectionVectors64_t`| | | | | | | | | | |
+|`curandDirectionVectors64_t`| | | | |`hiprandDirectionVectors64_t`|6.0.0| | | | |
 |`curandDiscreteDistribution_st`| | | | |`hiprandDiscreteDistribution_st`|1.5.0| | | | |
 |`curandDiscreteDistribution_t`| | | | |`hiprandDiscreteDistribution_t`|1.5.0| | | | |
 |`curandDistributionM2Shift_st`| | | | | | | | | | |

--- a/docs/tables/CURAND_API_supported_by_HIP_and_ROC.md
+++ b/docs/tables/CURAND_API_supported_by_HIP_and_ROC.md
@@ -56,7 +56,7 @@
 |`curandDirectionVectorSet`| | | | |`hiprandDirectionVectorSet_t`|6.0.0| | | | | | | | | | |
 |`curandDirectionVectorSet_t`| | | | |`hiprandDirectionVectorSet_t`|6.0.0| | | | | | | | | | |
 |`curandDirectionVectors32_t`| | | | |`hiprandDirectionVectors32_t`|1.5.0| | | | | | | | | | |
-|`curandDirectionVectors64_t`| | | | | | | | | | | | | | | | |
+|`curandDirectionVectors64_t`| | | | |`hiprandDirectionVectors64_t`|6.0.0| | | | | | | | | | |
 |`curandDiscreteDistribution_st`| | | | |`hiprandDiscreteDistribution_st`|1.5.0| | | | | | | | | | |
 |`curandDiscreteDistribution_t`| | | | |`hiprandDiscreteDistribution_t`|1.5.0| | | | | | | | | | |
 |`curandDistributionM2Shift_st`| | | | | | | | | | | | | | | | |

--- a/src/CUDA2HIP_RAND_API_types.cpp
+++ b/src/CUDA2HIP_RAND_API_types.cpp
@@ -81,7 +81,7 @@ const std::map<llvm::StringRef, hipCounter> CUDA_RAND_TYPE_NAME_MAP {
   {"curandMethod",                                  {"hiprandMethod_t",                                "", CONV_TYPE, API_RAND, 1, HIP_UNSUPPORTED}},
   {"curandMethod_t",                                {"hiprandMethod_t",                                "", CONV_TYPE, API_RAND, 1, HIP_UNSUPPORTED}},
   {"curandDirectionVectors32_t",                    {"hiprandDirectionVectors32_t",                    "", CONV_TYPE, API_RAND, 1}},
-  {"curandDirectionVectors64_t",                    {"hiprandDirectionVectors64_t",                    "", CONV_TYPE, API_RAND, 1, HIP_UNSUPPORTED}},
+  {"curandDirectionVectors64_t",                    {"hiprandDirectionVectors64_t",                    "", CONV_TYPE, API_RAND, 1, ROC_UNSUPPORTED}},
 
   // RAND types for Device functions
   {"curandStateMtgp32",                             {"hiprandStateMtgp32",                             "", CONV_TYPE, API_RAND, 1}},
@@ -190,6 +190,7 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_RAND_TYPE_NAME_VER_MAP {
   {"HIPRAND_SCRAMBLED_DIRECTION_VECTORS_32_JOEKUO6",{HIP_6000, HIP_0,    HIP_0   }},
   {"HIPRAND_DIRECTION_VECTORS_64_JOEKUO6",          {HIP_6000, HIP_0,    HIP_0   }},
   {"HIPRAND_SCRAMBLED_DIRECTION_VECTORS_64_JOEKUO6",{HIP_6000, HIP_0,    HIP_0   }},
+  {"hiprandDirectionVectors64_t",                   {HIP_6000, HIP_0,    HIP_0   }},
   {"hiprandOrdering",                               {HIP_6020, HIP_0,    HIP_0,  HIP_LATEST}},
   {"hiprandOrdering_t",                             {HIP_6020, HIP_0,    HIP_0,  HIP_LATEST}},
   {"HIPRAND_ORDERING_PSEUDO_BEST",                  {HIP_6020, HIP_0,    HIP_0,  HIP_LATEST}},

--- a/tests/unit_tests/synthetic/libraries/curand2hiprand.cu
+++ b/tests/unit_tests/synthetic/libraries/curand2hiprand.cu
@@ -111,10 +111,27 @@ int main() {
   curandStateScrambledSobol32 randStateScrambledSobol32;
   curandStateScrambledSobol32_t randStateScrambledSobol32_t;
 
+  // CHECK: hiprandDirectionVectors32_t directions32;
+  // CHECK-NEXT: hiprandDirectionVectors64_t directions64;
+  // CHECK-NEXT: hiprandDirectionVectors64_t *pDirections64 = nullptr;
+  curandDirectionVectors32_t directions32;
+  curandDirectionVectors64_t directions64;
+  curandDirectionVectors64_t *pDirections64 = nullptr;
+
+  // CHECK: hiprandDirectionVectorSet_t directionVectorSet;
+  // CHECK-NEXT: hiprandDirectionVectorSet_t directionVectorSet_t;
+  curandDirectionVectorSet directionVectorSet;
+  curandDirectionVectorSet_t directionVectorSet_t;
+
   // CUDA: curandStatus_t CURANDAPI curandSetGeneratorOrdering(curandGenerator_t generator, curandOrdering_t order);
   // HIP: hiprandStatus_t HIPRANDAPI hiprandSetGeneratorOrdering(hiprandGenerator_t generator, hiprandOrdering_t order);
   // CHECK: status = hiprandSetGeneratorOrdering(randGenerator, randOrdering_t);
   status = curandSetGeneratorOrdering(randGenerator, randOrdering_t);
+
+  // CUDA: curandStatus_t CURANDAPI curandGetDirectionVectors64(curandDirectionVectors64_t *vectors[], curandDirectionVectorSet_t set);
+  // HIP: hiprandStatus_t HIPRANDAPI hiprandGetDirectionVectors64(hiprandDirectionVectors64_t** vectors, hiprandDirectionVectorSet_t set);
+  // CHECK: status = hiprandGetDirectionVectors64(&pDirections64, directionVectorSet_t);
+  status = curandGetDirectionVectors64(&pDirections64, directionVectorSet_t);
 
 #if CUDA_VERSION >= 11000 && CURAND_VERSION >= 10200
   // CHECK: hiprandOrdering_t RAND_ORDERING_PSEUDO_LEGACY = HIPRAND_ORDERING_PSEUDO_LEGACY;


### PR DESCRIPTION
+ Updated synthetic tests, the regenerated `hipify-perl`, and `RAND` `CUDA2HIP` documentation
