### PR TITLE
[HIPIFY][6.3.0][BLAS] Sync with `hipBLAS` and `rocBLAS` - Step 9

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -1715,6 +1715,7 @@ sub rocSubstitutions {
     subst("cublasCsyrk_v2", "rocblas_csyrk", "library");
     subst("cublasCsyrk_v2_64", "rocblas_csyrk_64", "library");
     subst("cublasCsyrkx", "rocblas_csyrkx", "library");
+    subst("cublasCsyrkx_64", "rocblas_csyrkx_64", "library");
     subst("cublasCtbmv", "rocblas_ctbmv", "library");
     subst("cublasCtbmv_64", "rocblas_ctbmv_64", "library");
     subst("cublasCtbmv_v2", "rocblas_ctbmv", "library");
@@ -1860,6 +1861,7 @@ sub rocSubstitutions {
     subst("cublasDsyrk_v2", "rocblas_dsyrk", "library");
     subst("cublasDsyrk_v2_64", "rocblas_dsyrk_64", "library");
     subst("cublasDsyrkx", "rocblas_dsyrkx", "library");
+    subst("cublasDsyrkx_64", "rocblas_dsyrkx_64", "library");
     subst("cublasDtbmv", "rocblas_dtbmv", "library");
     subst("cublasDtbmv_64", "rocblas_dtbmv_64", "library");
     subst("cublasDtbmv_v2", "rocblas_dtbmv", "library");
@@ -2092,6 +2094,7 @@ sub rocSubstitutions {
     subst("cublasSsyrk_v2", "rocblas_ssyrk", "library");
     subst("cublasSsyrk_v2_64", "rocblas_ssyrk_64", "library");
     subst("cublasSsyrkx", "rocblas_ssyrkx", "library");
+    subst("cublasSsyrkx_64", "rocblas_ssyrkx_64", "library");
     subst("cublasStbmv", "rocblas_stbmv", "library");
     subst("cublasStbmv_64", "rocblas_stbmv_64", "library");
     subst("cublasStbmv_v2", "rocblas_stbmv", "library");
@@ -2265,6 +2268,7 @@ sub rocSubstitutions {
     subst("cublasZsyrk_v2", "rocblas_zsyrk", "library");
     subst("cublasZsyrk_v2_64", "rocblas_zsyrk_64", "library");
     subst("cublasZsyrkx", "rocblas_zsyrkx", "library");
+    subst("cublasZsyrkx_64", "rocblas_zsyrkx_64", "library");
     subst("cublasZtbmv", "rocblas_ztbmv", "library");
     subst("cublasZtbmv_64", "rocblas_ztbmv_64", "library");
     subst("cublasZtbmv_v2", "rocblas_ztbmv", "library");
@@ -4493,6 +4497,7 @@ sub simpleSubstitutions {
     subst("cublasCsyrk_v2", "hipblasCsyrk_v2", "library");
     subst("cublasCsyrk_v2_64", "hipblasCsyrk_v2_64", "library");
     subst("cublasCsyrkx", "hipblasCsyrkx_v2", "library");
+    subst("cublasCsyrkx_64", "hipblasCsyrkx_v2_64", "library");
     subst("cublasCtbmv", "hipblasCtbmv_v2", "library");
     subst("cublasCtbmv_64", "hipblasCtbmv_v2_64", "library");
     subst("cublasCtbmv_v2", "hipblasCtbmv_v2", "library");
@@ -4639,6 +4644,7 @@ sub simpleSubstitutions {
     subst("cublasDsyrk_v2", "hipblasDsyrk", "library");
     subst("cublasDsyrk_v2_64", "hipblasDsyrk_64", "library");
     subst("cublasDsyrkx", "hipblasDsyrkx", "library");
+    subst("cublasDsyrkx_64", "hipblasDsyrkx_64", "library");
     subst("cublasDtbmv", "hipblasDtbmv", "library");
     subst("cublasDtbmv_64", "hipblasDtbmv_64", "library");
     subst("cublasDtbmv_v2", "hipblasDtbmv", "library");
@@ -4882,6 +4888,7 @@ sub simpleSubstitutions {
     subst("cublasSsyrk_v2", "hipblasSsyrk", "library");
     subst("cublasSsyrk_v2_64", "hipblasSsyrk_64", "library");
     subst("cublasSsyrkx", "hipblasSsyrkx", "library");
+    subst("cublasSsyrkx_64", "hipblasSsyrkx_64", "library");
     subst("cublasStbmv", "hipblasStbmv", "library");
     subst("cublasStbmv_64", "hipblasStbmv_64", "library");
     subst("cublasStbmv_v2", "hipblasStbmv", "library");
@@ -5048,6 +5055,7 @@ sub simpleSubstitutions {
     subst("cublasZsyrk_v2", "hipblasZsyrk_v2", "library");
     subst("cublasZsyrk_v2_64", "hipblasZsyrk_v2_64", "library");
     subst("cublasZsyrkx", "hipblasZsyrkx_v2", "library");
+    subst("cublasZsyrkx_64", "hipblasZsyrkx_v2_64", "library");
     subst("cublasZtbmv", "hipblasZtbmv_v2", "library");
     subst("cublasZtbmv_64", "hipblasZtbmv_v2_64", "library");
     subst("cublasZtbmv_v2", "hipblasZtbmv_v2", "library");
@@ -11611,7 +11619,6 @@ sub warnHipOnlyUnsupportedFunctions {
         "cublasZtrmm_v2_64",
         "cublasZtrmm_64",
         "cublasZtpttr",
-        "cublasZsyrkx_64",
         "cublasZmatinvBatched",
         "cublasZhemm_v2_64",
         "cublasZhemm_64",
@@ -11638,7 +11645,6 @@ sub warnHipOnlyUnsupportedFunctions {
         "cublasStrmm_v2_64",
         "cublasStrmm_64",
         "cublasStpttr",
-        "cublasSsyrkx_64",
         "cublasSmatinvBatched",
         "cublasShutdown",
         "cublasSgemmGroupedBatched_64",
@@ -11736,7 +11742,6 @@ sub warnHipOnlyUnsupportedFunctions {
         "cublasDtrmm_v2_64",
         "cublasDtrmm_64",
         "cublasDtpttr",
-        "cublasDsyrkx_64",
         "cublasDmatinvBatched",
         "cublasDgemmGroupedBatched_64",
         "cublasDgemmGroupedBatched",
@@ -11749,7 +11754,6 @@ sub warnHipOnlyUnsupportedFunctions {
         "cublasCtrmm_v2_64",
         "cublasCtrmm_64",
         "cublasCtpttr",
-        "cublasCsyrkx_64",
         "cublasCsyrkEx_64",
         "cublasCsyrkEx",
         "cublasCsyrk3mEx_64",
@@ -13580,7 +13584,6 @@ sub warnRocOnlyUnsupportedFunctions {
         "cublasZtrmm_v2_64",
         "cublasZtrmm_64",
         "cublasZtpttr",
-        "cublasZsyrkx_64",
         "cublasZmatinvBatched",
         "cublasZhemm_v2_64",
         "cublasZhemm_64",
@@ -13601,7 +13604,6 @@ sub warnRocOnlyUnsupportedFunctions {
         "cublasStrmm_v2_64",
         "cublasStrmm_64",
         "cublasStpttr",
-        "cublasSsyrkx_64",
         "cublasSmatinvBatched",
         "cublasShutdown",
         "cublasSgetrsBatched",
@@ -13718,7 +13720,6 @@ sub warnRocOnlyUnsupportedFunctions {
         "cublasDtrmm_v2_64",
         "cublasDtrmm_64",
         "cublasDtpttr",
-        "cublasDsyrkx_64",
         "cublasDmatinvBatched",
         "cublasDgetrsBatched",
         "cublasDgetriBatched",
@@ -13733,7 +13734,6 @@ sub warnRocOnlyUnsupportedFunctions {
         "cublasCtrmm_v2_64",
         "cublasCtrmm_64",
         "cublasCtpttr",
-        "cublasCsyrkx_64",
         "cublasCsyrkEx_64",
         "cublasCsyrkEx",
         "cublasCsyrk3mEx_64",

--- a/docs/tables/CUBLAS_API_supported_by_HIP.md
+++ b/docs/tables/CUBLAS_API_supported_by_HIP.md
@@ -1383,7 +1383,7 @@
 |`cublasCsyrk_v2`| | | | |`hipblasCsyrk_v2`|6.0.0| | | | |
 |`cublasCsyrk_v2_64`|12.0| | | |`hipblasCsyrk_v2_64`|6.3.0| | | |6.3.0|
 |`cublasCsyrkx`| | | | |`hipblasCsyrkx_v2`|6.0.0| | | | |
-|`cublasCsyrkx_64`|12.0| | | | | | | | | |
+|`cublasCsyrkx_64`|12.0| | | |`hipblasCsyrkx_v2_64`|6.3.0| | | |6.3.0|
 |`cublasCtrmm`| | | | |`hipblasCtrmm_v2`|6.0.0| | | | |
 |`cublasCtrmm_64`|12.0| | | | | | | | | |
 |`cublasCtrmm_v2`| | | | |`hipblasCtrmm_v2`|6.0.0| | | | |
@@ -1419,7 +1419,7 @@
 |`cublasDsyrk_v2`| | | | |`hipblasDsyrk`|3.5.0| | | | |
 |`cublasDsyrk_v2_64`|12.0| | | |`hipblasDsyrk_64`|6.3.0| | | |6.3.0|
 |`cublasDsyrkx`| | | | |`hipblasDsyrkx`|3.5.0| | | | |
-|`cublasDsyrkx_64`|12.0| | | | | | | | | |
+|`cublasDsyrkx_64`|12.0| | | |`hipblasDsyrkx_64`|6.3.0| | | |6.3.0|
 |`cublasDtrmm`| | | | |`hipblasDtrmm`|3.2.0| |6.0.0| | |
 |`cublasDtrmm_64`|12.0| | | | | | | | | |
 |`cublasDtrmm_v2`| | | | |`hipblasDtrmm`|3.2.0| |6.0.0| | |
@@ -1471,7 +1471,7 @@
 |`cublasSsyrk_v2`| | | | |`hipblasSsyrk`|3.5.0| | | | |
 |`cublasSsyrk_v2_64`|12.0| | | |`hipblasSsyrk_64`|6.3.0| | | |6.3.0|
 |`cublasSsyrkx`| | | | |`hipblasSsyrkx`|3.5.0| | | | |
-|`cublasSsyrkx_64`|12.0| | | | | | | | | |
+|`cublasSsyrkx_64`|12.0| | | |`hipblasSsyrkx_64`|6.3.0| | | |6.3.0|
 |`cublasStrmm`| | | | |`hipblasStrmm`|3.2.0| |6.0.0| | |
 |`cublasStrmm_64`|12.0| | | | | | | | | |
 |`cublasStrmm_v2`| | | | |`hipblasStrmm`|3.2.0| |6.0.0| | |
@@ -1529,7 +1529,7 @@
 |`cublasZsyrk_v2`| | | | |`hipblasZsyrk_v2`|6.0.0| | | | |
 |`cublasZsyrk_v2_64`|12.0| | | |`hipblasZsyrk_v2_64`|6.3.0| | | |6.3.0|
 |`cublasZsyrkx`| | | | |`hipblasZsyrkx_v2`|6.0.0| | | | |
-|`cublasZsyrkx_64`|12.0| | | | | | | | | |
+|`cublasZsyrkx_64`|12.0| | | |`hipblasZsyrkx_v2_64`|6.3.0| | | |6.3.0|
 |`cublasZtrmm`| | | | |`hipblasZtrmm_v2`|6.0.0| | | | |
 |`cublasZtrmm_64`|12.0| | | | | | | | | |
 |`cublasZtrmm_v2`| | | | |`hipblasZtrmm_v2`|6.0.0| | | | |

--- a/docs/tables/CUBLAS_API_supported_by_HIP_and_ROC.md
+++ b/docs/tables/CUBLAS_API_supported_by_HIP_and_ROC.md
@@ -1383,7 +1383,7 @@
 |`cublasCsyrk_v2`| | | | |`hipblasCsyrk_v2`|6.0.0| | | | |`rocblas_csyrk`|3.5.0| | | | |
 |`cublasCsyrk_v2_64`|12.0| | | |`hipblasCsyrk_v2_64`|6.3.0| | | |6.3.0|`rocblas_csyrk_64`|6.3.0| | | |6.3.0|
 |`cublasCsyrkx`| | | | |`hipblasCsyrkx_v2`|6.0.0| | | | |`rocblas_csyrkx`|3.5.0| | | | |
-|`cublasCsyrkx_64`|12.0| | | | | | | | | | | | | | | |
+|`cublasCsyrkx_64`|12.0| | | |`hipblasCsyrkx_v2_64`|6.3.0| | | |6.3.0|`rocblas_csyrkx_64`|6.3.0| | | |6.3.0|
 |`cublasCtrmm`| | | | |`hipblasCtrmm_v2`|6.0.0| | | | |`rocblas_ctrmm`|3.5.0| |6.0.0| | |
 |`cublasCtrmm_64`|12.0| | | | | | | | | | | | | | | |
 |`cublasCtrmm_v2`| | | | |`hipblasCtrmm_v2`|6.0.0| | | | |`rocblas_ctrmm`|3.5.0| |6.0.0| | |
@@ -1419,7 +1419,7 @@
 |`cublasDsyrk_v2`| | | | |`hipblasDsyrk`|3.5.0| | | | |`rocblas_dsyrk`|3.5.0| | | | |
 |`cublasDsyrk_v2_64`|12.0| | | |`hipblasDsyrk_64`|6.3.0| | | |6.3.0|`rocblas_dsyrk_64`|6.3.0| | | |6.3.0|
 |`cublasDsyrkx`| | | | |`hipblasDsyrkx`|3.5.0| | | | |`rocblas_dsyrkx`|3.5.0| | | | |
-|`cublasDsyrkx_64`|12.0| | | | | | | | | | | | | | | |
+|`cublasDsyrkx_64`|12.0| | | |`hipblasDsyrkx_64`|6.3.0| | | |6.3.0|`rocblas_dsyrkx_64`|6.3.0| | | |6.3.0|
 |`cublasDtrmm`| | | | |`hipblasDtrmm`|3.2.0| |6.0.0| | |`rocblas_dtrmm`|3.5.0| |6.0.0| | |
 |`cublasDtrmm_64`|12.0| | | | | | | | | | | | | | | |
 |`cublasDtrmm_v2`| | | | |`hipblasDtrmm`|3.2.0| |6.0.0| | |`rocblas_dtrmm`|3.5.0| |6.0.0| | |
@@ -1471,7 +1471,7 @@
 |`cublasSsyrk_v2`| | | | |`hipblasSsyrk`|3.5.0| | | | |`rocblas_ssyrk`|3.5.0| | | | |
 |`cublasSsyrk_v2_64`|12.0| | | |`hipblasSsyrk_64`|6.3.0| | | |6.3.0|`rocblas_ssyrk_64`|6.3.0| | | |6.3.0|
 |`cublasSsyrkx`| | | | |`hipblasSsyrkx`|3.5.0| | | | |`rocblas_ssyrkx`|3.5.0| | | | |
-|`cublasSsyrkx_64`|12.0| | | | | | | | | | | | | | | |
+|`cublasSsyrkx_64`|12.0| | | |`hipblasSsyrkx_64`|6.3.0| | | |6.3.0|`rocblas_ssyrkx_64`|6.3.0| | | |6.3.0|
 |`cublasStrmm`| | | | |`hipblasStrmm`|3.2.0| |6.0.0| | |`rocblas_strmm`|3.5.0| |6.0.0| | |
 |`cublasStrmm_64`|12.0| | | | | | | | | | | | | | | |
 |`cublasStrmm_v2`| | | | |`hipblasStrmm`|3.2.0| |6.0.0| | |`rocblas_strmm`|3.5.0| |6.0.0| | |
@@ -1529,7 +1529,7 @@
 |`cublasZsyrk_v2`| | | | |`hipblasZsyrk_v2`|6.0.0| | | | |`rocblas_zsyrk`|3.5.0| | | | |
 |`cublasZsyrk_v2_64`|12.0| | | |`hipblasZsyrk_v2_64`|6.3.0| | | |6.3.0|`rocblas_zsyrk_64`|6.3.0| | | |6.3.0|
 |`cublasZsyrkx`| | | | |`hipblasZsyrkx_v2`|6.0.0| | | | |`rocblas_zsyrkx`|3.5.0| | | | |
-|`cublasZsyrkx_64`|12.0| | | | | | | | | | | | | | | |
+|`cublasZsyrkx_64`|12.0| | | |`hipblasZsyrkx_v2_64`|6.3.0| | | |6.3.0|`rocblas_zsyrkx_64`|6.3.0| | | |6.3.0|
 |`cublasZtrmm`| | | | |`hipblasZtrmm_v2`|6.0.0| | | | |`rocblas_ztrmm`|3.5.0| |6.0.0| | |
 |`cublasZtrmm_64`|12.0| | | | | | | | | | | | | | | |
 |`cublasZtrmm_v2`| | | | |`hipblasZtrmm_v2`|6.0.0| | | | |`rocblas_ztrmm`|3.5.0| |6.0.0| | |

--- a/docs/tables/CUBLAS_API_supported_by_ROC.md
+++ b/docs/tables/CUBLAS_API_supported_by_ROC.md
@@ -1383,7 +1383,7 @@
 |`cublasCsyrk_v2`| | | | |`rocblas_csyrk`|3.5.0| | | | |
 |`cublasCsyrk_v2_64`|12.0| | | |`rocblas_csyrk_64`|6.3.0| | | |6.3.0|
 |`cublasCsyrkx`| | | | |`rocblas_csyrkx`|3.5.0| | | | |
-|`cublasCsyrkx_64`|12.0| | | | | | | | | |
+|`cublasCsyrkx_64`|12.0| | | |`rocblas_csyrkx_64`|6.3.0| | | |6.3.0|
 |`cublasCtrmm`| | | | |`rocblas_ctrmm`|3.5.0| |6.0.0| | |
 |`cublasCtrmm_64`|12.0| | | | | | | | | |
 |`cublasCtrmm_v2`| | | | |`rocblas_ctrmm`|3.5.0| |6.0.0| | |
@@ -1419,7 +1419,7 @@
 |`cublasDsyrk_v2`| | | | |`rocblas_dsyrk`|3.5.0| | | | |
 |`cublasDsyrk_v2_64`|12.0| | | |`rocblas_dsyrk_64`|6.3.0| | | |6.3.0|
 |`cublasDsyrkx`| | | | |`rocblas_dsyrkx`|3.5.0| | | | |
-|`cublasDsyrkx_64`|12.0| | | | | | | | | |
+|`cublasDsyrkx_64`|12.0| | | |`rocblas_dsyrkx_64`|6.3.0| | | |6.3.0|
 |`cublasDtrmm`| | | | |`rocblas_dtrmm`|3.5.0| |6.0.0| | |
 |`cublasDtrmm_64`|12.0| | | | | | | | | |
 |`cublasDtrmm_v2`| | | | |`rocblas_dtrmm`|3.5.0| |6.0.0| | |
@@ -1471,7 +1471,7 @@
 |`cublasSsyrk_v2`| | | | |`rocblas_ssyrk`|3.5.0| | | | |
 |`cublasSsyrk_v2_64`|12.0| | | |`rocblas_ssyrk_64`|6.3.0| | | |6.3.0|
 |`cublasSsyrkx`| | | | |`rocblas_ssyrkx`|3.5.0| | | | |
-|`cublasSsyrkx_64`|12.0| | | | | | | | | |
+|`cublasSsyrkx_64`|12.0| | | |`rocblas_ssyrkx_64`|6.3.0| | | |6.3.0|
 |`cublasStrmm`| | | | |`rocblas_strmm`|3.5.0| |6.0.0| | |
 |`cublasStrmm_64`|12.0| | | | | | | | | |
 |`cublasStrmm_v2`| | | | |`rocblas_strmm`|3.5.0| |6.0.0| | |
@@ -1529,7 +1529,7 @@
 |`cublasZsyrk_v2`| | | | |`rocblas_zsyrk`|3.5.0| | | | |
 |`cublasZsyrk_v2_64`|12.0| | | |`rocblas_zsyrk_64`|6.3.0| | | |6.3.0|
 |`cublasZsyrkx`| | | | |`rocblas_zsyrkx`|3.5.0| | | | |
-|`cublasZsyrkx_64`|12.0| | | | | | | | | |
+|`cublasZsyrkx_64`|12.0| | | |`rocblas_zsyrkx_64`|6.3.0| | | |6.3.0|
 |`cublasZtrmm`| | | | |`rocblas_ztrmm`|3.5.0| |6.0.0| | |
 |`cublasZtrmm_64`|12.0| | | | | | | | | |
 |`cublasZtrmm_v2`| | | | |`rocblas_ztrmm`|3.5.0| |6.0.0| | |

--- a/src/CUDA2HIP_BLAS_API_functions.cpp
+++ b/src/CUDA2HIP_BLAS_API_functions.cpp
@@ -503,13 +503,13 @@ const std::map<llvm::StringRef, hipCounter> CUDA_BLAS_FUNCTION_MAP {
 
   // SYRKX - eXtended SYRK
   {"cublasSsyrkx",                                         {"hipblasSsyrkx",                                             "rocblas_ssyrkx",                                     CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3}},
-  {"cublasSsyrkx_64",                                      {"hipblasSsyrkx_64",                                          "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3, UNSUPPORTED}},
+  {"cublasSsyrkx_64",                                      {"hipblasSsyrkx_64",                                          "rocblas_ssyrkx_64",                                  CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3}},
   {"cublasDsyrkx",                                         {"hipblasDsyrkx",                                             "rocblas_dsyrkx",                                     CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3}},
-  {"cublasDsyrkx_64",                                      {"hipblasDsyrkx_64",                                          "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3, UNSUPPORTED}},
+  {"cublasDsyrkx_64",                                      {"hipblasDsyrkx_64",                                          "rocblas_dsyrkx_64",                                  CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3}},
   {"cublasCsyrkx",                                         {"hipblasCsyrkx_v2",                                          "rocblas_csyrkx",                                     CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3}},
-  {"cublasCsyrkx_64",                                      {"hipblasCsyrkx_64",                                          "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3, UNSUPPORTED}},
+  {"cublasCsyrkx_64",                                      {"hipblasCsyrkx_v2_64",                                       "rocblas_csyrkx_64",                                  CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3}},
   {"cublasZsyrkx",                                         {"hipblasZsyrkx_v2",                                          "rocblas_zsyrkx",                                     CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3}},
-  {"cublasZsyrkx_64",                                      {"hipblasZsyrkx_64",                                          "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3, UNSUPPORTED}},
+  {"cublasZsyrkx_64",                                      {"hipblasZsyrkx_v2_64",                                       "rocblas_zsyrkx_64",                                  CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3}},
 
   // HER2K
   {"cublasCher2k",                                         {"hipblasCher2k_v2",                                          "rocblas_cher2k",                                     CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3, HIP_SUPPORTED_V2_ONLY}},
@@ -2056,6 +2056,10 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_BLAS_FUNCTION_VER_MAP {
   {"hipblasDsyr2k_64",                                     {HIP_6030, HIP_0,    HIP_0,  HIP_LATEST}},
   {"hipblasCsyr2k_v2_64",                                  {HIP_6030, HIP_0,    HIP_0,  HIP_LATEST}},
   {"hipblasZsyr2k_v2_64",                                  {HIP_6030, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipblasSsyrkx_64",                                     {HIP_6030, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipblasDsyrkx_64",                                     {HIP_6030, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipblasCsyrkx_v2_64",                                  {HIP_6030, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipblasZsyrkx_v2_64",                                  {HIP_6030, HIP_0,    HIP_0,  HIP_LATEST}},
 
   {"rocblas_status_to_string",                             {HIP_3050, HIP_0,    HIP_0   }},
   {"rocblas_sscal",                                        {HIP_1050, HIP_0,    HIP_0   }},
@@ -2477,6 +2481,10 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_BLAS_FUNCTION_VER_MAP {
   {"rocblas_dsyr2k_64",                                    {HIP_6030, HIP_0,    HIP_0,  HIP_LATEST}},
   {"rocblas_csyr2k_64",                                    {HIP_6030, HIP_0,    HIP_0,  HIP_LATEST}},
   {"rocblas_zsyr2k_64",                                    {HIP_6030, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"rocblas_ssyrkx_64",                                    {HIP_6030, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"rocblas_dsyrkx_64",                                    {HIP_6030, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"rocblas_csyrkx_64",                                    {HIP_6030, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"rocblas_zsyrkx_64",                                    {HIP_6030, HIP_0,    HIP_0,  HIP_LATEST}},
 };
 
 const std::map<llvm::StringRef, hipAPIChangedVersions> HIP_BLAS_FUNCTION_CHANGED_VER_MAP {

--- a/tests/unit_tests/synthetic/libraries/cublas2hipblas_v2.cu
+++ b/tests/unit_tests/synthetic/libraries/cublas2hipblas_v2.cu
@@ -3030,6 +3030,26 @@ int main() {
   // CHECK-NEXT: blasStatus = hipblasZsyr2k_v2_64(blasHandle, blasFillMode, blasOperation, n_64, k_64, &dcomplexa, &dcomplexA, lda_64, &dcomplexB, ldb_64, &dcomplexb, &dcomplexC, ldc_64);
   blasStatus = cublasZsyr2k_64(blasHandle, blasFillMode, blasOperation, n_64, k_64, &dcomplexa, &dcomplexA, lda_64, &dcomplexB, ldb_64, &dcomplexb, &dcomplexC, ldc_64);
   blasStatus = cublasZsyr2k_v2_64(blasHandle, blasFillMode, blasOperation, n_64, k_64, &dcomplexa, &dcomplexA, lda_64, &dcomplexB, ldb_64, &dcomplexb, &dcomplexC, ldc_64);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasSsyrkx_64(cublasHandle_t handle, cublasFillMode_t uplo, cublasOperation_t trans, int64_t n, int64_t k, const float* alpha, const float* A, int64_t lda, const float* B, int64_t ldb, const float* beta, float* C, int64_t ldc);
+  // HIP: HIPBLAS_EXPORT hipblasStatus_t hipblasSsyrkx_64(hipblasHandle_t handle, hipblasFillMode_t uplo, hipblasOperation_t transA, int64_t n, int64_t k, const float* alpha, const float* AP, int64_t lda, const float* BP, int64_t ldb, const float* beta, float* CP, int64_t ldc);
+  // CHECK: blasStatus = hipblasSsyrkx_64(blasHandle, blasFillMode, blasOperation, n_64, k_64, &fa, &fA, lda_64, &fB, ldb_64, &fb, &fC, ldc_64);
+  blasStatus = cublasSsyrkx_64(blasHandle, blasFillMode, blasOperation, n_64, k_64, &fa, &fA, lda_64, &fB, ldb_64, &fb, &fC, ldc_64);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasDsyrkx_64(cublasHandle_t handle, cublasFillMode_t uplo, cublasOperation_t trans, int64_t n, int64_t k, const double* alpha, const double* A, int64_t lda, const double* B, int64_t ldb, const double* beta, double* C, int64_t ldc);
+  // HIP: HIPBLAS_EXPORT hipblasStatus_t hipblasDsyrkx_64(hipblasHandle_t handle, hipblasFillMode_t uplo, hipblasOperation_t transA, int64_t n, int64_t k, const double* alpha, const double* AP, int64_t lda, const double* BP, int64_t ldb, const double* beta, double* CP, int64_t ldc);
+  // CHECK: blasStatus = hipblasDsyrkx_64(blasHandle, blasFillMode, blasOperation, n_64, k_64, &da, &dA, lda_64, &dB, ldb_64, &db, &dC, ldc_64);
+  blasStatus = cublasDsyrkx_64(blasHandle, blasFillMode, blasOperation, n_64, k_64, &da, &dA, lda_64, &dB, ldb_64, &db, &dC, ldc_64);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasCsyrkx_64(cublasHandle_t handle, cublasFillMode_t uplo, cublasOperation_t trans, int64_t n, int64_t k, const cuComplex* alpha, const cuComplex* A, int64_t lda, const cuComplex* B, int64_t ldb, const cuComplex* beta, cuComplex* C, int64_t ldc);
+  // HIP: HIPBLAS_EXPORT hipblasStatus_t hipblasCsyrkx_v2_64(hipblasHandle_t handle, hipblasFillMode_t uplo, hipblasOperation_t transA, int64_t n, int64_t k, const hipComplex* alpha, const hipComplex* AP, int64_t lda, const hipComplex* BP, int64_t ldb, const hipComplex* beta, hipComplex* CP, int64_t ldc);
+  // CHECK: blasStatus = hipblasCsyrkx_v2_64(blasHandle, blasFillMode, blasOperation, n_64, k_64, &complexa, &complexA, lda_64, &complexB, ldb_64, &complexb, &complexC, ldc_64);
+  blasStatus = cublasCsyrkx_64(blasHandle, blasFillMode, blasOperation, n_64, k_64, &complexa, &complexA, lda_64, &complexB, ldb_64, &complexb, &complexC, ldc_64);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasZsyrkx_64(cublasHandle_t handle, cublasFillMode_t uplo, cublasOperation_t trans, int64_t n, int64_t k, const cuDoubleComplex* alpha, const cuDoubleComplex* A, int64_t lda, const cuDoubleComplex* B, int64_t ldb, const cuDoubleComplex* beta, cuDoubleComplex* C, int64_t ldc);
+  // HIP: HIPBLAS_EXPORT hipblasStatus_t hipblasZsyrkx_v2_64(hipblasHandle_t handle, hipblasFillMode_t uplo, hipblasOperation_t transA, int64_t n, int64_t k, const hipDoubleComplex* alpha, const hipDoubleComplex* AP, int64_t lda, const hipDoubleComplex* BP, int64_t ldb, const hipDoubleComplex* beta, hipDoubleComplex* CP, int64_t ldc);
+  // CHECK: blasStatus = hipblasZsyrkx_v2_64(blasHandle, blasFillMode, blasOperation, n_64, k_64, &dcomplexa, &dcomplexA, lda_64, &dcomplexB, ldb_64, &dcomplexb, &dcomplexC, ldc_64);
+  blasStatus = cublasZsyrkx_64(blasHandle, blasFillMode, blasOperation, n_64, k_64, &dcomplexa, &dcomplexA, lda_64, &dcomplexB, ldb_64, &dcomplexb, &dcomplexC, ldc_64);
 #endif
 
   return 0;

--- a/tests/unit_tests/synthetic/libraries/cublas2rocblas_v2.cu
+++ b/tests/unit_tests/synthetic/libraries/cublas2rocblas_v2.cu
@@ -3235,6 +3235,26 @@ int main() {
   // CHECK-NEXT: blasStatus = rocblas_zsyr2k_64(blasHandle, blasFillMode, blasOperation, n_64, k_64, &dcomplexa, &dcomplexA, lda_64, &dcomplexB, ldb_64, &dcomplexb, &dcomplexC, ldc_64);
   blasStatus = cublasZsyr2k_64(blasHandle, blasFillMode, blasOperation, n_64, k_64, &dcomplexa, &dcomplexA, lda_64, &dcomplexB, ldb_64, &dcomplexb, &dcomplexC, ldc_64);
   blasStatus = cublasZsyr2k_v2_64(blasHandle, blasFillMode, blasOperation, n_64, k_64, &dcomplexa, &dcomplexA, lda_64, &dcomplexB, ldb_64, &dcomplexb, &dcomplexC, ldc_64);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasSsyrkx_64(cublasHandle_t handle, cublasFillMode_t uplo, cublasOperation_t trans, int64_t n, int64_t k, const float* alpha, const float* A, int64_t lda, const float* B, int64_t ldb, const float* beta, float* C, int64_t ldc);
+  // ROC: ROCBLAS_EXPORT rocblas_status rocblas_ssyrkx_64(rocblas_handle handle, rocblas_fill uplo, rocblas_operation trans, int64_t n, int64_t k, const float* alpha, const float* A, int64_t lda, const float* B, int64_t ldb, const float* beta, float* C, int64_t ldc);
+  // CHECK: blasStatus = rocblas_ssyrkx_64(blasHandle, blasFillMode, blasOperation, n_64, k_64, &fa, &fA, lda_64, &fB, ldb_64, &fb, &fC, ldc_64);
+  blasStatus = cublasSsyrkx_64(blasHandle, blasFillMode, blasOperation, n_64, k_64, &fa, &fA, lda_64, &fB, ldb_64, &fb, &fC, ldc_64);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasDsyrkx_64(cublasHandle_t handle, cublasFillMode_t uplo, cublasOperation_t trans, int64_t n, int64_t k, const double* alpha, const double* A, int64_t lda, const double* B, int64_t ldb, const double* beta, double* C, int64_t ldc);
+  // ROC: ROCBLAS_EXPORT rocblas_status rocblas_dsyrkx_64(rocblas_handle handle, rocblas_fill uplo, rocblas_operation trans, int64_t n, int64_t k, const double* alpha, const double* A, int64_t lda, const double* B, int64_t ldb, const double* beta, double* C, int64_t ldc);
+  // CHECK: blasStatus = rocblas_dsyrkx_64(blasHandle, blasFillMode, blasOperation, n_64, k_64, &da, &dA, lda_64, &dB, ldb_64, &db, &dC, ldc_64);
+  blasStatus = cublasDsyrkx_64(blasHandle, blasFillMode, blasOperation, n_64, k_64, &da, &dA, lda_64, &dB, ldb_64, &db, &dC, ldc_64);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasCsyrkx_64(cublasHandle_t handle, cublasFillMode_t uplo, cublasOperation_t trans, int64_t n, int64_t k, const cuComplex* alpha, const cuComplex* A, int64_t lda, const cuComplex* B, int64_t ldb, const cuComplex* beta, cuComplex* C, int64_t ldc);
+  // ROC: ROCBLAS_EXPORT rocblas_status rocblas_csyrkx_64(rocblas_handle handle, rocblas_fill uplo, rocblas_operation trans, int64_t n, int64_t k, const rocblas_float_complex* alpha, const rocblas_float_complex* A, int64_t lda, const rocblas_float_complex* B, int64_t ldb, const rocblas_float_complex* beta, rocblas_float_complex* C, int64_t ldc);
+  // CHECK: blasStatus = rocblas_csyrkx_64(blasHandle, blasFillMode, blasOperation, n_64, k_64, &complexa, &complexA, lda_64, &complexB, ldb_64, &complexb, &complexC, ldc_64);
+  blasStatus = cublasCsyrkx_64(blasHandle, blasFillMode, blasOperation, n_64, k_64, &complexa, &complexA, lda_64, &complexB, ldb_64, &complexb, &complexC, ldc_64);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasZsyrkx_64(cublasHandle_t handle, cublasFillMode_t uplo, cublasOperation_t trans, int64_t n, int64_t k, const cuDoubleComplex* alpha, const cuDoubleComplex* A, int64_t lda, const cuDoubleComplex* B, int64_t ldb, const cuDoubleComplex* beta, cuDoubleComplex* C, int64_t ldc);
+  // ROC: ROCBLAS_EXPORT rocblas_status rocblas_zsyrkx_64(rocblas_handle handle, rocblas_fill uplo, rocblas_operation trans, int64_t n, int64_t k, const rocblas_double_complex* alpha, const rocblas_double_complex* A, int64_t lda, const rocblas_double_complex* B, int64_t ldb, const rocblas_double_complex* beta, rocblas_double_complex* C, int64_t ldc);
+  // CHECK: blasStatus = rocblas_zsyrkx_64(blasHandle, blasFillMode, blasOperation, n_64, k_64, &dcomplexa, &dcomplexA, lda_64, &dcomplexB, ldb_64, &dcomplexb, &dcomplexC, ldc_64);
+  blasStatus = cublasZsyrkx_64(blasHandle, blasFillMode, blasOperation, n_64, k_64, &dcomplexa, &dcomplexA, lda_64, &dcomplexB, ldb_64, &dcomplexb, &dcomplexC, ldc_64);
 #endif
 
   return 0;


### PR DESCRIPTION
+ `rocblas_(s|d|c|z)syrkx_64` and `hipblas(S|D|C|Z)syrkx(_v2)?_64` support
+ Updated synthetic tests, the regenerated `hipify-perl`, and `BLAS` `CUDA2HIP` documentation