### PR TITLE
[HIPIFY][rocBLAS] 64-bit functions support - Step 9

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -1597,7 +1597,9 @@ sub rocSubstitutions {
     subst("cublasCherk_v2", "rocblas_cherk", "library");
     subst("cublasCherkx", "rocblas_cherkx", "library");
     subst("cublasChpmv", "rocblas_chpmv", "library");
+    subst("cublasChpmv_64", "rocblas_chpmv_64", "library");
     subst("cublasChpmv_v2", "rocblas_chpmv", "library");
+    subst("cublasChpmv_v2_64", "rocblas_chpmv_64", "library");
     subst("cublasChpr", "rocblas_chpr", "library");
     subst("cublasChpr2", "rocblas_chpr2", "library");
     subst("cublasChpr2_v2", "rocblas_chpr2", "library");
@@ -1729,7 +1731,9 @@ sub rocSubstitutions {
     subst("cublasDscal_v2", "rocblas_dscal", "library");
     subst("cublasDscal_v2_64", "rocblas_dscal_64", "library");
     subst("cublasDspmv", "rocblas_dspmv", "library");
+    subst("cublasDspmv_64", "rocblas_dspmv_64", "library");
     subst("cublasDspmv_v2", "rocblas_dspmv", "library");
+    subst("cublasDspmv_v2_64", "rocblas_dspmv_64", "library");
     subst("cublasDspr", "rocblas_dspr", "library");
     subst("cublasDspr2", "rocblas_dspr2", "library");
     subst("cublasDspr2_v2", "rocblas_dspr2", "library");
@@ -1925,7 +1929,9 @@ sub rocSubstitutions {
     subst("cublasSscal_v2", "rocblas_sscal", "library");
     subst("cublasSscal_v2_64", "rocblas_sscal_64", "library");
     subst("cublasSspmv", "rocblas_sspmv", "library");
+    subst("cublasSspmv_64", "rocblas_sspmv_64", "library");
     subst("cublasSspmv_v2", "rocblas_sspmv", "library");
+    subst("cublasSspmv_v2_64", "rocblas_sspmv_64", "library");
     subst("cublasSspr", "rocblas_sspr", "library");
     subst("cublasSspr2", "rocblas_sspr2", "library");
     subst("cublasSspr2_v2", "rocblas_sspr2", "library");
@@ -2048,7 +2054,9 @@ sub rocSubstitutions {
     subst("cublasZherk_v2", "rocblas_zherk", "library");
     subst("cublasZherkx", "rocblas_zherkx", "library");
     subst("cublasZhpmv", "rocblas_zhpmv", "library");
+    subst("cublasZhpmv_64", "rocblas_zhpmv_64", "library");
     subst("cublasZhpmv_v2", "rocblas_zhpmv", "library");
+    subst("cublasZhpmv_v2_64", "rocblas_zhpmv_64", "library");
     subst("cublasZhpr", "rocblas_zhpr", "library");
     subst("cublasZhpr2", "rocblas_zhpr2", "library");
     subst("cublasZhpr2_v2", "rocblas_zhpr2", "library");
@@ -12597,8 +12605,6 @@ sub warnRocOnlyUnsupportedFunctions {
         "cublasZhpr_64",
         "cublasZhpr2_v2_64",
         "cublasZhpr2_64",
-        "cublasZhpmv_v2_64",
-        "cublasZhpmv_64",
         "cublasZherkx_64",
         "cublasZherk_v2_64",
         "cublasZherk_64",
@@ -12657,8 +12663,6 @@ sub warnRocOnlyUnsupportedFunctions {
         "cublasSspr_64",
         "cublasSspr2_v2_64",
         "cublasSspr2_64",
-        "cublasSspmv_v2_64",
-        "cublasSspmv_64",
         "cublasSmatinvBatched",
         "cublasShutdown",
         "cublasSgetrsBatched",
@@ -12810,8 +12814,6 @@ sub warnRocOnlyUnsupportedFunctions {
         "cublasDspr_64",
         "cublasDspr2_v2_64",
         "cublasDspr2_64",
-        "cublasDspmv_v2_64",
-        "cublasDspmv_64",
         "cublasDmatinvBatched",
         "cublasDgetrsBatched",
         "cublasDgetriBatched",
@@ -12865,8 +12867,6 @@ sub warnRocOnlyUnsupportedFunctions {
         "cublasChpr_64",
         "cublasChpr2_v2_64",
         "cublasChpr2_64",
-        "cublasChpmv_v2_64",
-        "cublasChpmv_64",
         "cublasCherkx_64",
         "cublasCherk_v2_64",
         "cublasCherk_64",

--- a/docs/tables/CUBLAS_API_supported_by_HIP_and_ROC.md
+++ b/docs/tables/CUBLAS_API_supported_by_HIP_and_ROC.md
@@ -755,9 +755,9 @@
 |`cublasCher_v2`| | | | |`hipblasCher_v2`|6.0.0| | | | |`rocblas_cher`|3.5.0| | | | |
 |`cublasCher_v2_64`|12.0| | | |`hipblasCher_v2_64`|6.2.0| | | | |`rocblas_cher_64`|6.2.0| | | | |
 |`cublasChpmv`| | | | |`hipblasChpmv_v2`|6.0.0| | | | |`rocblas_chpmv`|3.5.0| | | | |
-|`cublasChpmv_64`|12.0| | | |`hipblasChpmv_v2_64`|6.2.0| | | | | | | | | | |
+|`cublasChpmv_64`|12.0| | | |`hipblasChpmv_v2_64`|6.2.0| | | | |`rocblas_chpmv_64`|6.2.0| | | | |
 |`cublasChpmv_v2`| | | | |`hipblasChpmv_v2`|6.0.0| | | | |`rocblas_chpmv`|3.5.0| | | | |
-|`cublasChpmv_v2_64`|12.0| | | |`hipblasChpmv_v2_64`|6.2.0| | | | | | | | | | |
+|`cublasChpmv_v2_64`|12.0| | | |`hipblasChpmv_v2_64`|6.2.0| | | | |`rocblas_chpmv_64`|6.2.0| | | | |
 |`cublasChpr`| | | | |`hipblasChpr_v2`|6.0.0| | | | |`rocblas_chpr`|3.5.0| | | | |
 |`cublasChpr2`| | | | |`hipblasChpr2_v2`|6.0.0| | | | |`rocblas_chpr2`|3.5.0| | | | |
 |`cublasChpr2_64`|12.0| | | |`hipblasChpr2_v2_64`|6.2.0| | | | | | | | | | |
@@ -819,9 +819,9 @@
 |`cublasDsbmv_v2`| | | | |`hipblasDsbmv`|3.5.0| | | | |`rocblas_dsbmv`|3.5.0| | | | |
 |`cublasDsbmv_v2_64`|12.0| | | |`hipblasDsbmv_64`|6.2.0| | | | |`rocblas_dsbmv_64`|6.2.0| | | | |
 |`cublasDspmv`| | | | |`hipblasDspmv`|3.5.0| | | | |`rocblas_dspmv`|3.5.0| | | | |
-|`cublasDspmv_64`|12.0| | | |`hipblasDspmv_64`|6.2.0| | | | | | | | | | |
+|`cublasDspmv_64`|12.0| | | |`hipblasDspmv_64`|6.2.0| | | | |`rocblas_dspmv_64`|6.2.0| | | | |
 |`cublasDspmv_v2`| | | | |`hipblasDspmv`|3.5.0| | | | |`rocblas_dspmv`|3.5.0| | | | |
-|`cublasDspmv_v2_64`|12.0| | | |`hipblasDspmv_64`|6.2.0| | | | | | | | | | |
+|`cublasDspmv_v2_64`|12.0| | | |`hipblasDspmv_64`|6.2.0| | | | |`rocblas_dspmv_64`|6.2.0| | | | |
 |`cublasDspr`| | | | |`hipblasDspr`|3.5.0| | | | |`rocblas_dspr`|3.5.0| | | | |
 |`cublasDspr2`| | | | |`hipblasDspr2`|3.5.0| | | | |`rocblas_dspr2`|3.5.0| | | | |
 |`cublasDspr2_64`|12.0| | | |`hipblasDspr2_64`|6.2.0| | | | | | | | | | |
@@ -883,9 +883,9 @@
 |`cublasSsbmv_v2`| | | | |`hipblasSsbmv`|3.5.0| | | | |`rocblas_ssbmv`|3.5.0| | | | |
 |`cublasSsbmv_v2_64`|12.0| | | |`hipblasSsbmv_64`|6.2.0| | | | |`rocblas_ssbmv_64`|6.2.0| | | | |
 |`cublasSspmv`| | | | |`hipblasSspmv`|3.5.0| | | | |`rocblas_sspmv`|3.5.0| | | | |
-|`cublasSspmv_64`|12.0| | | |`hipblasSspmv_64`|6.2.0| | | | | | | | | | |
+|`cublasSspmv_64`|12.0| | | |`hipblasSspmv_64`|6.2.0| | | | |`rocblas_sspmv_64`|6.2.0| | | | |
 |`cublasSspmv_v2`| | | | |`hipblasSspmv`|3.5.0| | | | |`rocblas_sspmv`|3.5.0| | | | |
-|`cublasSspmv_v2_64`|12.0| | | |`hipblasSspmv_64`|6.2.0| | | | | | | | | | |
+|`cublasSspmv_v2_64`|12.0| | | |`hipblasSspmv_64`|6.2.0| | | | |`rocblas_sspmv_64`|6.2.0| | | | |
 |`cublasSspr`| | | | |`hipblasSspr`|3.5.0| | | | |`rocblas_sspr`|3.5.0| | | | |
 |`cublasSspr2`| | | | |`hipblasSspr2`|3.5.0| | | | |`rocblas_sspr2`|3.5.0| | | | |
 |`cublasSspr2_64`|12.0| | | |`hipblasSspr2_64`|6.2.0| | | | | | | | | | |
@@ -963,9 +963,9 @@
 |`cublasZher_v2`| | | | |`hipblasZher_v2`|6.0.0| | | | |`rocblas_zher`|3.5.0| | | | |
 |`cublasZher_v2_64`|12.0| | | |`hipblasZher_v2_64`|6.2.0| | | | |`rocblas_zher_64`|6.2.0| | | | |
 |`cublasZhpmv`| | | | |`hipblasZhpmv_v2`|6.0.0| | | | |`rocblas_zhpmv`|3.5.0| | | | |
-|`cublasZhpmv_64`|12.0| | | |`hipblasZhpmv_v2_64`|6.2.0| | | | | | | | | | |
+|`cublasZhpmv_64`|12.0| | | |`hipblasZhpmv_v2_64`|6.2.0| | | | |`rocblas_zhpmv_64`|6.2.0| | | | |
 |`cublasZhpmv_v2`| | | | |`hipblasZhpmv_v2`|6.0.0| | | | |`rocblas_zhpmv`|3.5.0| | | | |
-|`cublasZhpmv_v2_64`|12.0| | | |`hipblasZhpmv_v2_64`|6.2.0| | | | | | | | | | |
+|`cublasZhpmv_v2_64`|12.0| | | |`hipblasZhpmv_v2_64`|6.2.0| | | | |`rocblas_zhpmv_64`|6.2.0| | | | |
 |`cublasZhpr`| | | | |`hipblasZhpr_v2`|6.0.0| | | | |`rocblas_zhpr`|3.5.0| | | | |
 |`cublasZhpr2`| | | | |`hipblasZhpr2_v2`|6.0.0| | | | |`rocblas_zhpr2`|3.5.0| | | | |
 |`cublasZhpr2_64`|12.0| | | |`hipblasZhpr2_v2_64`|6.2.0| | | | | | | | | | |

--- a/docs/tables/CUBLAS_API_supported_by_ROC.md
+++ b/docs/tables/CUBLAS_API_supported_by_ROC.md
@@ -755,9 +755,9 @@
 |`cublasCher_v2`| | | | |`rocblas_cher`|3.5.0| | | | |
 |`cublasCher_v2_64`|12.0| | | |`rocblas_cher_64`|6.2.0| | | | |
 |`cublasChpmv`| | | | |`rocblas_chpmv`|3.5.0| | | | |
-|`cublasChpmv_64`|12.0| | | | | | | | | |
+|`cublasChpmv_64`|12.0| | | |`rocblas_chpmv_64`|6.2.0| | | | |
 |`cublasChpmv_v2`| | | | |`rocblas_chpmv`|3.5.0| | | | |
-|`cublasChpmv_v2_64`|12.0| | | | | | | | | |
+|`cublasChpmv_v2_64`|12.0| | | |`rocblas_chpmv_64`|6.2.0| | | | |
 |`cublasChpr`| | | | |`rocblas_chpr`|3.5.0| | | | |
 |`cublasChpr2`| | | | |`rocblas_chpr2`|3.5.0| | | | |
 |`cublasChpr2_64`|12.0| | | | | | | | | |
@@ -819,9 +819,9 @@
 |`cublasDsbmv_v2`| | | | |`rocblas_dsbmv`|3.5.0| | | | |
 |`cublasDsbmv_v2_64`|12.0| | | |`rocblas_dsbmv_64`|6.2.0| | | | |
 |`cublasDspmv`| | | | |`rocblas_dspmv`|3.5.0| | | | |
-|`cublasDspmv_64`|12.0| | | | | | | | | |
+|`cublasDspmv_64`|12.0| | | |`rocblas_dspmv_64`|6.2.0| | | | |
 |`cublasDspmv_v2`| | | | |`rocblas_dspmv`|3.5.0| | | | |
-|`cublasDspmv_v2_64`|12.0| | | | | | | | | |
+|`cublasDspmv_v2_64`|12.0| | | |`rocblas_dspmv_64`|6.2.0| | | | |
 |`cublasDspr`| | | | |`rocblas_dspr`|3.5.0| | | | |
 |`cublasDspr2`| | | | |`rocblas_dspr2`|3.5.0| | | | |
 |`cublasDspr2_64`|12.0| | | | | | | | | |
@@ -883,9 +883,9 @@
 |`cublasSsbmv_v2`| | | | |`rocblas_ssbmv`|3.5.0| | | | |
 |`cublasSsbmv_v2_64`|12.0| | | |`rocblas_ssbmv_64`|6.2.0| | | | |
 |`cublasSspmv`| | | | |`rocblas_sspmv`|3.5.0| | | | |
-|`cublasSspmv_64`|12.0| | | | | | | | | |
+|`cublasSspmv_64`|12.0| | | |`rocblas_sspmv_64`|6.2.0| | | | |
 |`cublasSspmv_v2`| | | | |`rocblas_sspmv`|3.5.0| | | | |
-|`cublasSspmv_v2_64`|12.0| | | | | | | | | |
+|`cublasSspmv_v2_64`|12.0| | | |`rocblas_sspmv_64`|6.2.0| | | | |
 |`cublasSspr`| | | | |`rocblas_sspr`|3.5.0| | | | |
 |`cublasSspr2`| | | | |`rocblas_sspr2`|3.5.0| | | | |
 |`cublasSspr2_64`|12.0| | | | | | | | | |
@@ -963,9 +963,9 @@
 |`cublasZher_v2`| | | | |`rocblas_zher`|3.5.0| | | | |
 |`cublasZher_v2_64`|12.0| | | |`rocblas_zher_64`|6.2.0| | | | |
 |`cublasZhpmv`| | | | |`rocblas_zhpmv`|3.5.0| | | | |
-|`cublasZhpmv_64`|12.0| | | | | | | | | |
+|`cublasZhpmv_64`|12.0| | | |`rocblas_zhpmv_64`|6.2.0| | | | |
 |`cublasZhpmv_v2`| | | | |`rocblas_zhpmv`|3.5.0| | | | |
-|`cublasZhpmv_v2_64`|12.0| | | | | | | | | |
+|`cublasZhpmv_v2_64`|12.0| | | |`rocblas_zhpmv_64`|6.2.0| | | | |
 |`cublasZhpr`| | | | |`rocblas_zhpr`|3.5.0| | | | |
 |`cublasZhpr2`| | | | |`rocblas_zhpr2`|3.5.0| | | | |
 |`cublasZhpr2_64`|12.0| | | | | | | | | |

--- a/src/CUDA2HIP_BLAS_API_functions.cpp
+++ b/src/CUDA2HIP_BLAS_API_functions.cpp
@@ -326,13 +326,13 @@ const std::map<llvm::StringRef, hipCounter> CUDA_BLAS_FUNCTION_MAP {
 
   // SPMV/HPMV
   {"cublasSspmv",                                          {"hipblasSspmv",                                              "rocblas_sspmv",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, HIP_SUPPORTED_V2_ONLY}},
-  {"cublasSspmv_64",                                       {"hipblasSspmv_64",                                           "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
+  {"cublasSspmv_64",                                       {"hipblasSspmv_64",                                           "rocblas_sspmv_64",                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
   {"cublasDspmv",                                          {"hipblasDspmv",                                              "rocblas_dspmv",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, HIP_SUPPORTED_V2_ONLY}},
-  {"cublasDspmv_64",                                       {"hipblasDspmv_64",                                           "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
+  {"cublasDspmv_64",                                       {"hipblasDspmv_64",                                           "rocblas_dspmv_64",                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
   {"cublasChpmv",                                          {"hipblasChpmv_v2",                                           "rocblas_chpmv",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, HIP_SUPPORTED_V2_ONLY}},
-  {"cublasChpmv_64",                                       {"hipblasChpmv_v2_64",                                        "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
+  {"cublasChpmv_64",                                       {"hipblasChpmv_v2_64",                                        "rocblas_chpmv_64",                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
   {"cublasZhpmv",                                          {"hipblasZhpmv_v2",                                           "rocblas_zhpmv",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, HIP_SUPPORTED_V2_ONLY}},
-  {"cublasZhpmv_64",                                       {"hipblasZhpmv_v2_64",                                        "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
+  {"cublasZhpmv_64",                                       {"hipblasZhpmv_v2_64",                                        "rocblas_zhpmv_64",                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
 
   // GER
   {"cublasSger",                                           {"hipblasSger",                                               "rocblas_sger",                                       CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, HIP_SUPPORTED_V2_ONLY}},
@@ -744,13 +744,13 @@ const std::map<llvm::StringRef, hipCounter> CUDA_BLAS_FUNCTION_MAP {
 
   // SPMV/HPMV
   {"cublasSspmv_v2",                                       {"hipblasSspmv",                                              "rocblas_sspmv",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
-  {"cublasSspmv_v2_64",                                    {"hipblasSspmv_64",                                           "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
+  {"cublasSspmv_v2_64",                                    {"hipblasSspmv_64",                                           "rocblas_sspmv_64",                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
   {"cublasDspmv_v2",                                       {"hipblasDspmv",                                              "rocblas_dspmv",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
-  {"cublasDspmv_v2_64",                                    {"hipblasDspmv_64",                                           "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
+  {"cublasDspmv_v2_64",                                    {"hipblasDspmv_64",                                           "rocblas_dspmv_64",                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
   {"cublasChpmv_v2",                                       {"hipblasChpmv_v2",                                           "rocblas_chpmv",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
-  {"cublasChpmv_v2_64",                                    {"hipblasChpmv_v2_64",                                        "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
+  {"cublasChpmv_v2_64",                                    {"hipblasChpmv_v2_64",                                        "rocblas_chpmv_64",                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
   {"cublasZhpmv_v2",                                       {"hipblasZhpmv_v2",                                           "rocblas_zhpmv",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
-  {"cublasZhpmv_v2_64",                                    {"hipblasZhpmv_v2_64",                                        "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
+  {"cublasZhpmv_v2_64",                                    {"hipblasZhpmv_v2_64",                                        "rocblas_zhpmv_64",                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
 
   // GER
   {"cublasSger_v2",                                        {"hipblasSger",                                               "rocblas_sger",                                       CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
@@ -2361,6 +2361,10 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_BLAS_FUNCTION_VER_MAP {
   {"rocblas_zsyr2_64",                                     {HIP_6020, HIP_0,    HIP_0   }},
   {"rocblas_cher2_64",                                     {HIP_6020, HIP_0,    HIP_0   }},
   {"rocblas_zher2_64",                                     {HIP_6020, HIP_0,    HIP_0   }},
+  {"rocblas_sspmv_64",                                     {HIP_6020, HIP_0,    HIP_0   }},
+  {"rocblas_dspmv_64",                                     {HIP_6020, HIP_0,    HIP_0   }},
+  {"rocblas_chpmv_64",                                     {HIP_6020, HIP_0,    HIP_0   }},
+  {"rocblas_zhpmv_64",                                     {HIP_6020, HIP_0,    HIP_0   }},
 };
 
 const std::map<llvm::StringRef, hipAPIChangedVersions> HIP_BLAS_FUNCTION_CHANGED_VER_MAP {

--- a/tests/unit_tests/synthetic/libraries/cublas2rocblas_v2.cu
+++ b/tests/unit_tests/synthetic/libraries/cublas2rocblas_v2.cu
@@ -2685,6 +2685,34 @@ int main() {
   // CHECK-NEXT: blasStatus = rocblas_zher2_64(blasHandle, blasFillMode, n_64, &dcomplexa, &dcomplexx, incx_64, &dcomplexy, incy_64, &dcomplexA, lda_64);
   blasStatus = cublasZher2_64(blasHandle, blasFillMode, n_64, &dcomplexa, &dcomplexx, incx_64, &dcomplexy, incy_64, &dcomplexA, lda_64);
   blasStatus = cublasZher2_v2_64(blasHandle, blasFillMode, n_64, &dcomplexa, &dcomplexx, incx_64, &dcomplexy, incy_64, &dcomplexA, lda_64);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasSspmv_v2_64(cublasHandle_t handle, cublasFillMode_t uplo, int64_t n, const float* alpha, const float* AP, const float* x, int64_t incx, const float* beta, float* y, int64_t incy);
+  // ROC: ROCBLAS_EXPORT rocblas_status rocblas_sspmv_64(rocblas_handle handle, rocblas_fill uplo, int64_t n, const float* alpha, const float* A, const float* x, int64_t incx, const float* beta, float* y, int64_t incy);
+  // CHECK: blasStatus = rocblas_sspmv_64(blasHandle, blasFillMode, n_64, &fa, &fA, &fx, incx_64, &fb, &fy, incy_64);
+  // CHECK-NEXT: blasStatus = rocblas_sspmv_64(blasHandle, blasFillMode, n_64, &fa, &fA, &fx, incx_64, &fb, &fy, incy_64);
+  blasStatus = cublasSspmv_64(blasHandle, blasFillMode, n_64, &fa, &fA, &fx, incx_64, &fb, &fy, incy_64);
+  blasStatus = cublasSspmv_v2_64(blasHandle, blasFillMode, n_64, &fa, &fA, &fx, incx_64, &fb, &fy, incy_64);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasDspmv_v2_64(cublasHandle_t handle, cublasFillMode_t uplo, int64_t n, const double* alpha, const double* AP, const double* x, int64_t incx, const double* beta, double* y, int64_t incy);
+  // ROC: ROCBLAS_EXPORT rocblas_status rocblas_dspmv_64(rocblas_handle handle, rocblas_fill uplo, int64_t n, const double* alpha, const double* A, const double* x, int64_t incx, const double* beta, double* y, int64_t incy);
+  // CHECK: blasStatus = rocblas_dspmv_64(blasHandle, blasFillMode, n_64, &da, &dA, &dx, incx_64, &db, &dy, incy_64);
+  // CHECK-NEXT: blasStatus = rocblas_dspmv_64(blasHandle, blasFillMode, n_64, &da, &dA, &dx, incx_64, &db, &dy, incy_64);
+  blasStatus = cublasDspmv_64(blasHandle, blasFillMode, n_64, &da, &dA, &dx, incx_64, &db, &dy, incy_64);
+  blasStatus = cublasDspmv_v2_64(blasHandle, blasFillMode, n_64, &da, &dA, &dx, incx_64, &db, &dy, incy_64);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasChpmv_v2_64(cublasHandle_t handle, cublasFillMode_t uplo, int64_t n, const cuComplex* alpha, const cuComplex* AP, const cuComplex* x, int64_t incx, const cuComplex* beta, cuComplex* y, int64_t incy);
+  // ROC: ROCBLAS_EXPORT rocblas_status rocblas_chpmv_64(rocblas_handle handle, rocblas_fill uplo, int64_t n, const rocblas_float_complex* alpha, const rocblas_float_complex* AP, const rocblas_float_complex* x, int64_t incx, const rocblas_float_complex* beta, rocblas_float_complex* y, int64_t incy);
+  // CHECK: blasStatus = rocblas_chpmv_64(blasHandle, blasFillMode, n_64, &complexa, &complexA, &complexx, incx_64, &complexb, &complexy, incy_64);
+  // CHECK-NEXT: blasStatus = rocblas_chpmv_64(blasHandle, blasFillMode, n_64, &complexa, &complexA, &complexx, incx_64, &complexb, &complexy, incy_64);
+  blasStatus = cublasChpmv_64(blasHandle, blasFillMode, n_64, &complexa, &complexA, &complexx, incx_64, &complexb, &complexy, incy_64);
+  blasStatus = cublasChpmv_v2_64(blasHandle, blasFillMode, n_64, &complexa, &complexA, &complexx, incx_64, &complexb, &complexy, incy_64);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasZhpmv_v2_64(cublasHandle_t handle, cublasFillMode_t uplo, int64_t n, const cuDoubleComplex* alpha, const cuDoubleComplex* AP, const cuDoubleComplex* x, int64_t incx, const cuDoubleComplex* beta, cuDoubleComplex* y, int64_t incy);
+  // ROC: ROCBLAS_EXPORT rocblas_status rocblas_zhpmv_64(rocblas_handle handle, rocblas_fill uplo, int64_t n, const rocblas_double_complex* alpha, const rocblas_double_complex* AP, const rocblas_double_complex* x, int64_t incx, const rocblas_double_complex* beta, rocblas_double_complex* y, int64_t incy);
+  // CHECK: blasStatus = rocblas_zhpmv_64(blasHandle, blasFillMode, n_64, &dcomplexa, &dcomplexA, &dcomplexx, incx_64, &dcomplexb, &dcomplexy, incy_64);
+  // CHECK-NEXT: blasStatus = rocblas_zhpmv_64(blasHandle, blasFillMode, n_64, &dcomplexa, &dcomplexA, &dcomplexx, incx_64, &dcomplexb, &dcomplexy, incy_64);
+  blasStatus = cublasZhpmv_64(blasHandle, blasFillMode, n_64, &dcomplexa, &dcomplexA, &dcomplexx, incx_64, &dcomplexb, &dcomplexy, incy_64);
+  blasStatus = cublasZhpmv_v2_64(blasHandle, blasFillMode, n_64, &dcomplexa, &dcomplexA, &dcomplexx, incx_64, &dcomplexb, &dcomplexy, incy_64);
 #endif
 
   return 0;


### PR DESCRIPTION
+ `rocblas_(s|d|c|z)hpmv_64` support
+ Updated synthetic tests, the regenerated `hipify-perl`, and `BLAS` `CUDA2HIP` documentation