### PR TITLE
[HIPIFY][rocBLAS] 64-bit functions support - Step 7

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -1588,7 +1588,9 @@ sub rocSubstitutions {
     subst("cublasCher2_v2", "rocblas_cher2", "library");
     subst("cublasCher2k", "rocblas_cher2k", "library");
     subst("cublasCher2k_v2", "rocblas_cher2k", "library");
+    subst("cublasCher_64", "rocblas_cher_64", "library");
     subst("cublasCher_v2", "rocblas_cher", "library");
+    subst("cublasCher_v2_64", "rocblas_cher_64", "library");
     subst("cublasCherk", "rocblas_cherk", "library");
     subst("cublasCherk_v2", "rocblas_cherk", "library");
     subst("cublasCherkx", "rocblas_cherkx", "library");
@@ -1633,7 +1635,9 @@ sub rocSubstitutions {
     subst("cublasCsyr2_v2", "rocblas_csyr2", "library");
     subst("cublasCsyr2k", "rocblas_csyr2k", "library");
     subst("cublasCsyr2k_v2", "rocblas_csyr2k", "library");
+    subst("cublasCsyr_64", "rocblas_csyr_64", "library");
     subst("cublasCsyr_v2", "rocblas_csyr", "library");
+    subst("cublasCsyr_v2_64", "rocblas_csyr_64", "library");
     subst("cublasCsyrk", "rocblas_csyrk", "library");
     subst("cublasCsyrk_v2", "rocblas_csyrk", "library");
     subst("cublasCsyrkx", "rocblas_csyrkx", "library");
@@ -1741,7 +1745,9 @@ sub rocSubstitutions {
     subst("cublasDsyr2_v2", "rocblas_dsyr2", "library");
     subst("cublasDsyr2k", "rocblas_dsyr2k", "library");
     subst("cublasDsyr2k_v2", "rocblas_dsyr2k", "library");
+    subst("cublasDsyr_64", "rocblas_dsyr_64", "library");
     subst("cublasDsyr_v2", "rocblas_dsyr", "library");
+    subst("cublasDsyr_v2_64", "rocblas_dsyr_64", "library");
     subst("cublasDsyrk", "rocblas_dsyrk", "library");
     subst("cublasDsyrk_v2", "rocblas_dsyrk", "library");
     subst("cublasDsyrkx", "rocblas_dsyrkx", "library");
@@ -1933,7 +1939,9 @@ sub rocSubstitutions {
     subst("cublasSsyr2_v2", "rocblas_ssyr2", "library");
     subst("cublasSsyr2k", "rocblas_ssyr2k", "library");
     subst("cublasSsyr2k_v2", "rocblas_ssyr2k", "library");
+    subst("cublasSsyr_64", "rocblas_ssyr_64", "library");
     subst("cublasSsyr_v2", "rocblas_ssyr", "library");
+    subst("cublasSsyr_v2_64", "rocblas_ssyr_64", "library");
     subst("cublasSsyrk", "rocblas_ssyrk", "library");
     subst("cublasSsyrk_v2", "rocblas_ssyrk", "library");
     subst("cublasSsyrkx", "rocblas_ssyrkx", "library");
@@ -2023,7 +2031,9 @@ sub rocSubstitutions {
     subst("cublasZher2_v2", "rocblas_zher2", "library");
     subst("cublasZher2k", "rocblas_zher2k", "library");
     subst("cublasZher2k_v2", "rocblas_zher2k", "library");
+    subst("cublasZher_64", "rocblas_zher_64", "library");
     subst("cublasZher_v2", "rocblas_zher", "library");
+    subst("cublasZher_v2_64", "rocblas_zher_64", "library");
     subst("cublasZherk", "rocblas_zherk", "library");
     subst("cublasZherk_v2", "rocblas_zherk", "library");
     subst("cublasZherkx", "rocblas_zherkx", "library");
@@ -2058,7 +2068,9 @@ sub rocSubstitutions {
     subst("cublasZsyr2_v2", "rocblas_zsyr2", "library");
     subst("cublasZsyr2k", "rocblas_zsyr2k", "library");
     subst("cublasZsyr2k_v2", "rocblas_zsyr2k", "library");
+    subst("cublasZsyr_64", "rocblas_zsyr_64", "library");
     subst("cublasZsyr_v2", "rocblas_zsyr", "library");
+    subst("cublasZsyr_v2_64", "rocblas_zsyr_64", "library");
     subst("cublasZsyrk", "rocblas_zsyrk", "library");
     subst("cublasZsyrk_v2", "rocblas_zsyrk", "library");
     subst("cublasZsyrkx", "rocblas_zsyrkx", "library");
@@ -12541,8 +12553,6 @@ sub warnRocOnlyUnsupportedFunctions {
         "cublasZsyrkx_64",
         "cublasZsyrk_v2_64",
         "cublasZsyrk_64",
-        "cublasZsyr_v2_64",
-        "cublasZsyr_64",
         "cublasZsyr2k_v2_64",
         "cublasZsyr2k_64",
         "cublasZsyr2_v2_64",
@@ -12559,8 +12569,6 @@ sub warnRocOnlyUnsupportedFunctions {
         "cublasZherkx_64",
         "cublasZherk_v2_64",
         "cublasZherk_64",
-        "cublasZher_v2_64",
-        "cublasZher_64",
         "cublasZher2k_v2_64",
         "cublasZher2k_64",
         "cublasZher2_v2_64",
@@ -12610,8 +12618,6 @@ sub warnRocOnlyUnsupportedFunctions {
         "cublasSsyrkx_64",
         "cublasSsyrk_v2_64",
         "cublasSsyrk_64",
-        "cublasSsyr_v2_64",
-        "cublasSsyr_64",
         "cublasSsyr2k_v2_64",
         "cublasSsyr2k_64",
         "cublasSsyr2_v2_64",
@@ -12767,8 +12773,6 @@ sub warnRocOnlyUnsupportedFunctions {
         "cublasDsyrkx_64",
         "cublasDsyrk_v2_64",
         "cublasDsyrk_64",
-        "cublasDsyr_v2_64",
-        "cublasDsyr_64",
         "cublasDsyr2k_v2_64",
         "cublasDsyr2k_64",
         "cublasDsyr2_v2_64",
@@ -12823,8 +12827,6 @@ sub warnRocOnlyUnsupportedFunctions {
         "cublasCsyrkEx",
         "cublasCsyrk3mEx_64",
         "cublasCsyrk3mEx",
-        "cublasCsyr_v2_64",
-        "cublasCsyr_64",
         "cublasCsyr2k_v2_64",
         "cublasCsyr2k_64",
         "cublasCsyr2_v2_64",
@@ -12847,8 +12849,6 @@ sub warnRocOnlyUnsupportedFunctions {
         "cublasCherkEx",
         "cublasCherk3mEx_64",
         "cublasCherk3mEx",
-        "cublasCher_v2_64",
-        "cublasCher_64",
         "cublasCher2k_v2_64",
         "cublasCher2k_64",
         "cublasCher2_v2_64",

--- a/docs/tables/CUBLAS_API_supported_by_HIP_and_ROC.md
+++ b/docs/tables/CUBLAS_API_supported_by_HIP_and_ROC.md
@@ -751,9 +751,9 @@
 |`cublasCher2_64`|12.0| | | |`hipblasCher2_v2_64`|6.2.0| | | | | | | | | | |
 |`cublasCher2_v2`| | | | |`hipblasCher2_v2`|6.0.0| | | | |`rocblas_cher2`|3.5.0| | | | |
 |`cublasCher2_v2_64`|12.0| | | |`hipblasCher2_v2_64`|6.2.0| | | | | | | | | | |
-|`cublasCher_64`|12.0| | | |`hipblasCher_v2_64`|6.2.0| | | | | | | | | | |
+|`cublasCher_64`|12.0| | | |`hipblasCher_v2_64`|6.2.0| | | | |`rocblas_cher_64`|6.2.0| | | | |
 |`cublasCher_v2`| | | | |`hipblasCher_v2`|6.0.0| | | | |`rocblas_cher`|3.5.0| | | | |
-|`cublasCher_v2_64`|12.0| | | |`hipblasCher_v2_64`|6.2.0| | | | | | | | | | |
+|`cublasCher_v2_64`|12.0| | | |`hipblasCher_v2_64`|6.2.0| | | | |`rocblas_cher_64`|6.2.0| | | | |
 |`cublasChpmv`| | | | |`hipblasChpmv_v2`|6.0.0| | | | |`rocblas_chpmv`|3.5.0| | | | |
 |`cublasChpmv_64`|12.0| | | |`hipblasChpmv_v2_64`|6.2.0| | | | | | | | | | |
 |`cublasChpmv_v2`| | | | |`hipblasChpmv_v2`|6.0.0| | | | |`rocblas_chpmv`|3.5.0| | | | |
@@ -775,9 +775,9 @@
 |`cublasCsyr2_64`|12.0| | | |`hipblasCsyr2_v2_64`|6.2.0| | | | | | | | | | |
 |`cublasCsyr2_v2`| | | | |`hipblasCsyr2_v2`|6.0.0| | | | |`rocblas_csyr2`|3.5.0| | | | |
 |`cublasCsyr2_v2_64`|12.0| | | |`hipblasCsyr2_v2_64`|6.2.0| | | | | | | | | | |
-|`cublasCsyr_64`|12.0| | | |`hipblasCsyr_v2_64`|6.2.0| | | | | | | | | | |
+|`cublasCsyr_64`|12.0| | | |`hipblasCsyr_v2_64`|6.2.0| | | | |`rocblas_csyr_64`|6.2.0| | | | |
 |`cublasCsyr_v2`| | | | |`hipblasCsyr_v2`|6.0.0| | | | |`rocblas_csyr`|1.7.1| | | | |
-|`cublasCsyr_v2_64`|12.0| | | |`hipblasCsyr_v2_64`|6.2.0| | | | | | | | | | |
+|`cublasCsyr_v2_64`|12.0| | | |`hipblasCsyr_v2_64`|6.2.0| | | | |`rocblas_csyr_64`|6.2.0| | | | |
 |`cublasCtbmv`| | | | |`hipblasCtbmv_v2`|6.0.0| | | | |`rocblas_ctbmv`|3.5.0| | | | |
 |`cublasCtbmv_64`|12.0| | | |`hipblasCtbmv_v2_64`|6.2.0| | | | | | | | | | |
 |`cublasCtbmv_v2`| | | | |`hipblasCtbmv_v2`|6.0.0| | | | |`rocblas_ctbmv`|3.5.0| | | | |
@@ -839,9 +839,9 @@
 |`cublasDsyr2_64`|12.0| | | |`hipblasDsyr2_64`|6.2.0| | | | | | | | | | |
 |`cublasDsyr2_v2`| | | | |`hipblasDsyr2`|3.5.0| | | | |`rocblas_dsyr2`|3.5.0| | | | |
 |`cublasDsyr2_v2_64`|12.0| | | |`hipblasDsyr2_64`|6.2.0| | | | | | | | | | |
-|`cublasDsyr_64`|12.0| | | |`hipblasDsyr_64`|6.2.0| | | | | | | | | | |
+|`cublasDsyr_64`|12.0| | | |`hipblasDsyr_64`|6.2.0| | | | |`rocblas_dsyr_64`|6.2.0| | | | |
 |`cublasDsyr_v2`| | | | |`hipblasDsyr`|3.0.0| | | | |`rocblas_dsyr`|1.7.1| | | | |
-|`cublasDsyr_v2_64`|12.0| | | |`hipblasDsyr_64`|6.2.0| | | | | | | | | | |
+|`cublasDsyr_v2_64`|12.0| | | |`hipblasDsyr_64`|6.2.0| | | | |`rocblas_dsyr_64`|6.2.0| | | | |
 |`cublasDtbmv`| | | | |`hipblasDtbmv`|3.5.0| | | | |`rocblas_dtbmv`|3.5.0| | | | |
 |`cublasDtbmv_64`|12.0| | | |`hipblasDtbmv_64`|6.2.0| | | | | | | | | | |
 |`cublasDtbmv_v2`| | | | |`hipblasDtbmv`|3.5.0| | | | |`rocblas_dtbmv`|3.5.0| | | | |
@@ -903,9 +903,9 @@
 |`cublasSsyr2_64`|12.0| | | |`hipblasSsyr2_64`|6.2.0| | | | | | | | | | |
 |`cublasSsyr2_v2`| | | | |`hipblasSsyr2`|3.5.0| | | | |`rocblas_ssyr2`|3.5.0| | | | |
 |`cublasSsyr2_v2_64`|12.0| | | |`hipblasSsyr2_64`|6.2.0| | | | | | | | | | |
-|`cublasSsyr_64`|12.0| | | |`hipblasSsyr_64`|6.2.0| | | | | | | | | | |
+|`cublasSsyr_64`|12.0| | | |`hipblasSsyr_64`|6.2.0| | | | |`rocblas_ssyr_64`|6.2.0| | | | |
 |`cublasSsyr_v2`| | | | |`hipblasSsyr`|3.0.0| | | | |`rocblas_ssyr`|1.7.1| | | | |
-|`cublasSsyr_v2_64`|12.0| | | |`hipblasSsyr_64`|6.2.0| | | | | | | | | | |
+|`cublasSsyr_v2_64`|12.0| | | |`hipblasSsyr_64`|6.2.0| | | | |`rocblas_ssyr_64`|6.2.0| | | | |
 |`cublasStbmv`| | | | |`hipblasStbmv`|3.5.0| | | | |`rocblas_stbmv`|3.5.0| | | | |
 |`cublasStbmv_64`|12.0| | | |`hipblasStbmv_64`|6.2.0| | | | | | | | | | |
 |`cublasStbmv_v2`| | | | |`hipblasStbmv`|3.5.0| | | | |`rocblas_stbmv`|3.5.0| | | | |
@@ -959,9 +959,9 @@
 |`cublasZher2_64`|12.0| | | |`hipblasZher2_v2_64`|6.2.0| | | | | | | | | | |
 |`cublasZher2_v2`| | | | |`hipblasZher2_v2`|6.0.0| | | | |`rocblas_zher2`|3.5.0| | | | |
 |`cublasZher2_v2_64`|12.0| | | |`hipblasZher2_v2_64`|6.2.0| | | | | | | | | | |
-|`cublasZher_64`|12.0| | | |`hipblasZher_v2_64`|6.2.0| | | | | | | | | | |
+|`cublasZher_64`|12.0| | | |`hipblasZher_v2_64`|6.2.0| | | | |`rocblas_zher_64`|6.2.0| | | | |
 |`cublasZher_v2`| | | | |`hipblasZher_v2`|6.0.0| | | | |`rocblas_zher`|3.5.0| | | | |
-|`cublasZher_v2_64`|12.0| | | |`hipblasZher_v2_64`|6.2.0| | | | | | | | | | |
+|`cublasZher_v2_64`|12.0| | | |`hipblasZher_v2_64`|6.2.0| | | | |`rocblas_zher_64`|6.2.0| | | | |
 |`cublasZhpmv`| | | | |`hipblasZhpmv_v2`|6.0.0| | | | |`rocblas_zhpmv`|3.5.0| | | | |
 |`cublasZhpmv_64`|12.0| | | |`hipblasZhpmv_v2_64`|6.2.0| | | | | | | | | | |
 |`cublasZhpmv_v2`| | | | |`hipblasZhpmv_v2`|6.0.0| | | | |`rocblas_zhpmv`|3.5.0| | | | |
@@ -983,9 +983,9 @@
 |`cublasZsyr2_64`|12.0| | | |`hipblasZsyr2_v2_64`|6.2.0| | | | | | | | | | |
 |`cublasZsyr2_v2`| | | | |`hipblasZsyr2_v2`|6.0.0| | | | |`rocblas_zsyr2`|3.5.0| | | | |
 |`cublasZsyr2_v2_64`|12.0| | | |`hipblasZsyr2_v2_64`|6.2.0| | | | | | | | | | |
-|`cublasZsyr_64`|12.0| | | |`hipblasZsyr_v2_64`|6.2.0| | | | | | | | | | |
+|`cublasZsyr_64`|12.0| | | |`hipblasZsyr_v2_64`|6.2.0| | | | |`rocblas_zsyr_64`|6.2.0| | | | |
 |`cublasZsyr_v2`| | | | |`hipblasZsyr_v2`|6.0.0| | | | |`rocblas_zsyr`|1.7.1| | | | |
-|`cublasZsyr_v2_64`|12.0| | | |`hipblasZsyr_v2_64`|6.2.0| | | | | | | | | | |
+|`cublasZsyr_v2_64`|12.0| | | |`hipblasZsyr_v2_64`|6.2.0| | | | |`rocblas_zsyr_64`|6.2.0| | | | |
 |`cublasZtbmv`| | | | |`hipblasZtbmv_v2`|6.0.0| | | | |`rocblas_ztbmv`|3.5.0| | | | |
 |`cublasZtbmv_64`|12.0| | | |`hipblasZtbmv_v2_64`|6.2.0| | | | | | | | | | |
 |`cublasZtbmv_v2`| | | | |`hipblasZtbmv_v2`|6.0.0| | | | |`rocblas_ztbmv`|3.5.0| | | | |

--- a/docs/tables/CUBLAS_API_supported_by_ROC.md
+++ b/docs/tables/CUBLAS_API_supported_by_ROC.md
@@ -751,9 +751,9 @@
 |`cublasCher2_64`|12.0| | | | | | | | | |
 |`cublasCher2_v2`| | | | |`rocblas_cher2`|3.5.0| | | | |
 |`cublasCher2_v2_64`|12.0| | | | | | | | | |
-|`cublasCher_64`|12.0| | | | | | | | | |
+|`cublasCher_64`|12.0| | | |`rocblas_cher_64`|6.2.0| | | | |
 |`cublasCher_v2`| | | | |`rocblas_cher`|3.5.0| | | | |
-|`cublasCher_v2_64`|12.0| | | | | | | | | |
+|`cublasCher_v2_64`|12.0| | | |`rocblas_cher_64`|6.2.0| | | | |
 |`cublasChpmv`| | | | |`rocblas_chpmv`|3.5.0| | | | |
 |`cublasChpmv_64`|12.0| | | | | | | | | |
 |`cublasChpmv_v2`| | | | |`rocblas_chpmv`|3.5.0| | | | |
@@ -775,9 +775,9 @@
 |`cublasCsyr2_64`|12.0| | | | | | | | | |
 |`cublasCsyr2_v2`| | | | |`rocblas_csyr2`|3.5.0| | | | |
 |`cublasCsyr2_v2_64`|12.0| | | | | | | | | |
-|`cublasCsyr_64`|12.0| | | | | | | | | |
+|`cublasCsyr_64`|12.0| | | |`rocblas_csyr_64`|6.2.0| | | | |
 |`cublasCsyr_v2`| | | | |`rocblas_csyr`|1.7.1| | | | |
-|`cublasCsyr_v2_64`|12.0| | | | | | | | | |
+|`cublasCsyr_v2_64`|12.0| | | |`rocblas_csyr_64`|6.2.0| | | | |
 |`cublasCtbmv`| | | | |`rocblas_ctbmv`|3.5.0| | | | |
 |`cublasCtbmv_64`|12.0| | | | | | | | | |
 |`cublasCtbmv_v2`| | | | |`rocblas_ctbmv`|3.5.0| | | | |
@@ -839,9 +839,9 @@
 |`cublasDsyr2_64`|12.0| | | | | | | | | |
 |`cublasDsyr2_v2`| | | | |`rocblas_dsyr2`|3.5.0| | | | |
 |`cublasDsyr2_v2_64`|12.0| | | | | | | | | |
-|`cublasDsyr_64`|12.0| | | | | | | | | |
+|`cublasDsyr_64`|12.0| | | |`rocblas_dsyr_64`|6.2.0| | | | |
 |`cublasDsyr_v2`| | | | |`rocblas_dsyr`|1.7.1| | | | |
-|`cublasDsyr_v2_64`|12.0| | | | | | | | | |
+|`cublasDsyr_v2_64`|12.0| | | |`rocblas_dsyr_64`|6.2.0| | | | |
 |`cublasDtbmv`| | | | |`rocblas_dtbmv`|3.5.0| | | | |
 |`cublasDtbmv_64`|12.0| | | | | | | | | |
 |`cublasDtbmv_v2`| | | | |`rocblas_dtbmv`|3.5.0| | | | |
@@ -903,9 +903,9 @@
 |`cublasSsyr2_64`|12.0| | | | | | | | | |
 |`cublasSsyr2_v2`| | | | |`rocblas_ssyr2`|3.5.0| | | | |
 |`cublasSsyr2_v2_64`|12.0| | | | | | | | | |
-|`cublasSsyr_64`|12.0| | | | | | | | | |
+|`cublasSsyr_64`|12.0| | | |`rocblas_ssyr_64`|6.2.0| | | | |
 |`cublasSsyr_v2`| | | | |`rocblas_ssyr`|1.7.1| | | | |
-|`cublasSsyr_v2_64`|12.0| | | | | | | | | |
+|`cublasSsyr_v2_64`|12.0| | | |`rocblas_ssyr_64`|6.2.0| | | | |
 |`cublasStbmv`| | | | |`rocblas_stbmv`|3.5.0| | | | |
 |`cublasStbmv_64`|12.0| | | | | | | | | |
 |`cublasStbmv_v2`| | | | |`rocblas_stbmv`|3.5.0| | | | |
@@ -959,9 +959,9 @@
 |`cublasZher2_64`|12.0| | | | | | | | | |
 |`cublasZher2_v2`| | | | |`rocblas_zher2`|3.5.0| | | | |
 |`cublasZher2_v2_64`|12.0| | | | | | | | | |
-|`cublasZher_64`|12.0| | | | | | | | | |
+|`cublasZher_64`|12.0| | | |`rocblas_zher_64`|6.2.0| | | | |
 |`cublasZher_v2`| | | | |`rocblas_zher`|3.5.0| | | | |
-|`cublasZher_v2_64`|12.0| | | | | | | | | |
+|`cublasZher_v2_64`|12.0| | | |`rocblas_zher_64`|6.2.0| | | | |
 |`cublasZhpmv`| | | | |`rocblas_zhpmv`|3.5.0| | | | |
 |`cublasZhpmv_64`|12.0| | | | | | | | | |
 |`cublasZhpmv_v2`| | | | |`rocblas_zhpmv`|3.5.0| | | | |
@@ -983,9 +983,9 @@
 |`cublasZsyr2_64`|12.0| | | | | | | | | |
 |`cublasZsyr2_v2`| | | | |`rocblas_zsyr2`|3.5.0| | | | |
 |`cublasZsyr2_v2_64`|12.0| | | | | | | | | |
-|`cublasZsyr_64`|12.0| | | | | | | | | |
+|`cublasZsyr_64`|12.0| | | |`rocblas_zsyr_64`|6.2.0| | | | |
 |`cublasZsyr_v2`| | | | |`rocblas_zsyr`|1.7.1| | | | |
-|`cublasZsyr_v2_64`|12.0| | | | | | | | | |
+|`cublasZsyr_v2_64`|12.0| | | |`rocblas_zsyr_64`|6.2.0| | | | |
 |`cublasZtbmv`| | | | |`rocblas_ztbmv`|3.5.0| | | | |
 |`cublasZtbmv_64`|12.0| | | | | | | | | |
 |`cublasZtbmv_v2`| | | | |`rocblas_ztbmv`|3.5.0| | | | |

--- a/src/CUDA2HIP_BLAS_API_functions.cpp
+++ b/src/CUDA2HIP_BLAS_API_functions.cpp
@@ -350,17 +350,17 @@ const std::map<llvm::StringRef, hipCounter> CUDA_BLAS_FUNCTION_MAP {
 
   // SYR/HER
   {"cublasSsyr",                                           {"hipblasSsyr",                                               "rocblas_ssyr",                                       CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, HIP_SUPPORTED_V2_ONLY}},
-  {"cublasSsyr_64",                                        {"hipblasSsyr_64",                                            "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
+  {"cublasSsyr_64",                                        {"hipblasSsyr_64",                                            "rocblas_ssyr_64",                                    CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
   {"cublasDsyr",                                           {"hipblasDsyr",                                               "rocblas_dsyr",                                       CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, HIP_SUPPORTED_V2_ONLY}},
-  {"cublasDsyr_64",                                        {"hipblasDsyr_64",                                            "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
+  {"cublasDsyr_64",                                        {"hipblasDsyr_64",                                            "rocblas_dsyr_64",                                    CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
   {"cublasCsyr",                                           {"hipblasCsyr_v2",                                            "rocblas_csyr",                                       CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, HIP_SUPPORTED_V2_ONLY}},
-  {"cublasCsyr_64",                                        {"hipblasCsyr_v2_64",                                         "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
+  {"cublasCsyr_64",                                        {"hipblasCsyr_v2_64",                                         "rocblas_csyr_64",                                    CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
   {"cublasZsyr",                                           {"hipblasZsyr_v2",                                            "rocblas_zsyr",                                       CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, HIP_SUPPORTED_V2_ONLY}},
-  {"cublasZsyr_64",                                        {"hipblasZsyr_v2_64",                                         "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
+  {"cublasZsyr_64",                                        {"hipblasZsyr_v2_64",                                         "rocblas_zsyr_64",                                    CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
   {"cublasCher",                                           {"hipblasCher_v2",                                            "rocblas_cher",                                       CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, HIP_SUPPORTED_V2_ONLY}},
-  {"cublasCher_64",                                        {"hipblasCher_v2_64",                                         "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
+  {"cublasCher_64",                                        {"hipblasCher_v2_64",                                         "rocblas_cher_64",                                    CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
   {"cublasZher",                                           {"hipblasZher_v2",                                            "rocblas_zher",                                       CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, HIP_SUPPORTED_V2_ONLY}},
-  {"cublasZher_64",                                        {"hipblasZher_v2_64",                                         "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
+  {"cublasZher_64",                                        {"hipblasZher_v2_64",                                         "rocblas_zher_64",                                    CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
 
   // SPR/HPR
   {"cublasSspr",                                           {"hipblasSspr",                                               "rocblas_sspr",                                       CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, HIP_SUPPORTED_V2_ONLY}},
@@ -768,17 +768,17 @@ const std::map<llvm::StringRef, hipCounter> CUDA_BLAS_FUNCTION_MAP {
 
   // SYR/HER
   {"cublasSsyr_v2",                                        {"hipblasSsyr",                                               "rocblas_ssyr",                                       CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
-  {"cublasSsyr_v2_64",                                     {"hipblasSsyr_64",                                            "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
+  {"cublasSsyr_v2_64",                                     {"hipblasSsyr_64",                                            "rocblas_ssyr_64",                                    CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
   {"cublasDsyr_v2",                                        {"hipblasDsyr",                                               "rocblas_dsyr",                                       CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
-  {"cublasDsyr_v2_64",                                     {"hipblasDsyr_64",                                            "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
+  {"cublasDsyr_v2_64",                                     {"hipblasDsyr_64",                                            "rocblas_dsyr_64",                                    CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
   {"cublasCsyr_v2",                                        {"hipblasCsyr_v2",                                            "rocblas_csyr",                                       CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
-  {"cublasCsyr_v2_64",                                     {"hipblasCsyr_v2_64",                                         "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
+  {"cublasCsyr_v2_64",                                     {"hipblasCsyr_v2_64",                                         "rocblas_csyr_64",                                    CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
   {"cublasZsyr_v2",                                        {"hipblasZsyr_v2",                                            "rocblas_zsyr",                                       CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
-  {"cublasZsyr_v2_64",                                     {"hipblasZsyr_v2_64",                                         "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
+  {"cublasZsyr_v2_64",                                     {"hipblasZsyr_v2_64",                                         "rocblas_zsyr_64",                                    CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
   {"cublasCher_v2",                                        {"hipblasCher_v2",                                            "rocblas_cher",                                       CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
-  {"cublasCher_v2_64",                                     {"hipblasCher_v2_64",                                         "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
+  {"cublasCher_v2_64",                                     {"hipblasCher_v2_64",                                         "rocblas_cher_64",                                    CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
   {"cublasZher_v2",                                        {"hipblasZher_v2",                                            "rocblas_zher",                                       CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
-  {"cublasZher_v2_64",                                     {"hipblasZher_v2_64",                                         "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
+  {"cublasZher_v2_64",                                     {"hipblasZher_v2_64",                                         "rocblas_zher_64",                                    CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
 
   // SPR/HPR
   {"cublasSspr_v2",                                        {"hipblasSspr",                                               "rocblas_sspr",                                       CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
@@ -2349,6 +2349,12 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_BLAS_FUNCTION_VER_MAP {
   {"rocblas_zsymv_64",                                     {HIP_6020, HIP_0,    HIP_0   }},
   {"rocblas_chemv_64",                                     {HIP_6020, HIP_0,    HIP_0   }},
   {"rocblas_zhemv_64",                                     {HIP_6020, HIP_0,    HIP_0   }},
+  {"rocblas_ssyr_64",                                      {HIP_6020, HIP_0,    HIP_0   }},
+  {"rocblas_dsyr_64",                                      {HIP_6020, HIP_0,    HIP_0   }},
+  {"rocblas_csyr_64",                                      {HIP_6020, HIP_0,    HIP_0   }},
+  {"rocblas_zsyr_64",                                      {HIP_6020, HIP_0,    HIP_0   }},
+  {"rocblas_cher_64",                                      {HIP_6020, HIP_0,    HIP_0   }},
+  {"rocblas_zher_64",                                      {HIP_6020, HIP_0,    HIP_0   }},
 };
 
 const std::map<llvm::StringRef, hipAPIChangedVersions> HIP_BLAS_FUNCTION_CHANGED_VER_MAP {

--- a/tests/unit_tests/synthetic/libraries/cublas2rocblas_v2.cu
+++ b/tests/unit_tests/synthetic/libraries/cublas2rocblas_v2.cu
@@ -2601,6 +2601,48 @@ int main() {
   // CHECK-NEXT: blasStatus = rocblas_zhemv_64(blasHandle, blasFillMode, n_64, &dcomplexa, &dcomplexA, lda_64, &dcomplexx, incx_64, &dcomplexb, &dcomplexy, incy_64);
   blasStatus = cublasZhemv_64(blasHandle, blasFillMode, n_64, &dcomplexa, &dcomplexA, lda_64, &dcomplexx, incx_64, &dcomplexb, &dcomplexy, incy_64);
   blasStatus = cublasZhemv_v2_64(blasHandle, blasFillMode, n_64, &dcomplexa, &dcomplexA, lda_64, &dcomplexx, incx_64, &dcomplexb, &dcomplexy, incy_64);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasSsyr_v2_64(cublasHandle_t handle, cublasFillMode_t uplo, int64_t n, const float* alpha, const float* x, int64_t incx, float* A, int64_t lda);
+  // ROC: ROCBLAS_EXPORT rocblas_status rocblas_ssyr_64(rocblas_handle handle, rocblas_fill uplo, int64_t n, const float* alpha, const float* x, int64_t incx, float* A, int64_t lda);
+  // CHECK: blasStatus = rocblas_ssyr_64(blasHandle, blasFillMode, n_64, &fa, &fx, incx_64, &fA, lda_64);
+  // CHECK-NEXT: blasStatus = rocblas_ssyr_64(blasHandle, blasFillMode, n_64, &fa, &fx, incx_64, &fA, lda_64);
+  blasStatus = cublasSsyr_64(blasHandle, blasFillMode, n_64, &fa, &fx, incx_64, &fA, lda_64);
+  blasStatus = cublasSsyr_v2_64(blasHandle, blasFillMode, n_64, &fa, &fx, incx_64, &fA, lda_64);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasDsyr_v2_64(cublasHandle_t handle, cublasFillMode_t uplo, int64_t n, const double* alpha, const double* x, int64_t incx, double* A, int64_t lda);
+  // ROC: ROCBLAS_EXPORT rocblas_status rocblas_dsyr_64(rocblas_handle handle, rocblas_fill uplo, int64_t n, const double* alpha, const double* x, int64_t incx, double* A, int64_t lda);
+  // CHECK: blasStatus = rocblas_dsyr_64(blasHandle, blasFillMode, n_64, &da, &dx, incx_64, &dA, lda_64);
+  // CHECK-NEXT: blasStatus = rocblas_dsyr_64(blasHandle, blasFillMode, n_64, &da, &dx, incx_64, &dA, lda_64);
+  blasStatus = cublasDsyr_64(blasHandle, blasFillMode, n_64, &da, &dx, incx_64, &dA, lda_64);
+  blasStatus = cublasDsyr_v2_64(blasHandle, blasFillMode, n_64, &da, &dx, incx_64, &dA, lda_64);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasCsyr_v2_64(cublasHandle_t handle, cublasFillMode_t uplo, int64_t n, const cuComplex* alpha, const cuComplex* x, int64_t incx, cuComplex* A, int64_t lda);
+  // ROC: ROCBLAS_EXPORT rocblas_status rocblas_csyr_64(rocblas_handle handle, rocblas_fill uplo, int64_t n, const rocblas_float_complex* alpha, const rocblas_float_complex* x, int64_t incx, rocblas_float_complex* A, int64_t lda);
+  // CHECK: blasStatus = rocblas_csyr_64(blasHandle, blasFillMode, n_64, &complexa, &complexx, incx_64, &complexA, lda_64);
+  // CHECK-NEXT: blasStatus = rocblas_csyr_64(blasHandle, blasFillMode, n_64, &complexa, &complexx, incx_64, &complexA, lda_64);
+  blasStatus = cublasCsyr_64(blasHandle, blasFillMode, n_64, &complexa, &complexx, incx_64, &complexA, lda_64);
+  blasStatus = cublasCsyr_v2_64(blasHandle, blasFillMode, n_64, &complexa, &complexx, incx_64, &complexA, lda_64);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasZsyr_v2_64(cublasHandle_t handle, cublasFillMode_t uplo, int64_t n, const cuDoubleComplex* alpha, const cuDoubleComplex* x, int64_t incx, cuDoubleComplex* A, int64_t lda);
+  // ROC: ROCBLAS_EXPORT rocblas_status rocblas_zsyr_64(rocblas_handle handle, rocblas_fill uplo, int64_t n, const rocblas_double_complex* alpha, const rocblas_double_complex* x, int64_t incx, rocblas_double_complex* A, int64_t lda);
+  // CHECK: blasStatus = rocblas_zsyr_64(blasHandle, blasFillMode, n_64, &dcomplexa, &dcomplexx, incx_64, &dcomplexA, lda_64);
+  // CHECK-NEXT: blasStatus = rocblas_zsyr_64(blasHandle, blasFillMode, n_64, &dcomplexa, &dcomplexx, incx_64, &dcomplexA, lda_64);
+  blasStatus = cublasZsyr_64(blasHandle, blasFillMode, n_64, &dcomplexa, &dcomplexx, incx_64, &dcomplexA, lda_64);
+  blasStatus = cublasZsyr_v2_64(blasHandle, blasFillMode, n_64, &dcomplexa, &dcomplexx, incx_64, &dcomplexA, lda_64);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasCher_v2_64(cublasHandle_t handle, cublasFillMode_t uplo, int64_t n, const float* alpha, const cuComplex* x, int64_t incx, cuComplex* A, int64_t lda);
+  // ROC: ROCBLAS_EXPORT rocblas_status rocblas_cher_64(rocblas_handle handle, rocblas_fill uplo, int64_t n, const float* alpha, const rocblas_float_complex* x, int64_t incx, rocblas_float_complex* A, int64_t lda);
+  // CHECK: blasStatus = rocblas_cher_64(blasHandle, blasFillMode, n_64, &fa, &complexx, incx_64, &complexA, lda_64);
+  // CHECK-NEXT: blasStatus = rocblas_cher_64(blasHandle, blasFillMode, n_64, &fa, &complexx, incx_64, &complexA, lda_64);
+  blasStatus = cublasCher_64(blasHandle, blasFillMode, n_64, &fa, &complexx, incx_64, &complexA, lda_64);
+  blasStatus = cublasCher_v2_64(blasHandle, blasFillMode, n_64, &fa, &complexx, incx_64, &complexA, lda_64);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasZher_v2_64(cublasHandle_t handle, cublasFillMode_t uplo, int64_t n, const double* alpha, const cuDoubleComplex* x, int64_t incx, cuDoubleComplex* A, int64_t lda);
+  // ROC: ROCBLAS_EXPORT rocblas_status rocblas_zher_64(rocblas_handle handle, rocblas_fill uplo, int64_t n, const double* alpha, const rocblas_double_complex* x, int64_t incx, rocblas_double_complex* A, int64_t lda);
+  // CHECK: blasStatus = rocblas_zher_64(blasHandle, blasFillMode, n_64, &da, &dcomplexx, incx_64, &dcomplexA, lda_64);
+  // CHECK-NEXT: blasStatus = rocblas_zher_64(blasHandle, blasFillMode, n_64, &da, &dcomplexx, incx_64, &dcomplexA, lda_64);
+  blasStatus = cublasZher_64(blasHandle, blasFillMode, n_64, &da, &dcomplexx, incx_64, &dcomplexA, lda_64);
+  blasStatus = cublasZher_v2_64(blasHandle, blasFillMode, n_64, &da, &dcomplexx, incx_64, &dcomplexA, lda_64);
 #endif
 
   return 0;


### PR DESCRIPTION
+ `rocblas_(s|d|c|z)syr_64` support
+ `rocblas_(c|z)her_64` support
+ Updated synthetic tests, the regenerated `hipify-perl`, and `BLAS` `CUDA2HIP` documentation