### PR TITLE
[HIPIFY][build][#1840][clang][fix] Make hipify-clang buildable with an LLVM configured to link `libLLVM.so`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,7 +65,7 @@ if (NOT HIPIFY_CLANG_TESTS_ONLY)
   file(GLOB_RECURSE HIPIFY_HEADERS src/*.h)
 
   # In order to be compatible with an LLVM that uses LLVM_LINK_LLVM_DYLIB=ON,
-  # must link core LLVM libraries via LLVM_LINK_COMPONENTS vs directly adding
+  # hipify-clang must link core LLVM libraries via LLVM_LINK_COMPONENTS vs directly adding
   # them.
   set(HIPIFY_ADDL_LINK_LIBS)
   set(LLVM_LINK_COMPONENTS
@@ -77,6 +77,11 @@ if (NOT HIPIFY_CLANG_TESTS_ONLY)
     Option
     Core
   )
+  
+  if(LLVM_PACKAGE_VERSION VERSION_GREATER "6.0.1")
+    list(APPEND HIPIFY_ADDL_LINK_LIBS clangToolingInclusions)
+  endif()
+
   if(LLVM_PACKAGE_VERSION VERSION_GREATER "9.0.1")
     list(APPEND LLVM_LINK_COMPONENTS FrontendOpenMP)
   endif()
@@ -86,9 +91,6 @@ if (NOT HIPIFY_CLANG_TESTS_ONLY)
     list(APPEND HIPIFY_ADDL_LINK_LIBS clangSupport)
   endif()
 
-  if(LLVM_PACKAGE_VERSION VERSION_GREATER "6.0.1")
-    list(APPEND HIPIFY_ADDL_LINK_LIBS clangToolingInclusions)
-  endif()
 
   add_llvm_executable(hipify-clang
     ${HIPIFY_SOURCES} ${HIPIFY_HEADERS}
@@ -115,11 +117,12 @@ if (NOT HIPIFY_CLANG_TESTS_ONLY)
           ${LLVM_BINARY_DIR}/tools/lld/include
           ${LLVM_EXTERNAL_LLD_SOURCE_DIR}/include)
     endif()
+
+  # Keep the existing compiler since MSVC-specific flags will be set later.
   elseif(MSVC)
-    # Keep the existing compiler since MSVC-specific flags will be set later.
+  else()
     # Overriding CMAKE_CXX_COMPILER/CMAKE_C_COMPILER below is sketchy - could
     # that be removed or reworked instead?
-  else()
     set(CMAKE_CXX_COMPILER ${LLVM_TOOLS_BINARY_DIR}/clang++)
     set(CMAKE_C_COMPILER ${LLVM_TOOLS_BINARY_DIR}/clang)
   endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,7 +64,35 @@ if (NOT HIPIFY_CLANG_TESTS_ONLY)
   file(GLOB_RECURSE HIPIFY_SOURCES src/*.cpp)
   file(GLOB_RECURSE HIPIFY_HEADERS src/*.h)
 
-  add_llvm_executable(hipify-clang ${HIPIFY_SOURCES} ${HIPIFY_HEADERS})
+  # In order to be compatible with an LLVM that uses LLVM_LINK_LLVM_DYLIB=ON,
+  # must link core LLVM libraries via LLVM_LINK_COMPONENTS vs directly adding
+  # them.
+  set(HIPIFY_ADDL_LINK_LIBS)
+  set(LLVM_LINK_COMPONENTS
+    ProfileData
+    Support
+    MCParser
+    MC
+    BitReader
+    Option
+    Core
+  )
+  if(LLVM_PACKAGE_VERSION VERSION_GREATER "9.0.1")
+    list(APPEND LLVM_LINK_COMPONENTS FrontendOpenMP)
+  endif()
+
+  if(LLVM_PACKAGE_VERSION VERSION_EQUAL "15.0.0" OR LLVM_PACKAGE_VERSION VERSION_GREATER "15.0.0")
+    list(APPEND LLVM_LINK_COMPONENTS WindowsDriver)
+    list(APPEND HIPIFY_ADDL_LINK_LIBS clangSupport)
+  endif()
+
+  if(LLVM_PACKAGE_VERSION VERSION_GREATER "6.0.1")
+    list(APPEND HIPIFY_ADDL_LINK_LIBS clangToolingInclusions)
+  endif()
+
+  add_llvm_executable(hipify-clang
+    ${HIPIFY_SOURCES} ${HIPIFY_HEADERS}
+  )
   target_link_directories(hipify-clang PRIVATE ${LLVM_LIBRARY_DIRS})
 
   if(HIPIFY_INCLUDE_IN_HIP_SDK)
@@ -109,25 +137,8 @@ if (NOT HIPIFY_CLANG_TESTS_ONLY)
     clangToolingCore
     clangRewrite
     clangBasic
-    LLVMProfileData
-    LLVMSupport
-    LLVMMCParser
-    LLVMMC
-    LLVMBitReader
-    LLVMOption
-    LLVMCore)
-
-  if(LLVM_PACKAGE_VERSION VERSION_GREATER "6.0.1")
-    target_link_libraries(hipify-clang PRIVATE clangToolingInclusions)
-  endif()
-
-  if(LLVM_PACKAGE_VERSION VERSION_GREATER "9.0.1")
-    target_link_libraries(hipify-clang PRIVATE LLVMFrontendOpenMP)
-  endif()
-
-  if(LLVM_PACKAGE_VERSION VERSION_EQUAL "15.0.0" OR LLVM_PACKAGE_VERSION VERSION_GREATER "15.0.0")
-    target_link_libraries(hipify-clang PRIVATE LLVMWindowsDriver clangSupport)
-  endif()
+    ${HIPIFY_ADDL_LINK_LIBS}
+  )
 
   if(LLVM_PACKAGE_VERSION VERSION_EQUAL "16.0.0" OR LLVM_PACKAGE_VERSION VERSION_GREATER "16.0.0")
     if(MSVC)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,6 +115,10 @@ if (NOT HIPIFY_CLANG_TESTS_ONLY)
           ${LLVM_BINARY_DIR}/tools/lld/include
           ${LLVM_EXTERNAL_LLD_SOURCE_DIR}/include)
     endif()
+  elseif(MSVC)
+    # Keep the existing compiler since MSVC-specific flags will be set later.
+    # Overriding CMAKE_CXX_COMPILER/CMAKE_C_COMPILER below is sketchy - could
+    # that be removed or reworked instead?
   else()
     set(CMAKE_CXX_COMPILER ${LLVM_TOOLS_BINARY_DIR}/clang++)
     set(CMAKE_C_COMPILER ${LLVM_TOOLS_BINARY_DIR}/clang)


### PR DESCRIPTION
Combine patches 1 and 3 from https://github.com/nod-ai/TheRock/tree/main/patches/amd-mainline/HIPIFY,
Clean up https://github.com/ROCm/HIPIFY/pull/1840 and target `amd-staging` branch

Original comment:
> Without these changes, if building against an LLVM configured with -DLLVM_LINK_LLVM_DYLIB=ON, the resulting binary will have ODR violations resulting in the dread duplicate CL option registered errors at runtime.
> 
> In order to work in this case, executables must be uniformly linked in the same way that LLVM binaries themselves are: by setting LLVM_LINK_COMPONENTS vs depending directly on the (static) individual libraries. This should work in all linking modes.
> 
> Note that the problem originate because an LLVM configured in this way will configure any clang libraries to carry a transitive dep on libLLVM. Therefore, it is illegal to depend on clang (static) libraries and LLVM static libraries in combination.
> 
> There is a step further that could be taken to also support building against a shared libClang, but this is merely an optimization vs an error: since libClang is a leaf library, it is ok to depend on its static components. Perhaps total package size could be reduced by also supporting libClang, but this is left for the future.