### PR TITLE
[HIPIFY][RT][6.4.0] Sync with `HIP LRT 6.4.0` - `hipDeviceGetTexture1DLinearMaxWidth` - incomplete

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -1403,6 +1403,7 @@ my %experimental_funcs = (
     "cudaEventRecordWithFlags" => "6.4.0",
     "cudaErrorInvalidTexture" => "6.4.0",
     "cudaErrorInvalidChannelDescriptor" => "6.4.0",
+    "cudaDeviceGetTexture1DLinearMaxWidth" => "6.4.0",
     "cuStreamBatchMemOp_v2" => "6.4.0",
     "cuStreamBatchMemOp" => "6.4.0",
     "cuGraphExecBatchMemOpNodeSetParams" => "6.4.0",
@@ -1410,6 +1411,7 @@ my %experimental_funcs = (
     "cuGraphBatchMemOpNodeGetParams" => "6.4.0",
     "cuGraphAddBatchMemOpNode" => "6.4.0",
     "cuEventRecordWithFlags" => "6.4.0",
+    "cuDeviceGetTexture1DLinearMaxWidth" => "6.4.0",
     "CUstreamBatchMemOpType_enum" => "6.4.0",
     "CUstreamBatchMemOpType" => "6.4.0",
     "CUstreamBatchMemOpParams_v1" => "6.4.0",
@@ -1565,6 +1567,8 @@ sub subst {
 }
 
 sub experimentalSubstitutions {
+    subst("cuDeviceGetTexture1DLinearMaxWidth", "hipDeviceGetTexture1DLinearMaxWidth", "device");
+    subst("cudaDeviceGetTexture1DLinearMaxWidth", "hipDeviceGetTexture1DLinearMaxWidth", "device");
     subst("cuEventRecordWithFlags", "hipEventRecordWithFlags", "event");
     subst("cudaEventRecordWithFlags", "hipEventRecordWithFlags", "event");
     subst("cuStreamBatchMemOp", "hipStreamBatchMemOp", "stream_memory");

--- a/docs/tables/CUDA_Driver_API_functions_supported_by_HIP.md
+++ b/docs/tables/CUDA_Driver_API_functions_supported_by_HIP.md
@@ -1477,7 +1477,7 @@
 |`cuDeviceGetMemPool`|11.2| | | |`hipDeviceGetMemPool`|5.2.0| | | | |
 |`cuDeviceGetName`| | | | |`hipDeviceGetName`|1.6.0| | | | |
 |`cuDeviceGetNvSciSyncAttributes`|10.2| | | | | | | | | |
-|`cuDeviceGetTexture1DLinearMaxWidth`|11.1| | | | | | | | | |
+|`cuDeviceGetTexture1DLinearMaxWidth`|11.1| | | |`hipDeviceGetTexture1DLinearMaxWidth`|6.4.0| | | |6.4.0|
 |`cuDeviceGetUuid`|9.2| | | |`hipDeviceGetUuid`|5.2.0| | | | |
 |`cuDeviceGetUuid_v2`|11.4| | | |`hipDeviceGetUuid`|5.2.0| | | | |
 |`cuDeviceSetMemPool`|11.2| | | |`hipDeviceSetMemPool`|5.2.0| | | | |

--- a/docs/tables/CUDA_Runtime_API_functions_supported_by_HIP.md
+++ b/docs/tables/CUDA_Runtime_API_functions_supported_by_HIP.md
@@ -16,7 +16,7 @@
 |`cudaDeviceGetP2PAttribute`|8.0| | | |`hipDeviceGetP2PAttribute`|3.8.0| | | | |
 |`cudaDeviceGetPCIBusId`| | | | |`hipDeviceGetPCIBusId`|1.6.0| | | | |
 |`cudaDeviceGetStreamPriorityRange`| | | | |`hipDeviceGetStreamPriorityRange`|2.0.0| | | | |
-|`cudaDeviceGetTexture1DLinearMaxWidth`|11.1| | | | | | | | | |
+|`cudaDeviceGetTexture1DLinearMaxWidth`|11.1| | | |`hipDeviceGetTexture1DLinearMaxWidth`|6.4.0| | | |6.4.0|
 |`cudaDeviceReset`| | | | |`hipDeviceReset`|1.6.0| | | | |
 |`cudaDeviceSetCacheConfig`| | | | |`hipDeviceSetCacheConfig`|1.6.0| | | | |
 |`cudaDeviceSetLimit`| | | | |`hipDeviceSetLimit`|5.3.0| | | | |

--- a/src/CUDA2HIP_Driver_API_functions.cpp
+++ b/src/CUDA2HIP_Driver_API_functions.cpp
@@ -63,8 +63,8 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_FUNCTION_MAP {
   // no analogue
   {"cuDeviceTotalMem",                                            {"hipDeviceTotalMem",                                           "", CONV_DEVICE, API_DRIVER, SEC::DEVICE}},
   {"cuDeviceTotalMem_v2",                                         {"hipDeviceTotalMem",                                           "", CONV_DEVICE, API_DRIVER, SEC::DEVICE}},
-  // cudaDeviceGetTexture1DLinearMaxWidth
-  {"cuDeviceGetTexture1DLinearMaxWidth",                          {"hipDeviceGetTexture1DLinearMaxWidth",                         "", CONV_DEVICE, API_DRIVER, SEC::DEVICE, HIP_UNSUPPORTED}},
+  // NOTE: incompatible with cudaDeviceGetTexture1DLinearMaxWidth
+  {"cuDeviceGetTexture1DLinearMaxWidth",                          {"hipDeviceGetTexture1DLinearMaxWidth",                         "", CONV_DEVICE, API_DRIVER, SEC::DEVICE, HIP_EXPERIMENTAL}},
   // cudaDeviceSetMemPool
   {"cuDeviceSetMemPool",                                          {"hipDeviceSetMemPool",                                         "", CONV_DEVICE, API_DRIVER, SEC::DEVICE}},
   // cudaDeviceGetMemPool
@@ -1671,6 +1671,7 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_DRIVER_FUNCTION_VER_MAP {
   {"hipGraphBatchMemOpNodeSetParams",                             {HIP_6040, HIP_0,    HIP_0,  HIP_LATEST}},
   {"hipGraphExecBatchMemOpNodeSetParams",                         {HIP_6040, HIP_0,    HIP_0,  HIP_LATEST}},
   {"hipEventRecordWithFlags",                                     {HIP_6040, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipDeviceGetTexture1DLinearMaxWidth",                         {HIP_6040, HIP_0,    HIP_0,  HIP_LATEST}},
 };
 
 const std::map<llvm::StringRef, cudaAPIChangedVersions> CUDA_DRIVER_FUNCTION_CHANGED_VER_MAP {

--- a/src/CUDA2HIP_Runtime_API_functions.cpp
+++ b/src/CUDA2HIP_Runtime_API_functions.cpp
@@ -81,8 +81,8 @@ const std::map<llvm::StringRef, hipCounter> CUDA_RUNTIME_FUNCTION_MAP {
   {"cudaSetDeviceFlags",                                      {"hipSetDeviceFlags",                                      "", CONV_DEVICE, API_RUNTIME, SEC::DEVICE}},
   // no analogue
   {"cudaSetValidDevices",                                     {"hipSetValidDevices",                                     "", CONV_DEVICE, API_RUNTIME, SEC::DEVICE}},
-  // cuDeviceGetTexture1DLinearMaxWidth
-  {"cudaDeviceGetTexture1DLinearMaxWidth",                    {"hipDeviceGetTexture1DLinearMaxWidth",                    "", CONV_DEVICE, API_RUNTIME, SEC::DEVICE, HIP_UNSUPPORTED}},
+  // NOTE: incompatible with cuDeviceGetTexture1DLinearMaxWidth
+  {"cudaDeviceGetTexture1DLinearMaxWidth",                    {"hipDeviceGetTexture1DLinearMaxWidth",                    "", CONV_DEVICE, API_RUNTIME, SEC::DEVICE, HIP_EXPERIMENTAL}},
   // cuDeviceGetDefaultMemPool
   {"cudaDeviceGetDefaultMemPool",                             {"hipDeviceGetDefaultMemPool",                             "", CONV_DEVICE, API_RUNTIME, SEC::DEVICE}},
   // cuDeviceSetMemPool

--- a/tests/unit_tests/synthetic/driver_functions.cu
+++ b/tests/unit_tests/synthetic/driver_functions.cu
@@ -1605,6 +1605,11 @@ int main() {
   // HIP: hipError_t hipEventRecordWithFlags(hipEvent_t event, hipStream_t stream __dparm(0), unsigned int flags __dparm(0));
   // CHECK: result = hipEventRecordWithFlags(event_, stream, flags);
   result = cuEventRecordWithFlags(event_, stream, flags);
+
+  // TODO [LRT]: make hipDeviceGetTexture1DLinearMaxWidth (better hipDrvDeviceGetTexture1DLinearMaxWidth) compatible with cuDeviceGetTexture1DLinearMaxWidth
+  // CUDA:CUresult CUDAAPI cuDeviceGetTexture1DLinearMaxWidth(size_t *maxWidthInElements, CUarray_format format, unsigned numChannels, CUdevice dev);
+  // HIP: hipError_t hipDeviceGetTexture1DLinearMaxWidth(hipMemPool_t* mem_pool, int device);
+  result = cuDeviceGetTexture1DLinearMaxWidth(&bytes, array_format, flags, device);
 #endif
 
 #if CUDA_VERSION >= 11020

--- a/tests/unit_tests/synthetic/runtime_functions.cu
+++ b/tests/unit_tests/synthetic/runtime_functions.cu
@@ -1321,6 +1321,11 @@ int main() {
   // HIP: hipError_t hipEventRecordWithFlags(hipEvent_t event, hipStream_t stream __dparm(0), unsigned int flags __dparm(0));
   // CHECK: result = hipEventRecordWithFlags(Event_t, stream, flags);
   result = cudaEventRecordWithFlags(Event_t, stream, flags);
+
+  // TODO [LRT]: make hipDeviceGetTexture1DLinearMaxWidth compatible with cudaDeviceGetTexture1DLinearMaxWidth
+  // CUDA:extern __host__ __cudart_builtin__ cudaError_t CUDARTAPI cudaDeviceGetTexture1DLinearMaxWidth(size_t *maxWidthInElements, const struct cudaChannelFormatDesc *fmtDesc, int device);
+  // HIP: hipError_t hipDeviceGetTexture1DLinearMaxWidth(hipMemPool_t* mem_pool, int device);
+  result = cudaDeviceGetTexture1DLinearMaxWidth(&bytes, &ChannelFormatDesc, device);
 #endif
 
 #if CUDA_VERSION >= 11020


### PR DESCRIPTION
+ Updated synthetic tests, the regenerated `hipify-perl`, and `Driver` and `Runtime` `CUDA2HIP` docs accordingly
+ [ToDo] File a ticket to HIP RT to make `hipDeviceGetTexture1DLinearMaxWidth` with `cudaDeviceGetTexture1DLinearMaxWidth`
+ [ToDo] File a ticket to HIP RT to create `hipDrvDeviceGetTexture1DLinearMaxWidth` for compatibility with `cuDeviceGetTexture1DLinearMaxWidth`
