### PR TITLE
[HIPIFY][#1777][Tensor][tests][fix] Fix the failed `cutensor2hiptensor.cu` test

### DIFF
--- a/tests/unit_tests/synthetic/libraries/cutensor2hiptensor.cu
+++ b/tests/unit_tests/synthetic/libraries/cutensor2hiptensor.cu
@@ -32,9 +32,6 @@ int main() {
   cutensorDataType_t TENSOR_R_8U = CUTENSOR_R_8U;
   cutensorDataType_t TENSOR_R_32I = CUTENSOR_R_32I;
   cutensorDataType_t TENSOR_R_32U = CUTENSOR_R_32U;
-
-  //CHECK: hiptensorWorksizePreference_t TENSOR_WORKSPACE_DEFAULT = HIPTENSOR_WORKSPACE_DEFAULT;
-  cutensorWorksizePreference_t TENSOR_WORKSPACE_DEFAULT = CUTENSOR_ALGO_DEFAULT_PATIENT;
 #endif
 
 #if CUTENSOR_MAJOR >= 1


### PR DESCRIPTION
**[Reasons]**
+ cutensor2hiptensor.cu-80ac9b.hip(37,32): error GF25AE0AB: cannot initialize a variable of type 'cutensorWorksizePreference_t' with an rvalue of type 'cutensorAlgo_t'
+ `HIPTENSOR_WORKSPACE_DEFAULT` is not supported by `hipTensor`