### PR TITLE
[HIPIFY][rocBLAS] 64-bit functions support - Step 11

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -1602,7 +1602,9 @@ sub rocSubstitutions {
     subst("cublasChpmv_v2_64", "rocblas_chpmv_64", "library");
     subst("cublasChpr", "rocblas_chpr", "library");
     subst("cublasChpr2", "rocblas_chpr2", "library");
+    subst("cublasChpr2_64", "rocblas_chpr2_64", "library");
     subst("cublasChpr2_v2", "rocblas_chpr2", "library");
+    subst("cublasChpr2_v2_64", "rocblas_chpr2_64", "library");
     subst("cublasChpr_64", "rocblas_chpr_64", "library");
     subst("cublasChpr_v2", "rocblas_chpr", "library");
     subst("cublasChpr_v2_64", "rocblas_chpr_64", "library");
@@ -1738,7 +1740,9 @@ sub rocSubstitutions {
     subst("cublasDspmv_v2_64", "rocblas_dspmv_64", "library");
     subst("cublasDspr", "rocblas_dspr", "library");
     subst("cublasDspr2", "rocblas_dspr2", "library");
+    subst("cublasDspr2_64", "rocblas_dspr2_64", "library");
     subst("cublasDspr2_v2", "rocblas_dspr2", "library");
+    subst("cublasDspr2_v2_64", "rocblas_dspr2_64", "library");
     subst("cublasDspr_64", "rocblas_dspr_64", "library");
     subst("cublasDspr_v2", "rocblas_dspr", "library");
     subst("cublasDspr_v2_64", "rocblas_dspr_64", "library");
@@ -1938,7 +1942,9 @@ sub rocSubstitutions {
     subst("cublasSspmv_v2_64", "rocblas_sspmv_64", "library");
     subst("cublasSspr", "rocblas_sspr", "library");
     subst("cublasSspr2", "rocblas_sspr2", "library");
+    subst("cublasSspr2_64", "rocblas_sspr2_64", "library");
     subst("cublasSspr2_v2", "rocblas_sspr2", "library");
+    subst("cublasSspr2_v2_64", "rocblas_sspr2_64", "library");
     subst("cublasSspr_64", "rocblas_sspr_64", "library");
     subst("cublasSspr_v2", "rocblas_sspr", "library");
     subst("cublasSspr_v2_64", "rocblas_sspr_64", "library");
@@ -2065,7 +2071,9 @@ sub rocSubstitutions {
     subst("cublasZhpmv_v2_64", "rocblas_zhpmv_64", "library");
     subst("cublasZhpr", "rocblas_zhpr", "library");
     subst("cublasZhpr2", "rocblas_zhpr2", "library");
+    subst("cublasZhpr2_64", "rocblas_zhpr2_64", "library");
     subst("cublasZhpr2_v2", "rocblas_zhpr2", "library");
+    subst("cublasZhpr2_v2_64", "rocblas_zhpr2_64", "library");
     subst("cublasZhpr_64", "rocblas_zhpr_64", "library");
     subst("cublasZhpr_v2", "rocblas_zhpr", "library");
     subst("cublasZhpr_v2_64", "rocblas_zhpr_64", "library");
@@ -12609,8 +12617,6 @@ sub warnRocOnlyUnsupportedFunctions {
         "cublasZsymm_v2_64",
         "cublasZsymm_64",
         "cublasZmatinvBatched",
-        "cublasZhpr2_v2_64",
-        "cublasZhpr2_64",
         "cublasZherkx_64",
         "cublasZherk_v2_64",
         "cublasZherk_64",
@@ -12665,8 +12671,6 @@ sub warnRocOnlyUnsupportedFunctions {
         "cublasSsyr2k_64",
         "cublasSsymm_v2_64",
         "cublasSsymm_64",
-        "cublasSspr2_v2_64",
-        "cublasSspr2_64",
         "cublasSmatinvBatched",
         "cublasShutdown",
         "cublasSgetrsBatched",
@@ -12814,8 +12818,6 @@ sub warnRocOnlyUnsupportedFunctions {
         "cublasDsyr2k_64",
         "cublasDsymm_v2_64",
         "cublasDsymm_64",
-        "cublasDspr2_v2_64",
-        "cublasDspr2_64",
         "cublasDmatinvBatched",
         "cublasDgetrsBatched",
         "cublasDgetriBatched",
@@ -12865,8 +12867,6 @@ sub warnRocOnlyUnsupportedFunctions {
         "cublasCopyEx_64",
         "cublasCopyEx",
         "cublasCmatinvBatched",
-        "cublasChpr2_v2_64",
-        "cublasChpr2_64",
         "cublasCherkx_64",
         "cublasCherk_v2_64",
         "cublasCherk_64",

--- a/docs/tables/CUBLAS_API_supported_by_HIP_and_ROC.md
+++ b/docs/tables/CUBLAS_API_supported_by_HIP_and_ROC.md
@@ -760,9 +760,9 @@
 |`cublasChpmv_v2_64`|12.0| | | |`hipblasChpmv_v2_64`|6.2.0| | | | |`rocblas_chpmv_64`|6.2.0| | | | |
 |`cublasChpr`| | | | |`hipblasChpr_v2`|6.0.0| | | | |`rocblas_chpr`|3.5.0| | | | |
 |`cublasChpr2`| | | | |`hipblasChpr2_v2`|6.0.0| | | | |`rocblas_chpr2`|3.5.0| | | | |
-|`cublasChpr2_64`|12.0| | | |`hipblasChpr2_v2_64`|6.2.0| | | | | | | | | | |
+|`cublasChpr2_64`|12.0| | | |`hipblasChpr2_v2_64`|6.2.0| | | | |`rocblas_chpr2_64`|6.2.0| | | | |
 |`cublasChpr2_v2`| | | | |`hipblasChpr2_v2`|6.0.0| | | | |`rocblas_chpr2`|3.5.0| | | | |
-|`cublasChpr2_v2_64`|12.0| | | |`hipblasChpr2_v2_64`|6.2.0| | | | | | | | | | |
+|`cublasChpr2_v2_64`|12.0| | | |`hipblasChpr2_v2_64`|6.2.0| | | | |`rocblas_chpr2_64`|6.2.0| | | | |
 |`cublasChpr_64`|12.0| | | |`hipblasChpr_v2_64`|6.2.0| | | | |`rocblas_chpr_64`|6.2.0| | | | |
 |`cublasChpr_v2`| | | | |`hipblasChpr_v2`|6.0.0| | | | |`rocblas_chpr`|3.5.0| | | | |
 |`cublasChpr_v2_64`|12.0| | | |`hipblasChpr_v2_64`|6.2.0| | | | |`rocblas_chpr_64`|6.2.0| | | | |
@@ -824,9 +824,9 @@
 |`cublasDspmv_v2_64`|12.0| | | |`hipblasDspmv_64`|6.2.0| | | | |`rocblas_dspmv_64`|6.2.0| | | | |
 |`cublasDspr`| | | | |`hipblasDspr`|3.5.0| | | | |`rocblas_dspr`|3.5.0| | | | |
 |`cublasDspr2`| | | | |`hipblasDspr2`|3.5.0| | | | |`rocblas_dspr2`|3.5.0| | | | |
-|`cublasDspr2_64`|12.0| | | |`hipblasDspr2_64`|6.2.0| | | | | | | | | | |
+|`cublasDspr2_64`|12.0| | | |`hipblasDspr2_64`|6.2.0| | | | |`rocblas_dspr2_64`|6.2.0| | | | |
 |`cublasDspr2_v2`| | | | |`hipblasDspr2`|3.5.0| | | | |`rocblas_dspr2`|3.5.0| | | | |
-|`cublasDspr2_v2_64`|12.0| | | |`hipblasDspr2_64`|6.2.0| | | | | | | | | | |
+|`cublasDspr2_v2_64`|12.0| | | |`hipblasDspr2_64`|6.2.0| | | | |`rocblas_dspr2_64`|6.2.0| | | | |
 |`cublasDspr_64`|12.0| | | |`hipblasDspr_64`|6.2.0| | | | |`rocblas_dspr_64`|6.2.0| | | | |
 |`cublasDspr_v2`| | | | |`hipblasDspr`|3.5.0| | | | |`rocblas_dspr`|3.5.0| | | | |
 |`cublasDspr_v2_64`|12.0| | | |`hipblasDspr_64`|6.2.0| | | | |`rocblas_dspr_64`|6.2.0| | | | |
@@ -888,9 +888,9 @@
 |`cublasSspmv_v2_64`|12.0| | | |`hipblasSspmv_64`|6.2.0| | | | |`rocblas_sspmv_64`|6.2.0| | | | |
 |`cublasSspr`| | | | |`hipblasSspr`|3.5.0| | | | |`rocblas_sspr`|3.5.0| | | | |
 |`cublasSspr2`| | | | |`hipblasSspr2`|3.5.0| | | | |`rocblas_sspr2`|3.5.0| | | | |
-|`cublasSspr2_64`|12.0| | | |`hipblasSspr2_64`|6.2.0| | | | | | | | | | |
+|`cublasSspr2_64`|12.0| | | |`hipblasSspr2_64`|6.2.0| | | | |`rocblas_sspr2_64`|6.2.0| | | | |
 |`cublasSspr2_v2`| | | | |`hipblasSspr2`|3.5.0| | | | |`rocblas_sspr2`|3.5.0| | | | |
-|`cublasSspr2_v2_64`|12.0| | | |`hipblasSspr2_64`|6.2.0| | | | | | | | | | |
+|`cublasSspr2_v2_64`|12.0| | | |`hipblasSspr2_64`|6.2.0| | | | |`rocblas_sspr2_64`|6.2.0| | | | |
 |`cublasSspr_64`|12.0| | | |`hipblasSspr_64`|6.2.0| | | | |`rocblas_sspr_64`|6.2.0| | | | |
 |`cublasSspr_v2`| | | | |`hipblasSspr`|3.5.0| | | | |`rocblas_sspr`|3.5.0| | | | |
 |`cublasSspr_v2_64`|12.0| | | |`hipblasSspr_64`|6.2.0| | | | |`rocblas_sspr_64`|6.2.0| | | | |
@@ -968,9 +968,9 @@
 |`cublasZhpmv_v2_64`|12.0| | | |`hipblasZhpmv_v2_64`|6.2.0| | | | |`rocblas_zhpmv_64`|6.2.0| | | | |
 |`cublasZhpr`| | | | |`hipblasZhpr_v2`|6.0.0| | | | |`rocblas_zhpr`|3.5.0| | | | |
 |`cublasZhpr2`| | | | |`hipblasZhpr2_v2`|6.0.0| | | | |`rocblas_zhpr2`|3.5.0| | | | |
-|`cublasZhpr2_64`|12.0| | | |`hipblasZhpr2_v2_64`|6.2.0| | | | | | | | | | |
+|`cublasZhpr2_64`|12.0| | | |`hipblasZhpr2_v2_64`|6.2.0| | | | |`rocblas_zhpr2_64`|6.2.0| | | | |
 |`cublasZhpr2_v2`| | | | |`hipblasZhpr2_v2`|6.0.0| | | | |`rocblas_zhpr2`|3.5.0| | | | |
-|`cublasZhpr2_v2_64`|12.0| | | |`hipblasZhpr2_v2_64`|6.2.0| | | | | | | | | | |
+|`cublasZhpr2_v2_64`|12.0| | | |`hipblasZhpr2_v2_64`|6.2.0| | | | |`rocblas_zhpr2_64`|6.2.0| | | | |
 |`cublasZhpr_64`|12.0| | | |`hipblasZhpr_v2_64`|6.2.0| | | | |`rocblas_zhpr_64`|6.2.0| | | | |
 |`cublasZhpr_v2`| | | | |`hipblasZhpr_v2`|6.0.0| | | | |`rocblas_zhpr`|3.5.0| | | | |
 |`cublasZhpr_v2_64`|12.0| | | |`hipblasZhpr_v2_64`|6.2.0| | | | |`rocblas_zhpr_64`|6.2.0| | | | |

--- a/docs/tables/CUBLAS_API_supported_by_ROC.md
+++ b/docs/tables/CUBLAS_API_supported_by_ROC.md
@@ -760,9 +760,9 @@
 |`cublasChpmv_v2_64`|12.0| | | |`rocblas_chpmv_64`|6.2.0| | | | |
 |`cublasChpr`| | | | |`rocblas_chpr`|3.5.0| | | | |
 |`cublasChpr2`| | | | |`rocblas_chpr2`|3.5.0| | | | |
-|`cublasChpr2_64`|12.0| | | | | | | | | |
+|`cublasChpr2_64`|12.0| | | |`rocblas_chpr2_64`|6.2.0| | | | |
 |`cublasChpr2_v2`| | | | |`rocblas_chpr2`|3.5.0| | | | |
-|`cublasChpr2_v2_64`|12.0| | | | | | | | | |
+|`cublasChpr2_v2_64`|12.0| | | |`rocblas_chpr2_64`|6.2.0| | | | |
 |`cublasChpr_64`|12.0| | | |`rocblas_chpr_64`|6.2.0| | | | |
 |`cublasChpr_v2`| | | | |`rocblas_chpr`|3.5.0| | | | |
 |`cublasChpr_v2_64`|12.0| | | |`rocblas_chpr_64`|6.2.0| | | | |
@@ -824,9 +824,9 @@
 |`cublasDspmv_v2_64`|12.0| | | |`rocblas_dspmv_64`|6.2.0| | | | |
 |`cublasDspr`| | | | |`rocblas_dspr`|3.5.0| | | | |
 |`cublasDspr2`| | | | |`rocblas_dspr2`|3.5.0| | | | |
-|`cublasDspr2_64`|12.0| | | | | | | | | |
+|`cublasDspr2_64`|12.0| | | |`rocblas_dspr2_64`|6.2.0| | | | |
 |`cublasDspr2_v2`| | | | |`rocblas_dspr2`|3.5.0| | | | |
-|`cublasDspr2_v2_64`|12.0| | | | | | | | | |
+|`cublasDspr2_v2_64`|12.0| | | |`rocblas_dspr2_64`|6.2.0| | | | |
 |`cublasDspr_64`|12.0| | | |`rocblas_dspr_64`|6.2.0| | | | |
 |`cublasDspr_v2`| | | | |`rocblas_dspr`|3.5.0| | | | |
 |`cublasDspr_v2_64`|12.0| | | |`rocblas_dspr_64`|6.2.0| | | | |
@@ -888,9 +888,9 @@
 |`cublasSspmv_v2_64`|12.0| | | |`rocblas_sspmv_64`|6.2.0| | | | |
 |`cublasSspr`| | | | |`rocblas_sspr`|3.5.0| | | | |
 |`cublasSspr2`| | | | |`rocblas_sspr2`|3.5.0| | | | |
-|`cublasSspr2_64`|12.0| | | | | | | | | |
+|`cublasSspr2_64`|12.0| | | |`rocblas_sspr2_64`|6.2.0| | | | |
 |`cublasSspr2_v2`| | | | |`rocblas_sspr2`|3.5.0| | | | |
-|`cublasSspr2_v2_64`|12.0| | | | | | | | | |
+|`cublasSspr2_v2_64`|12.0| | | |`rocblas_sspr2_64`|6.2.0| | | | |
 |`cublasSspr_64`|12.0| | | |`rocblas_sspr_64`|6.2.0| | | | |
 |`cublasSspr_v2`| | | | |`rocblas_sspr`|3.5.0| | | | |
 |`cublasSspr_v2_64`|12.0| | | |`rocblas_sspr_64`|6.2.0| | | | |
@@ -968,9 +968,9 @@
 |`cublasZhpmv_v2_64`|12.0| | | |`rocblas_zhpmv_64`|6.2.0| | | | |
 |`cublasZhpr`| | | | |`rocblas_zhpr`|3.5.0| | | | |
 |`cublasZhpr2`| | | | |`rocblas_zhpr2`|3.5.0| | | | |
-|`cublasZhpr2_64`|12.0| | | | | | | | | |
+|`cublasZhpr2_64`|12.0| | | |`rocblas_zhpr2_64`|6.2.0| | | | |
 |`cublasZhpr2_v2`| | | | |`rocblas_zhpr2`|3.5.0| | | | |
-|`cublasZhpr2_v2_64`|12.0| | | | | | | | | |
+|`cublasZhpr2_v2_64`|12.0| | | |`rocblas_zhpr2_64`|6.2.0| | | | |
 |`cublasZhpr_64`|12.0| | | |`rocblas_zhpr_64`|6.2.0| | | | |
 |`cublasZhpr_v2`| | | | |`rocblas_zhpr`|3.5.0| | | | |
 |`cublasZhpr_v2_64`|12.0| | | |`rocblas_zhpr_64`|6.2.0| | | | |

--- a/src/CUDA2HIP_BLAS_API_functions.cpp
+++ b/src/CUDA2HIP_BLAS_API_functions.cpp
@@ -388,13 +388,13 @@ const std::map<llvm::StringRef, hipCounter> CUDA_BLAS_FUNCTION_MAP {
 
   // SPR2/HPR2
   {"cublasSspr2",                                          {"hipblasSspr2",                                              "rocblas_sspr2",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, HIP_SUPPORTED_V2_ONLY}},
-  {"cublasSspr2_64",                                       {"hipblasSspr2_64",                                           "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
+  {"cublasSspr2_64",                                       {"hipblasSspr2_64",                                           "rocblas_sspr2_64",                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
   {"cublasDspr2",                                          {"hipblasDspr2",                                              "rocblas_dspr2",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, HIP_SUPPORTED_V2_ONLY}},
-  {"cublasDspr2_64",                                       {"hipblasDspr2_64",                                           "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
+  {"cublasDspr2_64",                                       {"hipblasDspr2_64",                                           "rocblas_dspr2_64",                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
   {"cublasChpr2",                                          {"hipblasChpr2_v2",                                           "rocblas_chpr2",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, HIP_SUPPORTED_V2_ONLY}},
-  {"cublasChpr2_64",                                       {"hipblasChpr2_v2_64",                                        "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
+  {"cublasChpr2_64",                                       {"hipblasChpr2_v2_64",                                        "rocblas_chpr2_64",                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
   {"cublasZhpr2",                                          {"hipblasZhpr2_v2",                                           "rocblas_zhpr2",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, HIP_SUPPORTED_V2_ONLY}},
-  {"cublasZhpr2_64",                                       {"hipblasZhpr2_v2_64",                                        "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
+  {"cublasZhpr2_64",                                       {"hipblasZhpr2_v2_64",                                        "rocblas_zhpr2_64",                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
 
   // Blas3 (v1) Routines
   // GEMM
@@ -806,13 +806,13 @@ const std::map<llvm::StringRef, hipCounter> CUDA_BLAS_FUNCTION_MAP {
 
   // SPR2/HPR2
   {"cublasSspr2_v2",                                       {"hipblasSspr2",                                              "rocblas_sspr2",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
-  {"cublasSspr2_v2_64",                                    {"hipblasSspr2_64",                                           "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
+  {"cublasSspr2_v2_64",                                    {"hipblasSspr2_64",                                           "rocblas_sspr2_64",                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
   {"cublasDspr2_v2",                                       {"hipblasDspr2",                                              "rocblas_dspr2",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
-  {"cublasDspr2_v2_64",                                    {"hipblasDspr2_64",                                           "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
+  {"cublasDspr2_v2_64",                                    {"hipblasDspr2_64",                                           "rocblas_dspr2_64",                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
   {"cublasChpr2_v2",                                       {"hipblasChpr2_v2",                                           "rocblas_chpr2",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
-  {"cublasChpr2_v2_64",                                    {"hipblasChpr2_v2_64",                                        "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
+  {"cublasChpr2_v2_64",                                    {"hipblasChpr2_v2_64",                                        "rocblas_chpr2_64",                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
   {"cublasZhpr2_v2",                                       {"hipblasZhpr2_v2",                                           "rocblas_zhpr2",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
-  {"cublasZhpr2_v2_64",                                    {"hipblasZhpr2_v2_64",                                        "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
+  {"cublasZhpr2_v2_64",                                    {"hipblasZhpr2_v2_64",                                        "rocblas_zhpr2_64",                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
 
   // Blas3 (v2) Routines
   // GEMM
@@ -2369,6 +2369,10 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_BLAS_FUNCTION_VER_MAP {
   {"rocblas_dspr_64",                                      {HIP_6020, HIP_0,    HIP_0   }},
   {"rocblas_chpr_64",                                      {HIP_6020, HIP_0,    HIP_0   }},
   {"rocblas_zhpr_64",                                      {HIP_6020, HIP_0,    HIP_0   }},
+  {"rocblas_sspr2_64",                                     {HIP_6020, HIP_0,    HIP_0   }},
+  {"rocblas_dspr2_64",                                     {HIP_6020, HIP_0,    HIP_0   }},
+  {"rocblas_chpr2_64",                                     {HIP_6020, HIP_0,    HIP_0   }},
+  {"rocblas_zhpr2_64",                                     {HIP_6020, HIP_0,    HIP_0   }},
 };
 
 const std::map<llvm::StringRef, hipAPIChangedVersions> HIP_BLAS_FUNCTION_CHANGED_VER_MAP {

--- a/tests/unit_tests/synthetic/libraries/cublas2rocblas_v2.cu
+++ b/tests/unit_tests/synthetic/libraries/cublas2rocblas_v2.cu
@@ -2741,6 +2741,34 @@ int main() {
   // CHECK-NEXT: blasStatus = rocblas_zhpr_64(blasHandle, blasFillMode, n_64, &da, &dcomplexx, incx_64, &dcomplexA);
   blasStatus = cublasZhpr_64(blasHandle, blasFillMode, n_64, &da, &dcomplexx, incx_64, &dcomplexA);
   blasStatus = cublasZhpr_v2_64(blasHandle, blasFillMode, n_64, &da, &dcomplexx, incx_64, &dcomplexA);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasSspr2_v2_64(cublasHandle_t handle, cublasFillMode_t uplo, int64_t n, const float* alpha, const float* x, int64_t incx, const float* y, int64_t incy, float* AP);
+  // ROC: ROCBLAS_EXPORT rocblas_status rocblas_sspr2_64(rocblas_handle handle, rocblas_fill uplo, int64_t n, const float* alpha, const float* x, int64_t incx, const float* y, int64_t incy, float* AP);
+  // CHECK: blasStatus = rocblas_sspr2_64(blasHandle, blasFillMode, n_64, &fa, &fx, incx_64, &fy, incy_64, &fA);
+  // CHECK-NEXT: blasStatus = rocblas_sspr2_64(blasHandle, blasFillMode, n_64, &fa, &fx, incx_64, &fy, incy_64, &fA);
+  blasStatus = cublasSspr2_64(blasHandle, blasFillMode, n_64, &fa, &fx, incx_64, &fy, incy_64, &fA);
+  blasStatus = cublasSspr2_v2_64(blasHandle, blasFillMode, n_64, &fa, &fx, incx_64, &fy, incy_64, &fA);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasDspr2_v2_64(cublasHandle_t handle, cublasFillMode_t uplo, int64_t n, const double* alpha, const double* x, int64_t incx, const double* y, int64_t incy, double* AP);
+  // ROC: ROCBLAS_EXPORT rocblas_status rocblas_dspr2_64(rocblas_handle handle, rocblas_fill uplo, int64_t n, const double* alpha, const double* x, int64_t incx, const double* y, int64_t incy, double* AP);
+  // CHECK: blasStatus = rocblas_dspr2_64(blasHandle, blasFillMode, n_64, &da, &dx, incx_64, &dy, incy_64, &dA);
+  // CHECK-NEXT: blasStatus = rocblas_dspr2_64(blasHandle, blasFillMode, n_64, &da, &dx, incx_64, &dy, incy_64, &dA);
+  blasStatus = cublasDspr2_64(blasHandle, blasFillMode, n_64, &da, &dx, incx_64, &dy, incy_64, &dA);
+  blasStatus = cublasDspr2_v2_64(blasHandle, blasFillMode, n_64, &da, &dx, incx_64, &dy, incy_64, &dA);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasChpr2_v2_64(cublasHandle_t handle, cublasFillMode_t uplo, int64_t n, const cuComplex* alpha, const cuComplex* x, int64_t incx, const cuComplex* y, int64_t incy, cuComplex* AP);
+  // ROC: ROCBLAS_EXPORT rocblas_status rocblas_chpr2_64(rocblas_handle handle, rocblas_fill uplo, int64_t n, const rocblas_float_complex* alpha, const rocblas_float_complex* x, int64_t incx, const rocblas_float_complex* y, int64_t incy, rocblas_float_complex* AP);
+  // CHECK: blasStatus = rocblas_chpr2_64(blasHandle, blasFillMode, n_64, &complexa, &complexx, incx_64, &complexy, incy_64, &complexA);
+  // CHECK-NEXT: blasStatus = rocblas_chpr2_64(blasHandle, blasFillMode, n_64, &complexa, &complexx, incx_64, &complexy, incy_64, &complexA);
+  blasStatus = cublasChpr2_64(blasHandle, blasFillMode, n_64, &complexa, &complexx, incx_64, &complexy, incy_64, &complexA);
+  blasStatus = cublasChpr2_v2_64(blasHandle, blasFillMode, n_64, &complexa, &complexx, incx_64, &complexy, incy_64, &complexA);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasZhpr2_v2_64(cublasHandle_t handle, cublasFillMode_t uplo, int64_t n, const cuDoubleComplex* alpha, const cuDoubleComplex* x, int64_t incx, const cuDoubleComplex* y, int64_t incy, cuDoubleComplex* AP);
+  // ROC: ROCBLAS_EXPORT rocblas_status rocblas_zhpr2_64(rocblas_handle handle, rocblas_fill uplo, int64_t n, const rocblas_double_complex* alpha, const rocblas_double_complex* x, int64_t incx, const rocblas_double_complex* y, int64_t incy, rocblas_double_complex* AP);
+  // CHECK: blasStatus = rocblas_zhpr2_64(blasHandle, blasFillMode, n_64, &dcomplexa, &dcomplexx, incx_64, &dcomplexy, incy_64, &dcomplexA);
+  // CHECK-NEXT: blasStatus = rocblas_zhpr2_64(blasHandle, blasFillMode, n_64, &dcomplexa, &dcomplexx, incx_64, &dcomplexy, incy_64, &dcomplexA);
+  blasStatus = cublasZhpr2_64(blasHandle, blasFillMode, n_64, &dcomplexa, &dcomplexx, incx_64, &dcomplexy, incy_64, &dcomplexA);
+  blasStatus = cublasZhpr2_v2_64(blasHandle, blasFillMode, n_64, &dcomplexa, &dcomplexx, incx_64, &dcomplexy, incy_64, &dcomplexA);
 #endif
 
   return 0;


### PR DESCRIPTION
+ `rocblas_(ss|ds|ch|zh)pr2_64` support
+ Updated synthetic tests, the regenerated `hipify-perl`, and `BLAS` `CUDA2HIP` documentation
