### PR TITLE
[HIPIFY][rocBLAS] 64-bit functions support - Step 2

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -1561,7 +1561,9 @@ sub rocSubstitutions {
     subst("cublasCgemv", "rocblas_cgemv", "library");
     subst("cublasCgemvBatched", "rocblas_cgemv_batched", "library");
     subst("cublasCgemvStridedBatched", "rocblas_cgemv_strided_batched", "library");
+    subst("cublasCgemv_64", "rocblas_cgemv_64", "library");
     subst("cublasCgemv_v2", "rocblas_cgemv", "library");
+    subst("cublasCgemv_v2_64", "rocblas_cgemv_64", "library");
     subst("cublasCgerc", "rocblas_cgerc", "library");
     subst("cublasCgerc_v2", "rocblas_cgerc", "library");
     subst("cublasCgeru", "rocblas_cgeru", "library");
@@ -1670,7 +1672,9 @@ sub rocSubstitutions {
     subst("cublasDgemmStridedBatched", "rocblas_dgemm_strided_batched", "library");
     subst("cublasDgemm_v2", "rocblas_dgemm", "library");
     subst("cublasDgemv", "rocblas_dgemv", "library");
+    subst("cublasDgemv_64", "rocblas_dgemv_64", "library");
     subst("cublasDgemv_v2", "rocblas_dgemv", "library");
+    subst("cublasDgemv_v2_64", "rocblas_dgemv_64", "library");
     subst("cublasDger", "rocblas_dger", "library");
     subst("cublasDger_v2", "rocblas_dger", "library");
     subst("cublasDnrm2", "rocblas_dnrm2", "library");
@@ -1852,7 +1856,9 @@ sub rocSubstitutions {
     subst("cublasSgemmStridedBatched", "rocblas_sgemm_strided_batched", "library");
     subst("cublasSgemm_v2", "rocblas_sgemm", "library");
     subst("cublasSgemv", "rocblas_sgemv", "library");
+    subst("cublasSgemv_64", "rocblas_sgemv_64", "library");
     subst("cublasSgemv_v2", "rocblas_sgemv", "library");
+    subst("cublasSgemv_v2_64", "rocblas_sgemv_64", "library");
     subst("cublasSger", "rocblas_sger", "library");
     subst("cublasSger_v2", "rocblas_sger", "library");
     subst("cublasSnrm2", "rocblas_snrm2", "library");
@@ -1958,7 +1964,9 @@ sub rocSubstitutions {
     subst("cublasZgemv", "rocblas_zgemv", "library");
     subst("cublasZgemvBatched", "rocblas_zgemv_batched", "library");
     subst("cublasZgemvStridedBatched", "rocblas_zgemv_strided_batched", "library");
+    subst("cublasZgemv_64", "rocblas_zgemv_64", "library");
     subst("cublasZgemv_v2", "rocblas_zgemv", "library");
+    subst("cublasZgemv_v2_64", "rocblas_zgemv_64", "library");
     subst("cublasZgerc", "rocblas_zgerc", "library");
     subst("cublasZgerc_v2", "rocblas_zgerc", "library");
     subst("cublasZgeru", "rocblas_zgeru", "library");
@@ -12481,8 +12489,6 @@ sub warnRocOnlyUnsupportedFunctions {
         "cublasZgerc_v2_64",
         "cublasZgerc_64",
         "cublasZgeqrfBatched",
-        "cublasZgemv_v2_64",
-        "cublasZgemv_64",
         "cublasZgemvStridedBatched_64",
         "cublasZgemvBatched_64",
         "cublasZgemm_v2_64",
@@ -12550,8 +12556,6 @@ sub warnRocOnlyUnsupportedFunctions {
         "cublasSger_v2_64",
         "cublasSger_64",
         "cublasSgeqrfBatched",
-        "cublasSgemv_v2_64",
-        "cublasSgemv_64",
         "cublasSgemvStridedBatched_64",
         "cublasSgemvStridedBatched",
         "cublasSgemvBatched_64",
@@ -12720,8 +12724,6 @@ sub warnRocOnlyUnsupportedFunctions {
         "cublasDger_v2_64",
         "cublasDger_64",
         "cublasDgeqrfBatched",
-        "cublasDgemv_v2_64",
-        "cublasDgemv_64",
         "cublasDgemvStridedBatched_64",
         "cublasDgemvStridedBatched",
         "cublasDgemvBatched_64",
@@ -12807,8 +12809,6 @@ sub warnRocOnlyUnsupportedFunctions {
         "cublasCgerc_v2_64",
         "cublasCgerc_64",
         "cublasCgeqrfBatched",
-        "cublasCgemv_v2_64",
-        "cublasCgemv_64",
         "cublasCgemvStridedBatched_64",
         "cublasCgemvBatched_64",
         "cublasCgemm_v2_64",

--- a/docs/tables/CUBLAS_API_supported_by_HIP_and_ROC.md
+++ b/docs/tables/CUBLAS_API_supported_by_HIP_and_ROC.md
@@ -727,9 +727,9 @@
 |`cublasCgbmv_v2`| | | | |`hipblasCgbmv_v2`|6.0.0| | | | |`rocblas_cgbmv`|3.5.0| | | | |
 |`cublasCgbmv_v2_64`|12.0| | | |`hipblasCgbmv_v2_64`|6.2.0| | | | |`rocblas_cgbmv_64`|6.2.0| | | | |
 |`cublasCgemv`| | | | |`hipblasCgemv_v2`|6.0.0| | | | |`rocblas_cgemv`|1.5.0| | | | |
-|`cublasCgemv_64`|12.0| | | |`hipblasCgemv_v2_64`|6.2.0| | | | | | | | | | |
+|`cublasCgemv_64`|12.0| | | |`hipblasCgemv_v2_64`|6.2.0| | | | |`rocblas_cgemv_64`|6.2.0| | | | |
 |`cublasCgemv_v2`| | | | |`hipblasCgemv_v2`|6.0.0| | | | |`rocblas_cgemv`|1.5.0| | | | |
-|`cublasCgemv_v2_64`|12.0| | | |`hipblasCgemv_v2_64`|6.2.0| | | | | | | | | | |
+|`cublasCgemv_v2_64`|12.0| | | |`hipblasCgemv_v2_64`|6.2.0| | | | |`rocblas_cgemv_64`|6.2.0| | | | |
 |`cublasCgerc`| | | | |`hipblasCgerc_v2`|6.0.0| | | | |`rocblas_cgerc`|3.5.0| | | | |
 |`cublasCgerc_64`|12.0| | | |`hipblasCgerc_v2_64`|6.2.0| | | | | | | | | | |
 |`cublasCgerc_v2`| | | | |`hipblasCgerc_v2`|6.0.0| | | | |`rocblas_cgerc`|3.5.0| | | | |
@@ -807,9 +807,9 @@
 |`cublasDgbmv_v2`| | | | |`hipblasDgbmv`|3.5.0| | | | |`rocblas_dgbmv`|3.5.0| | | | |
 |`cublasDgbmv_v2_64`|12.0| | | |`hipblasDgbmv_64`|6.2.0| | | | |`rocblas_dgbmv_64`|6.2.0| | | | |
 |`cublasDgemv`| | | | |`hipblasDgemv`|1.8.2| | | | |`rocblas_dgemv`|1.5.0| | | | |
-|`cublasDgemv_64`|12.0| | | |`hipblasDgemv_64`|6.2.0| | | | | | | | | | |
+|`cublasDgemv_64`|12.0| | | |`hipblasDgemv_64`|6.2.0| | | | |`rocblas_dgemv_64`|6.2.0| | | | |
 |`cublasDgemv_v2`| | | | |`hipblasDgemv`|1.8.2| | | | |`rocblas_dgemv`|1.5.0| | | | |
-|`cublasDgemv_v2_64`|12.0| | | |`hipblasDgemv_64`|6.2.0| | | | | | | | | | |
+|`cublasDgemv_v2_64`|12.0| | | |`hipblasDgemv_64`|6.2.0| | | | |`rocblas_dgemv_64`|6.2.0| | | | |
 |`cublasDger`| | | | |`hipblasDger`|1.8.2| | | | |`rocblas_dger`|1.5.0| | | | |
 |`cublasDger_64`|12.0| | | |`hipblasDger_64`|6.2.0| | | | | | | | | | |
 |`cublasDger_v2`| | | | |`hipblasDger`|1.8.2| | | | |`rocblas_dger`|1.5.0| | | | |
@@ -871,9 +871,9 @@
 |`cublasSgbmv_v2`| | | | |`hipblasSgbmv`|3.5.0| | | | |`rocblas_sgbmv`|3.5.0| | | | |
 |`cublasSgbmv_v2_64`|12.0| | | |`hipblasSgbmv_64`|6.2.0| | | | |`rocblas_sgbmv_64`|6.2.0| | | | |
 |`cublasSgemv`| | | | |`hipblasSgemv`|1.8.2| | | | |`rocblas_sgemv`|1.5.0| | | | |
-|`cublasSgemv_64`|12.0| | | |`hipblasSgemv_64`|6.2.0| | | | | | | | | | |
+|`cublasSgemv_64`|12.0| | | |`hipblasSgemv_64`|6.2.0| | | | |`rocblas_sgemv_64`|6.2.0| | | | |
 |`cublasSgemv_v2`| | | | |`hipblasSgemv`|1.8.2| | | | |`rocblas_sgemv`|1.5.0| | | | |
-|`cublasSgemv_v2_64`|12.0| | | |`hipblasSgemv_64`|6.2.0| | | | | | | | | | |
+|`cublasSgemv_v2_64`|12.0| | | |`hipblasSgemv_64`|6.2.0| | | | |`rocblas_sgemv_64`|6.2.0| | | | |
 |`cublasSger`| | | | |`hipblasSger`|1.8.2| | | | |`rocblas_sger`|1.5.0| | | | |
 |`cublasSger_64`|12.0| | | |`hipblasSger_64`|6.2.0| | | | | | | | | | |
 |`cublasSger_v2`| | | | |`hipblasSger`|1.8.2| | | | |`rocblas_sger`|1.5.0| | | | |
@@ -935,9 +935,9 @@
 |`cublasZgbmv_v2`| | | | |`hipblasZgbmv_v2`|6.0.0| | | | |`rocblas_zgbmv`|3.5.0| | | | |
 |`cublasZgbmv_v2_64`|12.0| | | |`hipblasZgbmv_v2_64`|6.2.0| | | | |`rocblas_zgbmv_64`|6.2.0| | | | |
 |`cublasZgemv`| | | | |`hipblasZgemv_v2`|6.0.0| | | | |`rocblas_zgemv`|1.5.0| | | | |
-|`cublasZgemv_64`|12.0| | | |`hipblasZgemv_v2_64`|6.2.0| | | | | | | | | | |
+|`cublasZgemv_64`|12.0| | | |`hipblasZgemv_v2_64`|6.2.0| | | | |`rocblas_zgemv_64`|6.2.0| | | | |
 |`cublasZgemv_v2`| | | | |`hipblasZgemv_v2`|6.0.0| | | | |`rocblas_zgemv`|1.5.0| | | | |
-|`cublasZgemv_v2_64`|12.0| | | |`hipblasZgemv_v2_64`|6.2.0| | | | | | | | | | |
+|`cublasZgemv_v2_64`|12.0| | | |`hipblasZgemv_v2_64`|6.2.0| | | | |`rocblas_zgemv_64`|6.2.0| | | | |
 |`cublasZgerc`| | | | |`hipblasZgerc_v2`|6.0.0| | | | |`rocblas_zgerc`|3.5.0| | | | |
 |`cublasZgerc_64`|12.0| | | |`hipblasZgerc_v2_64`|6.2.0| | | | | | | | | | |
 |`cublasZgerc_v2`| | | | |`hipblasZgerc_v2`|6.0.0| | | | |`rocblas_zgerc`|3.5.0| | | | |

--- a/docs/tables/CUBLAS_API_supported_by_ROC.md
+++ b/docs/tables/CUBLAS_API_supported_by_ROC.md
@@ -727,9 +727,9 @@
 |`cublasCgbmv_v2`| | | | |`rocblas_cgbmv`|3.5.0| | | | |
 |`cublasCgbmv_v2_64`|12.0| | | |`rocblas_cgbmv_64`|6.2.0| | | | |
 |`cublasCgemv`| | | | |`rocblas_cgemv`|1.5.0| | | | |
-|`cublasCgemv_64`|12.0| | | | | | | | | |
+|`cublasCgemv_64`|12.0| | | |`rocblas_cgemv_64`|6.2.0| | | | |
 |`cublasCgemv_v2`| | | | |`rocblas_cgemv`|1.5.0| | | | |
-|`cublasCgemv_v2_64`|12.0| | | | | | | | | |
+|`cublasCgemv_v2_64`|12.0| | | |`rocblas_cgemv_64`|6.2.0| | | | |
 |`cublasCgerc`| | | | |`rocblas_cgerc`|3.5.0| | | | |
 |`cublasCgerc_64`|12.0| | | | | | | | | |
 |`cublasCgerc_v2`| | | | |`rocblas_cgerc`|3.5.0| | | | |
@@ -807,9 +807,9 @@
 |`cublasDgbmv_v2`| | | | |`rocblas_dgbmv`|3.5.0| | | | |
 |`cublasDgbmv_v2_64`|12.0| | | |`rocblas_dgbmv_64`|6.2.0| | | | |
 |`cublasDgemv`| | | | |`rocblas_dgemv`|1.5.0| | | | |
-|`cublasDgemv_64`|12.0| | | | | | | | | |
+|`cublasDgemv_64`|12.0| | | |`rocblas_dgemv_64`|6.2.0| | | | |
 |`cublasDgemv_v2`| | | | |`rocblas_dgemv`|1.5.0| | | | |
-|`cublasDgemv_v2_64`|12.0| | | | | | | | | |
+|`cublasDgemv_v2_64`|12.0| | | |`rocblas_dgemv_64`|6.2.0| | | | |
 |`cublasDger`| | | | |`rocblas_dger`|1.5.0| | | | |
 |`cublasDger_64`|12.0| | | | | | | | | |
 |`cublasDger_v2`| | | | |`rocblas_dger`|1.5.0| | | | |
@@ -871,9 +871,9 @@
 |`cublasSgbmv_v2`| | | | |`rocblas_sgbmv`|3.5.0| | | | |
 |`cublasSgbmv_v2_64`|12.0| | | |`rocblas_sgbmv_64`|6.2.0| | | | |
 |`cublasSgemv`| | | | |`rocblas_sgemv`|1.5.0| | | | |
-|`cublasSgemv_64`|12.0| | | | | | | | | |
+|`cublasSgemv_64`|12.0| | | |`rocblas_sgemv_64`|6.2.0| | | | |
 |`cublasSgemv_v2`| | | | |`rocblas_sgemv`|1.5.0| | | | |
-|`cublasSgemv_v2_64`|12.0| | | | | | | | | |
+|`cublasSgemv_v2_64`|12.0| | | |`rocblas_sgemv_64`|6.2.0| | | | |
 |`cublasSger`| | | | |`rocblas_sger`|1.5.0| | | | |
 |`cublasSger_64`|12.0| | | | | | | | | |
 |`cublasSger_v2`| | | | |`rocblas_sger`|1.5.0| | | | |
@@ -935,9 +935,9 @@
 |`cublasZgbmv_v2`| | | | |`rocblas_zgbmv`|3.5.0| | | | |
 |`cublasZgbmv_v2_64`|12.0| | | |`rocblas_zgbmv_64`|6.2.0| | | | |
 |`cublasZgemv`| | | | |`rocblas_zgemv`|1.5.0| | | | |
-|`cublasZgemv_64`|12.0| | | | | | | | | |
+|`cublasZgemv_64`|12.0| | | |`rocblas_zgemv_64`|6.2.0| | | | |
 |`cublasZgemv_v2`| | | | |`rocblas_zgemv`|1.5.0| | | | |
-|`cublasZgemv_v2_64`|12.0| | | | | | | | | |
+|`cublasZgemv_v2_64`|12.0| | | |`rocblas_zgemv_64`|6.2.0| | | | |
 |`cublasZgerc`| | | | |`rocblas_zgerc`|3.5.0| | | | |
 |`cublasZgerc_64`|12.0| | | | | | | | | |
 |`cublasZgerc_v2`| | | | |`rocblas_zgerc`|3.5.0| | | | |

--- a/src/CUDA2HIP_BLAS_API_functions.cpp
+++ b/src/CUDA2HIP_BLAS_API_functions.cpp
@@ -222,13 +222,13 @@ const std::map<llvm::StringRef, hipCounter> CUDA_BLAS_FUNCTION_MAP {
 
   // GEMV
   {"cublasSgemv",                                          {"hipblasSgemv",                                              "rocblas_sgemv",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, HIP_SUPPORTED_V2_ONLY}},
-  {"cublasSgemv_64",                                       {"hipblasSgemv_64",                                           "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
+  {"cublasSgemv_64",                                       {"hipblasSgemv_64",                                           "rocblas_sgemv_64",                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
   {"cublasDgemv",                                          {"hipblasDgemv",                                              "rocblas_dgemv",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, HIP_SUPPORTED_V2_ONLY}},
-  {"cublasDgemv_64",                                       {"hipblasDgemv_64",                                           "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
+  {"cublasDgemv_64",                                       {"hipblasDgemv_64",                                           "rocblas_dgemv_64",                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
   {"cublasCgemv",                                          {"hipblasCgemv_v2",                                           "rocblas_cgemv",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, HIP_SUPPORTED_V2_ONLY}},
-  {"cublasCgemv_64",                                       {"hipblasCgemv_v2_64",                                        "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
+  {"cublasCgemv_64",                                       {"hipblasCgemv_v2_64",                                        "rocblas_cgemv_64",                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
   {"cublasZgemv",                                          {"hipblasZgemv_v2",                                           "rocblas_zgemv",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, HIP_SUPPORTED_V2_ONLY}},
-  {"cublasZgemv_64",                                       {"hipblasZgemv_v2_64",                                        "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
+  {"cublasZgemv_64",                                       {"hipblasZgemv_v2_64",                                        "rocblas_zgemv_64",                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
 
   // GBMV
   {"cublasSgbmv",                                          {"hipblasSgbmv",                                              "rocblas_sgbmv",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, HIP_SUPPORTED_V2_ONLY}},
@@ -640,13 +640,13 @@ const std::map<llvm::StringRef, hipCounter> CUDA_BLAS_FUNCTION_MAP {
 
   // GEMV
   {"cublasSgemv_v2",                                       {"hipblasSgemv",                                              "rocblas_sgemv",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
-  {"cublasSgemv_v2_64",                                    {"hipblasSgemv_64",                                           "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
+  {"cublasSgemv_v2_64",                                    {"hipblasSgemv_64",                                           "rocblas_sgemv_64",                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
   {"cublasDgemv_v2",                                       {"hipblasDgemv",                                              "rocblas_dgemv",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
-  {"cublasDgemv_v2_64",                                    {"hipblasDgemv_64",                                           "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
+  {"cublasDgemv_v2_64",                                    {"hipblasDgemv_64",                                           "rocblas_dgemv_64",                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
   {"cublasCgemv_v2",                                       {"hipblasCgemv_v2",                                           "rocblas_cgemv",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
-  {"cublasCgemv_v2_64",                                    {"hipblasCgemv_v2_64",                                        "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
+  {"cublasCgemv_v2_64",                                    {"hipblasCgemv_v2_64",                                        "rocblas_cgemv_64",                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
   {"cublasZgemv_v2",                                       {"hipblasZgemv_v2",                                           "rocblas_zgemv",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
-  {"cublasZgemv_v2_64",                                    {"hipblasZgemv_v2_64",                                        "rocblas_zgemv",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
+  {"cublasZgemv_v2_64",                                    {"hipblasZgemv_v2_64",                                        "rocblas_zgemv_64",                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
 
   // GBMV
   {"cublasSgbmv_v2",                                       {"hipblasSgbmv",                                              "rocblas_sgbmv",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
@@ -2315,6 +2315,10 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_BLAS_FUNCTION_VER_MAP {
   {"rocblas_dgbmv_64",                                     {HIP_6020, HIP_0,    HIP_0   }},
   {"rocblas_cgbmv_64",                                     {HIP_6020, HIP_0,    HIP_0   }},
   {"rocblas_zgbmv_64",                                     {HIP_6020, HIP_0,    HIP_0   }},
+  {"rocblas_sgemv_64",                                     {HIP_6020, HIP_0,    HIP_0   }},
+  {"rocblas_dgemv_64",                                     {HIP_6020, HIP_0,    HIP_0   }},
+  {"rocblas_cgemv_64",                                     {HIP_6020, HIP_0,    HIP_0   }},
+  {"rocblas_zgemv_64",                                     {HIP_6020, HIP_0,    HIP_0   }},
 };
 
 const std::map<llvm::StringRef, hipAPIChangedVersions> HIP_BLAS_FUNCTION_CHANGED_VER_MAP {

--- a/tests/unit_tests/synthetic/libraries/cublas2rocblas_v2.cu
+++ b/tests/unit_tests/synthetic/libraries/cublas2rocblas_v2.cu
@@ -2335,6 +2335,34 @@ int main() {
   // CHECK-NEXT: blasStatus = rocblas_zgbmv_64(blasHandle, blasOperation, m_64, n_64, kl_64, ku_64, &dcomplexa, &dcomplexA, lda_64, &dcomplexx, incx_64, &dcomplexb, &dcomplexy, incy_64);
   blasStatus = cublasZgbmv_64(blasHandle, blasOperation, m_64, n_64, kl_64, ku_64, &dcomplexa, &dcomplexA, lda_64, &dcomplexx, incx_64, &dcomplexb, &dcomplexy, incy_64);
   blasStatus = cublasZgbmv_v2_64(blasHandle, blasOperation, m_64, n_64, kl_64, ku_64, &dcomplexa, &dcomplexA, lda_64, &dcomplexx, incx_64, &dcomplexb, &dcomplexy, incy_64);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasSgemv_v2_64(cublasHandle_t handle, cublasOperation_t trans, int64_t m, int64_t n, const float* alpha, const float* A, int64_t lda, const float* x, int64_t incx, const float* beta, float* y, int64_t incy);
+  // ROC: ROCBLAS_EXPORT rocblas_status rocblas_sgemv_64(rocblas_handle handle, rocblas_operation trans, int64_t m, int64_t n, const float* alpha, const float* A, int64_t lda, const float* x, int64_t incx, const float* beta, float* y, int64_t incy);
+  // CHECK: blasStatus = rocblas_sgemv_64(blasHandle, blasOperation, m_64, n_64, &fa, &fAP, lda_64, &fx, incx_64, &fb, &fy, incy_64);
+  // CHECK-NEXT: blasStatus = rocblas_sgemv_64(blasHandle, blasOperation, m_64, n_64, &fa, &fAP, lda_64, &fx, incx_64, &fb, &fy, incy_64);
+  blasStatus = cublasSgemv_64(blasHandle, blasOperation, m_64, n_64, &fa, &fAP, lda_64, &fx, incx_64, &fb, &fy, incy_64);
+  blasStatus = cublasSgemv_v2_64(blasHandle, blasOperation, m_64, n_64, &fa, &fAP, lda_64, &fx, incx_64, &fb, &fy, incy_64);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasDgemv_v2_64(cublasHandle_t handle, cublasOperation_t trans, int64_t m, int64_t n, const double* alpha, const double* A, int64_t lda, const double* x, int64_t incx, const double* beta, double* y, int64_t incy);
+  // ROC: ROCBLAS_EXPORT rocblas_status rocblas_dgemv_64(rocblas_handle handle, rocblas_operation trans, int64_t m, int64_t n, const double* alpha, const double* A, int64_t lda, const double* x, int64_t incx, const double* beta, double* y, int64_t incy);
+  // CHECK: blasStatus = rocblas_dgemv_64(blasHandle, blasOperation, m_64, n_64, &da, &dA, lda_64, &dx, incx_64, &db, &dy, incy_64);
+  // CHECK-NEXT: blasStatus = rocblas_dgemv_64(blasHandle, blasOperation, m_64, n_64, &da, &dA, lda_64, &dx, incx_64, &db, &dy, incy_64);
+  blasStatus = cublasDgemv_64(blasHandle, blasOperation, m_64, n_64, &da, &dA, lda_64, &dx, incx_64, &db, &dy, incy_64);
+  blasStatus = cublasDgemv_v2_64(blasHandle, blasOperation, m_64, n_64, &da, &dA, lda_64, &dx, incx_64, &db, &dy, incy_64);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasCgemv_v2_64(cublasHandle_t handle, cublasOperation_t trans, int64_t m, int64_t n, const cuComplex* alpha, const cuComplex* A, int64_t lda, const cuComplex* x, int64_t incx, const cuComplex* beta, cuComplex* y, int64_t incy);
+  // ROC: ROCBLAS_EXPORT rocblas_status rocblas_cgemv_64(rocblas_handle handle, rocblas_operation trans, int64_t m, int64_t n, const rocblas_float_complex* alpha, const rocblas_float_complex* A, int64_t lda, const rocblas_float_complex* x, int64_t incx, const rocblas_float_complex* beta, rocblas_float_complex* y, int64_t incy);
+  // CHECK: blasStatus = rocblas_cgemv_64(blasHandle, blasOperation, m_64, n_64, &complexa, &complexA, lda_64, &complexx, incx_64, &complexb, &complexy, incy_64);
+  // CHECK-NEXT: blasStatus = rocblas_cgemv_64(blasHandle, blasOperation, m_64, n_64, &complexa, &complexA, lda_64, &complexx, incx_64, &complexb, &complexy, incy_64);
+  blasStatus = cublasCgemv_64(blasHandle, blasOperation, m_64, n_64, &complexa, &complexA, lda_64, &complexx, incx_64, &complexb, &complexy, incy_64);
+  blasStatus = cublasCgemv_v2_64(blasHandle, blasOperation, m_64, n_64, &complexa, &complexA, lda_64, &complexx, incx_64, &complexb, &complexy, incy_64);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasZgemv_v2_64(cublasHandle_t handle, cublasOperation_t trans, int64_t m, int64_t n, const cuDoubleComplex* alpha, const cuDoubleComplex* A, int64_t lda, const cuDoubleComplex* x, int64_t incx, const cuDoubleComplex* beta, cuDoubleComplex* y, int64_t incy);
+  // ROC: ROCBLAS_EXPORT rocblas_status rocblas_zgemv_64(rocblas_handle handle, rocblas_operation trans, int64_t m, int64_t n, const rocblas_double_complex* alpha, const rocblas_double_complex* A, int64_t lda, const rocblas_double_complex* x, int64_t incx, const rocblas_double_complex* beta, rocblas_double_complex* y, int64_t incy);
+  // CHECK: blasStatus = rocblas_zgemv_64(blasHandle, blasOperation, m_64, n_64, &dcomplexa, &dcomplexA, lda_64, &dcomplexx, incx_64, &dcomplexb, &dcomplexy, incy_64);
+  // CHECK-NEXT: blasStatus = rocblas_zgemv_64(blasHandle, blasOperation, m_64, n_64, &dcomplexa, &dcomplexA, lda_64, &dcomplexx, incx_64, &dcomplexb, &dcomplexy, incy_64);
+  blasStatus = cublasZgemv_64(blasHandle, blasOperation, m_64, n_64, &dcomplexa, &dcomplexA, lda_64, &dcomplexx, incx_64, &dcomplexb, &dcomplexy, incy_64);
+  blasStatus = cublasZgemv_v2_64(blasHandle, blasOperation, m_64, n_64, &dcomplexa, &dcomplexA, lda_64, &dcomplexx, incx_64, &dcomplexb, &dcomplexy, incy_64);
 #endif
 
   return 0;


### PR DESCRIPTION
+ `rocblas_(s|d|c|z)gemv_64` support
+ Updated synthetic tests, the regenerated `hipify-perl`, and `BLAS` `CUDA2HIP` documentation