### PR TITLE
[HIPIFY][6.3.0][BLAS] Sync with `hipBLAS` and `rocBLAS` - Step 4

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -1647,8 +1647,11 @@ sub rocSubstitutions {
     subst("cublasCher_v2", "rocblas_cher", "library");
     subst("cublasCher_v2_64", "rocblas_cher_64", "library");
     subst("cublasCherk", "rocblas_cherk", "library");
+    subst("cublasCherk_64", "rocblas_cherk_64", "library");
     subst("cublasCherk_v2", "rocblas_cherk", "library");
+    subst("cublasCherk_v2_64", "rocblas_cherk_64", "library");
     subst("cublasCherkx", "rocblas_cherkx", "library");
+    subst("cublasCherkx_64", "rocblas_cherkx_64", "library");
     subst("cublasChpmv", "rocblas_chpmv", "library");
     subst("cublasChpmv_64", "rocblas_chpmv_64", "library");
     subst("cublasChpmv_v2", "rocblas_chpmv", "library");
@@ -2184,8 +2187,11 @@ sub rocSubstitutions {
     subst("cublasZher_v2", "rocblas_zher", "library");
     subst("cublasZher_v2_64", "rocblas_zher_64", "library");
     subst("cublasZherk", "rocblas_zherk", "library");
+    subst("cublasZherk_64", "rocblas_zherk_64", "library");
     subst("cublasZherk_v2", "rocblas_zherk", "library");
+    subst("cublasZherk_v2_64", "rocblas_zherk_64", "library");
     subst("cublasZherkx", "rocblas_zherkx", "library");
+    subst("cublasZherkx_64", "rocblas_zherkx_64", "library");
     subst("cublasZhpmv", "rocblas_zhpmv", "library");
     subst("cublasZhpmv_64", "rocblas_zhpmv_64", "library");
     subst("cublasZhpmv_v2", "rocblas_zhpmv", "library");
@@ -4391,8 +4397,11 @@ sub simpleSubstitutions {
     subst("cublasCher_v2", "hipblasCher_v2", "library");
     subst("cublasCher_v2_64", "hipblasCher_v2_64", "library");
     subst("cublasCherk", "hipblasCherk_v2", "library");
+    subst("cublasCherk_64", "hipblasCherk_v2_64", "library");
     subst("cublasCherk_v2", "hipblasCherk_v2", "library");
+    subst("cublasCherk_v2_64", "hipblasCherk_v2_64", "library");
     subst("cublasCherkx", "hipblasCherkx_v2", "library");
+    subst("cublasCherkx_64", "hipblasCherkx_v2_64", "library");
     subst("cublasChpmv", "hipblasChpmv_v2", "library");
     subst("cublasChpmv_64", "hipblasChpmv_v2_64", "library");
     subst("cublasChpmv_v2", "hipblasChpmv_v2", "library");
@@ -4933,8 +4942,11 @@ sub simpleSubstitutions {
     subst("cublasZher_v2", "hipblasZher_v2", "library");
     subst("cublasZher_v2_64", "hipblasZher_v2_64", "library");
     subst("cublasZherk", "hipblasZherk_v2", "library");
+    subst("cublasZherk_64", "hipblasZherk_v2_64", "library");
     subst("cublasZherk_v2", "hipblasZherk_v2", "library");
+    subst("cublasZherk_v2_64", "hipblasZherk_v2_64", "library");
     subst("cublasZherkx", "hipblasZherkx_v2", "library");
+    subst("cublasZherkx_64", "hipblasZherkx_v2_64", "library");
     subst("cublasZhpmv", "hipblasZhpmv_v2", "library");
     subst("cublasZhpmv_64", "hipblasZhpmv_v2_64", "library");
     subst("cublasZhpmv_v2", "hipblasZhpmv_v2", "library");
@@ -11551,9 +11563,6 @@ sub warnHipOnlyUnsupportedFunctions {
         "cublasZsymm_v2_64",
         "cublasZsymm_64",
         "cublasZmatinvBatched",
-        "cublasZherkx_64",
-        "cublasZherk_v2_64",
-        "cublasZherk_64",
         "cublasZher2k_v2_64",
         "cublasZher2k_64",
         "cublasZhemm_v2_64",
@@ -11719,9 +11728,6 @@ sub warnHipOnlyUnsupportedFunctions {
         "cublasCopyEx",
         "cublasContext",
         "cublasCmatinvBatched",
-        "cublasCherkx_64",
-        "cublasCherk_v2_64",
-        "cublasCherk_64",
         "cublasCherkEx_64",
         "cublasCherkEx",
         "cublasCherk3mEx_64",
@@ -13339,9 +13345,6 @@ sub warnRocOnlyUnsupportedFunctions {
         "cublasZsymm_v2_64",
         "cublasZsymm_64",
         "cublasZmatinvBatched",
-        "cublasZherkx_64",
-        "cublasZherk_v2_64",
-        "cublasZherk_64",
         "cublasZher2k_v2_64",
         "cublasZher2k_64",
         "cublasZhemm_v2_64",
@@ -13521,9 +13524,6 @@ sub warnRocOnlyUnsupportedFunctions {
         "cublasCopyEx_64",
         "cublasCopyEx",
         "cublasCmatinvBatched",
-        "cublasCherkx_64",
-        "cublasCherk_v2_64",
-        "cublasCherk_64",
         "cublasCherkEx_64",
         "cublasCherkEx",
         "cublasCherk3mEx_64",

--- a/docs/tables/CUBLAS_API_supported_by_HIP.md
+++ b/docs/tables/CUBLAS_API_supported_by_HIP.md
@@ -1150,11 +1150,11 @@
 |`cublasCher2k_v2`| | | | |`hipblasCher2k_v2`|6.0.0| | | | |
 |`cublasCher2k_v2_64`|12.0| | | | | | | | | |
 |`cublasCherk`| | | | |`hipblasCherk_v2`|6.0.0| | | | |
-|`cublasCherk_64`|12.0| | | | | | | | | |
+|`cublasCherk_64`|12.0| | | |`hipblasCherk_v2_64`|6.3.0| | | |6.3.0|
 |`cublasCherk_v2`| | | | |`hipblasCherk_v2`|6.0.0| | | | |
-|`cublasCherk_v2_64`|12.0| | | | | | | | | |
+|`cublasCherk_v2_64`|12.0| | | |`hipblasCherk_v2_64`|6.3.0| | | |6.3.0|
 |`cublasCherkx`| | | | |`hipblasCherkx_v2`|6.0.0| | | | |
-|`cublasCherkx_64`|12.0| | | | | | | | | |
+|`cublasCherkx_64`|12.0| | | |`hipblasCherkx_v2_64`|6.3.0| | | |6.3.0|
 |`cublasCsymm`| | | | |`hipblasCsymm_v2`|6.0.0| | | | |
 |`cublasCsymm_64`|12.0| | | | | | | | | |
 |`cublasCsymm_v2`| | | | |`hipblasCsymm_v2`|6.0.0| | | | |
@@ -1296,11 +1296,11 @@
 |`cublasZher2k_v2`| | | | |`hipblasZher2k_v2`|6.0.0| | | | |
 |`cublasZher2k_v2_64`|12.0| | | | | | | | | |
 |`cublasZherk`| | | | |`hipblasZherk_v2`|6.0.0| | | | |
-|`cublasZherk_64`|12.0| | | | | | | | | |
+|`cublasZherk_64`|12.0| | | |`hipblasZherk_v2_64`|6.3.0| | | |6.3.0|
 |`cublasZherk_v2`| | | | |`hipblasZherk_v2`|6.0.0| | | | |
-|`cublasZherk_v2_64`|12.0| | | | | | | | | |
+|`cublasZherk_v2_64`|12.0| | | |`hipblasZherk_v2_64`|6.3.0| | | |6.3.0|
 |`cublasZherkx`| | | | |`hipblasZherkx_v2`|6.0.0| | | | |
-|`cublasZherkx_64`|12.0| | | | | | | | | |
+|`cublasZherkx_64`|12.0| | | |`hipblasZherkx_v2_64`|6.3.0| | | |6.3.0|
 |`cublasZsymm`| | | | |`hipblasZsymm_v2`|6.0.0| | | | |
 |`cublasZsymm_64`|12.0| | | | | | | | | |
 |`cublasZsymm_v2`| | | | |`hipblasZsymm_v2`|6.0.0| | | | |

--- a/docs/tables/CUBLAS_API_supported_by_HIP_and_ROC.md
+++ b/docs/tables/CUBLAS_API_supported_by_HIP_and_ROC.md
@@ -1150,11 +1150,11 @@
 |`cublasCher2k_v2`| | | | |`hipblasCher2k_v2`|6.0.0| | | | |`rocblas_cher2k`|3.5.0| | | | |
 |`cublasCher2k_v2_64`|12.0| | | | | | | | | | | | | | | |
 |`cublasCherk`| | | | |`hipblasCherk_v2`|6.0.0| | | | |`rocblas_cherk`|3.5.0| | | | |
-|`cublasCherk_64`|12.0| | | | | | | | | | | | | | | |
+|`cublasCherk_64`|12.0| | | |`hipblasCherk_v2_64`|6.3.0| | | |6.3.0|`rocblas_cherk_64`|6.3.0| | | |6.3.0|
 |`cublasCherk_v2`| | | | |`hipblasCherk_v2`|6.0.0| | | | |`rocblas_cherk`|3.5.0| | | | |
-|`cublasCherk_v2_64`|12.0| | | | | | | | | | | | | | | |
+|`cublasCherk_v2_64`|12.0| | | |`hipblasCherk_v2_64`|6.3.0| | | |6.3.0|`rocblas_cherk_64`|6.3.0| | | |6.3.0|
 |`cublasCherkx`| | | | |`hipblasCherkx_v2`|6.0.0| | | | |`rocblas_cherkx`|3.5.0| | | | |
-|`cublasCherkx_64`|12.0| | | | | | | | | | | | | | | |
+|`cublasCherkx_64`|12.0| | | |`hipblasCherkx_v2_64`|6.3.0| | | |6.3.0|`rocblas_cherkx_64`|6.3.0| | | |6.3.0|
 |`cublasCsymm`| | | | |`hipblasCsymm_v2`|6.0.0| | | | |`rocblas_csymm`|3.5.0| | | | |
 |`cublasCsymm_64`|12.0| | | | | | | | | | | | | | | |
 |`cublasCsymm_v2`| | | | |`hipblasCsymm_v2`|6.0.0| | | | |`rocblas_csymm`|3.5.0| | | | |
@@ -1296,11 +1296,11 @@
 |`cublasZher2k_v2`| | | | |`hipblasZher2k_v2`|6.0.0| | | | |`rocblas_zher2k`|3.5.0| | | | |
 |`cublasZher2k_v2_64`|12.0| | | | | | | | | | | | | | | |
 |`cublasZherk`| | | | |`hipblasZherk_v2`|6.0.0| | | | |`rocblas_zherk`|3.5.0| | | | |
-|`cublasZherk_64`|12.0| | | | | | | | | | | | | | | |
+|`cublasZherk_64`|12.0| | | |`hipblasZherk_v2_64`|6.3.0| | | |6.3.0|`rocblas_zherk_64`|6.3.0| | | |6.3.0|
 |`cublasZherk_v2`| | | | |`hipblasZherk_v2`|6.0.0| | | | |`rocblas_zherk`|3.5.0| | | | |
-|`cublasZherk_v2_64`|12.0| | | | | | | | | | | | | | | |
+|`cublasZherk_v2_64`|12.0| | | |`hipblasZherk_v2_64`|6.3.0| | | |6.3.0|`rocblas_zherk_64`|6.3.0| | | |6.3.0|
 |`cublasZherkx`| | | | |`hipblasZherkx_v2`|6.0.0| | | | |`rocblas_zherkx`|3.5.0| | | | |
-|`cublasZherkx_64`|12.0| | | | | | | | | | | | | | | |
+|`cublasZherkx_64`|12.0| | | |`hipblasZherkx_v2_64`|6.3.0| | | |6.3.0|`rocblas_zherkx_64`|6.3.0| | | |6.3.0|
 |`cublasZsymm`| | | | |`hipblasZsymm_v2`|6.0.0| | | | |`rocblas_zsymm`|3.5.0| | | | |
 |`cublasZsymm_64`|12.0| | | | | | | | | | | | | | | |
 |`cublasZsymm_v2`| | | | |`hipblasZsymm_v2`|6.0.0| | | | |`rocblas_zsymm`|3.5.0| | | | |

--- a/docs/tables/CUBLAS_API_supported_by_ROC.md
+++ b/docs/tables/CUBLAS_API_supported_by_ROC.md
@@ -1150,11 +1150,11 @@
 |`cublasCher2k_v2`| | | | |`rocblas_cher2k`|3.5.0| | | | |
 |`cublasCher2k_v2_64`|12.0| | | | | | | | | |
 |`cublasCherk`| | | | |`rocblas_cherk`|3.5.0| | | | |
-|`cublasCherk_64`|12.0| | | | | | | | | |
+|`cublasCherk_64`|12.0| | | |`rocblas_cherk_64`|6.3.0| | | |6.3.0|
 |`cublasCherk_v2`| | | | |`rocblas_cherk`|3.5.0| | | | |
-|`cublasCherk_v2_64`|12.0| | | | | | | | | |
+|`cublasCherk_v2_64`|12.0| | | |`rocblas_cherk_64`|6.3.0| | | |6.3.0|
 |`cublasCherkx`| | | | |`rocblas_cherkx`|3.5.0| | | | |
-|`cublasCherkx_64`|12.0| | | | | | | | | |
+|`cublasCherkx_64`|12.0| | | |`rocblas_cherkx_64`|6.3.0| | | |6.3.0|
 |`cublasCsymm`| | | | |`rocblas_csymm`|3.5.0| | | | |
 |`cublasCsymm_64`|12.0| | | | | | | | | |
 |`cublasCsymm_v2`| | | | |`rocblas_csymm`|3.5.0| | | | |
@@ -1296,11 +1296,11 @@
 |`cublasZher2k_v2`| | | | |`rocblas_zher2k`|3.5.0| | | | |
 |`cublasZher2k_v2_64`|12.0| | | | | | | | | |
 |`cublasZherk`| | | | |`rocblas_zherk`|3.5.0| | | | |
-|`cublasZherk_64`|12.0| | | | | | | | | |
+|`cublasZherk_64`|12.0| | | |`rocblas_zherk_64`|6.3.0| | | |6.3.0|
 |`cublasZherk_v2`| | | | |`rocblas_zherk`|3.5.0| | | | |
-|`cublasZherk_v2_64`|12.0| | | | | | | | | |
+|`cublasZherk_v2_64`|12.0| | | |`rocblas_zherk_64`|6.3.0| | | |6.3.0|
 |`cublasZherkx`| | | | |`rocblas_zherkx`|3.5.0| | | | |
-|`cublasZherkx_64`|12.0| | | | | | | | | |
+|`cublasZherkx_64`|12.0| | | |`rocblas_zherkx_64`|6.3.0| | | |6.3.0|
 |`cublasZsymm`| | | | |`rocblas_zsymm`|3.5.0| | | | |
 |`cublasZsymm_64`|12.0| | | | | | | | | |
 |`cublasZsymm_v2`| | | | |`rocblas_zsymm`|3.5.0| | | | |

--- a/src/CUDA2HIP_BLAS_API_functions.cpp
+++ b/src/CUDA2HIP_BLAS_API_functions.cpp
@@ -487,9 +487,9 @@ const std::map<llvm::StringRef, hipCounter> CUDA_BLAS_FUNCTION_MAP {
 
   // HERK
   {"cublasCherk",                                          {"hipblasCherk_v2",                                           "rocblas_cherk",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3, HIP_SUPPORTED_V2_ONLY}},
-  {"cublasCherk_64",                                       {"hipblasCherk_64",                                           "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3, UNSUPPORTED}},
+  {"cublasCherk_64",                                       {"hipblasCherk_v2_64",                                        "rocblas_cherk_64",                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3}},
   {"cublasZherk",                                          {"hipblasZherk_v2",                                           "rocblas_zherk",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3, HIP_SUPPORTED_V2_ONLY}},
-  {"cublasZherk_64",                                       {"hipblasZherk_64",                                           "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3, UNSUPPORTED}},
+  {"cublasZherk_64",                                       {"hipblasZherk_v2_64",                                        "rocblas_zherk_64",                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3}},
 
   // SYR2K
   {"cublasSsyr2k",                                         {"hipblasSsyr2k",                                             "rocblas_ssyr2k",                                     CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3, HIP_SUPPORTED_V2_ONLY}},
@@ -519,9 +519,9 @@ const std::map<llvm::StringRef, hipCounter> CUDA_BLAS_FUNCTION_MAP {
 
   // HERKX - eXtended HERK
   {"cublasCherkx",                                         {"hipblasCherkx_v2",                                          "rocblas_cherkx",                                     CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3}},
-  {"cublasCherkx_64",                                      {"hipblasCherkx_64",                                          "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3, UNSUPPORTED}},
+  {"cublasCherkx_64",                                      {"hipblasCherkx_v2_64",                                       "rocblas_cherkx_64",                                  CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3}},
   {"cublasZherkx",                                         {"hipblasZherkx_v2",                                          "rocblas_zherkx",                                     CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3}},
-  {"cublasZherkx_64",                                      {"hipblasZherkx_64",                                          "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3, UNSUPPORTED}},
+  {"cublasZherkx_64",                                      {"hipblasZherkx_v2_64",                                       "rocblas_zherkx_64",                                  CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3}},
 
   // SYMM
   {"cublasSsymm",                                          {"hipblasSsymm",                                              "rocblas_ssymm",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3, HIP_SUPPORTED_V2_ONLY}},
@@ -864,7 +864,7 @@ const std::map<llvm::StringRef, hipCounter> CUDA_BLAS_FUNCTION_MAP {
 
   // HERK
   {"cublasCherk_v2",                                       {"hipblasCherk_v2",                                           "rocblas_cherk",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3}},
-  {"cublasCherk_v2_64",                                    {"hipblasCherk_64",                                           "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3, UNSUPPORTED}},
+  {"cublasCherk_v2_64",                                    {"hipblasCherk_v2_64",                                        "rocblas_cherk_64",                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3}},
   // IO in Int8 complex/cuComplex, computation in cuComplex
   {"cublasCherkEx",                                        {"hipblasCherkEx",                                            "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_EXT, UNSUPPORTED}},
   {"cublasCherkEx_64",                                     {"hipblasCherkEx_64",                                         "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_EXT, UNSUPPORTED}},
@@ -872,7 +872,7 @@ const std::map<llvm::StringRef, hipCounter> CUDA_BLAS_FUNCTION_MAP {
   {"cublasCherk3mEx",                                      {"hipblasCherk3mEx",                                          "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_EXT, UNSUPPORTED}},
   {"cublasCherk3mEx_64",                                   {"hipblasCherk3mEx_64",                                       "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_EXT, UNSUPPORTED}},
   {"cublasZherk_v2",                                       {"hipblasZherk_v2",                                           "rocblas_zherk",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3}},
-  {"cublasZherk_v2_64",                                    {"hipblasZherk_64",                                           "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3, UNSUPPORTED}},
+  {"cublasZherk_v2_64",                                    {"hipblasZherk_v2_64",                                        "rocblas_zherk_64",                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3}},
 
   // SYR2K
   {"cublasSsyr2k_v2",                                      {"hipblasSsyr2k",                                             "rocblas_ssyr2k",                                     CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3}},
@@ -2038,6 +2038,10 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_BLAS_FUNCTION_VER_MAP {
   {"hipblasDgemmStridedBatched_64",                        {HIP_6030, HIP_0,    HIP_0,  HIP_LATEST}},
   {"hipblasCgemmStridedBatched_v2_64",                     {HIP_6030, HIP_0,    HIP_0,  HIP_LATEST}},
   {"hipblasZgemmStridedBatched_v2_64",                     {HIP_6030, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipblasCherk_v2_64",                                   {HIP_6030, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipblasZherk_v2_64",                                   {HIP_6030, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipblasCherkx_v2_64",                                  {HIP_6030, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipblasZherkx_v2_64",                                  {HIP_6030, HIP_0,    HIP_0,  HIP_LATEST}},
 
   {"rocblas_status_to_string",                             {HIP_3050, HIP_0,    HIP_0   }},
   {"rocblas_sscal",                                        {HIP_1050, HIP_0,    HIP_0   }},
@@ -2441,6 +2445,10 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_BLAS_FUNCTION_VER_MAP {
   {"rocblas_dgemm_strided_batched_64",                     {HIP_6030, HIP_0,    HIP_0,  HIP_LATEST}},
   {"rocblas_cgemm_strided_batched_64",                     {HIP_6030, HIP_0,    HIP_0,  HIP_LATEST}},
   {"rocblas_zgemm_strided_batched_64",                     {HIP_6030, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"rocblas_cherk_64",                                     {HIP_6030, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"rocblas_zherk_64",                                     {HIP_6030, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"rocblas_cherkx_64",                                    {HIP_6030, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"rocblas_zherkx_64",                                    {HIP_6030, HIP_0,    HIP_0,  HIP_LATEST}},
 };
 
 const std::map<llvm::StringRef, hipAPIChangedVersions> HIP_BLAS_FUNCTION_CHANGED_VER_MAP {

--- a/tests/unit_tests/synthetic/libraries/cublas2hipblas_v2.cu
+++ b/tests/unit_tests/synthetic/libraries/cublas2hipblas_v2.cu
@@ -2908,6 +2908,30 @@ int main() {
   // HIP: HIPBLAS_EXPORT hipblasStatus_t hipblasHgemmStridedBatched_64(hipblasHandle_t handle, hipblasOperation_t transA, hipblasOperation_t transB, int64_t m, int64_t n, int64_t k, const hipblasHalf* alpha, const hipblasHalf* AP, int64_t lda, long long strideA, const hipblasHalf* BP, int64_t ldb, long long strideB, const hipblasHalf* beta, hipblasHalf* CP, int64_t ldc, long long strideC, int64_t batchCount);
   // CHECK: blasStatus = hipblasHgemmStridedBatched_64(blasHandle, transa, transb, m_64, n_64, k_64, ha, hA, lda_64, strideA, hB, ldb_64, strideB, hb, hC, ldc_64, strideC, batchCount_64);
   blasStatus = cublasHgemmStridedBatched_64(blasHandle, transa, transb, m_64, n_64, k_64, ha, hA, lda_64, strideA, hB, ldb_64, strideB, hb, hC, ldc_64, strideC, batchCount_64);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasCherk_v2_64(cublasHandle_t handle, cublasFillMode_t uplo, cublasOperation_t trans, int64_t n, int64_t k, const float* alpha, const cuComplex* A, int64_t lda, const float* beta, cuComplex* C, int64_t ldc);
+  // HIP: HIPBLAS_EXPORT hipblasStatus_t hipblasCherk_v2_64(hipblasHandle_t handle, hipblasFillMode_t uplo, hipblasOperation_t transA, int64_t n, int64_t k, const float* alpha, const hipComplex* A, int64_t lda, const float* beta, hipComplex* C, int64_t ldc);
+  // CHECK: blasStatus = hipblasCherk_v2_64(blasHandle, blasFillMode, blasOperation,n_64, k_64, &fa, &complexA, lda_64, &fb, &complexC, ldc_64);
+  // CHECK-NEXT: blasStatus = hipblasCherk_v2_64(blasHandle, blasFillMode, blasOperation,n_64, k_64, &fa, &complexA, lda_64, &fb, &complexC, ldc_64);
+  blasStatus = cublasCherk_64(blasHandle, blasFillMode, blasOperation,n_64, k_64, &fa, &complexA, lda_64, &fb, &complexC, ldc_64);
+  blasStatus = cublasCherk_v2_64(blasHandle, blasFillMode, blasOperation,n_64, k_64, &fa, &complexA, lda_64, &fb, &complexC, ldc_64);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasZherk_v2_64(cublasHandle_t handle, cublasFillMode_t uplo, cublasOperation_t trans, int64_t n, int64_t k, const double* alpha, const cuDoubleComplex* A, int64_t lda, const double* beta, cuDoubleComplex* C, int64_t ldc);
+  // HIP: HIPBLAS_EXPORT hipblasStatus_t hipblasZherk_v2_64(hipblasHandle_t handle, hipblasFillMode_t uplo, hipblasOperation_t transA, int64_t n, int64_t k, const double* alpha, const hipDoubleComplex* AP, int64_t lda, const double* beta, hipDoubleComplex* CP, int64_t ldc);
+  // CHECK: blasStatus = hipblasZherk_v2_64(blasHandle, blasFillMode, blasOperation, n_64, k_64, &da, &dcomplexA, lda_64, &db, &dcomplexC, ldc_64);
+  // CHECK-NEXT: blasStatus = hipblasZherk_v2_64(blasHandle, blasFillMode, blasOperation, n_64, k_64, &da, &dcomplexA, lda_64, &db, &dcomplexC, ldc_64);
+  blasStatus = cublasZherk_64(blasHandle, blasFillMode, blasOperation, n_64, k_64, &da, &dcomplexA, lda_64, &db, &dcomplexC, ldc_64);
+  blasStatus = cublasZherk_v2_64(blasHandle, blasFillMode, blasOperation, n_64, k_64, &da, &dcomplexA, lda_64, &db, &dcomplexC, ldc_64);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasCherkx_64(cublasHandle_t handle, cublasFillMode_t uplo, cublasOperation_t trans, int64_t n, int64_t k, const cuComplex* alpha, const cuComplex* A, int64_t lda, const cuComplex* B, int64_t ldb, const float* beta, cuComplex* C, int64_t ldc);
+  // HIP: HIPBLAS_EXPORT hipblasStatus_t hipblasCherkx_v2_64(hipblasHandle_t handle, hipblasFillMode_t  uplo, hipblasOperation_t transA, int64_t n, int64_t k, const hipComplex* alpha, const hipComplex* AP, int64_t lda, const hipComplex* BP, int64_t ldb, const float* beta, hipComplex* CP, int64_t ldc);
+  // CHECK: blasStatus = hipblasCherkx_v2_64(blasHandle, blasFillMode, blasOperation, n_64, k_64, &complexa, &complexA, lda_64, &complexB, ldb_64, &fb, &complexC, ldc_64);
+  blasStatus = cublasCherkx_64(blasHandle, blasFillMode, blasOperation, n_64, k_64, &complexa, &complexA, lda_64, &complexB, ldb_64, &fb, &complexC, ldc_64);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasZherkx_64(cublasHandle_t handle, cublasFillMode_t uplo, cublasOperation_t trans, int64_t n, int64_t k, const cuDoubleComplex* alpha, const cuDoubleComplex* A, int64_t lda, const cuDoubleComplex* B, int64_t ldb, const double* beta, cuDoubleComplex* C, int64_t ldc);
+  // HIP: HIPBLAS_EXPORT hipblasStatus_t hipblasZherkx_v2_64(hipblasHandle_t handle, hipblasFillMode_t uplo, hipblasOperation_t transA, int64_t n, int64_t k, const hipDoubleComplex* alpha, const hipDoubleComplex* AP, int64_t lda, const hipDoubleComplex* BP, int64_t ldb, const double* beta, hipDoubleComplex* CP, int64_t ldc);
+  // CHECK: blasStatus = hipblasZherkx_v2_64(blasHandle, blasFillMode, blasOperation, n_64, k_64, &dcomplexa, &dcomplexA, lda_64, &dcomplexB, ldb_64, &db, &dcomplexC, ldc_64);
+  blasStatus = cublasZherkx_64(blasHandle, blasFillMode, blasOperation, n_64, k_64, &dcomplexa, &dcomplexA, lda_64, &dcomplexB, ldb_64, &db, &dcomplexC, ldc_64);
 #endif
 
   return 0;

--- a/tests/unit_tests/synthetic/libraries/cublas2rocblas_v2.cu
+++ b/tests/unit_tests/synthetic/libraries/cublas2rocblas_v2.cu
@@ -3113,6 +3113,30 @@ int main() {
   // ROC: ROCBLAS_EXPORT rocblas_status rocblas_hgemm_strided_batched_64(rocblas_handle handle, rocblas_operation transA, rocblas_operation transB, int64_t m, int64_t n, int64_t k, const rocblas_half* alpha, const rocblas_half* A, int64_t lda, rocblas_stride stride_a, const rocblas_half* B, int64_t ldb, rocblas_stride stride_b, const rocblas_half* beta, rocblas_half* C, int64_t ldc, rocblas_stride stride_c, int64_t batch_count);
   // CHECK: blasStatus = rocblas_hgemm_strided_batched_64(blasHandle, transa, transb, m_64, n_64, k_64, ha, hA, lda_64, strideA, hB, ldb_64, strideB, hb, hC, ldc_64, strideC, batchCount_64);
   blasStatus = cublasHgemmStridedBatched_64(blasHandle, transa, transb, m_64, n_64, k_64, ha, hA, lda_64, strideA, hB, ldb_64, strideB, hb, hC, ldc_64, strideC, batchCount_64);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasCherk_v2_64(cublasHandle_t handle, cublasFillMode_t uplo, cublasOperation_t trans, int64_t n, int64_t k, const float* alpha, const cuComplex* A, int64_t lda, const float* beta, cuComplex* C, int64_t ldc);
+  // ROC: ROCBLAS_EXPORT rocblas_status rocblas_cherk_64(rocblas_handle handle, rocblas_fill uplo, rocblas_operation transA, int64_t n, int64_t k, const float* alpha, const rocblas_float_complex* A, int64_t lda, const float* beta, rocblas_float_complex* C, int64_t ldc);
+  // CHECK: blasStatus = rocblas_cherk_64(blasHandle, blasFillMode, blasOperation,n_64, k_64, &fa, &complexA, lda_64, &fb, &complexC, ldc_64);
+  // CHECK-NEXT: blasStatus = rocblas_cherk_64(blasHandle, blasFillMode, blasOperation,n_64, k_64, &fa, &complexA, lda_64, &fb, &complexC, ldc_64);
+  blasStatus = cublasCherk_64(blasHandle, blasFillMode, blasOperation,n_64, k_64, &fa, &complexA, lda_64, &fb, &complexC, ldc_64);
+  blasStatus = cublasCherk_v2_64(blasHandle, blasFillMode, blasOperation,n_64, k_64, &fa, &complexA, lda_64, &fb, &complexC, ldc_64);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasZherk_v2_64(cublasHandle_t handle, cublasFillMode_t uplo, cublasOperation_t trans, int64_t n, int64_t k, const double* alpha, const cuDoubleComplex* A, int64_t lda, const double* beta, cuDoubleComplex* C, int64_t ldc);
+  // ROC: ROCBLAS_EXPORT rocblas_status rocblas_zherk_64(rocblas_handle handle, rocblas_fill uplo, rocblas_operation transA, int64_t n, int64_t k, const double* alpha, const rocblas_double_complex* A, int64_t lda, const double* beta, rocblas_double_complex* C, int64_t ldc);
+  // CHECK: blasStatus = rocblas_zherk_64(blasHandle, blasFillMode, blasOperation,n_64, k_64, &da, &dcomplexA, lda_64, &db, &dcomplexC, ldc_64);
+  // CHECK-NEXT: blasStatus = rocblas_zherk_64(blasHandle, blasFillMode, blasOperation,n_64, k_64, &da, &dcomplexA, lda_64, &db, &dcomplexC, ldc_64);
+  blasStatus = cublasZherk_64(blasHandle, blasFillMode, blasOperation,n_64, k_64, &da, &dcomplexA, lda_64, &db, &dcomplexC, ldc_64);
+  blasStatus = cublasZherk_v2_64(blasHandle, blasFillMode, blasOperation,n_64, k_64, &da, &dcomplexA, lda_64, &db, &dcomplexC, ldc_64);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasCherkx_64(cublasHandle_t handle, cublasFillMode_t uplo, cublasOperation_t trans, int64_t n, int64_t k, const cuComplex* alpha, const cuComplex* A, int64_t lda, const cuComplex* B, int64_t ldb, const float* beta, cuComplex* C, int64_t ldc);
+  // ROC: ROCBLAS_EXPORT rocblas_status rocblas_cherkx_64(rocblas_handle handle, rocblas_fill uplo, rocblas_operation trans, int64_t n, int64_t k, const rocblas_float_complex* alpha, const rocblas_float_complex* A, int64_t lda, const rocblas_float_complex* B, int64_t ldb, const float* beta, rocblas_float_complex* C, int64_t ldc);
+  // CHECK: blasStatus = rocblas_cherkx_64(blasHandle, blasFillMode, blasOperation, n_64, k_64, &complexa, &complexA, lda_64, &complexB, ldb_64, &fb, &complexC, ldc_64);
+  blasStatus = cublasCherkx_64(blasHandle, blasFillMode, blasOperation, n_64, k_64, &complexa, &complexA, lda_64, &complexB, ldb_64, &fb, &complexC, ldc_64);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasZherkx_64(cublasHandle_t handle, cublasFillMode_t uplo, cublasOperation_t trans, int64_t n, int64_t k, const cuDoubleComplex* alpha, const cuDoubleComplex* A, int64_t lda, const cuDoubleComplex* B, int64_t ldb, const double* beta, cuDoubleComplex* C, int64_t ldc);
+  // ROC: ROCBLAS_EXPORT rocblas_status rocblas_zherkx_64(rocblas_handle handle, rocblas_fill uplo, rocblas_operation trans, int64_t n, int64_t k, const rocblas_double_complex* alpha, const rocblas_double_complex* A, int64_t lda, const rocblas_double_complex* B, int64_t ldb, const double* beta, rocblas_double_complex* C, int64_t ldc);
+  // CHECK: blasStatus = rocblas_zherkx_64(blasHandle, blasFillMode, blasOperation, n_64, k_64, &dcomplexa, &dcomplexA, lda_64, &dcomplexB, ldb_64, &db, &dcomplexC, ldc_64);
+  blasStatus = cublasZherkx_64(blasHandle, blasFillMode, blasOperation, n_64, k_64, &dcomplexa, &dcomplexA, lda_64, &dcomplexB, ldb_64, &db, &dcomplexC, ldc_64);
 #endif
 
   return 0;


### PR DESCRIPTION
+ `rocblas_(c|z)herk(x)?_64` and `hipblas(C|Z)herk(x)?(_v2)?_64` support
+ Updated synthetic tests, the regenerated `hipify-perl`, and `BLAS` `CUDA2HIP` documentation