### PR TITLE
[HIPIFY][doc] `LLVM 19.1.4` is the latest supported LLVM release

### DIFF
--- a/docs/hipify-clang.rst
+++ b/docs/hipify-clang.rst
@@ -37,7 +37,7 @@ Dependencies
 
 * `LLVM+Clang <http://releases.llvm.org>`_ of at least version
   `4.0.0 <http://releases.llvm.org/download.html#4.0.0>`_; the latest stable and recommended release:
-  `19.1.3 <https://github.com/llvm/llvm-project/releases/tag/llvmorg-19.1.3>`_.
+  `19.1.4 <https://github.com/llvm/llvm-project/releases/tag/llvmorg-19.1.4>`_.
 
 * `CUDA <https://developer.nvidia.com/cuda-downloads>`_ of at least version
   `7.0 <https://developer.nvidia.com/cuda-toolkit-70>`_, the latest supported version is
@@ -187,7 +187,8 @@ Dependencies
   * - `19.1.0 <https://github.com/llvm/llvm-project/releases/tag/llvmorg-19.1.0>`_,
       `19.1.1 <https://github.com/llvm/llvm-project/releases/tag/llvmorg-19.1.1>`_,
       `19.1.2 <https://github.com/llvm/llvm-project/releases/tag/llvmorg-19.1.2>`_,
-      `19.1.3 <https://github.com/llvm/llvm-project/releases/tag/llvmorg-19.1.3>`_:sup:`4`
+      `19.1.3 <https://github.com/llvm/llvm-project/releases/tag/llvmorg-19.1.3>`_,
+      `19.1.4 <https://github.com/llvm/llvm-project/releases/tag/llvmorg-19.1.4>`_:sup:`4`
     - `12.6.2 <https://developer.nvidia.com/cuda-downloads>`_:sup:`4`
     - **Latest stable config**
     - **Latest stable config**
@@ -230,7 +231,7 @@ Dependencies
 In most cases, you can get a suitable version of ``LLVM+Clang`` with your package manager. However, you can also
 `download a release archive <http://releases.llvm.org/>`_ and build or install it. In case of multiple versions of ``LLVM`` installed, set
 `CMAKE_PREFIX_PATH <https://cmake.org/cmake/help/latest/variable/CMAKE_PREFIX_PATH.html>`_ so that
-``CMake`` can find the desired version of ``LLVM``. For example, ``-DCMAKE_PREFIX_PATH=D:\LLVM\19.1.3\dist``.
+``CMake`` can find the desired version of ``LLVM``. For example, ``-DCMAKE_PREFIX_PATH=D:\LLVM\19.1.4\dist``.
 
 Usage
 ============================================================
@@ -263,7 +264,7 @@ header files used during the hipification process:
 
 .. code:: shell
 
-  ./hipify-clang square.cu --cuda-path=/usr/local/cuda-12.6 --clang-resource-directory=/usr/llvm/19.1.3/dist/lib/clang/19
+  ./hipify-clang square.cu --cuda-path=/usr/local/cuda-12.6 --clang-resource-directory=/usr/llvm/19.1.4/dist/lib/clang/19
 
 For more information, refer to the `Clang manual for compiling CUDA <https://llvm.org/docs/CompileCudaWithLLVM.html#compiling-cuda-code>`_.
 
@@ -400,7 +401,7 @@ To ensure LLVM being found or in case of multiple LLVM instances, specify the pa
 
 .. code-block:: bash
 
-  -DCMAKE_PREFIX_PATH=/usr/llvm/19.1.3/dist
+  -DCMAKE_PREFIX_PATH=/usr/llvm/19.1.4/dist
 
 On Windows, specify the following option for CMake in the first place:
 ``-G "Visual Studio 17 2022"``. 
@@ -474,7 +475,7 @@ LLVM <= 9.0.1
 LLVM >= 10.0.0
 -----------------
 
-1. Download `LLVM project <https://github.com/llvm/llvm-project/releases/tag/llvmorg-19.1.3>`_ sources.
+1. Download `LLVM project <https://github.com/llvm/llvm-project/releases/tag/llvmorg-19.1.4>`_ sources.
 
 2. Build `LLVM project <http://llvm.org/docs/CMake.html>`_:
 
@@ -577,13 +578,13 @@ LLVM >= 10.0.0
 
      .. code-block:: bash
 
-      python /usr/llvm/19.1.3/llvm-project/llvm/utils/lit/setup.py install
+      python /usr/llvm/19.1.4/llvm-project/llvm/utils/lit/setup.py install
       
      **Windows**:
 
      .. code-block:: shell
 
