### PR TITLE
[HIPIFY][MIOpen][fix] Get rid of `miopenAcceleratorQueue_t`

### DIFF
--- a/src/CUDA2HIP_Runtime_API_types.cpp
+++ b/src/CUDA2HIP_Runtime_API_types.cpp
@@ -191,7 +191,7 @@ const std::map<llvm::StringRef, hipCounter> CUDA_RUNTIME_TYPE_NAME_MAP {
   // the same - CUstream_st
   {"CUstream_st",                                                      {"ihipStream_t",                                             "", CONV_TYPE, API_RUNTIME, SEC::DATA_TYPES}},
   // CUstream
-  {"cudaStream_t",                                                     {"hipStream_t",                      "miopenAcceleratorQueue_t", CONV_TYPE, API_RUNTIME, SEC::DATA_TYPES, ROC_MIOPEN_ONLY}},
+  {"cudaStream_t",                                                     {"hipStream_t",                                              "", CONV_TYPE, API_RUNTIME, SEC::DATA_TYPES}},
 
   // CUfunction
   {"cudaFunction_t",                                                   {"hipFunction_t",                                            "", CONV_TYPE, API_RUNTIME, SEC::DATA_TYPES}},

--- a/src/Statistics.cpp
+++ b/src/Statistics.cpp
@@ -367,7 +367,7 @@ void Statistics::setActive(const std::string &name) {
 bool Statistics::isToRoc(const hipCounter &counter) {
   return (counter.apiType == API_BLAS || counter.apiType == API_DNN || counter.apiType == API_SPARSE || counter.apiType == API_SOLVER ||
           counter.apiType == API_RUNTIME || counter.apiType == API_COMPLEX || counter.apiType == API_RAND) &&
-          ((TranslateToRoc && !TranslateToMIOpen && !isRocMiopenOnly(counter)) || TranslateToMIOpen);
+          ((TranslateToRoc && !TranslateToMIOpen) || TranslateToMIOpen);
 }
 
 bool Statistics::isHipExperimental(const hipCounter &counter) {
@@ -436,10 +436,6 @@ bool Statistics::isRemoved(const hipCounter &counter) {
 
 bool Statistics::isHipSupportedV2Only(const hipCounter &counter) {
   return HIP_SUPPORTED_V2_ONLY == (counter.supportDegree & HIP_SUPPORTED_V2_ONLY);
-}
-
-bool Statistics::isRocMiopenOnly(const hipCounter &counter) {
-  return ROC_MIOPEN_ONLY == (counter.supportDegree & ROC_MIOPEN_ONLY);
 }
 
 bool Statistics::isCudaOverloaded(const hipCounter &counter) {

--- a/src/Statistics.h
+++ b/src/Statistics.h
@@ -197,8 +197,7 @@ enum SupportDegree {
   REMOVED = 0x400,
   HIP_EXPERIMENTAL = 0x800,
   HIP_SUPPORTED_V2_ONLY = 0x1000,
-  ROC_MIOPEN_ONLY = 0x2000,
-  CUDA_OVERLOADED = 0x4000
+  CUDA_OVERLOADED = 0x2000
 };
 
 enum cudaVersions {
@@ -503,8 +502,6 @@ public:
   static bool isRemoved(const hipCounter &counter);
   // Check whether the counter is HIP_SUPPORTED_V2_ONLY or not.
   static bool isHipSupportedV2Only(const hipCounter &counter);
-  // Check whether the counter is ROC_MIOPEN_ONLY or not.
-  static bool isRocMiopenOnly(const hipCounter &counter);
   // Check whether the counter is CUDA_OVERLOADED or not.
   static bool isCudaOverloaded(const hipCounter &counter);
   // Get string CUDA version.

--- a/tests/unit_tests/synthetic/libraries/cudnn2miopen.cu
+++ b/tests/unit_tests/synthetic/libraries/cudnn2miopen.cu
@@ -56,7 +56,7 @@ int main() {
   // CHECK: const_ch = miopenGetErrorString(status);
   const_ch = cudnnGetErrorString(status);
 
-  // CHECK: miopenAcceleratorQueue_t streamId;
+  // CHECK: hipStream_t streamId;
   cudaStream_t streamId;
 
   // CUDA: cudnnStatus_t CUDNNWINAPI cudnnSetStream(cudnnHandle_t handle, cudaStream_t streamId);


### PR DESCRIPTION
+ Use `hipStream_t` instead
+ [Reason] `miopen.h`: typedef hipStream_t miopenAcceleratorQueue_t;
+ Get rid of `ROC_MIOPEN_ONLY` flag, too
+ [Reason] `ROC_MIOPEN_ONLY` was used only for `cudaStream_t` to `miopenAcceleratorQueue_t` hipification (if the `--miopen` option is used)
+ Now `cudaStream_t` is always hipified to `hipStream_t` for both `ROC` and `HIP` targets