### PR TITLE
[HIPIFY][#584][#1624][MIOpen] Support for backend `graphAPI` direct translation from `cuDNN` to `MIOpen` - Part 8

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -947,16 +947,7 @@ my %deprecated_funcs = (
     "CUDNN_STATUS_ARCH_MISMATCH" => "9.0.0",
     "CUDNN_STATUS_ALLOC_FAILED" => "9.0.0",
     "CUDNN_REDUCE_TENSOR_NO_INDICES" => "9.0.0",
-    "CUDNN_REDUCE_TENSOR_NORM2" => "9.0.0",
-    "CUDNN_REDUCE_TENSOR_NORM1" => "9.0.0",
-    "CUDNN_REDUCE_TENSOR_MUL_NO_ZEROS" => "9.0.0",
-    "CUDNN_REDUCE_TENSOR_MUL" => "9.0.0",
-    "CUDNN_REDUCE_TENSOR_MIN" => "9.0.0",
-    "CUDNN_REDUCE_TENSOR_MAX" => "9.0.0",
     "CUDNN_REDUCE_TENSOR_FLATTENED_INDICES" => "9.0.0",
-    "CUDNN_REDUCE_TENSOR_AVG" => "9.0.0",
-    "CUDNN_REDUCE_TENSOR_AMAX" => "9.0.0",
-    "CUDNN_REDUCE_TENSOR_ADD" => "9.0.0",
     "CUDNN_PROPAGATE_NAN" => "9.0.0",
     "CUDNN_POOLING_MAX_DETERMINISTIC" => "9.0.0",
     "CUDNN_POOLING_MAX" => "9.0.0",
@@ -3174,6 +3165,7 @@ sub rocSubstitutions {
     subst("cudnnBatchNormMode_t", "miopenBatchNormMode_t", "type");
     subst("cudnnCTCLossAlgo_t", "miopenCTCLossAlgo_t", "type");
     subst("cudnnCTCLossDescriptor_t", "miopenCTCLossDescriptor_t", "type");
+    subst("cudnnContext", "miopenHandle", "type");
     subst("cudnnConvolutionBwdDataAlgoPerfStruct", "miopenConvAlgoPerf_t", "type");
     subst("cudnnConvolutionBwdDataAlgoPerf_t", "miopenConvAlgoPerf_t", "type");
     subst("cudnnConvolutionBwdDataAlgo_t", "miopenConvBwdDataAlgorithm_t", "type");
@@ -3581,6 +3573,7 @@ sub rocSubstitutions {
     subst("CUDNN_DATA_FLOAT", "miopenFloat", "numeric_literal");
     subst("CUDNN_DATA_HALF", "miopenHalf", "numeric_literal");
     subst("CUDNN_DATA_INT32", "miopenInt32", "numeric_literal");
+    subst("CUDNN_DATA_INT64", "miopenInt64", "numeric_literal");
     subst("CUDNN_DATA_INT8", "miopenInt8", "numeric_literal");
     subst("CUDNN_DATA_INT8x4", "miopenInt8x4", "numeric_literal");
     subst("CUDNN_GRU", "miopenGRU", "numeric_literal");
@@ -3624,6 +3617,7 @@ sub rocSubstitutions {
     subst("CUDNN_STATUS_NOT_INITIALIZED", "miopenStatusNotInitialized", "numeric_literal");
     subst("CUDNN_STATUS_NOT_SUPPORTED", "miopenStatusUnsupportedOp", "numeric_literal");
     subst("CUDNN_STATUS_SUCCESS", "miopenStatusSuccess", "numeric_literal");
+    subst("CUDNN_STATUS_VERSION_MISMATCH", "miopenStatusVersionMismatch", "numeric_literal");
     subst("CUDNN_TENSOR_NCHW", "miopenTensorNCHW", "numeric_literal");
     subst("CUDNN_TENSOR_NHWC", "miopenTensorNHWC", "numeric_literal");
     subst("CUDNN_TYPE_ATTRIB_NAME", "MIOPEN_TYPE_ATTRIB_NAME", "numeric_literal");
@@ -9752,6 +9746,7 @@ sub warnUnsupportedFunctions {
         "cudnnCTCLossDescriptor_t",
         "cudnnCTCLossAlgo_t",
         "cudnnCTCLoss",
+        "cudnnCTCGradMode_t",
         "cudnnBuildRNNDynamic",
         "cudnnBnFinalizeStatsMode_t",
         "cudnnBatchNormalizationForwardTrainingEx",
@@ -11624,6 +11619,8 @@ sub warnUnsupportedFunctions {
         "CUDNN_DATA_FAST_FLOAT_FOR_FP8",
         "CUDNN_DATA_BOOLEAN",
         "CUDNN_DATA_BFLOAT16",
+        "CUDNN_CTC_ZERO_OOB_GRADIENTS",
+        "CUDNN_CTC_SKIP_OOB_GRADIENTS",
         "CUDNN_CTC_LOSS_ALGO_NON_DETERMINISTIC",
         "CUDNN_CTC_LOSS_ALGO_DETERMINISTIC",
         "CUDNN_BN_FINALIZE_STATISTICS_TRAINING",

--- a/docs/tables/CUDNN_API_supported_by_HIP.md
+++ b/docs/tables/CUDNN_API_supported_by_HIP.md
@@ -329,6 +329,8 @@
 |`CUDNN_CROSS_CORRELATION`|1.0.0|9.0.0| | |`HIPDNN_CROSS_CORRELATION`| | | | | |
 |`CUDNN_CTC_LOSS_ALGO_DETERMINISTIC`|7.0.5| | | | | | | | | |
 |`CUDNN_CTC_LOSS_ALGO_NON_DETERMINISTIC`|7.0.5| | | | | | | | | |
+|`CUDNN_CTC_SKIP_OOB_GRADIENTS`|9.0.0| | | | | | | | | |
+|`CUDNN_CTC_ZERO_OOB_GRADIENTS`|9.0.0| | | | | | | | | |
 |`CUDNN_DATA_BFLOAT16`|8.1.0| | | | | | | | | |
 |`CUDNN_DATA_BOOLEAN`|8.3.0| | | | | | | | | |
 |`CUDNN_DATA_DOUBLE`|1.0.0| | | |`HIPDNN_DATA_DOUBLE`| | | | | |
@@ -585,16 +587,16 @@
 |`CUDNN_PTR_YSQSUM`|7.6.0| | | | | | | | | |
 |`CUDNN_PTR_YSUM`|7.6.0| | | | | | | | | |
 |`CUDNN_PTR_ZDATA`|7.6.0| | | | | | | | | |
-|`CUDNN_REDUCE_TENSOR_ADD`|6.0.0|9.0.0| | |`HIPDNN_REDUCE_TENSOR_ADD`| | | | | |
-|`CUDNN_REDUCE_TENSOR_AMAX`|6.0.0|9.0.0| | |`HIPDNN_REDUCE_TENSOR_AMAX`| | | | | |
-|`CUDNN_REDUCE_TENSOR_AVG`|6.0.0|9.0.0| | |`HIPDNN_REDUCE_TENSOR_AVG`| | | | | |
+|`CUDNN_REDUCE_TENSOR_ADD`|6.0.0| | | |`HIPDNN_REDUCE_TENSOR_ADD`| | | | | |
+|`CUDNN_REDUCE_TENSOR_AMAX`|6.0.0| | | |`HIPDNN_REDUCE_TENSOR_AMAX`| | | | | |
+|`CUDNN_REDUCE_TENSOR_AVG`|6.0.0| | | |`HIPDNN_REDUCE_TENSOR_AVG`| | | | | |
 |`CUDNN_REDUCE_TENSOR_FLATTENED_INDICES`|6.0.0|9.0.0| | |`HIPDNN_REDUCE_TENSOR_FLATTENED_INDICES`| | | | | |
-|`CUDNN_REDUCE_TENSOR_MAX`|6.0.0|9.0.0| | |`HIPDNN_REDUCE_TENSOR_MAX`| | | | | |
-|`CUDNN_REDUCE_TENSOR_MIN`|6.0.0|9.0.0| | |`HIPDNN_REDUCE_TENSOR_MIN`| | | | | |
-|`CUDNN_REDUCE_TENSOR_MUL`|6.0.0|9.0.0| | |`HIPDNN_REDUCE_TENSOR_MUL`| | | | | |
-|`CUDNN_REDUCE_TENSOR_MUL_NO_ZEROS`|7.0.5|9.0.0| | |`HIPDNN_REDUCE_TENSOR_MUL_NO_ZEROS`| | | | | |
-|`CUDNN_REDUCE_TENSOR_NORM1`|6.0.0|9.0.0| | |`HIPDNN_REDUCE_TENSOR_NORM1`| | | | | |
-|`CUDNN_REDUCE_TENSOR_NORM2`|6.0.0|9.0.0| | |`HIPDNN_REDUCE_TENSOR_NORM2`| | | | | |
+|`CUDNN_REDUCE_TENSOR_MAX`|6.0.0| | | |`HIPDNN_REDUCE_TENSOR_MAX`| | | | | |
+|`CUDNN_REDUCE_TENSOR_MIN`|6.0.0| | | |`HIPDNN_REDUCE_TENSOR_MIN`| | | | | |
+|`CUDNN_REDUCE_TENSOR_MUL`|6.0.0| | | |`HIPDNN_REDUCE_TENSOR_MUL`| | | | | |
+|`CUDNN_REDUCE_TENSOR_MUL_NO_ZEROS`|7.0.5| | | |`HIPDNN_REDUCE_TENSOR_MUL_NO_ZEROS`| | | | | |
+|`CUDNN_REDUCE_TENSOR_NORM1`|6.0.0| | | |`HIPDNN_REDUCE_TENSOR_NORM1`| | | | | |
+|`CUDNN_REDUCE_TENSOR_NORM2`|6.0.0| | | |`HIPDNN_REDUCE_TENSOR_NORM2`| | | | | |
 |`CUDNN_REDUCE_TENSOR_NO_INDICES`|6.0.0|9.0.0| | |`HIPDNN_REDUCE_TENSOR_NO_INDICES`| | | | | |
 |`CUDNN_RESAMPLE_AVGPOOL`|8.3.0| | | | | | | | | |
 |`CUDNN_RESAMPLE_AVGPOOL_EXCLUDE_PADDING`|8.6.0| | | | | | | | | |
@@ -773,6 +775,7 @@
 |`cudnnBatchNormMode_t`|4.0.0|9.0.0| | |`hipdnnBatchNormMode_t`| | | | | |
 |`cudnnBatchNormOps_t`|7.4.1|9.0.0| | | | | | | | |
 |`cudnnBnFinalizeStatsMode_t`|8.1.0| | | | | | | | | |
+|`cudnnCTCGradMode_t`|9.0.0| | | | | | | | | |
 |`cudnnCTCLossAlgo_t`|7.0.5| | | | | | | | | |
 |`cudnnCTCLossDescriptor_t`|7.0.5| | | | | | | | | |
 |`cudnnCTCLossStruct`|7.0.5| | | | | | | | | |

--- a/docs/tables/CUDNN_API_supported_by_HIP_and_MIOPEN.md
+++ b/docs/tables/CUDNN_API_supported_by_HIP_and_MIOPEN.md
@@ -329,6 +329,8 @@
 |`CUDNN_CROSS_CORRELATION`|1.0.0|9.0.0| | |`HIPDNN_CROSS_CORRELATION`| | | | | | | | | | | |
 |`CUDNN_CTC_LOSS_ALGO_DETERMINISTIC`|7.0.5| | | | | | | | | |`MIOPEN_CTC_LOSS_ALGO_DETERMINISTIC`| | | | | |
 |`CUDNN_CTC_LOSS_ALGO_NON_DETERMINISTIC`|7.0.5| | | | | | | | | | | | | | | |
+|`CUDNN_CTC_SKIP_OOB_GRADIENTS`|9.0.0| | | | | | | | | | | | | | | |
+|`CUDNN_CTC_ZERO_OOB_GRADIENTS`|9.0.0| | | | | | | | | | | | | | | |
 |`CUDNN_DATA_BFLOAT16`|8.1.0| | | | | | | | | |`miopenBFloat16`| | | | | |
 |`CUDNN_DATA_BOOLEAN`|8.3.0| | | | | | | | | | | | | | | |
 |`CUDNN_DATA_DOUBLE`|1.0.0| | | |`HIPDNN_DATA_DOUBLE`| | | | | |`miopenDouble`| | | | | |
@@ -338,7 +340,7 @@
 |`CUDNN_DATA_FP8_E5M2`|8.6.0| | | | | | | | | | | | | | | |
 |`CUDNN_DATA_HALF`|3.0.0| | | |`HIPDNN_DATA_HALF`| | | | | |`miopenHalf`| | | | | |
 |`CUDNN_DATA_INT32`|6.0.0| | | |`HIPDNN_DATA_INT32`| | | | | |`miopenInt32`| | | | | |
-|`CUDNN_DATA_INT64`|8.1.0| | | | | | | | | | | | | | | |
+|`CUDNN_DATA_INT64`|8.1.0| | | | | | | | | |`miopenInt64`| | | | | |
 |`CUDNN_DATA_INT8`|6.0.0| | | |`HIPDNN_DATA_INT8`| | | | | |`miopenInt8`| | | | | |
 |`CUDNN_DATA_INT8x32`|7.2.1|9.0.0| | | | | | | | | | | | | | |
 |`CUDNN_DATA_INT8x4`|6.0.0|9.0.0| | |`HIPDNN_DATA_INT8x4`| | | | | |`miopenInt8x4`| | | | | |
@@ -585,16 +587,16 @@
 |`CUDNN_PTR_YSQSUM`|7.6.0| | | | | | | | | | | | | | | |
 |`CUDNN_PTR_YSUM`|7.6.0| | | | | | | | | | | | | | | |
 |`CUDNN_PTR_ZDATA`|7.6.0| | | | | | | | | | | | | | | |
-|`CUDNN_REDUCE_TENSOR_ADD`|6.0.0|9.0.0| | |`HIPDNN_REDUCE_TENSOR_ADD`| | | | | |`MIOPEN_REDUCE_TENSOR_ADD`| | | | | |
-|`CUDNN_REDUCE_TENSOR_AMAX`|6.0.0|9.0.0| | |`HIPDNN_REDUCE_TENSOR_AMAX`| | | | | |`MIOPEN_REDUCE_TENSOR_AMAX`| | | | | |
-|`CUDNN_REDUCE_TENSOR_AVG`|6.0.0|9.0.0| | |`HIPDNN_REDUCE_TENSOR_AVG`| | | | | |`MIOPEN_REDUCE_TENSOR_AVG`| | | | | |
+|`CUDNN_REDUCE_TENSOR_ADD`|6.0.0| | | |`HIPDNN_REDUCE_TENSOR_ADD`| | | | | |`MIOPEN_REDUCE_TENSOR_ADD`| | | | | |
+|`CUDNN_REDUCE_TENSOR_AMAX`|6.0.0| | | |`HIPDNN_REDUCE_TENSOR_AMAX`| | | | | |`MIOPEN_REDUCE_TENSOR_AMAX`| | | | | |
+|`CUDNN_REDUCE_TENSOR_AVG`|6.0.0| | | |`HIPDNN_REDUCE_TENSOR_AVG`| | | | | |`MIOPEN_REDUCE_TENSOR_AVG`| | | | | |
 |`CUDNN_REDUCE_TENSOR_FLATTENED_INDICES`|6.0.0|9.0.0| | |`HIPDNN_REDUCE_TENSOR_FLATTENED_INDICES`| | | | | |`MIOPEN_REDUCE_TENSOR_FLATTENED_INDICES`| | | | | |
-|`CUDNN_REDUCE_TENSOR_MAX`|6.0.0|9.0.0| | |`HIPDNN_REDUCE_TENSOR_MAX`| | | | | |`MIOPEN_REDUCE_TENSOR_MAX`| | | | | |
-|`CUDNN_REDUCE_TENSOR_MIN`|6.0.0|9.0.0| | |`HIPDNN_REDUCE_TENSOR_MIN`| | | | | |`MIOPEN_REDUCE_TENSOR_MIN`| | | | | |
-|`CUDNN_REDUCE_TENSOR_MUL`|6.0.0|9.0.0| | |`HIPDNN_REDUCE_TENSOR_MUL`| | | | | |`MIOPEN_REDUCE_TENSOR_MUL`| | | | | |
-|`CUDNN_REDUCE_TENSOR_MUL_NO_ZEROS`|7.0.5|9.0.0| | |`HIPDNN_REDUCE_TENSOR_MUL_NO_ZEROS`| | | | | | | | | | | |
-|`CUDNN_REDUCE_TENSOR_NORM1`|6.0.0|9.0.0| | |`HIPDNN_REDUCE_TENSOR_NORM1`| | | | | |`MIOPEN_REDUCE_TENSOR_NORM1`| | | | | |
-|`CUDNN_REDUCE_TENSOR_NORM2`|6.0.0|9.0.0| | |`HIPDNN_REDUCE_TENSOR_NORM2`| | | | | |`MIOPEN_REDUCE_TENSOR_NORM2`| | | | | |
+|`CUDNN_REDUCE_TENSOR_MAX`|6.0.0| | | |`HIPDNN_REDUCE_TENSOR_MAX`| | | | | |`MIOPEN_REDUCE_TENSOR_MAX`| | | | | |
+|`CUDNN_REDUCE_TENSOR_MIN`|6.0.0| | | |`HIPDNN_REDUCE_TENSOR_MIN`| | | | | |`MIOPEN_REDUCE_TENSOR_MIN`| | | | | |
+|`CUDNN_REDUCE_TENSOR_MUL`|6.0.0| | | |`HIPDNN_REDUCE_TENSOR_MUL`| | | | | |`MIOPEN_REDUCE_TENSOR_MUL`| | | | | |
+|`CUDNN_REDUCE_TENSOR_MUL_NO_ZEROS`|7.0.5| | | |`HIPDNN_REDUCE_TENSOR_MUL_NO_ZEROS`| | | | | | | | | | | |
+|`CUDNN_REDUCE_TENSOR_NORM1`|6.0.0| | | |`HIPDNN_REDUCE_TENSOR_NORM1`| | | | | |`MIOPEN_REDUCE_TENSOR_NORM1`| | | | | |
+|`CUDNN_REDUCE_TENSOR_NORM2`|6.0.0| | | |`HIPDNN_REDUCE_TENSOR_NORM2`| | | | | |`MIOPEN_REDUCE_TENSOR_NORM2`| | | | | |
 |`CUDNN_REDUCE_TENSOR_NO_INDICES`|6.0.0|9.0.0| | |`HIPDNN_REDUCE_TENSOR_NO_INDICES`| | | | | |`MIOPEN_REDUCE_TENSOR_NO_INDICES`| | | | | |
 |`CUDNN_RESAMPLE_AVGPOOL`|8.3.0| | | | | | | | | | | | | | | |
 |`CUDNN_RESAMPLE_AVGPOOL_EXCLUDE_PADDING`|8.6.0| | | | | | | | | | | | | | | |
@@ -701,7 +703,7 @@
 |`CUDNN_STATUS_SUBLIBRARY_LOADING_FAILED`|9.2.0| | | | | | | | | | | | | | | |
 |`CUDNN_STATUS_SUBLIBRARY_VERSION_MISMATCH`|9.0.0| | | | | | | | | | | | | | | |
 |`CUDNN_STATUS_SUCCESS`|1.0.0| | | |`HIPDNN_STATUS_SUCCESS`| | | | | |`miopenStatusSuccess`| | | | | |
-|`CUDNN_STATUS_VERSION_MISMATCH`|8.0.1|9.0.0| | | | | | | | | | | | | | |
+|`CUDNN_STATUS_VERSION_MISMATCH`|8.0.1|9.0.0| | | | | | | | |`miopenStatusVersionMismatch`| | | | | |
 |`CUDNN_TENSOR_NCHW`|1.0.0| | | |`HIPDNN_TENSOR_NCHW`| | | | | |`miopenTensorNCHW`| | | | | |
 |`CUDNN_TENSOR_NCHW_VECT_C`|6.0.0| | | |`HIPDNN_TENSOR_NCHW_VECT_C`| | | | | | | | | | | |
 |`CUDNN_TENSOR_NHWC`|1.0.0| | | |`HIPDNN_TENSOR_NHWC`| | | | | |`miopenTensorNHWC`| | | | | |
@@ -773,11 +775,12 @@
 |`cudnnBatchNormMode_t`|4.0.0|9.0.0| | |`hipdnnBatchNormMode_t`| | | | | |`miopenBatchNormMode_t`| | | | | |
 |`cudnnBatchNormOps_t`|7.4.1|9.0.0| | | | | | | | | | | | | | |
 |`cudnnBnFinalizeStatsMode_t`|8.1.0| | | | | | | | | | | | | | | |
+|`cudnnCTCGradMode_t`|9.0.0| | | | | | | | | | | | | | | |
 |`cudnnCTCLossAlgo_t`|7.0.5| | | | | | | | | |`miopenCTCLossAlgo_t`| | | | | |
 |`cudnnCTCLossDescriptor_t`|7.0.5| | | | | | | | | |`miopenCTCLossDescriptor_t`| | | | | |
 |`cudnnCTCLossStruct`|7.0.5| | | | | | | | | | | | | | | |
 |`cudnnCallback_t`|7.1.3| | | | | | | | | | | | | | | |
-|`cudnnContext`|1.0.0| | | | | | | | | | | | | | | |
+|`cudnnContext`|1.0.0| | | | | | | | | |`miopenHandle`| | | | | |
 |`cudnnConvolutionBwdDataAlgoPerfStruct`|8.2.0|9.0.0| | |`hipdnnConvolutionBwdDataAlgoPerf_t`| | | | | |`miopenConvAlgoPerf_t`| | | | | |
 |`cudnnConvolutionBwdDataAlgoPerf_t`|3.0.0|9.0.0| | |`hipdnnConvolutionBwdDataAlgoPerf_t`| | | | | |`miopenConvAlgoPerf_t`| | | | | |
 |`cudnnConvolutionBwdDataAlgo_t`|3.0.0| | | |`hipdnnConvolutionBwdDataAlgo_t`| | | | | |`miopenConvBwdDataAlgorithm_t`| | | | | |

--- a/docs/tables/CUDNN_API_supported_by_MIOPEN.md
+++ b/docs/tables/CUDNN_API_supported_by_MIOPEN.md
@@ -329,6 +329,8 @@
 |`CUDNN_CROSS_CORRELATION`|1.0.0|9.0.0| | | | | | | | |
 |`CUDNN_CTC_LOSS_ALGO_DETERMINISTIC`|7.0.5| | | |`MIOPEN_CTC_LOSS_ALGO_DETERMINISTIC`| | | | | |
 |`CUDNN_CTC_LOSS_ALGO_NON_DETERMINISTIC`|7.0.5| | | | | | | | | |
+|`CUDNN_CTC_SKIP_OOB_GRADIENTS`|9.0.0| | | | | | | | | |
+|`CUDNN_CTC_ZERO_OOB_GRADIENTS`|9.0.0| | | | | | | | | |
 |`CUDNN_DATA_BFLOAT16`|8.1.0| | | |`miopenBFloat16`| | | | | |
 |`CUDNN_DATA_BOOLEAN`|8.3.0| | | | | | | | | |
 |`CUDNN_DATA_DOUBLE`|1.0.0| | | |`miopenDouble`| | | | | |
@@ -338,7 +340,7 @@
 |`CUDNN_DATA_FP8_E5M2`|8.6.0| | | | | | | | | |
 |`CUDNN_DATA_HALF`|3.0.0| | | |`miopenHalf`| | | | | |
 |`CUDNN_DATA_INT32`|6.0.0| | | |`miopenInt32`| | | | | |
-|`CUDNN_DATA_INT64`|8.1.0| | | | | | | | | |
+|`CUDNN_DATA_INT64`|8.1.0| | | |`miopenInt64`| | | | | |
 |`CUDNN_DATA_INT8`|6.0.0| | | |`miopenInt8`| | | | | |
 |`CUDNN_DATA_INT8x32`|7.2.1|9.0.0| | | | | | | | |
 |`CUDNN_DATA_INT8x4`|6.0.0|9.0.0| | |`miopenInt8x4`| | | | | |
@@ -585,16 +587,16 @@
 |`CUDNN_PTR_YSQSUM`|7.6.0| | | | | | | | | |
 |`CUDNN_PTR_YSUM`|7.6.0| | | | | | | | | |
 |`CUDNN_PTR_ZDATA`|7.6.0| | | | | | | | | |
-|`CUDNN_REDUCE_TENSOR_ADD`|6.0.0|9.0.0| | |`MIOPEN_REDUCE_TENSOR_ADD`| | | | | |
-|`CUDNN_REDUCE_TENSOR_AMAX`|6.0.0|9.0.0| | |`MIOPEN_REDUCE_TENSOR_AMAX`| | | | | |
-|`CUDNN_REDUCE_TENSOR_AVG`|6.0.0|9.0.0| | |`MIOPEN_REDUCE_TENSOR_AVG`| | | | | |
+|`CUDNN_REDUCE_TENSOR_ADD`|6.0.0| | | |`MIOPEN_REDUCE_TENSOR_ADD`| | | | | |
+|`CUDNN_REDUCE_TENSOR_AMAX`|6.0.0| | | |`MIOPEN_REDUCE_TENSOR_AMAX`| | | | | |
+|`CUDNN_REDUCE_TENSOR_AVG`|6.0.0| | | |`MIOPEN_REDUCE_TENSOR_AVG`| | | | | |
 |`CUDNN_REDUCE_TENSOR_FLATTENED_INDICES`|6.0.0|9.0.0| | |`MIOPEN_REDUCE_TENSOR_FLATTENED_INDICES`| | | | | |
-|`CUDNN_REDUCE_TENSOR_MAX`|6.0.0|9.0.0| | |`MIOPEN_REDUCE_TENSOR_MAX`| | | | | |
-|`CUDNN_REDUCE_TENSOR_MIN`|6.0.0|9.0.0| | |`MIOPEN_REDUCE_TENSOR_MIN`| | | | | |
-|`CUDNN_REDUCE_TENSOR_MUL`|6.0.0|9.0.0| | |`MIOPEN_REDUCE_TENSOR_MUL`| | | | | |
-|`CUDNN_REDUCE_TENSOR_MUL_NO_ZEROS`|7.0.5|9.0.0| | | | | | | | |
-|`CUDNN_REDUCE_TENSOR_NORM1`|6.0.0|9.0.0| | |`MIOPEN_REDUCE_TENSOR_NORM1`| | | | | |
-|`CUDNN_REDUCE_TENSOR_NORM2`|6.0.0|9.0.0| | |`MIOPEN_REDUCE_TENSOR_NORM2`| | | | | |
+|`CUDNN_REDUCE_TENSOR_MAX`|6.0.0| | | |`MIOPEN_REDUCE_TENSOR_MAX`| | | | | |
+|`CUDNN_REDUCE_TENSOR_MIN`|6.0.0| | | |`MIOPEN_REDUCE_TENSOR_MIN`| | | | | |
+|`CUDNN_REDUCE_TENSOR_MUL`|6.0.0| | | |`MIOPEN_REDUCE_TENSOR_MUL`| | | | | |
+|`CUDNN_REDUCE_TENSOR_MUL_NO_ZEROS`|7.0.5| | | | | | | | | |
+|`CUDNN_REDUCE_TENSOR_NORM1`|6.0.0| | | |`MIOPEN_REDUCE_TENSOR_NORM1`| | | | | |
+|`CUDNN_REDUCE_TENSOR_NORM2`|6.0.0| | | |`MIOPEN_REDUCE_TENSOR_NORM2`| | | | | |
 |`CUDNN_REDUCE_TENSOR_NO_INDICES`|6.0.0|9.0.0| | |`MIOPEN_REDUCE_TENSOR_NO_INDICES`| | | | | |
 |`CUDNN_RESAMPLE_AVGPOOL`|8.3.0| | | | | | | | | |
 |`CUDNN_RESAMPLE_AVGPOOL_EXCLUDE_PADDING`|8.6.0| | | | | | | | | |
@@ -701,7 +703,7 @@
 |`CUDNN_STATUS_SUBLIBRARY_LOADING_FAILED`|9.2.0| | | | | | | | | |
 |`CUDNN_STATUS_SUBLIBRARY_VERSION_MISMATCH`|9.0.0| | | | | | | | | |
 |`CUDNN_STATUS_SUCCESS`|1.0.0| | | |`miopenStatusSuccess`| | | | | |
-|`CUDNN_STATUS_VERSION_MISMATCH`|8.0.1|9.0.0| | | | | | | | |
+|`CUDNN_STATUS_VERSION_MISMATCH`|8.0.1|9.0.0| | |`miopenStatusVersionMismatch`| | | | | |
 |`CUDNN_TENSOR_NCHW`|1.0.0| | | |`miopenTensorNCHW`| | | | | |
 |`CUDNN_TENSOR_NCHW_VECT_C`|6.0.0| | | | | | | | | |
 |`CUDNN_TENSOR_NHWC`|1.0.0| | | |`miopenTensorNHWC`| | | | | |
@@ -773,11 +775,12 @@
 |`cudnnBatchNormMode_t`|4.0.0|9.0.0| | |`miopenBatchNormMode_t`| | | | | |
 |`cudnnBatchNormOps_t`|7.4.1|9.0.0| | | | | | | | |
 |`cudnnBnFinalizeStatsMode_t`|8.1.0| | | | | | | | | |
+|`cudnnCTCGradMode_t`|9.0.0| | | | | | | | | |
 |`cudnnCTCLossAlgo_t`|7.0.5| | | |`miopenCTCLossAlgo_t`| | | | | |
 |`cudnnCTCLossDescriptor_t`|7.0.5| | | |`miopenCTCLossDescriptor_t`| | | | | |
 |`cudnnCTCLossStruct`|7.0.5| | | | | | | | | |
 |`cudnnCallback_t`|7.1.3| | | | | | | | | |
-|`cudnnContext`|1.0.0| | | | | | | | | |
+|`cudnnContext`|1.0.0| | | |`miopenHandle`| | | | | |
 |`cudnnConvolutionBwdDataAlgoPerfStruct`|8.2.0|9.0.0| | |`miopenConvAlgoPerf_t`| | | | | |
 |`cudnnConvolutionBwdDataAlgoPerf_t`|3.0.0|9.0.0| | |`miopenConvAlgoPerf_t`| | | | | |
 |`cudnnConvolutionBwdDataAlgo_t`|3.0.0| | | |`miopenConvBwdDataAlgorithm_t`| | | | | |

--- a/src/CUDA2HIP_DNN_API_types.cpp
+++ b/src/CUDA2HIP_DNN_API_types.cpp
@@ -56,7 +56,7 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DNN_TYPE_NAME_MAP {
   {"CUDNN_STATUS_RUNTIME_IN_PROGRESS",                               {"HIPDNN_STATUS_RUNTIME_IN_PROGRESS",                               "",                                                                CONV_NUMERIC_LITERAL, API_DNN, 1, UNSUPPORTED}},
   {"CUDNN_STATUS_RUNTIME_FP_OVERFLOW",                               {"HIPDNN_STATUS_RUNTIME_FP_OVERFLOW",                               "",                                                                CONV_NUMERIC_LITERAL, API_DNN, 1, UNSUPPORTED}},
   {"CUDNN_STATUS_SUBLIBRARY_LOADING_FAILED",                         {"HIPDNN_STATUS_SUBLIBRARY_LOADING_FAILED",                         "",                                                                CONV_NUMERIC_LITERAL, API_DNN, 1, UNSUPPORTED}},
-  {"CUDNN_STATUS_VERSION_MISMATCH",                                  {"HIPDNN_STATUS_VERSION_MISMATCH",                                  "",                                                                CONV_NUMERIC_LITERAL, API_DNN, 1, UNSUPPORTED | CUDA_DEPRECATED}},
+  {"CUDNN_STATUS_VERSION_MISMATCH",                                  {"HIPDNN_STATUS_VERSION_MISMATCH",                                  "miopenStatusVersionMismatch",                                     CONV_NUMERIC_LITERAL, API_DNN, 1, HIP_UNSUPPORTED | CUDA_DEPRECATED}},
   {"CUDNN_STATUS_SUBLIBRARY_VERSION_MISMATCH",                       {"HIPDNN_STATUS_SUBLIBRARY_VERSION_MISMATCH",                       "",                                                                CONV_NUMERIC_LITERAL, API_DNN, 1, UNSUPPORTED}},
   {"CUDNN_STATUS_SERIALIZATION_VERSION_MISMATCH",                    {"HIPDNN_STATUS_SERIALIZATION_VERSION_MISMATCH",                    "",                                                                CONV_NUMERIC_LITERAL, API_DNN, 1, UNSUPPORTED}},
   {"CUDNN_STATUS_DEPRECATED",                                        {"HIPDNN_STATUS_DEPRECATED",                                        "",                                                                CONV_NUMERIC_LITERAL, API_DNN, 1, UNSUPPORTED}},
@@ -114,7 +114,7 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DNN_TYPE_NAME_MAP {
   {"CUDNN_DATA_UINT8x4",                                             {"HIPDNN_DATA_UINT8x4",                                             "",                                                                CONV_NUMERIC_LITERAL, API_DNN, 1, UNSUPPORTED | CUDA_DEPRECATED}},  // 7
   {"CUDNN_DATA_INT8x32",                                             {"HIPDNN_DATA_INT8x32",                                             "",                                                                CONV_NUMERIC_LITERAL, API_DNN, 1, UNSUPPORTED | CUDA_DEPRECATED}},  // 8
   {"CUDNN_DATA_BFLOAT16",                                            {"HIPDNN_DATA_BFLOAT16",                                            "miopenBFloat16",                                                  CONV_NUMERIC_LITERAL, API_DNN, 1, HIP_UNSUPPORTED}},  // 9
-  {"CUDNN_DATA_INT64",                                               {"HIPDNN_DATA_INT64",                                               "",                                                                CONV_NUMERIC_LITERAL, API_DNN, 1, UNSUPPORTED}},  // 10
+  {"CUDNN_DATA_INT64",                                               {"HIPDNN_DATA_INT64",                                               "miopenInt64",                                                     CONV_NUMERIC_LITERAL, API_DNN, 1, HIP_UNSUPPORTED}},  // 10
   {"CUDNN_DATA_BOOLEAN",                                             {"HIPDNN_DATA_BOOLEAN",                                             "",                                                                CONV_NUMERIC_LITERAL, API_DNN, 1, UNSUPPORTED}},  // 11
   {"CUDNN_DATA_FP8_E4M3",                                            {"HIPDNN_DATA_FP8_E4M3",                                            "",                                                                CONV_NUMERIC_LITERAL, API_DNN, 1, UNSUPPORTED}},  // 12
   {"CUDNN_DATA_FP8_E5M2",                                            {"HIPDNN_DATA_FP8_E5M2",                                            "",                                                                CONV_NUMERIC_LITERAL, API_DNN, 1, UNSUPPORTED}},  // 13
@@ -211,15 +211,15 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DNN_TYPE_NAME_MAP {
   {"CUDNN_OP_TENSOR_SQRT",                                           {"HIPDNN_OP_TENSOR_SQRT",                                           "",                                                                CONV_NUMERIC_LITERAL, API_DNN, 1, ROC_UNSUPPORTED}},    // 4
   {"CUDNN_OP_TENSOR_NOT",                                            {"HIPDNN_OP_TENSOR_NOT",                                            "",                                                                CONV_NUMERIC_LITERAL, API_DNN, 1, UNSUPPORTED}},    // 5
   {"cudnnReduceTensorOp_t",                                          {"hipdnnReduceTensorOp_t",                                          "miopenReduceTensorOp_t",                                          CONV_TYPE, API_DNN, 1}},
-  {"CUDNN_REDUCE_TENSOR_ADD",                                        {"HIPDNN_REDUCE_TENSOR_ADD",                                        "MIOPEN_REDUCE_TENSOR_ADD",                                        CONV_NUMERIC_LITERAL, API_DNN, 1, CUDA_DEPRECATED}},    // 0
-  {"CUDNN_REDUCE_TENSOR_MUL",                                        {"HIPDNN_REDUCE_TENSOR_MUL",                                        "MIOPEN_REDUCE_TENSOR_MUL",                                        CONV_NUMERIC_LITERAL, API_DNN, 1, CUDA_DEPRECATED}},    // 1
-  {"CUDNN_REDUCE_TENSOR_MIN",                                        {"HIPDNN_REDUCE_TENSOR_MIN",                                        "MIOPEN_REDUCE_TENSOR_MIN",                                        CONV_NUMERIC_LITERAL, API_DNN, 1, CUDA_DEPRECATED}},    // 2
-  {"CUDNN_REDUCE_TENSOR_MAX",                                        {"HIPDNN_REDUCE_TENSOR_MAX",                                        "MIOPEN_REDUCE_TENSOR_MAX",                                        CONV_NUMERIC_LITERAL, API_DNN, 1, CUDA_DEPRECATED}},    // 3
-  {"CUDNN_REDUCE_TENSOR_AMAX",                                       {"HIPDNN_REDUCE_TENSOR_AMAX",                                       "MIOPEN_REDUCE_TENSOR_AMAX",                                       CONV_NUMERIC_LITERAL, API_DNN, 1, CUDA_DEPRECATED}},    // 4
-  {"CUDNN_REDUCE_TENSOR_AVG",                                        {"HIPDNN_REDUCE_TENSOR_AVG",                                        "MIOPEN_REDUCE_TENSOR_AVG",                                        CONV_NUMERIC_LITERAL, API_DNN, 1, CUDA_DEPRECATED}},    // 5
-  {"CUDNN_REDUCE_TENSOR_NORM1",                                      {"HIPDNN_REDUCE_TENSOR_NORM1",                                      "MIOPEN_REDUCE_TENSOR_NORM1",                                      CONV_NUMERIC_LITERAL, API_DNN, 1, CUDA_DEPRECATED}},    // 6
-  {"CUDNN_REDUCE_TENSOR_NORM2",                                      {"HIPDNN_REDUCE_TENSOR_NORM2",                                      "MIOPEN_REDUCE_TENSOR_NORM2",                                      CONV_NUMERIC_LITERAL, API_DNN, 1, CUDA_DEPRECATED}},    // 7
-  {"CUDNN_REDUCE_TENSOR_MUL_NO_ZEROS",                               {"HIPDNN_REDUCE_TENSOR_MUL_NO_ZEROS",                               "",                                                                CONV_NUMERIC_LITERAL, API_DNN, 1, ROC_UNSUPPORTED | CUDA_DEPRECATED}},    // 8
+  {"CUDNN_REDUCE_TENSOR_ADD",                                        {"HIPDNN_REDUCE_TENSOR_ADD",                                        "MIOPEN_REDUCE_TENSOR_ADD",                                        CONV_NUMERIC_LITERAL, API_DNN, 1}},    // 0
+  {"CUDNN_REDUCE_TENSOR_MUL",                                        {"HIPDNN_REDUCE_TENSOR_MUL",                                        "MIOPEN_REDUCE_TENSOR_MUL",                                        CONV_NUMERIC_LITERAL, API_DNN, 1}},    // 1
+  {"CUDNN_REDUCE_TENSOR_MIN",                                        {"HIPDNN_REDUCE_TENSOR_MIN",                                        "MIOPEN_REDUCE_TENSOR_MIN",                                        CONV_NUMERIC_LITERAL, API_DNN, 1}},    // 2
+  {"CUDNN_REDUCE_TENSOR_MAX",                                        {"HIPDNN_REDUCE_TENSOR_MAX",                                        "MIOPEN_REDUCE_TENSOR_MAX",                                        CONV_NUMERIC_LITERAL, API_DNN, 1}},    // 3
+  {"CUDNN_REDUCE_TENSOR_AMAX",                                       {"HIPDNN_REDUCE_TENSOR_AMAX",                                       "MIOPEN_REDUCE_TENSOR_AMAX",                                       CONV_NUMERIC_LITERAL, API_DNN, 1}},    // 4
+  {"CUDNN_REDUCE_TENSOR_AVG",                                        {"HIPDNN_REDUCE_TENSOR_AVG",                                        "MIOPEN_REDUCE_TENSOR_AVG",                                        CONV_NUMERIC_LITERAL, API_DNN, 1}},    // 5
+  {"CUDNN_REDUCE_TENSOR_NORM1",                                      {"HIPDNN_REDUCE_TENSOR_NORM1",                                      "MIOPEN_REDUCE_TENSOR_NORM1",                                      CONV_NUMERIC_LITERAL, API_DNN, 1}},    // 6
+  {"CUDNN_REDUCE_TENSOR_NORM2",                                      {"HIPDNN_REDUCE_TENSOR_NORM2",                                      "MIOPEN_REDUCE_TENSOR_NORM2",                                      CONV_NUMERIC_LITERAL, API_DNN, 1}},    // 7
+  {"CUDNN_REDUCE_TENSOR_MUL_NO_ZEROS",                               {"HIPDNN_REDUCE_TENSOR_MUL_NO_ZEROS",                               "",                                                                CONV_NUMERIC_LITERAL, API_DNN, 1, ROC_UNSUPPORTED}},    // 8
   {"cudnnReduceTensorIndices_t",                                     {"hipdnnReduceTensorIndices_t",                                     "miopenReduceTensorIndices_t",                                     CONV_TYPE, API_DNN, 1, CUDA_DEPRECATED}},
   {"CUDNN_REDUCE_TENSOR_NO_INDICES",                                 {"HIPDNN_REDUCE_TENSOR_NO_INDICES",                                 "MIOPEN_REDUCE_TENSOR_NO_INDICES",                                 CONV_NUMERIC_LITERAL, API_DNN, 1, CUDA_DEPRECATED}},    // 0
   {"CUDNN_REDUCE_TENSOR_FLATTENED_INDICES",                          {"HIPDNN_REDUCE_TENSOR_FLATTENED_INDICES",                          "MIOPEN_REDUCE_TENSOR_FLATTENED_INDICES",                          CONV_NUMERIC_LITERAL, API_DNN, 1, CUDA_DEPRECATED}},    // 1
@@ -841,9 +841,12 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DNN_TYPE_NAME_MAP {
   {"CUDNN_RNG_DISTRIBUTION_BERNOULLI",                               {"HIPDNN_RNG_DISTRIBUTION_BERNOULLI",                               "",                                                                CONV_NUMERIC_LITERAL, API_DNN, 1, UNSUPPORTED}},
   {"CUDNN_RNG_DISTRIBUTION_UNIFORM",                                 {"HIPDNN_RNG_DISTRIBUTION_UNIFORM",                                 "",                                                                CONV_NUMERIC_LITERAL, API_DNN, 1, UNSUPPORTED}},
   {"CUDNN_RNG_DISTRIBUTION_NORMAL",                                  {"HIPDNN_RNG_DISTRIBUTION_NORMAL",                                  "",                                                                CONV_NUMERIC_LITERAL, API_DNN, 1, UNSUPPORTED}},
+  {"cudnnCTCGradMode_t",                                             {"hipdnnCTCGradMode_t",                                             "",                                                                CONV_TYPE, API_DNN, 1, UNSUPPORTED}},
+  {"CUDNN_CTC_ZERO_OOB_GRADIENTS",                                   {"HIPDNN_CTC_ZERO_OOB_GRADIENTS",                                   "",                                                                CONV_NUMERIC_LITERAL, API_DNN, 1, UNSUPPORTED}},
+  {"CUDNN_CTC_SKIP_OOB_GRADIENTS",                                   {"HIPDNN_CTC_SKIP_OOB_GRADIENTS",                                   "",                                                                CONV_NUMERIC_LITERAL, API_DNN, 1, UNSUPPORTED}},
 
   // cuDNN types
-  {"cudnnContext",                                                   {"hipdnnContext",                                                   "",                                                                CONV_TYPE, API_DNN, 1, UNSUPPORTED}},
+  {"cudnnContext",                                                   {"hipdnnContext",                                                   "miopenHandle",                                                    CONV_TYPE, API_DNN, 1, HIP_UNSUPPORTED}},
   {"cudnnHandle_t",                                                  {"hipdnnHandle_t",                                                  "miopenHandle_t",                                                  CONV_TYPE, API_DNN, 1}},
   {"cudnnTensorStruct",                                              {"hipdnnTensorStruct",                                              "",                                                                CONV_TYPE, API_DNN, 1, UNSUPPORTED}},
   {"cudnnTensorDescriptor_t",                                        {"hipdnnTensorDescriptor_t",                                        "miopenTensorDescriptor_t",                                        CONV_TYPE, API_DNN, 1}},
@@ -1272,15 +1275,15 @@ const std::map<llvm::StringRef, cudaAPIversions> CUDA_DNN_TYPE_NAME_VER_MAP {
   {"CUDNN_OP_TENSOR_SQRT",                                           {CUDNN_60,  CUDA_0,    CUDA_0   }},
   {"CUDNN_OP_TENSOR_NOT",                                            {CUDNN_705, CUDA_0,    CUDA_0   }},
   {"cudnnReduceTensorOp_t",                                          {CUDNN_60,  CUDA_0,    CUDA_0   }},
-  {"CUDNN_REDUCE_TENSOR_ADD",                                        {CUDNN_60,  CUDNN_900, CUDA_0   }},
-  {"CUDNN_REDUCE_TENSOR_MUL",                                        {CUDNN_60,  CUDNN_900, CUDA_0   }},
-  {"CUDNN_REDUCE_TENSOR_MIN",                                        {CUDNN_60,  CUDNN_900, CUDA_0   }},
-  {"CUDNN_REDUCE_TENSOR_MAX",                                        {CUDNN_60,  CUDNN_900, CUDA_0   }},
-  {"CUDNN_REDUCE_TENSOR_AMAX",                                       {CUDNN_60,  CUDNN_900, CUDA_0   }},
-  {"CUDNN_REDUCE_TENSOR_AVG",                                        {CUDNN_60,  CUDNN_900, CUDA_0   }},
-  {"CUDNN_REDUCE_TENSOR_NORM1",                                      {CUDNN_60,  CUDNN_900, CUDA_0   }},
-  {"CUDNN_REDUCE_TENSOR_NORM2",                                      {CUDNN_60,  CUDNN_900, CUDA_0   }},
-  {"CUDNN_REDUCE_TENSOR_MUL_NO_ZEROS",                               {CUDNN_705, CUDNN_900, CUDA_0   }},
+  {"CUDNN_REDUCE_TENSOR_ADD",                                        {CUDNN_60,  CUDA_0,    CUDA_0   }},
+  {"CUDNN_REDUCE_TENSOR_MUL",                                        {CUDNN_60,  CUDA_0,    CUDA_0   }},
+  {"CUDNN_REDUCE_TENSOR_MIN",                                        {CUDNN_60,  CUDA_0,    CUDA_0   }},
+  {"CUDNN_REDUCE_TENSOR_MAX",                                        {CUDNN_60,  CUDA_0,    CUDA_0   }},
+  {"CUDNN_REDUCE_TENSOR_AMAX",                                       {CUDNN_60,  CUDA_0,    CUDA_0   }},
+  {"CUDNN_REDUCE_TENSOR_AVG",                                        {CUDNN_60,  CUDA_0,    CUDA_0   }},
+  {"CUDNN_REDUCE_TENSOR_NORM1",                                      {CUDNN_60,  CUDA_0,    CUDA_0   }},
+  {"CUDNN_REDUCE_TENSOR_NORM2",                                      {CUDNN_60,  CUDA_0,    CUDA_0   }},
+  {"CUDNN_REDUCE_TENSOR_MUL_NO_ZEROS",                               {CUDNN_705, CUDA_0,    CUDA_0   }},
   {"cudnnReduceTensorIndices_t",                                     {CUDNN_60,  CUDNN_900, CUDA_0   }},
   {"CUDNN_REDUCE_TENSOR_NO_INDICES",                                 {CUDNN_60,  CUDNN_900, CUDA_0   }},
   {"CUDNN_REDUCE_TENSOR_FLATTENED_INDICES",                          {CUDNN_60,  CUDNN_900, CUDA_0   }},
@@ -1784,6 +1787,9 @@ const std::map<llvm::StringRef, cudaAPIversions> CUDA_DNN_TYPE_NAME_VER_MAP {
   {"CUDNN_ATTR_KERNEL_CACHE_IS_ENGINECFG_KERNEL_CACHED",             {CUDNN_940, CUDA_0,    CUDA_0   }},
   {"CUDNN_BACKEND_KERNEL_CACHE_DESCRIPTOR",                          {CUDNN_940, CUDA_0,    CUDA_0   }},
   {"CUDNN_BACKEND_OPERATION_PAGED_CACHE_LOAD_DESCRIPTOR",            {CUDNN_940, CUDA_0,    CUDA_0   }},
+  {"cudnnCTCGradMode_t",                                             {CUDNN_900, CUDA_0,    CUDA_0   }},
+  {"CUDNN_CTC_ZERO_OOB_GRADIENTS",                                   {CUDNN_900, CUDA_0,    CUDA_0   }},
+  {"CUDNN_CTC_SKIP_OOB_GRADIENTS",                                   {CUDNN_900, CUDA_0,    CUDA_0   }},
 };
 
 const std::map<llvm::StringRef, hipAPIversions> HIP_DNN_TYPE_NAME_VER_MAP {

--- a/tests/unit_tests/synthetic/libraries/cudnn2miopen.cu
+++ b/tests/unit_tests/synthetic/libraries/cudnn2miopen.cu
@@ -29,7 +29,9 @@ int main() {
   // CHECK: miopenStatus_t status;
   cudnnStatus_t status;
 
-  // CHECK: miopenHandle_t handle;
+  // CHECK: miopenHandle *context = nullptr;
+  // CHECK-NEXT: miopenHandle_t handle;
+  cudnnContext *context = nullptr;
   cudnnHandle_t handle;
 
   // CUDA: cudnnStatus_t CUDNNWINAPI cudnnCreate(cudnnHandle_t *handle);
@@ -98,7 +100,6 @@ int main() {
   // CHECK-NEXT: miopenDataType_t DATA_INT8 = miopenInt8;
   // CHECK-NEXT: miopenDataType_t DATA_INT32 = miopenInt32;
   // CHECK-NEXT: miopenDataType_t DATA_INT8x4 = miopenInt8x4;
-  // CHECK-NEXT: miopenDataType_t DATA_BFLOAT16 = miopenBFloat16;
   cudnnDataType_t dataType;
   cudnnDataType_t DATA_FLOAT = CUDNN_DATA_FLOAT;
   cudnnDataType_t DATA_DOUBLE = CUDNN_DATA_DOUBLE;
@@ -106,7 +107,6 @@ int main() {
   cudnnDataType_t DATA_INT8 = CUDNN_DATA_INT8;
   cudnnDataType_t DATA_INT32 = CUDNN_DATA_INT32;
   cudnnDataType_t DATA_INT8x4 = CUDNN_DATA_INT8x4;
-  cudnnDataType_t DATA_BFLOAT16 = CUDNN_DATA_BFLOAT16;
 
   // CHECK: miopenRNNMode_t RNNMode;
   // CHECK-NEXT: miopenRNNMode_t RNN_RELU = miopenRNNRELU;
@@ -176,15 +176,9 @@ int main() {
   // CHECK: miopenActivationMode_t activationMode;
   // CHECK-NEXT: miopenActivationMode_t ACTIVATION_RELU = miopenActivationRELU;
   // CHECK-NEXT: miopenActivationMode_t ACTIVATION_TANH = miopenActivationTANH;
-  // CHECK-NEXT: miopenActivationMode_t ACTIVATION_CLIPPED_RELU = miopenActivationCLIPPEDRELU;
-  // CHECK-NEXT: miopenActivationMode_t ACTIVATION_ELU = miopenActivationELU;
-  // CHECK-NEXT: miopenActivationMode_t ACTIVATION_IDENTITY = miopenActivationPASTHRU;
   cudnnActivationMode_t activationMode;
   cudnnActivationMode_t ACTIVATION_RELU = CUDNN_ACTIVATION_RELU;
   cudnnActivationMode_t ACTIVATION_TANH = CUDNN_ACTIVATION_TANH;
-  cudnnActivationMode_t ACTIVATION_CLIPPED_RELU = CUDNN_ACTIVATION_CLIPPED_RELU;
-  cudnnActivationMode_t ACTIVATION_ELU = CUDNN_ACTIVATION_ELU;
-  cudnnActivationMode_t ACTIVATION_IDENTITY = CUDNN_ACTIVATION_IDENTITY;
 
   // CHECK: miopenSoftmaxAlgorithm_t softmaxAlgorithm;
   // CHECK-NEXT: miopenSoftmaxAlgorithm_t SOFTMAX_FAST = MIOPEN_SOFTMAX_FAST;
@@ -202,25 +196,6 @@ int main() {
   cudnnSoftmaxMode_t SOFTMAX_MODE_INSTANCE = CUDNN_SOFTMAX_MODE_INSTANCE;
   cudnnSoftmaxMode_t SOFTMAX_MODE_CHANNEL = CUDNN_SOFTMAX_MODE_CHANNEL;
 
-  // CHECK: miopenReduceTensorOp_t reduceTensorOp;
-  // CHECK-NEXT: miopenReduceTensorOp_t REDUCE_TENSOR_ADD = MIOPEN_REDUCE_TENSOR_ADD;
-  // CHECK-NEXT: miopenReduceTensorOp_t REDUCE_TENSOR_MUL = MIOPEN_REDUCE_TENSOR_MUL;
-  // CHECK-NEXT: miopenReduceTensorOp_t REDUCE_TENSOR_MIN = MIOPEN_REDUCE_TENSOR_MIN;
-  // CHECK-NEXT: miopenReduceTensorOp_t REDUCE_TENSOR_MAX = MIOPEN_REDUCE_TENSOR_MAX;
-  // CHECK-NEXT: miopenReduceTensorOp_t REDUCE_TENSOR_AMAX = MIOPEN_REDUCE_TENSOR_AMAX;
-  // CHECK-NEXT: miopenReduceTensorOp_t REDUCE_TENSOR_AVG = MIOPEN_REDUCE_TENSOR_AVG;
-  // CHECK-NEXT: miopenReduceTensorOp_t REDUCE_TENSOR_NORM1 = MIOPEN_REDUCE_TENSOR_NORM1;
-  // CHECK-NEXT: miopenReduceTensorOp_t REDUCE_TENSOR_NORM2 = MIOPEN_REDUCE_TENSOR_NORM2;
-  cudnnReduceTensorOp_t reduceTensorOp;
-  cudnnReduceTensorOp_t REDUCE_TENSOR_ADD = CUDNN_REDUCE_TENSOR_ADD;
-  cudnnReduceTensorOp_t REDUCE_TENSOR_MUL = CUDNN_REDUCE_TENSOR_MUL;
-  cudnnReduceTensorOp_t REDUCE_TENSOR_MIN = CUDNN_REDUCE_TENSOR_MIN;
-  cudnnReduceTensorOp_t REDUCE_TENSOR_MAX = CUDNN_REDUCE_TENSOR_MAX;
-  cudnnReduceTensorOp_t REDUCE_TENSOR_AMAX = CUDNN_REDUCE_TENSOR_AMAX;
-  cudnnReduceTensorOp_t REDUCE_TENSOR_AVG = CUDNN_REDUCE_TENSOR_AVG;
-  cudnnReduceTensorOp_t REDUCE_TENSOR_NORM1 = CUDNN_REDUCE_TENSOR_NORM1;
-  cudnnReduceTensorOp_t REDUCE_TENSOR_NORM2 = CUDNN_REDUCE_TENSOR_NORM2;
-
   // CHECK: miopenConvFwdAlgorithm_t convolutionFwdAlgo;
   // CHECK-NEXT: miopenConvFwdAlgorithm_t CONVOLUTION_FWD_ALGO_IMPLICIT_GEMM = miopenConvolutionFwdAlgoImplicitGEMM;
   // CHECK-NEXT: miopenConvFwdAlgorithm_t CONVOLUTION_FWD_ALGO_GEMM = miopenConvolutionFwdAlgoGEMM;
@@ -233,13 +208,6 @@ int main() {
   cudnnConvolutionFwdAlgo_t CONVOLUTION_FWD_ALGO_DIRECT = CUDNN_CONVOLUTION_FWD_ALGO_DIRECT;
   cudnnConvolutionFwdAlgo_t CONVOLUTION_FWD_ALGO_FFT = CUDNN_CONVOLUTION_FWD_ALGO_FFT;
   cudnnConvolutionFwdAlgo_t CONVOLUTION_FWD_ALGO_WINOGRAD = CUDNN_CONVOLUTION_FWD_ALGO_WINOGRAD;
-
-  // CHECK: miopenNanPropagation_t nanPropagation_t;
-  // CHECK-NEXT: miopenNanPropagation_t NOT_PROPAGATE_NAN = MIOPEN_NOT_PROPAGATE_NAN;
-  // CHECK-NEXT: miopenNanPropagation_t PROPAGATE_NAN = MIOPEN_PROPAGATE_NAN;
-  cudnnNanPropagation_t nanPropagation_t;
-  cudnnNanPropagation_t NOT_PROPAGATE_NAN = CUDNN_NOT_PROPAGATE_NAN;
-  cudnnNanPropagation_t PROPAGATE_NAN = CUDNN_PROPAGATE_NAN;
 
   // CHECK: miopenReduceTensorIndices_t reduceTensorIndices;
   // CHECK-NEXT: miopenReduceTensorIndices_t REDUCE_TENSOR_NO_INDICES = MIOPEN_REDUCE_TENSOR_NO_INDICES;
@@ -797,16 +765,6 @@ int main() {
   // CHECK: status = miopenDestroyReduceTensorDescriptor(ReduceTensorDescriptor);
   status = cudnnDestroyReduceTensorDescriptor(ReduceTensorDescriptor);
 
-  // CUDA: cudnnStatus_t CUDNNWINAPI cudnnSetReduceTensorDescriptor(cudnnReduceTensorDescriptor_t reduceTensorDesc, cudnnReduceTensorOp_t reduceTensorOp, cudnnDataType_t reduceTensorCompType, cudnnNanPropagation_t reduceTensorNanOpt, cudnnReduceTensorIndices_t reduceTensorIndices, cudnnIndicesType_t reduceTensorIndicesType);
-  // MIOPEN: MIOPEN_EXPORT miopenStatus_t miopenSetReduceTensorDescriptor(miopenReduceTensorDescriptor_t reduceTensorDesc, miopenReduceTensorOp_t reduceTensorOp, miopenDataType_t reduceTensorCompType, miopenNanPropagation_t reduceTensorNanOpt, miopenReduceTensorIndices_t reduceTensorIndices, miopenIndicesType_t reduceTensorIndicesType);
-  // CHECK: status = miopenSetReduceTensorDescriptor(ReduceTensorDescriptor, reduceTensorOp, dataType, nanPropagation_t, reduceTensorIndices, indicesType);
-  status = cudnnSetReduceTensorDescriptor(ReduceTensorDescriptor, reduceTensorOp, dataType, nanPropagation_t, reduceTensorIndices, indicesType);
-
-  // CUDA: cudnnStatus_t CUDNNWINAPI cudnnGetReduceTensorDescriptor(const cudnnReduceTensorDescriptor_t reduceTensorDesc, cudnnReduceTensorOp_t* reduceTensorOp, cudnnDataType_t* reduceTensorCompType, cudnnNanPropagation_t* reduceTensorNanOpt, cudnnReduceTensorIndices_t* reduceTensorIndices, cudnnIndicesType_t* reduceTensorIndicesType);
-  // MIOPEN: MIOPEN_EXPORT miopenStatus_t miopenGetReduceTensorDescriptor(const miopenReduceTensorDescriptor_t reduceTensorDesc, miopenReduceTensorOp_t* reduceTensorOp, miopenDataType_t* reduceTensorCompType, miopenNanPropagation_t* reduceTensorNanOpt, miopenReduceTensorIndices_t* reduceTensorIndices, miopenIndicesType_t* reduceTensorIndicesType);
-  // CHECK: status = miopenGetReduceTensorDescriptor(ReduceTensorDescriptor, &reduceTensorOp, &dataType, &nanPropagation_t, &reduceTensorIndices, &indicesType);
-  status = cudnnGetReduceTensorDescriptor(ReduceTensorDescriptor, &reduceTensorOp, &dataType, &nanPropagation_t, &reduceTensorIndices, &indicesType);
-
   // CUDA: cudnnStatus_t CUDNNWINAPI cudnnGetReductionIndicesSize(cudnnHandle_t handle, const cudnnReduceTensorDescriptor_t reduceTensorDesc, const cudnnTensorDescriptor_t aDesc, const cudnnTensorDescriptor_t cDesc, size_t* sizeInBytes);
   // MIOPEN: MIOPEN_EXPORT miopenStatus_t miopenGetReductionIndicesSize(miopenHandle_t handle, const miopenReduceTensorDescriptor_t reduceTensorDesc, const miopenTensorDescriptor_t aDesc, const miopenTensorDescriptor_t cDesc, size_t* sizeInBytes);
   // CHECK: status = miopenGetReductionIndicesSize(handle, ReduceTensorDescriptor, aD, cD, &workSpaceSizeInBytes);
@@ -822,7 +780,66 @@ int main() {
   // CHECK: status = miopenReduceTensor(handle, ReduceTensorDescriptor, indices, indicesSizeInBytes, workSpace, workSpaceSizeInBytes, alpha, aD, A, beta, cD, C);
   status = cudnnReduceTensor(handle, ReduceTensorDescriptor, indices, indicesSizeInBytes, workSpace, workSpaceSizeInBytes, alpha, aD, A, beta, cD, C);
 
+#if CUDNN_VERSION >= 3008
+  // CHECK: miopenDataType_t DATA_BFLOAT16 = miopenBFloat16;
+  cudnnDataType_t DATA_BFLOAT16 = CUDNN_DATA_BFLOAT16;
+#endif
+
+#if CUDNN_VERSION >= 4008
+  // CHECK: miopenNanPropagation_t nanPropagation_t;
+  // CHECK-NEXT: miopenNanPropagation_t NOT_PROPAGATE_NAN = MIOPEN_NOT_PROPAGATE_NAN;
+  // CHECK-NEXT: miopenNanPropagation_t PROPAGATE_NAN = MIOPEN_PROPAGATE_NAN;
+  cudnnNanPropagation_t nanPropagation_t;
+  cudnnNanPropagation_t NOT_PROPAGATE_NAN = CUDNN_NOT_PROPAGATE_NAN;
+  cudnnNanPropagation_t PROPAGATE_NAN = CUDNN_PROPAGATE_NAN;
+
+  // CHECK: miopenActivationMode_t ACTIVATION_CLIPPED_RELU = miopenActivationCLIPPEDRELU;
+  cudnnActivationMode_t ACTIVATION_CLIPPED_RELU = CUDNN_ACTIVATION_CLIPPED_RELU;
+#endif
+
+#if CUDNN_VERSION >= 6021
+  // CHECK: miopenReduceTensorOp_t reduceTensorOp;
+  // CHECK-NEXT: miopenReduceTensorOp_t REDUCE_TENSOR_ADD = MIOPEN_REDUCE_TENSOR_ADD;
+  // CHECK-NEXT: miopenReduceTensorOp_t REDUCE_TENSOR_MUL = MIOPEN_REDUCE_TENSOR_MUL;
+  // CHECK-NEXT: miopenReduceTensorOp_t REDUCE_TENSOR_MIN = MIOPEN_REDUCE_TENSOR_MIN;
+  // CHECK-NEXT: miopenReduceTensorOp_t REDUCE_TENSOR_MAX = MIOPEN_REDUCE_TENSOR_MAX;
+  // CHECK-NEXT: miopenReduceTensorOp_t REDUCE_TENSOR_AMAX = MIOPEN_REDUCE_TENSOR_AMAX;
+  // CHECK-NEXT: miopenReduceTensorOp_t REDUCE_TENSOR_AVG = MIOPEN_REDUCE_TENSOR_AVG;
+  // CHECK-NEXT: miopenReduceTensorOp_t REDUCE_TENSOR_NORM1 = MIOPEN_REDUCE_TENSOR_NORM1;
+  // CHECK-NEXT: miopenReduceTensorOp_t REDUCE_TENSOR_NORM2 = MIOPEN_REDUCE_TENSOR_NORM2;
+  cudnnReduceTensorOp_t reduceTensorOp;
+  cudnnReduceTensorOp_t REDUCE_TENSOR_ADD = CUDNN_REDUCE_TENSOR_ADD;
+  cudnnReduceTensorOp_t REDUCE_TENSOR_MUL = CUDNN_REDUCE_TENSOR_MUL;
+  cudnnReduceTensorOp_t REDUCE_TENSOR_MIN = CUDNN_REDUCE_TENSOR_MIN;
+  cudnnReduceTensorOp_t REDUCE_TENSOR_MAX = CUDNN_REDUCE_TENSOR_MAX;
+  cudnnReduceTensorOp_t REDUCE_TENSOR_AMAX = CUDNN_REDUCE_TENSOR_AMAX;
+  cudnnReduceTensorOp_t REDUCE_TENSOR_AVG = CUDNN_REDUCE_TENSOR_AVG;
+  cudnnReduceTensorOp_t REDUCE_TENSOR_NORM1 = CUDNN_REDUCE_TENSOR_NORM1;
+  cudnnReduceTensorOp_t REDUCE_TENSOR_NORM2 = CUDNN_REDUCE_TENSOR_NORM2;
+
+  // CHECK: miopenActivationMode_t ACTIVATION_ELU = miopenActivationELU;
+  cudnnActivationMode_t ACTIVATION_ELU = CUDNN_ACTIVATION_ELU;
+
+  // CUDA: cudnnStatus_t CUDNNWINAPI cudnnSetReduceTensorDescriptor(cudnnReduceTensorDescriptor_t reduceTensorDesc, cudnnReduceTensorOp_t reduceTensorOp, cudnnDataType_t reduceTensorCompType, cudnnNanPropagation_t reduceTensorNanOpt, cudnnReduceTensorIndices_t reduceTensorIndices, cudnnIndicesType_t reduceTensorIndicesType);
+  // MIOPEN: MIOPEN_EXPORT miopenStatus_t miopenSetReduceTensorDescriptor(miopenReduceTensorDescriptor_t reduceTensorDesc, miopenReduceTensorOp_t reduceTensorOp, miopenDataType_t reduceTensorCompType, miopenNanPropagation_t reduceTensorNanOpt, miopenReduceTensorIndices_t reduceTensorIndices, miopenIndicesType_t reduceTensorIndicesType);
+  // CHECK: status = miopenSetReduceTensorDescriptor(ReduceTensorDescriptor, reduceTensorOp, dataType, nanPropagation_t, reduceTensorIndices, indicesType);
+  status = cudnnSetReduceTensorDescriptor(ReduceTensorDescriptor, reduceTensorOp, dataType, nanPropagation_t, reduceTensorIndices, indicesType);
+
+  // CUDA: cudnnStatus_t CUDNNWINAPI cudnnGetReduceTensorDescriptor(const cudnnReduceTensorDescriptor_t reduceTensorDesc, cudnnReduceTensorOp_t* reduceTensorOp, cudnnDataType_t* reduceTensorCompType, cudnnNanPropagation_t* reduceTensorNanOpt, cudnnReduceTensorIndices_t* reduceTensorIndices, cudnnIndicesType_t* reduceTensorIndicesType);
+  // MIOPEN: MIOPEN_EXPORT miopenStatus_t miopenGetReduceTensorDescriptor(const miopenReduceTensorDescriptor_t reduceTensorDesc, miopenReduceTensorOp_t* reduceTensorOp, miopenDataType_t* reduceTensorCompType, miopenNanPropagation_t* reduceTensorNanOpt, miopenReduceTensorIndices_t* reduceTensorIndices, miopenIndicesType_t* reduceTensorIndicesType);
+  // CHECK: status = miopenGetReduceTensorDescriptor(ReduceTensorDescriptor, &reduceTensorOp, &dataType, &nanPropagation_t, &reduceTensorIndices, &indicesType);
+  status = cudnnGetReduceTensorDescriptor(ReduceTensorDescriptor, &reduceTensorOp, &dataType, &nanPropagation_t, &reduceTensorIndices, &indicesType);
+#endif
+
+#if CUDNN_VERSION >= 7103
+  // CHECK: miopenActivationMode_t ACTIVATION_IDENTITY = miopenActivationPASTHRU;
+  cudnnActivationMode_t ACTIVATION_IDENTITY = CUDNN_ACTIVATION_IDENTITY;
+#endif
+
 #if CUDNN_VERSION >= 8001
+  // CHECK: miopenStatus_t STATUS_VERSION_MISMATCH = miopenStatusVersionMismatch;
+  cudnnStatus_t STATUS_VERSION_MISMATCH = CUDNN_STATUS_VERSION_MISMATCH;
+
   // CHECK: miopenBackendDescriptorType_t backendDescriptorType_t;
   // CHECK-NEXT: miopenBackendDescriptorType_t BACKEND_POINTWISE_DESCRIPTOR = MIOPEN_BACKEND_POINTWISE_DESCRIPTOR;
   // CHECK-NEXT: miopenBackendDescriptorType_t BACKEND_CONVOLUTION_DESCRIPTOR = MIOPEN_BACKEND_CONVOLUTION_DESCRIPTOR;
@@ -1076,6 +1093,9 @@ int main() {
 #endif
 
 #if CUDNN_VERSION >= 8100
+  // CHECK: miopenDataType_t DATA_INT64 = miopenInt64;
+  cudnnDataType_t DATA_INT64 = CUDNN_DATA_INT64;
+
   // CHECK: miopenBackendDescriptorType_t BACKEND_MATMUL_DESCRIPTOR = MIOPEN_BACKEND_MATMUL_DESCRIPTOR;
   // CHECK-NEXT: miopenBackendDescriptorType_t BACKEND_OPERATION_MATMUL_DESCRIPTOR = MIOPEN_BACKEND_OPERATION_MATMUL_DESCRIPTOR;
   // CHECK-NEXT: miopenBackendDescriptorType_t BACKEND_REDUCTION_DESCRIPTOR = MIOPEN_BACKEND_REDUCTION_DESCRIPTOR;


### PR DESCRIPTION
+ Added the missing `cudnnCTCGradMode_t` appeared in cuDNN 9.0.0
+ Fixed: `cudnnReduceTensorOp_t` deprecated in cuDNN 9.0.0 was undeprecated in cuDNN 9.1.0
+ Updated synthetic tests, the regenerated `hipify-perl`, and `DNN` `CUDA2HIP` documentation