### PR TITLE
[HIPIFY][rocBLAS] 64-bit functions support - Step 16

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -1710,7 +1710,9 @@ sub rocSubstitutions {
     subst("cublasCtrsmBatched", "rocblas_ctrsm_batched", "library");
     subst("cublasCtrsm_v2", "rocblas_ctrsm", "library");
     subst("cublasCtrsv", "rocblas_ctrsv", "library");
+    subst("cublasCtrsv_64", "rocblas_ctrsv_64", "library");
     subst("cublasCtrsv_v2", "rocblas_ctrsv", "library");
+    subst("cublasCtrsv_v2_64", "rocblas_ctrsv_64", "library");
     subst("cublasDasum", "rocblas_dasum", "library");
     subst("cublasDasum_64", "rocblas_dasum_64", "library");
     subst("cublasDasum_v2", "rocblas_dasum", "library");
@@ -1836,7 +1838,9 @@ sub rocSubstitutions {
     subst("cublasDtrsmBatched", "rocblas_dtrsm_batched", "library");
     subst("cublasDtrsm_v2", "rocblas_dtrsm", "library");
     subst("cublasDtrsv", "rocblas_dtrsv", "library");
+    subst("cublasDtrsv_64", "rocblas_dtrsv_64", "library");
     subst("cublasDtrsv_v2", "rocblas_dtrsv", "library");
+    subst("cublasDtrsv_v2_64", "rocblas_dtrsv_64", "library");
     subst("cublasDzasum", "rocblas_dzasum", "library");
     subst("cublasDzasum_64", "rocblas_dzasum_64", "library");
     subst("cublasDzasum_v2", "rocblas_dzasum", "library");
@@ -2046,7 +2050,9 @@ sub rocSubstitutions {
     subst("cublasStrsmBatched", "rocblas_strsm_batched", "library");
     subst("cublasStrsm_v2", "rocblas_strsm", "library");
     subst("cublasStrsv", "rocblas_strsv", "library");
+    subst("cublasStrsv_64", "rocblas_strsv_64", "library");
     subst("cublasStrsv_v2", "rocblas_strsv", "library");
+    subst("cublasStrsv_v2_64", "rocblas_strsv_64", "library");
     subst("cublasTSSgemvBatched", "rocblas_tssgemv_batched", "library");
     subst("cublasTSSgemvBatched_64", "rocblas_tssgemv_batched_64", "library");
     subst("cublasTSSgemvStridedBatched", "rocblas_tssgemv_strided_batched", "library");
@@ -2193,7 +2199,9 @@ sub rocSubstitutions {
     subst("cublasZtrsmBatched", "rocblas_ztrsm_batched", "library");
     subst("cublasZtrsm_v2", "rocblas_ztrsm", "library");
     subst("cublasZtrsv", "rocblas_ztrsv", "library");
+    subst("cublasZtrsv_64", "rocblas_ztrsv_64", "library");
     subst("cublasZtrsv_v2", "rocblas_ztrsv", "library");
+    subst("cublasZtrsv_v2_64", "rocblas_ztrsv_64", "library");
     subst("cudnnActivationBackward", "miopenActivationBackward", "library");
     subst("cudnnActivationForward", "miopenActivationForward", "library");
     subst("cudnnBackendCreateDescriptor", "miopenBackendCreateDescriptor", "library");
@@ -12647,8 +12655,6 @@ sub warnRocOnlyUnsupportedFunctions {
     my $k = 0;
     foreach $func (
         "cublasZtrttp",
-        "cublasZtrsv_v2_64",
-        "cublasZtrsv_64",
         "cublasZtrsm_v2_64",
         "cublasZtrsm_64",
         "cublasZtrsmBatched_64",
@@ -12694,8 +12700,6 @@ sub warnRocOnlyUnsupportedFunctions {
         "cublasSwapEx_64",
         "cublasSwapEx",
         "cublasStrttp",
-        "cublasStrsv_v2_64",
-        "cublasStrsv_64",
         "cublasStrsm_v2_64",
         "cublasStrsm_64",
         "cublasStrsmBatched_64",
@@ -12833,8 +12837,6 @@ sub warnRocOnlyUnsupportedFunctions {
         "cublasGemmBatchedEx_64",
         "cublasFree",
         "cublasDtrttp",
-        "cublasDtrsv_v2_64",
-        "cublasDtrsv_64",
         "cublasDtrsm_v2_64",
         "cublasDtrsm_64",
         "cublasDtrsmBatched_64",
@@ -12867,8 +12869,6 @@ sub warnRocOnlyUnsupportedFunctions {
         "cublasDgeam_64",
         "cublasDdgmm_64",
         "cublasCtrttp",
-        "cublasCtrsv_v2_64",
-        "cublasCtrsv_64",
         "cublasCtrsm_v2_64",
         "cublasCtrsm_64",
         "cublasCtrsmBatched_64",

--- a/docs/tables/CUBLAS_API_supported_by_HIP_and_ROC.md
+++ b/docs/tables/CUBLAS_API_supported_by_HIP_and_ROC.md
@@ -799,9 +799,9 @@
 |`cublasCtrmv_v2`| | | | |`hipblasCtrmv_v2`|6.0.0| | | | |`rocblas_ctrmv`|3.5.0| | | | |
 |`cublasCtrmv_v2_64`|12.0| | | |`hipblasCtrmv_v2_64`|6.2.0| | | | |`rocblas_ctrmv_64`|6.2.0| | | | |
 |`cublasCtrsv`| | | | |`hipblasCtrsv_v2`|6.0.0| | | | |`rocblas_ctrsv`|3.5.0| | | | |
-|`cublasCtrsv_64`|12.0| | | |`hipblasCtrsv_v2_64`|6.2.0| | | | | | | | | | |
+|`cublasCtrsv_64`|12.0| | | |`hipblasCtrsv_v2_64`|6.2.0| | | | |`rocblas_ctrsv_64`|6.2.0| | | | |
 |`cublasCtrsv_v2`| | | | |`hipblasCtrsv_v2`|6.0.0| | | | |`rocblas_ctrsv`|3.5.0| | | | |
-|`cublasCtrsv_v2_64`|12.0| | | |`hipblasCtrsv_v2_64`|6.2.0| | | | | | | | | | |
+|`cublasCtrsv_v2_64`|12.0| | | |`hipblasCtrsv_v2_64`|6.2.0| | | | |`rocblas_ctrsv_64`|6.2.0| | | | |
 |`cublasDgbmv`| | | | |`hipblasDgbmv`|3.5.0| | | | |`rocblas_dgbmv`|3.5.0| | | | |
 |`cublasDgbmv_64`|12.0| | | |`hipblasDgbmv_64`|6.2.0| | | | |`rocblas_dgbmv_64`|6.2.0| | | | |
 |`cublasDgbmv_v2`| | | | |`hipblasDgbmv`|3.5.0| | | | |`rocblas_dgbmv`|3.5.0| | | | |
@@ -863,9 +863,9 @@
 |`cublasDtrmv_v2`| | | | |`hipblasDtrmv`|3.5.0| | | | |`rocblas_dtrmv`|3.5.0| | | | |
 |`cublasDtrmv_v2_64`|12.0| | | |`hipblasDtrmv_64`|6.2.0| | | | |`rocblas_dtrmv_64`|6.2.0| | | | |
 |`cublasDtrsv`| | | | |`hipblasDtrsv`|3.0.0| | | | |`rocblas_dtrsv`|3.5.0| | | | |
-|`cublasDtrsv_64`|12.0| | | |`hipblasDtrsv_64`|6.2.0| | | | | | | | | | |
+|`cublasDtrsv_64`|12.0| | | |`hipblasDtrsv_64`|6.2.0| | | | |`rocblas_dtrsv_64`|6.2.0| | | | |
 |`cublasDtrsv_v2`| | | | |`hipblasDtrsv`|3.0.0| | | | |`rocblas_dtrsv`|3.5.0| | | | |
-|`cublasDtrsv_v2_64`|12.0| | | |`hipblasDtrsv_64`|6.2.0| | | | | | | | | | |
+|`cublasDtrsv_v2_64`|12.0| | | |`hipblasDtrsv_64`|6.2.0| | | | |`rocblas_dtrsv_64`|6.2.0| | | | |
 |`cublasSgbmv`| | | | |`hipblasSgbmv`|3.5.0| | | | |`rocblas_sgbmv`|3.5.0| | | | |
 |`cublasSgbmv_64`|12.0| | | |`hipblasSgbmv_64`|6.2.0| | | | |`rocblas_sgbmv_64`|6.2.0| | | | |
 |`cublasSgbmv_v2`| | | | |`hipblasSgbmv`|3.5.0| | | | |`rocblas_sgbmv`|3.5.0| | | | |
@@ -927,9 +927,9 @@
 |`cublasStrmv_v2`| | | | |`hipblasStrmv`|3.5.0| | | | |`rocblas_strmv`|3.5.0| | | | |
 |`cublasStrmv_v2_64`|12.0| | | |`hipblasStrmv_64`|6.2.0| | | | |`rocblas_strmv_64`|6.2.0| | | | |
 |`cublasStrsv`| | | | |`hipblasStrsv`|3.0.0| | | | |`rocblas_strsv`|3.5.0| | | | |
-|`cublasStrsv_64`|12.0| | | |`hipblasStrsv_64`|6.2.0| | | | | | | | | | |
+|`cublasStrsv_64`|12.0| | | |`hipblasStrsv_64`|6.2.0| | | | |`rocblas_strsv_64`|6.2.0| | | | |
 |`cublasStrsv_v2`| | | | |`hipblasStrsv`|3.0.0| | | | |`rocblas_strsv`|3.5.0| | | | |
-|`cublasStrsv_v2_64`|12.0| | | |`hipblasStrsv_64`|6.2.0| | | | | | | | | | |
+|`cublasStrsv_v2_64`|12.0| | | |`hipblasStrsv_64`|6.2.0| | | | |`rocblas_strsv_64`|6.2.0| | | | |
 |`cublasZgbmv`| | | | |`hipblasZgbmv_v2`|6.0.0| | | | |`rocblas_zgbmv`|3.5.0| | | | |
 |`cublasZgbmv_64`|12.0| | | |`hipblasZgbmv_v2_64`|6.2.0| | | | |`rocblas_zgbmv_64`|6.2.0| | | | |
 |`cublasZgbmv_v2`| | | | |`hipblasZgbmv_v2`|6.0.0| | | | |`rocblas_zgbmv`|3.5.0| | | | |
@@ -1007,9 +1007,9 @@
 |`cublasZtrmv_v2`| | | | |`hipblasZtrmv_v2`|6.0.0| | | | |`rocblas_ztrmv`|3.5.0| | | | |
 |`cublasZtrmv_v2_64`|12.0| | | |`hipblasZtrmv_v2_64`|6.2.0| | | | |`rocblas_ztrmv_64`|6.2.0| | | | |
 |`cublasZtrsv`| | | | |`hipblasZtrsv_v2`|6.0.0| | | | |`rocblas_ztrsv`|3.5.0| | | | |
-|`cublasZtrsv_64`|12.0| | | |`hipblasZtrsv_v2_64`|6.2.0| | | | | | | | | | |
+|`cublasZtrsv_64`|12.0| | | |`hipblasZtrsv_v2_64`|6.2.0| | | | |`rocblas_ztrsv_64`|6.2.0| | | | |
 |`cublasZtrsv_v2`| | | | |`hipblasZtrsv_v2`|6.0.0| | | | |`rocblas_ztrsv`|3.5.0| | | | |
-|`cublasZtrsv_v2_64`|12.0| | | |`hipblasZtrsv_v2_64`|6.2.0| | | | | | | | | | |
+|`cublasZtrsv_v2_64`|12.0| | | |`hipblasZtrsv_v2_64`|6.2.0| | | | |`rocblas_ztrsv_64`|6.2.0| | | | |
 
 ## **7. CUBLAS Level-3 Function Reference**
 

--- a/docs/tables/CUBLAS_API_supported_by_ROC.md
+++ b/docs/tables/CUBLAS_API_supported_by_ROC.md
@@ -799,9 +799,9 @@
 |`cublasCtrmv_v2`| | | | |`rocblas_ctrmv`|3.5.0| | | | |
 |`cublasCtrmv_v2_64`|12.0| | | |`rocblas_ctrmv_64`|6.2.0| | | | |
 |`cublasCtrsv`| | | | |`rocblas_ctrsv`|3.5.0| | | | |
-|`cublasCtrsv_64`|12.0| | | | | | | | | |
+|`cublasCtrsv_64`|12.0| | | |`rocblas_ctrsv_64`|6.2.0| | | | |
 |`cublasCtrsv_v2`| | | | |`rocblas_ctrsv`|3.5.0| | | | |
-|`cublasCtrsv_v2_64`|12.0| | | | | | | | | |
+|`cublasCtrsv_v2_64`|12.0| | | |`rocblas_ctrsv_64`|6.2.0| | | | |
 |`cublasDgbmv`| | | | |`rocblas_dgbmv`|3.5.0| | | | |
 |`cublasDgbmv_64`|12.0| | | |`rocblas_dgbmv_64`|6.2.0| | | | |
 |`cublasDgbmv_v2`| | | | |`rocblas_dgbmv`|3.5.0| | | | |
@@ -863,9 +863,9 @@
 |`cublasDtrmv_v2`| | | | |`rocblas_dtrmv`|3.5.0| | | | |
 |`cublasDtrmv_v2_64`|12.0| | | |`rocblas_dtrmv_64`|6.2.0| | | | |
 |`cublasDtrsv`| | | | |`rocblas_dtrsv`|3.5.0| | | | |
-|`cublasDtrsv_64`|12.0| | | | | | | | | |
+|`cublasDtrsv_64`|12.0| | | |`rocblas_dtrsv_64`|6.2.0| | | | |
 |`cublasDtrsv_v2`| | | | |`rocblas_dtrsv`|3.5.0| | | | |
-|`cublasDtrsv_v2_64`|12.0| | | | | | | | | |
+|`cublasDtrsv_v2_64`|12.0| | | |`rocblas_dtrsv_64`|6.2.0| | | | |
 |`cublasSgbmv`| | | | |`rocblas_sgbmv`|3.5.0| | | | |
 |`cublasSgbmv_64`|12.0| | | |`rocblas_sgbmv_64`|6.2.0| | | | |
 |`cublasSgbmv_v2`| | | | |`rocblas_sgbmv`|3.5.0| | | | |
@@ -927,9 +927,9 @@
 |`cublasStrmv_v2`| | | | |`rocblas_strmv`|3.5.0| | | | |
 |`cublasStrmv_v2_64`|12.0| | | |`rocblas_strmv_64`|6.2.0| | | | |
 |`cublasStrsv`| | | | |`rocblas_strsv`|3.5.0| | | | |
-|`cublasStrsv_64`|12.0| | | | | | | | | |
+|`cublasStrsv_64`|12.0| | | |`rocblas_strsv_64`|6.2.0| | | | |
 |`cublasStrsv_v2`| | | | |`rocblas_strsv`|3.5.0| | | | |
-|`cublasStrsv_v2_64`|12.0| | | | | | | | | |
+|`cublasStrsv_v2_64`|12.0| | | |`rocblas_strsv_64`|6.2.0| | | | |
 |`cublasZgbmv`| | | | |`rocblas_zgbmv`|3.5.0| | | | |
 |`cublasZgbmv_64`|12.0| | | |`rocblas_zgbmv_64`|6.2.0| | | | |
 |`cublasZgbmv_v2`| | | | |`rocblas_zgbmv`|3.5.0| | | | |
@@ -1007,9 +1007,9 @@
 |`cublasZtrmv_v2`| | | | |`rocblas_ztrmv`|3.5.0| | | | |
 |`cublasZtrmv_v2_64`|12.0| | | |`rocblas_ztrmv_64`|6.2.0| | | | |
 |`cublasZtrsv`| | | | |`rocblas_ztrsv`|3.5.0| | | | |
-|`cublasZtrsv_64`|12.0| | | | | | | | | |
+|`cublasZtrsv_64`|12.0| | | |`rocblas_ztrsv_64`|6.2.0| | | | |
 |`cublasZtrsv_v2`| | | | |`rocblas_ztrsv`|3.5.0| | | | |
-|`cublasZtrsv_v2_64`|12.0| | | | | | | | | |
+|`cublasZtrsv_v2_64`|12.0| | | |`rocblas_ztrsv_64`|6.2.0| | | | |
 
 ## **7. CUBLAS Level-3 Function Reference**
 

--- a/src/CUDA2HIP_BLAS_API_functions.cpp
+++ b/src/CUDA2HIP_BLAS_API_functions.cpp
@@ -272,13 +272,13 @@ const std::map<llvm::StringRef, hipCounter> CUDA_BLAS_FUNCTION_MAP {
 
   // TRSV
   {"cublasStrsv",                                          {"hipblasStrsv",                                              "rocblas_strsv",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, HIP_SUPPORTED_V2_ONLY}},
-  {"cublasStrsv_64",                                       {"hipblasStrsv_64",                                           "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
+  {"cublasStrsv_64",                                       {"hipblasStrsv_64",                                           "rocblas_strsv_64",                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
   {"cublasDtrsv",                                          {"hipblasDtrsv",                                              "rocblas_dtrsv",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, HIP_SUPPORTED_V2_ONLY}},
-  {"cublasDtrsv_64",                                       {"hipblasDtrsv_64",                                           "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
+  {"cublasDtrsv_64",                                       {"hipblasDtrsv_64",                                           "rocblas_dtrsv_64",                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
   {"cublasCtrsv",                                          {"hipblasCtrsv_v2",                                           "rocblas_ctrsv",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, HIP_SUPPORTED_V2_ONLY}},
-  {"cublasCtrsv_64",                                       {"hipblasCtrsv_v2_64",                                        "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
+  {"cublasCtrsv_64",                                       {"hipblasCtrsv_v2_64",                                        "rocblas_ctrsv_64",                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
   {"cublasZtrsv",                                          {"hipblasZtrsv_v2",                                           "rocblas_ztrsv",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, HIP_SUPPORTED_V2_ONLY}},
-  {"cublasZtrsv_64",                                       {"hipblasZtrsv_v2_64",                                        "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
+  {"cublasZtrsv_64",                                       {"hipblasZtrsv_v2_64",                                        "rocblas_ztrsv_64",                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
 
   // TPSV
   {"cublasStpsv",                                          {"hipblasStpsv",                                              "rocblas_stpsv",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, HIP_SUPPORTED_V2_ONLY}},
@@ -690,13 +690,13 @@ const std::map<llvm::StringRef, hipCounter> CUDA_BLAS_FUNCTION_MAP {
 
   // TRSV
   {"cublasStrsv_v2",                                       {"hipblasStrsv",                                              "rocblas_strsv",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
-  {"cublasStrsv_v2_64",                                    {"hipblasStrsv_64",                                           "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
+  {"cublasStrsv_v2_64",                                    {"hipblasStrsv_64",                                           "rocblas_strsv_64",                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
   {"cublasDtrsv_v2",                                       {"hipblasDtrsv",                                              "rocblas_dtrsv",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
-  {"cublasDtrsv_v2_64",                                    {"hipblasDtrsv_64",                                           "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
+  {"cublasDtrsv_v2_64",                                    {"hipblasDtrsv_64",                                           "rocblas_dtrsv_64",                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
   {"cublasCtrsv_v2",                                       {"hipblasCtrsv_v2",                                           "rocblas_ctrsv",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
-  {"cublasCtrsv_v2_64",                                    {"hipblasCtrsv_v2_64",                                        "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
+  {"cublasCtrsv_v2_64",                                    {"hipblasCtrsv_v2_64",                                        "rocblas_ctrsv_64",                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
   {"cublasZtrsv_v2",                                       {"hipblasZtrsv_v2",                                           "rocblas_ztrsv",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
-  {"cublasZtrsv_v2_64",                                    {"hipblasZtrsv_v2_64",                                        "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2, ROC_UNSUPPORTED}},
+  {"cublasZtrsv_v2_64",                                    {"hipblasZtrsv_v2_64",                                        "rocblas_ztrsv_64",                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
 
   // TPSV
   {"cublasStpsv_v2",                                       {"hipblasStpsv",                                              "rocblas_stpsv",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_2}},
@@ -2389,6 +2389,10 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_BLAS_FUNCTION_VER_MAP {
   {"rocblas_dtbsv_64",                                     {HIP_6020, HIP_0,    HIP_0   }},
   {"rocblas_ctbsv_64",                                     {HIP_6020, HIP_0,    HIP_0   }},
   {"rocblas_ztbsv_64",                                     {HIP_6020, HIP_0,    HIP_0   }},
+  {"rocblas_strsv_64",                                     {HIP_6020, HIP_0,    HIP_0   }},
+  {"rocblas_dtrsv_64",                                     {HIP_6020, HIP_0,    HIP_0   }},
+  {"rocblas_ctrsv_64",                                     {HIP_6020, HIP_0,    HIP_0   }},
+  {"rocblas_ztrsv_64",                                     {HIP_6020, HIP_0,    HIP_0   }},
 };
 
 const std::map<llvm::StringRef, hipAPIChangedVersions> HIP_BLAS_FUNCTION_CHANGED_VER_MAP {

--- a/tests/unit_tests/synthetic/libraries/cublas2rocblas_v2.cu
+++ b/tests/unit_tests/synthetic/libraries/cublas2rocblas_v2.cu
@@ -2881,6 +2881,34 @@ int main() {
   // CHECK-NEXT: blasStatus = rocblas_ztbsv_64(blasHandle, blasFillMode, blasOperation, blasDiagType, n_64, k_64, &dcomplexA, lda_64, &dcomplexx, incx_64);
   blasStatus = cublasZtbsv_64(blasHandle, blasFillMode, blasOperation, blasDiagType, n_64, k_64, &dcomplexA, lda_64, &dcomplexx, incx_64);
   blasStatus = cublasZtbsv_v2_64(blasHandle, blasFillMode, blasOperation, blasDiagType, n_64, k_64, &dcomplexA, lda_64, &dcomplexx, incx_64);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasStrsv_v2_64(cublasHandle_t handle, cublasFillMode_t uplo, cublasOperation_t trans, cublasDiagType_t diag, int64_t n, const float* A, int64_t lda, float* x, int64_t incx);
+  // ROC: ROCBLAS_EXPORT rocblas_status rocblas_strsv_64(rocblas_handle handle, rocblas_fill uplo, rocblas_operation transA, rocblas_diagonal diag, int64_t n, const float* A, int64_t lda, float* x, int64_t incx);
+  // CHECK: blasStatus = rocblas_strsv_64(blasHandle, blasFillMode, blasOperation, blasDiagType, n_64, &fA, lda_64, &fx, incx_64);
+  // CHECK-NEXT: blasStatus = rocblas_strsv_64(blasHandle, blasFillMode, blasOperation, blasDiagType, n_64, &fA, lda_64, &fx, incx_64);
+  blasStatus = cublasStrsv_64(blasHandle, blasFillMode, blasOperation, blasDiagType, n_64, &fA, lda_64, &fx, incx_64);
+  blasStatus = cublasStrsv_v2_64(blasHandle, blasFillMode, blasOperation, blasDiagType, n_64, &fA, lda_64, &fx, incx_64);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasDtrsv_v2_64(cublasHandle_t handle, cublasFillMode_t uplo, cublasOperation_t trans, cublasDiagType_t diag, int64_t n, const double* A, int64_t lda, double* x, int64_t incx);
+  // ROC: ROCBLAS_EXPORT rocblas_status rocblas_dtrsv_64(rocblas_handle handle, rocblas_fill uplo, rocblas_operation transA, rocblas_diagonal diag, int64_t n, const double* A, int64_t lda, double* x, int64_t incx);
+  // CHECK: blasStatus = rocblas_dtrsv_64(blasHandle, blasFillMode, blasOperation, blasDiagType, n_64, &dA, lda_64, &dx, incx_64);
+  // CHECK-NEXT: blasStatus = rocblas_dtrsv_64(blasHandle, blasFillMode, blasOperation, blasDiagType, n_64, &dA, lda_64, &dx, incx_64);
+  blasStatus = cublasDtrsv_64(blasHandle, blasFillMode, blasOperation, blasDiagType, n_64, &dA, lda_64, &dx, incx_64);
+  blasStatus = cublasDtrsv_v2_64(blasHandle, blasFillMode, blasOperation, blasDiagType, n_64, &dA, lda_64, &dx, incx_64);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasCtrsv_v2_64(cublasHandle_t handle, cublasFillMode_t uplo, cublasOperation_t trans, cublasDiagType_t diag, int64_t n, const cuComplex* A, int64_t lda, cuComplex* x, int64_t incx);
+  // ROC: ROCBLAS_EXPORT rocblas_status rocblas_ctrsv_64(rocblas_handle handle, rocblas_fill uplo, rocblas_operation transA, rocblas_diagonal diag, int64_t n, const rocblas_float_complex* A, int64_t lda, rocblas_float_complex* x, int64_t incx);
+  // CHECK: blasStatus = rocblas_ctrsv_64(blasHandle, blasFillMode, blasOperation, blasDiagType, n_64, &complexA, lda_64, &complexx, incx_64);
+  // CHECK-NEXT: blasStatus = rocblas_ctrsv_64(blasHandle, blasFillMode, blasOperation, blasDiagType, n_64, &complexA, lda_64, &complexx, incx_64);
+  blasStatus = cublasCtrsv_64(blasHandle, blasFillMode, blasOperation, blasDiagType, n_64, &complexA, lda_64, &complexx, incx_64);
+  blasStatus = cublasCtrsv_v2_64(blasHandle, blasFillMode, blasOperation, blasDiagType, n_64, &complexA, lda_64, &complexx, incx_64);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasZtrsv_v2_64(cublasHandle_t handle, cublasFillMode_t uplo, cublasOperation_t trans, cublasDiagType_t diag, int64_t n, const cuDoubleComplex* A, int64_t lda, cuDoubleComplex* x, int64_t incx);
+  // ROC: ROCBLAS_EXPORT rocblas_status rocblas_ztrsv_64(rocblas_handle handle, rocblas_fill uplo, rocblas_operation transA, rocblas_diagonal diag, int64_t n, const rocblas_double_complex* A, int64_t lda, rocblas_double_complex* x, int64_t incx);
+  // CHECK: blasStatus = rocblas_ztrsv_64(blasHandle, blasFillMode, blasOperation, blasDiagType, n_64, &dcomplexA, lda_64, &dcomplexx, incx_64);
+  // CHECK-NEXT: blasStatus = rocblas_ztrsv_64(blasHandle, blasFillMode, blasOperation, blasDiagType, n_64, &dcomplexA, lda_64, &dcomplexx, incx_64);
+  blasStatus = cublasZtrsv_64(blasHandle, blasFillMode, blasOperation, blasDiagType, n_64, &dcomplexA, lda_64, &dcomplexx, incx_64);
+  blasStatus = cublasZtrsv_v2_64(blasHandle, blasFillMode, blasOperation, blasDiagType, n_64, &dcomplexA, lda_64, &dcomplexx, incx_64);
 #endif
 
   return 0;


### PR DESCRIPTION
+ `rocblas_(s|d|c|z)trsv_64` support
+ Updated synthetic tests, the regenerated `hipify-perl`, and `BLAS` `CUDA2HIP` documentation