### PR TITLE
[HIPIFY][6.3.0][BLAS] Sync with `hipBLAS` and `rocBLAS` - Step 5

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -1642,7 +1642,9 @@ sub rocSubstitutions {
     subst("cublasCher2_v2", "rocblas_cher2", "library");
     subst("cublasCher2_v2_64", "rocblas_cher2_64", "library");
     subst("cublasCher2k", "rocblas_cher2k", "library");
+    subst("cublasCher2k_64", "rocblas_cher2k_64", "library");
     subst("cublasCher2k_v2", "rocblas_cher2k", "library");
+    subst("cublasCher2k_v2_64", "rocblas_cher2k_64", "library");
     subst("cublasCher_64", "rocblas_cher_64", "library");
     subst("cublasCher_v2", "rocblas_cher", "library");
     subst("cublasCher_v2_64", "rocblas_cher_64", "library");
@@ -2182,7 +2184,9 @@ sub rocSubstitutions {
     subst("cublasZher2_v2", "rocblas_zher2", "library");
     subst("cublasZher2_v2_64", "rocblas_zher2_64", "library");
     subst("cublasZher2k", "rocblas_zher2k", "library");
+    subst("cublasZher2k_64", "rocblas_zher2k_64", "library");
     subst("cublasZher2k_v2", "rocblas_zher2k", "library");
+    subst("cublasZher2k_v2_64", "rocblas_zher2k_64", "library");
     subst("cublasZher_64", "rocblas_zher_64", "library");
     subst("cublasZher_v2", "rocblas_zher", "library");
     subst("cublasZher_v2_64", "rocblas_zher_64", "library");
@@ -4392,7 +4396,9 @@ sub simpleSubstitutions {
     subst("cublasCher2_v2", "hipblasCher2_v2", "library");
     subst("cublasCher2_v2_64", "hipblasCher2_v2_64", "library");
     subst("cublasCher2k", "hipblasCher2k_v2", "library");
+    subst("cublasCher2k_64", "hipblasCher2k_v2_64", "library");
     subst("cublasCher2k_v2", "hipblasCher2k_v2", "library");
+    subst("cublasCher2k_v2_64", "hipblasCher2k_v2_64", "library");
     subst("cublasCher_64", "hipblasCher_v2_64", "library");
     subst("cublasCher_v2", "hipblasCher_v2", "library");
     subst("cublasCher_v2_64", "hipblasCher_v2_64", "library");
@@ -4937,7 +4943,9 @@ sub simpleSubstitutions {
     subst("cublasZher2_v2", "hipblasZher2_v2", "library");
     subst("cublasZher2_v2_64", "hipblasZher2_v2_64", "library");
     subst("cublasZher2k", "hipblasZher2k_v2", "library");
+    subst("cublasZher2k_64", "hipblasZher2k_v2_64", "library");
     subst("cublasZher2k_v2", "hipblasZher2k_v2", "library");
+    subst("cublasZher2k_v2_64", "hipblasZher2k_v2_64", "library");
     subst("cublasZher_64", "hipblasZher_v2_64", "library");
     subst("cublasZher_v2", "hipblasZher_v2", "library");
     subst("cublasZher_v2_64", "hipblasZher_v2_64", "library");
@@ -11563,8 +11571,6 @@ sub warnHipOnlyUnsupportedFunctions {
         "cublasZsymm_v2_64",
         "cublasZsymm_64",
         "cublasZmatinvBatched",
-        "cublasZher2k_v2_64",
-        "cublasZher2k_64",
         "cublasZhemm_v2_64",
         "cublasZhemm_64",
         "cublasZgemm3m_64",
@@ -11732,8 +11738,6 @@ sub warnHipOnlyUnsupportedFunctions {
         "cublasCherkEx",
         "cublasCherk3mEx_64",
         "cublasCherk3mEx",
-        "cublasCher2k_v2_64",
-        "cublasCher2k_64",
         "cublasChemm_v2_64",
         "cublasChemm_64",
         "cublasCgemmEx_64",
@@ -13385,8 +13389,6 @@ sub warnRocOnlyUnsupportedFunctions {
         "cublasZsymm_v2_64",
         "cublasZsymm_64",
         "cublasZmatinvBatched",
-        "cublasZher2k_v2_64",
-        "cublasZher2k_64",
         "cublasZhemm_v2_64",
         "cublasZhemm_64",
         "cublasZgetrsBatched",
@@ -13568,8 +13570,6 @@ sub warnRocOnlyUnsupportedFunctions {
         "cublasCherkEx",
         "cublasCherk3mEx_64",
         "cublasCherk3mEx",
-        "cublasCher2k_v2_64",
-        "cublasCher2k_64",
         "cublasChemm_v2_64",
         "cublasChemm_64",
         "cublasCgetrsBatched",

--- a/docs/tables/CUBLAS_API_supported_by_HIP.md
+++ b/docs/tables/CUBLAS_API_supported_by_HIP.md
@@ -1186,9 +1186,9 @@
 |`cublasChemm_v2`| | | | |`hipblasChemm_v2`|6.0.0| | | | |
 |`cublasChemm_v2_64`|12.0| | | | | | | | | |
 |`cublasCher2k`| | | | |`hipblasCher2k_v2`|6.0.0| | | | |
-|`cublasCher2k_64`|12.0| | | | | | | | | |
+|`cublasCher2k_64`|12.0| | | |`hipblasCher2k_v2_64`|6.3.0| | | |6.3.0|
 |`cublasCher2k_v2`| | | | |`hipblasCher2k_v2`|6.0.0| | | | |
-|`cublasCher2k_v2_64`|12.0| | | | | | | | | |
+|`cublasCher2k_v2_64`|12.0| | | |`hipblasCher2k_v2_64`|6.3.0| | | |6.3.0|
 |`cublasCherk`| | | | |`hipblasCherk_v2`|6.0.0| | | | |
 |`cublasCherk_64`|12.0| | | |`hipblasCherk_v2_64`|6.3.0| | | |6.3.0|
 |`cublasCherk_v2`| | | | |`hipblasCherk_v2`|6.0.0| | | | |
@@ -1332,9 +1332,9 @@
 |`cublasZhemm_v2`| | | | |`hipblasZhemm_v2`|6.0.0| | | | |
 |`cublasZhemm_v2_64`|12.0| | | | | | | | | |
 |`cublasZher2k`| | | | |`hipblasZher2k_v2`|6.0.0| | | | |
-|`cublasZher2k_64`|12.0| | | | | | | | | |
+|`cublasZher2k_64`|12.0| | | |`hipblasZher2k_v2_64`|6.3.0| | | |6.3.0|
 |`cublasZher2k_v2`| | | | |`hipblasZher2k_v2`|6.0.0| | | | |
-|`cublasZher2k_v2_64`|12.0| | | | | | | | | |
+|`cublasZher2k_v2_64`|12.0| | | |`hipblasZher2k_v2_64`|6.3.0| | | |6.3.0|
 |`cublasZherk`| | | | |`hipblasZherk_v2`|6.0.0| | | | |
 |`cublasZherk_64`|12.0| | | |`hipblasZherk_v2_64`|6.3.0| | | |6.3.0|
 |`cublasZherk_v2`| | | | |`hipblasZherk_v2`|6.0.0| | | | |

--- a/docs/tables/CUBLAS_API_supported_by_HIP_and_ROC.md
+++ b/docs/tables/CUBLAS_API_supported_by_HIP_and_ROC.md
@@ -1186,9 +1186,9 @@
 |`cublasChemm_v2`| | | | |`hipblasChemm_v2`|6.0.0| | | | |`rocblas_chemm`|3.5.0| | | | |
 |`cublasChemm_v2_64`|12.0| | | | | | | | | | | | | | | |
 |`cublasCher2k`| | | | |`hipblasCher2k_v2`|6.0.0| | | | |`rocblas_cher2k`|3.5.0| | | | |
-|`cublasCher2k_64`|12.0| | | | | | | | | | | | | | | |
+|`cublasCher2k_64`|12.0| | | |`hipblasCher2k_v2_64`|6.3.0| | | |6.3.0|`rocblas_cher2k_64`|6.3.0| | | |6.3.0|
 |`cublasCher2k_v2`| | | | |`hipblasCher2k_v2`|6.0.0| | | | |`rocblas_cher2k`|3.5.0| | | | |
-|`cublasCher2k_v2_64`|12.0| | | | | | | | | | | | | | | |
+|`cublasCher2k_v2_64`|12.0| | | |`hipblasCher2k_v2_64`|6.3.0| | | |6.3.0|`rocblas_cher2k_64`|6.3.0| | | |6.3.0|
 |`cublasCherk`| | | | |`hipblasCherk_v2`|6.0.0| | | | |`rocblas_cherk`|3.5.0| | | | |
 |`cublasCherk_64`|12.0| | | |`hipblasCherk_v2_64`|6.3.0| | | |6.3.0|`rocblas_cherk_64`|6.3.0| | | |6.3.0|
 |`cublasCherk_v2`| | | | |`hipblasCherk_v2`|6.0.0| | | | |`rocblas_cherk`|3.5.0| | | | |
@@ -1332,9 +1332,9 @@
 |`cublasZhemm_v2`| | | | |`hipblasZhemm_v2`|6.0.0| | | | |`rocblas_zhemm`|3.5.0| | | | |
 |`cublasZhemm_v2_64`|12.0| | | | | | | | | | | | | | | |
 |`cublasZher2k`| | | | |`hipblasZher2k_v2`|6.0.0| | | | |`rocblas_zher2k`|3.5.0| | | | |
-|`cublasZher2k_64`|12.0| | | | | | | | | | | | | | | |
+|`cublasZher2k_64`|12.0| | | |`hipblasZher2k_v2_64`|6.3.0| | | |6.3.0|`rocblas_zher2k_64`|6.3.0| | | |6.3.0|
 |`cublasZher2k_v2`| | | | |`hipblasZher2k_v2`|6.0.0| | | | |`rocblas_zher2k`|3.5.0| | | | |
-|`cublasZher2k_v2_64`|12.0| | | | | | | | | | | | | | | |
+|`cublasZher2k_v2_64`|12.0| | | |`hipblasZher2k_v2_64`|6.3.0| | | |6.3.0|`rocblas_zher2k_64`|6.3.0| | | |6.3.0|
 |`cublasZherk`| | | | |`hipblasZherk_v2`|6.0.0| | | | |`rocblas_zherk`|3.5.0| | | | |
 |`cublasZherk_64`|12.0| | | |`hipblasZherk_v2_64`|6.3.0| | | |6.3.0|`rocblas_zherk_64`|6.3.0| | | |6.3.0|
 |`cublasZherk_v2`| | | | |`hipblasZherk_v2`|6.0.0| | | | |`rocblas_zherk`|3.5.0| | | | |

--- a/docs/tables/CUBLAS_API_supported_by_ROC.md
+++ b/docs/tables/CUBLAS_API_supported_by_ROC.md
@@ -1186,9 +1186,9 @@
 |`cublasChemm_v2`| | | | |`rocblas_chemm`|3.5.0| | | | |
 |`cublasChemm_v2_64`|12.0| | | | | | | | | |
 |`cublasCher2k`| | | | |`rocblas_cher2k`|3.5.0| | | | |
-|`cublasCher2k_64`|12.0| | | | | | | | | |
+|`cublasCher2k_64`|12.0| | | |`rocblas_cher2k_64`|6.3.0| | | |6.3.0|
 |`cublasCher2k_v2`| | | | |`rocblas_cher2k`|3.5.0| | | | |
-|`cublasCher2k_v2_64`|12.0| | | | | | | | | |
+|`cublasCher2k_v2_64`|12.0| | | |`rocblas_cher2k_64`|6.3.0| | | |6.3.0|
 |`cublasCherk`| | | | |`rocblas_cherk`|3.5.0| | | | |
 |`cublasCherk_64`|12.0| | | |`rocblas_cherk_64`|6.3.0| | | |6.3.0|
 |`cublasCherk_v2`| | | | |`rocblas_cherk`|3.5.0| | | | |
@@ -1332,9 +1332,9 @@
 |`cublasZhemm_v2`| | | | |`rocblas_zhemm`|3.5.0| | | | |
 |`cublasZhemm_v2_64`|12.0| | | | | | | | | |
 |`cublasZher2k`| | | | |`rocblas_zher2k`|3.5.0| | | | |
-|`cublasZher2k_64`|12.0| | | | | | | | | |
+|`cublasZher2k_64`|12.0| | | |`rocblas_zher2k_64`|6.3.0| | | |6.3.0|
 |`cublasZher2k_v2`| | | | |`rocblas_zher2k`|3.5.0| | | | |
-|`cublasZher2k_v2_64`|12.0| | | | | | | | | |
+|`cublasZher2k_v2_64`|12.0| | | |`rocblas_zher2k_64`|6.3.0| | | |6.3.0|
 |`cublasZherk`| | | | |`rocblas_zherk`|3.5.0| | | | |
 |`cublasZherk_64`|12.0| | | |`rocblas_zherk_64`|6.3.0| | | |6.3.0|
 |`cublasZherk_v2`| | | | |`rocblas_zherk`|3.5.0| | | | |

--- a/src/CUDA2HIP_BLAS_API_functions.cpp
+++ b/src/CUDA2HIP_BLAS_API_functions.cpp
@@ -513,9 +513,9 @@ const std::map<llvm::StringRef, hipCounter> CUDA_BLAS_FUNCTION_MAP {
 
   // HER2K
   {"cublasCher2k",                                         {"hipblasCher2k_v2",                                          "rocblas_cher2k",                                     CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3, HIP_SUPPORTED_V2_ONLY}},
-  {"cublasCher2k_64",                                      {"hipblasCher2k_64",                                          "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3, UNSUPPORTED}},
+  {"cublasCher2k_64",                                      {"hipblasCher2k_v2_64",                                       "rocblas_cher2k_64",                                  CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3}},
   {"cublasZher2k",                                         {"hipblasZher2k_v2",                                          "rocblas_zher2k",                                     CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3, HIP_SUPPORTED_V2_ONLY}},
-  {"cublasZher2k_64",                                      {"hipblasZher2k_64",                                          "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3, UNSUPPORTED}},
+  {"cublasZher2k_64",                                      {"hipblasZher2k_v2_64",                                       "rocblas_zher2k_64",                                  CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3}},
 
   // HERKX - eXtended HERK
   {"cublasCherkx",                                         {"hipblasCherkx_v2",                                          "rocblas_cherkx",                                     CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3}},
@@ -886,9 +886,9 @@ const std::map<llvm::StringRef, hipCounter> CUDA_BLAS_FUNCTION_MAP {
 
   // HER2K
   {"cublasCher2k_v2",                                      {"hipblasCher2k_v2",                                          "rocblas_cher2k",                                     CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3}},
-  {"cublasCher2k_v2_64",                                   {"hipblasCher2k_64",                                          "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3, UNSUPPORTED}},
+  {"cublasCher2k_v2_64",                                   {"hipblasCher2k_v2_64",                                       "rocblas_cher2k_64",                                  CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3}},
   {"cublasZher2k_v2",                                      {"hipblasZher2k_v2",                                          "rocblas_zher2k",                                     CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3}},
-  {"cublasZher2k_v2_64",                                   {"hipblasZher2k_64",                                          "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3, UNSUPPORTED}},
+  {"cublasZher2k_v2_64",                                   {"hipblasZher2k_v2_64",                                       "rocblas_zher2k_64",                                  CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3}},
 
   // SYMM
   {"cublasSsymm_v2",                                       {"hipblasSsymm",                                              "rocblas_ssymm",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3}},
@@ -2042,6 +2042,8 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_BLAS_FUNCTION_VER_MAP {
   {"hipblasZherk_v2_64",                                   {HIP_6030, HIP_0,    HIP_0,  HIP_LATEST}},
   {"hipblasCherkx_v2_64",                                  {HIP_6030, HIP_0,    HIP_0,  HIP_LATEST}},
   {"hipblasZherkx_v2_64",                                  {HIP_6030, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipblasCher2k_v2_64",                                  {HIP_6030, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipblasZher2k_v2_64",                                  {HIP_6030, HIP_0,    HIP_0,  HIP_LATEST}},
 
   {"rocblas_status_to_string",                             {HIP_3050, HIP_0,    HIP_0   }},
   {"rocblas_sscal",                                        {HIP_1050, HIP_0,    HIP_0   }},
@@ -2449,6 +2451,8 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_BLAS_FUNCTION_VER_MAP {
   {"rocblas_zherk_64",                                     {HIP_6030, HIP_0,    HIP_0,  HIP_LATEST}},
   {"rocblas_cherkx_64",                                    {HIP_6030, HIP_0,    HIP_0,  HIP_LATEST}},
   {"rocblas_zherkx_64",                                    {HIP_6030, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"rocblas_cher2k_64",                                    {HIP_6030, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"rocblas_zher2k_64",                                    {HIP_6030, HIP_0,    HIP_0,  HIP_LATEST}},
 };
 
 const std::map<llvm::StringRef, hipAPIChangedVersions> HIP_BLAS_FUNCTION_CHANGED_VER_MAP {

--- a/tests/unit_tests/synthetic/libraries/cublas2hipblas_v2.cu
+++ b/tests/unit_tests/synthetic/libraries/cublas2hipblas_v2.cu
@@ -2911,10 +2911,10 @@ int main() {
 
   // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasCherk_v2_64(cublasHandle_t handle, cublasFillMode_t uplo, cublasOperation_t trans, int64_t n, int64_t k, const float* alpha, const cuComplex* A, int64_t lda, const float* beta, cuComplex* C, int64_t ldc);
   // HIP: HIPBLAS_EXPORT hipblasStatus_t hipblasCherk_v2_64(hipblasHandle_t handle, hipblasFillMode_t uplo, hipblasOperation_t transA, int64_t n, int64_t k, const float* alpha, const hipComplex* A, int64_t lda, const float* beta, hipComplex* C, int64_t ldc);
-  // CHECK: blasStatus = hipblasCherk_v2_64(blasHandle, blasFillMode, blasOperation,n_64, k_64, &fa, &complexA, lda_64, &fb, &complexC, ldc_64);
-  // CHECK-NEXT: blasStatus = hipblasCherk_v2_64(blasHandle, blasFillMode, blasOperation,n_64, k_64, &fa, &complexA, lda_64, &fb, &complexC, ldc_64);
-  blasStatus = cublasCherk_64(blasHandle, blasFillMode, blasOperation,n_64, k_64, &fa, &complexA, lda_64, &fb, &complexC, ldc_64);
-  blasStatus = cublasCherk_v2_64(blasHandle, blasFillMode, blasOperation,n_64, k_64, &fa, &complexA, lda_64, &fb, &complexC, ldc_64);
+  // CHECK: blasStatus = hipblasCherk_v2_64(blasHandle, blasFillMode, blasOperation, n_64, k_64, &fa, &complexA, lda_64, &fb, &complexC, ldc_64);
+  // CHECK-NEXT: blasStatus = hipblasCherk_v2_64(blasHandle, blasFillMode, blasOperation, n_64, k_64, &fa, &complexA, lda_64, &fb, &complexC, ldc_64);
+  blasStatus = cublasCherk_64(blasHandle, blasFillMode, blasOperation, n_64, k_64, &fa, &complexA, lda_64, &fb, &complexC, ldc_64);
+  blasStatus = cublasCherk_v2_64(blasHandle, blasFillMode, blasOperation, n_64, k_64, &fa, &complexA, lda_64, &fb, &complexC, ldc_64);
 
   // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasZherk_v2_64(cublasHandle_t handle, cublasFillMode_t uplo, cublasOperation_t trans, int64_t n, int64_t k, const double* alpha, const cuDoubleComplex* A, int64_t lda, const double* beta, cuDoubleComplex* C, int64_t ldc);
   // HIP: HIPBLAS_EXPORT hipblasStatus_t hipblasZherk_v2_64(hipblasHandle_t handle, hipblasFillMode_t uplo, hipblasOperation_t transA, int64_t n, int64_t k, const double* alpha, const hipDoubleComplex* AP, int64_t lda, const double* beta, hipDoubleComplex* CP, int64_t ldc);
@@ -2932,6 +2932,20 @@ int main() {
   // HIP: HIPBLAS_EXPORT hipblasStatus_t hipblasZherkx_v2_64(hipblasHandle_t handle, hipblasFillMode_t uplo, hipblasOperation_t transA, int64_t n, int64_t k, const hipDoubleComplex* alpha, const hipDoubleComplex* AP, int64_t lda, const hipDoubleComplex* BP, int64_t ldb, const double* beta, hipDoubleComplex* CP, int64_t ldc);
   // CHECK: blasStatus = hipblasZherkx_v2_64(blasHandle, blasFillMode, blasOperation, n_64, k_64, &dcomplexa, &dcomplexA, lda_64, &dcomplexB, ldb_64, &db, &dcomplexC, ldc_64);
   blasStatus = cublasZherkx_64(blasHandle, blasFillMode, blasOperation, n_64, k_64, &dcomplexa, &dcomplexA, lda_64, &dcomplexB, ldb_64, &db, &dcomplexC, ldc_64);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasCher2k_v2_64(cublasHandle_t handle, cublasFillMode_t uplo, cublasOperation_t trans, int64_t n, int64_t k, const cuComplex* alpha, const cuComplex* A, int64_t lda, const cuComplex* B, int64_t ldb, const float* beta, cuComplex* C, int64_t ldc);
+  // HIP: HIPBLAS_EXPORT hipblasStatus_t hipblasCher2k_v2_64(hipblasHandle_t handle, hipblasFillMode_t uplo, hipblasOperation_t transA, int64_t n, int64_t k, const hipComplex* alpha, const hipComplex* AP, int64_t lda, const hipComplex* BP, int64_t ldb, const float* beta, hipComplex* CP, int64_t ldc);
+  // CHECK: blasStatus = hipblasCher2k_v2_64(blasHandle, blasFillMode, blasOperation, n_64, k_64, &complexa, &complexA, lda_64, &complexB, ldb_64, &fb, &complexC, ldc_64);
+  // CHECK-NEXT: blasStatus = hipblasCher2k_v2_64(blasHandle, blasFillMode, blasOperation, n_64, k_64, &complexa, &complexA, lda_64, &complexB, ldb_64, &fb, &complexC, ldc_64);
+  blasStatus = cublasCher2k_64(blasHandle, blasFillMode, blasOperation, n_64, k_64, &complexa, &complexA, lda_64, &complexB, ldb_64, &fb, &complexC, ldc_64);
+  blasStatus = cublasCher2k_v2_64(blasHandle, blasFillMode, blasOperation, n_64, k_64, &complexa, &complexA, lda_64, &complexB, ldb_64, &fb, &complexC, ldc_64);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasZher2k_v2_64(cublasHandle_t handle, cublasFillMode_t uplo, cublasOperation_t trans, int64_t n, int64_t k, const cuDoubleComplex* alpha, const cuDoubleComplex* A, int64_t lda, const cuDoubleComplex* B, int64_t ldb, const double* beta, cuDoubleComplex* C, int64_t ldc);
+  // HIP: HIPBLAS_EXPORT hipblasStatus_t hipblasZher2k_v2_64(hipblasHandle_t handle, hipblasFillMode_t uplo, hipblasOperation_t transA, int64_t n, int64_t k, const hipDoubleComplex* alpha, const hipDoubleComplex* AP, int64_t lda, const hipDoubleComplex* BP, int64_t ldb, const double* beta, hipDoubleComplex* CP, int64_t ldc);
+  // CHECK: blasStatus = hipblasZher2k_v2_64(blasHandle, blasFillMode, blasOperation, n_64, k_64, &dcomplexa, &dcomplexA, lda_64, &dcomplexB, ldb_64, &db, &dcomplexC, ldc_64);
+  // CHECK-NEXT: blasStatus = hipblasZher2k_v2_64(blasHandle, blasFillMode, blasOperation, n_64, k_64, &dcomplexa, &dcomplexA, lda_64, &dcomplexB, ldb_64, &db, &dcomplexC, ldc_64);
+  blasStatus = cublasZher2k_64(blasHandle, blasFillMode, blasOperation, n_64, k_64, &dcomplexa, &dcomplexA, lda_64, &dcomplexB, ldb_64, &db, &dcomplexC, ldc_64);
+  blasStatus = cublasZher2k_v2_64(blasHandle, blasFillMode, blasOperation, n_64, k_64, &dcomplexa, &dcomplexA, lda_64, &dcomplexB, ldb_64, &db, &dcomplexC, ldc_64);
 #endif
 
   return 0;

--- a/tests/unit_tests/synthetic/libraries/cublas2rocblas_v2.cu
+++ b/tests/unit_tests/synthetic/libraries/cublas2rocblas_v2.cu
@@ -3116,10 +3116,10 @@ int main() {
 
   // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasCherk_v2_64(cublasHandle_t handle, cublasFillMode_t uplo, cublasOperation_t trans, int64_t n, int64_t k, const float* alpha, const cuComplex* A, int64_t lda, const float* beta, cuComplex* C, int64_t ldc);
   // ROC: ROCBLAS_EXPORT rocblas_status rocblas_cherk_64(rocblas_handle handle, rocblas_fill uplo, rocblas_operation transA, int64_t n, int64_t k, const float* alpha, const rocblas_float_complex* A, int64_t lda, const float* beta, rocblas_float_complex* C, int64_t ldc);
-  // CHECK: blasStatus = rocblas_cherk_64(blasHandle, blasFillMode, blasOperation,n_64, k_64, &fa, &complexA, lda_64, &fb, &complexC, ldc_64);
-  // CHECK-NEXT: blasStatus = rocblas_cherk_64(blasHandle, blasFillMode, blasOperation,n_64, k_64, &fa, &complexA, lda_64, &fb, &complexC, ldc_64);
-  blasStatus = cublasCherk_64(blasHandle, blasFillMode, blasOperation,n_64, k_64, &fa, &complexA, lda_64, &fb, &complexC, ldc_64);
-  blasStatus = cublasCherk_v2_64(blasHandle, blasFillMode, blasOperation,n_64, k_64, &fa, &complexA, lda_64, &fb, &complexC, ldc_64);
+  // CHECK: blasStatus = rocblas_cherk_64(blasHandle, blasFillMode, blasOperation, n_64, k_64, &fa, &complexA, lda_64, &fb, &complexC, ldc_64);
+  // CHECK-NEXT: blasStatus = rocblas_cherk_64(blasHandle, blasFillMode, blasOperation, n_64, k_64, &fa, &complexA, lda_64, &fb, &complexC, ldc_64);
+  blasStatus = cublasCherk_64(blasHandle, blasFillMode, blasOperation, n_64, k_64, &fa, &complexA, lda_64, &fb, &complexC, ldc_64);
+  blasStatus = cublasCherk_v2_64(blasHandle, blasFillMode, blasOperation, n_64, k_64, &fa, &complexA, lda_64, &fb, &complexC, ldc_64);
 
   // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasZherk_v2_64(cublasHandle_t handle, cublasFillMode_t uplo, cublasOperation_t trans, int64_t n, int64_t k, const double* alpha, const cuDoubleComplex* A, int64_t lda, const double* beta, cuDoubleComplex* C, int64_t ldc);
   // ROC: ROCBLAS_EXPORT rocblas_status rocblas_zherk_64(rocblas_handle handle, rocblas_fill uplo, rocblas_operation transA, int64_t n, int64_t k, const double* alpha, const rocblas_double_complex* A, int64_t lda, const double* beta, rocblas_double_complex* C, int64_t ldc);
@@ -3137,6 +3137,20 @@ int main() {
   // ROC: ROCBLAS_EXPORT rocblas_status rocblas_zherkx_64(rocblas_handle handle, rocblas_fill uplo, rocblas_operation trans, int64_t n, int64_t k, const rocblas_double_complex* alpha, const rocblas_double_complex* A, int64_t lda, const rocblas_double_complex* B, int64_t ldb, const double* beta, rocblas_double_complex* C, int64_t ldc);
   // CHECK: blasStatus = rocblas_zherkx_64(blasHandle, blasFillMode, blasOperation, n_64, k_64, &dcomplexa, &dcomplexA, lda_64, &dcomplexB, ldb_64, &db, &dcomplexC, ldc_64);
   blasStatus = cublasZherkx_64(blasHandle, blasFillMode, blasOperation, n_64, k_64, &dcomplexa, &dcomplexA, lda_64, &dcomplexB, ldb_64, &db, &dcomplexC, ldc_64);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasCher2k_v2_64(cublasHandle_t handle, cublasFillMode_t uplo, cublasOperation_t trans, int64_t n, int64_t k, const cuComplex* alpha, const cuComplex* A, int64_t lda, const cuComplex* B, int64_t ldb, const float* beta, cuComplex* C, int64_t ldc);
+  // ROC: ROCBLAS_EXPORT rocblas_status rocblas_cher2k_64(rocblas_handle handle, rocblas_fill uplo, rocblas_operation trans, int64_t n, int64_t k, const rocblas_float_complex* alpha, const rocblas_float_complex* A, int64_t lda, const rocblas_float_complex* B, int64_t ldb, const float* beta, rocblas_float_complex* C, int64_t ldc);
+  // CHECK: blasStatus = rocblas_cher2k_64(blasHandle, blasFillMode, blasOperation, n_64, k_64, &complexa, &complexA, lda_64, &complexB, ldb_64, &fb, &complexC, ldc_64);
+  // CHECK-NEXT: blasStatus = rocblas_cher2k_64(blasHandle, blasFillMode, blasOperation, n_64, k_64, &complexa, &complexA, lda_64, &complexB, ldb_64, &fb, &complexC, ldc_64);
+  blasStatus = cublasCher2k_64(blasHandle, blasFillMode, blasOperation, n_64, k_64, &complexa, &complexA, lda_64, &complexB, ldb_64, &fb, &complexC, ldc_64);
+  blasStatus = cublasCher2k_v2_64(blasHandle, blasFillMode, blasOperation, n_64, k_64, &complexa, &complexA, lda_64, &complexB, ldb_64, &fb, &complexC, ldc_64);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasZher2k_v2_64(cublasHandle_t handle, cublasFillMode_t uplo, cublasOperation_t trans, int64_t n, int64_t k, const cuDoubleComplex* alpha, const cuDoubleComplex* A, int64_t lda, const cuDoubleComplex* B, int64_t ldb, const double* beta, cuDoubleComplex* C, int64_t ldc);
+  // ROC: ROCBLAS_EXPORT rocblas_status rocblas_zher2k_64(rocblas_handle handle, rocblas_fill uplo, rocblas_operation trans, int64_t n, int64_t k, const rocblas_double_complex* alpha, const rocblas_double_complex* A, int64_t lda, const rocblas_double_complex* B, int64_t ldb, const double* beta, rocblas_double_complex* C, int64_t ldc);
+  // CHECK: blasStatus = rocblas_zher2k_64(blasHandle, blasFillMode, blasOperation, n_64, k_64, &dcomplexa, &dcomplexA, lda_64, &dcomplexB, ldb_64, &db, &dcomplexC, ldc_64);
+  // CHECK-NEXT: blasStatus = rocblas_zher2k_64(blasHandle, blasFillMode, blasOperation, n_64, k_64, &dcomplexa, &dcomplexA, lda_64, &dcomplexB, ldb_64, &db, &dcomplexC, ldc_64);
+  blasStatus = cublasZher2k_64(blasHandle, blasFillMode, blasOperation, n_64, k_64, &dcomplexa, &dcomplexA, lda_64, &dcomplexB, ldb_64, &db, &dcomplexC, ldc_64);
+  blasStatus = cublasZher2k_v2_64(blasHandle, blasFillMode, blasOperation, n_64, k_64, &dcomplexa, &dcomplexA, lda_64, &dcomplexB, ldb_64, &db, &dcomplexC, ldc_64);
 #endif
 
   return 0;


### PR DESCRIPTION
+ `rocblas_(c|z)her2k(x)?_64` and `hipblas(C|Z)her2k(x)?(_v2)?_64` support
+ Updated synthetic tests, the regenerated `hipify-perl`, and `BLAS` `CUDA2HIP` documentation