### PR TITLE
[HIPIFY][rocRAND][doc] `cuRAND` direct hipification to `rocRAND` is finally supported

### DIFF
--- a/docs/supported_apis.md
+++ b/docs/supported_apis.md
@@ -10,7 +10,7 @@
 | CUBLAS API        | [HIP BLAS API](tables/CUBLAS_API_supported_by_HIP.md)                | [ROC BLAS API](tables/CUBLAS_API_supported_by_ROC.md)     | [HIP + ROC BLAS API](tables/CUBLAS_API_supported_by_HIP_and_ROC.md)     |
 | CUSPARSE API      | [HIP SPARSE API](tables/CUSPARSE_API_supported_by_HIP.md)            | [ROC SPARSE API](tables/CUSPARSE_API_supported_by_ROC.md) | [HIP + ROC SPARSE API](tables/CUSPARSE_API_supported_by_HIP_and_ROC.md) |
 | CUSOLVER API      | [HIP SOLVER API](tables/CUSOLVER_API_supported_by_HIP.md)            |       |        |
-| CURAND API        | [HIP RAND API](tables/CURAND_API_supported_by_HIP.md)                |       |        |
+| CURAND API        | [HIP RAND API](tables/CURAND_API_supported_by_HIP.md)                |[ROC RAND API](tables/CURAND_API_supported_by_ROC.md) | [HIP + ROC RAND API](tables/CURAND_API_supported_by_HIP_and_ROC.md) |
 | CUFFT API         | [HIP FFT API](tables/CUFFT_API_supported_by_HIP.md)                  |       |        |
 | CUDNN API         | [HIP DNN API](tables/CUDNN_API_supported_by_HIP.md)                  |       |        |
 | CUB API           | [HIP CUB API](tables/CUB_API_supported_by_HIP.md)                    |       |        |


### PR DESCRIPTION
+ The corresponding documentation is available at [supported_apis.md](https://github.com/ROCm/HIPIFY/blob/amd-staging/docs/supported_apis.md)
+ To hipify directly to `rocRAND`, the `--roc` option has to be added to `hipify-clang` or `hipify-perl`