-      python D:/LLVM/19.1.3/llvm-project/llvm/utils/lit/setup.py install
+      python D:/LLVM/19.1.4/llvm-project/llvm/utils/lit/setup.py install
 
      In case of errors similar to ``ModuleNotFoundError: No module named 'setuptools'``, upgrade the ``setuptools`` package:
 
@@ -597,23 +598,23 @@ LLVM >= 10.0.0
 
      .. code-block:: bash
 
-      -DLLVM_EXTERNAL_LIT=/usr/llvm/19.1.3/build/bin/llvm-lit
+      -DLLVM_EXTERNAL_LIT=/usr/llvm/19.1.4/build/bin/llvm-lit
 
      **Windows**:
 
      .. code-block:: shell
 
-      -DLLVM_EXTERNAL_LIT=D:/LLVM/19.1.3/build/Release/bin/llvm-lit.py
+      -DLLVM_EXTERNAL_LIT=D:/LLVM/19.1.4/build/Release/bin/llvm-lit.py
 
    * ``FileCheck``:
 
      **Linux**:
 
-     Copy from ``/usr/llvm/19.1.3/build/bin/`` to ``CMAKE_INSTALL_PREFIX/dist/bin``.
+     Copy from ``/usr/llvm/19.1.4/build/bin/`` to ``CMAKE_INSTALL_PREFIX/dist/bin``.
 
      **Windows**:
 
-     Copy from ``D:/LLVM/19.1.3/build/Release/bin`` to ``CMAKE_INSTALL_PREFIX/dist/bin``.
+     Copy from ``D:/LLVM/19.1.4/build/Release/bin`` to ``CMAKE_INSTALL_PREFIX/dist/bin``.
 
      Alternatively, specify the path to ``FileCheck`` in the ``CMAKE_INSTALL_PREFIX`` option.
 
@@ -640,8 +641,8 @@ On Linux, the following configurations are tested:
 
 * Ubuntu 14: LLVM 4.0.0 - 7.1.0, CUDA 7.0 - 9.0, cuDNN 5.0.5 - 7.6.5
 * Ubuntu 16-19: LLVM 8.0.0 - 14.0.6, CUDA 7.0 - 10.2, cuDNN 5.1.10 - 8.0.5
-* Ubuntu 20-21: LLVM 9.0.0 - 19.1.3, CUDA 7.0 - 12.6.2, cuDNN 5.1.10 - 9.5.1
-* Ubuntu 22-23: LLVM 13.0.0 - 19.1.3, CUDA 7.0 - 12.6.2, cuDNN 8.0.5 - 9.5.1
+* Ubuntu 20-21: LLVM 9.0.0 - 19.1.4, CUDA 7.0 - 12.6.2, cuDNN 5.1.10 - 9.5.1
+* Ubuntu 22-23: LLVM 13.0.0 - 19.1.4, CUDA 7.0 - 12.6.2, cuDNN 8.0.5 - 9.5.1
 
 Minimum build system requirements for the above configurations:
 
@@ -659,10 +660,10 @@ Here's how to build ``hipify-clang`` with testing support on ``Ubuntu 23.10.01``
   -DHIPIFY_CLANG_TESTS=ON \
   -DCMAKE_BUILD_TYPE=Release \
   -DCMAKE_INSTALL_PREFIX=../dist \
-  -DCMAKE_PREFIX_PATH=/usr/llvm/19.1.3/dist \
+  -DCMAKE_PREFIX_PATH=/usr/llvm/19.1.4/dist \
   -DCUDA_TOOLKIT_ROOT_DIR=/usr/local/cuda-12.6.2 \
   -DCUDA_DNN_ROOT_DIR=/usr/local/cudnn-9.5.1 \
-  -DLLVM_EXTERNAL_LIT=/usr/llvm/19.1.3/build/bin/llvm-lit \
+  -DLLVM_EXTERNAL_LIT=/usr/llvm/19.1.4/build/bin/llvm-lit \
   ../hipify
 
 The corresponding successful output is:
@@ -686,11 +687,11 @@ The corresponding successful output is:
   --    - Test  hipify-clang : ON
   --    - Is part of HIP SDK : OFF
   -- Found ZLIB: /usr/lib/x86_64-linux-gnu/libz.so (found version "1.2.13")
