### PR TITLE
[HIPIFY][rocBLAS] 64-bit functions support - Step 15

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -1656,7 +1656,9 @@ sub rocSubstitutions {
     subst("cublasCtbmv_v2", "rocblas_ctbmv", "library");
     subst("cublasCtbmv_v2_64", "rocblas_ctbmv_64", "library");
     subst("cublasCtbsv", "rocblas_ctbsv", "library");
+    subst("cublasCtbsv_64", "rocblas_ctbsv_64", "library");
     subst("cublasCtbsv_v2", "rocblas_ctbsv", "library");
+    subst("cublasCtbsv_v2_64", "rocblas_ctbsv_64", "library");
     subst("cublasCtpmv", "rocblas_ctpmv", "library");
     subst("cublasCtpmv_64", "rocblas_ctpmv_64", "library");
     subst("cublasCtpmv_v2", "rocblas_ctpmv", "library");
@@ -1780,7 +1782,9 @@ sub rocSubstitutions {
     subst("cublasDtbmv_v2", "rocblas_dtbmv", "library");
     subst("cublasDtbmv_v2_64", "rocblas_dtbmv_64", "library");
     subst("cublasDtbsv", "rocblas_dtbsv", "library");
+    subst("cublasDtbsv_64", "rocblas_dtbsv_64", "library");
     subst("cublasDtbsv_v2", "rocblas_dtbsv", "library");
+    subst("cublasDtbsv_v2_64", "rocblas_dtbsv_64", "library");
     subst("cublasDtpmv", "rocblas_dtpmv", "library");
     subst("cublasDtpmv_64", "rocblas_dtpmv_64", "library");
     subst("cublasDtpmv_v2", "rocblas_dtpmv", "library");
@@ -1988,7 +1992,9 @@ sub rocSubstitutions {
     subst("cublasStbmv_v2", "rocblas_stbmv", "library");
     subst("cublasStbmv_v2_64", "rocblas_stbmv_64", "library");
     subst("cublasStbsv", "rocblas_stbsv", "library");
+    subst("cublasStbsv_64", "rocblas_stbsv_64", "library");
     subst("cublasStbsv_v2", "rocblas_stbsv", "library");
+    subst("cublasStbsv_v2_64", "rocblas_stbsv_64", "library");
     subst("cublasStpmv", "rocblas_stpmv", "library");
     subst("cublasStpmv_64", "rocblas_stpmv_64", "library");
     subst("cublasStpmv_v2", "rocblas_stpmv", "library");
@@ -2133,7 +2139,9 @@ sub rocSubstitutions {
     subst("cublasZtbmv_v2", "rocblas_ztbmv", "library");
     subst("cublasZtbmv_v2_64", "rocblas_ztbmv_64", "library");
     subst("cublasZtbsv", "rocblas_ztbsv", "library");
+    subst("cublasZtbsv_64", "rocblas_ztbsv_64", "library");
     subst("cublasZtbsv_v2", "rocblas_ztbsv", "library");
+    subst("cublasZtbsv_v2_64", "rocblas_ztbsv_64", "library");
     subst("cublasZtpmv", "rocblas_ztpmv", "library");
     subst("cublasZtpmv_64", "rocblas_ztpmv_64", "library");
     subst("cublasZtpmv_v2", "rocblas_ztpmv", "library");
@@ -12631,8 +12639,6 @@ sub warnRocOnlyUnsupportedFunctions {
         "cublasZtpttr",
         "cublasZtpsv_v2_64",
         "cublasZtpsv_64",
-        "cublasZtbsv_v2_64",
-        "cublasZtbsv_64",
         "cublasZsyrkx_64",
         "cublasZsyrk_v2_64",
         "cublasZsyrk_64",
@@ -12680,8 +12686,6 @@ sub warnRocOnlyUnsupportedFunctions {
         "cublasStpttr",
         "cublasStpsv_v2_64",
         "cublasStpsv_64",
-        "cublasStbsv_v2_64",
-        "cublasStbsv_64",
         "cublasSsyrkx_64",
         "cublasSsyrk_v2_64",
         "cublasSsyrk_64",
@@ -12821,8 +12825,6 @@ sub warnRocOnlyUnsupportedFunctions {
         "cublasDtpttr",
         "cublasDtpsv_v2_64",
         "cublasDtpsv_64",
-        "cublasDtbsv_v2_64",
-        "cublasDtbsv_64",
         "cublasDsyrkx_64",
         "cublasDsyrk_v2_64",
         "cublasDsyrk_64",
@@ -12857,8 +12859,6 @@ sub warnRocOnlyUnsupportedFunctions {
         "cublasCtpttr",
         "cublasCtpsv_v2_64",
         "cublasCtpsv_64",
-        "cublasCtbsv_v2_64",
-        "cublasCtbsv_64",
         "cublasCsyrkx_64",
         "cublasCsyrk_v2_64",
         "cublasCsyrk_64",

--- a/docs/tables/CUBLAS_API_supported_by_HIP_and_ROC.md
+++ b/docs/tables/CUBLAS_API_supported_by_HIP_and_ROC.md
@@ -783,9 +783,9 @@
 |`cublasCtbmv_v2`| | | | |`hipblasCtbmv_v2`|6.0.0| | | | |`rocblas_ctbmv`|3.5.0| | | | |
 |`cublasCtbmv_v2_64`|12.0| | | |`hipblasCtbmv_v2_64`|6.2.0| | | | |`rocblas_ctbmv_64`|6.2.0| | | | |
 |`cublasCtbsv`| | | | |`hipblasCtbsv_v2`|6.0.0| | | | |`rocblas_ctbsv`|3.5.0| | | | |
-|`cublasCtbsv_64`|12.0| | | |`hipblasCtbsv_v2_64`|6.2.0| | | | | | | | | | |
+|`cublasCtbsv_64`|12.0| | | |`hipblasCtbsv_v2_64`|6.2.0| | | | |`rocblas_ctbsv_64`|6.2.0| | | | |
 |`cublasCtbsv_v2`| | | | |`hipblasCtbsv_v2`|6.0.0| | | | |`rocblas_ctbsv`|3.5.0| | | | |
-|`cublasCtbsv_v2_64`|12.0| | | |`hipblasCtbsv_v2_64`|6.2.0| | | | | | | | | | |
+|`cublasCtbsv_v2_64`|12.0| | | |`hipblasCtbsv_v2_64`|6.2.0| | | | |`rocblas_ctbsv_64`|6.2.0| | | | |
 |`cublasCtpmv`| | | | |`hipblasCtpmv_v2`|6.0.0| | | | |`rocblas_ctpmv`|3.5.0| | | | |
 |`cublasCtpmv_64`|12.0| | | |`hipblasCtpmv_v2_64`|6.2.0| | | | |`rocblas_ctpmv_64`|6.2.0| | | | |
 |`cublasCtpmv_v2`| | | | |`hipblasCtpmv_v2`|6.0.0| | | | |`rocblas_ctpmv`|3.5.0| | | | |
@@ -847,9 +847,9 @@
 |`cublasDtbmv_v2`| | | | |`hipblasDtbmv`|3.5.0| | | | |`rocblas_dtbmv`|3.5.0| | | | |
 |`cublasDtbmv_v2_64`|12.0| | | |`hipblasDtbmv_64`|6.2.0| | | | |`rocblas_dtbmv_64`|6.2.0| | | | |
 |`cublasDtbsv`| | | | |`hipblasDtbsv`|3.6.0| | | | |`rocblas_dtbsv`|3.5.0| | | | |
-|`cublasDtbsv_64`|12.0| | | |`hipblasDtbsv_64`|6.2.0| | | | | | | | | | |
+|`cublasDtbsv_64`|12.0| | | |`hipblasDtbsv_64`|6.2.0| | | | |`rocblas_dtbsv_64`|6.2.0| | | | |
 |`cublasDtbsv_v2`| | | | |`hipblasDtbsv`|3.6.0| | | | |`rocblas_dtbsv`|3.5.0| | | | |
-|`cublasDtbsv_v2_64`|12.0| | | |`hipblasDtbsv_64`|6.2.0| | | | | | | | | | |
+|`cublasDtbsv_v2_64`|12.0| | | |`hipblasDtbsv_64`|6.2.0| | | | |`rocblas_dtbsv_64`|6.2.0| | | | |
 |`cublasDtpmv`| | | | |`hipblasDtpmv`|3.5.0| | | | |`rocblas_dtpmv`|3.5.0| | | | |
 |`cublasDtpmv_64`|12.0| | | |`hipblasDtpmv_64`|6.2.0| | | | |`rocblas_dtpmv_64`|6.2.0| | | | |
 |`cublasDtpmv_v2`| | | | |`hipblasDtpmv`|3.5.0| | | | |`rocblas_dtpmv`|3.5.0| | | | |
@@ -911,9 +911,9 @@
 |`cublasStbmv_v2`| | | | |`hipblasStbmv`|3.5.0| | | | |`rocblas_stbmv`|3.5.0| | | | |
 |`cublasStbmv_v2_64`|12.0| | | |`hipblasStbmv_64`|6.2.0| | | | |`rocblas_stbmv_64`|6.2.0| | | | |
 |`cublasStbsv`| | | | |`hipblasStbsv`|3.6.0| | | | |`rocblas_stbsv`|3.5.0| | | | |
-|`cublasStbsv_64`|12.0| | | |`hipblasStbsv_64`|6.2.0| | | | | | | | | | |
+|`cublasStbsv_64`|12.0| | | |`hipblasStbsv_64`|6.2.0| | | | |`rocblas_stbsv_64`|6.2.0| | | | |
 |`cublasStbsv_v2`| | | | |`hipblasStbsv`|3.6.0| | | | |`rocblas_stbsv`|3.5.0| | | | |
-|`cublasStbsv_v2_64`|12.0| | | |`hipblasStbsv_64`|6.2.0| | | | | | | | | | |
+|`cublasStbsv_v2_64`|12.0| | | |`hipblasStbsv_64`|6.2.0| | | | |`rocblas_stbsv_64`|6.2.0| | | | |
 |`cublasStpmv`| | | | |`hipblasStpmv`|3.5.0| | | | |`rocblas_stpmv`|3.5.0| | | | |
 |`cublasStpmv_64`|12.0| | | |`hipblasStpmv_64`|6.2.0| | | | |`rocblas_stpmv_64`|6.2.0| | | | |
 |`cublasStpmv_v2`| | | | |`hipblasStpmv`|3.5.0| | | | |`rocblas_stpmv`|3.5.0| | | | |
@@ -991,9 +991,9 @@
 |`cublasZtbmv_v2`| | | | |`hipblasZtbmv_v2`|6.0.0| | | | |`rocblas_ztbmv`|3.5.0| | | | |
 |`cublasZtbmv_v2_64`|12.0| | | |`hipblasZtbmv_v2_64`|6.2.0| | | | |`rocblas_ztbmv_64`|6.2.0| | | | |
 |`cublasZtbsv`| | | | |`hipblasZtbsv_v2`|6.0.0| | | | |`rocblas_ztbsv`|3.5.0| | | | |
-|`cublasZtbsv_64`|12.0| | | |`hipblasZtbsv_v2_64`|6.2.0| | | | | | | | | | |
+|`cublasZtbsv_64`|12.0| | | |`hipblasZtbsv_v2_64`|6.2.0| | | | |`rocblas_ztbsv_64`|6.2.0| | | | |
 |`cublasZtbsv_v2`| | | | |`hipblasZtbsv_v2`|6.0.0| | | | |`rocblas_ztbsv`|3.5.0| | | | |
-|`cublasZtbsv_v2_64`|12.0| | | |`hipblasZtbsv_v2_64`|6.2.0| | | | | | | | | | |
+|`cublasZtbsv_v2_64`|12.0| | | |`hipblasZtbsv_v2_64`|6.2.0| | | | |`rocblas_ztbsv_64`|6.2.0| | | | |
 |`cublasZtpmv`| | | | |`hipblasZtpmv_v2`|6.0.0| | | | |`rocblas_ztpmv`|3.5.0| | | | |
 |`cublasZtpmv_64`|12.0| | | |`hipblasZtpmv_v2_64`|6.2.0| | | | |`rocblas_ztpmv_64`|6.2.0| | | | |
 |`cublasZtpmv_v2`| | | | |`hipblasZtpmv_v2`|6.0.0| | | | |`rocblas_ztpmv`|3.5.0| | | | |

--- a/docs/tables/CUBLAS_API_supported_by_ROC.md
+++ b/docs/tables/CUBLAS_API_supported_by_ROC.md
@@ -783,9 +783,9 @@
 |`cublasCtbmv_v2`| | | | |`rocblas_ctbmv`|3.5.0| | | | |
 |`cublasCtbmv_v2_64`|12.0| | | |`rocblas_ctbmv_64`|6.2.0| | | | |
 |`cublasCtbsv`| | | | |`rocblas_ctbsv`|3.5.0| | | | |
-|`cublasCtbsv_64`|12.0| | | | | | | | | |
+|`cublasCtbsv_64`|12.0| | | |`rocblas_ctbsv_64`|6.2.0| | | | |
 |`cublasCtbsv_v2`| | | | |`rocblas_ctbsv`|3.5.0| | | | |
-|`cublasCtbsv_v2_64`|12.0| | | | | | | | | |
+|`cublasCtbsv_v2_64`|12.0| | | |`rocblas_ctbsv_64`|6.2.0| | | | |
 |`cublasCtpmv`| | | | |`rocblas_ctpmv`|3.5.0| | | | |
 |`cublasCtpmv_64`|12.0| | | |`rocblas_ctpmv_64`|6.2.0| | | | |
 |`cublasCtpmv_v2`| | | | |`rocblas_ctpmv`|3.5.0| | | | |
@@ -847,9 +847,9 @@
 |`cublasDtbmv_v2`| | | | |`rocblas_dtbmv`|3.5.0| | | | |
 |`cublasDtbmv_v2_64`|12.0| | | |`rocblas_dtbmv_64`|6.2.0| | | | |
 |`cublasDtbsv`| | | | |`rocblas_dtbsv`|3.5.0| | | | |
-|`cublasDtbsv_64`|12.0| | | | | | | | | |
+|`cublasDtbsv_64`|12.0| | | |`rocblas_dtbsv_64`|6.2.0| | | | |
 |`cublasDtbsv_v2`| | | | |`rocblas_dtbsv`|3.5.0| | | | |
-|`cublasDtbsv_v2_64`|12.0| | | | | | | | | |
+|`cublasDtbsv_v2_64`|12.0| | | |`rocblas_dtbsv_64`|6.2.0| | | | |
 |`cublasDtpmv`| | | | |`rocblas_dtpmv`|3.5.0| | | | |
 |`cublasDtpmv_64`|12.0| | | |`rocblas_dtpmv_64`|6.2.0| | | | |
 |`cublasDtpmv_v2`| | | | |`rocblas_dtpmv`|3.5.0| | | | |
@@ -911,9 +911,9 @@
 |`cublasStbmv_v2`| | | | |`rocblas_stbmv`|3.5.0| | | | |
 |`cublasStbmv_v2_64`|12.0| | | |`rocblas_stbmv_64`|6.2.0| | | | |
 |`cublasStbsv`| | | | |`rocblas_stbsv`|3.5.0| | | | |
-|`cublasStbsv_64`|12.0| | | | | | | | | |
+|`cublasStbsv_64`|12.0| | | |`rocblas_stbsv_64`|6.2.0| | | | |
 |`cublasStbsv_v2`| | | | |`rocblas_stbsv`|3.5.0| | | | |
-|`cublasStbsv_v2_64`|12.0| | | | | | | | | |
+|`cublasStbsv_v2_64`|12.0| | | |`rocblas_stbsv_64`|6.2.0| | | | |
 |`cublasStpmv`| | | | |`rocblas_stpmv`|3.5.0| | | | |
 |`cublasStpmv_64`|12.0| | | |`rocblas_stpmv_64`|6.2.0| | | | |
 |`cublasStpmv_v2`| | | | |`rocblas_stpmv`|3.5.0| | | | |
@@ -991,9 +991,9 @@
 |`cublasZtbmv_v2`| | | | |`rocblas_ztbmv`|3.5.0| | | | |
 |`cublasZtbmv_v2_64`|12.0| | | |`rocblas_ztbmv_64`|6.2.0| | | | |
 |`cublasZtbsv`| | | | |`rocblas_ztbsv`|3.5.0| | | | |
-|`cublasZtbsv_64`|12.0| | | | | | | | | |
+|`cublasZtbsv_64`|12.0| | | |`rocblas_ztbsv_64`|6.2.0| | | | |
 |`cublasZtbsv_v2`| | | | |`rocblas_ztbsv`|3.5.0| | | | |
-|`cublasZtbsv_v2_64`|12.0| | | | | | | | | |
+|`cublasZtbsv_v2_64`|12.0| | | |`rocblas_ztbsv_64`|6.2.0| | | | |
 |`cublasZtpmv`| | | | |`rocblas_ztpmv`|3.5.0| | | | |
 |`cublasZtpmv_64`|12.0| | | |`rocblas_ztpmv_64`|6.2.0| | | | |
 |`cublasZtpmv_v2`| | | | |`rocblas_ztpmv`|3.5.0| | | | |

--- a/src/CUDA2HIP_BLAS_API_functions.cpp
+++ b/src/CUDA2HIP_BLAS_API_functions.cpp
@@ -292,13 +292,13 @@ const std::map<llvm::StringRef, hipCounter> CUDA_BLAS_FUNCTION_MAP {
 
   // TBSV
   {"cublasStbsv",                                          {"hipblasStbsv",                                              "rocblas_stbsv",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, HIP_SUPPORTED_V2_ONLY}},
-  {"cublasStbsv_64",                                       {"hipblasStbsv_64",                                           "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
+  {"cublasStbsv_64",                                       {"hipblasStbsv_64",                                           "rocblas_stbsv_64",                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
   {"cublasDtbsv",                                          {"hipblasDtbsv",                                              "rocblas_dtbsv",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, HIP_SUPPORTED_V2_ONLY}},
-  {"cublasDtbsv_64",                                       {"hipblasDtbsv_64",                                           "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
+  {"cublasDtbsv_64",                                       {"hipblasDtbsv_64",                                           "rocblas_dtbsv_64",                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
   {"cublasCtbsv",                                          {"hipblasCtbsv_v2",                                           "rocblas_ctbsv",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, HIP_SUPPORTED_V2_ONLY}},
-  {"cublasCtbsv_64",                                       {"hipblasCtbsv_v2_64",                                        "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
+  {"cublasCtbsv_64",                                       {"hipblasCtbsv_v2_64",                                        "rocblas_ctbsv_64",                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
   {"cublasZtbsv",                                          {"hipblasZtbsv_v2",                                           "rocblas_ztbsv",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, HIP_SUPPORTED_V2_ONLY}},
-  {"cublasZtbsv_64",                                       {"hipblasZtbsv_v2_64",                                        "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
+  {"cublasZtbsv_64",                                       {"hipblasZtbsv_v2_64",                                        "rocblas_ztbsv_64",                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
 
   // SYMV/HEMV
   {"cublasSsymv",                                          {"hipblasSsymv",                                              "rocblas_ssymv",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, HIP_SUPPORTED_V2_ONLY}},
@@ -710,13 +710,13 @@ const std::map<llvm::StringRef, hipCounter> CUDA_BLAS_FUNCTION_MAP {
 
   // TBSV
   {"cublasStbsv_v2",                                       {"hipblasStbsv",                                              "rocblas_stbsv",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
-  {"cublasStbsv_v2_64",                                    {"hipblasStbsv_64",                                           "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
+  {"cublasStbsv_v2_64",                                    {"hipblasStbsv_64",                                           "rocblas_stbsv_64",                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
   {"cublasDtbsv_v2",                                       {"hipblasDtbsv",                                              "rocblas_dtbsv",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
-  {"cublasDtbsv_v2_64",                                    {"hipblasDtbsv_64",                                           "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
+  {"cublasDtbsv_v2_64",                                    {"hipblasDtbsv_64",                                           "rocblas_dtbsv_64",                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
   {"cublasCtbsv_v2",                                       {"hipblasCtbsv_v2",                                           "rocblas_ctbsv",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
-  {"cublasCtbsv_v2_64",                                    {"hipblasCtbsv_v2_64",                                        "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
+  {"cublasCtbsv_v2_64",                                    {"hipblasCtbsv_v2_64",                                        "rocblas_ctbsv_64",                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
   {"cublasZtbsv_v2",                                       {"hipblasZtbsv_v2",                                           "rocblas_ztbsv",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
-  {"cublasZtbsv_v2_64",                                    {"hipblasZtbsv_v2_64",                                        "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
+  {"cublasZtbsv_v2_64",                                    {"hipblasZtbsv_v2_64",                                        "rocblas_ztbsv_64",                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
 
   // SYMV/HEMV
   {"cublasSsymv_v2",                                       {"hipblasSsymv",                                              "rocblas_ssymv",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
@@ -2385,6 +2385,10 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_BLAS_FUNCTION_VER_MAP {
   {"rocblas_dtbmv_64",                                     {HIP_6020, HIP_0,    HIP_0   }},
   {"rocblas_ctbmv_64",                                     {HIP_6020, HIP_0,    HIP_0   }},
   {"rocblas_ztbmv_64",                                     {HIP_6020, HIP_0,    HIP_0   }},
+  {"rocblas_stbsv_64",                                     {HIP_6020, HIP_0,    HIP_0   }},
+  {"rocblas_dtbsv_64",                                     {HIP_6020, HIP_0,    HIP_0   }},
+  {"rocblas_ctbsv_64",                                     {HIP_6020, HIP_0,    HIP_0   }},
+  {"rocblas_ztbsv_64",                                     {HIP_6020, HIP_0,    HIP_0   }},
 };
 
 const std::map<llvm::StringRef, hipAPIChangedVersions> HIP_BLAS_FUNCTION_CHANGED_VER_MAP {

--- a/tests/unit_tests/synthetic/libraries/cublas2rocblas_v2.cu
+++ b/tests/unit_tests/synthetic/libraries/cublas2rocblas_v2.cu
@@ -2853,6 +2853,34 @@ int main() {
   // CHECK-NEXT: blasStatus = rocblas_ztbmv_64(blasHandle, blasFillMode, blasOperation, blasDiagType, n_64, k_64, &dcomplexA, lda_64, &dcomplexx, incx_64);
   blasStatus = cublasZtbmv_64(blasHandle, blasFillMode, blasOperation, blasDiagType, n_64, k_64, &dcomplexA, lda_64, &dcomplexx, incx_64);
   blasStatus = cublasZtbmv_v2_64(blasHandle, blasFillMode, blasOperation, blasDiagType, n_64, k_64, &dcomplexA, lda_64, &dcomplexx, incx_64);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasStbsv_v2_64(cublasHandle_t handle, cublasFillMode_t uplo, cublasOperation_t trans, cublasDiagType_t diag, int64_t n, int64_t k, const float* A, int64_t lda, float* x, int64_t incx);
+  // ROC: ROCBLAS_EXPORT rocblas_status rocblas_stbsv_64(rocblas_handle handle, rocblas_fill uplo, rocblas_operation transA, rocblas_diagonal diag, int64_t n, int64_t k, const float* A, int64_t lda, float* x, int64_t incx);
+  // CHECK: blasStatus = rocblas_stbsv_64(blasHandle, blasFillMode, blasOperation, blasDiagType, n_64, k_64, &fA, lda_64, &fx, incx_64);
+  // CHECK-NEXT: blasStatus = rocblas_stbsv_64(blasHandle, blasFillMode, blasOperation, blasDiagType, n_64, k_64, &fA, lda_64, &fx, incx_64);
+  blasStatus = cublasStbsv_64(blasHandle, blasFillMode, blasOperation, blasDiagType, n_64, k_64, &fA, lda_64, &fx, incx_64);
+  blasStatus = cublasStbsv_v2_64(blasHandle, blasFillMode, blasOperation, blasDiagType, n_64, k_64, &fA, lda_64, &fx, incx_64);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasDtbsv_v2_64(cublasHandle_t handle, cublasFillMode_t uplo, cublasOperation_t trans, cublasDiagType_t diag, int64_t n, int64_t k, const double* A, int64_t lda, double* x, int64_t incx);
+  // ROC: ROCBLAS_EXPORT rocblas_status rocblas_dtbsv_64(rocblas_handle handle, rocblas_fill uplo, rocblas_operation transA, rocblas_diagonal diag, int64_t n, int64_t k, const double* A, int64_t lda, double* x, int64_t incx);
+  // CHECK: blasStatus = rocblas_dtbsv_64(blasHandle, blasFillMode, blasOperation, blasDiagType, n_64, k_64, &dA, lda_64, &dx, incx_64);
+  // CHECK-NEXT: blasStatus = rocblas_dtbsv_64(blasHandle, blasFillMode, blasOperation, blasDiagType, n_64, k_64, &dA, lda_64, &dx, incx_64);
+  blasStatus = cublasDtbsv_64(blasHandle, blasFillMode, blasOperation, blasDiagType, n_64, k_64, &dA, lda_64, &dx, incx_64);
+  blasStatus = cublasDtbsv_v2_64(blasHandle, blasFillMode, blasOperation, blasDiagType, n_64, k_64, &dA, lda_64, &dx, incx_64);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasCtbsv_v2_64(cublasHandle_t handle, cublasFillMode_t uplo, cublasOperation_t trans, cublasDiagType_t diag, int64_t n, int64_t k, const cuComplex* A, int64_t lda, cuComplex* x, int64_t incx);
+  // ROC: ROCBLAS_EXPORT rocblas_status rocblas_ctbsv_64(rocblas_handle handle, rocblas_fill uplo, rocblas_operation transA, rocblas_diagonal diag, int64_t n, int64_t k, const rocblas_float_complex* A, int64_t lda, rocblas_float_complex* x, int64_t incx);
+  // CHECK: blasStatus = rocblas_ctbsv_64(blasHandle, blasFillMode, blasOperation, blasDiagType, n_64, k_64, &complexA, lda_64, &complexx, incx_64);
+  // CHECK-NEXT: blasStatus = rocblas_ctbsv_64(blasHandle, blasFillMode, blasOperation, blasDiagType, n_64, k_64, &complexA, lda_64, &complexx, incx_64);
+  blasStatus = cublasCtbsv_64(blasHandle, blasFillMode, blasOperation, blasDiagType, n_64, k_64, &complexA, lda_64, &complexx, incx_64);
+  blasStatus = cublasCtbsv_v2_64(blasHandle, blasFillMode, blasOperation, blasDiagType, n_64, k_64, &complexA, lda_64, &complexx, incx_64);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasZtbsv_v2_64(cublasHandle_t handle, cublasFillMode_t uplo, cublasOperation_t trans, cublasDiagType_t diag, int64_t n, int64_t k, const cuDoubleComplex* A, int64_t lda, cuDoubleComplex* x, int64_t incx);
+  // ROC: ROCBLAS_EXPORT rocblas_status rocblas_ztbsv_64(rocblas_handle handle, rocblas_fill uplo, rocblas_operation transA, rocblas_diagonal diag, int64_t n, int64_t k, const rocblas_double_complex* A, int64_t lda, rocblas_double_complex* x, int64_t incx);
+  // CHECK: blasStatus = rocblas_ztbsv_64(blasHandle, blasFillMode, blasOperation, blasDiagType, n_64, k_64, &dcomplexA, lda_64, &dcomplexx, incx_64);
+  // CHECK-NEXT: blasStatus = rocblas_ztbsv_64(blasHandle, blasFillMode, blasOperation, blasDiagType, n_64, k_64, &dcomplexA, lda_64, &dcomplexx, incx_64);
+  blasStatus = cublasZtbsv_64(blasHandle, blasFillMode, blasOperation, blasDiagType, n_64, k_64, &dcomplexA, lda_64, &dcomplexx, incx_64);
+  blasStatus = cublasZtbsv_v2_64(blasHandle, blasFillMode, blasOperation, blasDiagType, n_64, k_64, &dcomplexA, lda_64, &dcomplexx, incx_64);
 #endif
 
   return 0;


### PR DESCRIPTION
+ `rocblas_(s|d|c|z)tbsv_64` support
+ Updated synthetic tests, the regenerated `hipify-perl`, and `BLAS` `CUDA2HIP` documentation
