### PR TITLE
[HIPIFY][6.3.0][BLAS] Sync with `hipBLAS` and `rocBLAS` - Step 8

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -1704,7 +1704,9 @@ sub rocSubstitutions {
     subst("cublasCsyr2_v2", "rocblas_csyr2", "library");
     subst("cublasCsyr2_v2_64", "rocblas_csyr2_64", "library");
     subst("cublasCsyr2k", "rocblas_csyr2k", "library");
+    subst("cublasCsyr2k_64", "rocblas_csyr2k_64", "library");
     subst("cublasCsyr2k_v2", "rocblas_csyr2k", "library");
+    subst("cublasCsyr2k_v2_64", "rocblas_csyr2k_64", "library");
     subst("cublasCsyr_64", "rocblas_csyr_64", "library");
     subst("cublasCsyr_v2", "rocblas_csyr", "library");
     subst("cublasCsyr_v2_64", "rocblas_csyr_64", "library");
@@ -1847,7 +1849,9 @@ sub rocSubstitutions {
     subst("cublasDsyr2_v2", "rocblas_dsyr2", "library");
     subst("cublasDsyr2_v2_64", "rocblas_dsyr2_64", "library");
     subst("cublasDsyr2k", "rocblas_dsyr2k", "library");
+    subst("cublasDsyr2k_64", "rocblas_dsyr2k_64", "library");
     subst("cublasDsyr2k_v2", "rocblas_dsyr2k", "library");
+    subst("cublasDsyr2k_v2_64", "rocblas_dsyr2k_64", "library");
     subst("cublasDsyr_64", "rocblas_dsyr_64", "library");
     subst("cublasDsyr_v2", "rocblas_dsyr", "library");
     subst("cublasDsyr_v2_64", "rocblas_dsyr_64", "library");
@@ -2077,7 +2081,9 @@ sub rocSubstitutions {
     subst("cublasSsyr2_v2", "rocblas_ssyr2", "library");
     subst("cublasSsyr2_v2_64", "rocblas_ssyr2_64", "library");
     subst("cublasSsyr2k", "rocblas_ssyr2k", "library");
+    subst("cublasSsyr2k_64", "rocblas_ssyr2k_64", "library");
     subst("cublasSsyr2k_v2", "rocblas_ssyr2k", "library");
+    subst("cublasSsyr2k_v2_64", "rocblas_ssyr2k_64", "library");
     subst("cublasSsyr_64", "rocblas_ssyr_64", "library");
     subst("cublasSsyr_v2", "rocblas_ssyr", "library");
     subst("cublasSsyr_v2_64", "rocblas_ssyr_64", "library");
@@ -2248,7 +2254,9 @@ sub rocSubstitutions {
     subst("cublasZsyr2_v2", "rocblas_zsyr2", "library");
     subst("cublasZsyr2_v2_64", "rocblas_zsyr2_64", "library");
     subst("cublasZsyr2k", "rocblas_zsyr2k", "library");
+    subst("cublasZsyr2k_64", "rocblas_zsyr2k_64", "library");
     subst("cublasZsyr2k_v2", "rocblas_zsyr2k", "library");
+    subst("cublasZsyr2k_v2_64", "rocblas_zsyr2k_64", "library");
     subst("cublasZsyr_64", "rocblas_zsyr_64", "library");
     subst("cublasZsyr_v2", "rocblas_zsyr", "library");
     subst("cublasZsyr_v2_64", "rocblas_zsyr_64", "library");
@@ -4474,7 +4482,9 @@ sub simpleSubstitutions {
     subst("cublasCsyr2_v2", "hipblasCsyr2_v2", "library");
     subst("cublasCsyr2_v2_64", "hipblasCsyr2_v2_64", "library");
     subst("cublasCsyr2k", "hipblasCsyr2k_v2", "library");
+    subst("cublasCsyr2k_64", "hipblasCsyr2k_v2_64", "library");
     subst("cublasCsyr2k_v2", "hipblasCsyr2k_v2", "library");
+    subst("cublasCsyr2k_v2_64", "hipblasCsyr2k_v2_64", "library");
     subst("cublasCsyr_64", "hipblasCsyr_v2_64", "library");
     subst("cublasCsyr_v2", "hipblasCsyr_v2", "library");
     subst("cublasCsyr_v2_64", "hipblasCsyr_v2_64", "library");
@@ -4618,7 +4628,9 @@ sub simpleSubstitutions {
     subst("cublasDsyr2_v2", "hipblasDsyr2", "library");
     subst("cublasDsyr2_v2_64", "hipblasDsyr2_64", "library");
     subst("cublasDsyr2k", "hipblasDsyr2k", "library");
+    subst("cublasDsyr2k_64", "hipblasDsyr2k_64", "library");
     subst("cublasDsyr2k_v2", "hipblasDsyr2k", "library");
+    subst("cublasDsyr2k_v2_64", "hipblasDsyr2k_64", "library");
     subst("cublasDsyr_64", "hipblasDsyr_64", "library");
     subst("cublasDsyr_v2", "hipblasDsyr", "library");
     subst("cublasDsyr_v2_64", "hipblasDsyr_64", "library");
@@ -4859,7 +4871,9 @@ sub simpleSubstitutions {
     subst("cublasSsyr2_v2", "hipblasSsyr2", "library");
     subst("cublasSsyr2_v2_64", "hipblasSsyr2_64", "library");
     subst("cublasSsyr2k", "hipblasSsyr2k", "library");
+    subst("cublasSsyr2k_64", "hipblasSsyr2k_64", "library");
     subst("cublasSsyr2k_v2", "hipblasSsyr2k", "library");
+    subst("cublasSsyr2k_v2_64", "hipblasSsyr2k_64", "library");
     subst("cublasSsyr_64", "hipblasSsyr_64", "library");
     subst("cublasSsyr_v2", "hipblasSsyr", "library");
     subst("cublasSsyr_v2_64", "hipblasSsyr_64", "library");
@@ -5023,7 +5037,9 @@ sub simpleSubstitutions {
     subst("cublasZsyr2_v2", "hipblasZsyr2_v2", "library");
     subst("cublasZsyr2_v2_64", "hipblasZsyr2_v2_64", "library");
     subst("cublasZsyr2k", "hipblasZsyr2k_v2", "library");
+    subst("cublasZsyr2k_64", "hipblasZsyr2k_v2_64", "library");
     subst("cublasZsyr2k_v2", "hipblasZsyr2k_v2", "library");
+    subst("cublasZsyr2k_v2_64", "hipblasZsyr2k_v2_64", "library");
     subst("cublasZsyr_64", "hipblasZsyr_v2_64", "library");
     subst("cublasZsyr_v2", "hipblasZsyr_v2", "library");
     subst("cublasZsyr_v2_64", "hipblasZsyr_v2_64", "library");
@@ -11596,8 +11612,6 @@ sub warnHipOnlyUnsupportedFunctions {
         "cublasZtrmm_64",
         "cublasZtpttr",
         "cublasZsyrkx_64",
-        "cublasZsyr2k_v2_64",
-        "cublasZsyr2k_64",
         "cublasZmatinvBatched",
         "cublasZhemm_v2_64",
         "cublasZhemm_64",
@@ -11625,8 +11639,6 @@ sub warnHipOnlyUnsupportedFunctions {
         "cublasStrmm_64",
         "cublasStpttr",
         "cublasSsyrkx_64",
-        "cublasSsyr2k_v2_64",
-        "cublasSsyr2k_64",
         "cublasSmatinvBatched",
         "cublasShutdown",
         "cublasSgemmGroupedBatched_64",
@@ -11725,8 +11737,6 @@ sub warnHipOnlyUnsupportedFunctions {
         "cublasDtrmm_64",
         "cublasDtpttr",
         "cublasDsyrkx_64",
-        "cublasDsyr2k_v2_64",
-        "cublasDsyr2k_64",
         "cublasDmatinvBatched",
         "cublasDgemmGroupedBatched_64",
         "cublasDgemmGroupedBatched",
@@ -11744,8 +11754,6 @@ sub warnHipOnlyUnsupportedFunctions {
         "cublasCsyrkEx",
         "cublasCsyrk3mEx_64",
         "cublasCsyrk3mEx",
-        "cublasCsyr2k_v2_64",
-        "cublasCsyr2k_64",
         "cublasCopyEx_64",
         "cublasCopyEx",
         "cublasContext",
@@ -13527,8 +13535,6 @@ sub warnRocOnlyUnsupportedFunctions {
         "cublasZtrmm_64",
         "cublasZtpttr",
         "cublasZsyrkx_64",
-        "cublasZsyr2k_v2_64",
-        "cublasZsyr2k_64",
         "cublasZmatinvBatched",
         "cublasZhemm_v2_64",
         "cublasZhemm_64",
@@ -13550,8 +13556,6 @@ sub warnRocOnlyUnsupportedFunctions {
         "cublasStrmm_64",
         "cublasStpttr",
         "cublasSsyrkx_64",
-        "cublasSsyr2k_v2_64",
-        "cublasSsyr2k_64",
         "cublasSmatinvBatched",
         "cublasShutdown",
         "cublasSgetrsBatched",
@@ -13669,8 +13673,6 @@ sub warnRocOnlyUnsupportedFunctions {
         "cublasDtrmm_64",
         "cublasDtpttr",
         "cublasDsyrkx_64",
-        "cublasDsyr2k_v2_64",
-        "cublasDsyr2k_64",
         "cublasDmatinvBatched",
         "cublasDgetrsBatched",
         "cublasDgetriBatched",
@@ -13690,8 +13692,6 @@ sub warnRocOnlyUnsupportedFunctions {
         "cublasCsyrkEx",
         "cublasCsyrk3mEx_64",
         "cublasCsyrk3mEx",
-        "cublasCsyr2k_v2_64",
-        "cublasCsyr2k_64",
         "cublasCopyEx_64",
         "cublasCopyEx",
         "cublasCmatinvBatched",

--- a/docs/tables/CUBLAS_API_supported_by_HIP.md
+++ b/docs/tables/CUBLAS_API_supported_by_HIP.md
@@ -1329,9 +1329,9 @@
 |`cublasCsymm_v2`| | | | |`hipblasCsymm_v2`|6.0.0| | | | |
 |`cublasCsymm_v2_64`|12.0| | | |`hipblasCsymm_v2_64`|6.3.0| | | |6.3.0|
 |`cublasCsyr2k`| | | | |`hipblasCsyr2k_v2`|6.0.0| | | | |
-|`cublasCsyr2k_64`|12.0| | | | | | | | | |
+|`cublasCsyr2k_64`|12.0| | | |`hipblasCsyr2k_v2_64`|6.3.0| | | |6.3.0|
 |`cublasCsyr2k_v2`| | | | |`hipblasCsyr2k_v2`|6.0.0| | | | |
-|`cublasCsyr2k_v2_64`|12.0| | | | | | | | | |
+|`cublasCsyr2k_v2_64`|12.0| | | |`hipblasCsyr2k_v2_64`|6.3.0| | | |6.3.0|
 |`cublasCsyrk`| | | | |`hipblasCsyrk_v2`|6.0.0| | | | |
 |`cublasCsyrk_64`|12.0| | | |`hipblasCsyrk_v2_64`|6.3.0| | | |6.3.0|
 |`cublasCsyrk_v2`| | | | |`hipblasCsyrk_v2`|6.0.0| | | | |
@@ -1365,9 +1365,9 @@
 |`cublasDsymm_v2`| | | | |`hipblasDsymm`|3.6.0| | | | |
 |`cublasDsymm_v2_64`|12.0| | | |`hipblasDsymm_64`|6.3.0| | | |6.3.0|
 |`cublasDsyr2k`| | | | |`hipblasDsyr2k`|3.5.0| | | | |
-|`cublasDsyr2k_64`|12.0| | | | | | | | | |
+|`cublasDsyr2k_64`|12.0| | | |`hipblasDsyr2k_64`|6.3.0| | | |6.3.0|
 |`cublasDsyr2k_v2`| | | | |`hipblasDsyr2k`|3.5.0| | | | |
-|`cublasDsyr2k_v2_64`|12.0| | | | | | | | | |
+|`cublasDsyr2k_v2_64`|12.0| | | |`hipblasDsyr2k_64`|6.3.0| | | |6.3.0|
 |`cublasDsyrk`| | | | |`hipblasDsyrk`|3.5.0| | | | |
 |`cublasDsyrk_64`|12.0| | | |`hipblasDsyrk_64`|6.3.0| | | |6.3.0|
 |`cublasDsyrk_v2`| | | | |`hipblasDsyrk`|3.5.0| | | | |
@@ -1417,9 +1417,9 @@
 |`cublasSsymm_v2`| | | | |`hipblasSsymm`|3.6.0| | | | |
 |`cublasSsymm_v2_64`|12.0| | | |`hipblasSsymm_64`|6.3.0| | | |6.3.0|
 |`cublasSsyr2k`| | | | |`hipblasSsyr2k`|3.5.0| | | | |
-|`cublasSsyr2k_64`|12.0| | | | | | | | | |
+|`cublasSsyr2k_64`|12.0| | | |`hipblasSsyr2k_64`|6.3.0| | | |6.3.0|
 |`cublasSsyr2k_v2`| | | | |`hipblasSsyr2k`|3.5.0| | | | |
-|`cublasSsyr2k_v2_64`|12.0| | | | | | | | | |
+|`cublasSsyr2k_v2_64`|12.0| | | |`hipblasSsyr2k_64`|6.3.0| | | |6.3.0|
 |`cublasSsyrk`| | | | |`hipblasSsyrk`|3.5.0| | | | |
 |`cublasSsyrk_64`|12.0| | | |`hipblasSsyrk_64`|6.3.0| | | |6.3.0|
 |`cublasSsyrk_v2`| | | | |`hipblasSsyrk`|3.5.0| | | | |
@@ -1475,9 +1475,9 @@
 |`cublasZsymm_v2`| | | | |`hipblasZsymm_v2`|6.0.0| | | | |
 |`cublasZsymm_v2_64`|12.0| | | |`hipblasZsymm_v2_64`|6.3.0| | | |6.3.0|
 |`cublasZsyr2k`| | | | |`hipblasZsyr2k_v2`|6.0.0| | | | |
-|`cublasZsyr2k_64`|12.0| | | | | | | | | |
+|`cublasZsyr2k_64`|12.0| | | |`hipblasZsyr2k_v2_64`| | | | | |
 |`cublasZsyr2k_v2`| | | | |`hipblasZsyr2k_v2`|6.0.0| | | | |
-|`cublasZsyr2k_v2_64`|12.0| | | | | | | | | |
+|`cublasZsyr2k_v2_64`|12.0| | | |`hipblasZsyr2k_v2_64`| | | | | |
 |`cublasZsyrk`| | | | |`hipblasZsyrk_v2`|6.0.0| | | | |
 |`cublasZsyrk_64`|12.0| | | |`hipblasZsyrk_v2_64`|6.3.0| | | |6.3.0|
 |`cublasZsyrk_v2`| | | | |`hipblasZsyrk_v2`|6.0.0| | | | |

--- a/docs/tables/CUBLAS_API_supported_by_HIP.md
+++ b/docs/tables/CUBLAS_API_supported_by_HIP.md
@@ -1475,9 +1475,9 @@
 |`cublasZsymm_v2`| | | | |`hipblasZsymm_v2`|6.0.0| | | | |
 |`cublasZsymm_v2_64`|12.0| | | |`hipblasZsymm_v2_64`|6.3.0| | | |6.3.0|
 |`cublasZsyr2k`| | | | |`hipblasZsyr2k_v2`|6.0.0| | | | |
-|`cublasZsyr2k_64`|12.0| | | |`hipblasZsyr2k_v2_64`| | | | | |
+|`cublasZsyr2k_64`|12.0| | | |`hipblasZsyr2k_v2_64`|6.3.0| | | |6.3.0|
 |`cublasZsyr2k_v2`| | | | |`hipblasZsyr2k_v2`|6.0.0| | | | |
-|`cublasZsyr2k_v2_64`|12.0| | | |`hipblasZsyr2k_v2_64`| | | | | |
+|`cublasZsyr2k_v2_64`|12.0| | | |`hipblasZsyr2k_v2_64`|6.3.0| | | |6.3.0|
 |`cublasZsyrk`| | | | |`hipblasZsyrk_v2`|6.0.0| | | | |
 |`cublasZsyrk_64`|12.0| | | |`hipblasZsyrk_v2_64`|6.3.0| | | |6.3.0|
 |`cublasZsyrk_v2`| | | | |`hipblasZsyrk_v2`|6.0.0| | | | |

--- a/docs/tables/CUBLAS_API_supported_by_HIP_and_ROC.md
+++ b/docs/tables/CUBLAS_API_supported_by_HIP_and_ROC.md
@@ -1329,9 +1329,9 @@
 |`cublasCsymm_v2`| | | | |`hipblasCsymm_v2`|6.0.0| | | | |`rocblas_csymm`|3.5.0| | | | |
 |`cublasCsymm_v2_64`|12.0| | | |`hipblasCsymm_v2_64`|6.3.0| | | |6.3.0|`rocblas_csymm_64`|6.3.0| | | |6.3.0|
 |`cublasCsyr2k`| | | | |`hipblasCsyr2k_v2`|6.0.0| | | | |`rocblas_csyr2k`|3.5.0| | | | |
-|`cublasCsyr2k_64`|12.0| | | | | | | | | | | | | | | |
+|`cublasCsyr2k_64`|12.0| | | |`hipblasCsyr2k_v2_64`|6.3.0| | | |6.3.0|`rocblas_csyr2k_64`|6.3.0| | | |6.3.0|
 |`cublasCsyr2k_v2`| | | | |`hipblasCsyr2k_v2`|6.0.0| | | | |`rocblas_csyr2k`|3.5.0| | | | |
-|`cublasCsyr2k_v2_64`|12.0| | | | | | | | | | | | | | | |
+|`cublasCsyr2k_v2_64`|12.0| | | |`hipblasCsyr2k_v2_64`|6.3.0| | | |6.3.0|`rocblas_csyr2k_64`|6.3.0| | | |6.3.0|
 |`cublasCsyrk`| | | | |`hipblasCsyrk_v2`|6.0.0| | | | |`rocblas_csyrk`|3.5.0| | | | |
 |`cublasCsyrk_64`|12.0| | | |`hipblasCsyrk_v2_64`|6.3.0| | | |6.3.0|`rocblas_csyrk_64`|6.3.0| | | |6.3.0|
 |`cublasCsyrk_v2`| | | | |`hipblasCsyrk_v2`|6.0.0| | | | |`rocblas_csyrk`|3.5.0| | | | |
@@ -1365,9 +1365,9 @@
 |`cublasDsymm_v2`| | | | |`hipblasDsymm`|3.6.0| | | | |`rocblas_dsymm`|3.5.0| | | | |
 |`cublasDsymm_v2_64`|12.0| | | |`hipblasDsymm_64`|6.3.0| | | |6.3.0|`rocblas_dsymm_64`|6.3.0| | | |6.3.0|
 |`cublasDsyr2k`| | | | |`hipblasDsyr2k`|3.5.0| | | | |`rocblas_dsyr2k`|3.5.0| | | | |
-|`cublasDsyr2k_64`|12.0| | | | | | | | | | | | | | | |
+|`cublasDsyr2k_64`|12.0| | | |`hipblasDsyr2k_64`|6.3.0| | | |6.3.0|`rocblas_dsyr2k_64`|6.3.0| | | |6.3.0|
 |`cublasDsyr2k_v2`| | | | |`hipblasDsyr2k`|3.5.0| | | | |`rocblas_dsyr2k`|3.5.0| | | | |
-|`cublasDsyr2k_v2_64`|12.0| | | | | | | | | | | | | | | |
+|`cublasDsyr2k_v2_64`|12.0| | | |`hipblasDsyr2k_64`|6.3.0| | | |6.3.0|`rocblas_dsyr2k_64`|6.3.0| | | |6.3.0|
 |`cublasDsyrk`| | | | |`hipblasDsyrk`|3.5.0| | | | |`rocblas_dsyrk`|3.5.0| | | | |
 |`cublasDsyrk_64`|12.0| | | |`hipblasDsyrk_64`|6.3.0| | | |6.3.0|`rocblas_dsyrk_64`|6.3.0| | | |6.3.0|
 |`cublasDsyrk_v2`| | | | |`hipblasDsyrk`|3.5.0| | | | |`rocblas_dsyrk`|3.5.0| | | | |
@@ -1417,9 +1417,9 @@
 |`cublasSsymm_v2`| | | | |`hipblasSsymm`|3.6.0| | | | |`rocblas_ssymm`|3.5.0| | | | |
 |`cublasSsymm_v2_64`|12.0| | | |`hipblasSsymm_64`|6.3.0| | | |6.3.0|`rocblas_ssymm_64`|6.3.0| | | |6.3.0|
 |`cublasSsyr2k`| | | | |`hipblasSsyr2k`|3.5.0| | | | |`rocblas_ssyr2k`|3.5.0| | | | |
-|`cublasSsyr2k_64`|12.0| | | | | | | | | | | | | | | |
+|`cublasSsyr2k_64`|12.0| | | |`hipblasSsyr2k_64`|6.3.0| | | |6.3.0|`rocblas_ssyr2k_64`|6.3.0| | | |6.3.0|
 |`cublasSsyr2k_v2`| | | | |`hipblasSsyr2k`|3.5.0| | | | |`rocblas_ssyr2k`|3.5.0| | | | |
-|`cublasSsyr2k_v2_64`|12.0| | | | | | | | | | | | | | | |
+|`cublasSsyr2k_v2_64`|12.0| | | |`hipblasSsyr2k_64`|6.3.0| | | |6.3.0|`rocblas_ssyr2k_64`|6.3.0| | | |6.3.0|
 |`cublasSsyrk`| | | | |`hipblasSsyrk`|3.5.0| | | | |`rocblas_ssyrk`|3.5.0| | | | |
 |`cublasSsyrk_64`|12.0| | | |`hipblasSsyrk_64`|6.3.0| | | |6.3.0|`rocblas_ssyrk_64`|6.3.0| | | |6.3.0|
 |`cublasSsyrk_v2`| | | | |`hipblasSsyrk`|3.5.0| | | | |`rocblas_ssyrk`|3.5.0| | | | |
@@ -1475,9 +1475,9 @@
 |`cublasZsymm_v2`| | | | |`hipblasZsymm_v2`|6.0.0| | | | |`rocblas_zsymm`|3.5.0| | | | |
 |`cublasZsymm_v2_64`|12.0| | | |`hipblasZsymm_v2_64`|6.3.0| | | |6.3.0|`rocblas_zsymm_64`|6.3.0| | | |6.3.0|
 |`cublasZsyr2k`| | | | |`hipblasZsyr2k_v2`|6.0.0| | | | |`rocblas_zsyr2k`|3.5.0| | | | |
-|`cublasZsyr2k_64`|12.0| | | | | | | | | | | | | | | |
+|`cublasZsyr2k_64`|12.0| | | |`hipblasZsyr2k_v2_64`| | | | | |`rocblas_zsyr2k_64`|6.3.0| | | |6.3.0|
 |`cublasZsyr2k_v2`| | | | |`hipblasZsyr2k_v2`|6.0.0| | | | |`rocblas_zsyr2k`|3.5.0| | | | |
-|`cublasZsyr2k_v2_64`|12.0| | | | | | | | | | | | | | | |
+|`cublasZsyr2k_v2_64`|12.0| | | |`hipblasZsyr2k_v2_64`| | | | | |`rocblas_zsyr2k_64`|6.3.0| | | |6.3.0|
 |`cublasZsyrk`| | | | |`hipblasZsyrk_v2`|6.0.0| | | | |`rocblas_zsyrk`|3.5.0| | | | |
 |`cublasZsyrk_64`|12.0| | | |`hipblasZsyrk_v2_64`|6.3.0| | | |6.3.0|`rocblas_zsyrk_64`|6.3.0| | | |6.3.0|
 |`cublasZsyrk_v2`| | | | |`hipblasZsyrk_v2`|6.0.0| | | | |`rocblas_zsyrk`|3.5.0| | | | |

--- a/docs/tables/CUBLAS_API_supported_by_HIP_and_ROC.md
+++ b/docs/tables/CUBLAS_API_supported_by_HIP_and_ROC.md
@@ -1475,9 +1475,9 @@
 |`cublasZsymm_v2`| | | | |`hipblasZsymm_v2`|6.0.0| | | | |`rocblas_zsymm`|3.5.0| | | | |
 |`cublasZsymm_v2_64`|12.0| | | |`hipblasZsymm_v2_64`|6.3.0| | | |6.3.0|`rocblas_zsymm_64`|6.3.0| | | |6.3.0|
 |`cublasZsyr2k`| | | | |`hipblasZsyr2k_v2`|6.0.0| | | | |`rocblas_zsyr2k`|3.5.0| | | | |
-|`cublasZsyr2k_64`|12.0| | | |`hipblasZsyr2k_v2_64`| | | | | |`rocblas_zsyr2k_64`|6.3.0| | | |6.3.0|
+|`cublasZsyr2k_64`|12.0| | | |`hipblasZsyr2k_v2_64`|6.3.0| | | |6.3.0|`rocblas_zsyr2k_64`|6.3.0| | | |6.3.0|
 |`cublasZsyr2k_v2`| | | | |`hipblasZsyr2k_v2`|6.0.0| | | | |`rocblas_zsyr2k`|3.5.0| | | | |
-|`cublasZsyr2k_v2_64`|12.0| | | |`hipblasZsyr2k_v2_64`| | | | | |`rocblas_zsyr2k_64`|6.3.0| | | |6.3.0|
+|`cublasZsyr2k_v2_64`|12.0| | | |`hipblasZsyr2k_v2_64`|6.3.0| | | |6.3.0|`rocblas_zsyr2k_64`|6.3.0| | | |6.3.0|
 |`cublasZsyrk`| | | | |`hipblasZsyrk_v2`|6.0.0| | | | |`rocblas_zsyrk`|3.5.0| | | | |
 |`cublasZsyrk_64`|12.0| | | |`hipblasZsyrk_v2_64`|6.3.0| | | |6.3.0|`rocblas_zsyrk_64`|6.3.0| | | |6.3.0|
 |`cublasZsyrk_v2`| | | | |`hipblasZsyrk_v2`|6.0.0| | | | |`rocblas_zsyrk`|3.5.0| | | | |

--- a/docs/tables/CUBLAS_API_supported_by_ROC.md
+++ b/docs/tables/CUBLAS_API_supported_by_ROC.md
@@ -1329,9 +1329,9 @@
 |`cublasCsymm_v2`| | | | |`rocblas_csymm`|3.5.0| | | | |
 |`cublasCsymm_v2_64`|12.0| | | |`rocblas_csymm_64`|6.3.0| | | |6.3.0|
 |`cublasCsyr2k`| | | | |`rocblas_csyr2k`|3.5.0| | | | |
-|`cublasCsyr2k_64`|12.0| | | | | | | | | |
+|`cublasCsyr2k_64`|12.0| | | |`rocblas_csyr2k_64`|6.3.0| | | |6.3.0|
 |`cublasCsyr2k_v2`| | | | |`rocblas_csyr2k`|3.5.0| | | | |
-|`cublasCsyr2k_v2_64`|12.0| | | | | | | | | |
+|`cublasCsyr2k_v2_64`|12.0| | | |`rocblas_csyr2k_64`|6.3.0| | | |6.3.0|
 |`cublasCsyrk`| | | | |`rocblas_csyrk`|3.5.0| | | | |
 |`cublasCsyrk_64`|12.0| | | |`rocblas_csyrk_64`|6.3.0| | | |6.3.0|
 |`cublasCsyrk_v2`| | | | |`rocblas_csyrk`|3.5.0| | | | |
@@ -1365,9 +1365,9 @@
 |`cublasDsymm_v2`| | | | |`rocblas_dsymm`|3.5.0| | | | |
 |`cublasDsymm_v2_64`|12.0| | | |`rocblas_dsymm_64`|6.3.0| | | |6.3.0|
 |`cublasDsyr2k`| | | | |`rocblas_dsyr2k`|3.5.0| | | | |
-|`cublasDsyr2k_64`|12.0| | | | | | | | | |
+|`cublasDsyr2k_64`|12.0| | | |`rocblas_dsyr2k_64`|6.3.0| | | |6.3.0|
 |`cublasDsyr2k_v2`| | | | |`rocblas_dsyr2k`|3.5.0| | | | |
-|`cublasDsyr2k_v2_64`|12.0| | | | | | | | | |
+|`cublasDsyr2k_v2_64`|12.0| | | |`rocblas_dsyr2k_64`|6.3.0| | | |6.3.0|
 |`cublasDsyrk`| | | | |`rocblas_dsyrk`|3.5.0| | | | |
 |`cublasDsyrk_64`|12.0| | | |`rocblas_dsyrk_64`|6.3.0| | | |6.3.0|
 |`cublasDsyrk_v2`| | | | |`rocblas_dsyrk`|3.5.0| | | | |
@@ -1417,9 +1417,9 @@
 |`cublasSsymm_v2`| | | | |`rocblas_ssymm`|3.5.0| | | | |
 |`cublasSsymm_v2_64`|12.0| | | |`rocblas_ssymm_64`|6.3.0| | | |6.3.0|
 |`cublasSsyr2k`| | | | |`rocblas_ssyr2k`|3.5.0| | | | |
-|`cublasSsyr2k_64`|12.0| | | | | | | | | |
+|`cublasSsyr2k_64`|12.0| | | |`rocblas_ssyr2k_64`|6.3.0| | | |6.3.0|
 |`cublasSsyr2k_v2`| | | | |`rocblas_ssyr2k`|3.5.0| | | | |
-|`cublasSsyr2k_v2_64`|12.0| | | | | | | | | |
+|`cublasSsyr2k_v2_64`|12.0| | | |`rocblas_ssyr2k_64`|6.3.0| | | |6.3.0|
 |`cublasSsyrk`| | | | |`rocblas_ssyrk`|3.5.0| | | | |
 |`cublasSsyrk_64`|12.0| | | |`rocblas_ssyrk_64`|6.3.0| | | |6.3.0|
 |`cublasSsyrk_v2`| | | | |`rocblas_ssyrk`|3.5.0| | | | |
@@ -1475,9 +1475,9 @@
 |`cublasZsymm_v2`| | | | |`rocblas_zsymm`|3.5.0| | | | |
 |`cublasZsymm_v2_64`|12.0| | | |`rocblas_zsymm_64`|6.3.0| | | |6.3.0|
 |`cublasZsyr2k`| | | | |`rocblas_zsyr2k`|3.5.0| | | | |
-|`cublasZsyr2k_64`|12.0| | | | | | | | | |
+|`cublasZsyr2k_64`|12.0| | | |`rocblas_zsyr2k_64`|6.3.0| | | |6.3.0|
 |`cublasZsyr2k_v2`| | | | |`rocblas_zsyr2k`|3.5.0| | | | |
-|`cublasZsyr2k_v2_64`|12.0| | | | | | | | | |
+|`cublasZsyr2k_v2_64`|12.0| | | |`rocblas_zsyr2k_64`|6.3.0| | | |6.3.0|
 |`cublasZsyrk`| | | | |`rocblas_zsyrk`|3.5.0| | | | |
 |`cublasZsyrk_64`|12.0| | | |`rocblas_zsyrk_64`|6.3.0| | | |6.3.0|
 |`cublasZsyrk_v2`| | | | |`rocblas_zsyrk`|3.5.0| | | | |

--- a/src/CUDA2HIP_BLAS_API_functions.cpp
+++ b/src/CUDA2HIP_BLAS_API_functions.cpp
@@ -493,13 +493,13 @@ const std::map<llvm::StringRef, hipCounter> CUDA_BLAS_FUNCTION_MAP {
 
   // SYR2K
   {"cublasSsyr2k",                                         {"hipblasSsyr2k",                                             "rocblas_ssyr2k",                                     CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3, HIP_SUPPORTED_V2_ONLY}},
-  {"cublasSsyr2k_64",                                      {"hipblasSsyr2k_64",                                          "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3, UNSUPPORTED}},
+  {"cublasSsyr2k_64",                                      {"hipblasSsyr2k_64",                                          "rocblas_ssyr2k_64",                                  CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3}},
   {"cublasDsyr2k",                                         {"hipblasDsyr2k",                                             "rocblas_dsyr2k",                                     CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3, HIP_SUPPORTED_V2_ONLY}},
-  {"cublasDsyr2k_64",                                      {"hipblasDsyr2k_64",                                          "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3, UNSUPPORTED}},
+  {"cublasDsyr2k_64",                                      {"hipblasDsyr2k_64",                                          "rocblas_dsyr2k_64",                                  CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3}},
   {"cublasCsyr2k",                                         {"hipblasCsyr2k_v2",                                          "rocblas_csyr2k",                                     CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3, HIP_SUPPORTED_V2_ONLY}},
-  {"cublasCsyr2k_64",                                      {"hipblasCsyr2k_64",                                          "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3, UNSUPPORTED}},
+  {"cublasCsyr2k_64",                                      {"hipblasCsyr2k_v2_64",                                       "rocblas_csyr2k_64",                                  CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3}},
   {"cublasZsyr2k",                                         {"hipblasZsyr2k_v2",                                          "rocblas_zsyr2k",                                     CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3, HIP_SUPPORTED_V2_ONLY}},
-  {"cublasZsyr2k_64",                                      {"hipblasZsyr2k_64",                                          "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3, UNSUPPORTED}},
+  {"cublasZsyr2k_64",                                      {"hipblasZsyr2k_v2_64",                                       "rocblas_zsyr2k_64",                                  CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3}},
 
   // SYRKX - eXtended SYRK
   {"cublasSsyrkx",                                         {"hipblasSsyrkx",                                             "rocblas_ssyrkx",                                     CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3}},
@@ -876,13 +876,13 @@ const std::map<llvm::StringRef, hipCounter> CUDA_BLAS_FUNCTION_MAP {
 
   // SYR2K
   {"cublasSsyr2k_v2",                                      {"hipblasSsyr2k",                                             "rocblas_ssyr2k",                                     CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3}},
-  {"cublasSsyr2k_v2_64",                                   {"hipblasSsyr2k_64",                                          "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3, UNSUPPORTED}},
+  {"cublasSsyr2k_v2_64",                                   {"hipblasSsyr2k_64",                                          "rocblas_ssyr2k_64",                                  CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3}},
   {"cublasDsyr2k_v2",                                      {"hipblasDsyr2k",                                             "rocblas_dsyr2k",                                     CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3}},
-  {"cublasDsyr2k_v2_64",                                   {"hipblasDsyr2k_64",                                          "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3, UNSUPPORTED}},
+  {"cublasDsyr2k_v2_64",                                   {"hipblasDsyr2k_64",                                          "rocblas_dsyr2k_64",                                  CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3}},
   {"cublasCsyr2k_v2",                                      {"hipblasCsyr2k_v2",                                          "rocblas_csyr2k",                                     CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3}},
-  {"cublasCsyr2k_v2_64",                                   {"hipblasCsyr2k_64",                                          "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3, UNSUPPORTED}},
+  {"cublasCsyr2k_v2_64",                                   {"hipblasCsyr2k_v2_64",                                       "rocblas_csyr2k_64",                                  CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3}},
   {"cublasZsyr2k_v2",                                      {"hipblasZsyr2k_v2",                                          "rocblas_zsyr2k",                                     CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3}},
-  {"cublasZsyr2k_v2_64",                                   {"hipblasZsyr2k_64",                                          "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3, UNSUPPORTED}},
+  {"cublasZsyr2k_v2_64",                                   {"hipblasZsyr2k_v2_64",                                       "rocblas_zsyr2k_64",                                  CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3}},
 
   // HER2K
   {"cublasCher2k_v2",                                      {"hipblasCher2k_v2",                                          "rocblas_cher2k",                                     CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3}},
@@ -2052,6 +2052,10 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_BLAS_FUNCTION_VER_MAP {
   {"hipblasDsyrk_64",                                      {HIP_6030, HIP_0,    HIP_0,  HIP_LATEST}},
   {"hipblasCsyrk_v2_64",                                   {HIP_6030, HIP_0,    HIP_0,  HIP_LATEST}},
   {"hipblasZsyrk_v2_64",                                   {HIP_6030, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipblasSsyr2k_64",                                     {HIP_6030, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipblasDsyr2k_64",                                     {HIP_6030, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipblasCsyr2k_v2_64",                                  {HIP_6030, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipblasZsyr2k_64_v2",                                  {HIP_6030, HIP_0,    HIP_0,  HIP_LATEST}},
 
   {"rocblas_status_to_string",                             {HIP_3050, HIP_0,    HIP_0   }},
   {"rocblas_sscal",                                        {HIP_1050, HIP_0,    HIP_0   }},
@@ -2469,6 +2473,10 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_BLAS_FUNCTION_VER_MAP {
   {"rocblas_dsyrk_64",                                     {HIP_6030, HIP_0,    HIP_0,  HIP_LATEST}},
   {"rocblas_csyrk_64",                                     {HIP_6030, HIP_0,    HIP_0,  HIP_LATEST}},
   {"rocblas_zsyrk_64",                                     {HIP_6030, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"rocblas_ssyr2k_64",                                    {HIP_6030, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"rocblas_dsyr2k_64",                                    {HIP_6030, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"rocblas_csyr2k_64",                                    {HIP_6030, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"rocblas_zsyr2k_64",                                    {HIP_6030, HIP_0,    HIP_0,  HIP_LATEST}},
 };
 
 const std::map<llvm::StringRef, hipAPIChangedVersions> HIP_BLAS_FUNCTION_CHANGED_VER_MAP {

--- a/src/CUDA2HIP_BLAS_API_functions.cpp
+++ b/src/CUDA2HIP_BLAS_API_functions.cpp
@@ -2055,7 +2055,7 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_BLAS_FUNCTION_VER_MAP {
   {"hipblasSsyr2k_64",                                     {HIP_6030, HIP_0,    HIP_0,  HIP_LATEST}},
   {"hipblasDsyr2k_64",                                     {HIP_6030, HIP_0,    HIP_0,  HIP_LATEST}},
   {"hipblasCsyr2k_v2_64",                                  {HIP_6030, HIP_0,    HIP_0,  HIP_LATEST}},
-  {"hipblasZsyr2k_64_v2",                                  {HIP_6030, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipblasZsyr2k_v2_64",                                  {HIP_6030, HIP_0,    HIP_0,  HIP_LATEST}},
 
   {"rocblas_status_to_string",                             {HIP_3050, HIP_0,    HIP_0   }},
   {"rocblas_sscal",                                        {HIP_1050, HIP_0,    HIP_0   }},

--- a/tests/unit_tests/synthetic/libraries/cublas2hipblas_v2.cu
+++ b/tests/unit_tests/synthetic/libraries/cublas2hipblas_v2.cu
@@ -3002,6 +3002,34 @@ int main() {
   // CHECK-NEXT: blasStatus = hipblasZsyrk_v2_64(blasHandle, blasFillMode, blasOperation, n_64, k_64, &dcomplexa, &dcomplexA, lda_64, &dcomplexb, &dcomplexC, ldc_64);
   blasStatus = cublasZsyrk_64(blasHandle, blasFillMode, blasOperation, n_64, k_64, &dcomplexa, &dcomplexA, lda_64, &dcomplexb, &dcomplexC, ldc_64);
   blasStatus = cublasZsyrk_v2_64(blasHandle, blasFillMode, blasOperation, n_64, k_64, &dcomplexa, &dcomplexA, lda_64, &dcomplexb, &dcomplexC, ldc_64);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasSsyr2k_v2_64(cublasHandle_t handle, cublasFillMode_t uplo, cublasOperation_t trans, int64_t n, int64_t k, const float* alpha, const float* A, int64_t lda, const float* B, int64_t ldb, const float* beta, float* C, int64_t ldc);
+  // HIP: HIPBLAS_EXPORT hipblasStatus_t hipblasSsyr2k_64(hipblasHandle_t handle, hipblasFillMode_t uplo, hipblasOperation_t transA, int64_t n, int64_t k, const float* alpha, const float* AP, int64_t lda, const float* BP, int64_t ldb, const float* beta, float* CP, int64_t ldc);
+  // CHECK: blasStatus = hipblasSsyr2k_64(blasHandle, blasFillMode, blasOperation, n_64, k_64, &fa, &fA, lda_64, &fB, ldb_64, &fb, &fC, ldc_64);
+  // CHECK-NEXT: blasStatus = hipblasSsyr2k_64(blasHandle, blasFillMode, blasOperation, n_64, k_64, &fa, &fA, lda_64, &fB, ldb_64, &fb, &fC, ldc_64);
+  blasStatus = cublasSsyr2k_64(blasHandle, blasFillMode, blasOperation, n_64, k_64, &fa, &fA, lda_64, &fB, ldb_64, &fb, &fC, ldc_64);
+  blasStatus = cublasSsyr2k_v2_64(blasHandle, blasFillMode, blasOperation, n_64, k_64, &fa, &fA, lda_64, &fB, ldb_64, &fb, &fC, ldc_64);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasDsyr2k_v2_64(cublasHandle_t handle, cublasFillMode_t uplo, cublasOperation_t trans, int64_t n, int64_t k, const double* alpha, const double* A, int64_t lda, const double* B, int64_t ldb, const double* beta, double* C, int64_t ldc);
+  // HIP: HIPBLAS_EXPORT hipblasStatus_t hipblasDsyr2k_64(hipblasHandle_t handle, hipblasFillMode_t uplo, hipblasOperation_t transA, int64_t n, int64_t k, const double* alpha, const double* AP, int64_t lda, const double* BP, int64_t ldb, const double* beta, double* CP, int64_t ldc);
+  // CHECK: blasStatus = hipblasDsyr2k_64(blasHandle, blasFillMode, blasOperation, n_64, k_64, &da, &dA, lda_64, &dB, ldb_64, &db, &dC, ldc_64);
+  // CHECK-NEXT: blasStatus = hipblasDsyr2k_64(blasHandle, blasFillMode, blasOperation, n_64, k_64, &da, &dA, lda_64, &dB, ldb_64, &db, &dC, ldc_64);
+  blasStatus = cublasDsyr2k_64(blasHandle, blasFillMode, blasOperation, n_64, k_64, &da, &dA, lda_64, &dB, ldb_64, &db, &dC, ldc_64);
+  blasStatus = cublasDsyr2k_v2_64(blasHandle, blasFillMode, blasOperation, n_64, k_64, &da, &dA, lda_64, &dB, ldb_64, &db, &dC, ldc_64);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasCsyr2k_v2_64(cublasHandle_t handle, cublasFillMode_t uplo, cublasOperation_t trans, int64_t n, int64_t k, const cuComplex* alpha, const cuComplex* A, int64_t lda, const cuComplex* B, int64_t ldb, const cuComplex* beta, cuComplex* C, int64_t ldc);
+  // HIP: HIPBLAS_EXPORT hipblasStatus_t hipblasCsyr2k_v2_64(hipblasHandle_t handle, hipblasFillMode_t uplo, hipblasOperation_t transA, int64_t n, int64_t k, const hipComplex* alpha, const hipComplex* AP, int64_t lda, const hipComplex* BP, int64_t ldb, const hipComplex* beta, hipComplex* CP, int64_t ldc);
+  // CHECK: blasStatus = hipblasCsyr2k_v2_64(blasHandle, blasFillMode, blasOperation, n_64, k_64, &complexa, &complexA, lda_64, &complexB, ldb_64, &complexb, &complexC, ldc_64);
+  // CHECK-NEXT: blasStatus = hipblasCsyr2k_v2_64(blasHandle, blasFillMode, blasOperation, n_64, k_64, &complexa, &complexA, lda_64, &complexB, ldb_64, &complexb, &complexC, ldc_64);
+  blasStatus = cublasCsyr2k_64(blasHandle, blasFillMode, blasOperation, n_64, k_64, &complexa, &complexA, lda_64, &complexB, ldb_64, &complexb, &complexC, ldc_64);
+  blasStatus = cublasCsyr2k_v2_64(blasHandle, blasFillMode, blasOperation, n_64, k_64, &complexa, &complexA, lda_64, &complexB, ldb_64, &complexb, &complexC, ldc_64);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasZsyr2k_v2_64(cublasHandle_t handle, cublasFillMode_t uplo, cublasOperation_t trans, int64_t n, int64_t k, const cuDoubleComplex* alpha, const cuDoubleComplex* A, int64_t lda, const cuDoubleComplex* B, int64_t ldb, const cuDoubleComplex* beta, cuDoubleComplex* C, int64_t ldc);
+  // HIP: HIPBLAS_EXPORT hipblasStatus_t hipblasZsyr2k_v2_64(hipblasHandle_t handle, hipblasFillMode_t uplo, hipblasOperation_t transA, int64_t n, int64_t k, const hipDoubleComplex* alpha, const hipDoubleComplex* AP, int64_t lda, const hipDoubleComplex* BP, int64_t ldb, const hipDoubleComplex* beta, hipDoubleComplex* CP, int64_t ldc);
+  // CHECK: blasStatus = hipblasZsyr2k_v2_64(blasHandle, blasFillMode, blasOperation, n_64, k_64, &dcomplexa, &dcomplexA, lda_64, &dcomplexB, ldb_64, &dcomplexb, &dcomplexC, ldc_64);
+  // CHECK-NEXT: blasStatus = hipblasZsyr2k_v2_64(blasHandle, blasFillMode, blasOperation, n_64, k_64, &dcomplexa, &dcomplexA, lda_64, &dcomplexB, ldb_64, &dcomplexb, &dcomplexC, ldc_64);
+  blasStatus = cublasZsyr2k_64(blasHandle, blasFillMode, blasOperation, n_64, k_64, &dcomplexa, &dcomplexA, lda_64, &dcomplexB, ldb_64, &dcomplexb, &dcomplexC, ldc_64);
+  blasStatus = cublasZsyr2k_v2_64(blasHandle, blasFillMode, blasOperation, n_64, k_64, &dcomplexa, &dcomplexA, lda_64, &dcomplexB, ldb_64, &dcomplexb, &dcomplexC, ldc_64);
 #endif
 
   return 0;

--- a/tests/unit_tests/synthetic/libraries/cublas2rocblas_v2.cu
+++ b/tests/unit_tests/synthetic/libraries/cublas2rocblas_v2.cu
@@ -3207,6 +3207,34 @@ int main() {
   // CHECK-NEXT: blasStatus = rocblas_zsyrk_64(blasHandle, blasFillMode, blasOperation, n_64, k_64, &dcomplexa, &dcomplexA, lda_64, &dcomplexb, &dcomplexC, ldc_64);
   blasStatus = cublasZsyrk_64(blasHandle, blasFillMode, blasOperation, n_64, k_64, &dcomplexa, &dcomplexA, lda_64, &dcomplexb, &dcomplexC, ldc_64);
   blasStatus = cublasZsyrk_v2_64(blasHandle, blasFillMode, blasOperation, n_64, k_64, &dcomplexa, &dcomplexA, lda_64, &dcomplexb, &dcomplexC, ldc_64);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasSsyr2k_v2_64(cublasHandle_t handle, cublasFillMode_t uplo, cublasOperation_t trans, int64_t n, int64_t k, const float* alpha, const float* A, int64_t lda, const float* B, int64_t ldb, const float* beta, float* C, int64_t ldc);
+  // ROC: ROCBLAS_EXPORT rocblas_status rocblas_ssyr2k_64(rocblas_handle handle, rocblas_fill uplo, rocblas_operation trans, int64_t n, int64_t k, const float* alpha, const float* A, int64_t lda, const float* B, int64_t ldb, const float* beta, float* C, int64_t ldc);
+  // CHECK: blasStatus = rocblas_ssyr2k_64(blasHandle, blasFillMode, blasOperation, n_64, k_64, &fa, &fA, lda_64, &fB, ldb_64, &fb, &fC, ldc_64);
+  // CHECK-NEXT: blasStatus = rocblas_ssyr2k_64(blasHandle, blasFillMode, blasOperation, n_64, k_64, &fa, &fA, lda_64, &fB, ldb_64, &fb, &fC, ldc_64);
+  blasStatus = cublasSsyr2k_64(blasHandle, blasFillMode, blasOperation, n_64, k_64, &fa, &fA, lda_64, &fB, ldb_64, &fb, &fC, ldc_64);
+  blasStatus = cublasSsyr2k_v2_64(blasHandle, blasFillMode, blasOperation, n_64, k_64, &fa, &fA, lda_64, &fB, ldb_64, &fb, &fC, ldc_64);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasDsyr2k_v2_64(cublasHandle_t handle, cublasFillMode_t uplo, cublasOperation_t trans, int64_t n, int64_t k, const double* alpha, const double* A, int64_t lda, const double* B, int64_t ldb, const double* beta, double* C, int64_t ldc);
+  // ROC: ROCBLAS_EXPORT rocblas_status rocblas_dsyr2k_64(rocblas_handle handle, rocblas_fill uplo, rocblas_operation trans, int64_t n, int64_t k, const double* alpha, const double* A, int64_t lda, const double* B, int64_t ldb, const double* beta, double* C, int64_t ldc);
+  // CHECK: blasStatus = rocblas_dsyr2k_64(blasHandle, blasFillMode, blasOperation, n_64, k_64, &da, &dA, lda_64, &dB, ldb_64, &db, &dC, ldc_64);
+  // CHECK-NEXT: blasStatus = rocblas_dsyr2k_64(blasHandle, blasFillMode, blasOperation, n_64, k_64, &da, &dA, lda_64, &dB, ldb_64, &db, &dC, ldc_64);
+  blasStatus = cublasDsyr2k_64(blasHandle, blasFillMode, blasOperation, n_64, k_64, &da, &dA, lda_64, &dB, ldb_64, &db, &dC, ldc_64);
+  blasStatus = cublasDsyr2k_v2_64(blasHandle, blasFillMode, blasOperation, n_64, k_64, &da, &dA, lda_64, &dB, ldb_64, &db, &dC, ldc_64);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasCsyr2k_v2_64(cublasHandle_t handle, cublasFillMode_t uplo, cublasOperation_t trans, int64_t n, int64_t k, const cuComplex* alpha, const cuComplex* A, int64_t lda, const cuComplex* B, int64_t ldb, const cuComplex* beta, cuComplex* C, int64_t ldc);
+  // ROC: ROCBLAS_EXPORT rocblas_status rocblas_csyr2k_64(rocblas_handle handle, rocblas_fill uplo, rocblas_operation trans, int64_t n, int64_t k, const rocblas_float_complex* alpha, const rocblas_float_complex* A, int64_t lda, const rocblas_float_complex* B, int64_t ldb, const rocblas_float_complex* beta, rocblas_float_complex* C, int64_t ldc);
+  // CHECK: blasStatus = rocblas_csyr2k_64(blasHandle, blasFillMode, blasOperation, n_64, k_64, &complexa, &complexA, lda_64, &complexB, ldb_64, &complexb, &complexC, ldc_64);
+  // CHECK-NEXT: blasStatus = rocblas_csyr2k_64(blasHandle, blasFillMode, blasOperation, n_64, k_64, &complexa, &complexA, lda_64, &complexB, ldb_64, &complexb, &complexC, ldc_64);
+  blasStatus = cublasCsyr2k_64(blasHandle, blasFillMode, blasOperation, n_64, k_64, &complexa, &complexA, lda_64, &complexB, ldb_64, &complexb, &complexC, ldc_64);
+  blasStatus = cublasCsyr2k_v2_64(blasHandle, blasFillMode, blasOperation, n_64, k_64, &complexa, &complexA, lda_64, &complexB, ldb_64, &complexb, &complexC, ldc_64);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasZsyr2k_v2_64(cublasHandle_t handle, cublasFillMode_t uplo, cublasOperation_t trans, int64_t n, int64_t k, const cuDoubleComplex* alpha, const cuDoubleComplex* A, int64_t lda, const cuDoubleComplex* B, int64_t ldb, const cuDoubleComplex* beta, cuDoubleComplex* C, int64_t ldc);
+  // ROC: ROCBLAS_EXPORT rocblas_status rocblas_zsyr2k_64(rocblas_handle handle, rocblas_fill uplo, rocblas_operation trans, int64_t n, int64_t k, const rocblas_double_complex* alpha, const rocblas_double_complex* A, int64_t lda, const rocblas_double_complex* B, int64_t ldb, const rocblas_double_complex* beta, rocblas_double_complex* C, int64_t ldc);
+  // CHECK: blasStatus = rocblas_zsyr2k_64(blasHandle, blasFillMode, blasOperation, n_64, k_64, &dcomplexa, &dcomplexA, lda_64, &dcomplexB, ldb_64, &dcomplexb, &dcomplexC, ldc_64);
+  // CHECK-NEXT: blasStatus = rocblas_zsyr2k_64(blasHandle, blasFillMode, blasOperation, n_64, k_64, &dcomplexa, &dcomplexA, lda_64, &dcomplexB, ldb_64, &dcomplexb, &dcomplexC, ldc_64);
+  blasStatus = cublasZsyr2k_64(blasHandle, blasFillMode, blasOperation, n_64, k_64, &dcomplexa, &dcomplexA, lda_64, &dcomplexB, ldb_64, &dcomplexb, &dcomplexC, ldc_64);
+  blasStatus = cublasZsyr2k_v2_64(blasHandle, blasFillMode, blasOperation, n_64, k_64, &dcomplexa, &dcomplexA, lda_64, &dcomplexB, ldb_64, &dcomplexb, &dcomplexC, ldc_64);
 #endif
 
   return 0;


### PR DESCRIPTION
+ `rocblas_(s|d|c|z)syr2k_64` and `hipblas(S|D|C|Z)syr2k(_v2)?_64` support
+ Updated synthetic tests, the regenerated `hipify-perl`, and `BLAS` `CUDA2HIP` documentation