### PR TITLE
[HIPIFY][Device][#1846][doc][fix] Added the `Changed` CUDA version to the rest device `fp16` APIs

### DIFF
--- a/docs/reference/tables/CUDA_Device_API_supported_by_HIP.md
+++ b/docs/reference/tables/CUDA_Device_API_supported_by_HIP.md
@@ -19,7 +19,7 @@
 |`__ballot`| | | | |`__ballot`|1.6.0| | | | |
 |`__ballot_sync`|9.0| | | |`__ballot_sync`|6.2.0| | | | |
 |`__bfloat1622float2`|11.0| | | |`__bfloat1622float2`|5.7.0| | | | |
-|`__bfloat162bfloat162`|11.0| | | |`__bfloat162bfloat162`|5.7.0| | | | |
+|`__bfloat162bfloat162`|11.0| |12.2| |`__bfloat162bfloat162`|5.7.0| | | | |
 |`__bfloat162char_rz`|12.2| | | | | | | | | |
 |`__bfloat162float`|11.0| | | |`__bfloat162float`|5.7.0| | | | |
 |`__bfloat162int_rd`|11.0| | | | | | | | | |
@@ -264,12 +264,12 @@
 |`__hgtu`| | | | |`__hgtu`|1.9.0| | | | |
 |`__hgtu2`| | | | |`__hgtu2`|1.9.0| | | | |
 |`__hgtu2_mask`|12.0| | | | | | | | | |
-|`__high2bfloat16`|11.0| | | |`__high2bfloat16`|5.7.0| | | | |
+|`__high2bfloat16`|11.0| |12.2| |`__high2bfloat16`|5.7.0| | | | |
 |`__high2bfloat162`|11.0| |12.2| |`__high2bfloat162`|5.7.0| | | | |
 |`__high2float`| | | | |`__high2float`|1.6.0| | | | |
 |`__high2half`| | | | |`__high2half`|1.6.0| | | | |
 |`__high2half2`| | | | |`__high2half2`|1.6.0| | | | |
-|`__highs2bfloat162`|11.0| | | |`__highs2bfloat162`|5.7.0| | | | |
+|`__highs2bfloat162`|11.0| |12.2| |`__highs2bfloat162`|5.7.0| | | | |
 |`__highs2half2`| | | | |`__highs2half2`|1.6.0| | | | |
 |`__hiloint2double`| | | | |`__hiloint2double`|1.6.0| | | | |
 |`__hisinf`| | | | |`__hisinf`|1.6.0| | | | |
@@ -367,7 +367,7 @@
 |`__low2half`| | | | |`__low2half`|1.6.0| | | | |
 |`__low2half2`| | | | |`__low2half2`|1.6.0| | | | |
 |`__lowhigh2highlow`| | | | |`__lowhigh2highlow`|1.6.0| | | | |
-|`__lows2bfloat162`|11.0| | | |`__lows2bfloat162`|5.7.0| | | | |
+|`__lows2bfloat162`|11.0| |12.2| |`__lows2bfloat162`|5.7.0| | | | |
 |`__lows2half2`| | | | |`__lows2half2`|1.6.0| | | | |
 |`__match_all_sync`|9.0| | | |`__match_all_sync`|6.2.0| | | | |
 |`__match_any_sync`|9.0| | | |`__match_any_sync`|6.2.0| | | | |

--- a/src/CUDA2HIP_Device_functions.cpp
+++ b/src/CUDA2HIP_Device_functions.cpp
@@ -1541,6 +1541,10 @@ const std::map<llvm::StringRef, cudaAPIChangedVersions> CUDA_DEVICE_FUNCTION_CHA
   {"__bfloat16_as_ushort",              {CUDA_122}},
   {"__short_as_bfloat16",               {CUDA_122}},
   {"__ushort_as_bfloat16",              {CUDA_122}},
+  {"__bfloat162bfloat162",              {CUDA_122}},
+  {"__lows2bfloat162",                  {CUDA_122}},
+  {"__highs2bfloat162",                 {CUDA_122}},
+  {"__high2bfloat16",                   {CUDA_122}},
 };
 
 const std::map<unsigned int, llvm::StringRef> CUDA_DEVICE_FUNCTION_API_SECTION_MAP {

--- a/tests/unit_tests/synthetic/libraries/cudevice2hipdevice_before_11080_after_12011.cu
+++ b/tests/unit_tests/synthetic/libraries/cudevice2hipdevice_before_11080_after_12011.cu
@@ -103,12 +103,12 @@ int main() {
   // CUDA: __CUDA_HOSTDEVICE_BF16_DECL__ __nv_bfloat16 __short_as_bfloat16(const short int i);
   // HIP: __BF16_HOST_DEVICE_STATIC__ __hip_bfloat16 __short_as_bfloat16(const short int a);
   // CHECK: _bf16 = __short_as_bfloat16(shi);
-  _bf16 = __short_as_bfloat16(shi); 
+  _bf16 = __short_as_bfloat16(shi);
 
   // CUDA: __CUDA_HOSTDEVICE_BF16_DECL__ __nv_bfloat16 __ushort_as_bfloat16(const unsigned short int i);
   // HIP: __BF16_HOST_DEVICE_STATIC__ __hip_bfloat16 __ushort_as_bfloat16(const unsigned short int a);
   // CHECK: _bf16 = __ushort_as_bfloat16(ushi);
-  _bf16 = __ushort_as_bfloat16(ushi); 
+  _bf16 = __ushort_as_bfloat16(ushi);
 #endif
 
 #endif


### PR DESCRIPTION
+ Updated the regenerated `Device` `CUDA2HIP` docs accordingly
