### PR TITLE
[HIPIFY][build][install][fix] Pass `USE_SOURCE_PERMISSIONS` when installing scripts

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -181,6 +181,7 @@ if (NOT HIPIFY_CLANG_TESTS_ONLY)
   install(
     DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/bin
     DESTINATION .
+    USE_SOURCE_PERMISSIONS
     PATTERN "hipify-perl"
     PATTERN "*.sh"
     PATTERN "findcode.sh" EXCLUDE


### PR DESCRIPTION
Pass USE_SOURCE_PERMISSIONS when installing scripts.

Without this, hipify-perl and friends are installed with non-executable permissions, requiring after the fact fixup.