### PR TITLE
[HIPIFY][6.3.0][BLAS] Sync with `hipBLAS` and `rocBLAS` - Step 11

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -1632,7 +1632,9 @@ sub rocSubstitutions {
     subst("cublasChbmv_v2", "rocblas_chbmv", "library");
     subst("cublasChbmv_v2_64", "rocblas_chbmv_64", "library");
     subst("cublasChemm", "rocblas_chemm", "library");
+    subst("cublasChemm_64", "rocblas_chemm_64", "library");
     subst("cublasChemm_v2", "rocblas_chemm", "library");
+    subst("cublasChemm_v2_64", "rocblas_chemm_64", "library");
     subst("cublasChemv", "rocblas_chemv", "library");
     subst("cublasChemv_64", "rocblas_chemv_64", "library");
     subst("cublasChemv_v2", "rocblas_chemv", "library");
@@ -2198,7 +2200,9 @@ sub rocSubstitutions {
     subst("cublasZhbmv_v2", "rocblas_zhbmv", "library");
     subst("cublasZhbmv_v2_64", "rocblas_zhbmv_64", "library");
     subst("cublasZhemm", "rocblas_zhemm", "library");
+    subst("cublasZhemm_64", "rocblas_zhemm_64", "library");
     subst("cublasZhemm_v2", "rocblas_zhemm", "library");
+    subst("cublasZhemm_v2_64", "rocblas_zhemm_64", "library");
     subst("cublasZhemv", "rocblas_zhemv", "library");
     subst("cublasZhemv_64", "rocblas_zhemv_64", "library");
     subst("cublasZhemv_v2", "rocblas_zhemv", "library");
@@ -4418,7 +4422,9 @@ sub simpleSubstitutions {
     subst("cublasChbmv_v2", "hipblasChbmv_v2", "library");
     subst("cublasChbmv_v2_64", "hipblasChbmv_v2_64", "library");
     subst("cublasChemm", "hipblasChemm_v2", "library");
+    subst("cublasChemm_64", "hipblasChemm_v2_64", "library");
     subst("cublasChemm_v2", "hipblasChemm_v2", "library");
+    subst("cublasChemm_v2_64", "hipblasChemm_v2_64", "library");
     subst("cublasChemv", "hipblasChemv_v2", "library");
     subst("cublasChemv_64", "hipblasChemv_v2_64", "library");
     subst("cublasChemv_v2", "hipblasChemv_v2", "library");
@@ -4989,7 +4995,9 @@ sub simpleSubstitutions {
     subst("cublasZhbmv_v2", "hipblasZhbmv_v2", "library");
     subst("cublasZhbmv_v2_64", "hipblasZhbmv_v2_64", "library");
     subst("cublasZhemm", "hipblasZhemm_v2", "library");
+    subst("cublasZhemm_64", "hipblasZhemm_v2_64", "library");
     subst("cublasZhemm_v2", "hipblasZhemm_v2", "library");
+    subst("cublasZhemm_v2_64", "hipblasZhemm_v2_64", "library");
     subst("cublasZhemv", "hipblasZhemv_v2", "library");
     subst("cublasZhemv_64", "hipblasZhemv_v2_64", "library");
     subst("cublasZhemv_v2", "hipblasZhemv_v2", "library");
@@ -11628,8 +11636,6 @@ sub warnHipOnlyUnsupportedFunctions {
         "cublasZtrmm_64",
         "cublasZtpttr",
         "cublasZmatinvBatched",
-        "cublasZhemm_v2_64",
-        "cublasZhemm_64",
         "cublasZgemm3m_64",
         "cublasZgemm3m",
         "cublasZdgmm_64",
@@ -11771,8 +11777,6 @@ sub warnHipOnlyUnsupportedFunctions {
         "cublasCherkEx",
         "cublasCherk3mEx_64",
         "cublasCherk3mEx",
-        "cublasChemm_v2_64",
-        "cublasChemm_64",
         "cublasCgemmEx_64",
         "cublasCgemmEx",
         "cublasCgemm3m_64",
@@ -13727,8 +13731,6 @@ sub warnRocOnlyUnsupportedFunctions {
         "cublasZtrmm_64",
         "cublasZtpttr",
         "cublasZmatinvBatched",
-        "cublasZhemm_v2_64",
-        "cublasZhemm_64",
         "cublasZgetrsBatched",
         "cublasZgetriBatched",
         "cublasZgetrfBatched",
@@ -13884,8 +13886,6 @@ sub warnRocOnlyUnsupportedFunctions {
         "cublasCherkEx",
         "cublasCherk3mEx_64",
         "cublasCherk3mEx",
-        "cublasChemm_v2_64",
-        "cublasChemm_64",
         "cublasCgetrsBatched",
         "cublasCgetriBatched",
         "cublasCgetrfBatched",

--- a/docs/tables/CUBLAS_API_supported_by_HIP.md
+++ b/docs/tables/CUBLAS_API_supported_by_HIP.md
@@ -1495,9 +1495,9 @@
 |`cublasCgemvStridedBatched`|11.6| | | |`hipblasCgemvStridedBatched_v2`|6.0.0| | | | |
 |`cublasCgemvStridedBatched_64`|12.0| | | |`hipblasCgemvStridedBatched_v2_64`|6.2.0| | | | |
 |`cublasChemm`| | | | |`hipblasChemm_v2`|6.0.0| | | | |
-|`cublasChemm_64`|12.0| | | | | | | | | |
+|`cublasChemm_64`|12.0| | | |`hipblasChemm_v2_64`|6.3.0| | | |6.3.0|
 |`cublasChemm_v2`| | | | |`hipblasChemm_v2`|6.0.0| | | | |
-|`cublasChemm_v2_64`|12.0| | | | | | | | | |
+|`cublasChemm_v2_64`|12.0| | | |`hipblasChemm_v2_64`|6.3.0| | | |6.3.0|
 |`cublasCher2k`| | | | |`hipblasCher2k_v2`|6.0.0| | | | |
 |`cublasCher2k_64`|12.0| | | |`hipblasCher2k_v2_64`|6.3.0| | | |6.3.0|
 |`cublasCher2k_v2`| | | | |`hipblasCher2k_v2`|6.0.0| | | | |
@@ -1641,9 +1641,9 @@
 |`cublasZgemvStridedBatched`|11.6| | | |`hipblasZgemvStridedBatched_v2`|6.0.0| | | | |
 |`cublasZgemvStridedBatched_64`|12.0| | | |`hipblasZgemvStridedBatched_v2_64`|6.2.0| | | | |
 |`cublasZhemm`| | | | |`hipblasZhemm_v2`|6.0.0| | | | |
-|`cublasZhemm_64`|12.0| | | | | | | | | |
+|`cublasZhemm_64`|12.0| | | |`hipblasZhemm_v2_64`|6.3.0| | | |6.3.0|
 |`cublasZhemm_v2`| | | | |`hipblasZhemm_v2`|6.0.0| | | | |
-|`cublasZhemm_v2_64`|12.0| | | | | | | | | |
+|`cublasZhemm_v2_64`|12.0| | | |`hipblasZhemm_v2_64`|6.3.0| | | |6.3.0|
 |`cublasZher2k`| | | | |`hipblasZher2k_v2`|6.0.0| | | | |
 |`cublasZher2k_64`|12.0| | | |`hipblasZher2k_v2_64`|6.3.0| | | |6.3.0|
 |`cublasZher2k_v2`| | | | |`hipblasZher2k_v2`|6.0.0| | | | |

--- a/docs/tables/CUBLAS_API_supported_by_HIP_and_ROC.md
+++ b/docs/tables/CUBLAS_API_supported_by_HIP_and_ROC.md
@@ -1495,9 +1495,9 @@
 |`cublasCgemvStridedBatched`|11.6| | | |`hipblasCgemvStridedBatched_v2`|6.0.0| | | | |`rocblas_cgemv_strided_batched`|3.5.0| | | | |
 |`cublasCgemvStridedBatched_64`|12.0| | | |`hipblasCgemvStridedBatched_v2_64`|6.2.0| | | | |`rocblas_cgemv_strided_batched_64`|6.2.0| | | | |
 |`cublasChemm`| | | | |`hipblasChemm_v2`|6.0.0| | | | |`rocblas_chemm`|3.5.0| | | | |
-|`cublasChemm_64`|12.0| | | | | | | | | | | | | | | |
+|`cublasChemm_64`|12.0| | | |`hipblasChemm_v2_64`|6.3.0| | | |6.3.0|`rocblas_chemm_64`|6.3.0| | | |6.3.0|
 |`cublasChemm_v2`| | | | |`hipblasChemm_v2`|6.0.0| | | | |`rocblas_chemm`|3.5.0| | | | |
-|`cublasChemm_v2_64`|12.0| | | | | | | | | | | | | | | |
+|`cublasChemm_v2_64`|12.0| | | |`hipblasChemm_v2_64`|6.3.0| | | |6.3.0|`rocblas_chemm_64`|6.3.0| | | |6.3.0|
 |`cublasCher2k`| | | | |`hipblasCher2k_v2`|6.0.0| | | | |`rocblas_cher2k`|3.5.0| | | | |
 |`cublasCher2k_64`|12.0| | | |`hipblasCher2k_v2_64`|6.3.0| | | |6.3.0|`rocblas_cher2k_64`|6.3.0| | | |6.3.0|
 |`cublasCher2k_v2`| | | | |`hipblasCher2k_v2`|6.0.0| | | | |`rocblas_cher2k`|3.5.0| | | | |
@@ -1641,9 +1641,9 @@
 |`cublasZgemvStridedBatched`|11.6| | | |`hipblasZgemvStridedBatched_v2`|6.0.0| | | | |`rocblas_zgemv_strided_batched`|3.5.0| | | | |
 |`cublasZgemvStridedBatched_64`|12.0| | | |`hipblasZgemvStridedBatched_v2_64`|6.2.0| | | | |`rocblas_zgemv_strided_batched_64`|6.2.0| | | | |
 |`cublasZhemm`| | | | |`hipblasZhemm_v2`|6.0.0| | | | |`rocblas_zhemm`|3.5.0| | | | |
-|`cublasZhemm_64`|12.0| | | | | | | | | | | | | | | |
+|`cublasZhemm_64`|12.0| | | |`hipblasZhemm_v2_64`|6.3.0| | | |6.3.0|`rocblas_zhemm_64`|6.3.0| | | |6.3.0|
 |`cublasZhemm_v2`| | | | |`hipblasZhemm_v2`|6.0.0| | | | |`rocblas_zhemm`|3.5.0| | | | |
-|`cublasZhemm_v2_64`|12.0| | | | | | | | | | | | | | | |
+|`cublasZhemm_v2_64`|12.0| | | |`hipblasZhemm_v2_64`|6.3.0| | | |6.3.0|`rocblas_zhemm_64`|6.3.0| | | |6.3.0|
 |`cublasZher2k`| | | | |`hipblasZher2k_v2`|6.0.0| | | | |`rocblas_zher2k`|3.5.0| | | | |
 |`cublasZher2k_64`|12.0| | | |`hipblasZher2k_v2_64`|6.3.0| | | |6.3.0|`rocblas_zher2k_64`|6.3.0| | | |6.3.0|
 |`cublasZher2k_v2`| | | | |`hipblasZher2k_v2`|6.0.0| | | | |`rocblas_zher2k`|3.5.0| | | | |

--- a/docs/tables/CUBLAS_API_supported_by_ROC.md
+++ b/docs/tables/CUBLAS_API_supported_by_ROC.md
@@ -1495,9 +1495,9 @@
 |`cublasCgemvStridedBatched`|11.6| | | |`rocblas_cgemv_strided_batched`|3.5.0| | | | |
 |`cublasCgemvStridedBatched_64`|12.0| | | |`rocblas_cgemv_strided_batched_64`|6.2.0| | | | |
 |`cublasChemm`| | | | |`rocblas_chemm`|3.5.0| | | | |
-|`cublasChemm_64`|12.0| | | | | | | | | |
+|`cublasChemm_64`|12.0| | | |`rocblas_chemm_64`|6.3.0| | | |6.3.0|
 |`cublasChemm_v2`| | | | |`rocblas_chemm`|3.5.0| | | | |
-|`cublasChemm_v2_64`|12.0| | | | | | | | | |
+|`cublasChemm_v2_64`|12.0| | | |`rocblas_chemm_64`|6.3.0| | | |6.3.0|
 |`cublasCher2k`| | | | |`rocblas_cher2k`|3.5.0| | | | |
 |`cublasCher2k_64`|12.0| | | |`rocblas_cher2k_64`|6.3.0| | | |6.3.0|
 |`cublasCher2k_v2`| | | | |`rocblas_cher2k`|3.5.0| | | | |
@@ -1641,9 +1641,9 @@
 |`cublasZgemvStridedBatched`|11.6| | | |`rocblas_zgemv_strided_batched`|3.5.0| | | | |
 |`cublasZgemvStridedBatched_64`|12.0| | | |`rocblas_zgemv_strided_batched_64`|6.2.0| | | | |
 |`cublasZhemm`| | | | |`rocblas_zhemm`|3.5.0| | | | |
-|`cublasZhemm_64`|12.0| | | | | | | | | |
+|`cublasZhemm_64`|12.0| | | |`rocblas_zhemm_64`|6.3.0| | | |6.3.0|
 |`cublasZhemm_v2`| | | | |`rocblas_zhemm`|3.5.0| | | | |
-|`cublasZhemm_v2_64`|12.0| | | | | | | | | |
+|`cublasZhemm_v2_64`|12.0| | | |`rocblas_zhemm_64`|6.3.0| | | |6.3.0|
 |`cublasZher2k`| | | | |`rocblas_zher2k`|3.5.0| | | | |
 |`cublasZher2k_64`|12.0| | | |`rocblas_zher2k_64`|6.3.0| | | |6.3.0|
 |`cublasZher2k_v2`| | | | |`rocblas_zher2k`|3.5.0| | | | |

--- a/src/CUDA2HIP_BLAS_API_functions.cpp
+++ b/src/CUDA2HIP_BLAS_API_functions.cpp
@@ -535,9 +535,9 @@ const std::map<llvm::StringRef, hipCounter> CUDA_BLAS_FUNCTION_MAP {
 
   // HEMM
   {"cublasChemm",                                          {"hipblasChemm_v2",                                           "rocblas_chemm",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3, HIP_SUPPORTED_V2_ONLY}},
-  {"cublasChemm_64",                                       {"hipblasChemm_64",                                           "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3, UNSUPPORTED}},
+  {"cublasChemm_64",                                       {"hipblasChemm_v2_64",                                        "rocblas_chemm_64",                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3}},
   {"cublasZhemm",                                          {"hipblasZhemm_v2",                                           "rocblas_zhemm",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3, HIP_SUPPORTED_V2_ONLY}},
-  {"cublasZhemm_64",                                       {"hipblasZhemm_64",                                           "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3, UNSUPPORTED}},
+  {"cublasZhemm_64",                                       {"hipblasZhemm_v2_64",                                        "rocblas_zhemm_64",                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3}},
 
   // TRSM
   {"cublasStrsm",                                          {"hipblasStrsm",                                              "rocblas_strsm",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3, HIP_SUPPORTED_V2_ONLY}},
@@ -902,9 +902,9 @@ const std::map<llvm::StringRef, hipCounter> CUDA_BLAS_FUNCTION_MAP {
 
   // HEMM
   {"cublasChemm_v2",                                       {"hipblasChemm_v2",                                           "rocblas_chemm",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3}},
-  {"cublasChemm_v2_64",                                    {"hipblasChemm_64",                                           "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3, UNSUPPORTED}},
+  {"cublasChemm_v2_64",                                    {"hipblasChemm_v2_64",                                        "rocblas_chemm_64",                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3}},
   {"cublasZhemm_v2",                                       {"hipblasZhemm_v2",                                           "rocblas_zhemm",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3}},
-  {"cublasZhemm_v2_64",                                    {"hipblasZhemm_64",                                           "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3, UNSUPPORTED}},
+  {"cublasZhemm_v2_64",                                    {"hipblasZhemm_v2_64",                                        "rocblas_zhemm_64",                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3}},
 
   // TRSM
   {"cublasStrsm_v2",                                       {"hipblasStrsm",                                              "rocblas_strsm",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_3}},
@@ -2064,6 +2064,8 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_BLAS_FUNCTION_VER_MAP {
   {"hipblasDgeam_64",                                      {HIP_6030, HIP_0,    HIP_0,  HIP_LATEST}},
   {"hipblasCgeam_v2_64",                                   {HIP_6030, HIP_0,    HIP_0,  HIP_LATEST}},
   {"hipblasZgeam_v2_64",                                   {HIP_6030, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipblasChemm_v2_64",                                   {HIP_6030, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipblasZhemm_v2_64",                                   {HIP_6030, HIP_0,    HIP_0,  HIP_LATEST}},
 
   {"rocblas_status_to_string",                             {HIP_3050, HIP_0,    HIP_0   }},
   {"rocblas_sscal",                                        {HIP_1050, HIP_0,    HIP_0   }},
@@ -2493,6 +2495,8 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_BLAS_FUNCTION_VER_MAP {
   {"rocblas_dgeam_64",                                     {HIP_6030, HIP_0,    HIP_0,  HIP_LATEST}},
   {"rocblas_cgeam_64",                                     {HIP_6030, HIP_0,    HIP_0,  HIP_LATEST}},
   {"rocblas_zgeam_64",                                     {HIP_6030, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"rocblas_chemm_64",                                     {HIP_6030, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"rocblas_zhemm_64",                                     {HIP_6030, HIP_0,    HIP_0,  HIP_LATEST}},
 };
 
 const std::map<llvm::StringRef, hipAPIChangedVersions> HIP_BLAS_FUNCTION_CHANGED_VER_MAP {

--- a/tests/unit_tests/synthetic/libraries/cublas2hipblas_v2.cu
+++ b/tests/unit_tests/synthetic/libraries/cublas2hipblas_v2.cu
@@ -3070,6 +3070,20 @@ int main() {
   // HIP: HIPBLAS_EXPORT hipblasStatus_t hipblasZgeam_v2_64(hipblasHandle_t handle, hipblasOperation_t transA, hipblasOperation_t transB, int64_t m, int64_t n, const hipDoubleComplex* alpha, const hipDoubleComplex* AP, int64_t lda, const hipDoubleComplex* beta, const hipDoubleComplex* BP, int64_t ldb, hipDoubleComplex* CP, int64_t ldc);
   // CHECK: blasStatus = hipblasZgeam_v2_64(blasHandle, transa, transb, m_64, n_64, &dcomplexa, &dcomplexA, lda_64, &dcomplexb, &dcomplexB, ldb_64, &dcomplexC, ldc_64);
   blasStatus = cublasZgeam_64(blasHandle, transa, transb, m_64, n_64, &dcomplexa, &dcomplexA, lda_64, &dcomplexb, &dcomplexB, ldb_64, &dcomplexC, ldc_64);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasChemm_v2_64(cublasHandle_t handle, cublasSideMode_t side, cublasFillMode_t uplo, int64_t m, int64_t n, const cuComplex* alpha, const cuComplex* A, int64_t lda, const cuComplex* B, int64_t ldb, const cuComplex* beta, cuComplex* C, int64_t ldc);
+  // HIP: HIPBLAS_EXPORT hipblasStatus_t hipblasChemm_v2_64(hipblasHandle_t handle, hipblasSideMode_t side, hipblasFillMode_t uplo, int64_t n, int64_t k, const hipComplex* alpha, const hipComplex* AP, int64_t lda, const hipComplex* BP, int64_t ldb, const hipComplex* beta, hipComplex* CP, int64_t ldc);
+  // CHECK: blasStatus = hipblasChemm_v2_64(blasHandle, blasSideMode, blasFillMode, m_64, n_64, &complexa, &complexA, lda_64, &complexB, ldb_64, &complexb, &complexC, ldc_64);
+  // CHECK-NEXT: blasStatus = hipblasChemm_v2_64(blasHandle, blasSideMode, blasFillMode, m_64, n_64, &complexa, &complexA, lda_64, &complexB, ldb_64, &complexb, &complexC, ldc_64);
+  blasStatus = cublasChemm_64(blasHandle, blasSideMode, blasFillMode, m_64, n_64, &complexa, &complexA, lda_64, &complexB, ldb_64, &complexb, &complexC, ldc_64);
+  blasStatus = cublasChemm_v2_64(blasHandle, blasSideMode, blasFillMode, m_64, n_64, &complexa, &complexA, lda_64, &complexB, ldb_64, &complexb, &complexC, ldc_64);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasZhemm_v2_64(cublasHandle_t handle, cublasSideMode_t side, cublasFillMode_t uplo, int64_t m, int64_t n, const cuDoubleComplex* alpha, const cuDoubleComplex* A, int64_t lda, const cuDoubleComplex* B, int64_t ldb, const cuDoubleComplex* beta, cuDoubleComplex* C, int64_t ldc);
+  // HIP: HIPBLAS_EXPORT hipblasStatus_t hipblasZhemm_v2_64(hipblasHandle_t handle, hipblasSideMode_t side, hipblasFillMode_t uplo, int64_t n, int64_t k, const hipDoubleComplex* alpha, const hipDoubleComplex* AP, int64_t lda, const hipDoubleComplex* BP, int64_t ldb, const hipDoubleComplex* beta, hipDoubleComplex* CP, int64_t ldc);
+  // CHECK: blasStatus = hipblasZhemm_v2_64(blasHandle, blasSideMode, blasFillMode, m_64, n_64, &dcomplexa, &dcomplexA, lda_64, &dcomplexB, ldb_64, &dcomplexb, &dcomplexC, ldc_64);
+  // CHECK-NEXT: blasStatus = hipblasZhemm_v2_64(blasHandle, blasSideMode, blasFillMode, m_64, n_64, &dcomplexa, &dcomplexA, lda_64, &dcomplexB, ldb_64, &dcomplexb, &dcomplexC, ldc_64);
+  blasStatus = cublasZhemm_64(blasHandle, blasSideMode, blasFillMode, m_64, n_64, &dcomplexa, &dcomplexA, lda_64, &dcomplexB, ldb_64, &dcomplexb, &dcomplexC, ldc_64);
+  blasStatus = cublasZhemm_v2_64(blasHandle, blasSideMode, blasFillMode, m_64, n_64, &dcomplexa, &dcomplexA, lda_64, &dcomplexB, ldb_64, &dcomplexb, &dcomplexC, ldc_64);
 #endif
 
   return 0;

--- a/tests/unit_tests/synthetic/libraries/cublas2rocblas_v2.cu
+++ b/tests/unit_tests/synthetic/libraries/cublas2rocblas_v2.cu
@@ -3275,6 +3275,20 @@ int main() {
   // ROC: ROCBLAS_EXPORT rocblas_status rocblas_zgeam_64(rocblas_handle handle, rocblas_operation transA, rocblas_operation transB, int64_t m, int64_t n, const rocblas_double_complex* alpha, const rocblas_double_complex* A, int64_t lda, const rocblas_double_complex* beta, const rocblas_double_complex* B, int64_t ldb, rocblas_double_complex* C, int64_t ldc);
   // CHECK: blasStatus = rocblas_zgeam_64(blasHandle, transa, transb, m_64, n_64, &dcomplexa, &dcomplexA, lda_64, &dcomplexb, &dcomplexB, ldb_64, &dcomplexC, ldc_64);
   blasStatus = cublasZgeam_64(blasHandle, transa, transb, m_64, n_64, &dcomplexa, &dcomplexA, lda_64, &dcomplexb, &dcomplexB, ldb_64, &dcomplexC, ldc_64);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasChemm_v2_64(cublasHandle_t handle, cublasSideMode_t side, cublasFillMode_t uplo, int64_t m, int64_t n, const cuComplex* alpha, const cuComplex* A, int64_t lda, const cuComplex* B, int64_t ldb, const cuComplex* beta, cuComplex* C, int64_t ldc);
+  // ROC: ROCBLAS_EXPORT rocblas_status rocblas_chemm_64(rocblas_handle handle, rocblas_side side, rocblas_fill uplo, int64_t m, int64_t n, const rocblas_float_complex* alpha, const rocblas_float_complex* A, int64_t lda, const rocblas_float_complex* B, int64_t ldb, const rocblas_float_complex* beta, rocblas_float_complex* C, int64_t ldc);
+  // CHECK: blasStatus = rocblas_chemm_64(blasHandle, blasSideMode, blasFillMode, m_64, n_64, &complexa, &complexA, lda_64, &complexB, ldb_64, &complexb, &complexC, ldc_64);
+  // CHECK-NEXT: blasStatus = rocblas_chemm_64(blasHandle, blasSideMode, blasFillMode, m_64, n_64, &complexa, &complexA, lda_64, &complexB, ldb_64, &complexb, &complexC, ldc_64);
+  blasStatus = cublasChemm_64(blasHandle, blasSideMode, blasFillMode, m_64, n_64, &complexa, &complexA, lda_64, &complexB, ldb_64, &complexb, &complexC, ldc_64);
+  blasStatus = cublasChemm_v2_64(blasHandle, blasSideMode, blasFillMode, m_64, n_64, &complexa, &complexA, lda_64, &complexB, ldb_64, &complexb, &complexC, ldc_64);
+
+  // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasZhemm_v2_64(cublasHandle_t handle, cublasSideMode_t side, cublasFillMode_t uplo, int64_t m, int64_t n, const cuDoubleComplex* alpha, const cuDoubleComplex* A, int64_t lda, const cuDoubleComplex* B, int64_t ldb, const cuDoubleComplex* beta, cuDoubleComplex* C, int64_t ldc);
+  // ROC: ROCBLAS_EXPORT rocblas_status rocblas_zhemm_64(rocblas_handle handle, rocblas_side side, rocblas_fill uplo, int64_t m, int64_t n, const rocblas_double_complex* alpha, const rocblas_double_complex* A, int64_t lda, const rocblas_double_complex* B, int64_t ldb, const rocblas_double_complex* beta, rocblas_double_complex* C, int64_t ldc);
+  // CHECK: blasStatus = rocblas_zhemm_64(blasHandle, blasSideMode, blasFillMode, m_64, n_64, &dcomplexa, &dcomplexA, lda_64, &dcomplexB, ldb_64, &dcomplexb, &dcomplexC, ldc_64);
+  // CHECK-NEXT: blasStatus = rocblas_zhemm_64(blasHandle, blasSideMode, blasFillMode, m_64, n_64, &dcomplexa, &dcomplexA, lda_64, &dcomplexB, ldb_64, &dcomplexb, &dcomplexC, ldc_64);
+  blasStatus = cublasZhemm_64(blasHandle, blasSideMode, blasFillMode, m_64, n_64, &dcomplexa, &dcomplexA, lda_64, &dcomplexB, ldb_64, &dcomplexb, &dcomplexC, ldc_64);
+  blasStatus = cublasZhemm_v2_64(blasHandle, blasSideMode, blasFillMode, m_64, n_64, &dcomplexa, &dcomplexA, lda_64, &dcomplexB, ldb_64, &dcomplexb, &dcomplexC, ldc_64);
 #endif
 
   return 0;


### PR DESCRIPTION
+ `rocblas_(c|z)hemm_64` and `hipblas(C|Z)hemm_v2_64` support
+ Updated synthetic tests, the regenerated `hipify-perl`, and `BLAS` `CUDA2HIP` documentation
