### PR TITLE
[HIPIFY][doc] `cuTensor 2.1.0.9` is the latest supported version

### DIFF
--- a/docs/building/building-hipify.rst
+++ b/docs/building/building-hipify.rst
@@ -131,7 +131,7 @@ LLVM >= 10.0.0
 
      .. code-block:: shell
 
-      -DCUDA_TENSOR_ROOT_DIR=D:/CUDA/cuTensor/2.0.2.1
+      -DCUDA_TENSOR_ROOT_DIR=D:/CUDA/cuTensor/2.1.0.9
 
 5. [Optional] Install `cuDNN <https://developer.nvidia.com/rdp/cudnn-archive>`_ belonging to the version corresponding
    to the CUDA version:
@@ -281,8 +281,8 @@ Linux testing
 
 On Linux, the following configurations are tested:
 
-* Ubuntu 22-23: LLVM 13.0.0 - 19.1.7, CUDA 7.0 - 12.6.3, cuDNN 8.0.5 - 9.7.0, cuTensor 1.0.1.0 - 2.0.2.1
-* Ubuntu 20-21: LLVM 9.0.0 - 19.1.7, CUDA 7.0 - 12.6.3, cuDNN 5.1.10 - 9.7.0, cuTensor 1.0.1.0 - 2.0.2.1
+* Ubuntu 22-23: LLVM 13.0.0 - 19.1.7, CUDA 7.0 - 12.6.3, cuDNN 8.0.5 - 9.7.0, cuTensor 1.0.1.0 - 2.1.0.9
+* Ubuntu 20-21: LLVM 9.0.0 - 19.1.7, CUDA 7.0 - 12.6.3, cuDNN 5.1.10 - 9.7.0, cuTensor 1.0.1.0 - 2.1.0.9
 * Ubuntu 16-19: LLVM 8.0.0 - 14.0.6, CUDA 7.0 - 10.2, cuDNN 5.1.10 - 8.0.5
 * Ubuntu 14: LLVM 4.0.0 - 7.1.0, CUDA 7.0 - 9.0, cuDNN 5.0.5 - 7.6.5
 
@@ -305,7 +305,7 @@ Here's how to build ``hipify-clang`` with testing support on ``Ubuntu 23.10.01``
   -DCMAKE_PREFIX_PATH=/usr/llvm/19.1.7/dist \
   -DCUDA_TOOLKIT_ROOT_DIR=/usr/local/cuda-12.6.3 \
   -DCUDA_DNN_ROOT_DIR=/usr/local/cudnn-9.7.0 \
-  -DCUDA_TENSOR_ROOT_DIR=/usr/local/cutensor-2.0.2.1 \
+  -DCUDA_TENSOR_ROOT_DIR=/usr/local/cutensor-2.1.0.9 \
   -DLLVM_EXTERNAL_LIT=/usr/llvm/19.1.7/build/bin/llvm-lit \
   ../hipify
 
@@ -345,7 +345,7 @@ The corresponding successful output is:
   --    - CUDA Toolkit path     : /usr/local/cuda-12.6.3
   --    - CUDA Samples path     :
   --    - cuDNN path            : /usr/local/cudnn-9.7.0
-  --    - cuTENSOR path         : /usr/local/cuTensor/2.0.2.1
+  --    - cuTENSOR path         : /usr/local/cuTensor/2.1.0.9
   --    - CUB path              :
   -- Found CUDAToolkit: /usr/local/cuda-12.6.3/targets/x86_64-linux/include (found version "12.6.85")
   -- Performing Test CMAKE_HAVE_LIBC_PTHREAD
@@ -356,7 +356,7 @@ The corresponding successful output is:
   --    - CUDA Samples path     : OFF
   --    - cuDNN path            : /usr/local/cudnn-9.7.0
   --    - CUB path              : /usr/local/cuda-12.6.3/include/cub
-  --    - cuTENSOR path         : /usr/local/cuTensor/2.0.2.1
+  --    - cuTENSOR path         : /usr/local/cuTensor/2.1.0.9
   -- Configuring done (0.6s)
   -- Generating done (0.0s)
   -- Build files have been written to: /usr/hipify/build
@@ -506,7 +506,7 @@ Building with testing support using ``Visual Studio 17 2022`` on ``Windows 11``:
   -DCUDA_TOOLKIT_ROOT_DIR="C:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v12.6" \
   -DCUDA_SDK_ROOT_DIR="C:/ProgramData/NVIDIA Corporation/CUDA Samples/v12.5" \
   -DCUDA_DNN_ROOT_DIR=D:/CUDA/cuDNN/9.7.0 \
-  -DCUDA_TENSOR_ROOT_DIR=D:/CUDA/cuTensor/2.0.2.1 \
+  -DCUDA_TENSOR_ROOT_DIR=D:/CUDA/cuTensor/2.1.0.9 \
   -DLLVM_EXTERNAL_LIT=D:/LLVM/19.1.7/build/Release/bin/llvm-lit.py \
   ../hipify
 
@@ -545,14 +545,14 @@ The corresponding successful output is:
   --    - CUDA Toolkit path     : C:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v12.6
   --    - CUDA Samples path     : C:/ProgramData/NVIDIA Corporation/CUDA Samples/v12.5
   --    - cuDNN path            : D:/CUDA/cuDNN/9.7.0
-  --    - cuTENSOR path         : D:/CUDA/cuTensor/2.0.2.1
+  --    - cuTENSOR path         : D:/CUDA/cuTensor/2.1.0.9
   --    - CUB path              :
   -- Found CUDAToolkit: C:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v12.6/include (found version "12.6.85")
   -- Found CUDA config:
   --    - CUDA Toolkit path     : C:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v12.6
   --    - CUDA Samples path     : C:/ProgramData/NVIDIA Corporation/CUDA Samples/v12.5
   --    - cuDNN path            : D:/CUDA/cuDNN/9.7.0
-  --    - cuTENSOR path         : D:/CUDA/cuTensor/2.0.2.1
+  --    - cuTENSOR path         : D:/CUDA/cuTensor/2.1.0.9
   --    - CUB path              : C:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v12.6/include/cub
   -- Configuring done (4.4s)
   -- Generating done (0.1s)


### PR DESCRIPTION
+ No API changes since 2.0.2.1