### PR TITLE
[HIPIFY][6.3.0][BLAS] Sync with `hipBLAS` and `rocBLAS` - Step 7

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -1709,7 +1709,9 @@ sub rocSubstitutions {
     subst("cublasCsyr_v2", "rocblas_csyr", "library");
     subst("cublasCsyr_v2_64", "rocblas_csyr_64", "library");
     subst("cublasCsyrk", "rocblas_csyrk", "library");
+    subst("cublasCsyrk_64", "rocblas_csyrk_64", "library");
     subst("cublasCsyrk_v2", "rocblas_csyrk", "library");
+    subst("cublasCsyrk_v2_64", "rocblas_csyrk_64", "library");
     subst("cublasCsyrkx", "rocblas_csyrkx", "library");
     subst("cublasCtbmv", "rocblas_ctbmv", "library");
     subst("cublasCtbmv_64", "rocblas_ctbmv_64", "library");
@@ -1850,7 +1852,9 @@ sub rocSubstitutions {
     subst("cublasDsyr_v2", "rocblas_dsyr", "library");
     subst("cublasDsyr_v2_64", "rocblas_dsyr_64", "library");
     subst("cublasDsyrk", "rocblas_dsyrk", "library");
+    subst("cublasDsyrk_64", "rocblas_dsyrk_64", "library");
     subst("cublasDsyrk_v2", "rocblas_dsyrk", "library");
+    subst("cublasDsyrk_v2_64", "rocblas_dsyrk_64", "library");
     subst("cublasDsyrkx", "rocblas_dsyrkx", "library");
     subst("cublasDtbmv", "rocblas_dtbmv", "library");
     subst("cublasDtbmv_64", "rocblas_dtbmv_64", "library");
@@ -2078,7 +2082,9 @@ sub rocSubstitutions {
     subst("cublasSsyr_v2", "rocblas_ssyr", "library");
     subst("cublasSsyr_v2_64", "rocblas_ssyr_64", "library");
     subst("cublasSsyrk", "rocblas_ssyrk", "library");
+    subst("cublasSsyrk_64", "rocblas_ssyrk_64", "library");
     subst("cublasSsyrk_v2", "rocblas_ssyrk", "library");
+    subst("cublasSsyrk_v2_64", "rocblas_ssyrk_64", "library");
     subst("cublasSsyrkx", "rocblas_ssyrkx", "library");
     subst("cublasStbmv", "rocblas_stbmv", "library");
     subst("cublasStbmv_64", "rocblas_stbmv_64", "library");
@@ -2247,7 +2253,9 @@ sub rocSubstitutions {
     subst("cublasZsyr_v2", "rocblas_zsyr", "library");
     subst("cublasZsyr_v2_64", "rocblas_zsyr_64", "library");
     subst("cublasZsyrk", "rocblas_zsyrk", "library");
+    subst("cublasZsyrk_64", "rocblas_zsyrk_64", "library");
     subst("cublasZsyrk_v2", "rocblas_zsyrk", "library");
+    subst("cublasZsyrk_v2_64", "rocblas_zsyrk_64", "library");
     subst("cublasZsyrkx", "rocblas_zsyrkx", "library");
     subst("cublasZtbmv", "rocblas_ztbmv", "library");
     subst("cublasZtbmv_64", "rocblas_ztbmv_64", "library");
@@ -4471,7 +4479,9 @@ sub simpleSubstitutions {
     subst("cublasCsyr_v2", "hipblasCsyr_v2", "library");
     subst("cublasCsyr_v2_64", "hipblasCsyr_v2_64", "library");
     subst("cublasCsyrk", "hipblasCsyrk_v2", "library");
+    subst("cublasCsyrk_64", "hipblasCsyrk_v2_64", "library");
     subst("cublasCsyrk_v2", "hipblasCsyrk_v2", "library");
+    subst("cublasCsyrk_v2_64", "hipblasCsyrk_v2_64", "library");
     subst("cublasCsyrkx", "hipblasCsyrkx_v2", "library");
     subst("cublasCtbmv", "hipblasCtbmv_v2", "library");
     subst("cublasCtbmv_64", "hipblasCtbmv_v2_64", "library");
@@ -4613,7 +4623,9 @@ sub simpleSubstitutions {
     subst("cublasDsyr_v2", "hipblasDsyr", "library");
     subst("cublasDsyr_v2_64", "hipblasDsyr_64", "library");
     subst("cublasDsyrk", "hipblasDsyrk", "library");
+    subst("cublasDsyrk_64", "hipblasDsyrk_64", "library");
     subst("cublasDsyrk_v2", "hipblasDsyrk", "library");
+    subst("cublasDsyrk_v2_64", "hipblasDsyrk_64", "library");
     subst("cublasDsyrkx", "hipblasDsyrkx", "library");
     subst("cublasDtbmv", "hipblasDtbmv", "library");
     subst("cublasDtbmv_64", "hipblasDtbmv_64", "library");
@@ -4852,7 +4864,9 @@ sub simpleSubstitutions {
     subst("cublasSsyr_v2", "hipblasSsyr", "library");
     subst("cublasSsyr_v2_64", "hipblasSsyr_64", "library");
     subst("cublasSsyrk", "hipblasSsyrk", "library");
+    subst("cublasSsyrk_64", "hipblasSsyrk_64", "library");
     subst("cublasSsyrk_v2", "hipblasSsyrk", "library");
+    subst("cublasSsyrk_v2_64", "hipblasSsyrk_64", "library");
     subst("cublasSsyrkx", "hipblasSsyrkx", "library");
     subst("cublasStbmv", "hipblasStbmv", "library");
     subst("cublasStbmv_64", "hipblasStbmv_64", "library");
@@ -5014,7 +5028,9 @@ sub simpleSubstitutions {
     subst("cublasZsyr_v2", "hipblasZsyr_v2", "library");
     subst("cublasZsyr_v2_64", "hipblasZsyr_v2_64", "library");
     subst("cublasZsyrk", "hipblasZsyrk_v2", "library");
+    subst("cublasZsyrk_64", "hipblasZsyrk_v2_64", "library");
     subst("cublasZsyrk_v2", "hipblasZsyrk_v2", "library");
+    subst("cublasZsyrk_v2_64", "hipblasZsyrk_v2_64", "library");
     subst("cublasZsyrkx", "hipblasZsyrkx_v2", "library");
     subst("cublasZtbmv", "hipblasZtbmv_v2", "library");
     subst("cublasZtbmv_64", "hipblasZtbmv_v2_64", "library");
@@ -11580,8 +11596,6 @@ sub warnHipOnlyUnsupportedFunctions {
         "cublasZtrmm_64",
         "cublasZtpttr",
         "cublasZsyrkx_64",
-        "cublasZsyrk_v2_64",
-        "cublasZsyrk_64",
         "cublasZsyr2k_v2_64",
         "cublasZsyr2k_64",
         "cublasZmatinvBatched",
@@ -11611,8 +11625,6 @@ sub warnHipOnlyUnsupportedFunctions {
         "cublasStrmm_64",
         "cublasStpttr",
         "cublasSsyrkx_64",
-        "cublasSsyrk_v2_64",
-        "cublasSsyrk_64",
         "cublasSsyr2k_v2_64",
         "cublasSsyr2k_64",
         "cublasSmatinvBatched",
@@ -11713,8 +11725,6 @@ sub warnHipOnlyUnsupportedFunctions {
         "cublasDtrmm_64",
         "cublasDtpttr",
         "cublasDsyrkx_64",
-        "cublasDsyrk_v2_64",
-        "cublasDsyrk_64",
         "cublasDsyr2k_v2_64",
         "cublasDsyr2k_64",
         "cublasDmatinvBatched",
@@ -11730,8 +11740,6 @@ sub warnHipOnlyUnsupportedFunctions {
         "cublasCtrmm_64",
         "cublasCtpttr",
         "cublasCsyrkx_64",
-        "cublasCsyrk_v2_64",
-        "cublasCsyrk_64",
         "cublasCsyrkEx_64",
         "cublasCsyrkEx",
         "cublasCsyrk3mEx_64",
@@ -13473,8 +13481,6 @@ sub warnRocOnlyUnsupportedFunctions {
         "cublasZtrmm_64",
         "cublasZtpttr",
         "cublasZsyrkx_64",
-        "cublasZsyrk_v2_64",
-        "cublasZsyrk_64",
         "cublasZsyr2k_v2_64",
         "cublasZsyr2k_64",
         "cublasZmatinvBatched",
@@ -13498,8 +13504,6 @@ sub warnRocOnlyUnsupportedFunctions {
         "cublasStrmm_64",
         "cublasStpttr",
         "cublasSsyrkx_64",
-        "cublasSsyrk_v2_64",
-        "cublasSsyrk_64",
         "cublasSsyr2k_v2_64",
         "cublasSsyr2k_64",
         "cublasSmatinvBatched",
@@ -13619,8 +13623,6 @@ sub warnRocOnlyUnsupportedFunctions {
         "cublasDtrmm_64",
         "cublasDtpttr",
         "cublasDsyrkx_64",
-        "cublasDsyrk_v2_64",
-        "cublasDsyrk_64",
         "cublasDsyr2k_v2_64",
         "cublasDsyr2k_64",
         "cublasDmatinvBatched",
@@ -13638,8 +13640,6 @@ sub warnRocOnlyUnsupportedFunctions {
         "cublasCtrmm_64",
         "cublasCtpttr",
         "cublasCsyrkx_64",
-        "cublasCsyrk_v2_64",
-        "cublasCsyrk_64",
         "cublasCsyrkEx_64",
         "cublasCsyrkEx",
         "cublasCsyrk3mEx_64",

--- a/docs/tables/CUBLAS_API_supported_by_HIP.md
+++ b/docs/tables/CUBLAS_API_supported_by_HIP.md
@@ -1287,9 +1287,9 @@
 |`cublasCsyr2k_v2`| | | | |`hipblasCsyr2k_v2`|6.0.0| | | | |
 |`cublasCsyr2k_v2_64`|12.0| | | | | | | | | |
 |`cublasCsyrk`| | | | |`hipblasCsyrk_v2`|6.0.0| | | | |
-|`cublasCsyrk_64`|12.0| | | | | | | | | |
+|`cublasCsyrk_64`|12.0| | | |`hipblasCsyrk_v2_64`|6.3.0| | | |6.3.0|
 |`cublasCsyrk_v2`| | | | |`hipblasCsyrk_v2`|6.0.0| | | | |
-|`cublasCsyrk_v2_64`|12.0| | | | | | | | | |
+|`cublasCsyrk_v2_64`|12.0| | | |`hipblasCsyrk_v2_64`|6.3.0| | | |6.3.0|
 |`cublasCsyrkx`| | | | |`hipblasCsyrkx_v2`|6.0.0| | | | |
 |`cublasCsyrkx_64`|12.0| | | | | | | | | |
 |`cublasCtrmm`| | | | |`hipblasCtrmm_v2`|6.0.0| | | | |
@@ -1323,9 +1323,9 @@
 |`cublasDsyr2k_v2`| | | | |`hipblasDsyr2k`|3.5.0| | | | |
 |`cublasDsyr2k_v2_64`|12.0| | | | | | | | | |
 |`cublasDsyrk`| | | | |`hipblasDsyrk`|3.5.0| | | | |
-|`cublasDsyrk_64`|12.0| | | | | | | | | |
+|`cublasDsyrk_64`|12.0| | | |`hipblasDsyrk_64`|6.3.0| | | |6.3.0|
 |`cublasDsyrk_v2`| | | | |`hipblasDsyrk`|3.5.0| | | | |
-|`cublasDsyrk_v2_64`|12.0| | | | | | | | | |
+|`cublasDsyrk_v2_64`|12.0| | | |`hipblasDsyrk_64`|6.3.0| | | |6.3.0|
 |`cublasDsyrkx`| | | | |`hipblasDsyrkx`|3.5.0| | | | |
 |`cublasDsyrkx_64`|12.0| | | | | | | | | |
 |`cublasDtrmm`| | | | |`hipblasDtrmm`|3.2.0| |6.0.0| | |
@@ -1375,9 +1375,9 @@
 |`cublasSsyr2k_v2`| | | | |`hipblasSsyr2k`|3.5.0| | | | |
 |`cublasSsyr2k_v2_64`|12.0| | | | | | | | | |
 |`cublasSsyrk`| | | | |`hipblasSsyrk`|3.5.0| | | | |
-|`cublasSsyrk_64`|12.0| | | | | | | | | |
+|`cublasSsyrk_64`|12.0| | | |`hipblasSsyrk_64`|6.3.0| | | |6.3.0|
 |`cublasSsyrk_v2`| | | | |`hipblasSsyrk`|3.5.0| | | | |
-|`cublasSsyrk_v2_64`|12.0| | | | | | | | | |
+|`cublasSsyrk_v2_64`|12.0| | | |`hipblasSsyrk_64`|6.3.0| | | |6.3.0|
 |`cublasSsyrkx`| | | | |`hipblasSsyrkx`|3.5.0| | | | |
 |`cublasSsyrkx_64`|12.0| | | | | | | | | |
 |`cublasStrmm`| | | | |`hipblasStrmm`|3.2.0| |6.0.0| | |
@@ -1433,9 +1433,9 @@
 |`cublasZsyr2k_v2`| | | | |`hipblasZsyr2k_v2`|6.0.0| | | | |
 |`cublasZsyr2k_v2_64`|12.0| | | | | | | | | |
 |`cublasZsyrk`| | | | |`hipblasZsyrk_v2`|6.0.0| | | | |
-|`cublasZsyrk_64`|12.0| | | | | | | | | |
+|`cublasZsyrk_64`|12.0| | | |`hipblasZsyrk_v2_64`|6.3.0| | | |6.3.0|
 |`cublasZsyrk_v2`| | | | |`hipblasZsyrk_v2`|6.0.0| | | | |
-|`cublasZsyrk_v2_64`|12.0| | | | | | | | | |
+|`cublasZsyrk_v2_64`|12.0| | | |`hipblasZsyrk_v2_64`|6.3.0| | | |6.3.0|
 |`cublasZsyrkx`| | | | |`hipblasZsyrkx_v2`|6.0.0| | | | |
 |`cublasZsyrkx_64`|12.0| | | | | | | | | |
 |`cublasZtrmm`| | | | |`hipblasZtrmm_v2`|6.0.0| | | | |

--- a/docs/tables/CUBLAS_API_supported_by_HIP_and_ROC.md
+++ b/docs/tables/CUBLAS_API_supported_by_HIP_and_ROC.md
@@ -1287,9 +1287,9 @@
 |`cublasCsyr2k_v2`| | | | |`hipblasCsyr2k_v2`|6.0.0| | | | |`rocblas_csyr2k`|3.5.0| | | | |
 |`cublasCsyr2k_v2_64`|12.0| | | | | | | | | | | | | | | |
 |`cublasCsyrk`| | | | |`hipblasCsyrk_v2`|6.0.0| | | | |`rocblas_csyrk`|3.5.0| | | | |
-|`cublasCsyrk_64`|12.0| | | | | | | | | | | | | | | |
+|`cublasCsyrk_64`|12.0| | | |`hipblasCsyrk_v2_64`|6.3.0| | | |6.3.0|`rocblas_csyrk_64`|6.3.0| | | |6.3.0|
 |`cublasCsyrk_v2`| | | | |`hipblasCsyrk_v2`|6.0.0| | | | |`rocblas_csyrk`|3.5.0| | | | |
-|`cublasCsyrk_v2_64`|12.0| | | | | | | | | | | | | | | |
+|`cublasCsyrk_v2_64`|12.0| | | |`hipblasCsyrk_v2_64`|6.3.0| | | |6.3.0|`rocblas_csyrk_64`|6.3.0| | | |6.3.0|
 |`cublasCsyrkx`| | | | |`hipblasCsyrkx_v2`|6.0.0| | | | |`rocblas_csyrkx`|3.5.0| | | | |
 |`cublasCsyrkx_64`|12.0| | | | | | | | | | | | | | | |
 |`cublasCtrmm`| | | | |`hipblasCtrmm_v2`|6.0.0| | | | |`rocblas_ctrmm`|3.5.0| |6.0.0| | |
@@ -1323,9 +1323,9 @@
 |`cublasDsyr2k_v2`| | | | |`hipblasDsyr2k`|3.5.0| | | | |`rocblas_dsyr2k`|3.5.0| | | | |
 |`cublasDsyr2k_v2_64`|12.0| | | | | | | | | | | | | | | |
 |`cublasDsyrk`| | | | |`hipblasDsyrk`|3.5.0| | | | |`rocblas_dsyrk`|3.5.0| | | | |
-|`cublasDsyrk_64`|12.0| | | | | | | | | | | | | | | |
+|`cublasDsyrk_64`|12.0| | | |`hipblasDsyrk_64`|6.3.0| | | |6.3.0|`rocblas_dsyrk_64`|6.3.0| | | |6.3.0|
 |`cublasDsyrk_v2`| | | | |`hipblasDsyrk`|3.5.0| | | | |`rocblas_dsyrk`|3.5.0| | | | |
-|`cublasDsyrk_v2_64`|12.0| | | | | | | | | | | | | | | |
+|`cublasDsyrk_v2_64`|12.0| | | |`hipblasDsyrk_64`|6.3.0| | | |6.3.0|`rocblas_dsyrk_64`|6.3.0| | | |6.3.0|
 |`cublasDsyrkx`| | | | |`hipblasDsyrkx`|3.5.0| | | | |`rocblas_dsyrkx`|3.5.0| | | | |
 |`cublasDsyrkx_64`|12.0| | | | | | | | | | | | | | | |
 |`cublasDtrmm`| | | | |`hipblasDtrmm`|3.2.0| |6.0.0| | |`rocblas_dtrmm`|3.5.0| |6.0.0| | |
@@ -1375,9 +1375,9 @@
 |`cublasSsyr2k_v2`| | | | |`hipblasSsyr2k`|3.5.0| | | | |`rocblas_ssyr2k`|3.5.0| | | | |
 |`cublasSsyr2k_v2_64`|12.0| | | | | | | | | | | | | | | |
 |`cublasSsyrk`| | | | |`hipblasSsyrk`|3.5.0| | | | |`rocblas_ssyrk`|3.5.0| | | | |
-|`cublasSsyrk_64`|12.0| | | | | | | | | | | | | | | |
+|`cublasSsyrk_64`|12.0| | | |`hipblasSsyrk_64`|6.3.0| | | |6.3.0|`rocblas_ssyrk_64`|6.3.0| | | |6.3.0|
 |`cublasSsyrk_v2`| | | | |`hipblasSsyrk`|3.5.0| | | | |`rocblas_ssyrk`|3.5.0| | | | |
-|`cublasSsyrk_v2_64`|12.0| | | | | | | | | | | | | | | |
+|`cublasSsyrk_v2_64`|12.0| | | |`hipblasSsyrk_64`|6.3.0| | | |6.3.0|`rocblas_ssyrk_64`|6.3.0| | | |6.3.0|
 |`cublasSsyrkx`| | | | |`hipblasSsyrkx`|3.5.0| | | | |`rocblas_ssyrkx`|3.5.0| | | | |
 |`cublasSsyrkx_64`|12.0| | | | | | | | | | | | | | | |
 |`cublasStrmm`| | | | |`hipblasStrmm`|3.2.0| |6.0.0| | |`rocblas_strmm`|3.5.0| |6.0.0| | |
@@ -1433,9 +1433,9 @@
 |`cublasZsyr2k_v2`| | | | |`hipblasZsyr2k_v2`|6.0.0| | | | |`rocblas_zsyr2k`|3.5.0| | | | |
 |`cublasZsyr2k_v2_64`|12.0| | | | | | | | | | | | | | | |
 |`cublasZsyrk`| | | | |`hipblasZsyrk_v2`|6.0.0| | | | |`rocblas_zsyrk`|3.5.0| | | | |
-|`cublasZsyrk_64`|12.0| | | | | | | | | | | | | | | |
+|`cublasZsyrk_64`|12.0| | | |`hipblasZsyrk_v2_64`|6.3.0| | | |6.3.0|`rocblas_zsyrk_64`|6.3.0| | | |6.3.0|
 |`cublasZsyrk_v2`| | | | |`hipblasZsyrk_v2`|6.0.0| | | | |`rocblas_zsyrk`|3.5.0| | | | |
-|`cublasZsyrk_v2_64`|12.0| | | | | | | | | | | | | | | |
+|`cublasZsyrk_v2_64`|12.0| | | |`hipblasZsyrk_v2_64`|6.3.0| | | |6.3.0|`rocblas_zsyrk_64`|6.3.0| | | |6.3.0|
 |`cublasZsyrkx`| | | | |`hipblasZsyrkx_v2`|6.0.0| | | | |`rocblas_zsyrkx`|3.5.0| | | | |
 |`cublasZsyrkx_64`|12.0| | | | | | | | | | | | | | | |
 |`cublasZtrmm`| | | | |`hipblasZtrmm_v2`|6.0.0| | | | |`rocblas_ztrmm`|3.5.0| |6.0.0| | |

--- a/docs/tables/CUBLAS_API_supported_by_ROC.md
+++ b/docs/tables/CUBLAS_API_supported_by_ROC.md
@@ -1287,9 +1287,9 @@
 |`cublasCsyr2k_v2`| | | | |`rocblas_csyr2k`|3.5.0| | | | |
 |`cublasCsyr2k_v2_64`|12.0| | | | | | | | | |
 |`cublasCsyrk`| | | | |`rocblas_csyrk`|3.5.0| | | | |
-|`cublasCsyrk_64`|12.0| | | | | | | | | |
+|`cublasCsyrk_64`|12.0| | | |`rocblas_csyrk_64`|6.3.0| | | |6.3.0|
 |`cublasCsyrk_v2`| | | | |`rocblas_csyrk`|3.5.0| | | | |
-|`cublasCsyrk_v2_64`|12.0| | | | | | | | | |
+|`cublasCsyrk_v2_64`|12.0| | | |`rocblas_csyrk_64`|6.3.0| | | |6.3.0|
 |`cublasCsyrkx`| | | | |`rocblas_csyrkx`|3.5.0| | | | |
 |`cublasCsyrkx_64`|12.0| | | | | | | | | |
 |`cublasCtrmm`| | | | |`rocblas_ctrmm`|3.5.0| |6.0.0| | |
@@ -1323,9 +1323,9 @@
 |`cublasDsyr2k_v2`| | | | |`rocblas_dsyr2k`|3.5.0| | | | |
 |`cublasDsyr2k_v2_64`|12.0| | | | | | | | | |
 |`cublasDsyrk`| | | | |`rocblas_dsyrk`|3.5.0| | | | |
-|`cublasDsyrk_64`|12.0| | | | | | | | | |
+|`cublasDsyrk_64`|12.0| | | |`rocblas_dsyrk_64`|6.3.0| | | |6.3.0|
 |`cublasDsyrk_v2`| | | | |`rocblas_dsyrk`|3.5.0| | | | |
-|`cublasDsyrk_v2_64`|12.0| | | | | | | | | |
+|`cublasDsyrk_v2_64`|12.0| | | |`rocblas_dsyrk_64`|6.3.0| | | |6.3.0|
 |`cublasDsyrkx`| | | | |`rocblas_dsyrkx`|3.5.0| | | | |
 |`cublasDsyrkx_64`|12.0| | | | | | | | | |
 |`cublasDtrmm`| | | | |`rocblas_dtrmm`|3.5.0| |6.0.0| | |
@@ -1375,9 +1375,9 @@
 |`cublasSsyr2k_v2`| | | | |`rocblas_ssyr2k`|3.5.0| | | | |
 |`cublasSsyr2k_v2_64`|12.0| | | | | | | | | |
 |`cublasSsyrk`| | | | |`rocblas_ssyrk`|3.5.0| | | | |
-|`cublasSsyrk_64`|12.0| | | | | | | | | |
+|`cublasSsyrk_64`|12.0| | | |`rocblas_ssyrk_64`|6.3.0| | | |6.3.0|
 |`cublasSsyrk_v2`| | | | |`rocblas_ssyrk`|3.5.0| | | | |
-|`cublasSsyrk_v2_64`|12.0| | | | | | | | | |
+|`cublasSsyrk_v2_64`|12.0| | | |`rocblas_ssyrk_64`|6.3.0| | | |6.3.0|
 |`cublasSsyrkx`| | | | |`rocblas_ssyrkx`|3.5.0| | | | |
 |`cublasSsyrkx_64`|12.0| | | | | | | | | |
 |`cublasStrmm`| | | | |`rocblas_strmm`|3.5.0| |6.0.0| | |
@@ -1433,9 +1433,9 @@
 |`cublasZsyr2k_v2`| | | | |`rocblas_zsyr2k`|3.5.0| | | | |
 |`cublasZsyr2k_v2_64`|12.0| | | | | | | | | |
 |`cublasZsyrk`| | | | |`rocblas_zsyrk`|3.5.0| | | | |
-|`cublasZsyrk_64`|12.0| | | | | | | | | |
+|`cublasZsyrk_64`|12.0| | | |`rocblas_zsyrk_64`|6.3.0| | | |6.3.0|
 |`cublasZsyrk_v2`| | | | |`rocblas_zsyrk`|3.5.0| | | | |
-|`cublasZsyrk_v2_64`|12.0| | | | | | | | | |
+|`cublasZsyrk_v2_64`|12.0| | | |`rocblas_zsyrk_64`|6.3.0| | | |6.3.0|
 |`cublasZsyrkx`| | | | |`rocblas_zsyrkx`|3.5.0| | | | |
 |`cublasZsyrkx_64`|12.0| | | | | | | | | |
 |`cublasZtrmm`| | | | |`rocblas_ztrmm`|3.5.0| |6.0.0| | |

--- a/src/CUDA2HIP_BLAS_API_functions.cpp
+++ b/src/CUDA2HIP_BLAS_API_functions.cpp
@@ -477,13 +477,13 @@ const std::map<llvm::StringRef, hipCounter> CUDA_BLAS_FUNCTION_MAP {
 
   // SYRK
   {"cublasSsyrk",                                          {"hipblasSsyrk",                                              "rocblas_ssyrk",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3, HIP_SUPPORTED_V2_ONLY}},
-  {"cublasSsyrk_64",                                       {"hipblasSsyrk_64",                                           "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3, UNSUPPORTED}},
+  {"cublasSsyrk_64",                                       {"hipblasSsyrk_64",                                           "rocblas_ssyrk_64",                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3}},
   {"cublasDsyrk",                                          {"hipblasDsyrk",                                              "rocblas_dsyrk",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3, HIP_SUPPORTED_V2_ONLY}},
-  {"cublasDsyrk_64",                                       {"hipblasDsyrk_64",                                           "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3, UNSUPPORTED}},
+  {"cublasDsyrk_64",                                       {"hipblasDsyrk_64",                                           "rocblas_dsyrk_64",                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3}},
   {"cublasCsyrk",                                          {"hipblasCsyrk_v2",                                           "rocblas_csyrk",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3, HIP_SUPPORTED_V2_ONLY}},
-  {"cublasCsyrk_64",                                       {"hipblasCsyrk_64",                                           "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3, UNSUPPORTED}},
+  {"cublasCsyrk_64",                                       {"hipblasCsyrk_v2_64",                                        "rocblas_csyrk_64",                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3}},
   {"cublasZsyrk",                                          {"hipblasZsyrk_v2",                                           "rocblas_zsyrk",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3, HIP_SUPPORTED_V2_ONLY}},
-  {"cublasZsyrk_64",                                       {"hipblasZsyrk_64",                                           "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3, UNSUPPORTED}},
+  {"cublasZsyrk_64",                                       {"hipblasZsyrk_v2_64",                                        "rocblas_zsyrk_64",                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3}},
 
   // HERK
   {"cublasCherk",                                          {"hipblasCherk_v2",                                           "rocblas_cherk",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3, HIP_SUPPORTED_V2_ONLY}},
@@ -847,13 +847,13 @@ const std::map<llvm::StringRef, hipCounter> CUDA_BLAS_FUNCTION_MAP {
 
   // SYRK
   {"cublasSsyrk_v2",                                       {"hipblasSsyrk",                                              "rocblas_ssyrk",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3}},
-  {"cublasSsyrk_v2_64",                                    {"hipblasSsyrk_64",                                           "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3, UNSUPPORTED}},
+  {"cublasSsyrk_v2_64",                                    {"hipblasSsyrk_64",                                           "rocblas_ssyrk_64",                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3}},
   {"cublasDsyrk_v2",                                       {"hipblasDsyrk",                                              "rocblas_dsyrk",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3}},
-  {"cublasDsyrk_v2_64",                                    {"hipblasDsyrk_64",                                           "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3, UNSUPPORTED}},
+  {"cublasDsyrk_v2_64",                                    {"hipblasDsyrk_64",                                           "rocblas_dsyrk_64",                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3}},
   {"cublasCsyrk_v2",                                       {"hipblasCsyrk_v2",                                           "rocblas_csyrk",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3}},
-  {"cublasCsyrk_v2_64",                                    {"hipblasCsyrk_64",                                           "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3, UNSUPPORTED}},
+  {"cublasCsyrk_v2_64",                                    {"hipblasCsyrk_v2_64",                                        "rocblas_csyrk_64",                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3}},
   {"cublasZsyrk_v2",                                       {"hipblasZsyrk_v2",                                           "rocblas_zsyrk",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3}},
-  {"cublasZsyrk_v2_64",                                    {"hipblasZsyrk_64",                                           "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3, UNSUPPORTED}},
+  {"cublasZsyrk_v2_64",                                    {"hipblasZsyrk_v2_64",                                        "rocblas_zsyrk_64",                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3}},
 
   // IO in Int8 complex/cuComplex, computation in cuComplex
   {"cublasCsyrkEx",                                        {"hipblasCsyrkEx",                                            "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_EXT, UNSUPPORTED}},
@@ -2048,6 +2048,10 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_BLAS_FUNCTION_VER_MAP {
   {"hipblasDsymm_64",                                      {HIP_6030, HIP_0,    HIP_0,  HIP_LATEST}},
   {"hipblasCsymm_v2_64",                                   {HIP_6030, HIP_0,    HIP_0,  HIP_LATEST}},
   {"hipblasZsymm_v2_64",                                   {HIP_6030, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipblasSsyrk_64",                                      {HIP_6030, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipblasDsyrk_64",                                      {HIP_6030, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipblasCsyrk_v2_64",                                   {HIP_6030, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipblasZsyrk_v2_64",                                   {HIP_6030, HIP_0,    HIP_0,  HIP_LATEST}},
 
   {"rocblas_status_to_string",                             {HIP_3050, HIP_0,    HIP_0   }},
   {"rocblas_sscal",                                        {HIP_1050, HIP_0,    HIP_0   }},
@@ -2461,6 +2465,10 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_BLAS_FUNCTION_VER_MAP {
   {"rocblas_dsymm_64",                                     {HIP_6030, HIP_0,    HIP_0,  HIP_LATEST}},
   {"rocblas_csymm_64",                                     {HIP_6030, HIP_0,    HIP_0,  HIP_LATEST}},
   {"rocblas_zsymm_64",                                     {HIP_6030, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"rocblas_ssyrk_64",                                     {HIP_6030, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"rocblas_dsyrk_64",                                     {HIP_6030, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"rocblas_csyrk_64",                                     {HIP_6030, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"rocblas_zsyrk_64",                                     {HIP_6030, HIP_0,    HIP_0,  HIP_LATEST}},
 };
 
 const std::map<llvm::StringRef, hipAPIChangedVersions> HIP_BLAS_FUNCTION_CHANGED_VER_MAP {

--- a/tests/unit_tests/synthetic/libraries/cublas2hipblas_v2.cu
+++ b/tests/unit_tests/synthetic/libraries/cublas2hipblas_v2.cu
@@ -2974,6 +2974,34 @@ int main() {
   // CHECK-NEXT: blasStatus = hipblasZsymm_v2_64(blasHandle, blasSideMode, blasFillMode, m_64, n_64, &dcomplexa, &dcomplexA, lda_64, &dcomplexB, ldb_64, &dcomplexb, &dcomplexC, ldc_64);
   blasStatus = cublasZsymm_64(blasHandle, blasSideMode, blasFillMode, m_64, n_64, &dcomplexa, &dcomplexA, lda_64, &dcomplexB, ldb_64, &dcomplexb, &dcomplexC, ldc_64);
   blasStatus = cublasZsymm_v2_64(blasHandle, blasSideMode, blasFillMode, m_64, n_64, &dcomplexa, &dcomplexA, lda_64, &dcomplexB, ldb_64, &dcomplexb, &dcomplexC, ldc_64);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasSsyrk_v2_64(cublasHandle_t handle, cublasFillMode_t uplo, cublasOperation_t trans, int64_t n, int64_t k, const float* alpha, const float* A, int64_t lda, const float* beta, float* C, int64_t ldc);
+  // HIP: HIPBLAS_EXPORT hipblasStatus_t hipblasSsyrk_64(hipblasHandle_t handle, hipblasFillMode_t uplo, hipblasOperation_t transA, int64_t n, int64_t k, const float* alpha, const float* AP, int64_t lda, const float* beta, float* CP, int64_t ldc);
+  // CHECK: blasStatus = hipblasSsyrk_64(blasHandle, blasFillMode, blasOperation, n_64, k_64, &fa, &fA, lda_64, &fb, &fC, ldc_64);
+  // CHECK-NEXT: blasStatus = hipblasSsyrk_64(blasHandle, blasFillMode, blasOperation, n_64, k_64, &fa, &fA, lda_64, &fb, &fC, ldc_64);
+  blasStatus = cublasSsyrk_64(blasHandle, blasFillMode, blasOperation, n_64, k_64, &fa, &fA, lda_64, &fb, &fC, ldc_64);
+  blasStatus = cublasSsyrk_v2_64(blasHandle, blasFillMode, blasOperation, n_64, k_64, &fa, &fA, lda_64, &fb, &fC, ldc_64);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasDsyrk_v2_64(cublasHandle_t handle, cublasFillMode_t uplo, cublasOperation_t trans, int64_t n, int64_t k, const double* alpha, const double* A, int64_t lda, const double* beta, double* C, int64_t ldc);
+  // HIP: HIPBLAS_EXPORT hipblasStatus_t hipblasDsyrk_64(hipblasHandle_t handle, hipblasFillMode_t uplo, hipblasOperation_t transA, int64_t n, int64_t k, const double* alpha, const double* AP, int64_t lda, const double* beta, double* CP, int64_t ldc);
+  // CHECK: blasStatus = hipblasDsyrk_64(blasHandle, blasFillMode, blasOperation, n_64, k_64, &da, &dA, lda_64, &db, &dC, ldc_64);
+  // CHECK-NEXT: blasStatus = hipblasDsyrk_64(blasHandle, blasFillMode, blasOperation, n_64, k_64, &da, &dA, lda_64, &db, &dC, ldc_64);
+  blasStatus = cublasDsyrk_64(blasHandle, blasFillMode, blasOperation, n_64, k_64, &da, &dA, lda_64, &db, &dC, ldc_64);
+  blasStatus = cublasDsyrk_v2_64(blasHandle, blasFillMode, blasOperation, n_64, k_64, &da, &dA, lda_64, &db, &dC, ldc_64);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasCsyrk_v2_64(cublasHandle_t handle, cublasFillMode_t uplo, cublasOperation_t trans, int64_t n, int64_t k, const cuComplex* alpha, const cuComplex* A, int64_t lda, const cuComplex* beta, cuComplex* C, int64_t ldc);
+  // HIP: HIPBLAS_EXPORT hipblasStatus_t hipblasCsyrk_v2_64(hipblasHandle_t handle, hipblasFillMode_t uplo, hipblasOperation_t transA, int64_t n, int64_t k, const hipComplex* alpha, const hipComplex* AP, int64_t lda, const hipComplex* beta, hipComplex* CP, int64_t ldc);
+  // CHECK: blasStatus = hipblasCsyrk_v2_64(blasHandle, blasFillMode, blasOperation, n_64, k_64, &complexa, &complexA, lda_64, &complexb, &complexC, ldc_64);
+  // CHECK-NEXT: blasStatus = hipblasCsyrk_v2_64(blasHandle, blasFillMode, blasOperation, n_64, k_64, &complexa, &complexA, lda_64, &complexb, &complexC, ldc_64);
+  blasStatus = cublasCsyrk_64(blasHandle, blasFillMode, blasOperation, n_64, k_64, &complexa, &complexA, lda_64, &complexb, &complexC, ldc_64);
+  blasStatus = cublasCsyrk_v2_64(blasHandle, blasFillMode, blasOperation, n_64, k_64, &complexa, &complexA, lda_64, &complexb, &complexC, ldc_64);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasZsyrk_v2_64(cublasHandle_t handle, cublasFillMode_t uplo, cublasOperation_t trans, int64_t n, int64_t k, const cuDoubleComplex* alpha, const cuDoubleComplex* A, int64_t lda, const cuDoubleComplex* beta, cuDoubleComplex* C, int64_t ldc);
+  // HIP: HIPBLAS_EXPORT hipblasStatus_t hipblasZsyrk_v2_64(hipblasHandle_t handle, hipblasFillMode_t uplo, hipblasOperation_t transA, int64_t n, int64_t k, const hipDoubleComplex* alpha, const hipDoubleComplex* AP, int64_t lda, const hipDoubleComplex* beta, hipDoubleComplex* CP, int64_t ldc);
+  // CHECK: blasStatus = hipblasZsyrk_v2_64(blasHandle, blasFillMode, blasOperation, n_64, k_64, &dcomplexa, &dcomplexA, lda_64, &dcomplexb, &dcomplexC, ldc_64);
+  // CHECK-NEXT: blasStatus = hipblasZsyrk_v2_64(blasHandle, blasFillMode, blasOperation, n_64, k_64, &dcomplexa, &dcomplexA, lda_64, &dcomplexb, &dcomplexC, ldc_64);
+  blasStatus = cublasZsyrk_64(blasHandle, blasFillMode, blasOperation, n_64, k_64, &dcomplexa, &dcomplexA, lda_64, &dcomplexb, &dcomplexC, ldc_64);
+  blasStatus = cublasZsyrk_v2_64(blasHandle, blasFillMode, blasOperation, n_64, k_64, &dcomplexa, &dcomplexA, lda_64, &dcomplexb, &dcomplexC, ldc_64);
 #endif
 
   return 0;

--- a/tests/unit_tests/synthetic/libraries/cublas2rocblas_v2.cu
+++ b/tests/unit_tests/synthetic/libraries/cublas2rocblas_v2.cu
@@ -3179,6 +3179,34 @@ int main() {
   // CHECK-NEXT: blasStatus = rocblas_zsymm_64(blasHandle, blasSideMode, blasFillMode, m_64, n_64, &dcomplexa, &dcomplexA, lda_64, &dcomplexB, ldb_64, &dcomplexb, &dcomplexC, ldc_64);
   blasStatus = cublasZsymm_64(blasHandle, blasSideMode, blasFillMode, m_64, n_64, &dcomplexa, &dcomplexA, lda_64, &dcomplexB, ldb_64, &dcomplexb, &dcomplexC, ldc_64);
   blasStatus = cublasZsymm_v2_64(blasHandle, blasSideMode, blasFillMode, m_64, n_64, &dcomplexa, &dcomplexA, lda_64, &dcomplexB, ldb_64, &dcomplexb, &dcomplexC, ldc_64);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasSsyrk_v2_64(cublasHandle_t handle, cublasFillMode_t uplo, cublasOperation_t trans, int64_t n, int64_t k, const float* alpha, const float* A, int64_t lda, const float* beta, float* C, int64_t ldc);
+  // ROC: ROCBLAS_EXPORT rocblas_status rocblas_ssyrk_64(rocblas_handle handle, rocblas_fill uplo, rocblas_operation transA, int64_t n, int64_t k, const float* alpha, const float* A, int64_t lda, const float* beta, float* C, int64_t ldc);
+  // CHECK: blasStatus = rocblas_ssyrk_64(blasHandle, blasFillMode, blasOperation, n_64, k_64, &fa, &fA, lda_64, &fb, &fC, ldc_64);
+  // CHECK-NEXT: blasStatus = rocblas_ssyrk_64(blasHandle, blasFillMode, blasOperation, n_64, k_64, &fa, &fA, lda_64, &fb, &fC, ldc_64);
+  blasStatus = cublasSsyrk_64(blasHandle, blasFillMode, blasOperation, n_64, k_64, &fa, &fA, lda_64, &fb, &fC, ldc_64);
+  blasStatus = cublasSsyrk_v2_64(blasHandle, blasFillMode, blasOperation, n_64, k_64, &fa, &fA, lda_64, &fb, &fC, ldc_64);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasDsyrk_v2_64(cublasHandle_t handle, cublasFillMode_t uplo, cublasOperation_t trans, int64_t n, int64_t k, const double* alpha, const double* A, int64_t lda, const double* beta, double* C, int64_t ldc);
+  // ROC: ROCBLAS_EXPORT rocblas_status rocblas_dsyrk_64(rocblas_handle handle, rocblas_fill uplo, rocblas_operation transA, int64_t n, int64_t k, const double* alpha, const double* A, int64_t lda, const double* beta, double* C, int64_t ldc);
+  // CHECK: blasStatus = rocblas_dsyrk_64(blasHandle, blasFillMode, blasOperation, n_64, k_64, &da, &dA, lda_64, &db, &dC, ldc_64);
+  // CHECK-NEXT: blasStatus = rocblas_dsyrk_64(blasHandle, blasFillMode, blasOperation, n_64, k_64, &da, &dA, lda_64, &db, &dC, ldc_64);
+  blasStatus = cublasDsyrk_64(blasHandle, blasFillMode, blasOperation, n_64, k_64, &da, &dA, lda_64, &db, &dC, ldc_64);
+  blasStatus = cublasDsyrk_v2_64(blasHandle, blasFillMode, blasOperation, n_64, k_64, &da, &dA, lda_64, &db, &dC, ldc_64);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasCsyrk_v2_64(cublasHandle_t handle, cublasFillMode_t uplo, cublasOperation_t trans, int64_t n, int64_t k, const cuComplex* alpha, const cuComplex* A, int64_t lda, const cuComplex* beta, cuComplex* C, int64_t ldc);
+  // ROC: ROCBLAS_EXPORT rocblas_status rocblas_csyrk_64(rocblas_handle handle, rocblas_fill uplo, rocblas_operation transA, int64_t n, int64_t k, const rocblas_float_complex* alpha, const rocblas_float_complex* A, int64_t lda, const rocblas_float_complex* beta, rocblas_float_complex* C, int64_t ldc);
+  // CHECK: blasStatus = rocblas_csyrk_64(blasHandle, blasFillMode, blasOperation, n_64, k_64, &complexa, &complexA, lda_64, &complexb, &complexC, ldc_64);
+  // CHECK-NEXT: blasStatus = rocblas_csyrk_64(blasHandle, blasFillMode, blasOperation, n_64, k_64, &complexa, &complexA, lda_64, &complexb, &complexC, ldc_64);
+  blasStatus = cublasCsyrk_64(blasHandle, blasFillMode, blasOperation, n_64, k_64, &complexa, &complexA, lda_64, &complexb, &complexC, ldc_64);
+  blasStatus = cublasCsyrk_v2_64(blasHandle, blasFillMode, blasOperation, n_64, k_64, &complexa, &complexA, lda_64, &complexb, &complexC, ldc_64);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasZsyrk_v2_64(cublasHandle_t handle, cublasFillMode_t uplo, cublasOperation_t trans, int64_t n, int64_t k, const cuDoubleComplex* alpha, const cuDoubleComplex* A, int64_t lda, const cuDoubleComplex* beta, cuDoubleComplex* C, int64_t ldc);
+  // ROC: ROCBLAS_EXPORT rocblas_status rocblas_zsyrk_64(rocblas_handle handle, rocblas_fill uplo, rocblas_operation transA, int64_t n, int64_t k, const rocblas_double_complex* alpha, const rocblas_double_complex* A, int64_t lda, const rocblas_double_complex* beta, rocblas_double_complex* C, int64_t ldc);
+  // CHECK: blasStatus = rocblas_zsyrk_64(blasHandle, blasFillMode, blasOperation, n_64, k_64, &dcomplexa, &dcomplexA, lda_64, &dcomplexb, &dcomplexC, ldc_64);
+  // CHECK-NEXT: blasStatus = rocblas_zsyrk_64(blasHandle, blasFillMode, blasOperation, n_64, k_64, &dcomplexa, &dcomplexA, lda_64, &dcomplexb, &dcomplexC, ldc_64);
+  blasStatus = cublasZsyrk_64(blasHandle, blasFillMode, blasOperation, n_64, k_64, &dcomplexa, &dcomplexA, lda_64, &dcomplexb, &dcomplexC, ldc_64);
+  blasStatus = cublasZsyrk_v2_64(blasHandle, blasFillMode, blasOperation, n_64, k_64, &dcomplexa, &dcomplexA, lda_64, &dcomplexb, &dcomplexC, ldc_64);
 #endif
 
   return 0;


### PR DESCRIPTION
+ `rocblas_(s|d|c|z)syrk_64` and `hipblas(S|D|C|Z)syrk(_v2)?_64` support
+ Updated synthetic tests, the regenerated `hipify-perl`, and `BLAS` `CUDA2HIP` documentation