### PR TITLE
[HIPIFY][doc] CUDA `12.6.2` is the latest supported release (LLVM 20.x)

### DIFF
--- a/docs/hipify-clang.rst
+++ b/docs/hipify-clang.rst
@@ -41,7 +41,7 @@ Dependencies
 
 * `CUDA <https://developer.nvidia.com/cuda-downloads>`_ of at least version
   `7.0 <https://developer.nvidia.com/cuda-toolkit-70>`_, the latest supported version is
-  `12.6.1 <https://developer.nvidia.com/cuda-downloads>`_.
+  `12.6.2 <https://developer.nvidia.com/cuda-downloads>`_.
 
 .. list-table::
 
@@ -188,7 +188,7 @@ Dependencies
       `19.1.1 <https://github.com/llvm/llvm-project/releases/tag/llvmorg-19.1.1>`_,
       `19.1.2 <https://github.com/llvm/llvm-project/releases/tag/llvmorg-19.1.2>`_,
       `19.1.3 <https://github.com/llvm/llvm-project/releases/tag/llvmorg-19.1.3>`_:sup:`4`
-    - `12.6.1 <https://developer.nvidia.com/cuda-downloads>`_:sup:`4`
+    - `12.6.2 <https://developer.nvidia.com/cuda-downloads>`_:sup:`4`
     - **Latest stable config**
     - **Latest stable config**
 
@@ -640,8 +640,8 @@ On Linux, the following configurations are tested:
 
 * Ubuntu 14: LLVM 4.0.0 - 7.1.0, CUDA 7.0 - 9.0, cuDNN 5.0.5 - 7.6.5
 * Ubuntu 16-19: LLVM 8.0.0 - 14.0.6, CUDA 7.0 - 10.2, cuDNN 5.1.10 - 8.0.5
-* Ubuntu 20-21: LLVM 9.0.0 - 19.1.3, CUDA 7.0 - 12.6.1, cuDNN 5.1.10 - 9.5.1
-* Ubuntu 22-23: LLVM 13.0.0 - 19.1.3, CUDA 7.0 - 12.6.1, cuDNN 8.0.5 - 9.5.1
+* Ubuntu 20-21: LLVM 9.0.0 - 19.1.3, CUDA 7.0 - 12.6.2, cuDNN 5.1.10 - 9.5.1
+* Ubuntu 22-23: LLVM 13.0.0 - 19.1.3, CUDA 7.0 - 12.6.2, cuDNN 8.0.5 - 9.5.1
 
 Minimum build system requirements for the above configurations:
 
@@ -660,7 +660,7 @@ Here's how to build ``hipify-clang`` with testing support on ``Ubuntu 23.10.01``
   -DCMAKE_BUILD_TYPE=Release \
   -DCMAKE_INSTALL_PREFIX=../dist \
   -DCMAKE_PREFIX_PATH=/usr/llvm/19.1.3/dist \
-  -DCUDA_TOOLKIT_ROOT_DIR=/usr/local/cuda-12.6.1 \
+  -DCUDA_TOOLKIT_ROOT_DIR=/usr/local/cuda-12.6.2 \
   -DCUDA_DNN_ROOT_DIR=/usr/local/cudnn-9.5.1 \
   -DLLVM_EXTERNAL_LIT=/usr/llvm/19.1.3/build/bin/llvm-lit \
   ../hipify
@@ -697,19 +697,19 @@ The corresponding successful output is:
   -- Found lit: /usr/local/bin/lit
   -- Found FileCheck: /GIT/LLVM/trunk/dist/FileCheck
   -- Initial CUDA to configure:
-  --    - CUDA Toolkit path  : /usr/local/cuda-12.6.1
+  --    - CUDA Toolkit path  : /usr/local/cuda-12.6.2
   --    - CUDA Samples path  :
   --    - cuDNN path         : /usr/local/cudnn-9.5.1
   --    - CUB path           :
-  -- Found CUDAToolkit: /usr/local/cuda-12.6.1/targets/x86_64-linux/include (found version "12.6.68")
+  -- Found CUDAToolkit: /usr/local/cuda-12.6.2/targets/x86_64-linux/include (found version "12.6.68")
   -- Performing Test CMAKE_HAVE_LIBC_PTHREAD
   -- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Success
   -- Found Threads: TRUE
   -- Found CUDA config:
-  --    - CUDA Toolkit path  : /usr/local/cuda-12.6.1
+  --    - CUDA Toolkit path  : /usr/local/cuda-12.6.2
   --    - CUDA Samples path  : OFF
   --    - cuDNN path         : /usr/local/cudnn-9.5.1
-  --    - CUB path           : /usr/local/cuda-12.6.1/include/cub
+  --    - CUB path           : /usr/local/cuda-12.6.2/include/cub
   -- Configuring done (0.5s)
   -- Generating done (0.0s)
   -- Build files have been written to: /usr/hipify/build
@@ -826,7 +826,7 @@ Tested configurations:
     - ``3.30.4``
     - ``3.13.0``
   * - ``19.1.0 - 19.1.3``
-    - ``7.0 - 12.6.1``
+    - ``7.0 - 12.6.2``
     - ``8.0.5  - 9.5.1``
     - ``2019.16.11.40, 2022.17.11.4``
     - ``3.30.4``


### PR DESCRIPTION
+ `CUDA 12.6.2` is partially supported by LLVM >= 20.0.0, but might work with the `hipify-clang` built against LLVM 19.x
+ Tested on Windows 11 and Ubuntu 23.10
