### PR TITLE
[HIPIFY][rocBLAS] 64-bit functions support - Step 14

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -1652,7 +1652,9 @@ sub rocSubstitutions {
     subst("cublasCsyrk_v2", "rocblas_csyrk", "library");
     subst("cublasCsyrkx", "rocblas_csyrkx", "library");
     subst("cublasCtbmv", "rocblas_ctbmv", "library");
+    subst("cublasCtbmv_64", "rocblas_ctbmv_64", "library");
     subst("cublasCtbmv_v2", "rocblas_ctbmv", "library");
+    subst("cublasCtbmv_v2_64", "rocblas_ctbmv_64", "library");
     subst("cublasCtbsv", "rocblas_ctbsv", "library");
     subst("cublasCtbsv_v2", "rocblas_ctbsv", "library");
     subst("cublasCtpmv", "rocblas_ctpmv", "library");
@@ -1774,7 +1776,9 @@ sub rocSubstitutions {
     subst("cublasDsyrk_v2", "rocblas_dsyrk", "library");
     subst("cublasDsyrkx", "rocblas_dsyrkx", "library");
     subst("cublasDtbmv", "rocblas_dtbmv", "library");
+    subst("cublasDtbmv_64", "rocblas_dtbmv_64", "library");
     subst("cublasDtbmv_v2", "rocblas_dtbmv", "library");
+    subst("cublasDtbmv_v2_64", "rocblas_dtbmv_64", "library");
     subst("cublasDtbsv", "rocblas_dtbsv", "library");
     subst("cublasDtbsv_v2", "rocblas_dtbsv", "library");
     subst("cublasDtpmv", "rocblas_dtpmv", "library");
@@ -1980,7 +1984,9 @@ sub rocSubstitutions {
     subst("cublasSsyrk_v2", "rocblas_ssyrk", "library");
     subst("cublasSsyrkx", "rocblas_ssyrkx", "library");
     subst("cublasStbmv", "rocblas_stbmv", "library");
+    subst("cublasStbmv_64", "rocblas_stbmv_64", "library");
     subst("cublasStbmv_v2", "rocblas_stbmv", "library");
+    subst("cublasStbmv_v2_64", "rocblas_stbmv_64", "library");
     subst("cublasStbsv", "rocblas_stbsv", "library");
     subst("cublasStbsv_v2", "rocblas_stbsv", "library");
     subst("cublasStpmv", "rocblas_stpmv", "library");
@@ -2123,7 +2129,9 @@ sub rocSubstitutions {
     subst("cublasZsyrk_v2", "rocblas_zsyrk", "library");
     subst("cublasZsyrkx", "rocblas_zsyrkx", "library");
     subst("cublasZtbmv", "rocblas_ztbmv", "library");
+    subst("cublasZtbmv_64", "rocblas_ztbmv_64", "library");
     subst("cublasZtbmv_v2", "rocblas_ztbmv", "library");
+    subst("cublasZtbmv_v2_64", "rocblas_ztbmv_64", "library");
     subst("cublasZtbsv", "rocblas_ztbsv", "library");
     subst("cublasZtbsv_v2", "rocblas_ztbsv", "library");
     subst("cublasZtpmv", "rocblas_ztpmv", "library");
@@ -12625,8 +12633,6 @@ sub warnRocOnlyUnsupportedFunctions {
         "cublasZtpsv_64",
         "cublasZtbsv_v2_64",
         "cublasZtbsv_64",
-        "cublasZtbmv_v2_64",
-        "cublasZtbmv_64",
         "cublasZsyrkx_64",
         "cublasZsyrk_v2_64",
         "cublasZsyrk_64",
@@ -12676,8 +12682,6 @@ sub warnRocOnlyUnsupportedFunctions {
         "cublasStpsv_64",
         "cublasStbsv_v2_64",
         "cublasStbsv_64",
-        "cublasStbmv_v2_64",
-        "cublasStbmv_64",
         "cublasSsyrkx_64",
         "cublasSsyrk_v2_64",
         "cublasSsyrk_64",
@@ -12819,8 +12823,6 @@ sub warnRocOnlyUnsupportedFunctions {
         "cublasDtpsv_64",
         "cublasDtbsv_v2_64",
         "cublasDtbsv_64",
-        "cublasDtbmv_v2_64",
-        "cublasDtbmv_64",
         "cublasDsyrkx_64",
         "cublasDsyrk_v2_64",
         "cublasDsyrk_64",
@@ -12857,8 +12859,6 @@ sub warnRocOnlyUnsupportedFunctions {
         "cublasCtpsv_64",
         "cublasCtbsv_v2_64",
         "cublasCtbsv_64",
-        "cublasCtbmv_v2_64",
-        "cublasCtbmv_64",
         "cublasCsyrkx_64",
         "cublasCsyrk_v2_64",
         "cublasCsyrk_64",

--- a/docs/tables/CUBLAS_API_supported_by_HIP_and_ROC.md
+++ b/docs/tables/CUBLAS_API_supported_by_HIP_and_ROC.md
@@ -779,9 +779,9 @@
 |`cublasCsyr_v2`| | | | |`hipblasCsyr_v2`|6.0.0| | | | |`rocblas_csyr`|1.7.1| | | | |
 |`cublasCsyr_v2_64`|12.0| | | |`hipblasCsyr_v2_64`|6.2.0| | | | |`rocblas_csyr_64`|6.2.0| | | | |
 |`cublasCtbmv`| | | | |`hipblasCtbmv_v2`|6.0.0| | | | |`rocblas_ctbmv`|3.5.0| | | | |
-|`cublasCtbmv_64`|12.0| | | |`hipblasCtbmv_v2_64`|6.2.0| | | | | | | | | | |
+|`cublasCtbmv_64`|12.0| | | |`hipblasCtbmv_v2_64`|6.2.0| | | | |`rocblas_ctbmv_64`|6.2.0| | | | |
 |`cublasCtbmv_v2`| | | | |`hipblasCtbmv_v2`|6.0.0| | | | |`rocblas_ctbmv`|3.5.0| | | | |
-|`cublasCtbmv_v2_64`|12.0| | | |`hipblasCtbmv_v2_64`|6.2.0| | | | | | | | | | |
+|`cublasCtbmv_v2_64`|12.0| | | |`hipblasCtbmv_v2_64`|6.2.0| | | | |`rocblas_ctbmv_64`|6.2.0| | | | |
 |`cublasCtbsv`| | | | |`hipblasCtbsv_v2`|6.0.0| | | | |`rocblas_ctbsv`|3.5.0| | | | |
 |`cublasCtbsv_64`|12.0| | | |`hipblasCtbsv_v2_64`|6.2.0| | | | | | | | | | |
 |`cublasCtbsv_v2`| | | | |`hipblasCtbsv_v2`|6.0.0| | | | |`rocblas_ctbsv`|3.5.0| | | | |
@@ -843,9 +843,9 @@
 |`cublasDsyr_v2`| | | | |`hipblasDsyr`|3.0.0| | | | |`rocblas_dsyr`|1.7.1| | | | |
 |`cublasDsyr_v2_64`|12.0| | | |`hipblasDsyr_64`|6.2.0| | | | |`rocblas_dsyr_64`|6.2.0| | | | |
 |`cublasDtbmv`| | | | |`hipblasDtbmv`|3.5.0| | | | |`rocblas_dtbmv`|3.5.0| | | | |
-|`cublasDtbmv_64`|12.0| | | |`hipblasDtbmv_64`|6.2.0| | | | | | | | | | |
+|`cublasDtbmv_64`|12.0| | | |`hipblasDtbmv_64`|6.2.0| | | | |`rocblas_dtbmv_64`|6.2.0| | | | |
 |`cublasDtbmv_v2`| | | | |`hipblasDtbmv`|3.5.0| | | | |`rocblas_dtbmv`|3.5.0| | | | |
-|`cublasDtbmv_v2_64`|12.0| | | |`hipblasDtbmv_64`|6.2.0| | | | | | | | | | |
+|`cublasDtbmv_v2_64`|12.0| | | |`hipblasDtbmv_64`|6.2.0| | | | |`rocblas_dtbmv_64`|6.2.0| | | | |
 |`cublasDtbsv`| | | | |`hipblasDtbsv`|3.6.0| | | | |`rocblas_dtbsv`|3.5.0| | | | |
 |`cublasDtbsv_64`|12.0| | | |`hipblasDtbsv_64`|6.2.0| | | | | | | | | | |
 |`cublasDtbsv_v2`| | | | |`hipblasDtbsv`|3.6.0| | | | |`rocblas_dtbsv`|3.5.0| | | | |
@@ -907,9 +907,9 @@
 |`cublasSsyr_v2`| | | | |`hipblasSsyr`|3.0.0| | | | |`rocblas_ssyr`|1.7.1| | | | |
 |`cublasSsyr_v2_64`|12.0| | | |`hipblasSsyr_64`|6.2.0| | | | |`rocblas_ssyr_64`|6.2.0| | | | |
 |`cublasStbmv`| | | | |`hipblasStbmv`|3.5.0| | | | |`rocblas_stbmv`|3.5.0| | | | |
-|`cublasStbmv_64`|12.0| | | |`hipblasStbmv_64`|6.2.0| | | | | | | | | | |
+|`cublasStbmv_64`|12.0| | | |`hipblasStbmv_64`|6.2.0| | | | |`rocblas_stbmv_64`|6.2.0| | | | |
 |`cublasStbmv_v2`| | | | |`hipblasStbmv`|3.5.0| | | | |`rocblas_stbmv`|3.5.0| | | | |
-|`cublasStbmv_v2_64`|12.0| | | |`hipblasStbmv_64`|6.2.0| | | | | | | | | | |
+|`cublasStbmv_v2_64`|12.0| | | |`hipblasStbmv_64`|6.2.0| | | | |`rocblas_stbmv_64`|6.2.0| | | | |
 |`cublasStbsv`| | | | |`hipblasStbsv`|3.6.0| | | | |`rocblas_stbsv`|3.5.0| | | | |
 |`cublasStbsv_64`|12.0| | | |`hipblasStbsv_64`|6.2.0| | | | | | | | | | |
 |`cublasStbsv_v2`| | | | |`hipblasStbsv`|3.6.0| | | | |`rocblas_stbsv`|3.5.0| | | | |
@@ -987,9 +987,9 @@
 |`cublasZsyr_v2`| | | | |`hipblasZsyr_v2`|6.0.0| | | | |`rocblas_zsyr`|1.7.1| | | | |
 |`cublasZsyr_v2_64`|12.0| | | |`hipblasZsyr_v2_64`|6.2.0| | | | |`rocblas_zsyr_64`|6.2.0| | | | |
 |`cublasZtbmv`| | | | |`hipblasZtbmv_v2`|6.0.0| | | | |`rocblas_ztbmv`|3.5.0| | | | |
-|`cublasZtbmv_64`|12.0| | | |`hipblasZtbmv_v2_64`|6.2.0| | | | | | | | | | |
+|`cublasZtbmv_64`|12.0| | | |`hipblasZtbmv_v2_64`|6.2.0| | | | |`rocblas_ztbmv_64`|6.2.0| | | | |
 |`cublasZtbmv_v2`| | | | |`hipblasZtbmv_v2`|6.0.0| | | | |`rocblas_ztbmv`|3.5.0| | | | |
-|`cublasZtbmv_v2_64`|12.0| | | |`hipblasZtbmv_v2_64`|6.2.0| | | | | | | | | | |
+|`cublasZtbmv_v2_64`|12.0| | | |`hipblasZtbmv_v2_64`|6.2.0| | | | |`rocblas_ztbmv_64`|6.2.0| | | | |
 |`cublasZtbsv`| | | | |`hipblasZtbsv_v2`|6.0.0| | | | |`rocblas_ztbsv`|3.5.0| | | | |
 |`cublasZtbsv_64`|12.0| | | |`hipblasZtbsv_v2_64`|6.2.0| | | | | | | | | | |
 |`cublasZtbsv_v2`| | | | |`hipblasZtbsv_v2`|6.0.0| | | | |`rocblas_ztbsv`|3.5.0| | | | |

--- a/docs/tables/CUBLAS_API_supported_by_ROC.md
+++ b/docs/tables/CUBLAS_API_supported_by_ROC.md
@@ -779,9 +779,9 @@
 |`cublasCsyr_v2`| | | | |`rocblas_csyr`|1.7.1| | | | |
 |`cublasCsyr_v2_64`|12.0| | | |`rocblas_csyr_64`|6.2.0| | | | |
 |`cublasCtbmv`| | | | |`rocblas_ctbmv`|3.5.0| | | | |
-|`cublasCtbmv_64`|12.0| | | | | | | | | |
+|`cublasCtbmv_64`|12.0| | | |`rocblas_ctbmv_64`|6.2.0| | | | |
 |`cublasCtbmv_v2`| | | | |`rocblas_ctbmv`|3.5.0| | | | |
-|`cublasCtbmv_v2_64`|12.0| | | | | | | | | |
+|`cublasCtbmv_v2_64`|12.0| | | |`rocblas_ctbmv_64`|6.2.0| | | | |
 |`cublasCtbsv`| | | | |`rocblas_ctbsv`|3.5.0| | | | |
 |`cublasCtbsv_64`|12.0| | | | | | | | | |
 |`cublasCtbsv_v2`| | | | |`rocblas_ctbsv`|3.5.0| | | | |
@@ -843,9 +843,9 @@
 |`cublasDsyr_v2`| | | | |`rocblas_dsyr`|1.7.1| | | | |
 |`cublasDsyr_v2_64`|12.0| | | |`rocblas_dsyr_64`|6.2.0| | | | |
 |`cublasDtbmv`| | | | |`rocblas_dtbmv`|3.5.0| | | | |
-|`cublasDtbmv_64`|12.0| | | | | | | | | |
+|`cublasDtbmv_64`|12.0| | | |`rocblas_dtbmv_64`|6.2.0| | | | |
 |`cublasDtbmv_v2`| | | | |`rocblas_dtbmv`|3.5.0| | | | |
-|`cublasDtbmv_v2_64`|12.0| | | | | | | | | |
+|`cublasDtbmv_v2_64`|12.0| | | |`rocblas_dtbmv_64`|6.2.0| | | | |
 |`cublasDtbsv`| | | | |`rocblas_dtbsv`|3.5.0| | | | |
 |`cublasDtbsv_64`|12.0| | | | | | | | | |
 |`cublasDtbsv_v2`| | | | |`rocblas_dtbsv`|3.5.0| | | | |
@@ -907,9 +907,9 @@
 |`cublasSsyr_v2`| | | | |`rocblas_ssyr`|1.7.1| | | | |
 |`cublasSsyr_v2_64`|12.0| | | |`rocblas_ssyr_64`|6.2.0| | | | |
 |`cublasStbmv`| | | | |`rocblas_stbmv`|3.5.0| | | | |
-|`cublasStbmv_64`|12.0| | | | | | | | | |
+|`cublasStbmv_64`|12.0| | | |`rocblas_stbmv_64`|6.2.0| | | | |
 |`cublasStbmv_v2`| | | | |`rocblas_stbmv`|3.5.0| | | | |
-|`cublasStbmv_v2_64`|12.0| | | | | | | | | |
+|`cublasStbmv_v2_64`|12.0| | | |`rocblas_stbmv_64`|6.2.0| | | | |
 |`cublasStbsv`| | | | |`rocblas_stbsv`|3.5.0| | | | |
 |`cublasStbsv_64`|12.0| | | | | | | | | |
 |`cublasStbsv_v2`| | | | |`rocblas_stbsv`|3.5.0| | | | |
@@ -987,9 +987,9 @@
 |`cublasZsyr_v2`| | | | |`rocblas_zsyr`|1.7.1| | | | |
 |`cublasZsyr_v2_64`|12.0| | | |`rocblas_zsyr_64`|6.2.0| | | | |
 |`cublasZtbmv`| | | | |`rocblas_ztbmv`|3.5.0| | | | |
-|`cublasZtbmv_64`|12.0| | | | | | | | | |
+|`cublasZtbmv_64`|12.0| | | |`rocblas_ztbmv_64`|6.2.0| | | | |
 |`cublasZtbmv_v2`| | | | |`rocblas_ztbmv`|3.5.0| | | | |
-|`cublasZtbmv_v2_64`|12.0| | | | | | | | | |
+|`cublasZtbmv_v2_64`|12.0| | | |`rocblas_ztbmv_64`|6.2.0| | | | |
 |`cublasZtbsv`| | | | |`rocblas_ztbsv`|3.5.0| | | | |
 |`cublasZtbsv_64`|12.0| | | | | | | | | |
 |`cublasZtbsv_v2`| | | | |`rocblas_ztbsv`|3.5.0| | | | |

--- a/src/CUDA2HIP_BLAS_API_functions.cpp
+++ b/src/CUDA2HIP_BLAS_API_functions.cpp
@@ -252,13 +252,13 @@ const std::map<llvm::StringRef, hipCounter> CUDA_BLAS_FUNCTION_MAP {
 
   // TBMV
   {"cublasStbmv",                                          {"hipblasStbmv",                                              "rocblas_stbmv",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, HIP_SUPPORTED_V2_ONLY}},
-  {"cublasStbmv_64",                                       {"hipblasStbmv_64",                                           "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
+  {"cublasStbmv_64",                                       {"hipblasStbmv_64",                                           "rocblas_stbmv_64",                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
   {"cublasDtbmv",                                          {"hipblasDtbmv",                                              "rocblas_dtbmv",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, HIP_SUPPORTED_V2_ONLY}},
-  {"cublasDtbmv_64",                                       {"hipblasDtbmv_64",                                           "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
+  {"cublasDtbmv_64",                                       {"hipblasDtbmv_64",                                           "rocblas_dtbmv_64",                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
   {"cublasCtbmv",                                          {"hipblasCtbmv_v2",                                           "rocblas_ctbmv",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, HIP_SUPPORTED_V2_ONLY}},
-  {"cublasCtbmv_64",                                       {"hipblasCtbmv_v2_64",                                        "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
+  {"cublasCtbmv_64",                                       {"hipblasCtbmv_v2_64",                                        "rocblas_ctbmv_64",                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
   {"cublasZtbmv",                                          {"hipblasZtbmv_v2",                                           "rocblas_ztbmv",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, HIP_SUPPORTED_V2_ONLY}},
-  {"cublasZtbmv_64",                                       {"hipblasZtbmv_v2_64",                                        "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
+  {"cublasZtbmv_64",                                       {"hipblasZtbmv_v2_64",                                        "rocblas_ztbmv_64",                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
 
   // TPMV
   {"cublasStpmv",                                          {"hipblasStpmv",                                              "rocblas_stpmv",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, HIP_SUPPORTED_V2_ONLY}},
@@ -670,13 +670,13 @@ const std::map<llvm::StringRef, hipCounter> CUDA_BLAS_FUNCTION_MAP {
 
   // TBMV
   {"cublasStbmv_v2",                                       {"hipblasStbmv",                                              "rocblas_stbmv",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
-  {"cublasStbmv_v2_64",                                    {"hipblasStbmv_64",                                           "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
+  {"cublasStbmv_v2_64",                                    {"hipblasStbmv_64",                                           "rocblas_stbmv_64",                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
   {"cublasDtbmv_v2",                                       {"hipblasDtbmv",                                              "rocblas_dtbmv",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
-  {"cublasDtbmv_v2_64",                                    {"hipblasDtbmv_64",                                           "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
+  {"cublasDtbmv_v2_64",                                    {"hipblasDtbmv_64",                                           "rocblas_dtbmv_64",                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
   {"cublasCtbmv_v2",                                       {"hipblasCtbmv_v2",                                           "rocblas_ctbmv",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
-  {"cublasCtbmv_v2_64",                                    {"hipblasCtbmv_v2_64",                                        "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
+  {"cublasCtbmv_v2_64",                                    {"hipblasCtbmv_v2_64",                                        "rocblas_ctbmv_64",                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
   {"cublasZtbmv_v2",                                       {"hipblasZtbmv_v2",                                           "rocblas_ztbmv",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
-  {"cublasZtbmv_v2_64",                                    {"hipblasZtbmv_v2_64",                                        "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
+  {"cublasZtbmv_v2_64",                                    {"hipblasZtbmv_v2_64",                                        "rocblas_ztbmv_64",                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
 
   // TPMV
   {"cublasStpmv_v2",                                       {"hipblasStpmv",                                              "rocblas_stpmv",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
@@ -2381,6 +2381,10 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_BLAS_FUNCTION_VER_MAP {
   {"rocblas_dtpmv_64",                                     {HIP_6020, HIP_0,    HIP_0   }},
   {"rocblas_ctpmv_64",                                     {HIP_6020, HIP_0,    HIP_0   }},
   {"rocblas_ztpmv_64",                                     {HIP_6020, HIP_0,    HIP_0   }},
+  {"rocblas_stbmv_64",                                     {HIP_6020, HIP_0,    HIP_0   }},
+  {"rocblas_dtbmv_64",                                     {HIP_6020, HIP_0,    HIP_0   }},
+  {"rocblas_ctbmv_64",                                     {HIP_6020, HIP_0,    HIP_0   }},
+  {"rocblas_ztbmv_64",                                     {HIP_6020, HIP_0,    HIP_0   }},
 };
 
 const std::map<llvm::StringRef, hipAPIChangedVersions> HIP_BLAS_FUNCTION_CHANGED_VER_MAP {

--- a/tests/unit_tests/synthetic/libraries/cublas2rocblas_v2.cu
+++ b/tests/unit_tests/synthetic/libraries/cublas2rocblas_v2.cu
@@ -2825,6 +2825,34 @@ int main() {
   // CHECK-NEXT: blasStatus = rocblas_ztpmv_64(blasHandle, blasFillMode, blasOperation, blasDiagType, n_64, &dcomplexA, &dcomplexx, incx_64);
   blasStatus = cublasZtpmv_64(blasHandle, blasFillMode, blasOperation, blasDiagType, n_64, &dcomplexA, &dcomplexx, incx_64);
   blasStatus = cublasZtpmv_v2_64(blasHandle, blasFillMode, blasOperation, blasDiagType, n_64, &dcomplexA, &dcomplexx, incx_64);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasStbmv_v2_64(cublasHandle_t handle, cublasFillMode_t uplo, cublasOperation_t trans, cublasDiagType_t diag, int64_t n, int64_t k, const float* A, int64_t lda, float* x, int64_t incx);
+  // ROC: ROCBLAS_EXPORT rocblas_status rocblas_stbmv_64(rocblas_handle handle, rocblas_fill uplo, rocblas_operation trans, rocblas_diagonal diag, int64_t n, int64_t k, const float* A, int64_t lda, float* x, int64_t incx);
+  // CHECK: blasStatus = rocblas_stbmv_64(blasHandle, blasFillMode, blasOperation, blasDiagType, n_64, k_64, &fA, lda_64, &fx, incx_64);
+  // CHECK-NEXT: blasStatus = rocblas_stbmv_64(blasHandle, blasFillMode, blasOperation, blasDiagType, n_64, k_64, &fA, lda_64, &fx, incx_64);
+  blasStatus = cublasStbmv_64(blasHandle, blasFillMode, blasOperation, blasDiagType, n_64, k_64, &fA, lda_64, &fx, incx_64);
+  blasStatus = cublasStbmv_v2_64(blasHandle, blasFillMode, blasOperation, blasDiagType, n_64, k_64, &fA, lda_64, &fx, incx_64);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasDtbmv_v2_64(cublasHandle_t handle, cublasFillMode_t uplo, cublasOperation_t trans, cublasDiagType_t diag, int64_t n, int64_t k, const double* A, int64_t lda, double* x, int64_t incx);
+  // ROC: ROCBLAS_EXPORT rocblas_status rocblas_dtbmv_64(rocblas_handle handle,  rocblas_fill uplo,  rocblas_operation trans,  rocblas_diagonal diag,  int64_t n,  int64_t k,  const double* A,  int64_t lda,  double* x,  int64_t incx);
+  // CHECK: blasStatus = rocblas_dtbmv_64(blasHandle, blasFillMode, blasOperation, blasDiagType, n_64, k_64, &dA, lda_64, &dx, incx_64);
+  // CHECK-NEXT: blasStatus = rocblas_dtbmv_64(blasHandle, blasFillMode, blasOperation, blasDiagType, n_64, k_64, &dA, lda_64, &dx, incx_64);
+  blasStatus = cublasDtbmv_64(blasHandle, blasFillMode, blasOperation, blasDiagType, n_64, k_64, &dA, lda_64, &dx, incx_64);
+  blasStatus = cublasDtbmv_v2_64(blasHandle, blasFillMode, blasOperation, blasDiagType, n_64, k_64, &dA, lda_64, &dx, incx_64);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasCtbmv_v2_64(cublasHandle_t handle, cublasFillMode_t uplo, cublasOperation_t trans, cublasDiagType_t diag, int64_t n, int64_t k, const cuComplex* A, int64_t lda, cuComplex* x, int64_t incx);
+  // ROC: ROCBLAS_EXPORT rocblas_status rocblas_ctbmv_64(rocblas_handle handle, rocblas_fill uplo, rocblas_operation trans, rocblas_diagonal diag, int64_t n, int64_t k, const rocblas_float_complex* A, int64_t lda, rocblas_float_complex* x, int64_t incx);
+  // CHECK: blasStatus = rocblas_ctbmv_64(blasHandle, blasFillMode, blasOperation, blasDiagType, n_64, k_64, &complexA, lda_64, &complexx, incx_64);
+  // CHECK-NEXT: blasStatus = rocblas_ctbmv_64(blasHandle, blasFillMode, blasOperation, blasDiagType, n_64, k_64, &complexA, lda_64, &complexx, incx_64);
+  blasStatus = cublasCtbmv_64(blasHandle, blasFillMode, blasOperation, blasDiagType, n_64, k_64, &complexA, lda_64, &complexx, incx_64);
+  blasStatus = cublasCtbmv_v2_64(blasHandle, blasFillMode, blasOperation, blasDiagType, n_64, k_64, &complexA, lda_64, &complexx, incx_64);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasZtbmv_v2_64(cublasHandle_t handle, cublasFillMode_t uplo, cublasOperation_t trans, cublasDiagType_t diag, int64_t n, int64_t k, const cuDoubleComplex* A, int64_t lda, cuDoubleComplex* x, int64_t incx);
+  // ROC: ROCBLAS_EXPORT rocblas_status rocblas_ztbmv_64(rocblas_handle handle, rocblas_fill uplo, rocblas_operation trans, rocblas_diagonal diag, int64_t n, int64_t k, const rocblas_double_complex* A, int64_t lda, rocblas_double_complex* x, int64_t incx);
+  // CHECK: blasStatus = rocblas_ztbmv_64(blasHandle, blasFillMode, blasOperation, blasDiagType, n_64, k_64, &dcomplexA, lda_64, &dcomplexx, incx_64);
+  // CHECK-NEXT: blasStatus = rocblas_ztbmv_64(blasHandle, blasFillMode, blasOperation, blasDiagType, n_64, k_64, &dcomplexA, lda_64, &dcomplexx, incx_64);
+  blasStatus = cublasZtbmv_64(blasHandle, blasFillMode, blasOperation, blasDiagType, n_64, k_64, &dcomplexA, lda_64, &dcomplexx, incx_64);
+  blasStatus = cublasZtbmv_v2_64(blasHandle, blasFillMode, blasOperation, blasDiagType, n_64, k_64, &dcomplexA, lda_64, &dcomplexx, incx_64);
 #endif
 
   return 0;


### PR DESCRIPTION
+ `rocblas_(s|d|c|z)tbmv_64` support
+ Updated synthetic tests, the regenerated `hipify-perl`, and `BLAS` `CUDA2HIP` documentation
