### PR TITLE
[HIPIFY][#1679][doc][fix] Fix the version in `CHANGELOG.md`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 Documentation for HIPIFY is available at
 [https://rocmdocs.amd.com/projects/HIPIFY/en/latest/](https://rocmdocs.amd.com/projects/HIPIFY/en/latest/).
 
-## HIPIFY for ROCm 6.2.2
+## HIPIFY for ROCm 6.2.4
 
 ### Additions
 


### PR DESCRIPTION
+ HIPIFY `6.2.2` is unchanged; the Release information for [6.2.2](https://github.com/ROCm/HIPIFY/releases/tag/rocm-6.2.2) is correct, but the `Changelog.md` is not.
+ [fix] Changes initially reported for HIPIFY `6.2.2` are going to appear in `6.2.4`.