### PR TITLE
[HIPIFY][rocBLAS] 64-bit functions support - Step 5

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -1571,7 +1571,9 @@ sub rocSubstitutions {
     subst("cublasCgeru", "rocblas_cgeru", "library");
     subst("cublasCgeru_v2", "rocblas_cgeru", "library");
     subst("cublasChbmv", "rocblas_chbmv", "library");
+    subst("cublasChbmv_64", "rocblas_chbmv_64", "library");
     subst("cublasChbmv_v2", "rocblas_chbmv", "library");
+    subst("cublasChbmv_v2_64", "rocblas_chbmv_64", "library");
     subst("cublasChemm", "rocblas_chemm", "library");
     subst("cublasChemm_v2", "rocblas_chemm", "library");
     subst("cublasChemv", "rocblas_chemv", "library");
@@ -1704,7 +1706,9 @@ sub rocSubstitutions {
     subst("cublasDrotmg", "rocblas_drotmg", "library");
     subst("cublasDrotmg_v2", "rocblas_drotmg", "library");
     subst("cublasDsbmv", "rocblas_dsbmv", "library");
+    subst("cublasDsbmv_64", "rocblas_dsbmv_64", "library");
     subst("cublasDsbmv_v2", "rocblas_dsbmv", "library");
+    subst("cublasDsbmv_v2_64", "rocblas_dsbmv_64", "library");
     subst("cublasDscal", "rocblas_dscal", "library");
     subst("cublasDscal_64", "rocblas_dscal_64", "library");
     subst("cublasDscal_v2", "rocblas_dscal", "library");
@@ -1892,7 +1896,9 @@ sub rocSubstitutions {
     subst("cublasSrotmg", "rocblas_srotmg", "library");
     subst("cublasSrotmg_v2", "rocblas_srotmg", "library");
     subst("cublasSsbmv", "rocblas_ssbmv", "library");
+    subst("cublasSsbmv_64", "rocblas_ssbmv_64", "library");
     subst("cublasSsbmv_v2", "rocblas_ssbmv", "library");
+    subst("cublasSsbmv_v2_64", "rocblas_ssbmv_64", "library");
     subst("cublasSscal", "rocblas_sscal", "library");
     subst("cublasSscal_64", "rocblas_sscal_64", "library");
     subst("cublasSscal_v2", "rocblas_sscal", "library");
@@ -1992,7 +1998,9 @@ sub rocSubstitutions {
     subst("cublasZgeru", "rocblas_zgeru", "library");
     subst("cublasZgeru_v2", "rocblas_zgeru", "library");
     subst("cublasZhbmv", "rocblas_zhbmv", "library");
+    subst("cublasZhbmv_64", "rocblas_zhbmv_64", "library");
     subst("cublasZhbmv_v2", "rocblas_zhbmv", "library");
+    subst("cublasZhbmv_v2_64", "rocblas_zhbmv_64", "library");
     subst("cublasZhemm", "rocblas_zhemm", "library");
     subst("cublasZhemm_v2", "rocblas_zhemm", "library");
     subst("cublasZhemv", "rocblas_zhemv", "library");
@@ -12518,8 +12526,6 @@ sub warnRocOnlyUnsupportedFunctions {
         "cublasZhemv_64",
         "cublasZhemm_v2_64",
         "cublasZhemm_64",
-        "cublasZhbmv_v2_64",
-        "cublasZhbmv_64",
         "cublasZgetrsBatched",
         "cublasZgetriBatched",
         "cublasZgetrfBatched",
@@ -12579,8 +12585,6 @@ sub warnRocOnlyUnsupportedFunctions {
         "cublasSspr2_64",
         "cublasSspmv_v2_64",
         "cublasSspmv_64",
-        "cublasSsbmv_v2_64",
-        "cublasSsbmv_64",
         "cublasSmatinvBatched",
         "cublasShutdown",
         "cublasSgetrsBatched",
@@ -12740,8 +12744,6 @@ sub warnRocOnlyUnsupportedFunctions {
         "cublasDspr2_64",
         "cublasDspmv_v2_64",
         "cublasDspmv_64",
-        "cublasDsbmv_v2_64",
-        "cublasDsbmv_64",
         "cublasDmatinvBatched",
         "cublasDgetrsBatched",
         "cublasDgetriBatched",
@@ -12820,8 +12822,6 @@ sub warnRocOnlyUnsupportedFunctions {
         "cublasChemv_64",
         "cublasChemm_v2_64",
         "cublasChemm_64",
-        "cublasChbmv_v2_64",
-        "cublasChbmv_64",
         "cublasCgetrsBatched",
         "cublasCgetriBatched",
         "cublasCgetrfBatched",

--- a/docs/tables/CUBLAS_API_supported_by_HIP_and_ROC.md
+++ b/docs/tables/CUBLAS_API_supported_by_HIP_and_ROC.md
@@ -739,9 +739,9 @@
 |`cublasCgeru_v2`| | | | |`hipblasCgeru_v2`|6.0.0| | | | |`rocblas_cgeru`|3.5.0| | | | |
 |`cublasCgeru_v2_64`|12.0| | | |`hipblasCgeru_v2_64`|6.2.0| | | | | | | | | | |
 |`cublasChbmv`| | | | |`hipblasChbmv_v2`|6.0.0| | | | |`rocblas_chbmv`|3.5.0| | | | |
-|`cublasChbmv_64`|12.0| | | |`hipblasChbmv_v2_64`|6.2.0| | | | | | | | | | |
+|`cublasChbmv_64`|12.0| | | |`hipblasChbmv_v2_64`|6.2.0| | | | |`rocblas_chbmv_64`|6.2.0| | | | |
 |`cublasChbmv_v2`| | | | |`hipblasChbmv_v2`|6.0.0| | | | |`rocblas_chbmv`|3.5.0| | | | |
-|`cublasChbmv_v2_64`|12.0| | | |`hipblasChbmv_v2_64`|6.2.0| | | | | | | | | | |
+|`cublasChbmv_v2_64`|12.0| | | |`hipblasChbmv_v2_64`|6.2.0| | | | |`rocblas_chbmv_64`|6.2.0| | | | |
 |`cublasChemv`| | | | |`hipblasChemv_v2`|6.0.0| | | | |`rocblas_chemv`|1.5.0| | | | |
 |`cublasChemv_64`|12.0| | | |`hipblasChemv_v2_64`|6.2.0| | | | | | | | | | |
 |`cublasChemv_v2`| | | | |`hipblasChemv_v2`|6.0.0| | | | |`rocblas_chemv`|1.5.0| | | | |
@@ -815,9 +815,9 @@
 |`cublasDger_v2`| | | | |`hipblasDger`|1.8.2| | | | |`rocblas_dger`|1.5.0| | | | |
 |`cublasDger_v2_64`|12.0| | | |`hipblasDger_64`|6.2.0| | | | | | | | | | |
 |`cublasDsbmv`| | | | |`hipblasDsbmv`|3.5.0| | | | |`rocblas_dsbmv`|3.5.0| | | | |
-|`cublasDsbmv_64`|12.0| | | |`hipblasDsbmv_64`|6.2.0| | | | | | | | | | |
+|`cublasDsbmv_64`|12.0| | | |`hipblasDsbmv_64`|6.2.0| | | | |`rocblas_dsbmv_64`|6.2.0| | | | |
 |`cublasDsbmv_v2`| | | | |`hipblasDsbmv`|3.5.0| | | | |`rocblas_dsbmv`|3.5.0| | | | |
-|`cublasDsbmv_v2_64`|12.0| | | |`hipblasDsbmv_64`|6.2.0| | | | | | | | | | |
+|`cublasDsbmv_v2_64`|12.0| | | |`hipblasDsbmv_64`|6.2.0| | | | |`rocblas_dsbmv_64`|6.2.0| | | | |
 |`cublasDspmv`| | | | |`hipblasDspmv`|3.5.0| | | | |`rocblas_dspmv`|3.5.0| | | | |
 |`cublasDspmv_64`|12.0| | | |`hipblasDspmv_64`|6.2.0| | | | | | | | | | |
 |`cublasDspmv_v2`| | | | |`hipblasDspmv`|3.5.0| | | | |`rocblas_dspmv`|3.5.0| | | | |
@@ -879,9 +879,9 @@
 |`cublasSger_v2`| | | | |`hipblasSger`|1.8.2| | | | |`rocblas_sger`|1.5.0| | | | |
 |`cublasSger_v2_64`|12.0| | | |`hipblasSger_64`|6.2.0| | | | | | | | | | |
 |`cublasSsbmv`| | | | |`hipblasSsbmv`|3.5.0| | | | |`rocblas_ssbmv`|3.5.0| | | | |
-|`cublasSsbmv_64`|12.0| | | |`hipblasSsbmv_64`|6.2.0| | | | | | | | | | |
+|`cublasSsbmv_64`|12.0| | | |`hipblasSsbmv_64`|6.2.0| | | | |`rocblas_ssbmv_64`|6.2.0| | | | |
 |`cublasSsbmv_v2`| | | | |`hipblasSsbmv`|3.5.0| | | | |`rocblas_ssbmv`|3.5.0| | | | |
-|`cublasSsbmv_v2_64`|12.0| | | |`hipblasSsbmv_64`|6.2.0| | | | | | | | | | |
+|`cublasSsbmv_v2_64`|12.0| | | |`hipblasSsbmv_64`|6.2.0| | | | |`rocblas_ssbmv_64`|6.2.0| | | | |
 |`cublasSspmv`| | | | |`hipblasSspmv`|3.5.0| | | | |`rocblas_sspmv`|3.5.0| | | | |
 |`cublasSspmv_64`|12.0| | | |`hipblasSspmv_64`|6.2.0| | | | | | | | | | |
 |`cublasSspmv_v2`| | | | |`hipblasSspmv`|3.5.0| | | | |`rocblas_sspmv`|3.5.0| | | | |
@@ -947,9 +947,9 @@
 |`cublasZgeru_v2`| | | | |`hipblasZgeru_v2`|6.0.0| | | | |`rocblas_zgeru`|3.5.0| | | | |
 |`cublasZgeru_v2_64`|12.0| | | |`hipblasZgeru_v2_64`|6.2.0| | | | | | | | | | |
 |`cublasZhbmv`| | | | |`hipblasZhbmv_v2`|6.0.0| | | | |`rocblas_zhbmv`|3.5.0| | | | |
-|`cublasZhbmv_64`|12.0| | | |`hipblasZhbmv_v2_64`|6.2.0| | | | | | | | | | |
+|`cublasZhbmv_64`|12.0| | | |`hipblasZhbmv_v2_64`|6.2.0| | | | |`rocblas_zhbmv_64`|6.2.0| | | | |
 |`cublasZhbmv_v2`| | | | |`hipblasZhbmv_v2`|6.0.0| | | | |`rocblas_zhbmv`|3.5.0| | | | |
-|`cublasZhbmv_v2_64`|12.0| | | |`hipblasZhbmv_v2_64`|6.2.0| | | | | | | | | | |
+|`cublasZhbmv_v2_64`|12.0| | | |`hipblasZhbmv_v2_64`|6.2.0| | | | |`rocblas_zhbmv_64`|6.2.0| | | | |
 |`cublasZhemv`| | | | |`hipblasZhemv_v2`|6.0.0| | | | |`rocblas_zhemv`|1.5.0| | | | |
 |`cublasZhemv_64`|12.0| | | |`hipblasZhemv_v2_64`|6.2.0| | | | | | | | | | |
 |`cublasZhemv_v2`| | | | |`hipblasZhemv_v2`|6.0.0| | | | |`rocblas_zhemv`|1.5.0| | | | |

--- a/docs/tables/CUBLAS_API_supported_by_ROC.md
+++ b/docs/tables/CUBLAS_API_supported_by_ROC.md
@@ -739,9 +739,9 @@
 |`cublasCgeru_v2`| | | | |`rocblas_cgeru`|3.5.0| | | | |
 |`cublasCgeru_v2_64`|12.0| | | | | | | | | |
 |`cublasChbmv`| | | | |`rocblas_chbmv`|3.5.0| | | | |
-|`cublasChbmv_64`|12.0| | | | | | | | | |
+|`cublasChbmv_64`|12.0| | | |`rocblas_chbmv_64`|6.2.0| | | | |
 |`cublasChbmv_v2`| | | | |`rocblas_chbmv`|3.5.0| | | | |
-|`cublasChbmv_v2_64`|12.0| | | | | | | | | |
+|`cublasChbmv_v2_64`|12.0| | | |`rocblas_chbmv_64`|6.2.0| | | | |
 |`cublasChemv`| | | | |`rocblas_chemv`|1.5.0| | | | |
 |`cublasChemv_64`|12.0| | | | | | | | | |
 |`cublasChemv_v2`| | | | |`rocblas_chemv`|1.5.0| | | | |
@@ -815,9 +815,9 @@
 |`cublasDger_v2`| | | | |`rocblas_dger`|1.5.0| | | | |
 |`cublasDger_v2_64`|12.0| | | | | | | | | |
 |`cublasDsbmv`| | | | |`rocblas_dsbmv`|3.5.0| | | | |
-|`cublasDsbmv_64`|12.0| | | | | | | | | |
+|`cublasDsbmv_64`|12.0| | | |`rocblas_dsbmv_64`|6.2.0| | | | |
 |`cublasDsbmv_v2`| | | | |`rocblas_dsbmv`|3.5.0| | | | |
-|`cublasDsbmv_v2_64`|12.0| | | | | | | | | |
+|`cublasDsbmv_v2_64`|12.0| | | |`rocblas_dsbmv_64`|6.2.0| | | | |
 |`cublasDspmv`| | | | |`rocblas_dspmv`|3.5.0| | | | |
 |`cublasDspmv_64`|12.0| | | | | | | | | |
 |`cublasDspmv_v2`| | | | |`rocblas_dspmv`|3.5.0| | | | |
@@ -879,9 +879,9 @@
 |`cublasSger_v2`| | | | |`rocblas_sger`|1.5.0| | | | |
 |`cublasSger_v2_64`|12.0| | | | | | | | | |
 |`cublasSsbmv`| | | | |`rocblas_ssbmv`|3.5.0| | | | |
-|`cublasSsbmv_64`|12.0| | | | | | | | | |
+|`cublasSsbmv_64`|12.0| | | |`rocblas_ssbmv_64`|6.2.0| | | | |
 |`cublasSsbmv_v2`| | | | |`rocblas_ssbmv`|3.5.0| | | | |
-|`cublasSsbmv_v2_64`|12.0| | | | | | | | | |
+|`cublasSsbmv_v2_64`|12.0| | | |`rocblas_ssbmv_64`|6.2.0| | | | |
 |`cublasSspmv`| | | | |`rocblas_sspmv`|3.5.0| | | | |
 |`cublasSspmv_64`|12.0| | | | | | | | | |
 |`cublasSspmv_v2`| | | | |`rocblas_sspmv`|3.5.0| | | | |
@@ -947,9 +947,9 @@
 |`cublasZgeru_v2`| | | | |`rocblas_zgeru`|3.5.0| | | | |
 |`cublasZgeru_v2_64`|12.0| | | | | | | | | |
 |`cublasZhbmv`| | | | |`rocblas_zhbmv`|3.5.0| | | | |
-|`cublasZhbmv_64`|12.0| | | | | | | | | |
+|`cublasZhbmv_64`|12.0| | | |`rocblas_zhbmv_64`|6.2.0| | | | |
 |`cublasZhbmv_v2`| | | | |`rocblas_zhbmv`|3.5.0| | | | |
-|`cublasZhbmv_v2_64`|12.0| | | | | | | | | |
+|`cublasZhbmv_v2_64`|12.0| | | |`rocblas_zhbmv_64`|6.2.0| | | | |
 |`cublasZhemv`| | | | |`rocblas_zhemv`|1.5.0| | | | |
 |`cublasZhemv_64`|12.0| | | | | | | | | |
 |`cublasZhemv_v2`| | | | |`rocblas_zhemv`|1.5.0| | | | |

--- a/src/CUDA2HIP_BLAS_API_functions.cpp
+++ b/src/CUDA2HIP_BLAS_API_functions.cpp
@@ -316,13 +316,13 @@ const std::map<llvm::StringRef, hipCounter> CUDA_BLAS_FUNCTION_MAP {
 
   // SBMV/HBMV
   {"cublasSsbmv",                                          {"hipblasSsbmv",                                              "rocblas_ssbmv",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, HIP_SUPPORTED_V2_ONLY}},
-  {"cublasSsbmv_64",                                       {"hipblasSsbmv_64",                                           "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
+  {"cublasSsbmv_64",                                       {"hipblasSsbmv_64",                                           "rocblas_ssbmv_64",                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
   {"cublasDsbmv",                                          {"hipblasDsbmv",                                              "rocblas_dsbmv",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, HIP_SUPPORTED_V2_ONLY}},
-  {"cublasDsbmv_64",                                       {"hipblasDsbmv_64",                                           "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
+  {"cublasDsbmv_64",                                       {"hipblasDsbmv_64",                                           "rocblas_dsbmv_64",                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
   {"cublasChbmv",                                          {"hipblasChbmv_v2",                                           "rocblas_chbmv",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, HIP_SUPPORTED_V2_ONLY}},
-  {"cublasChbmv_64",                                       {"hipblasChbmv_v2_64",                                        "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
+  {"cublasChbmv_64",                                       {"hipblasChbmv_v2_64",                                        "rocblas_chbmv_64",                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
   {"cublasZhbmv",                                          {"hipblasZhbmv_v2",                                           "rocblas_zhbmv",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, HIP_SUPPORTED_V2_ONLY}},
-  {"cublasZhbmv_64",                                       {"hipblasZhbmv_v2_64",                                        "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
+  {"cublasZhbmv_64",                                       {"hipblasZhbmv_v2_64",                                        "rocblas_zhbmv_64",                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
 
   // SPMV/HPMV
   {"cublasSspmv",                                          {"hipblasSspmv",                                              "rocblas_sspmv",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, HIP_SUPPORTED_V2_ONLY}},
@@ -734,13 +734,13 @@ const std::map<llvm::StringRef, hipCounter> CUDA_BLAS_FUNCTION_MAP {
 
   // SBMV/HBMV
   {"cublasSsbmv_v2",                                       {"hipblasSsbmv",                                              "rocblas_ssbmv",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
-  {"cublasSsbmv_v2_64",                                    {"hipblasSsbmv_64",                                           "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
+  {"cublasSsbmv_v2_64",                                    {"hipblasSsbmv_64",                                           "rocblas_ssbmv_64",                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
   {"cublasDsbmv_v2",                                       {"hipblasDsbmv",                                              "rocblas_dsbmv",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
-  {"cublasDsbmv_v2_64",                                    {"hipblasDsbmv_64",                                           "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
+  {"cublasDsbmv_v2_64",                                    {"hipblasDsbmv_64",                                           "rocblas_dsbmv_64",                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
   {"cublasChbmv_v2",                                       {"hipblasChbmv_v2",                                           "rocblas_chbmv",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
-  {"cublasChbmv_v2_64",                                    {"hipblasChbmv_v2_64",                                        "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
+  {"cublasChbmv_v2_64",                                    {"hipblasChbmv_v2_64",                                        "rocblas_chbmv_64",                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
   {"cublasZhbmv_v2",                                       {"hipblasZhbmv_v2",                                           "rocblas_zhbmv",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
-  {"cublasZhbmv_v2_64",                                    {"hipblasZhbmv_v2_64",                                        "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
+  {"cublasZhbmv_v2_64",                                    {"hipblasZhbmv_v2_64",                                        "rocblas_zhbmv_64",                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
 
   // SPMV/HPMV
   {"cublasSspmv_v2",                                       {"hipblasSspmv",                                              "rocblas_sspmv",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
@@ -2339,6 +2339,10 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_BLAS_FUNCTION_VER_MAP {
   {"rocblas_hssgemv_strided_batched_64",                   {HIP_6020, HIP_0,    HIP_0   }},
   {"rocblas_tstgemv_strided_batched_64",                   {HIP_6020, HIP_0,    HIP_0   }},
   {"rocblas_tssgemv_strided_batched_64",                   {HIP_6020, HIP_0,    HIP_0   }},
+  {"rocblas_ssbmv_64",                                     {HIP_6020, HIP_0,    HIP_0   }},
+  {"rocblas_dsbmv_64",                                     {HIP_6020, HIP_0,    HIP_0   }},
+  {"rocblas_chbmv_64",                                     {HIP_6020, HIP_0,    HIP_0   }},
+  {"rocblas_zhbmv_64",                                     {HIP_6020, HIP_0,    HIP_0   }},
 };
 
 const std::map<llvm::StringRef, hipAPIChangedVersions> HIP_BLAS_FUNCTION_CHANGED_VER_MAP {

--- a/tests/unit_tests/synthetic/libraries/cublas2rocblas_v2.cu
+++ b/tests/unit_tests/synthetic/libraries/cublas2rocblas_v2.cu
@@ -166,6 +166,7 @@ int main() {
   int incy = 0;
   int64_t incy_64 = 0;
   int k = 0;
+  int64_t k_64 = 0;
   int kl = 0;
   int64_t kl_64 = 0;
   int ku = 0;
@@ -2530,6 +2531,34 @@ int main() {
   // ROC: ROCBLAS_EXPORT rocblas_status rocblas_tssgemv_strided_batched_64(rocblas_handle handle, rocblas_operation transA, int64_t m, int64_t n, const float* alpha, const rocblas_bfloat16* A, int64_t lda, rocblas_stride strideA, const rocblas_bfloat16* x, int64_t incx, rocblas_stride stridex, const float* beta, float* y, int64_t incy, rocblas_stride stridey, int64_t batch_count);
   // CHECK: blasStatus = rocblas_tssgemv_strided_batched_64(blasHandle, blasOperation, m_64, n_64, &fa, bf16A, lda_64, strideA, bf16X, incx_64, strideX, &fb, &fy, incy_64, strideY, batchCount_64);
   blasStatus = cublasTSSgemvStridedBatched_64(blasHandle, blasOperation, m_64, n_64, &fa, bf16A, lda_64, strideA, bf16X, incx_64, strideX, &fb, &fy, incy_64, strideY, batchCount_64);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasSsbmv_v2_64(cublasHandle_t handle, cublasFillMode_t uplo, int64_t n, int64_t k, const float* alpha, const float* A, int64_t lda, const float* x, int64_t incx, const float* beta, float* y, int64_t incy);
+  // ROC: ROCBLAS_EXPORT rocblas_status rocblas_ssbmv_64(rocblas_handle handle, rocblas_fill uplo, int64_t n, int64_t k, const float* alpha, const float* A, int64_t lda, const float* x, int64_t incx, const float* beta, float* y, int64_t incy);
+  // CHECK: blasStatus = rocblas_ssbmv_64(blasHandle, blasFillMode, n_64, k_64, &fa, &fA, lda_64, &fx, incx_64, &fb, &fy, incy_64);
+  // CHECK-NEXT: blasStatus = rocblas_ssbmv_64(blasHandle, blasFillMode, n_64, k_64, &fa, &fA, lda_64, &fx, incx_64, &fb, &fy, incy_64);
+  blasStatus = cublasSsbmv_64(blasHandle, blasFillMode, n_64, k_64, &fa, &fA, lda_64, &fx, incx_64, &fb, &fy, incy_64);
+  blasStatus = cublasSsbmv_v2_64(blasHandle, blasFillMode, n_64, k_64, &fa, &fA, lda_64, &fx, incx_64, &fb, &fy, incy_64);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasDsbmv_v2_64(cublasHandle_t handle, cublasFillMode_t uplo, int64_t n, int64_t k, const double* alpha, const double* A, int64_t lda, const double* x, int64_t incx, const double* beta, double* y, int64_t incy);
+  // ROC: ROCBLAS_EXPORT rocblas_status rocblas_dsbmv_64(rocblas_handle handle, rocblas_fill uplo, int64_t n, int64_t k, const double* alpha, const double* A, int64_t lda, const double* x, int64_t incx, const double* beta, double* y, int64_t incy);
+  // CHECK: blasStatus = rocblas_dsbmv_64(blasHandle, blasFillMode, n_64, k_64, &da, &dA, lda_64, &dx, incx_64, &db, &dy, incy_64);
+  // CHECK-NEXT: blasStatus = rocblas_dsbmv_64(blasHandle, blasFillMode, n_64, k_64, &da, &dA, lda_64, &dx, incx_64, &db, &dy, incy_64);
+  blasStatus = cublasDsbmv_64(blasHandle, blasFillMode, n_64, k_64, &da, &dA, lda_64, &dx, incx_64, &db, &dy, incy_64);
+  blasStatus = cublasDsbmv_v2_64(blasHandle, blasFillMode, n_64, k_64, &da, &dA, lda_64, &dx, incx_64, &db, &dy, incy_64);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasChbmv_v2_64(cublasHandle_t handle, cublasFillMode_t uplo, int64_t n, int64_t k, const cuComplex* alpha, const cuComplex* A, int64_t lda, const cuComplex* x, int64_t incx, const cuComplex* beta, cuComplex* y, int64_t incy);
+  // ROC: ROCBLAS_EXPORT rocblas_status rocblas_chbmv_64(rocblas_handle handle, rocblas_fill uplo, int64_t n, int64_t k, const rocblas_float_complex* alpha, const rocblas_float_complex* A, int64_t lda, const rocblas_float_complex* x, int64_t incx, const rocblas_float_complex* beta, rocblas_float_complex* y, int64_t incy);
+  // CHECK: blasStatus = rocblas_chbmv_64(blasHandle, blasFillMode, n_64, k_64, &complexa, &complexA, lda_64, &complexx, incx_64, &complexb, &complexy, incy_64);
+  // CHECK-NEXT: blasStatus = rocblas_chbmv_64(blasHandle, blasFillMode, n_64, k_64, &complexa, &complexA, lda_64, &complexx, incx_64, &complexb, &complexy, incy_64);
+  blasStatus = cublasChbmv_64(blasHandle, blasFillMode, n_64, k_64, &complexa, &complexA, lda_64, &complexx, incx_64, &complexb, &complexy, incy_64);
+  blasStatus = cublasChbmv_v2_64(blasHandle, blasFillMode, n_64, k_64, &complexa, &complexA, lda_64, &complexx, incx_64, &complexb, &complexy, incy_64);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasZhbmv_v2_64(cublasHandle_t handle, cublasFillMode_t uplo, int64_t n, int64_t k, const cuDoubleComplex* alpha, const cuDoubleComplex* A, int64_t lda, const cuDoubleComplex* x, int64_t incx, const cuDoubleComplex* beta, cuDoubleComplex* y, int64_t incy);
+  // ROC: ROCBLAS_EXPORT rocblas_status rocblas_zhbmv_64(rocblas_handle handle, rocblas_fill uplo, int64_t n, int64_t k, const rocblas_double_complex* alpha, const rocblas_double_complex* A, int64_t lda, const rocblas_double_complex* x, int64_t incx, const rocblas_double_complex* beta, rocblas_double_complex* y, int64_t incy);
+  // CHECK: blasStatus = rocblas_zhbmv_64(blasHandle, blasFillMode, n_64, k_64, &dcomplexa, &dcomplexA, lda_64, &dcomplexx, incx_64, &dcomplexb, &dcomplexy, incy_64);
+  // CHECK-NEXT: blasStatus = rocblas_zhbmv_64(blasHandle, blasFillMode, n_64, k_64, &dcomplexa, &dcomplexA, lda_64, &dcomplexx, incx_64, &dcomplexb, &dcomplexy, incy_64);
+  blasStatus = cublasZhbmv_64(blasHandle, blasFillMode, n_64, k_64, &dcomplexa, &dcomplexA, lda_64, &dcomplexx, incx_64, &dcomplexb, &dcomplexy, incy_64);
+  blasStatus = cublasZhbmv_v2_64(blasHandle, blasFillMode, n_64, k_64, &dcomplexa, &dcomplexA, lda_64, &dcomplexx, incx_64, &dcomplexb, &dcomplexy, incy_64);
 #endif
 
   return 0;


### PR DESCRIPTION
+ `rocblas_(s|d|c|z)sbmv_64` support
+ Updated synthetic tests, the regenerated `hipify-perl`, and `BLAS` `CUDA2HIP` documentation