### PR TITLE
[HIPIFY][rocBLAS] 64-bit functions support - Step 8

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -1585,7 +1585,9 @@ sub rocSubstitutions {
     subst("cublasChemv_v2_64", "rocblas_chemv_64", "library");
     subst("cublasCher", "rocblas_cher", "library");
     subst("cublasCher2", "rocblas_cher2", "library");
+    subst("cublasCher2_64", "rocblas_cher2_64", "library");
     subst("cublasCher2_v2", "rocblas_cher2", "library");
+    subst("cublasCher2_v2_64", "rocblas_cher2_64", "library");
     subst("cublasCher2k", "rocblas_cher2k", "library");
     subst("cublasCher2k_v2", "rocblas_cher2k", "library");
     subst("cublasCher_64", "rocblas_cher_64", "library");
@@ -1632,7 +1634,9 @@ sub rocSubstitutions {
     subst("cublasCsymv_v2_64", "rocblas_csymv_64", "library");
     subst("cublasCsyr", "rocblas_csyr", "library");
     subst("cublasCsyr2", "rocblas_csyr2", "library");
+    subst("cublasCsyr2_64", "rocblas_csyr2_64", "library");
     subst("cublasCsyr2_v2", "rocblas_csyr2", "library");
+    subst("cublasCsyr2_v2_64", "rocblas_csyr2_64", "library");
     subst("cublasCsyr2k", "rocblas_csyr2k", "library");
     subst("cublasCsyr2k_v2", "rocblas_csyr2k", "library");
     subst("cublasCsyr_64", "rocblas_csyr_64", "library");
@@ -1742,7 +1746,9 @@ sub rocSubstitutions {
     subst("cublasDsymv_v2_64", "rocblas_dsymv_64", "library");
     subst("cublasDsyr", "rocblas_dsyr", "library");
     subst("cublasDsyr2", "rocblas_dsyr2", "library");
+    subst("cublasDsyr2_64", "rocblas_dsyr2_64", "library");
     subst("cublasDsyr2_v2", "rocblas_dsyr2", "library");
+    subst("cublasDsyr2_v2_64", "rocblas_dsyr2_64", "library");
     subst("cublasDsyr2k", "rocblas_dsyr2k", "library");
     subst("cublasDsyr2k_v2", "rocblas_dsyr2k", "library");
     subst("cublasDsyr_64", "rocblas_dsyr_64", "library");
@@ -1936,7 +1942,9 @@ sub rocSubstitutions {
     subst("cublasSsymv_v2_64", "rocblas_ssymv_64", "library");
     subst("cublasSsyr", "rocblas_ssyr", "library");
     subst("cublasSsyr2", "rocblas_ssyr2", "library");
+    subst("cublasSsyr2_64", "rocblas_ssyr2_64", "library");
     subst("cublasSsyr2_v2", "rocblas_ssyr2", "library");
+    subst("cublasSsyr2_v2_64", "rocblas_ssyr2_64", "library");
     subst("cublasSsyr2k", "rocblas_ssyr2k", "library");
     subst("cublasSsyr2k_v2", "rocblas_ssyr2k", "library");
     subst("cublasSsyr_64", "rocblas_ssyr_64", "library");
@@ -2028,7 +2036,9 @@ sub rocSubstitutions {
     subst("cublasZhemv_v2_64", "rocblas_zhemv_64", "library");
     subst("cublasZher", "rocblas_zher", "library");
     subst("cublasZher2", "rocblas_zher2", "library");
+    subst("cublasZher2_64", "rocblas_zher2_64", "library");
     subst("cublasZher2_v2", "rocblas_zher2", "library");
+    subst("cublasZher2_v2_64", "rocblas_zher2_64", "library");
     subst("cublasZher2k", "rocblas_zher2k", "library");
     subst("cublasZher2k_v2", "rocblas_zher2k", "library");
     subst("cublasZher_64", "rocblas_zher_64", "library");
@@ -2065,7 +2075,9 @@ sub rocSubstitutions {
     subst("cublasZsymv_v2_64", "rocblas_zsymv_64", "library");
     subst("cublasZsyr", "rocblas_zsyr", "library");
     subst("cublasZsyr2", "rocblas_zsyr2", "library");
+    subst("cublasZsyr2_64", "rocblas_zsyr2_64", "library");
     subst("cublasZsyr2_v2", "rocblas_zsyr2", "library");
+    subst("cublasZsyr2_v2_64", "rocblas_zsyr2_64", "library");
     subst("cublasZsyr2k", "rocblas_zsyr2k", "library");
     subst("cublasZsyr2k_v2", "rocblas_zsyr2k", "library");
     subst("cublasZsyr_64", "rocblas_zsyr_64", "library");
@@ -12578,8 +12590,6 @@ sub warnRocOnlyUnsupportedFunctions {
         "cublasZsyrk_64",
         "cublasZsyr2k_v2_64",
         "cublasZsyr2k_64",
-        "cublasZsyr2_v2_64",
-        "cublasZsyr2_64",
         "cublasZsymm_v2_64",
         "cublasZsymm_64",
         "cublasZmatinvBatched",
@@ -12594,8 +12604,6 @@ sub warnRocOnlyUnsupportedFunctions {
         "cublasZherk_64",
         "cublasZher2k_v2_64",
         "cublasZher2k_64",
-        "cublasZher2_v2_64",
-        "cublasZher2_64",
         "cublasZhemm_v2_64",
         "cublasZhemm_64",
         "cublasZgetrsBatched",
@@ -12643,8 +12651,6 @@ sub warnRocOnlyUnsupportedFunctions {
         "cublasSsyrk_64",
         "cublasSsyr2k_v2_64",
         "cublasSsyr2k_64",
-        "cublasSsyr2_v2_64",
-        "cublasSsyr2_64",
         "cublasSsymm_v2_64",
         "cublasSsymm_64",
         "cublasSspr_v2_64",
@@ -12798,8 +12804,6 @@ sub warnRocOnlyUnsupportedFunctions {
         "cublasDsyrk_64",
         "cublasDsyr2k_v2_64",
         "cublasDsyr2k_64",
-        "cublasDsyr2_v2_64",
-        "cublasDsyr2_64",
         "cublasDsymm_v2_64",
         "cublasDsymm_64",
         "cublasDspr_v2_64",
@@ -12852,8 +12856,6 @@ sub warnRocOnlyUnsupportedFunctions {
         "cublasCsyrk3mEx",
         "cublasCsyr2k_v2_64",
         "cublasCsyr2k_64",
-        "cublasCsyr2_v2_64",
-        "cublasCsyr2_64",
         "cublasCsymm_v2_64",
         "cublasCsymm_64",
         "cublasCopyEx_64",
@@ -12874,8 +12876,6 @@ sub warnRocOnlyUnsupportedFunctions {
         "cublasCherk3mEx",
         "cublasCher2k_v2_64",
         "cublasCher2k_64",
-        "cublasCher2_v2_64",
-        "cublasCher2_64",
         "cublasChemm_v2_64",
         "cublasChemm_64",
         "cublasCgetrsBatched",

--- a/docs/tables/CUBLAS_API_supported_by_HIP_and_ROC.md
+++ b/docs/tables/CUBLAS_API_supported_by_HIP_and_ROC.md
@@ -748,9 +748,9 @@
 |`cublasChemv_v2_64`|12.0| | | |`hipblasChemv_v2_64`|6.2.0| | | | |`rocblas_chemv_64`|6.2.0| | | | |
 |`cublasCher`| | | | |`hipblasCher_v2`|6.0.0| | | | |`rocblas_cher`|3.5.0| | | | |
 |`cublasCher2`| | | | |`hipblasCher2_v2`|6.0.0| | | | |`rocblas_cher2`|3.5.0| | | | |
-|`cublasCher2_64`|12.0| | | |`hipblasCher2_v2_64`|6.2.0| | | | | | | | | | |
+|`cublasCher2_64`|12.0| | | |`hipblasCher2_v2_64`|6.2.0| | | | |`rocblas_cher2_64`|6.2.0| | | | |
 |`cublasCher2_v2`| | | | |`hipblasCher2_v2`|6.0.0| | | | |`rocblas_cher2`|3.5.0| | | | |
-|`cublasCher2_v2_64`|12.0| | | |`hipblasCher2_v2_64`|6.2.0| | | | | | | | | | |
+|`cublasCher2_v2_64`|12.0| | | |`hipblasCher2_v2_64`|6.2.0| | | | |`rocblas_cher2_64`|6.2.0| | | | |
 |`cublasCher_64`|12.0| | | |`hipblasCher_v2_64`|6.2.0| | | | |`rocblas_cher_64`|6.2.0| | | | |
 |`cublasCher_v2`| | | | |`hipblasCher_v2`|6.0.0| | | | |`rocblas_cher`|3.5.0| | | | |
 |`cublasCher_v2_64`|12.0| | | |`hipblasCher_v2_64`|6.2.0| | | | |`rocblas_cher_64`|6.2.0| | | | |
@@ -772,9 +772,9 @@
 |`cublasCsymv_v2_64`|12.0| | | |`hipblasCsymv_v2_64`|6.2.0| | | | |`rocblas_csymv_64`|6.2.0| | | | |
 |`cublasCsyr`| | | | |`hipblasCsyr_v2`|6.0.0| | | | |`rocblas_csyr`|1.7.1| | | | |
 |`cublasCsyr2`| | | | |`hipblasCsyr2_v2`|6.0.0| | | | |`rocblas_csyr2`|3.5.0| | | | |
-|`cublasCsyr2_64`|12.0| | | |`hipblasCsyr2_v2_64`|6.2.0| | | | | | | | | | |
+|`cublasCsyr2_64`|12.0| | | |`hipblasCsyr2_v2_64`|6.2.0| | | | |`rocblas_csyr2_64`|6.2.0| | | | |
 |`cublasCsyr2_v2`| | | | |`hipblasCsyr2_v2`|6.0.0| | | | |`rocblas_csyr2`|3.5.0| | | | |
-|`cublasCsyr2_v2_64`|12.0| | | |`hipblasCsyr2_v2_64`|6.2.0| | | | | | | | | | |
+|`cublasCsyr2_v2_64`|12.0| | | |`hipblasCsyr2_v2_64`|6.2.0| | | | |`rocblas_csyr2_64`|6.2.0| | | | |
 |`cublasCsyr_64`|12.0| | | |`hipblasCsyr_v2_64`|6.2.0| | | | |`rocblas_csyr_64`|6.2.0| | | | |
 |`cublasCsyr_v2`| | | | |`hipblasCsyr_v2`|6.0.0| | | | |`rocblas_csyr`|1.7.1| | | | |
 |`cublasCsyr_v2_64`|12.0| | | |`hipblasCsyr_v2_64`|6.2.0| | | | |`rocblas_csyr_64`|6.2.0| | | | |
@@ -836,9 +836,9 @@
 |`cublasDsymv_v2_64`|12.0| | | |`hipblasDsymv_64`|6.2.0| | | | |`rocblas_dsymv_64`|6.2.0| | | | |
 |`cublasDsyr`| | | | |`hipblasDsyr`|3.0.0| | | | |`rocblas_dsyr`|1.7.1| | | | |
 |`cublasDsyr2`| | | | |`hipblasDsyr2`|3.5.0| | | | |`rocblas_dsyr2`|3.5.0| | | | |
-|`cublasDsyr2_64`|12.0| | | |`hipblasDsyr2_64`|6.2.0| | | | | | | | | | |
+|`cublasDsyr2_64`|12.0| | | |`hipblasDsyr2_64`|6.2.0| | | | |`rocblas_dsyr2_64`|6.2.0| | | | |
 |`cublasDsyr2_v2`| | | | |`hipblasDsyr2`|3.5.0| | | | |`rocblas_dsyr2`|3.5.0| | | | |
-|`cublasDsyr2_v2_64`|12.0| | | |`hipblasDsyr2_64`|6.2.0| | | | | | | | | | |
+|`cublasDsyr2_v2_64`|12.0| | | |`hipblasDsyr2_64`|6.2.0| | | | |`rocblas_dsyr2_64`|6.2.0| | | | |
 |`cublasDsyr_64`|12.0| | | |`hipblasDsyr_64`|6.2.0| | | | |`rocblas_dsyr_64`|6.2.0| | | | |
 |`cublasDsyr_v2`| | | | |`hipblasDsyr`|3.0.0| | | | |`rocblas_dsyr`|1.7.1| | | | |
 |`cublasDsyr_v2_64`|12.0| | | |`hipblasDsyr_64`|6.2.0| | | | |`rocblas_dsyr_64`|6.2.0| | | | |
@@ -900,9 +900,9 @@
 |`cublasSsymv_v2_64`|12.0| | | |`hipblasSsymv_64`|6.2.0| | | | |`rocblas_ssymv_64`|6.2.0| | | | |
 |`cublasSsyr`| | | | |`hipblasSsyr`|3.0.0| | | | |`rocblas_ssyr`|1.7.1| | | | |
 |`cublasSsyr2`| | | | |`hipblasSsyr2`|3.5.0| | | | |`rocblas_ssyr2`|3.5.0| | | | |
-|`cublasSsyr2_64`|12.0| | | |`hipblasSsyr2_64`|6.2.0| | | | | | | | | | |
+|`cublasSsyr2_64`|12.0| | | |`hipblasSsyr2_64`|6.2.0| | | | |`rocblas_ssyr2_64`|6.2.0| | | | |
 |`cublasSsyr2_v2`| | | | |`hipblasSsyr2`|3.5.0| | | | |`rocblas_ssyr2`|3.5.0| | | | |
-|`cublasSsyr2_v2_64`|12.0| | | |`hipblasSsyr2_64`|6.2.0| | | | | | | | | | |
+|`cublasSsyr2_v2_64`|12.0| | | |`hipblasSsyr2_64`|6.2.0| | | | |`rocblas_ssyr2_64`|6.2.0| | | | |
 |`cublasSsyr_64`|12.0| | | |`hipblasSsyr_64`|6.2.0| | | | |`rocblas_ssyr_64`|6.2.0| | | | |
 |`cublasSsyr_v2`| | | | |`hipblasSsyr`|3.0.0| | | | |`rocblas_ssyr`|1.7.1| | | | |
 |`cublasSsyr_v2_64`|12.0| | | |`hipblasSsyr_64`|6.2.0| | | | |`rocblas_ssyr_64`|6.2.0| | | | |
@@ -956,9 +956,9 @@
 |`cublasZhemv_v2_64`|12.0| | | |`hipblasZhemv_v2_64`|6.2.0| | | | |`rocblas_zhemv_64`|6.2.0| | | | |
 |`cublasZher`| | | | |`hipblasZher_v2`|6.0.0| | | | |`rocblas_zher`|3.5.0| | | | |
 |`cublasZher2`| | | | |`hipblasZher2_v2`|6.0.0| | | | |`rocblas_zher2`|3.5.0| | | | |
-|`cublasZher2_64`|12.0| | | |`hipblasZher2_v2_64`|6.2.0| | | | | | | | | | |
+|`cublasZher2_64`|12.0| | | |`hipblasZher2_v2_64`|6.2.0| | | | |`rocblas_zher2_64`|6.2.0| | | | |
 |`cublasZher2_v2`| | | | |`hipblasZher2_v2`|6.0.0| | | | |`rocblas_zher2`|3.5.0| | | | |
-|`cublasZher2_v2_64`|12.0| | | |`hipblasZher2_v2_64`|6.2.0| | | | | | | | | | |
+|`cublasZher2_v2_64`|12.0| | | |`hipblasZher2_v2_64`|6.2.0| | | | |`rocblas_zher2_64`|6.2.0| | | | |
 |`cublasZher_64`|12.0| | | |`hipblasZher_v2_64`|6.2.0| | | | |`rocblas_zher_64`|6.2.0| | | | |
 |`cublasZher_v2`| | | | |`hipblasZher_v2`|6.0.0| | | | |`rocblas_zher`|3.5.0| | | | |
 |`cublasZher_v2_64`|12.0| | | |`hipblasZher_v2_64`|6.2.0| | | | |`rocblas_zher_64`|6.2.0| | | | |
@@ -980,9 +980,9 @@
 |`cublasZsymv_v2_64`|12.0| | | |`hipblasZsymv_v2_64`|6.2.0| | | | |`rocblas_zsymv_64`|6.2.0| | | | |
 |`cublasZsyr`| | | | |`hipblasZsyr_v2`|6.0.0| | | | |`rocblas_zsyr`|1.7.1| | | | |
 |`cublasZsyr2`| | | | |`hipblasZsyr2_v2`|6.0.0| | | | |`rocblas_zsyr2`|3.5.0| | | | |
-|`cublasZsyr2_64`|12.0| | | |`hipblasZsyr2_v2_64`|6.2.0| | | | | | | | | | |
+|`cublasZsyr2_64`|12.0| | | |`hipblasZsyr2_v2_64`|6.2.0| | | | |`rocblas_zsyr2_64`|6.2.0| | | | |
 |`cublasZsyr2_v2`| | | | |`hipblasZsyr2_v2`|6.0.0| | | | |`rocblas_zsyr2`|3.5.0| | | | |
-|`cublasZsyr2_v2_64`|12.0| | | |`hipblasZsyr2_v2_64`|6.2.0| | | | | | | | | | |
+|`cublasZsyr2_v2_64`|12.0| | | |`hipblasZsyr2_v2_64`|6.2.0| | | | |`rocblas_zsyr2_64`|6.2.0| | | | |
 |`cublasZsyr_64`|12.0| | | |`hipblasZsyr_v2_64`|6.2.0| | | | |`rocblas_zsyr_64`|6.2.0| | | | |
 |`cublasZsyr_v2`| | | | |`hipblasZsyr_v2`|6.0.0| | | | |`rocblas_zsyr`|1.7.1| | | | |
 |`cublasZsyr_v2_64`|12.0| | | |`hipblasZsyr_v2_64`|6.2.0| | | | |`rocblas_zsyr_64`|6.2.0| | | | |

--- a/docs/tables/CUBLAS_API_supported_by_ROC.md
+++ b/docs/tables/CUBLAS_API_supported_by_ROC.md
@@ -748,9 +748,9 @@
 |`cublasChemv_v2_64`|12.0| | | |`rocblas_chemv_64`|6.2.0| | | | |
 |`cublasCher`| | | | |`rocblas_cher`|3.5.0| | | | |
 |`cublasCher2`| | | | |`rocblas_cher2`|3.5.0| | | | |
-|`cublasCher2_64`|12.0| | | | | | | | | |
+|`cublasCher2_64`|12.0| | | |`rocblas_cher2_64`|6.2.0| | | | |
 |`cublasCher2_v2`| | | | |`rocblas_cher2`|3.5.0| | | | |
-|`cublasCher2_v2_64`|12.0| | | | | | | | | |
+|`cublasCher2_v2_64`|12.0| | | |`rocblas_cher2_64`|6.2.0| | | | |
 |`cublasCher_64`|12.0| | | |`rocblas_cher_64`|6.2.0| | | | |
 |`cublasCher_v2`| | | | |`rocblas_cher`|3.5.0| | | | |
 |`cublasCher_v2_64`|12.0| | | |`rocblas_cher_64`|6.2.0| | | | |
@@ -772,9 +772,9 @@
 |`cublasCsymv_v2_64`|12.0| | | |`rocblas_csymv_64`|6.2.0| | | | |
 |`cublasCsyr`| | | | |`rocblas_csyr`|1.7.1| | | | |
 |`cublasCsyr2`| | | | |`rocblas_csyr2`|3.5.0| | | | |
-|`cublasCsyr2_64`|12.0| | | | | | | | | |
+|`cublasCsyr2_64`|12.0| | | |`rocblas_csyr2_64`|6.2.0| | | | |
 |`cublasCsyr2_v2`| | | | |`rocblas_csyr2`|3.5.0| | | | |
-|`cublasCsyr2_v2_64`|12.0| | | | | | | | | |
+|`cublasCsyr2_v2_64`|12.0| | | |`rocblas_csyr2_64`|6.2.0| | | | |
 |`cublasCsyr_64`|12.0| | | |`rocblas_csyr_64`|6.2.0| | | | |
 |`cublasCsyr_v2`| | | | |`rocblas_csyr`|1.7.1| | | | |
 |`cublasCsyr_v2_64`|12.0| | | |`rocblas_csyr_64`|6.2.0| | | | |
@@ -836,9 +836,9 @@
 |`cublasDsymv_v2_64`|12.0| | | |`rocblas_dsymv_64`|6.2.0| | | | |
 |`cublasDsyr`| | | | |`rocblas_dsyr`|1.7.1| | | | |
 |`cublasDsyr2`| | | | |`rocblas_dsyr2`|3.5.0| | | | |
-|`cublasDsyr2_64`|12.0| | | | | | | | | |
+|`cublasDsyr2_64`|12.0| | | |`rocblas_dsyr2_64`|6.2.0| | | | |
 |`cublasDsyr2_v2`| | | | |`rocblas_dsyr2`|3.5.0| | | | |
-|`cublasDsyr2_v2_64`|12.0| | | | | | | | | |
+|`cublasDsyr2_v2_64`|12.0| | | |`rocblas_dsyr2_64`|6.2.0| | | | |
 |`cublasDsyr_64`|12.0| | | |`rocblas_dsyr_64`|6.2.0| | | | |
 |`cublasDsyr_v2`| | | | |`rocblas_dsyr`|1.7.1| | | | |
 |`cublasDsyr_v2_64`|12.0| | | |`rocblas_dsyr_64`|6.2.0| | | | |
@@ -900,9 +900,9 @@
 |`cublasSsymv_v2_64`|12.0| | | |`rocblas_ssymv_64`|6.2.0| | | | |
 |`cublasSsyr`| | | | |`rocblas_ssyr`|1.7.1| | | | |
 |`cublasSsyr2`| | | | |`rocblas_ssyr2`|3.5.0| | | | |
-|`cublasSsyr2_64`|12.0| | | | | | | | | |
+|`cublasSsyr2_64`|12.0| | | |`rocblas_ssyr2_64`|6.2.0| | | | |
 |`cublasSsyr2_v2`| | | | |`rocblas_ssyr2`|3.5.0| | | | |
-|`cublasSsyr2_v2_64`|12.0| | | | | | | | | |
+|`cublasSsyr2_v2_64`|12.0| | | |`rocblas_ssyr2_64`|6.2.0| | | | |
 |`cublasSsyr_64`|12.0| | | |`rocblas_ssyr_64`|6.2.0| | | | |
 |`cublasSsyr_v2`| | | | |`rocblas_ssyr`|1.7.1| | | | |
 |`cublasSsyr_v2_64`|12.0| | | |`rocblas_ssyr_64`|6.2.0| | | | |
@@ -956,9 +956,9 @@
 |`cublasZhemv_v2_64`|12.0| | | |`rocblas_zhemv_64`|6.2.0| | | | |
 |`cublasZher`| | | | |`rocblas_zher`|3.5.0| | | | |
 |`cublasZher2`| | | | |`rocblas_zher2`|3.5.0| | | | |
-|`cublasZher2_64`|12.0| | | | | | | | | |
+|`cublasZher2_64`|12.0| | | |`rocblas_zher2_64`|6.2.0| | | | |
 |`cublasZher2_v2`| | | | |`rocblas_zher2`|3.5.0| | | | |
-|`cublasZher2_v2_64`|12.0| | | | | | | | | |
+|`cublasZher2_v2_64`|12.0| | | |`rocblas_zher2_64`|6.2.0| | | | |
 |`cublasZher_64`|12.0| | | |`rocblas_zher_64`|6.2.0| | | | |
 |`cublasZher_v2`| | | | |`rocblas_zher`|3.5.0| | | | |
 |`cublasZher_v2_64`|12.0| | | |`rocblas_zher_64`|6.2.0| | | | |
@@ -980,9 +980,9 @@
 |`cublasZsymv_v2_64`|12.0| | | |`rocblas_zsymv_64`|6.2.0| | | | |
 |`cublasZsyr`| | | | |`rocblas_zsyr`|1.7.1| | | | |
 |`cublasZsyr2`| | | | |`rocblas_zsyr2`|3.5.0| | | | |
-|`cublasZsyr2_64`|12.0| | | | | | | | | |
+|`cublasZsyr2_64`|12.0| | | |`rocblas_zsyr2_64`|6.2.0| | | | |
 |`cublasZsyr2_v2`| | | | |`rocblas_zsyr2`|3.5.0| | | | |
-|`cublasZsyr2_v2_64`|12.0| | | | | | | | | |
+|`cublasZsyr2_v2_64`|12.0| | | |`rocblas_zsyr2_64`|6.2.0| | | | |
 |`cublasZsyr_64`|12.0| | | |`rocblas_zsyr_64`|6.2.0| | | | |
 |`cublasZsyr_v2`| | | | |`rocblas_zsyr`|1.7.1| | | | |
 |`cublasZsyr_v2_64`|12.0| | | |`rocblas_zsyr_64`|6.2.0| | | | |

--- a/src/CUDA2HIP_BLAS_API_functions.cpp
+++ b/src/CUDA2HIP_BLAS_API_functions.cpp
@@ -374,17 +374,17 @@ const std::map<llvm::StringRef, hipCounter> CUDA_BLAS_FUNCTION_MAP {
 
   // SYR2/HER2
   {"cublasSsyr2",                                          {"hipblasSsyr2",                                              "rocblas_ssyr2",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, HIP_SUPPORTED_V2_ONLY}},
-  {"cublasSsyr2_64",                                       {"hipblasSsyr2_64",                                           "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
+  {"cublasSsyr2_64",                                       {"hipblasSsyr2_64",                                           "rocblas_ssyr2_64",                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
   {"cublasDsyr2",                                          {"hipblasDsyr2",                                              "rocblas_dsyr2",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, HIP_SUPPORTED_V2_ONLY}},
-  {"cublasDsyr2_64",                                       {"hipblasDsyr2_64",                                           "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
+  {"cublasDsyr2_64",                                       {"hipblasDsyr2_64",                                           "rocblas_dsyr2_64",                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
   {"cublasCsyr2",                                          {"hipblasCsyr2_v2",                                           "rocblas_csyr2",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, HIP_SUPPORTED_V2_ONLY}},
-  {"cublasCsyr2_64",                                       {"hipblasCsyr2_v2_64",                                        "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
+  {"cublasCsyr2_64",                                       {"hipblasCsyr2_v2_64",                                        "rocblas_csyr2_64",                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
   {"cublasZsyr2",                                          {"hipblasZsyr2_v2",                                           "rocblas_zsyr2",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, HIP_SUPPORTED_V2_ONLY}},
-  {"cublasZsyr2_64",                                       {"hipblasZsyr2_v2_64",                                        "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
+  {"cublasZsyr2_64",                                       {"hipblasZsyr2_v2_64",                                        "rocblas_zsyr2_64",                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
   {"cublasCher2",                                          {"hipblasCher2_v2",                                           "rocblas_cher2",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, HIP_SUPPORTED_V2_ONLY}},
-  {"cublasCher2_64",                                       {"hipblasCher2_v2_64",                                        "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
+  {"cublasCher2_64",                                       {"hipblasCher2_v2_64",                                        "rocblas_cher2_64",                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
   {"cublasZher2",                                          {"hipblasZher2_v2",                                           "rocblas_zher2",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, HIP_SUPPORTED_V2_ONLY}},
-  {"cublasZher2_64",                                       {"hipblasZher2_v2_64",                                        "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
+  {"cublasZher2_64",                                       {"hipblasZher2_v2_64",                                        "rocblas_zher2_64",                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
 
   // SPR2/HPR2
   {"cublasSspr2",                                          {"hipblasSspr2",                                              "rocblas_sspr2",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, HIP_SUPPORTED_V2_ONLY}},
@@ -792,17 +792,17 @@ const std::map<llvm::StringRef, hipCounter> CUDA_BLAS_FUNCTION_MAP {
 
   // SYR2/HER2
   {"cublasSsyr2_v2",                                       {"hipblasSsyr2",                                              "rocblas_ssyr2",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
-  {"cublasSsyr2_v2_64",                                    {"hipblasSsyr2_64",                                           "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
+  {"cublasSsyr2_v2_64",                                    {"hipblasSsyr2_64",                                           "rocblas_ssyr2_64",                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
   {"cublasDsyr2_v2",                                       {"hipblasDsyr2",                                              "rocblas_dsyr2",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
-  {"cublasDsyr2_v2_64",                                    {"hipblasDsyr2_64",                                           "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
+  {"cublasDsyr2_v2_64",                                    {"hipblasDsyr2_64",                                           "rocblas_dsyr2_64",                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
   {"cublasCsyr2_v2",                                       {"hipblasCsyr2_v2",                                           "rocblas_csyr2",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
-  {"cublasCsyr2_v2_64",                                    {"hipblasCsyr2_v2_64",                                        "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
+  {"cublasCsyr2_v2_64",                                    {"hipblasCsyr2_v2_64",                                        "rocblas_csyr2_64",                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
   {"cublasZsyr2_v2",                                       {"hipblasZsyr2_v2",                                           "rocblas_zsyr2",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
-  {"cublasZsyr2_v2_64",                                    {"hipblasZsyr2_v2_64",                                        "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
+  {"cublasZsyr2_v2_64",                                    {"hipblasZsyr2_v2_64",                                        "rocblas_zsyr2_64",                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
   {"cublasCher2_v2",                                       {"hipblasCher2_v2",                                           "rocblas_cher2",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
-  {"cublasCher2_v2_64",                                    {"hipblasCher2_v2_64",                                        "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
+  {"cublasCher2_v2_64",                                    {"hipblasCher2_v2_64",                                        "rocblas_cher2_64",                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
   {"cublasZher2_v2",                                       {"hipblasZher2_v2",                                           "rocblas_zher2",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
-  {"cublasZher2_v2_64",                                    {"hipblasZher2_v2_64",                                        "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
+  {"cublasZher2_v2_64",                                    {"hipblasZher2_v2_64",                                        "rocblas_zher2_64",                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
 
   // SPR2/HPR2
   {"cublasSspr2_v2",                                       {"hipblasSspr2",                                              "rocblas_sspr2",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
@@ -2355,6 +2355,12 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_BLAS_FUNCTION_VER_MAP {
   {"rocblas_zsyr_64",                                      {HIP_6020, HIP_0,    HIP_0   }},
   {"rocblas_cher_64",                                      {HIP_6020, HIP_0,    HIP_0   }},
   {"rocblas_zher_64",                                      {HIP_6020, HIP_0,    HIP_0   }},
+  {"rocblas_ssyr2_64",                                     {HIP_6020, HIP_0,    HIP_0   }},
+  {"rocblas_dsyr2_64",                                     {HIP_6020, HIP_0,    HIP_0   }},
+  {"rocblas_csyr2_64",                                     {HIP_6020, HIP_0,    HIP_0   }},
+  {"rocblas_zsyr2_64",                                     {HIP_6020, HIP_0,    HIP_0   }},
+  {"rocblas_cher2_64",                                     {HIP_6020, HIP_0,    HIP_0   }},
+  {"rocblas_zher2_64",                                     {HIP_6020, HIP_0,    HIP_0   }},
 };
 
 const std::map<llvm::StringRef, hipAPIChangedVersions> HIP_BLAS_FUNCTION_CHANGED_VER_MAP {

--- a/tests/unit_tests/synthetic/libraries/cublas2rocblas_v2.cu
+++ b/tests/unit_tests/synthetic/libraries/cublas2rocblas_v2.cu
@@ -2643,6 +2643,48 @@ int main() {
   // CHECK-NEXT: blasStatus = rocblas_zher_64(blasHandle, blasFillMode, n_64, &da, &dcomplexx, incx_64, &dcomplexA, lda_64);
   blasStatus = cublasZher_64(blasHandle, blasFillMode, n_64, &da, &dcomplexx, incx_64, &dcomplexA, lda_64);
   blasStatus = cublasZher_v2_64(blasHandle, blasFillMode, n_64, &da, &dcomplexx, incx_64, &dcomplexA, lda_64);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasSsyr2_v2_64(cublasHandle_t handle, cublasFillMode_t uplo, int64_t n, const float* alpha, const float* x, int64_t incx, const float* y, int64_t incy, float* A, int64_t lda);
+  // ROC: ROCBLAS_EXPORT rocblas_status rocblas_ssyr2_64(rocblas_handle handle, rocblas_fill uplo, int64_t n, const float* alpha, const float* x, int64_t incx, const float* y, int64_t incy, float* A, int64_t lda);
+  // CHECK: blasStatus = rocblas_ssyr2_64(blasHandle, blasFillMode, n_64, &fa, &fx, incx_64, &fy, incy_64, &fA, lda_64);
+  // CHECK-NEXT: blasStatus = rocblas_ssyr2_64(blasHandle, blasFillMode, n_64, &fa, &fx, incx_64, &fy, incy_64, &fA, lda_64);
+  blasStatus = cublasSsyr2_64(blasHandle, blasFillMode, n_64, &fa, &fx, incx_64, &fy, incy_64, &fA, lda_64);
+  blasStatus = cublasSsyr2_v2_64(blasHandle, blasFillMode, n_64, &fa, &fx, incx_64, &fy, incy_64, &fA, lda_64);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasDsyr2_v2_64(cublasHandle_t handle, cublasFillMode_t uplo, int64_t n, const double* alpha, const double* x, int64_t incx, const double* y, int64_t incy, double* A, int64_t lda);
+  // ROC: ROCBLAS_EXPORT rocblas_status rocblas_dsyr2_64(rocblas_handle handle, rocblas_fill uplo, int64_t n, const double* alpha, const double* x, int64_t incx, const double* y, int64_t incy, double* A, int64_t lda);
+  // CHECK: blasStatus = rocblas_dsyr2_64(blasHandle, blasFillMode, n_64, &da, &dx, incx_64, &dy, incy_64, &dA, lda_64);
+  // CHECK-NEXT: blasStatus = rocblas_dsyr2_64(blasHandle, blasFillMode, n_64, &da, &dx, incx_64, &dy, incy_64, &dA, lda_64);
+  blasStatus = cublasDsyr2_64(blasHandle, blasFillMode, n_64, &da, &dx, incx_64, &dy, incy_64, &dA, lda_64);
+  blasStatus = cublasDsyr2_v2_64(blasHandle, blasFillMode, n_64, &da, &dx, incx_64, &dy, incy_64, &dA, lda_64);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasCsyr2_v2_64(cublasHandle_t handle, cublasFillMode_t uplo, int64_t n, const cuComplex* alpha, const cuComplex* x, int64_t incx, const cuComplex* y, int64_t incy, cuComplex* A, int64_t lda);
+  // ROC: ROCBLAS_EXPORT rocblas_status rocblas_csyr2_64(rocblas_handle handle, rocblas_fill uplo, int64_t n, const rocblas_float_complex* alpha, const rocblas_float_complex* x, int64_t incx, const rocblas_float_complex* y, int64_t incy, rocblas_float_complex* A, int64_t lda);
+  // CHECK: blasStatus = rocblas_csyr2_64(blasHandle, blasFillMode, n_64, &complexa, &complexx, incx_64, &complexy, incy_64, &complexA, lda_64);
+  // CHECK-NEXT: blasStatus = rocblas_csyr2_64(blasHandle, blasFillMode, n_64, &complexa, &complexx, incx_64, &complexy, incy_64, &complexA, lda_64);
+  blasStatus = cublasCsyr2_64(blasHandle, blasFillMode, n_64, &complexa, &complexx, incx_64, &complexy, incy_64, &complexA, lda_64);
+  blasStatus = cublasCsyr2_v2_64(blasHandle, blasFillMode, n_64, &complexa, &complexx, incx_64, &complexy, incy_64, &complexA, lda_64);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasZsyr2_v2_64(cublasHandle_t handle, cublasFillMode_t uplo, int64_t n, const cuDoubleComplex* alpha, const cuDoubleComplex* x, int64_t incx, const cuDoubleComplex* y, int64_t incy, cuDoubleComplex* A, int64_t lda);
+  // ROC: ROCBLAS_EXPORT rocblas_status rocblas_zsyr2_64(rocblas_handle handle, rocblas_fill uplo, int64_t n, const rocblas_double_complex* alpha, const rocblas_double_complex* x, int64_t incx, const rocblas_double_complex* y, int64_t incy, rocblas_double_complex* A, int64_t lda);
+  // CHECK: blasStatus = rocblas_zsyr2_64(blasHandle, blasFillMode, n_64, &dcomplexa, &dcomplexx, incx_64, &dcomplexy, incy_64, &dcomplexA, lda_64);
+  // CHECK-NEXT: blasStatus = rocblas_zsyr2_64(blasHandle, blasFillMode, n_64, &dcomplexa, &dcomplexx, incx_64, &dcomplexy, incy_64, &dcomplexA, lda_64);
+  blasStatus = cublasZsyr2_64(blasHandle, blasFillMode, n_64, &dcomplexa, &dcomplexx, incx_64, &dcomplexy, incy_64, &dcomplexA, lda_64);
+  blasStatus = cublasZsyr2_v2_64(blasHandle, blasFillMode, n_64, &dcomplexa, &dcomplexx, incx_64, &dcomplexy, incy_64, &dcomplexA, lda_64);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasCher2_v2_64(cublasHandle_t handle, cublasFillMode_t uplo, int64_t n, const cuComplex* alpha, const cuComplex* x, int64_t incx, const cuComplex* y, int64_t incy, cuComplex* A, int64_t lda);
+  // ROC: ROCBLAS_EXPORT rocblas_status rocblas_cher2_64(rocblas_handle handle, rocblas_fill uplo, int64_t n, const rocblas_float_complex* alpha, const rocblas_float_complex* x, int64_t incx, const rocblas_float_complex* y, int64_t incy, rocblas_float_complex* A, int64_t lda);
+  // CHECK: blasStatus = rocblas_cher2_64(blasHandle, blasFillMode, n_64, &complexa, &complexx, incx_64, &complexy, incy_64, &complexA, lda_64);
+  // CHECK-NEXT: blasStatus = rocblas_cher2_64(blasHandle, blasFillMode, n_64, &complexa, &complexx, incx_64, &complexy, incy_64, &complexA, lda_64);
+  blasStatus = cublasCher2_64(blasHandle, blasFillMode, n_64, &complexa, &complexx, incx_64, &complexy, incy_64, &complexA, lda_64);
+  blasStatus = cublasCher2_v2_64(blasHandle, blasFillMode, n_64, &complexa, &complexx, incx_64, &complexy, incy_64, &complexA, lda_64);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasZher2_v2_64(cublasHandle_t handle, cublasFillMode_t uplo, int64_t n, const cuDoubleComplex* alpha, const cuDoubleComplex* x, int64_t incx, const cuDoubleComplex* y, int64_t incy, cuDoubleComplex* A, int64_t lda);
+  // ROC: ROCBLAS_EXPORT rocblas_status rocblas_zher2_64(rocblas_handle handle, rocblas_fill uplo, int64_t n, const rocblas_double_complex* alpha, const rocblas_double_complex* x, int64_t incx, const rocblas_double_complex* y, int64_t incy, rocblas_double_complex* A, int64_t lda);
+  // CHECK: blasStatus = rocblas_zher2_64(blasHandle, blasFillMode, n_64, &dcomplexa, &dcomplexx, incx_64, &dcomplexy, incy_64, &dcomplexA, lda_64);
+  // CHECK-NEXT: blasStatus = rocblas_zher2_64(blasHandle, blasFillMode, n_64, &dcomplexa, &dcomplexx, incx_64, &dcomplexy, incy_64, &dcomplexA, lda_64);
+  blasStatus = cublasZher2_64(blasHandle, blasFillMode, n_64, &dcomplexa, &dcomplexx, incx_64, &dcomplexy, incy_64, &dcomplexA, lda_64);
+  blasStatus = cublasZher2_v2_64(blasHandle, blasFillMode, n_64, &dcomplexa, &dcomplexx, incx_64, &dcomplexy, incy_64, &dcomplexA, lda_64);
 #endif
 
   return 0;


### PR DESCRIPTION
+ `rocblas_(s|d|c|z)syr2_64` support
+ `rocblas_(c|z)her2_64` support
+ Updated synthetic tests, the regenerated `hipify-perl`, and `BLAS` `CUDA2HIP` documentation