### PR TITLE
[HIPIFY][#1800][doc][Linux][clang][fix] Fix instructions on building `LLVM` for `HIPIFY` on `Linux`

### DIFF
--- a/docs/hipify-clang.rst
+++ b/docs/hipify-clang.rst
@@ -450,7 +450,7 @@ LLVM <= 9.0.1
     cmake \
       -DCMAKE_INSTALL_PREFIX=../dist \
       -DLLVM_SOURCE_DIR=../llvm \
-      -DLLVM_TARGETS_TO_BUILD="X86;NVPTX" \
+      -DLLVM_TARGETS_TO_BUILD="X86" \
       -DLLVM_INCLUDE_TESTS=OFF \
       -DCMAKE_BUILD_TYPE=Release \
       ../llvm
@@ -466,7 +466,7 @@ LLVM <= 9.0.1
       -Thost=x64 \
       -DCMAKE_INSTALL_PREFIX=../dist \
       -DLLVM_SOURCE_DIR=../llvm \
-      -DLLVM_TARGETS_TO_BUILD="NVPTX" \
+      -DLLVM_TARGETS_TO_BUILD="" \
       -DLLVM_INCLUDE_TESTS=OFF \
       -DCMAKE_BUILD_TYPE=Release \
       ../llvm
@@ -492,7 +492,7 @@ LLVM >= 10.0.0
 
     cmake \
       -DCMAKE_INSTALL_PREFIX=../dist \
-      -DLLVM_TARGETS_TO_BUILD="" \
+      -DLLVM_TARGETS_TO_BUILD="X86" \
       -DLLVM_ENABLE_PROJECTS="clang" \
       -DLLVM_INCLUDE_TESTS=OFF \
       -DCMAKE_BUILD_TYPE=Release \


### PR DESCRIPTION
+ [Reason] It turned out that the `X86` target needed to be specified for LLVM build on Linux, whereas there is no such obligatory dependence on Windows
+ There is no dependency on the `NVPTX` target on both OSs
