### PR TITLE
[HIPIFY][rocBLAS] 64-bit functions support - Step 10

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -1603,7 +1603,9 @@ sub rocSubstitutions {
     subst("cublasChpr", "rocblas_chpr", "library");
     subst("cublasChpr2", "rocblas_chpr2", "library");
     subst("cublasChpr2_v2", "rocblas_chpr2", "library");
+    subst("cublasChpr_64", "rocblas_chpr_64", "library");
     subst("cublasChpr_v2", "rocblas_chpr", "library");
+    subst("cublasChpr_v2_64", "rocblas_chpr_64", "library");
     subst("cublasCreate", "rocblas_create_handle", "library");
     subst("cublasCreate_v2", "rocblas_create_handle", "library");
     subst("cublasCrot", "rocblas_crot", "library");
@@ -1737,7 +1739,9 @@ sub rocSubstitutions {
     subst("cublasDspr", "rocblas_dspr", "library");
     subst("cublasDspr2", "rocblas_dspr2", "library");
     subst("cublasDspr2_v2", "rocblas_dspr2", "library");
+    subst("cublasDspr_64", "rocblas_dspr_64", "library");
     subst("cublasDspr_v2", "rocblas_dspr", "library");
+    subst("cublasDspr_v2_64", "rocblas_dspr_64", "library");
     subst("cublasDswap", "rocblas_dswap", "library");
     subst("cublasDswap_64", "rocblas_dswap_64", "library");
     subst("cublasDswap_v2", "rocblas_dswap", "library");
@@ -1935,7 +1939,9 @@ sub rocSubstitutions {
     subst("cublasSspr", "rocblas_sspr", "library");
     subst("cublasSspr2", "rocblas_sspr2", "library");
     subst("cublasSspr2_v2", "rocblas_sspr2", "library");
+    subst("cublasSspr_64", "rocblas_sspr_64", "library");
     subst("cublasSspr_v2", "rocblas_sspr", "library");
+    subst("cublasSspr_v2_64", "rocblas_sspr_64", "library");
     subst("cublasSswap", "rocblas_sswap", "library");
     subst("cublasSswap_64", "rocblas_sswap_64", "library");
     subst("cublasSswap_v2", "rocblas_sswap", "library");
@@ -2060,7 +2066,9 @@ sub rocSubstitutions {
     subst("cublasZhpr", "rocblas_zhpr", "library");
     subst("cublasZhpr2", "rocblas_zhpr2", "library");
     subst("cublasZhpr2_v2", "rocblas_zhpr2", "library");
+    subst("cublasZhpr_64", "rocblas_zhpr_64", "library");
     subst("cublasZhpr_v2", "rocblas_zhpr", "library");
+    subst("cublasZhpr_v2_64", "rocblas_zhpr_64", "library");
     subst("cublasZrot", "rocblas_zrot", "library");
     subst("cublasZrot_64", "rocblas_zrot_64", "library");
     subst("cublasZrot_v2", "rocblas_zrot", "library");
@@ -12601,8 +12609,6 @@ sub warnRocOnlyUnsupportedFunctions {
         "cublasZsymm_v2_64",
         "cublasZsymm_64",
         "cublasZmatinvBatched",
-        "cublasZhpr_v2_64",
-        "cublasZhpr_64",
         "cublasZhpr2_v2_64",
         "cublasZhpr2_64",
         "cublasZherkx_64",
@@ -12659,8 +12665,6 @@ sub warnRocOnlyUnsupportedFunctions {
         "cublasSsyr2k_64",
         "cublasSsymm_v2_64",
         "cublasSsymm_64",
-        "cublasSspr_v2_64",
-        "cublasSspr_64",
         "cublasSspr2_v2_64",
         "cublasSspr2_64",
         "cublasSmatinvBatched",
@@ -12810,8 +12814,6 @@ sub warnRocOnlyUnsupportedFunctions {
         "cublasDsyr2k_64",
         "cublasDsymm_v2_64",
         "cublasDsymm_64",
-        "cublasDspr_v2_64",
-        "cublasDspr_64",
         "cublasDspr2_v2_64",
         "cublasDspr2_64",
         "cublasDmatinvBatched",
@@ -12863,8 +12865,6 @@ sub warnRocOnlyUnsupportedFunctions {
         "cublasCopyEx_64",
         "cublasCopyEx",
         "cublasCmatinvBatched",
-        "cublasChpr_v2_64",
-        "cublasChpr_64",
         "cublasChpr2_v2_64",
         "cublasChpr2_64",
         "cublasCherkx_64",

--- a/docs/tables/CUBLAS_API_supported_by_HIP_and_ROC.md
+++ b/docs/tables/CUBLAS_API_supported_by_HIP_and_ROC.md
@@ -763,9 +763,9 @@
 |`cublasChpr2_64`|12.0| | | |`hipblasChpr2_v2_64`|6.2.0| | | | | | | | | | |
 |`cublasChpr2_v2`| | | | |`hipblasChpr2_v2`|6.0.0| | | | |`rocblas_chpr2`|3.5.0| | | | |
 |`cublasChpr2_v2_64`|12.0| | | |`hipblasChpr2_v2_64`|6.2.0| | | | | | | | | | |
-|`cublasChpr_64`|12.0| | | |`hipblasChpr_v2_64`|6.2.0| | | | | | | | | | |
+|`cublasChpr_64`|12.0| | | |`hipblasChpr_v2_64`|6.2.0| | | | |`rocblas_chpr_64`|6.2.0| | | | |
 |`cublasChpr_v2`| | | | |`hipblasChpr_v2`|6.0.0| | | | |`rocblas_chpr`|3.5.0| | | | |
-|`cublasChpr_v2_64`|12.0| | | |`hipblasChpr_v2_64`|6.2.0| | | | | | | | | | |
+|`cublasChpr_v2_64`|12.0| | | |`hipblasChpr_v2_64`|6.2.0| | | | |`rocblas_chpr_64`|6.2.0| | | | |
 |`cublasCsymv`| | | | |`hipblasCsymv_v2`|6.0.0| | | | |`rocblas_csymv`|3.5.0| | | | |
 |`cublasCsymv_64`|12.0| | | |`hipblasCsymv_v2_64`|6.2.0| | | | |`rocblas_csymv_64`|6.2.0| | | | |
 |`cublasCsymv_v2`| | | | |`hipblasCsymv_v2`|6.0.0| | | | |`rocblas_csymv`|3.5.0| | | | |
@@ -827,9 +827,9 @@
 |`cublasDspr2_64`|12.0| | | |`hipblasDspr2_64`|6.2.0| | | | | | | | | | |
 |`cublasDspr2_v2`| | | | |`hipblasDspr2`|3.5.0| | | | |`rocblas_dspr2`|3.5.0| | | | |
 |`cublasDspr2_v2_64`|12.0| | | |`hipblasDspr2_64`|6.2.0| | | | | | | | | | |
-|`cublasDspr_64`|12.0| | | |`hipblasDspr_64`|6.2.0| | | | | | | | | | |
+|`cublasDspr_64`|12.0| | | |`hipblasDspr_64`|6.2.0| | | | |`rocblas_dspr_64`|6.2.0| | | | |
 |`cublasDspr_v2`| | | | |`hipblasDspr`|3.5.0| | | | |`rocblas_dspr`|3.5.0| | | | |
-|`cublasDspr_v2_64`|12.0| | | |`hipblasDspr_64`|6.2.0| | | | | | | | | | |
+|`cublasDspr_v2_64`|12.0| | | |`hipblasDspr_64`|6.2.0| | | | |`rocblas_dspr_64`|6.2.0| | | | |
 |`cublasDsymv`| | | | |`hipblasDsymv`|3.5.0| | | | |`rocblas_dsymv`|1.5.0| | | | |
 |`cublasDsymv_64`|12.0| | | |`hipblasDsymv_64`|6.2.0| | | | |`rocblas_dsymv_64`|6.2.0| | | | |
 |`cublasDsymv_v2`| | | | |`hipblasDsymv`|3.5.0| | | | |`rocblas_dsymv`|1.5.0| | | | |
@@ -891,9 +891,9 @@
 |`cublasSspr2_64`|12.0| | | |`hipblasSspr2_64`|6.2.0| | | | | | | | | | |
 |`cublasSspr2_v2`| | | | |`hipblasSspr2`|3.5.0| | | | |`rocblas_sspr2`|3.5.0| | | | |
 |`cublasSspr2_v2_64`|12.0| | | |`hipblasSspr2_64`|6.2.0| | | | | | | | | | |
-|`cublasSspr_64`|12.0| | | |`hipblasSspr_64`|6.2.0| | | | | | | | | | |
+|`cublasSspr_64`|12.0| | | |`hipblasSspr_64`|6.2.0| | | | |`rocblas_sspr_64`|6.2.0| | | | |
 |`cublasSspr_v2`| | | | |`hipblasSspr`|3.5.0| | | | |`rocblas_sspr`|3.5.0| | | | |
-|`cublasSspr_v2_64`|12.0| | | |`hipblasSspr_64`|6.2.0| | | | | | | | | | |
+|`cublasSspr_v2_64`|12.0| | | |`hipblasSspr_64`|6.2.0| | | | |`rocblas_sspr_64`|6.2.0| | | | |
 |`cublasSsymv`| | | | |`hipblasSsymv`|3.5.0| | | | |`rocblas_ssymv`|1.5.0| | | | |
 |`cublasSsymv_64`|12.0| | | |`hipblasSsymv_64`|6.2.0| | | | |`rocblas_ssymv_64`|6.2.0| | | | |
 |`cublasSsymv_v2`| | | | |`hipblasSsymv`|3.5.0| | | | |`rocblas_ssymv`|1.5.0| | | | |
@@ -971,9 +971,9 @@
 |`cublasZhpr2_64`|12.0| | | |`hipblasZhpr2_v2_64`|6.2.0| | | | | | | | | | |
 |`cublasZhpr2_v2`| | | | |`hipblasZhpr2_v2`|6.0.0| | | | |`rocblas_zhpr2`|3.5.0| | | | |
 |`cublasZhpr2_v2_64`|12.0| | | |`hipblasZhpr2_v2_64`|6.2.0| | | | | | | | | | |
-|`cublasZhpr_64`|12.0| | | |`hipblasZhpr_v2_64`|6.2.0| | | | | | | | | | |
+|`cublasZhpr_64`|12.0| | | |`hipblasZhpr_v2_64`|6.2.0| | | | |`rocblas_zhpr_64`|6.2.0| | | | |
 |`cublasZhpr_v2`| | | | |`hipblasZhpr_v2`|6.0.0| | | | |`rocblas_zhpr`|3.5.0| | | | |
-|`cublasZhpr_v2_64`|12.0| | | |`hipblasZhpr_v2_64`|6.2.0| | | | | | | | | | |
+|`cublasZhpr_v2_64`|12.0| | | |`hipblasZhpr_v2_64`|6.2.0| | | | |`rocblas_zhpr_64`|6.2.0| | | | |
 |`cublasZsymv`| | | | |`hipblasZsymv_v2`|6.0.0| | | | |`rocblas_zsymv`|3.5.0| | | | |
 |`cublasZsymv_64`|12.0| | | |`hipblasZsymv_v2_64`|6.2.0| | | | |`rocblas_zsymv_64`|6.2.0| | | | |
 |`cublasZsymv_v2`| | | | |`hipblasZsymv_v2`|6.0.0| | | | |`rocblas_zsymv`|3.5.0| | | | |

--- a/docs/tables/CUBLAS_API_supported_by_ROC.md
+++ b/docs/tables/CUBLAS_API_supported_by_ROC.md
@@ -763,9 +763,9 @@
 |`cublasChpr2_64`|12.0| | | | | | | | | |
 |`cublasChpr2_v2`| | | | |`rocblas_chpr2`|3.5.0| | | | |
 |`cublasChpr2_v2_64`|12.0| | | | | | | | | |
-|`cublasChpr_64`|12.0| | | | | | | | | |
+|`cublasChpr_64`|12.0| | | |`rocblas_chpr_64`|6.2.0| | | | |
 |`cublasChpr_v2`| | | | |`rocblas_chpr`|3.5.0| | | | |
-|`cublasChpr_v2_64`|12.0| | | | | | | | | |
+|`cublasChpr_v2_64`|12.0| | | |`rocblas_chpr_64`|6.2.0| | | | |
 |`cublasCsymv`| | | | |`rocblas_csymv`|3.5.0| | | | |
 |`cublasCsymv_64`|12.0| | | |`rocblas_csymv_64`|6.2.0| | | | |
 |`cublasCsymv_v2`| | | | |`rocblas_csymv`|3.5.0| | | | |
@@ -827,9 +827,9 @@
 |`cublasDspr2_64`|12.0| | | | | | | | | |
 |`cublasDspr2_v2`| | | | |`rocblas_dspr2`|3.5.0| | | | |
 |`cublasDspr2_v2_64`|12.0| | | | | | | | | |
-|`cublasDspr_64`|12.0| | | | | | | | | |
+|`cublasDspr_64`|12.0| | | |`rocblas_dspr_64`|6.2.0| | | | |
 |`cublasDspr_v2`| | | | |`rocblas_dspr`|3.5.0| | | | |
-|`cublasDspr_v2_64`|12.0| | | | | | | | | |
+|`cublasDspr_v2_64`|12.0| | | |`rocblas_dspr_64`|6.2.0| | | | |
 |`cublasDsymv`| | | | |`rocblas_dsymv`|1.5.0| | | | |
 |`cublasDsymv_64`|12.0| | | |`rocblas_dsymv_64`|6.2.0| | | | |
 |`cublasDsymv_v2`| | | | |`rocblas_dsymv`|1.5.0| | | | |
@@ -891,9 +891,9 @@
 |`cublasSspr2_64`|12.0| | | | | | | | | |
 |`cublasSspr2_v2`| | | | |`rocblas_sspr2`|3.5.0| | | | |
 |`cublasSspr2_v2_64`|12.0| | | | | | | | | |
-|`cublasSspr_64`|12.0| | | | | | | | | |
+|`cublasSspr_64`|12.0| | | |`rocblas_sspr_64`|6.2.0| | | | |
 |`cublasSspr_v2`| | | | |`rocblas_sspr`|3.5.0| | | | |
-|`cublasSspr_v2_64`|12.0| | | | | | | | | |
+|`cublasSspr_v2_64`|12.0| | | |`rocblas_sspr_64`|6.2.0| | | | |
 |`cublasSsymv`| | | | |`rocblas_ssymv`|1.5.0| | | | |
 |`cublasSsymv_64`|12.0| | | |`rocblas_ssymv_64`|6.2.0| | | | |
 |`cublasSsymv_v2`| | | | |`rocblas_ssymv`|1.5.0| | | | |
@@ -971,9 +971,9 @@
 |`cublasZhpr2_64`|12.0| | | | | | | | | |
 |`cublasZhpr2_v2`| | | | |`rocblas_zhpr2`|3.5.0| | | | |
 |`cublasZhpr2_v2_64`|12.0| | | | | | | | | |
-|`cublasZhpr_64`|12.0| | | | | | | | | |
+|`cublasZhpr_64`|12.0| | | |`rocblas_zhpr_64`|6.2.0| | | | |
 |`cublasZhpr_v2`| | | | |`rocblas_zhpr`|3.5.0| | | | |
-|`cublasZhpr_v2_64`|12.0| | | | | | | | | |
+|`cublasZhpr_v2_64`|12.0| | | |`rocblas_zhpr_64`|6.2.0| | | | |
 |`cublasZsymv`| | | | |`rocblas_zsymv`|3.5.0| | | | |
 |`cublasZsymv_64`|12.0| | | |`rocblas_zsymv_64`|6.2.0| | | | |
 |`cublasZsymv_v2`| | | | |`rocblas_zsymv`|3.5.0| | | | |

--- a/src/CUDA2HIP_BLAS_API_functions.cpp
+++ b/src/CUDA2HIP_BLAS_API_functions.cpp
@@ -364,13 +364,13 @@ const std::map<llvm::StringRef, hipCounter> CUDA_BLAS_FUNCTION_MAP {
 
   // SPR/HPR
   {"cublasSspr",                                           {"hipblasSspr",                                               "rocblas_sspr",                                       CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, HIP_SUPPORTED_V2_ONLY}},
-  {"cublasSspr_64",                                        {"hipblasSspr_64",                                            "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
+  {"cublasSspr_64",                                        {"hipblasSspr_64",                                            "rocblas_sspr_64",                                    CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
   {"cublasDspr",                                           {"hipblasDspr",                                               "rocblas_dspr",                                       CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, HIP_SUPPORTED_V2_ONLY}},
-  {"cublasDspr_64",                                        {"hipblasDspr_64",                                            "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
+  {"cublasDspr_64",                                        {"hipblasDspr_64",                                            "rocblas_dspr_64",                                    CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
   {"cublasChpr",                                           {"hipblasChpr_v2",                                            "rocblas_chpr",                                       CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, HIP_SUPPORTED_V2_ONLY}},
-  {"cublasChpr_64",                                        {"hipblasChpr_v2_64",                                         "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
+  {"cublasChpr_64",                                        {"hipblasChpr_v2_64",                                         "rocblas_chpr_64",                                    CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
   {"cublasZhpr",                                           {"hipblasZhpr_v2",                                            "rocblas_zhpr",                                       CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, HIP_SUPPORTED_V2_ONLY}},
-  {"cublasZhpr_64",                                        {"hipblasZhpr_v2_64",                                         "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
+  {"cublasZhpr_64",                                        {"hipblasZhpr_v2_64",                                         "rocblas_zhpr_64",                                    CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
 
   // SYR2/HER2
   {"cublasSsyr2",                                          {"hipblasSsyr2",                                              "rocblas_ssyr2",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, HIP_SUPPORTED_V2_ONLY}},
@@ -782,13 +782,13 @@ const std::map<llvm::StringRef, hipCounter> CUDA_BLAS_FUNCTION_MAP {
 
   // SPR/HPR
   {"cublasSspr_v2",                                        {"hipblasSspr",                                               "rocblas_sspr",                                       CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
-  {"cublasSspr_v2_64",                                     {"hipblasSspr_64",                                            "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
+  {"cublasSspr_v2_64",                                     {"hipblasSspr_64",                                            "rocblas_sspr_64",                                    CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
   {"cublasDspr_v2",                                        {"hipblasDspr",                                               "rocblas_dspr",                                       CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
-  {"cublasDspr_v2_64",                                     {"hipblasDspr_64",                                            "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
+  {"cublasDspr_v2_64",                                     {"hipblasDspr_64",                                            "rocblas_dspr_64",                                    CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
   {"cublasChpr_v2",                                        {"hipblasChpr_v2",                                            "rocblas_chpr",                                       CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
-  {"cublasChpr_v2_64",                                     {"hipblasChpr_v2_64",                                         "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
+  {"cublasChpr_v2_64",                                     {"hipblasChpr_v2_64",                                         "rocblas_chpr_64",                                    CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
   {"cublasZhpr_v2",                                        {"hipblasZhpr_v2",                                            "rocblas_zhpr",                                       CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
-  {"cublasZhpr_v2_64",                                     {"hipblasZhpr_v2_64",                                         "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
+  {"cublasZhpr_v2_64",                                     {"hipblasZhpr_v2_64",                                         "rocblas_zhpr_64",                                    CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
 
   // SYR2/HER2
   {"cublasSsyr2_v2",                                       {"hipblasSsyr2",                                              "rocblas_ssyr2",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
@@ -2365,6 +2365,10 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_BLAS_FUNCTION_VER_MAP {
   {"rocblas_dspmv_64",                                     {HIP_6020, HIP_0,    HIP_0   }},
   {"rocblas_chpmv_64",                                     {HIP_6020, HIP_0,    HIP_0   }},
   {"rocblas_zhpmv_64",                                     {HIP_6020, HIP_0,    HIP_0   }},
+  {"rocblas_sspr_64",                                      {HIP_6020, HIP_0,    HIP_0   }},
+  {"rocblas_dspr_64",                                      {HIP_6020, HIP_0,    HIP_0   }},
+  {"rocblas_chpr_64",                                      {HIP_6020, HIP_0,    HIP_0   }},
+  {"rocblas_zhpr_64",                                      {HIP_6020, HIP_0,    HIP_0   }},
 };
 
 const std::map<llvm::StringRef, hipAPIChangedVersions> HIP_BLAS_FUNCTION_CHANGED_VER_MAP {

--- a/tests/unit_tests/synthetic/libraries/cublas2rocblas_v2.cu
+++ b/tests/unit_tests/synthetic/libraries/cublas2rocblas_v2.cu
@@ -2713,6 +2713,34 @@ int main() {
   // CHECK-NEXT: blasStatus = rocblas_zhpmv_64(blasHandle, blasFillMode, n_64, &dcomplexa, &dcomplexA, &dcomplexx, incx_64, &dcomplexb, &dcomplexy, incy_64);
   blasStatus = cublasZhpmv_64(blasHandle, blasFillMode, n_64, &dcomplexa, &dcomplexA, &dcomplexx, incx_64, &dcomplexb, &dcomplexy, incy_64);
   blasStatus = cublasZhpmv_v2_64(blasHandle, blasFillMode, n_64, &dcomplexa, &dcomplexA, &dcomplexx, incx_64, &dcomplexb, &dcomplexy, incy_64);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasSspr_v2_64(cublasHandle_t handle, cublasFillMode_t uplo, int64_t n, const float* alpha, const float* x, int64_t incx, float* AP);
+  // ROC: ROCBLAS_EXPORT rocblas_status rocblas_sspr_64(rocblas_handle handle, rocblas_fill uplo, int64_t n, const float* alpha, const float* x, int64_t incx, float* AP);
+  // CHECK: blasStatus = rocblas_sspr_64(blasHandle, blasFillMode, n_64, &fa, &fx, incx_64, &fA);
+  // CHECK-NEXT: blasStatus = rocblas_sspr_64(blasHandle, blasFillMode, n_64, &fa, &fx, incx_64, &fA);
+  blasStatus = cublasSspr_64(blasHandle, blasFillMode, n_64, &fa, &fx, incx_64, &fA);
+  blasStatus = cublasSspr_v2_64(blasHandle, blasFillMode, n_64, &fa, &fx, incx_64, &fA);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasDspr_v2_64(cublasHandle_t handle, cublasFillMode_t uplo, int64_t n, const double* alpha, const double* x, int64_t incx, double* AP);
+  // ROC: ROCBLAS_EXPORT rocblas_status rocblas_dspr_64(rocblas_handle handle, rocblas_fill uplo, int64_t n, const double* alpha, const double* x, int64_t incx, double* AP);
+  // CHECK: blasStatus = rocblas_dspr_64(blasHandle, blasFillMode, n_64, &da, &dx, incx_64, &dA);
+  // CHECK-NEXT: blasStatus = rocblas_dspr_64(blasHandle, blasFillMode, n_64, &da, &dx, incx_64, &dA);
+  blasStatus = cublasDspr_64(blasHandle, blasFillMode, n_64, &da, &dx, incx_64, &dA);
+  blasStatus = cublasDspr_v2_64(blasHandle, blasFillMode, n_64, &da, &dx, incx_64, &dA);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasChpr_v2_64(cublasHandle_t handle, cublasFillMode_t uplo, int64_t n, const float* alpha, const cuComplex* x, int64_t incx, cuComplex* AP);
+  // ROC: ROCBLAS_EXPORT rocblas_status rocblas_chpr_64(rocblas_handle handle, rocblas_fill uplo, int64_t n, const float* alpha, const rocblas_float_complex* x, int64_t incx, rocblas_float_complex* AP);
+  // CHECK: blasStatus = rocblas_chpr_64(blasHandle, blasFillMode, n_64, &fa, &complexx, incx_64, &complexA);
+  // CHECK-NEXT: blasStatus = rocblas_chpr_64(blasHandle, blasFillMode, n_64, &fa, &complexx, incx_64, &complexA);
+  blasStatus = cublasChpr_64(blasHandle, blasFillMode, n_64, &fa, &complexx, incx_64, &complexA);
+  blasStatus = cublasChpr_v2_64(blasHandle, blasFillMode, n_64, &fa, &complexx, incx_64, &complexA);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasZhpr_v2_64(cublasHandle_t handle, cublasFillMode_t uplo, int64_t n, const double* alpha, const cuDoubleComplex* x, int64_t incx, cuDoubleComplex* AP);
+  // ROC: ROCBLAS_EXPORT rocblas_status rocblas_zhpr_64(rocblas_handle handle, rocblas_fill uplo, int64_t n, const double* alpha, const rocblas_double_complex* x, int64_t incx, rocblas_double_complex* AP);
+  // CHECK: blasStatus = rocblas_zhpr_64(blasHandle, blasFillMode, n_64, &da, &dcomplexx, incx_64, &dcomplexA);
+  // CHECK-NEXT: blasStatus = rocblas_zhpr_64(blasHandle, blasFillMode, n_64, &da, &dcomplexx, incx_64, &dcomplexA);
+  blasStatus = cublasZhpr_64(blasHandle, blasFillMode, n_64, &da, &dcomplexx, incx_64, &dcomplexA);
+  blasStatus = cublasZhpr_v2_64(blasHandle, blasFillMode, n_64, &da, &dcomplexx, incx_64, &dcomplexA);
 #endif
 
   return 0;


### PR DESCRIPTION
+ `rocblas_(ss|ds|ch|zh)pr_64` support
+ Updated synthetic tests, the regenerated `hipify-perl`, and `BLAS` `CUDA2HIP` documentation