### PR TITLE
[HIPIFY][rocBLAS] 64-bit functions support - Step 6

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -1580,7 +1580,9 @@ sub rocSubstitutions {
     subst("cublasChemm", "rocblas_chemm", "library");
     subst("cublasChemm_v2", "rocblas_chemm", "library");
     subst("cublasChemv", "rocblas_chemv", "library");
+    subst("cublasChemv_64", "rocblas_chemv_64", "library");
     subst("cublasChemv_v2", "rocblas_chemv", "library");
+    subst("cublasChemv_v2_64", "rocblas_chemv_64", "library");
     subst("cublasCher", "rocblas_cher", "library");
     subst("cublasCher2", "rocblas_cher2", "library");
     subst("cublasCher2_v2", "rocblas_cher2", "library");
@@ -1623,7 +1625,9 @@ sub rocSubstitutions {
     subst("cublasCsymm", "rocblas_csymm", "library");
     subst("cublasCsymm_v2", "rocblas_csymm", "library");
     subst("cublasCsymv", "rocblas_csymv", "library");
+    subst("cublasCsymv_64", "rocblas_csymv_64", "library");
     subst("cublasCsymv_v2", "rocblas_csymv", "library");
+    subst("cublasCsymv_v2_64", "rocblas_csymv_64", "library");
     subst("cublasCsyr", "rocblas_csyr", "library");
     subst("cublasCsyr2", "rocblas_csyr2", "library");
     subst("cublasCsyr2_v2", "rocblas_csyr2", "library");
@@ -1729,7 +1733,9 @@ sub rocSubstitutions {
     subst("cublasDsymm", "rocblas_dsymm", "library");
     subst("cublasDsymm_v2", "rocblas_dsymm", "library");
     subst("cublasDsymv", "rocblas_dsymv", "library");
+    subst("cublasDsymv_64", "rocblas_dsymv_64", "library");
     subst("cublasDsymv_v2", "rocblas_dsymv", "library");
+    subst("cublasDsymv_v2_64", "rocblas_dsymv_64", "library");
     subst("cublasDsyr", "rocblas_dsyr", "library");
     subst("cublasDsyr2", "rocblas_dsyr2", "library");
     subst("cublasDsyr2_v2", "rocblas_dsyr2", "library");
@@ -1919,7 +1925,9 @@ sub rocSubstitutions {
     subst("cublasSsymm", "rocblas_ssymm", "library");
     subst("cublasSsymm_v2", "rocblas_ssymm", "library");
     subst("cublasSsymv", "rocblas_ssymv", "library");
+    subst("cublasSsymv_64", "rocblas_ssymv_64", "library");
     subst("cublasSsymv_v2", "rocblas_ssymv", "library");
+    subst("cublasSsymv_v2_64", "rocblas_ssymv_64", "library");
     subst("cublasSsyr", "rocblas_ssyr", "library");
     subst("cublasSsyr2", "rocblas_ssyr2", "library");
     subst("cublasSsyr2_v2", "rocblas_ssyr2", "library");
@@ -2007,7 +2015,9 @@ sub rocSubstitutions {
     subst("cublasZhemm", "rocblas_zhemm", "library");
     subst("cublasZhemm_v2", "rocblas_zhemm", "library");
     subst("cublasZhemv", "rocblas_zhemv", "library");
+    subst("cublasZhemv_64", "rocblas_zhemv_64", "library");
     subst("cublasZhemv_v2", "rocblas_zhemv", "library");
+    subst("cublasZhemv_v2_64", "rocblas_zhemv_64", "library");
     subst("cublasZher", "rocblas_zher", "library");
     subst("cublasZher2", "rocblas_zher2", "library");
     subst("cublasZher2_v2", "rocblas_zher2", "library");
@@ -2040,7 +2050,9 @@ sub rocSubstitutions {
     subst("cublasZsymm", "rocblas_zsymm", "library");
     subst("cublasZsymm_v2", "rocblas_zsymm", "library");
     subst("cublasZsymv", "rocblas_zsymv", "library");
+    subst("cublasZsymv_64", "rocblas_zsymv_64", "library");
     subst("cublasZsymv_v2", "rocblas_zsymv", "library");
+    subst("cublasZsymv_v2_64", "rocblas_zsymv_64", "library");
     subst("cublasZsyr", "rocblas_zsyr", "library");
     subst("cublasZsyr2", "rocblas_zsyr2", "library");
     subst("cublasZsyr2_v2", "rocblas_zsyr2", "library");
@@ -12521,8 +12533,6 @@ sub warnRocOnlyUnsupportedFunctions {
         "cublasZsyr2k_64",
         "cublasZsyr2_v2_64",
         "cublasZsyr2_64",
-        "cublasZsymv_v2_64",
-        "cublasZsymv_64",
         "cublasZsymm_v2_64",
         "cublasZsymm_64",
         "cublasZmatinvBatched",
@@ -12541,8 +12551,6 @@ sub warnRocOnlyUnsupportedFunctions {
         "cublasZher2k_64",
         "cublasZher2_v2_64",
         "cublasZher2_64",
-        "cublasZhemv_v2_64",
-        "cublasZhemv_64",
         "cublasZhemm_v2_64",
         "cublasZhemm_64",
         "cublasZgetrsBatched",
@@ -12594,8 +12602,6 @@ sub warnRocOnlyUnsupportedFunctions {
         "cublasSsyr2k_64",
         "cublasSsyr2_v2_64",
         "cublasSsyr2_64",
-        "cublasSsymv_v2_64",
-        "cublasSsymv_64",
         "cublasSsymm_v2_64",
         "cublasSsymm_64",
         "cublasSspr_v2_64",
@@ -12753,8 +12759,6 @@ sub warnRocOnlyUnsupportedFunctions {
         "cublasDsyr2k_64",
         "cublasDsyr2_v2_64",
         "cublasDsyr2_64",
-        "cublasDsymv_v2_64",
-        "cublasDsymv_64",
         "cublasDsymm_v2_64",
         "cublasDsymm_64",
         "cublasDspr_v2_64",
@@ -12811,8 +12815,6 @@ sub warnRocOnlyUnsupportedFunctions {
         "cublasCsyr2k_64",
         "cublasCsyr2_v2_64",
         "cublasCsyr2_64",
-        "cublasCsymv_v2_64",
-        "cublasCsymv_64",
         "cublasCsymm_v2_64",
         "cublasCsymm_64",
         "cublasCopyEx_64",
@@ -12837,8 +12839,6 @@ sub warnRocOnlyUnsupportedFunctions {
         "cublasCher2k_64",
         "cublasCher2_v2_64",
         "cublasCher2_64",
-        "cublasChemv_v2_64",
-        "cublasChemv_64",
         "cublasChemm_v2_64",
         "cublasChemm_64",
         "cublasCgetrsBatched",

--- a/docs/tables/CUBLAS_API_supported_by_HIP_and_ROC.md
+++ b/docs/tables/CUBLAS_API_supported_by_HIP_and_ROC.md
@@ -743,9 +743,9 @@
 |`cublasChbmv_v2`| | | | |`hipblasChbmv_v2`|6.0.0| | | | |`rocblas_chbmv`|3.5.0| | | | |
 |`cublasChbmv_v2_64`|12.0| | | |`hipblasChbmv_v2_64`|6.2.0| | | | |`rocblas_chbmv_64`|6.2.0| | | | |
 |`cublasChemv`| | | | |`hipblasChemv_v2`|6.0.0| | | | |`rocblas_chemv`|1.5.0| | | | |
-|`cublasChemv_64`|12.0| | | |`hipblasChemv_v2_64`|6.2.0| | | | | | | | | | |
+|`cublasChemv_64`|12.0| | | |`hipblasChemv_v2_64`|6.2.0| | | | |`rocblas_chemv_64`|6.2.0| | | | |
 |`cublasChemv_v2`| | | | |`hipblasChemv_v2`|6.0.0| | | | |`rocblas_chemv`|1.5.0| | | | |
-|`cublasChemv_v2_64`|12.0| | | |`hipblasChemv_v2_64`|6.2.0| | | | | | | | | | |
+|`cublasChemv_v2_64`|12.0| | | |`hipblasChemv_v2_64`|6.2.0| | | | |`rocblas_chemv_64`|6.2.0| | | | |
 |`cublasCher`| | | | |`hipblasCher_v2`|6.0.0| | | | |`rocblas_cher`|3.5.0| | | | |
 |`cublasCher2`| | | | |`hipblasCher2_v2`|6.0.0| | | | |`rocblas_cher2`|3.5.0| | | | |
 |`cublasCher2_64`|12.0| | | |`hipblasCher2_v2_64`|6.2.0| | | | | | | | | | |
@@ -767,9 +767,9 @@
 |`cublasChpr_v2`| | | | |`hipblasChpr_v2`|6.0.0| | | | |`rocblas_chpr`|3.5.0| | | | |
 |`cublasChpr_v2_64`|12.0| | | |`hipblasChpr_v2_64`|6.2.0| | | | | | | | | | |
 |`cublasCsymv`| | | | |`hipblasCsymv_v2`|6.0.0| | | | |`rocblas_csymv`|3.5.0| | | | |
-|`cublasCsymv_64`|12.0| | | |`hipblasCsymv_v2_64`|6.2.0| | | | | | | | | | |
+|`cublasCsymv_64`|12.0| | | |`hipblasCsymv_v2_64`|6.2.0| | | | |`rocblas_csymv_64`|6.2.0| | | | |
 |`cublasCsymv_v2`| | | | |`hipblasCsymv_v2`|6.0.0| | | | |`rocblas_csymv`|3.5.0| | | | |
-|`cublasCsymv_v2_64`|12.0| | | |`hipblasCsymv_v2_64`|6.2.0| | | | | | | | | | |
+|`cublasCsymv_v2_64`|12.0| | | |`hipblasCsymv_v2_64`|6.2.0| | | | |`rocblas_csymv_64`|6.2.0| | | | |
 |`cublasCsyr`| | | | |`hipblasCsyr_v2`|6.0.0| | | | |`rocblas_csyr`|1.7.1| | | | |
 |`cublasCsyr2`| | | | |`hipblasCsyr2_v2`|6.0.0| | | | |`rocblas_csyr2`|3.5.0| | | | |
 |`cublasCsyr2_64`|12.0| | | |`hipblasCsyr2_v2_64`|6.2.0| | | | | | | | | | |
@@ -831,9 +831,9 @@
 |`cublasDspr_v2`| | | | |`hipblasDspr`|3.5.0| | | | |`rocblas_dspr`|3.5.0| | | | |
 |`cublasDspr_v2_64`|12.0| | | |`hipblasDspr_64`|6.2.0| | | | | | | | | | |
 |`cublasDsymv`| | | | |`hipblasDsymv`|3.5.0| | | | |`rocblas_dsymv`|1.5.0| | | | |
-|`cublasDsymv_64`|12.0| | | |`hipblasDsymv_64`|6.2.0| | | | | | | | | | |
+|`cublasDsymv_64`|12.0| | | |`hipblasDsymv_64`|6.2.0| | | | |`rocblas_dsymv_64`|6.2.0| | | | |
 |`cublasDsymv_v2`| | | | |`hipblasDsymv`|3.5.0| | | | |`rocblas_dsymv`|1.5.0| | | | |
-|`cublasDsymv_v2_64`|12.0| | | |`hipblasDsymv_64`|6.2.0| | | | | | | | | | |
+|`cublasDsymv_v2_64`|12.0| | | |`hipblasDsymv_64`|6.2.0| | | | |`rocblas_dsymv_64`|6.2.0| | | | |
 |`cublasDsyr`| | | | |`hipblasDsyr`|3.0.0| | | | |`rocblas_dsyr`|1.7.1| | | | |
 |`cublasDsyr2`| | | | |`hipblasDsyr2`|3.5.0| | | | |`rocblas_dsyr2`|3.5.0| | | | |
 |`cublasDsyr2_64`|12.0| | | |`hipblasDsyr2_64`|6.2.0| | | | | | | | | | |
@@ -895,9 +895,9 @@
 |`cublasSspr_v2`| | | | |`hipblasSspr`|3.5.0| | | | |`rocblas_sspr`|3.5.0| | | | |
 |`cublasSspr_v2_64`|12.0| | | |`hipblasSspr_64`|6.2.0| | | | | | | | | | |
 |`cublasSsymv`| | | | |`hipblasSsymv`|3.5.0| | | | |`rocblas_ssymv`|1.5.0| | | | |
-|`cublasSsymv_64`|12.0| | | |`hipblasSsymv_64`|6.2.0| | | | | | | | | | |
+|`cublasSsymv_64`|12.0| | | |`hipblasSsymv_64`|6.2.0| | | | |`rocblas_ssymv_64`|6.2.0| | | | |
 |`cublasSsymv_v2`| | | | |`hipblasSsymv`|3.5.0| | | | |`rocblas_ssymv`|1.5.0| | | | |
-|`cublasSsymv_v2_64`|12.0| | | |`hipblasSsymv_64`|6.2.0| | | | | | | | | | |
+|`cublasSsymv_v2_64`|12.0| | | |`hipblasSsymv_64`|6.2.0| | | | |`rocblas_ssymv_64`|6.2.0| | | | |
 |`cublasSsyr`| | | | |`hipblasSsyr`|3.0.0| | | | |`rocblas_ssyr`|1.7.1| | | | |
 |`cublasSsyr2`| | | | |`hipblasSsyr2`|3.5.0| | | | |`rocblas_ssyr2`|3.5.0| | | | |
 |`cublasSsyr2_64`|12.0| | | |`hipblasSsyr2_64`|6.2.0| | | | | | | | | | |
@@ -951,9 +951,9 @@
 |`cublasZhbmv_v2`| | | | |`hipblasZhbmv_v2`|6.0.0| | | | |`rocblas_zhbmv`|3.5.0| | | | |
 |`cublasZhbmv_v2_64`|12.0| | | |`hipblasZhbmv_v2_64`|6.2.0| | | | |`rocblas_zhbmv_64`|6.2.0| | | | |
 |`cublasZhemv`| | | | |`hipblasZhemv_v2`|6.0.0| | | | |`rocblas_zhemv`|1.5.0| | | | |
-|`cublasZhemv_64`|12.0| | | |`hipblasZhemv_v2_64`|6.2.0| | | | | | | | | | |
+|`cublasZhemv_64`|12.0| | | |`hipblasZhemv_v2_64`|6.2.0| | | | |`rocblas_zhemv_64`|6.2.0| | | | |
 |`cublasZhemv_v2`| | | | |`hipblasZhemv_v2`|6.0.0| | | | |`rocblas_zhemv`|1.5.0| | | | |
-|`cublasZhemv_v2_64`|12.0| | | |`hipblasZhemv_v2_64`|6.2.0| | | | | | | | | | |
+|`cublasZhemv_v2_64`|12.0| | | |`hipblasZhemv_v2_64`|6.2.0| | | | |`rocblas_zhemv_64`|6.2.0| | | | |
 |`cublasZher`| | | | |`hipblasZher_v2`|6.0.0| | | | |`rocblas_zher`|3.5.0| | | | |
 |`cublasZher2`| | | | |`hipblasZher2_v2`|6.0.0| | | | |`rocblas_zher2`|3.5.0| | | | |
 |`cublasZher2_64`|12.0| | | |`hipblasZher2_v2_64`|6.2.0| | | | | | | | | | |
@@ -975,9 +975,9 @@
 |`cublasZhpr_v2`| | | | |`hipblasZhpr_v2`|6.0.0| | | | |`rocblas_zhpr`|3.5.0| | | | |
 |`cublasZhpr_v2_64`|12.0| | | |`hipblasZhpr_v2_64`|6.2.0| | | | | | | | | | |
 |`cublasZsymv`| | | | |`hipblasZsymv_v2`|6.0.0| | | | |`rocblas_zsymv`|3.5.0| | | | |
-|`cublasZsymv_64`|12.0| | | |`hipblasZsymv_v2_64`|6.2.0| | | | | | | | | | |
+|`cublasZsymv_64`|12.0| | | |`hipblasZsymv_v2_64`|6.2.0| | | | |`rocblas_zsymv_64`|6.2.0| | | | |
 |`cublasZsymv_v2`| | | | |`hipblasZsymv_v2`|6.0.0| | | | |`rocblas_zsymv`|3.5.0| | | | |
-|`cublasZsymv_v2_64`|12.0| | | |`hipblasZsymv_v2_64`|6.2.0| | | | | | | | | | |
+|`cublasZsymv_v2_64`|12.0| | | |`hipblasZsymv_v2_64`|6.2.0| | | | |`rocblas_zsymv_64`|6.2.0| | | | |
 |`cublasZsyr`| | | | |`hipblasZsyr_v2`|6.0.0| | | | |`rocblas_zsyr`|1.7.1| | | | |
 |`cublasZsyr2`| | | | |`hipblasZsyr2_v2`|6.0.0| | | | |`rocblas_zsyr2`|3.5.0| | | | |
 |`cublasZsyr2_64`|12.0| | | |`hipblasZsyr2_v2_64`|6.2.0| | | | | | | | | | |

--- a/docs/tables/CUBLAS_API_supported_by_ROC.md
+++ b/docs/tables/CUBLAS_API_supported_by_ROC.md
@@ -743,9 +743,9 @@
 |`cublasChbmv_v2`| | | | |`rocblas_chbmv`|3.5.0| | | | |
 |`cublasChbmv_v2_64`|12.0| | | |`rocblas_chbmv_64`|6.2.0| | | | |
 |`cublasChemv`| | | | |`rocblas_chemv`|1.5.0| | | | |
-|`cublasChemv_64`|12.0| | | | | | | | | |
+|`cublasChemv_64`|12.0| | | |`rocblas_chemv_64`|6.2.0| | | | |
 |`cublasChemv_v2`| | | | |`rocblas_chemv`|1.5.0| | | | |
-|`cublasChemv_v2_64`|12.0| | | | | | | | | |
+|`cublasChemv_v2_64`|12.0| | | |`rocblas_chemv_64`|6.2.0| | | | |
 |`cublasCher`| | | | |`rocblas_cher`|3.5.0| | | | |
 |`cublasCher2`| | | | |`rocblas_cher2`|3.5.0| | | | |
 |`cublasCher2_64`|12.0| | | | | | | | | |
@@ -767,9 +767,9 @@
 |`cublasChpr_v2`| | | | |`rocblas_chpr`|3.5.0| | | | |
 |`cublasChpr_v2_64`|12.0| | | | | | | | | |
 |`cublasCsymv`| | | | |`rocblas_csymv`|3.5.0| | | | |
-|`cublasCsymv_64`|12.0| | | | | | | | | |
+|`cublasCsymv_64`|12.0| | | |`rocblas_csymv_64`|6.2.0| | | | |
 |`cublasCsymv_v2`| | | | |`rocblas_csymv`|3.5.0| | | | |
-|`cublasCsymv_v2_64`|12.0| | | | | | | | | |
+|`cublasCsymv_v2_64`|12.0| | | |`rocblas_csymv_64`|6.2.0| | | | |
 |`cublasCsyr`| | | | |`rocblas_csyr`|1.7.1| | | | |
 |`cublasCsyr2`| | | | |`rocblas_csyr2`|3.5.0| | | | |
 |`cublasCsyr2_64`|12.0| | | | | | | | | |
@@ -831,9 +831,9 @@
 |`cublasDspr_v2`| | | | |`rocblas_dspr`|3.5.0| | | | |
 |`cublasDspr_v2_64`|12.0| | | | | | | | | |
 |`cublasDsymv`| | | | |`rocblas_dsymv`|1.5.0| | | | |
-|`cublasDsymv_64`|12.0| | | | | | | | | |
+|`cublasDsymv_64`|12.0| | | |`rocblas_dsymv_64`|6.2.0| | | | |
 |`cublasDsymv_v2`| | | | |`rocblas_dsymv`|1.5.0| | | | |
-|`cublasDsymv_v2_64`|12.0| | | | | | | | | |
+|`cublasDsymv_v2_64`|12.0| | | |`rocblas_dsymv_64`|6.2.0| | | | |
 |`cublasDsyr`| | | | |`rocblas_dsyr`|1.7.1| | | | |
 |`cublasDsyr2`| | | | |`rocblas_dsyr2`|3.5.0| | | | |
 |`cublasDsyr2_64`|12.0| | | | | | | | | |
@@ -895,9 +895,9 @@
 |`cublasSspr_v2`| | | | |`rocblas_sspr`|3.5.0| | | | |
 |`cublasSspr_v2_64`|12.0| | | | | | | | | |
 |`cublasSsymv`| | | | |`rocblas_ssymv`|1.5.0| | | | |
-|`cublasSsymv_64`|12.0| | | | | | | | | |
+|`cublasSsymv_64`|12.0| | | |`rocblas_ssymv_64`|6.2.0| | | | |
 |`cublasSsymv_v2`| | | | |`rocblas_ssymv`|1.5.0| | | | |
-|`cublasSsymv_v2_64`|12.0| | | | | | | | | |
+|`cublasSsymv_v2_64`|12.0| | | |`rocblas_ssymv_64`|6.2.0| | | | |
 |`cublasSsyr`| | | | |`rocblas_ssyr`|1.7.1| | | | |
 |`cublasSsyr2`| | | | |`rocblas_ssyr2`|3.5.0| | | | |
 |`cublasSsyr2_64`|12.0| | | | | | | | | |
@@ -951,9 +951,9 @@
 |`cublasZhbmv_v2`| | | | |`rocblas_zhbmv`|3.5.0| | | | |
 |`cublasZhbmv_v2_64`|12.0| | | |`rocblas_zhbmv_64`|6.2.0| | | | |
 |`cublasZhemv`| | | | |`rocblas_zhemv`|1.5.0| | | | |
-|`cublasZhemv_64`|12.0| | | | | | | | | |
+|`cublasZhemv_64`|12.0| | | |`rocblas_zhemv_64`|6.2.0| | | | |
 |`cublasZhemv_v2`| | | | |`rocblas_zhemv`|1.5.0| | | | |
-|`cublasZhemv_v2_64`|12.0| | | | | | | | | |
+|`cublasZhemv_v2_64`|12.0| | | |`rocblas_zhemv_64`|6.2.0| | | | |
 |`cublasZher`| | | | |`rocblas_zher`|3.5.0| | | | |
 |`cublasZher2`| | | | |`rocblas_zher2`|3.5.0| | | | |
 |`cublasZher2_64`|12.0| | | | | | | | | |
@@ -975,9 +975,9 @@
 |`cublasZhpr_v2`| | | | |`rocblas_zhpr`|3.5.0| | | | |
 |`cublasZhpr_v2_64`|12.0| | | | | | | | | |
 |`cublasZsymv`| | | | |`rocblas_zsymv`|3.5.0| | | | |
-|`cublasZsymv_64`|12.0| | | | | | | | | |
+|`cublasZsymv_64`|12.0| | | |`rocblas_zsymv_64`|6.2.0| | | | |
 |`cublasZsymv_v2`| | | | |`rocblas_zsymv`|3.5.0| | | | |
-|`cublasZsymv_v2_64`|12.0| | | | | | | | | |
+|`cublasZsymv_v2_64`|12.0| | | |`rocblas_zsymv_64`|6.2.0| | | | |
 |`cublasZsyr`| | | | |`rocblas_zsyr`|1.7.1| | | | |
 |`cublasZsyr2`| | | | |`rocblas_zsyr2`|3.5.0| | | | |
 |`cublasZsyr2_64`|12.0| | | | | | | | | |

--- a/src/CUDA2HIP_BLAS_API_functions.cpp
+++ b/src/CUDA2HIP_BLAS_API_functions.cpp
@@ -302,17 +302,17 @@ const std::map<llvm::StringRef, hipCounter> CUDA_BLAS_FUNCTION_MAP {
 
   // SYMV/HEMV
   {"cublasSsymv",                                          {"hipblasSsymv",                                              "rocblas_ssymv",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, HIP_SUPPORTED_V2_ONLY}},
-  {"cublasSsymv_64",                                       {"hipblasSsymv_64",                                           "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
+  {"cublasSsymv_64",                                       {"hipblasSsymv_64",                                           "rocblas_ssymv_64",                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
   {"cublasDsymv",                                          {"hipblasDsymv",                                              "rocblas_dsymv",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, HIP_SUPPORTED_V2_ONLY}},
-  {"cublasDsymv_64",                                       {"hipblasDsymv_64",                                           "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
+  {"cublasDsymv_64",                                       {"hipblasDsymv_64",                                           "rocblas_dsymv_64",                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
   {"cublasCsymv",                                          {"hipblasCsymv_v2",                                           "rocblas_csymv",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, HIP_SUPPORTED_V2_ONLY}},
-  {"cublasCsymv_64",                                       {"hipblasCsymv_v2_64",                                        "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
+  {"cublasCsymv_64",                                       {"hipblasCsymv_v2_64",                                        "rocblas_csymv_64",                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
   {"cublasZsymv",                                          {"hipblasZsymv_v2",                                           "rocblas_zsymv",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, HIP_SUPPORTED_V2_ONLY}},
-  {"cublasZsymv_64",                                       {"hipblasZsymv_v2_64",                                        "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
+  {"cublasZsymv_64",                                       {"hipblasZsymv_v2_64",                                        "rocblas_zsymv_64",                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
   {"cublasChemv",                                          {"hipblasChemv_v2",                                           "rocblas_chemv",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, HIP_SUPPORTED_V2_ONLY}},
-  {"cublasChemv_64",                                       {"hipblasChemv_v2_64",                                        "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
+  {"cublasChemv_64",                                       {"hipblasChemv_v2_64",                                        "rocblas_chemv_64",                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
   {"cublasZhemv",                                          {"hipblasZhemv_v2",                                           "rocblas_zhemv",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, HIP_SUPPORTED_V2_ONLY}},
-  {"cublasZhemv_64",                                       {"hipblasZhemv_v2_64",                                        "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
+  {"cublasZhemv_64",                                       {"hipblasZhemv_v2_64",                                        "rocblas_zhemv_64",                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
 
   // SBMV/HBMV
   {"cublasSsbmv",                                          {"hipblasSsbmv",                                              "rocblas_ssbmv",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, HIP_SUPPORTED_V2_ONLY}},
@@ -720,17 +720,17 @@ const std::map<llvm::StringRef, hipCounter> CUDA_BLAS_FUNCTION_MAP {
 
   // SYMV/HEMV
   {"cublasSsymv_v2",                                       {"hipblasSsymv",                                              "rocblas_ssymv",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
-  {"cublasSsymv_v2_64",                                    {"hipblasSsymv_64",                                           "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
+  {"cublasSsymv_v2_64",                                    {"hipblasSsymv_64",                                           "rocblas_ssymv_64",                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
   {"cublasDsymv_v2",                                       {"hipblasDsymv",                                              "rocblas_dsymv",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
-  {"cublasDsymv_v2_64",                                    {"hipblasDsymv_64",                                           "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
+  {"cublasDsymv_v2_64",                                    {"hipblasDsymv_64",                                           "rocblas_dsymv_64",                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
   {"cublasCsymv_v2",                                       {"hipblasCsymv_v2",                                           "rocblas_csymv",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
-  {"cublasCsymv_v2_64",                                    {"hipblasCsymv_v2_64",                                        "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
+  {"cublasCsymv_v2_64",                                    {"hipblasCsymv_v2_64",                                        "rocblas_csymv_64",                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
   {"cublasZsymv_v2",                                       {"hipblasZsymv_v2",                                           "rocblas_zsymv",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
-  {"cublasZsymv_v2_64",                                    {"hipblasZsymv_v2_64",                                        "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
+  {"cublasZsymv_v2_64",                                    {"hipblasZsymv_v2_64",                                        "rocblas_zsymv_64",                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
   {"cublasChemv_v2",                                       {"hipblasChemv_v2",                                           "rocblas_chemv",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
-  {"cublasChemv_v2_64",                                    {"hipblasChemv_v2_64",                                        "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
+  {"cublasChemv_v2_64",                                    {"hipblasChemv_v2_64",                                        "rocblas_chemv_64",                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
   {"cublasZhemv_v2",                                       {"hipblasZhemv_v2",                                           "rocblas_zhemv",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
-  {"cublasZhemv_v2_64",                                    {"hipblasZhemv_v2_64",                                        "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
+  {"cublasZhemv_v2_64",                                    {"hipblasZhemv_v2_64",                                        "rocblas_zhemv_64",                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
 
   // SBMV/HBMV
   {"cublasSsbmv_v2",                                       {"hipblasSsbmv",                                              "rocblas_ssbmv",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
@@ -2343,6 +2343,12 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_BLAS_FUNCTION_VER_MAP {
   {"rocblas_dsbmv_64",                                     {HIP_6020, HIP_0,    HIP_0   }},
   {"rocblas_chbmv_64",                                     {HIP_6020, HIP_0,    HIP_0   }},
   {"rocblas_zhbmv_64",                                     {HIP_6020, HIP_0,    HIP_0   }},
+  {"rocblas_ssymv_64",                                     {HIP_6020, HIP_0,    HIP_0   }},
+  {"rocblas_dsymv_64",                                     {HIP_6020, HIP_0,    HIP_0   }},
+  {"rocblas_csymv_64",                                     {HIP_6020, HIP_0,    HIP_0   }},
+  {"rocblas_zsymv_64",                                     {HIP_6020, HIP_0,    HIP_0   }},
+  {"rocblas_chemv_64",                                     {HIP_6020, HIP_0,    HIP_0   }},
+  {"rocblas_zhemv_64",                                     {HIP_6020, HIP_0,    HIP_0   }},
 };
 
 const std::map<llvm::StringRef, hipAPIChangedVersions> HIP_BLAS_FUNCTION_CHANGED_VER_MAP {

--- a/tests/unit_tests/synthetic/libraries/cublas2rocblas_v2.cu
+++ b/tests/unit_tests/synthetic/libraries/cublas2rocblas_v2.cu
@@ -2559,6 +2559,48 @@ int main() {
   // CHECK-NEXT: blasStatus = rocblas_zhbmv_64(blasHandle, blasFillMode, n_64, k_64, &dcomplexa, &dcomplexA, lda_64, &dcomplexx, incx_64, &dcomplexb, &dcomplexy, incy_64);
   blasStatus = cublasZhbmv_64(blasHandle, blasFillMode, n_64, k_64, &dcomplexa, &dcomplexA, lda_64, &dcomplexx, incx_64, &dcomplexb, &dcomplexy, incy_64);
   blasStatus = cublasZhbmv_v2_64(blasHandle, blasFillMode, n_64, k_64, &dcomplexa, &dcomplexA, lda_64, &dcomplexx, incx_64, &dcomplexb, &dcomplexy, incy_64);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasSsymv_v2_64(cublasHandle_t handle, cublasFillMode_t uplo, int64_t n, const float* alpha, const float* A, int64_t lda, const float* x, int64_t incx, const float* beta, float* y, int64_t incy);
+  // ROC: ROCBLAS_EXPORT rocblas_status rocblas_ssymv_64(rocblas_handle handle, rocblas_fill uplo, int64_t n, const float* alpha, const float* A, int64_t lda, const float* x, int64_t incx, const float* beta, float* y, int64_t incy);
+  // CHECK: blasStatus = rocblas_ssymv_64(blasHandle, blasFillMode, n_64, &fa, &fA, lda_64, &fx, incx_64, &fb, &fy, incy_64);
+  // CHECK-NEXT: blasStatus = rocblas_ssymv_64(blasHandle, blasFillMode, n_64, &fa, &fA, lda_64, &fx, incx_64, &fb, &fy, incy_64);
+  blasStatus = cublasSsymv_64(blasHandle, blasFillMode, n_64, &fa, &fA, lda_64, &fx, incx_64, &fb, &fy, incy_64);
+  blasStatus = cublasSsymv_v2_64(blasHandle, blasFillMode, n_64, &fa, &fA, lda_64, &fx, incx_64, &fb, &fy, incy_64);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasDsymv_v2_64(cublasHandle_t handle, cublasFillMode_t uplo, int64_t n, const double* alpha, const double* A, int64_t lda, const double* x, int64_t incx, const double* beta, double* y, int64_t incy);
+  // ROC: ROCBLAS_EXPORT rocblas_status rocblas_dsymv_64(rocblas_handle handle, rocblas_fill uplo, int64_t n, const double* alpha, const double* A, int64_t lda, const double* x, int64_t incx, const double* beta, double* y, int64_t incy);
+  // CHECK: blasStatus = rocblas_dsymv_64(blasHandle, blasFillMode, n_64, &da, &dA, lda_64, &dx, incx_64, &db, &dy, incy_64);
+  // CHECK-NEXT: blasStatus = rocblas_dsymv_64(blasHandle, blasFillMode, n_64, &da, &dA, lda_64, &dx, incx_64, &db, &dy, incy_64);
+  blasStatus = cublasDsymv_64(blasHandle, blasFillMode, n_64, &da, &dA, lda_64, &dx, incx_64, &db, &dy, incy_64);
+  blasStatus = cublasDsymv_v2_64(blasHandle, blasFillMode, n_64, &da, &dA, lda_64, &dx, incx_64, &db, &dy, incy_64);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasCsymv_v2_64(cublasHandle_t handle, cublasFillMode_t uplo, int64_t n, const cuComplex* alpha, const cuComplex* A, int64_t lda, const cuComplex* x, int64_t incx, const cuComplex* beta, cuComplex* y, int64_t incy);
+  // ROC: ROCBLAS_EXPORT rocblas_status rocblas_csymv_64(rocblas_handle handle, rocblas_fill uplo, int64_t n, const rocblas_float_complex* alpha, const rocblas_float_complex* A, int64_t lda, const rocblas_float_complex* x, int64_t incx, const rocblas_float_complex* beta, rocblas_float_complex* y, int64_t incy);
+  // CHECK: blasStatus = rocblas_csymv_64(blasHandle, blasFillMode, n_64, &complexa, &complexA, lda_64, &complexx, incx_64, &complexb, &complexy, incy_64);
+  // CHECK-NEXT: blasStatus = rocblas_csymv_64(blasHandle, blasFillMode, n_64, &complexa, &complexA, lda_64, &complexx, incx_64, &complexb, &complexy, incy_64);
+  blasStatus = cublasCsymv_64(blasHandle, blasFillMode, n_64, &complexa, &complexA, lda_64, &complexx, incx_64, &complexb, &complexy, incy_64);
+  blasStatus = cublasCsymv_v2_64(blasHandle, blasFillMode, n_64, &complexa, &complexA, lda_64, &complexx, incx_64, &complexb, &complexy, incy_64);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasZsymv_v2_64(cublasHandle_t handle, cublasFillMode_t uplo, int64_t n, const cuDoubleComplex* alpha, const cuDoubleComplex* A, int64_t lda, const cuDoubleComplex* x, int64_t incx, const cuDoubleComplex* beta, cuDoubleComplex* y, int64_t incy);
+  // ROC: ROCBLAS_EXPORT rocblas_status rocblas_zsymv_64(rocblas_handle handle, rocblas_fill uplo, int64_t n, const rocblas_double_complex* alpha, const rocblas_double_complex* A, int64_t lda, const rocblas_double_complex* x, int64_t incx, const rocblas_double_complex* beta, rocblas_double_complex* y, int64_t incy);
+  // CHECK: blasStatus = rocblas_zsymv_64(blasHandle, blasFillMode, n_64, &dcomplexa, &dcomplexA, lda_64, &dcomplexx, incx_64, &dcomplexb, &dcomplexy, incy_64);
+  // CHECK-NEXT: blasStatus = rocblas_zsymv_64(blasHandle, blasFillMode, n_64, &dcomplexa, &dcomplexA, lda_64, &dcomplexx, incx_64, &dcomplexb, &dcomplexy, incy_64);
+  blasStatus = cublasZsymv_64(blasHandle, blasFillMode, n_64, &dcomplexa, &dcomplexA, lda_64, &dcomplexx, incx_64, &dcomplexb, &dcomplexy, incy_64);
+  blasStatus = cublasZsymv_v2_64(blasHandle, blasFillMode, n_64, &dcomplexa, &dcomplexA, lda_64, &dcomplexx, incx_64, &dcomplexb, &dcomplexy, incy_64);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasChemv_v2_64(cublasHandle_t handle, cublasFillMode_t uplo, int64_t n, const cuComplex* alpha, const cuComplex* A, int64_t lda, const cuComplex* x, int64_t incx, const cuComplex* beta, cuComplex* y, int64_t incy);
+  // ROC: ROCBLAS_EXPORT rocblas_status rocblas_chemv_64(rocblas_handle handle, rocblas_fill uplo, int64_t n, const rocblas_float_complex* alpha, const rocblas_float_complex* A, int64_t lda, const rocblas_float_complex* x, int64_t incx, const rocblas_float_complex* beta, rocblas_float_complex* y, int64_t incy);
+  // CHECK: blasStatus = rocblas_chemv_64(blasHandle, blasFillMode, n_64, &complexa, &complexA, lda_64, &complexx, incx_64, &complexb, &complexy, incy_64);
+  // CHECK-NEXT: blasStatus = rocblas_chemv_64(blasHandle, blasFillMode, n_64, &complexa, &complexA, lda_64, &complexx, incx_64, &complexb, &complexy, incy_64);
+  blasStatus = cublasChemv_64(blasHandle, blasFillMode, n_64, &complexa, &complexA, lda_64, &complexx, incx_64, &complexb, &complexy, incy_64);
+  blasStatus = cublasChemv_v2_64(blasHandle, blasFillMode, n_64, &complexa, &complexA, lda_64, &complexx, incx_64, &complexb, &complexy, incy_64);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasZhemv_v2_64(cublasHandle_t handle, cublasFillMode_t uplo, int64_t n, const cuDoubleComplex* alpha, const cuDoubleComplex* A, int64_t lda, const cuDoubleComplex* x, int64_t incx, const cuDoubleComplex* beta, cuDoubleComplex* y, int64_t incy);
+  // ROC: ROCBLAS_EXPORT rocblas_status rocblas_zhemv_64(rocblas_handle handle, rocblas_fill uplo, int64_t n, const rocblas_double_complex* alpha, const rocblas_double_complex* A, int64_t lda, const rocblas_double_complex* x, int64_t incx, const rocblas_double_complex* beta, rocblas_double_complex* y, int64_t incy);
+  // CHECK: blasStatus = rocblas_zhemv_64(blasHandle, blasFillMode, n_64, &dcomplexa, &dcomplexA, lda_64, &dcomplexx, incx_64, &dcomplexb, &dcomplexy, incy_64);
+  // CHECK-NEXT: blasStatus = rocblas_zhemv_64(blasHandle, blasFillMode, n_64, &dcomplexa, &dcomplexA, lda_64, &dcomplexx, incx_64, &dcomplexb, &dcomplexy, incy_64);
+  blasStatus = cublasZhemv_64(blasHandle, blasFillMode, n_64, &dcomplexa, &dcomplexA, lda_64, &dcomplexx, incx_64, &dcomplexb, &dcomplexy, incy_64);
+  blasStatus = cublasZhemv_v2_64(blasHandle, blasFillMode, n_64, &dcomplexa, &dcomplexA, lda_64, &dcomplexx, incx_64, &dcomplexb, &dcomplexy, incy_64);
 #endif
 
   return 0;


### PR DESCRIPTION
+ `rocblas_(s|d|c|z)symv_64` support
+ `rocblas_(c|z)hemv_64` support
+ Updated synthetic tests, the regenerated `hipify-perl`, and `BLAS` `CUDA2HIP` documentation