### PR TITLE
[HIPIFY][6.3.0][BLAS] Sync with `hipBLAS` and `rocBLAS` - Step 6

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -1691,7 +1691,9 @@ sub rocSubstitutions {
     subst("cublasCswap_v2", "rocblas_cswap", "library");
     subst("cublasCswap_v2_64", "rocblas_cswap_64", "library");
     subst("cublasCsymm", "rocblas_csymm", "library");
+    subst("cublasCsymm_64", "rocblas_csymm_64", "library");
     subst("cublasCsymm_v2", "rocblas_csymm", "library");
+    subst("cublasCsymm_v2_64", "rocblas_csymm_64", "library");
     subst("cublasCsymv", "rocblas_csymv", "library");
     subst("cublasCsymv_64", "rocblas_csymv_64", "library");
     subst("cublasCsymv_v2", "rocblas_csymv", "library");
@@ -1830,7 +1832,9 @@ sub rocSubstitutions {
     subst("cublasDswap_v2", "rocblas_dswap", "library");
     subst("cublasDswap_v2_64", "rocblas_dswap_64", "library");
     subst("cublasDsymm", "rocblas_dsymm", "library");
+    subst("cublasDsymm_64", "rocblas_dsymm_64", "library");
     subst("cublasDsymm_v2", "rocblas_dsymm", "library");
+    subst("cublasDsymm_v2_64", "rocblas_dsymm_64", "library");
     subst("cublasDsymv", "rocblas_dsymv", "library");
     subst("cublasDsymv_64", "rocblas_dsymv_64", "library");
     subst("cublasDsymv_v2", "rocblas_dsymv", "library");
@@ -2056,7 +2060,9 @@ sub rocSubstitutions {
     subst("cublasSswap_v2", "rocblas_sswap", "library");
     subst("cublasSswap_v2_64", "rocblas_sswap_64", "library");
     subst("cublasSsymm", "rocblas_ssymm", "library");
+    subst("cublasSsymm_64", "rocblas_ssymm_64", "library");
     subst("cublasSsymm_v2", "rocblas_ssymm", "library");
+    subst("cublasSsymm_v2_64", "rocblas_ssymm_64", "library");
     subst("cublasSsymv", "rocblas_ssymv", "library");
     subst("cublasSsymv_64", "rocblas_ssymv_64", "library");
     subst("cublasSsymv_v2", "rocblas_ssymv", "library");
@@ -2223,7 +2229,9 @@ sub rocSubstitutions {
     subst("cublasZswap_v2", "rocblas_zswap", "library");
     subst("cublasZswap_v2_64", "rocblas_zswap_64", "library");
     subst("cublasZsymm", "rocblas_zsymm", "library");
+    subst("cublasZsymm_64", "rocblas_zsymm_64", "library");
     subst("cublasZsymm_v2", "rocblas_zsymm", "library");
+    subst("cublasZsymm_v2_64", "rocblas_zsymm_64", "library");
     subst("cublasZsymv", "rocblas_zsymv", "library");
     subst("cublasZsymv_64", "rocblas_zsymv_64", "library");
     subst("cublasZsymv_v2", "rocblas_zsymv", "library");
@@ -4445,7 +4453,9 @@ sub simpleSubstitutions {
     subst("cublasCswap_v2", "hipblasCswap_v2", "library");
     subst("cublasCswap_v2_64", "hipblasCswap_v2_64", "library");
     subst("cublasCsymm", "hipblasCsymm_v2", "library");
+    subst("cublasCsymm_64", "hipblasCsymm_v2_64", "library");
     subst("cublasCsymm_v2", "hipblasCsymm_v2", "library");
+    subst("cublasCsymm_v2_64", "hipblasCsymm_v2_64", "library");
     subst("cublasCsymv", "hipblasCsymv_v2", "library");
     subst("cublasCsymv_64", "hipblasCsymv_v2_64", "library");
     subst("cublasCsymv_v2", "hipblasCsymv_v2", "library");
@@ -4585,7 +4595,9 @@ sub simpleSubstitutions {
     subst("cublasDswap_v2", "hipblasDswap", "library");
     subst("cublasDswap_v2_64", "hipblasDswap_64", "library");
     subst("cublasDsymm", "hipblasDsymm", "library");
+    subst("cublasDsymm_64", "hipblasDsymm_64", "library");
     subst("cublasDsymm_v2", "hipblasDsymm", "library");
+    subst("cublasDsymm_v2_64", "hipblasDsymm_64", "library");
     subst("cublasDsymv", "hipblasDsymv", "library");
     subst("cublasDsymv_64", "hipblasDsymv_64", "library");
     subst("cublasDsymv_v2", "hipblasDsymv", "library");
@@ -4822,7 +4834,9 @@ sub simpleSubstitutions {
     subst("cublasSswap_v2", "hipblasSswap", "library");
     subst("cublasSswap_v2_64", "hipblasSswap_64", "library");
     subst("cublasSsymm", "hipblasSsymm", "library");
+    subst("cublasSsymm_64", "hipblasSsymm_64", "library");
     subst("cublasSsymm_v2", "hipblasSsymm", "library");
+    subst("cublasSsymm_v2_64", "hipblasSsymm_64", "library");
     subst("cublasSsymv", "hipblasSsymv", "library");
     subst("cublasSsymv_64", "hipblasSsymv_64", "library");
     subst("cublasSsymv_v2", "hipblasSsymv", "library");
@@ -4982,7 +4996,9 @@ sub simpleSubstitutions {
     subst("cublasZswap_v2", "hipblasZswap_v2", "library");
     subst("cublasZswap_v2_64", "hipblasZswap_v2_64", "library");
     subst("cublasZsymm", "hipblasZsymm_v2", "library");
+    subst("cublasZsymm_64", "hipblasZsymm_v2_64", "library");
     subst("cublasZsymm_v2", "hipblasZsymm_v2", "library");
+    subst("cublasZsymm_v2_64", "hipblasZsymm_v2_64", "library");
     subst("cublasZsymv", "hipblasZsymv_v2", "library");
     subst("cublasZsymv_64", "hipblasZsymv_v2_64", "library");
     subst("cublasZsymv_v2", "hipblasZsymv_v2", "library");
@@ -11568,8 +11584,6 @@ sub warnHipOnlyUnsupportedFunctions {
         "cublasZsyrk_64",
         "cublasZsyr2k_v2_64",
         "cublasZsyr2k_64",
-        "cublasZsymm_v2_64",
-        "cublasZsymm_64",
         "cublasZmatinvBatched",
         "cublasZhemm_v2_64",
         "cublasZhemm_64",
@@ -11601,8 +11615,6 @@ sub warnHipOnlyUnsupportedFunctions {
         "cublasSsyrk_64",
         "cublasSsyr2k_v2_64",
         "cublasSsyr2k_64",
-        "cublasSsymm_v2_64",
-        "cublasSsymm_64",
         "cublasSmatinvBatched",
         "cublasShutdown",
         "cublasSgemmGroupedBatched_64",
@@ -11705,8 +11717,6 @@ sub warnHipOnlyUnsupportedFunctions {
         "cublasDsyrk_64",
         "cublasDsyr2k_v2_64",
         "cublasDsyr2k_64",
-        "cublasDsymm_v2_64",
-        "cublasDsymm_64",
         "cublasDmatinvBatched",
         "cublasDgemmGroupedBatched_64",
         "cublasDgemmGroupedBatched",
@@ -11728,8 +11738,6 @@ sub warnHipOnlyUnsupportedFunctions {
         "cublasCsyrk3mEx",
         "cublasCsyr2k_v2_64",
         "cublasCsyr2k_64",
-        "cublasCsymm_v2_64",
-        "cublasCsymm_64",
         "cublasCopyEx_64",
         "cublasCopyEx",
         "cublasContext",
@@ -13429,8 +13437,6 @@ sub warnRocOnlyUnsupportedFunctions {
         "cublasZsyrk_64",
         "cublasZsyr2k_v2_64",
         "cublasZsyr2k_64",
-        "cublasZsymm_v2_64",
-        "cublasZsymm_64",
         "cublasZmatinvBatched",
         "cublasZhemm_v2_64",
         "cublasZhemm_64",
@@ -13456,8 +13462,6 @@ sub warnRocOnlyUnsupportedFunctions {
         "cublasSsyrk_64",
         "cublasSsyr2k_v2_64",
         "cublasSsyr2k_64",
-        "cublasSsymm_v2_64",
-        "cublasSsymm_64",
         "cublasSmatinvBatched",
         "cublasShutdown",
         "cublasSgetrsBatched",
@@ -13579,8 +13583,6 @@ sub warnRocOnlyUnsupportedFunctions {
         "cublasDsyrk_64",
         "cublasDsyr2k_v2_64",
         "cublasDsyr2k_64",
-        "cublasDsymm_v2_64",
-        "cublasDsymm_64",
         "cublasDmatinvBatched",
         "cublasDgetrsBatched",
         "cublasDgetriBatched",
@@ -13604,8 +13606,6 @@ sub warnRocOnlyUnsupportedFunctions {
         "cublasCsyrk3mEx",
         "cublasCsyr2k_v2_64",
         "cublasCsyr2k_64",
-        "cublasCsymm_v2_64",
-        "cublasCsymm_64",
         "cublasCopyEx_64",
         "cublasCopyEx",
         "cublasCmatinvBatched",

--- a/docs/tables/CUBLAS_API_supported_by_HIP.md
+++ b/docs/tables/CUBLAS_API_supported_by_HIP.md
@@ -1239,9 +1239,9 @@
 |`cublasCherkx`| | | | |`hipblasCherkx_v2`|6.0.0| | | | |
 |`cublasCherkx_64`|12.0| | | |`hipblasCherkx_v2_64`|6.3.0| | | |6.3.0|
 |`cublasCsymm`| | | | |`hipblasCsymm_v2`|6.0.0| | | | |
-|`cublasCsymm_64`|12.0| | | | | | | | | |
+|`cublasCsymm_64`|12.0| | | |`hipblasCsymm_v2_64`|6.3.0| | | |6.3.0|
 |`cublasCsymm_v2`| | | | |`hipblasCsymm_v2`|6.0.0| | | | |
-|`cublasCsymm_v2_64`|12.0| | | | | | | | | |
+|`cublasCsymm_v2_64`|12.0| | | |`hipblasCsymm_v2_64`|6.3.0| | | |6.3.0|
 |`cublasCsyr2k`| | | | |`hipblasCsyr2k_v2`|6.0.0| | | | |
 |`cublasCsyr2k_64`|12.0| | | | | | | | | |
 |`cublasCsyr2k_v2`| | | | |`hipblasCsyr2k_v2`|6.0.0| | | | |
@@ -1275,9 +1275,9 @@
 |`cublasDgemvStridedBatched`|11.6| | | |`hipblasDgemvStridedBatched`|3.0.0| | | | |
 |`cublasDgemvStridedBatched_64`|12.0| | | |`hipblasDgemvStridedBatched_64`|6.2.0| | | | |
 |`cublasDsymm`| | | | |`hipblasDsymm`|3.6.0| | | | |
-|`cublasDsymm_64`|12.0| | | | | | | | | |
+|`cublasDsymm_64`|12.0| | | |`hipblasDsymm_64`|6.3.0| | | |6.3.0|
 |`cublasDsymm_v2`| | | | |`hipblasDsymm`|3.6.0| | | | |
-|`cublasDsymm_v2_64`|12.0| | | | | | | | | |
+|`cublasDsymm_v2_64`|12.0| | | |`hipblasDsymm_64`|6.3.0| | | |6.3.0|
 |`cublasDsyr2k`| | | | |`hipblasDsyr2k`|3.5.0| | | | |
 |`cublasDsyr2k_64`|12.0| | | | | | | | | |
 |`cublasDsyr2k_v2`| | | | |`hipblasDsyr2k`|3.5.0| | | | |
@@ -1327,9 +1327,9 @@
 |`cublasSgemvStridedBatched`|11.6| | | |`hipblasSgemvStridedBatched`|3.0.0| | | | |
 |`cublasSgemvStridedBatched_64`|12.0| | | |`hipblasSgemvStridedBatched_64`|6.2.0| | | | |
 |`cublasSsymm`| | | | |`hipblasSsymm`|3.6.0| | | | |
-|`cublasSsymm_64`|12.0| | | | | | | | | |
+|`cublasSsymm_64`|12.0| | | |`hipblasSsymm_64`|6.3.0| | | |6.3.0|
 |`cublasSsymm_v2`| | | | |`hipblasSsymm`|3.6.0| | | | |
-|`cublasSsymm_v2_64`|12.0| | | | | | | | | |
+|`cublasSsymm_v2_64`|12.0| | | |`hipblasSsymm_64`|6.3.0| | | |6.3.0|
 |`cublasSsyr2k`| | | | |`hipblasSsyr2k`|3.5.0| | | | |
 |`cublasSsyr2k_64`|12.0| | | | | | | | | |
 |`cublasSsyr2k_v2`| | | | |`hipblasSsyr2k`|3.5.0| | | | |
@@ -1385,9 +1385,9 @@
 |`cublasZherkx`| | | | |`hipblasZherkx_v2`|6.0.0| | | | |
 |`cublasZherkx_64`|12.0| | | |`hipblasZherkx_v2_64`|6.3.0| | | |6.3.0|
 |`cublasZsymm`| | | | |`hipblasZsymm_v2`|6.0.0| | | | |
-|`cublasZsymm_64`|12.0| | | | | | | | | |
+|`cublasZsymm_64`|12.0| | | |`hipblasZsymm_v2_64`|6.3.0| | | |6.3.0|
 |`cublasZsymm_v2`| | | | |`hipblasZsymm_v2`|6.0.0| | | | |
-|`cublasZsymm_v2_64`|12.0| | | | | | | | | |
+|`cublasZsymm_v2_64`|12.0| | | |`hipblasZsymm_v2_64`|6.3.0| | | |6.3.0|
 |`cublasZsyr2k`| | | | |`hipblasZsyr2k_v2`|6.0.0| | | | |
 |`cublasZsyr2k_64`|12.0| | | | | | | | | |
 |`cublasZsyr2k_v2`| | | | |`hipblasZsyr2k_v2`|6.0.0| | | | |

--- a/docs/tables/CUBLAS_API_supported_by_HIP_and_ROC.md
+++ b/docs/tables/CUBLAS_API_supported_by_HIP_and_ROC.md
@@ -1239,9 +1239,9 @@
 |`cublasCherkx`| | | | |`hipblasCherkx_v2`|6.0.0| | | | |`rocblas_cherkx`|3.5.0| | | | |
 |`cublasCherkx_64`|12.0| | | |`hipblasCherkx_v2_64`|6.3.0| | | |6.3.0|`rocblas_cherkx_64`|6.3.0| | | |6.3.0|
 |`cublasCsymm`| | | | |`hipblasCsymm_v2`|6.0.0| | | | |`rocblas_csymm`|3.5.0| | | | |
-|`cublasCsymm_64`|12.0| | | | | | | | | | | | | | | |
+|`cublasCsymm_64`|12.0| | | |`hipblasCsymm_v2_64`|6.3.0| | | |6.3.0|`rocblas_csymm_64`|6.3.0| | | |6.3.0|
 |`cublasCsymm_v2`| | | | |`hipblasCsymm_v2`|6.0.0| | | | |`rocblas_csymm`|3.5.0| | | | |
-|`cublasCsymm_v2_64`|12.0| | | | | | | | | | | | | | | |
+|`cublasCsymm_v2_64`|12.0| | | |`hipblasCsymm_v2_64`|6.3.0| | | |6.3.0|`rocblas_csymm_64`|6.3.0| | | |6.3.0|
 |`cublasCsyr2k`| | | | |`hipblasCsyr2k_v2`|6.0.0| | | | |`rocblas_csyr2k`|3.5.0| | | | |
 |`cublasCsyr2k_64`|12.0| | | | | | | | | | | | | | | |
 |`cublasCsyr2k_v2`| | | | |`hipblasCsyr2k_v2`|6.0.0| | | | |`rocblas_csyr2k`|3.5.0| | | | |
@@ -1275,9 +1275,9 @@
 |`cublasDgemvStridedBatched`|11.6| | | |`hipblasDgemvStridedBatched`|3.0.0| | | | |`rocblas_dgemv_strided_batched`|3.5.0| | | | |
 |`cublasDgemvStridedBatched_64`|12.0| | | |`hipblasDgemvStridedBatched_64`|6.2.0| | | | |`rocblas_dgemv_strided_batched_64`|6.2.0| | | | |
 |`cublasDsymm`| | | | |`hipblasDsymm`|3.6.0| | | | |`rocblas_dsymm`|3.5.0| | | | |
-|`cublasDsymm_64`|12.0| | | | | | | | | | | | | | | |
+|`cublasDsymm_64`|12.0| | | |`hipblasDsymm_64`|6.3.0| | | |6.3.0|`rocblas_dsymm_64`|6.3.0| | | |6.3.0|
 |`cublasDsymm_v2`| | | | |`hipblasDsymm`|3.6.0| | | | |`rocblas_dsymm`|3.5.0| | | | |
-|`cublasDsymm_v2_64`|12.0| | | | | | | | | | | | | | | |
+|`cublasDsymm_v2_64`|12.0| | | |`hipblasDsymm_64`|6.3.0| | | |6.3.0|`rocblas_dsymm_64`|6.3.0| | | |6.3.0|
 |`cublasDsyr2k`| | | | |`hipblasDsyr2k`|3.5.0| | | | |`rocblas_dsyr2k`|3.5.0| | | | |
 |`cublasDsyr2k_64`|12.0| | | | | | | | | | | | | | | |
 |`cublasDsyr2k_v2`| | | | |`hipblasDsyr2k`|3.5.0| | | | |`rocblas_dsyr2k`|3.5.0| | | | |
@@ -1327,9 +1327,9 @@
 |`cublasSgemvStridedBatched`|11.6| | | |`hipblasSgemvStridedBatched`|3.0.0| | | | |`rocblas_sgemv_strided_batched`|3.5.0| | | | |
 |`cublasSgemvStridedBatched_64`|12.0| | | |`hipblasSgemvStridedBatched_64`|6.2.0| | | | |`rocblas_sgemv_strided_batched_64`|6.2.0| | | | |
 |`cublasSsymm`| | | | |`hipblasSsymm`|3.6.0| | | | |`rocblas_ssymm`|3.5.0| | | | |
-|`cublasSsymm_64`|12.0| | | | | | | | | | | | | | | |
+|`cublasSsymm_64`|12.0| | | |`hipblasSsymm_64`|6.3.0| | | |6.3.0|`rocblas_ssymm_64`|6.3.0| | | |6.3.0|
 |`cublasSsymm_v2`| | | | |`hipblasSsymm`|3.6.0| | | | |`rocblas_ssymm`|3.5.0| | | | |
-|`cublasSsymm_v2_64`|12.0| | | | | | | | | | | | | | | |
+|`cublasSsymm_v2_64`|12.0| | | |`hipblasSsymm_64`|6.3.0| | | |6.3.0|`rocblas_ssymm_64`|6.3.0| | | |6.3.0|
 |`cublasSsyr2k`| | | | |`hipblasSsyr2k`|3.5.0| | | | |`rocblas_ssyr2k`|3.5.0| | | | |
 |`cublasSsyr2k_64`|12.0| | | | | | | | | | | | | | | |
 |`cublasSsyr2k_v2`| | | | |`hipblasSsyr2k`|3.5.0| | | | |`rocblas_ssyr2k`|3.5.0| | | | |
@@ -1385,9 +1385,9 @@
 |`cublasZherkx`| | | | |`hipblasZherkx_v2`|6.0.0| | | | |`rocblas_zherkx`|3.5.0| | | | |
 |`cublasZherkx_64`|12.0| | | |`hipblasZherkx_v2_64`|6.3.0| | | |6.3.0|`rocblas_zherkx_64`|6.3.0| | | |6.3.0|
 |`cublasZsymm`| | | | |`hipblasZsymm_v2`|6.0.0| | | | |`rocblas_zsymm`|3.5.0| | | | |
-|`cublasZsymm_64`|12.0| | | | | | | | | | | | | | | |
+|`cublasZsymm_64`|12.0| | | |`hipblasZsymm_v2_64`|6.3.0| | | |6.3.0|`rocblas_zsymm_64`|6.3.0| | | |6.3.0|
 |`cublasZsymm_v2`| | | | |`hipblasZsymm_v2`|6.0.0| | | | |`rocblas_zsymm`|3.5.0| | | | |
-|`cublasZsymm_v2_64`|12.0| | | | | | | | | | | | | | | |
+|`cublasZsymm_v2_64`|12.0| | | |`hipblasZsymm_v2_64`|6.3.0| | | |6.3.0|`rocblas_zsymm_64`|6.3.0| | | |6.3.0|
 |`cublasZsyr2k`| | | | |`hipblasZsyr2k_v2`|6.0.0| | | | |`rocblas_zsyr2k`|3.5.0| | | | |
 |`cublasZsyr2k_64`|12.0| | | | | | | | | | | | | | | |
 |`cublasZsyr2k_v2`| | | | |`hipblasZsyr2k_v2`|6.0.0| | | | |`rocblas_zsyr2k`|3.5.0| | | | |

--- a/docs/tables/CUBLAS_API_supported_by_ROC.md
+++ b/docs/tables/CUBLAS_API_supported_by_ROC.md
@@ -1239,9 +1239,9 @@
 |`cublasCherkx`| | | | |`rocblas_cherkx`|3.5.0| | | | |
 |`cublasCherkx_64`|12.0| | | |`rocblas_cherkx_64`|6.3.0| | | |6.3.0|
 |`cublasCsymm`| | | | |`rocblas_csymm`|3.5.0| | | | |
-|`cublasCsymm_64`|12.0| | | | | | | | | |
+|`cublasCsymm_64`|12.0| | | |`rocblas_csymm_64`|6.3.0| | | |6.3.0|
 |`cublasCsymm_v2`| | | | |`rocblas_csymm`|3.5.0| | | | |
-|`cublasCsymm_v2_64`|12.0| | | | | | | | | |
+|`cublasCsymm_v2_64`|12.0| | | |`rocblas_csymm_64`|6.3.0| | | |6.3.0|
 |`cublasCsyr2k`| | | | |`rocblas_csyr2k`|3.5.0| | | | |
 |`cublasCsyr2k_64`|12.0| | | | | | | | | |
 |`cublasCsyr2k_v2`| | | | |`rocblas_csyr2k`|3.5.0| | | | |
@@ -1275,9 +1275,9 @@
 |`cublasDgemvStridedBatched`|11.6| | | |`rocblas_dgemv_strided_batched`|3.5.0| | | | |
 |`cublasDgemvStridedBatched_64`|12.0| | | |`rocblas_dgemv_strided_batched_64`|6.2.0| | | | |
 |`cublasDsymm`| | | | |`rocblas_dsymm`|3.5.0| | | | |
-|`cublasDsymm_64`|12.0| | | | | | | | | |
+|`cublasDsymm_64`|12.0| | | |`rocblas_dsymm_64`|6.3.0| | | |6.3.0|
 |`cublasDsymm_v2`| | | | |`rocblas_dsymm`|3.5.0| | | | |
-|`cublasDsymm_v2_64`|12.0| | | | | | | | | |
+|`cublasDsymm_v2_64`|12.0| | | |`rocblas_dsymm_64`|6.3.0| | | |6.3.0|
 |`cublasDsyr2k`| | | | |`rocblas_dsyr2k`|3.5.0| | | | |
 |`cublasDsyr2k_64`|12.0| | | | | | | | | |
 |`cublasDsyr2k_v2`| | | | |`rocblas_dsyr2k`|3.5.0| | | | |
@@ -1327,9 +1327,9 @@
 |`cublasSgemvStridedBatched`|11.6| | | |`rocblas_sgemv_strided_batched`|3.5.0| | | | |
 |`cublasSgemvStridedBatched_64`|12.0| | | |`rocblas_sgemv_strided_batched_64`|6.2.0| | | | |
 |`cublasSsymm`| | | | |`rocblas_ssymm`|3.5.0| | | | |
-|`cublasSsymm_64`|12.0| | | | | | | | | |
+|`cublasSsymm_64`|12.0| | | |`rocblas_ssymm_64`|6.3.0| | | |6.3.0|
 |`cublasSsymm_v2`| | | | |`rocblas_ssymm`|3.5.0| | | | |
-|`cublasSsymm_v2_64`|12.0| | | | | | | | | |
+|`cublasSsymm_v2_64`|12.0| | | |`rocblas_ssymm_64`|6.3.0| | | |6.3.0|
 |`cublasSsyr2k`| | | | |`rocblas_ssyr2k`|3.5.0| | | | |
 |`cublasSsyr2k_64`|12.0| | | | | | | | | |
 |`cublasSsyr2k_v2`| | | | |`rocblas_ssyr2k`|3.5.0| | | | |
@@ -1385,9 +1385,9 @@
 |`cublasZherkx`| | | | |`rocblas_zherkx`|3.5.0| | | | |
 |`cublasZherkx_64`|12.0| | | |`rocblas_zherkx_64`|6.3.0| | | |6.3.0|
 |`cublasZsymm`| | | | |`rocblas_zsymm`|3.5.0| | | | |
-|`cublasZsymm_64`|12.0| | | | | | | | | |
+|`cublasZsymm_64`|12.0| | | |`rocblas_zsymm_64`|6.3.0| | | |6.3.0|
 |`cublasZsymm_v2`| | | | |`rocblas_zsymm`|3.5.0| | | | |
-|`cublasZsymm_v2_64`|12.0| | | | | | | | | |
+|`cublasZsymm_v2_64`|12.0| | | |`rocblas_zsymm_64`|6.3.0| | | |6.3.0|
 |`cublasZsyr2k`| | | | |`rocblas_zsyr2k`|3.5.0| | | | |
 |`cublasZsyr2k_64`|12.0| | | | | | | | | |
 |`cublasZsyr2k_v2`| | | | |`rocblas_zsyr2k`|3.5.0| | | | |

--- a/src/CUDA2HIP_BLAS_API_functions.cpp
+++ b/src/CUDA2HIP_BLAS_API_functions.cpp
@@ -525,13 +525,13 @@ const std::map<llvm::StringRef, hipCounter> CUDA_BLAS_FUNCTION_MAP {
 
   // SYMM
   {"cublasSsymm",                                          {"hipblasSsymm",                                              "rocblas_ssymm",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3, HIP_SUPPORTED_V2_ONLY}},
-  {"cublasSsymm_64",                                       {"hipblasSsymm_64",                                           "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3, UNSUPPORTED}},
+  {"cublasSsymm_64",                                       {"hipblasSsymm_64",                                           "rocblas_ssymm_64",                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3}},
   {"cublasDsymm",                                          {"hipblasDsymm",                                              "rocblas_dsymm",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3, HIP_SUPPORTED_V2_ONLY}},
-  {"cublasDsymm_64",                                       {"hipblasDsymm_64",                                           "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3, UNSUPPORTED}},
+  {"cublasDsymm_64",                                       {"hipblasDsymm_64",                                           "rocblas_dsymm_64",                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3}},
   {"cublasCsymm",                                          {"hipblasCsymm_v2",                                           "rocblas_csymm",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3, HIP_SUPPORTED_V2_ONLY}},
-  {"cublasCsymm_64",                                       {"hipblasCsymm_64",                                           "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3, UNSUPPORTED}},
+  {"cublasCsymm_64",                                       {"hipblasCsymm_v2_64",                                        "rocblas_csymm_64",                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3}},
   {"cublasZsymm",                                          {"hipblasZsymm_v2",                                           "rocblas_zsymm",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3, HIP_SUPPORTED_V2_ONLY}},
-  {"cublasZsymm_64",                                       {"hipblasZsymm_64",                                           "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3, UNSUPPORTED}},
+  {"cublasZsymm_64",                                       {"hipblasZsymm_v2_64",                                        "rocblas_zsymm_64",                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3}},
 
   // HEMM
   {"cublasChemm",                                          {"hipblasChemm_v2",                                           "rocblas_chemm",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3, HIP_SUPPORTED_V2_ONLY}},
@@ -892,13 +892,13 @@ const std::map<llvm::StringRef, hipCounter> CUDA_BLAS_FUNCTION_MAP {
 
   // SYMM
   {"cublasSsymm_v2",                                       {"hipblasSsymm",                                              "rocblas_ssymm",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3}},
-  {"cublasSsymm_v2_64",                                    {"hipblasSsymm_64",                                           "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3, UNSUPPORTED}},
+  {"cublasSsymm_v2_64",                                    {"hipblasSsymm_64",                                           "rocblas_ssymm_64",                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3}},
   {"cublasDsymm_v2",                                       {"hipblasDsymm",                                              "rocblas_dsymm",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3}},
-  {"cublasDsymm_v2_64",                                    {"hipblasDsymm_64",                                           "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3, UNSUPPORTED}},
+  {"cublasDsymm_v2_64",                                    {"hipblasDsymm_64",                                           "rocblas_dsymm_64",                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3}},
   {"cublasCsymm_v2",                                       {"hipblasCsymm_v2",                                           "rocblas_csymm",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3}},
-  {"cublasCsymm_v2_64",                                    {"hipblasCsymm_64",                                           "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3, UNSUPPORTED}},
+  {"cublasCsymm_v2_64",                                    {"hipblasCsymm_v2_64",                                        "rocblas_csymm_64",                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3}},
   {"cublasZsymm_v2",                                       {"hipblasZsymm_v2",                                           "rocblas_zsymm",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3}},
-  {"cublasZsymm_v2_64",                                    {"hipblasZsymm_64",                                           "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3, UNSUPPORTED}},
+  {"cublasZsymm_v2_64",                                    {"hipblasZsymm_v2_64",                                        "rocblas_zsymm_64",                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3}},
 
   // HEMM
   {"cublasChemm_v2",                                       {"hipblasChemm_v2",                                           "rocblas_chemm",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3}},
@@ -2044,6 +2044,10 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_BLAS_FUNCTION_VER_MAP {
   {"hipblasZherkx_v2_64",                                  {HIP_6030, HIP_0,    HIP_0,  HIP_LATEST}},
   {"hipblasCher2k_v2_64",                                  {HIP_6030, HIP_0,    HIP_0,  HIP_LATEST}},
   {"hipblasZher2k_v2_64",                                  {HIP_6030, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipblasSsymm_64",                                      {HIP_6030, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipblasDsymm_64",                                      {HIP_6030, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipblasCsymm_v2_64",                                   {HIP_6030, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipblasZsymm_v2_64",                                   {HIP_6030, HIP_0,    HIP_0,  HIP_LATEST}},
 
   {"rocblas_status_to_string",                             {HIP_3050, HIP_0,    HIP_0   }},
   {"rocblas_sscal",                                        {HIP_1050, HIP_0,    HIP_0   }},
@@ -2453,6 +2457,10 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_BLAS_FUNCTION_VER_MAP {
   {"rocblas_zherkx_64",                                    {HIP_6030, HIP_0,    HIP_0,  HIP_LATEST}},
   {"rocblas_cher2k_64",                                    {HIP_6030, HIP_0,    HIP_0,  HIP_LATEST}},
   {"rocblas_zher2k_64",                                    {HIP_6030, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"rocblas_ssymm_64",                                     {HIP_6030, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"rocblas_dsymm_64",                                     {HIP_6030, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"rocblas_csymm_64",                                     {HIP_6030, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"rocblas_zsymm_64",                                     {HIP_6030, HIP_0,    HIP_0,  HIP_LATEST}},
 };
 
 const std::map<llvm::StringRef, hipAPIChangedVersions> HIP_BLAS_FUNCTION_CHANGED_VER_MAP {

--- a/tests/unit_tests/synthetic/libraries/cublas2hipblas_v2.cu
+++ b/tests/unit_tests/synthetic/libraries/cublas2hipblas_v2.cu
@@ -2946,6 +2946,34 @@ int main() {
   // CHECK-NEXT: blasStatus = hipblasZher2k_v2_64(blasHandle, blasFillMode, blasOperation, n_64, k_64, &dcomplexa, &dcomplexA, lda_64, &dcomplexB, ldb_64, &db, &dcomplexC, ldc_64);
   blasStatus = cublasZher2k_64(blasHandle, blasFillMode, blasOperation, n_64, k_64, &dcomplexa, &dcomplexA, lda_64, &dcomplexB, ldb_64, &db, &dcomplexC, ldc_64);
   blasStatus = cublasZher2k_v2_64(blasHandle, blasFillMode, blasOperation, n_64, k_64, &dcomplexa, &dcomplexA, lda_64, &dcomplexB, ldb_64, &db, &dcomplexC, ldc_64);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasSsymm_v2_64(cublasHandle_t handle, cublasSideMode_t side, cublasFillMode_t uplo, int64_t m, int64_t n, const float* alpha, const float* A, int64_t lda, const float* B, int64_t ldb, const float* beta, float* C, int64_t ldc);
+  // HIP: HIPBLAS_EXPORT hipblasStatus_t hipblasSsymm_64(hipblasHandle_t handle, hipblasSideMode_t side, hipblasFillMode_t uplo, int64_t m, int64_t n, const float* alpha, const float* AP, int64_t lda, const float* BP, int64_t ldb, const float* beta, float* CP, int64_t ldc);
+  // CHECK: blasStatus = hipblasSsymm_64(blasHandle, blasSideMode, blasFillMode, m_64, n_64, &fa, &fA, lda_64, &fB, ldb_64, &fb, &fC, ldc_64);
+  // CHECK-NEXT: blasStatus = hipblasSsymm_64(blasHandle, blasSideMode, blasFillMode, m_64, n_64, &fa, &fA, lda_64, &fB, ldb_64, &fb, &fC, ldc_64);
+  blasStatus = cublasSsymm_64(blasHandle, blasSideMode, blasFillMode, m_64, n_64, &fa, &fA, lda_64, &fB, ldb_64, &fb, &fC, ldc_64);
+  blasStatus = cublasSsymm_v2_64(blasHandle, blasSideMode, blasFillMode, m_64, n_64, &fa, &fA, lda_64, &fB, ldb_64, &fb, &fC, ldc_64);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasDsymm_v2_64(cublasHandle_t handle, cublasSideMode_t side, cublasFillMode_t uplo, int64_t m, int64_t n, const double* alpha, const double* A, int64_t lda, const double* B, int64_t ldb, const double* beta, double* C, int64_t ldc);
+  // HIP: HIPBLAS_EXPORT hipblasStatus_t hipblasDsymm_64(hipblasHandle_t handle, hipblasSideMode_t side, hipblasFillMode_t uplo, int64_t m, int64_t n, const double* alpha, const double* AP, int64_t lda, const double* BP, int64_t ldb, const double* beta, double* CP, int64_t ldc);
+  // CHECK: blasStatus = hipblasDsymm_64(blasHandle, blasSideMode, blasFillMode, m_64, n_64, &da, &dA, lda_64, &dB, ldb_64, &db, &dC, ldc_64);
+  // CHECK-NEXT: blasStatus = hipblasDsymm_64(blasHandle, blasSideMode, blasFillMode, m_64, n_64, &da, &dA, lda_64, &dB, ldb_64, &db, &dC, ldc_64);
+  blasStatus = cublasDsymm_64(blasHandle, blasSideMode, blasFillMode, m_64, n_64, &da, &dA, lda_64, &dB, ldb_64, &db, &dC, ldc_64);
+  blasStatus = cublasDsymm_v2_64(blasHandle, blasSideMode, blasFillMode, m_64, n_64, &da, &dA, lda_64, &dB, ldb_64, &db, &dC, ldc_64);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasCsymm_v2_64(cublasHandle_t handle, cublasSideMode_t side, cublasFillMode_t uplo, int64_t m, int64_t n, const cuComplex* alpha, const cuComplex* A, int64_t lda, const cuComplex* B, int64_t ldb, const cuComplex* beta, cuComplex* C, int64_t ldc);
+  // HIP: HIPBLAS_EXPORT hipblasStatus_t hipblasCsymm_v2_64(hipblasHandle_t handle, hipblasSideMode_t side, hipblasFillMode_t uplo, int64_t m, int64_t n, const hipComplex* alpha, const hipComplex* AP, int64_t lda, const hipComplex* BP, int64_t ldb, const hipComplex* beta, hipComplex* CP, int64_t ldc);
+  // CHECK: blasStatus = hipblasCsymm_v2_64(blasHandle, blasSideMode, blasFillMode, m_64, n_64, &complexa, &complexA, lda_64, &complexB, ldb_64, &complexb, &complexC, ldc_64);
+  // CHECK-NEXT: blasStatus = hipblasCsymm_v2_64(blasHandle, blasSideMode, blasFillMode, m_64, n_64, &complexa, &complexA, lda_64, &complexB, ldb_64, &complexb, &complexC, ldc_64);
+  blasStatus = cublasCsymm_64(blasHandle, blasSideMode, blasFillMode, m_64, n_64, &complexa, &complexA, lda_64, &complexB, ldb_64, &complexb, &complexC, ldc_64);
+  blasStatus = cublasCsymm_v2_64(blasHandle, blasSideMode, blasFillMode, m_64, n_64, &complexa, &complexA, lda_64, &complexB, ldb_64, &complexb, &complexC, ldc_64);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasZsymm_v2_64(cublasHandle_t handle, cublasSideMode_t side, cublasFillMode_t uplo, int64_t m, int64_t n, const cuDoubleComplex* alpha, const cuDoubleComplex* A, int64_t lda, const cuDoubleComplex* B, int64_t ldb, const cuDoubleComplex* beta, cuDoubleComplex* C, int64_t ldc);
+  // HIP: HIPBLAS_EXPORT hipblasStatus_t hipblasZsymm_v2_64(hipblasHandle_t handle, hipblasSideMode_t side, hipblasFillMode_t uplo, int64_t m, int64_t n, const hipDoubleComplex* alpha, const hipDoubleComplex* AP, int64_t lda, const hipDoubleComplex* BP, int64_t ldb, const hipDoubleComplex* beta, hipDoubleComplex* CP, int64_t ldc);
+  // CHECK: blasStatus = hipblasZsymm_v2_64(blasHandle, blasSideMode, blasFillMode, m_64, n_64, &dcomplexa, &dcomplexA, lda_64, &dcomplexB, ldb_64, &dcomplexb, &dcomplexC, ldc_64);
+  // CHECK-NEXT: blasStatus = hipblasZsymm_v2_64(blasHandle, blasSideMode, blasFillMode, m_64, n_64, &dcomplexa, &dcomplexA, lda_64, &dcomplexB, ldb_64, &dcomplexb, &dcomplexC, ldc_64);
+  blasStatus = cublasZsymm_64(blasHandle, blasSideMode, blasFillMode, m_64, n_64, &dcomplexa, &dcomplexA, lda_64, &dcomplexB, ldb_64, &dcomplexb, &dcomplexC, ldc_64);
+  blasStatus = cublasZsymm_v2_64(blasHandle, blasSideMode, blasFillMode, m_64, n_64, &dcomplexa, &dcomplexA, lda_64, &dcomplexB, ldb_64, &dcomplexb, &dcomplexC, ldc_64);
 #endif
 
   return 0;

--- a/tests/unit_tests/synthetic/libraries/cublas2rocblas_v2.cu
+++ b/tests/unit_tests/synthetic/libraries/cublas2rocblas_v2.cu
@@ -3151,6 +3151,34 @@ int main() {
   // CHECK-NEXT: blasStatus = rocblas_zher2k_64(blasHandle, blasFillMode, blasOperation, n_64, k_64, &dcomplexa, &dcomplexA, lda_64, &dcomplexB, ldb_64, &db, &dcomplexC, ldc_64);
   blasStatus = cublasZher2k_64(blasHandle, blasFillMode, blasOperation, n_64, k_64, &dcomplexa, &dcomplexA, lda_64, &dcomplexB, ldb_64, &db, &dcomplexC, ldc_64);
   blasStatus = cublasZher2k_v2_64(blasHandle, blasFillMode, blasOperation, n_64, k_64, &dcomplexa, &dcomplexA, lda_64, &dcomplexB, ldb_64, &db, &dcomplexC, ldc_64);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasSsymm_v2_64(cublasHandle_t handle, cublasSideMode_t side, cublasFillMode_t uplo, int64_t m, int64_t n, const float* alpha, const float* A, int64_t lda, const float* B, int64_t ldb, const float* beta, float* C, int64_t ldc);
+  // ROC: ROCBLAS_EXPORT rocblas_status rocblas_ssymm_64(rocblas_handle handle, rocblas_side side, rocblas_fill uplo, int64_t m, int64_t n, const float* alpha, const float* A, int64_t lda, const float* B, int64_t ldb, const float* beta, float* C, int64_t ldc);
+  // CHECK: blasStatus = rocblas_ssymm_64(blasHandle, blasSideMode, blasFillMode, m_64, n_64, &fa, &fA, lda_64, &fB, ldb_64, &fb, &fC, ldc_64);
+  // CHECK-NEXT: blasStatus = rocblas_ssymm_64(blasHandle, blasSideMode, blasFillMode, m_64, n_64, &fa, &fA, lda_64, &fB, ldb_64, &fb, &fC, ldc_64);
+  blasStatus = cublasSsymm_64(blasHandle, blasSideMode, blasFillMode, m_64, n_64, &fa, &fA, lda_64, &fB, ldb_64, &fb, &fC, ldc_64);
+  blasStatus = cublasSsymm_v2_64(blasHandle, blasSideMode, blasFillMode, m_64, n_64, &fa, &fA, lda_64, &fB, ldb_64, &fb, &fC, ldc_64);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasDsymm_v2_64(cublasHandle_t handle, cublasSideMode_t side, cublasFillMode_t uplo, int64_t m, int64_t n, const double* alpha, const double* A, int64_t lda, const double* B, int64_t ldb, const double* beta, double* C, int64_t ldc);
+  // ROC: ROCBLAS_EXPORT rocblas_status rocblas_dsymm_64(rocblas_handle handle, rocblas_side side, rocblas_fill uplo, int64_t m, int64_t n, const double* alpha, const double* A, int64_t lda, const double* B, int64_t ldb, const double* beta, double* C, int64_t ldc);
+  // CHECK: blasStatus = rocblas_dsymm_64(blasHandle, blasSideMode, blasFillMode, m_64, n_64, &da, &dA, lda_64, &dB, ldb_64, &db, &dC, ldc_64);
+  // CHECK-NEXT: blasStatus = rocblas_dsymm_64(blasHandle, blasSideMode, blasFillMode, m_64, n_64, &da, &dA, lda_64, &dB, ldb_64, &db, &dC, ldc_64);
+  blasStatus = cublasDsymm_64(blasHandle, blasSideMode, blasFillMode, m_64, n_64, &da, &dA, lda_64, &dB, ldb_64, &db, &dC, ldc_64);
+  blasStatus = cublasDsymm_v2_64(blasHandle, blasSideMode, blasFillMode, m_64, n_64, &da, &dA, lda_64, &dB, ldb_64, &db, &dC, ldc_64);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasCsymm_v2_64(cublasHandle_t handle, cublasSideMode_t side, cublasFillMode_t uplo, int64_t m, int64_t n, const cuComplex* alpha, const cuComplex* A, int64_t lda, const cuComplex* B, int64_t ldb, const cuComplex* beta, cuComplex* C, int64_t ldc);
+  // ROC: ROCBLAS_EXPORT rocblas_status rocblas_csymm_64(rocblas_handle handle, rocblas_side side, rocblas_fill uplo, int64_t m, int64_t n, const rocblas_float_complex* alpha, const rocblas_float_complex* A, int64_t lda, const rocblas_float_complex* B, int64_t ldb, const rocblas_float_complex* beta, rocblas_float_complex* C, int64_t ldc);
+  // CHECK: blasStatus = rocblas_csymm_64(blasHandle, blasSideMode, blasFillMode, m_64, n_64, &complexa, &complexA, lda_64, &complexB, ldb_64, &complexb, &complexC, ldc_64);
+  // CHECK-NEXT: blasStatus = rocblas_csymm_64(blasHandle, blasSideMode, blasFillMode, m_64, n_64, &complexa, &complexA, lda_64, &complexB, ldb_64, &complexb, &complexC, ldc_64);
+  blasStatus = cublasCsymm_64(blasHandle, blasSideMode, blasFillMode, m_64, n_64, &complexa, &complexA, lda_64, &complexB, ldb_64, &complexb, &complexC, ldc_64);
+  blasStatus = cublasCsymm_v2_64(blasHandle, blasSideMode, blasFillMode, m_64, n_64, &complexa, &complexA, lda_64, &complexB, ldb_64, &complexb, &complexC, ldc_64);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasZsymm_v2_64(cublasHandle_t handle, cublasSideMode_t side, cublasFillMode_t uplo, int64_t m, int64_t n, const cuDoubleComplex* alpha, const cuDoubleComplex* A, int64_t lda, const cuDoubleComplex* B, int64_t ldb, const cuDoubleComplex* beta, cuDoubleComplex* C, int64_t ldc);
+  // ROC: ROCBLAS_EXPORT rocblas_status rocblas_zsymm_64(rocblas_handle handle, rocblas_side side, rocblas_fill uplo, int64_t m, int64_t n, const rocblas_double_complex* alpha, const rocblas_double_complex* A, int64_t lda, const rocblas_double_complex* B, int64_t ldb, const rocblas_double_complex* beta, rocblas_double_complex* C, int64_t ldc);
+  // CHECK: blasStatus = rocblas_zsymm_64(blasHandle, blasSideMode, blasFillMode, m_64, n_64, &dcomplexa, &dcomplexA, lda_64, &dcomplexB, ldb_64, &dcomplexb, &dcomplexC, ldc_64);
+  // CHECK-NEXT: blasStatus = rocblas_zsymm_64(blasHandle, blasSideMode, blasFillMode, m_64, n_64, &dcomplexa, &dcomplexA, lda_64, &dcomplexB, ldb_64, &dcomplexb, &dcomplexC, ldc_64);
+  blasStatus = cublasZsymm_64(blasHandle, blasSideMode, blasFillMode, m_64, n_64, &dcomplexa, &dcomplexA, lda_64, &dcomplexB, ldb_64, &dcomplexb, &dcomplexC, ldc_64);
+  blasStatus = cublasZsymm_v2_64(blasHandle, blasSideMode, blasFillMode, m_64, n_64, &dcomplexa, &dcomplexA, lda_64, &dcomplexB, ldb_64, &dcomplexb, &dcomplexC, ldc_64);
 #endif
 
   return 0;


### PR DESCRIPTION
+ `rocblas_(s|d|c|z)symm_64` and `hipblas(S|D|C|Z)symm(_v2)?_64` support
+ Updated synthetic tests, the regenerated `hipify-perl`, and `BLAS` `CUDA2HIP` documentation