-  -- Found LLVM 19.1.3:
-  --    - CMake module path  : /usr/llvm/19.1.3/dist/lib/cmake/llvm
-  --    - Clang include path : /usr/llvm/19.1.3/dist/include
-  --    - LLVM Include path  : /usr/llvm/19.1.3/dist/include
-  --    - Binary path        : /usr/llvm/19.1.3/dist/bin
+  -- Found LLVM 19.1.4:
+  --    - CMake module path  : /usr/llvm/19.1.4/dist/lib/cmake/llvm
+  --    - Clang include path : /usr/llvm/19.1.4/dist/include
+  --    - LLVM Include path  : /usr/llvm/19.1.4/dist/include
+  --    - Binary path        : /usr/llvm/19.1.4/dist/bin
   -- Linker detection: GNU ld
   -- ---- The below configuring for hipify-clang testing only ----
   -- Found Python: /usr/bin/python3.13 (found version "3.13.0") found components: Interpreter 
@@ -725,7 +726,7 @@ The corresponding successful output is:
   Running HIPify regression tests
   ===============================================================
   CUDA 12.6.68 - will be used for testing
-  LLVM 19.1.3 - will be used for testing
+  LLVM 19.1.4 - will be used for testing
   x86_64 - Platform architecture
   Linux 6.5.0-15-generic - Platform OS
   64 - hipify-clang binary bitness
@@ -825,7 +826,7 @@ Tested configurations:
     - ``2019.16.11.42, 2022.17.11.6``
     - ``3.31.0``
     - ``3.13.0``
-  * - ``19.1.0 - 19.1.3``
+  * - ``19.1.0 - 19.1.4``
     - ``7.0 - 12.6.2``
     - ``8.0.5  - 9.5.1``
     - ``2019.16.11.42, 2022.17.11.6``
@@ -855,11 +856,11 @@ Building with testing support using ``Visual Studio 17 2022`` on ``Windows 11``:
   -DHIPIFY_CLANG_TESTS=ON \
   -DCMAKE_BUILD_TYPE=Release \
   -DCMAKE_INSTALL_PREFIX=../dist \
-  -DCMAKE_PREFIX_PATH=D:/LLVM/19.1.3/dist \
+  -DCMAKE_PREFIX_PATH=D:/LLVM/19.1.4/dist \
   -DCUDA_TOOLKIT_ROOT_DIR="C:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v12.6" \
   -DCUDA_SDK_ROOT_DIR="C:/ProgramData/NVIDIA Corporation/CUDA Samples/v12.5" \
   -DCUDA_DNN_ROOT_DIR=D:/CUDA/cuDNN/9.5.1 \
-  -DLLVM_EXTERNAL_LIT=D:/LLVM/19.1.3/build/Release/bin/llvm-lit.py \
+  -DLLVM_EXTERNAL_LIT=D:/LLVM/19.1.4/build/Release/bin/llvm-lit.py \
   ../hipify
 
 The corresponding successful output is:
@@ -883,15 +884,15 @@ The corresponding successful output is:
   --    - Build hipify-clang : ON
   --    - Test  hipify-clang : ON
   --    - Is part of HIP SDK : OFF
-  -- Found LLVM 19.1.3:
-  --    - CMake module path  : D:/LLVM/19.1.3/dist/lib/cmake/llvm
-  --    - Clang include path : D:/LLVM/19.1.3/dist/include
-  --    - LLVM Include path  : D:/LLVM/19.1.3/dist/include
-  --    - Binary path        : D:/LLVM/19.1.3/dist/bin
+  -- Found LLVM 19.1.4:
+  --    - CMake module path  : D:/LLVM/19.1.4/dist/lib/cmake/llvm
+  --    - Clang include path : D:/LLVM/19.1.4/dist/include
+  --    - LLVM Include path  : D:/LLVM/19.1.4/dist/include
+  --    - Binary path        : D:/LLVM/19.1.4/dist/bin
   -- ---- The below configuring for hipify-clang testing only ----
   -- Found Python: C:/Users/TT/AppData/Local/Programs/Python/Python313/python.exe (found version "3.13.0") found components: Interpreter
   -- Found lit: C:/Users/TT/AppData/Local/Programs/Python/Python313/Scripts/lit.exe
-  -- Found FileCheck: D:/LLVM/19.1.3/dist/bin/FileCheck.exe
+  -- Found FileCheck: D:/LLVM/19.1.4/dist/bin/FileCheck.exe
   -- Initial CUDA to configure:
   --    - CUDA Toolkit path  : C:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v12.6
   --    - CUDA Samples path  : C:/ProgramData/NVIDIA Corporation/CUDA Samples/v12.5


### PR DESCRIPTION
+ No patches are needed
+ Updated the `README.md` accordingly
+ `hipify-clang` built with `LLVM 19.1.4` works correctly with the latest supported `CUDA 12.6.2`, even though clang may report that `CUDA 12.6.2` is not fully supported
+ Tested on `Windows 11` (`VS 2019` and `VS 2022`)  and `Ubuntu 23.10`