### PR TITLE
[HIPIFY][6.3.0][BLAS] Sync with `hipBLAS` and `rocBLAS` - Step 10

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -1602,6 +1602,7 @@ sub rocSubstitutions {
     subst("cublasCgbmv_v2", "rocblas_cgbmv", "library");
     subst("cublasCgbmv_v2_64", "rocblas_cgbmv_64", "library");
     subst("cublasCgeam", "rocblas_cgeam", "library");
+    subst("cublasCgeam_64", "rocblas_cgeam_64", "library");
     subst("cublasCgemm", "rocblas_cgemm", "library");
     subst("cublasCgemmBatched", "rocblas_cgemm_batched", "library");
     subst("cublasCgemmBatched_64", "rocblas_cgemm_batched_64", "library");
@@ -1772,6 +1773,7 @@ sub rocSubstitutions {
     subst("cublasDgbmv_v2", "rocblas_dgbmv", "library");
     subst("cublasDgbmv_v2_64", "rocblas_dgbmv_64", "library");
     subst("cublasDgeam", "rocblas_dgeam", "library");
+    subst("cublasDgeam_64", "rocblas_dgeam_64", "library");
     subst("cublasDgemm", "rocblas_dgemm", "library");
     subst("cublasDgemmBatched", "rocblas_dgemm_batched", "library");
     subst("cublasDgemmBatched_64", "rocblas_dgemm_batched_64", "library");
@@ -2009,6 +2011,7 @@ sub rocSubstitutions {
     subst("cublasSgbmv_v2", "rocblas_sgbmv", "library");
     subst("cublasSgbmv_v2_64", "rocblas_sgbmv_64", "library");
     subst("cublasSgeam", "rocblas_sgeam", "library");
+    subst("cublasSgeam_64", "rocblas_sgeam_64", "library");
     subst("cublasSgemm", "rocblas_sgemm", "library");
     subst("cublasSgemmBatched", "rocblas_sgemm_batched", "library");
     subst("cublasSgemmBatched_64", "rocblas_sgemm_batched_64", "library");
@@ -2165,6 +2168,7 @@ sub rocSubstitutions {
     subst("cublasZgbmv_v2", "rocblas_zgbmv", "library");
     subst("cublasZgbmv_v2_64", "rocblas_zgbmv_64", "library");
     subst("cublasZgeam", "rocblas_zgeam", "library");
+    subst("cublasZgeam_64", "rocblas_zgeam_64", "library");
     subst("cublasZgemm", "rocblas_zgemm", "library");
     subst("cublasZgemmBatched", "rocblas_zgemm_batched", "library");
     subst("cublasZgemmBatched_64", "rocblas_zgemm_batched_64", "library");
@@ -4380,6 +4384,7 @@ sub simpleSubstitutions {
     subst("cublasCgbmv_v2", "hipblasCgbmv_v2", "library");
     subst("cublasCgbmv_v2_64", "hipblasCgbmv_v2_64", "library");
     subst("cublasCgeam", "hipblasCgeam_v2", "library");
+    subst("cublasCgeam_64", "hipblasCgeam_v2_64", "library");
     subst("cublasCgelsBatched", "hipblasCgelsBatched_v2", "library");
     subst("cublasCgemm", "hipblasCgemm_v2", "library");
     subst("cublasCgemmBatched", "hipblasCgemmBatched_v2", "library");
@@ -4551,6 +4556,7 @@ sub simpleSubstitutions {
     subst("cublasDgbmv_v2", "hipblasDgbmv", "library");
     subst("cublasDgbmv_v2_64", "hipblasDgbmv_64", "library");
     subst("cublasDgeam", "hipblasDgeam", "library");
+    subst("cublasDgeam_64", "hipblasDgeam_64", "library");
     subst("cublasDgelsBatched", "hipblasDgelsBatched", "library");
     subst("cublasDgemm", "hipblasDgemm", "library");
     subst("cublasDgemmBatched", "hipblasDgemmBatched", "library");
@@ -4799,6 +4805,7 @@ sub simpleSubstitutions {
     subst("cublasSgbmv_v2", "hipblasSgbmv", "library");
     subst("cublasSgbmv_v2_64", "hipblasSgbmv_64", "library");
     subst("cublasSgeam", "hipblasSgeam", "library");
+    subst("cublasSgeam_64", "hipblasSgeam_64", "library");
     subst("cublasSgelsBatched", "hipblasSgelsBatched", "library");
     subst("cublasSgemm", "hipblasSgemm", "library");
     subst("cublasSgemmBatched", "hipblasSgemmBatched", "library");
@@ -4948,6 +4955,7 @@ sub simpleSubstitutions {
     subst("cublasZgbmv_v2", "hipblasZgbmv_v2", "library");
     subst("cublasZgbmv_v2_64", "hipblasZgbmv_v2_64", "library");
     subst("cublasZgeam", "hipblasZgeam_v2", "library");
+    subst("cublasZgeam_64", "hipblasZgeam_v2_64", "library");
     subst("cublasZgelsBatched", "hipblasZgelsBatched_v2", "library");
     subst("cublasZgemm", "hipblasZgemm_v2", "library");
     subst("cublasZgemmBatched", "hipblasZgemmBatched_v2", "library");
@@ -11624,7 +11632,6 @@ sub warnHipOnlyUnsupportedFunctions {
         "cublasZhemm_64",
         "cublasZgemm3m_64",
         "cublasZgemm3m",
-        "cublasZgeam_64",
         "cublasZdgmm_64",
         "cublasXerbla",
         "cublasUint8gemmBias",
@@ -11651,7 +11658,6 @@ sub warnHipOnlyUnsupportedFunctions {
         "cublasSgemmGroupedBatched",
         "cublasSgemmEx_64",
         "cublasSgemmEx",
-        "cublasSgeam_64",
         "cublasSetVector_64",
         "cublasSetVectorAsync_64",
         "cublasSetSmCountTarget",
@@ -11745,7 +11751,6 @@ sub warnHipOnlyUnsupportedFunctions {
         "cublasDmatinvBatched",
         "cublasDgemmGroupedBatched_64",
         "cublasDgemmGroupedBatched",
-        "cublasDgeam_64",
         "cublasDdgmm_64",
         "cublasCtrttp",
         "cublasCtrsm_v2_64",
@@ -11778,7 +11783,6 @@ sub warnHipOnlyUnsupportedFunctions {
         "cublasCgemm3mBatched_64",
         "cublasCgemm3mBatched",
         "cublasCgemm3m",
-        "cublasCgeam_64",
         "cublasCdgmm_64",
         "cublasAsumEx_64",
         "cublasAsumEx",
@@ -13642,7 +13646,6 @@ sub warnRocOnlyUnsupportedFunctions {
         "cublasZgemm3m_64",
         "cublasZgemm3m",
         "cublasZgelsBatched",
-        "cublasZgeam_64",
         "cublasZdgmm_64",
         "cublasXerbla",
         "cublasUint8gemmBias",
@@ -13663,7 +13666,6 @@ sub warnRocOnlyUnsupportedFunctions {
         "cublasSgemmEx_64",
         "cublasSgemmEx",
         "cublasSgelsBatched",
-        "cublasSgeam_64",
         "cublasSetVector_64",
         "cublasSetVectorAsync_64",
         "cublasSetSmCountTarget",
@@ -13776,7 +13778,6 @@ sub warnRocOnlyUnsupportedFunctions {
         "cublasDgemmGroupedBatched_64",
         "cublasDgemmGroupedBatched",
         "cublasDgelsBatched",
-        "cublasDgeam_64",
         "cublasDdgmm_64",
         "cublasCtrttp",
         "cublasCtrmm_v2_64",
@@ -13810,7 +13811,6 @@ sub warnRocOnlyUnsupportedFunctions {
         "cublasCgemm3mBatched",
         "cublasCgemm3m",
         "cublasCgelsBatched",
-        "cublasCgeam_64",
         "cublasCdgmm_64",
         "cublasAsumEx_64",
         "cublasAsumEx",

--- a/docs/tables/CUBLAS_API_supported_by_HIP.md
+++ b/docs/tables/CUBLAS_API_supported_by_HIP.md
@@ -1598,7 +1598,7 @@
 |`cublasCdgmm`| | | | |`hipblasCdgmm_v2`|6.0.0| | | | |
 |`cublasCdgmm_64`|12.0| | | | | | | | | |
 |`cublasCgeam`| | | | |`hipblasCgeam_v2`|6.0.0| | | | |
-|`cublasCgeam_64`|12.0| | | | | | | | | |
+|`cublasCgeam_64`|12.0| | | |`hipblasCgeam_v2_64`|6.3.0| | | |6.3.0|
 |`cublasCgelsBatched`| | | | |`hipblasCgelsBatched_v2`|6.0.0| | | | |
 |`cublasCgemmEx`|8.0| | | | | | | | | |
 |`cublasCgemmEx_64`|12.0| | | | | | | | | |
@@ -1624,7 +1624,7 @@
 |`cublasDdgmm`| | | | |`hipblasDdgmm`|3.6.0| | | | |
 |`cublasDdgmm_64`|12.0| | | | | | | | | |
 |`cublasDgeam`| | | | |`hipblasDgeam`|1.8.2| | | | |
-|`cublasDgeam_64`|12.0| | | | | | | | | |
+|`cublasDgeam_64`|12.0| | | |`hipblasDgeam_64`|6.3.0| | | |6.3.0|
 |`cublasDgelsBatched`| | | | |`hipblasDgelsBatched`|5.4.0| | | | |
 |`cublasDgeqrfBatched`| | | | |`hipblasDgeqrfBatched`|3.5.0| | | | |
 |`cublasDgetrfBatched`| | | | |`hipblasDgetrfBatched`|3.5.0| | | | |
@@ -1660,7 +1660,7 @@
 |`cublasSdgmm`| | | | |`hipblasSdgmm`|3.6.0| | | | |
 |`cublasSdgmm_64`|12.0| | | | | | | | | |
 |`cublasSgeam`| | | | |`hipblasSgeam`|1.8.2| | | | |
-|`cublasSgeam_64`|12.0| | | | | | | | | |
+|`cublasSgeam_64`|12.0| | | |`hipblasSgeam_64`|6.3.0| | | |6.3.0|
 |`cublasSgelsBatched`| | | | |`hipblasSgelsBatched`|5.4.0| | | | |
 |`cublasSgemmEx`|7.5| | | | | | | | | |
 |`cublasSgemmEx_64`|12.0| | | | | | | | | |
@@ -1679,7 +1679,7 @@
 |`cublasZdgmm`| | | | |`hipblasZdgmm_v2`|6.0.0| | | | |
 |`cublasZdgmm_64`|12.0| | | | | | | | | |
 |`cublasZgeam`| | | | |`hipblasZgeam_v2`|6.0.0| | | | |
-|`cublasZgeam_64`|12.0| | | | | | | | | |
+|`cublasZgeam_64`|12.0| | | |`hipblasZgeam_v2_64`|6.3.0| | | |6.3.0|
 |`cublasZgelsBatched`| | | | |`hipblasZgelsBatched_v2`|6.0.0| | | | |
 |`cublasZgeqrfBatched`| | | | |`hipblasZgeqrfBatched_v2`|6.0.0| | | | |
 |`cublasZgetrfBatched`| | | | |`hipblasZgetrfBatched_v2`|6.0.0| | | | |

--- a/docs/tables/CUBLAS_API_supported_by_HIP_and_ROC.md
+++ b/docs/tables/CUBLAS_API_supported_by_HIP_and_ROC.md
@@ -1598,7 +1598,7 @@
 |`cublasCdgmm`| | | | |`hipblasCdgmm_v2`|6.0.0| | | | |`rocblas_cdgmm`|3.5.0| | | | |
 |`cublasCdgmm_64`|12.0| | | | | | | | | | | | | | | |
 |`cublasCgeam`| | | | |`hipblasCgeam_v2`|6.0.0| | | | |`rocblas_cgeam`|3.5.0| | | | |
-|`cublasCgeam_64`|12.0| | | | | | | | | | | | | | | |
+|`cublasCgeam_64`|12.0| | | |`hipblasCgeam_v2_64`|6.3.0| | | |6.3.0|`rocblas_cgeam_64`|6.3.0| | | |6.3.0|
 |`cublasCgelsBatched`| | | | |`hipblasCgelsBatched_v2`|6.0.0| | | | | | | | | | |
 |`cublasCgemmEx`|8.0| | | | | | | | | | | | | | | |
 |`cublasCgemmEx_64`|12.0| | | | | | | | | | | | | | | |
@@ -1624,7 +1624,7 @@
 |`cublasDdgmm`| | | | |`hipblasDdgmm`|3.6.0| | | | |`rocblas_ddgmm`|3.5.0| | | | |
 |`cublasDdgmm_64`|12.0| | | | | | | | | | | | | | | |
 |`cublasDgeam`| | | | |`hipblasDgeam`|1.8.2| | | | |`rocblas_dgeam`|1.6.4| | | | |
-|`cublasDgeam_64`|12.0| | | | | | | | | | | | | | | |
+|`cublasDgeam_64`|12.0| | | |`hipblasDgeam_64`|6.3.0| | | |6.3.0|`rocblas_dgeam_64`|6.3.0| | | |6.3.0|
 |`cublasDgelsBatched`| | | | |`hipblasDgelsBatched`|5.4.0| | | | | | | | | | |
 |`cublasDgeqrfBatched`| | | | |`hipblasDgeqrfBatched`|3.5.0| | | | | | | | | | |
 |`cublasDgetrfBatched`| | | | |`hipblasDgetrfBatched`|3.5.0| | | | | | | | | | |
@@ -1660,7 +1660,7 @@
 |`cublasSdgmm`| | | | |`hipblasSdgmm`|3.6.0| | | | |`rocblas_sdgmm`|3.5.0| | | | |
 |`cublasSdgmm_64`|12.0| | | | | | | | | | | | | | | |
 |`cublasSgeam`| | | | |`hipblasSgeam`|1.8.2| | | | |`rocblas_sgeam`|1.6.4| | | | |
-|`cublasSgeam_64`|12.0| | | | | | | | | | | | | | | |
+|`cublasSgeam_64`|12.0| | | |`hipblasSgeam_64`|6.3.0| | | |6.3.0|`rocblas_sgeam_64`|6.3.0| | | |6.3.0|
 |`cublasSgelsBatched`| | | | |`hipblasSgelsBatched`|5.4.0| | | | | | | | | | |
 |`cublasSgemmEx`|7.5| | | | | | | | | | | | | | | |
 |`cublasSgemmEx_64`|12.0| | | | | | | | | | | | | | | |
@@ -1679,7 +1679,7 @@
 |`cublasZdgmm`| | | | |`hipblasZdgmm_v2`|6.0.0| | | | |`rocblas_zdgmm`|3.5.0| | | | |
 |`cublasZdgmm_64`|12.0| | | | | | | | | | | | | | | |
 |`cublasZgeam`| | | | |`hipblasZgeam_v2`|6.0.0| | | | |`rocblas_zgeam`|3.5.0| | | | |
-|`cublasZgeam_64`|12.0| | | | | | | | | | | | | | | |
+|`cublasZgeam_64`|12.0| | | |`hipblasZgeam_v2_64`|6.3.0| | | |6.3.0|`rocblas_zgeam_64`|6.3.0| | | |6.3.0|
 |`cublasZgelsBatched`| | | | |`hipblasZgelsBatched_v2`|6.0.0| | | | | | | | | | |
 |`cublasZgeqrfBatched`| | | | |`hipblasZgeqrfBatched_v2`|6.0.0| | | | | | | | | | |
 |`cublasZgetrfBatched`| | | | |`hipblasZgetrfBatched_v2`|6.0.0| | | | | | | | | | |

--- a/docs/tables/CUBLAS_API_supported_by_ROC.md
+++ b/docs/tables/CUBLAS_API_supported_by_ROC.md
@@ -1598,7 +1598,7 @@
 |`cublasCdgmm`| | | | |`rocblas_cdgmm`|3.5.0| | | | |
 |`cublasCdgmm_64`|12.0| | | | | | | | | |
 |`cublasCgeam`| | | | |`rocblas_cgeam`|3.5.0| | | | |
-|`cublasCgeam_64`|12.0| | | | | | | | | |
+|`cublasCgeam_64`|12.0| | | |`rocblas_cgeam_64`|6.3.0| | | |6.3.0|
 |`cublasCgelsBatched`| | | | | | | | | | |
 |`cublasCgemmEx`|8.0| | | | | | | | | |
 |`cublasCgemmEx_64`|12.0| | | | | | | | | |
@@ -1624,7 +1624,7 @@
 |`cublasDdgmm`| | | | |`rocblas_ddgmm`|3.5.0| | | | |
 |`cublasDdgmm_64`|12.0| | | | | | | | | |
 |`cublasDgeam`| | | | |`rocblas_dgeam`|1.6.4| | | | |
-|`cublasDgeam_64`|12.0| | | | | | | | | |
+|`cublasDgeam_64`|12.0| | | |`rocblas_dgeam_64`|6.3.0| | | |6.3.0|
 |`cublasDgelsBatched`| | | | | | | | | | |
 |`cublasDgeqrfBatched`| | | | | | | | | | |
 |`cublasDgetrfBatched`| | | | | | | | | | |
@@ -1660,7 +1660,7 @@
 |`cublasSdgmm`| | | | |`rocblas_sdgmm`|3.5.0| | | | |
 |`cublasSdgmm_64`|12.0| | | | | | | | | |
 |`cublasSgeam`| | | | |`rocblas_sgeam`|1.6.4| | | | |
-|`cublasSgeam_64`|12.0| | | | | | | | | |
+|`cublasSgeam_64`|12.0| | | |`rocblas_sgeam_64`|6.3.0| | | |6.3.0|
 |`cublasSgelsBatched`| | | | | | | | | | |
 |`cublasSgemmEx`|7.5| | | | | | | | | |
 |`cublasSgemmEx_64`|12.0| | | | | | | | | |
@@ -1679,7 +1679,7 @@
 |`cublasZdgmm`| | | | |`rocblas_zdgmm`|3.5.0| | | | |
 |`cublasZdgmm_64`|12.0| | | | | | | | | |
 |`cublasZgeam`| | | | |`rocblas_zgeam`|3.5.0| | | | |
-|`cublasZgeam_64`|12.0| | | | | | | | | |
+|`cublasZgeam_64`|12.0| | | |`rocblas_zgeam_64`|6.3.0| | | |6.3.0|
 |`cublasZgelsBatched`| | | | | | | | | | |
 |`cublasZgeqrfBatched`| | | | | | | | | | |
 |`cublasZgetrfBatched`| | | | | | | | | | |

--- a/src/CUDA2HIP_BLAS_API_functions.cpp
+++ b/src/CUDA2HIP_BLAS_API_functions.cpp
@@ -562,13 +562,13 @@ const std::map<llvm::StringRef, hipCounter> CUDA_BLAS_FUNCTION_MAP {
   // ------------------------ CUBLAS BLAS - like extension (cublas_api.h)
   // GEAM
   {"cublasSgeam",                                          {"hipblasSgeam",                                              "rocblas_sgeam",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_EXT}},
-  {"cublasSgeam_64",                                       {"hipblasSgeam_64",                                           "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_EXT, UNSUPPORTED}},
+  {"cublasSgeam_64",                                       {"hipblasSgeam_64",                                           "rocblas_sgeam_64",                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_EXT}},
   {"cublasDgeam",                                          {"hipblasDgeam",                                              "rocblas_dgeam",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_EXT}},
-  {"cublasDgeam_64",                                       {"hipblasDgeam_64",                                           "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_EXT, UNSUPPORTED}},
+  {"cublasDgeam_64",                                       {"hipblasDgeam_64",                                           "rocblas_dgeam_64",                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_EXT}},
   {"cublasCgeam",                                          {"hipblasCgeam_v2",                                           "rocblas_cgeam",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_EXT}},
-  {"cublasCgeam_64",                                       {"hipblasCgeam_64",                                           "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_EXT, UNSUPPORTED}},
+  {"cublasCgeam_64",                                       {"hipblasCgeam_v2_64",                                        "rocblas_cgeam_64",                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_EXT}},
   {"cublasZgeam",                                          {"hipblasZgeam_v2",                                           "rocblas_zgeam",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_EXT}},
-  {"cublasZgeam_64",                                       {"hipblasZgeam_64",                                           "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_EXT, UNSUPPORTED}},
+  {"cublasZgeam_64",                                       {"hipblasZgeam_v2_64",                                        "rocblas_zgeam_64",                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_EXT}},
 
   // GETRF - Batched LU
   {"cublasSgetrfBatched",                                  {"hipblasSgetrfBatched",                                      "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_EXT, ROC_UNSUPPORTED}},
@@ -2060,6 +2060,10 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_BLAS_FUNCTION_VER_MAP {
   {"hipblasDsyrkx_64",                                     {HIP_6030, HIP_0,    HIP_0,  HIP_LATEST}},
   {"hipblasCsyrkx_v2_64",                                  {HIP_6030, HIP_0,    HIP_0,  HIP_LATEST}},
   {"hipblasZsyrkx_v2_64",                                  {HIP_6030, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipblasSgeam_64",                                      {HIP_6030, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipblasDgeam_64",                                      {HIP_6030, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipblasCgeam_v2_64",                                   {HIP_6030, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipblasZgeam_v2_64",                                   {HIP_6030, HIP_0,    HIP_0,  HIP_LATEST}},
 
   {"rocblas_status_to_string",                             {HIP_3050, HIP_0,    HIP_0   }},
   {"rocblas_sscal",                                        {HIP_1050, HIP_0,    HIP_0   }},
@@ -2485,6 +2489,10 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_BLAS_FUNCTION_VER_MAP {
   {"rocblas_dsyrkx_64",                                    {HIP_6030, HIP_0,    HIP_0,  HIP_LATEST}},
   {"rocblas_csyrkx_64",                                    {HIP_6030, HIP_0,    HIP_0,  HIP_LATEST}},
   {"rocblas_zsyrkx_64",                                    {HIP_6030, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"rocblas_sgeam_64",                                     {HIP_6030, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"rocblas_dgeam_64",                                     {HIP_6030, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"rocblas_cgeam_64",                                     {HIP_6030, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"rocblas_zgeam_64",                                     {HIP_6030, HIP_0,    HIP_0,  HIP_LATEST}},
 };
 
 const std::map<llvm::StringRef, hipAPIChangedVersions> HIP_BLAS_FUNCTION_CHANGED_VER_MAP {

--- a/tests/unit_tests/synthetic/libraries/cublas2hipblas_v2.cu
+++ b/tests/unit_tests/synthetic/libraries/cublas2hipblas_v2.cu
@@ -3050,6 +3050,26 @@ int main() {
   // HIP: HIPBLAS_EXPORT hipblasStatus_t hipblasZsyrkx_v2_64(hipblasHandle_t handle, hipblasFillMode_t uplo, hipblasOperation_t transA, int64_t n, int64_t k, const hipDoubleComplex* alpha, const hipDoubleComplex* AP, int64_t lda, const hipDoubleComplex* BP, int64_t ldb, const hipDoubleComplex* beta, hipDoubleComplex* CP, int64_t ldc);
   // CHECK: blasStatus = hipblasZsyrkx_v2_64(blasHandle, blasFillMode, blasOperation, n_64, k_64, &dcomplexa, &dcomplexA, lda_64, &dcomplexB, ldb_64, &dcomplexb, &dcomplexC, ldc_64);
   blasStatus = cublasZsyrkx_64(blasHandle, blasFillMode, blasOperation, n_64, k_64, &dcomplexa, &dcomplexA, lda_64, &dcomplexB, ldb_64, &dcomplexb, &dcomplexC, ldc_64);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasSgeam_64(cublasHandle_t handle, cublasOperation_t transa, cublasOperation_t transb, int64_t m, int64_t n, const float* alpha, const float* A, int64_t lda, const float* beta, const float* B, int64_t ldb, float* C, int64_t ldc);
+  // HIP: HIPBLAS_EXPORT hipblasStatus_t hipblasSgeam_64(hipblasHandle_t handle, hipblasOperation_t transA, hipblasOperation_t transB, int64_t m, int64_t n, const float* alpha, const float* AP, int64_t lda, const float* beta, const float* BP, int64_t ldb, float* CP, int64_t ldc);
+  // CHECK: blasStatus = hipblasSgeam_64(blasHandle, transa, transb, m_64, n_64, &fa, &fA, lda_64, &fb, &fB, ldb_64, &fC, ldc_64);
+  blasStatus = cublasSgeam_64(blasHandle, transa, transb, m_64, n_64, &fa, &fA, lda_64, &fb, &fB, ldb_64, &fC, ldc_64);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasDgeam_64(cublasHandle_t handle, cublasOperation_t transa, cublasOperation_t transb, int64_t m, int64_t n, const double* alpha, const double* A, int64_t lda, const double* beta, const double* B, int64_t ldb, double* C, int64_t ldc);
+  // HIP: HIPBLAS_EXPORT hipblasStatus_t hipblasDgeam_64(hipblasHandle_t handle, hipblasOperation_t transA, hipblasOperation_t transB, int64_t m, int64_t n, const double* alpha, const double* AP, int64_t lda, const double* beta, const double* BP, int64_t ldb, double* CP, int64_t ldc);
+  // CHECK: blasStatus = hipblasDgeam_64(blasHandle, transa, transb, m_64, n_64, &da, &dA, lda_64, &db, &dB, ldb_64, &dC, ldc_64);
+  blasStatus = cublasDgeam_64(blasHandle, transa, transb, m_64, n_64, &da, &dA, lda_64, &db, &dB, ldb_64, &dC, ldc_64);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasCgeam_64(cublasHandle_t handle, cublasOperation_t transa, cublasOperation_t transb, int64_t m, int64_t n, const cuComplex* alpha, const cuComplex* A, int64_t lda, const cuComplex* beta, const cuComplex* B, int64_t ldb, cuComplex* C, int64_t ldc);
+  // HIP: HIPBLAS_EXPORT hipblasStatus_t hipblasCgeam_v2_64(hipblasHandle_t handle, hipblasOperation_t transA, hipblasOperation_t transB, int64_t m, int64_t n, const hipComplex* alpha, const hipComplex* AP, int64_t lda, const hipComplex* beta, const hipComplex* BP, int64_t ldb, hipComplex* CP, int64_t ldc);
+  // CHECK: blasStatus = hipblasCgeam_v2_64(blasHandle, transa, transb, m_64, n_64, &complexa, &complexA, lda_64, &complexb, &complexB, ldb_64, &complexC, ldc_64);
+  blasStatus = cublasCgeam_64(blasHandle, transa, transb, m_64, n_64, &complexa, &complexA, lda_64, &complexb, &complexB, ldb_64, &complexC, ldc_64);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasZgeam_64(cublasHandle_t handle, cublasOperation_t transa, cublasOperation_t transb, int64_t m, int64_t n, const cuDoubleComplex* alpha, const cuDoubleComplex* A, int64_t lda, const cuDoubleComplex* beta, const cuDoubleComplex* B, int64_t ldb, cuDoubleComplex* C, int64_t ldc);
+  // HIP: HIPBLAS_EXPORT hipblasStatus_t hipblasZgeam_v2_64(hipblasHandle_t handle, hipblasOperation_t transA, hipblasOperation_t transB, int64_t m, int64_t n, const hipDoubleComplex* alpha, const hipDoubleComplex* AP, int64_t lda, const hipDoubleComplex* beta, const hipDoubleComplex* BP, int64_t ldb, hipDoubleComplex* CP, int64_t ldc);
+  // CHECK: blasStatus = hipblasZgeam_v2_64(blasHandle, transa, transb, m_64, n_64, &dcomplexa, &dcomplexA, lda_64, &dcomplexb, &dcomplexB, ldb_64, &dcomplexC, ldc_64);
+  blasStatus = cublasZgeam_64(blasHandle, transa, transb, m_64, n_64, &dcomplexa, &dcomplexA, lda_64, &dcomplexb, &dcomplexB, ldb_64, &dcomplexC, ldc_64);
 #endif
 
   return 0;

--- a/tests/unit_tests/synthetic/libraries/cublas2rocblas_v2.cu
+++ b/tests/unit_tests/synthetic/libraries/cublas2rocblas_v2.cu
@@ -3255,6 +3255,26 @@ int main() {
   // ROC: ROCBLAS_EXPORT rocblas_status rocblas_zsyrkx_64(rocblas_handle handle, rocblas_fill uplo, rocblas_operation trans, int64_t n, int64_t k, const rocblas_double_complex* alpha, const rocblas_double_complex* A, int64_t lda, const rocblas_double_complex* B, int64_t ldb, const rocblas_double_complex* beta, rocblas_double_complex* C, int64_t ldc);
   // CHECK: blasStatus = rocblas_zsyrkx_64(blasHandle, blasFillMode, blasOperation, n_64, k_64, &dcomplexa, &dcomplexA, lda_64, &dcomplexB, ldb_64, &dcomplexb, &dcomplexC, ldc_64);
   blasStatus = cublasZsyrkx_64(blasHandle, blasFillMode, blasOperation, n_64, k_64, &dcomplexa, &dcomplexA, lda_64, &dcomplexB, ldb_64, &dcomplexb, &dcomplexC, ldc_64);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasSgeam_64(cublasHandle_t handle, cublasOperation_t transa, cublasOperation_t transb, int64_t m, int64_t n, const float* alpha, const float* A, int64_t lda, const float* beta, const float* B, int64_t ldb, float* C, int64_t ldc);
+  // ROC: ROCBLAS_EXPORT rocblas_status rocblas_sgeam_64(rocblas_handle handle, rocblas_operation transA, rocblas_operation transB, int64_t m, int64_t n, const float* alpha, const float* A, int64_t lda, const float* beta, const float* B, int64_t ldb, float* C, int64_t ldc);
+  // CHECK: blasStatus = rocblas_sgeam_64(blasHandle, transa, transb, m_64, n_64, &fa, &fA, lda_64, &fb, &fB, ldb_64, &fC, ldc_64);
+  blasStatus = cublasSgeam_64(blasHandle, transa, transb, m_64, n_64, &fa, &fA, lda_64, &fb, &fB, ldb_64, &fC, ldc_64);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasDgeam_64(cublasHandle_t handle, cublasOperation_t transa, cublasOperation_t transb, int64_t m, int64_t n, const double* alpha, const double* A, int64_t lda, const double* beta, const double* B, int64_t ldb, double* C, int64_t ldc);
+  // ROC: ROCBLAS_EXPORT rocblas_status rocblas_dgeam_64(rocblas_handle handle, rocblas_operation transA, rocblas_operation transB, int64_t m, int64_t n, const double* alpha, const double* A, int64_t lda, const double* beta, const double* B, int64_t ldb, double* C, int64_t ldc);
+  // CHECK: blasStatus = rocblas_dgeam_64(blasHandle, transa, transb, m_64, n_64, &da, &dA, lda_64, &db, &dB, ldb_64, &dC, ldc_64);
+  blasStatus = cublasDgeam_64(blasHandle, transa, transb, m_64, n_64, &da, &dA, lda_64, &db, &dB, ldb_64, &dC, ldc_64);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasCgeam_64(cublasHandle_t handle, cublasOperation_t transa, cublasOperation_t transb, int64_t m, int64_t n, const cuComplex* alpha, const cuComplex* A, int64_t lda, const cuComplex* beta, const cuComplex* B, int64_t ldb, cuComplex* C, int64_t ldc);
+  // ROC: ROCBLAS_EXPORT rocblas_status rocblas_cgeam_64(rocblas_handle handle, rocblas_operation transA, rocblas_operation transB, int64_t m, int64_t n, const rocblas_float_complex* alpha, const rocblas_float_complex* A, int64_t lda, const rocblas_float_complex* beta, const rocblas_float_complex* B, int64_t ldb, rocblas_float_complex* C, int64_t ldc);
+  // CHECK: blasStatus = rocblas_cgeam_64(blasHandle, transa, transb, m_64, n_64, &complexa, &complexA, lda_64, &complexb, &complexB, ldb_64, &complexC, ldc_64);
+  blasStatus = cublasCgeam_64(blasHandle, transa, transb, m_64, n_64, &complexa, &complexA, lda_64, &complexb, &complexB, ldb_64, &complexC, ldc_64);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasZgeam_64(cublasHandle_t handle, cublasOperation_t transa, cublasOperation_t transb, int64_t m, int64_t n, const cuDoubleComplex* alpha, const cuDoubleComplex* A, int64_t lda, const cuDoubleComplex* beta, const cuDoubleComplex* B, int64_t ldb, cuDoubleComplex* C, int64_t ldc);
+  // ROC: ROCBLAS_EXPORT rocblas_status rocblas_zgeam_64(rocblas_handle handle, rocblas_operation transA, rocblas_operation transB, int64_t m, int64_t n, const rocblas_double_complex* alpha, const rocblas_double_complex* A, int64_t lda, const rocblas_double_complex* beta, const rocblas_double_complex* B, int64_t ldb, rocblas_double_complex* C, int64_t ldc);
+  // CHECK: blasStatus = rocblas_zgeam_64(blasHandle, transa, transb, m_64, n_64, &dcomplexa, &dcomplexA, lda_64, &dcomplexb, &dcomplexB, ldb_64, &dcomplexC, ldc_64);
+  blasStatus = cublasZgeam_64(blasHandle, transa, transb, m_64, n_64, &dcomplexa, &dcomplexA, lda_64, &dcomplexb, &dcomplexB, ldb_64, &dcomplexC, ldc_64);
 #endif
 
   return 0;


### PR DESCRIPTION
+ `rocblas_(s|d|c|z)geam_64` and `hipblas(S|D|C|Z)geam(_v2)?_64` support
+ Updated synthetic tests, the regenerated `hipify-perl`, and `BLAS` `CUDA2HIP` documentation