### PR TITLE
[HIPIFY][doc] `LLVM 20.1.0` is the latest stable supported LLVM release

### DIFF
--- a/docs/building/building-hipify.rst
+++ b/docs/building/building-hipify.rst
@@ -27,7 +27,7 @@ To ensure LLVM is found, or in case of multiple LLVM instances, specify the path
 
 .. code-block:: bash
 
-  -DCMAKE_PREFIX_PATH=/usr/llvm/19.1.7/dist
+  -DCMAKE_PREFIX_PATH=/usr/llvm/20.1.0/dist
 
 On Windows, specify the following option for CMake:
 ``-G "Visual Studio 17 2022"``
@@ -58,7 +58,7 @@ belongs to an appropriate version.
 LLVM >= 10.0.0
 -----------------
 
-1. Download `LLVM project <https://github.com/llvm/llvm-project/releases/tag/llvmorg-19.1.7>`_ sources.
+1. Download `LLVM project <https://github.com/llvm/llvm-project/releases/tag/llvmorg-20.1.0>`_ sources.
 
 2. Build `LLVM project <http://llvm.org/docs/CMake.html>`_:
 
@@ -177,13 +177,13 @@ LLVM >= 10.0.0
 
      .. code-block:: bash
 
-      python /usr/llvm/19.1.7/llvm-project/llvm/utils/lit/setup.py install
+      python /usr/llvm/20.1.0/llvm-project/llvm/utils/lit/setup.py install
       
      **Windows**:
 
      .. code-block:: shell
 
-      python D:/LLVM/19.1.7/llvm-project/llvm/utils/lit/setup.py install
+      python D:/LLVM/20.1.0/llvm-project/llvm/utils/lit/setup.py install
 
      In case of errors similar to ``ModuleNotFoundError: No module named 'setuptools'``, upgrade the ``setuptools`` package:
 
@@ -197,23 +197,23 @@ LLVM >= 10.0.0
 
      .. code-block:: bash
 
-      -DLLVM_EXTERNAL_LIT=/usr/llvm/19.1.7/build/bin/llvm-lit
+      -DLLVM_EXTERNAL_LIT=/usr/llvm/20.1.0/build/bin/llvm-lit
 
      **Windows**:
 
      .. code-block:: shell
 
-      -DLLVM_EXTERNAL_LIT=D:/LLVM/19.1.7/build/Release/bin/llvm-lit.py
+      -DLLVM_EXTERNAL_LIT=D:/LLVM/20.1.0/build/Release/bin/llvm-lit.py
 
    * ``FileCheck``:
 
      **Linux**:
 
-     Copy from ``/usr/llvm/19.1.7/build/bin/`` to ``CMAKE_INSTALL_PREFIX/dist/bin``.
+     Copy from ``/usr/llvm/20.1.0/build/bin/`` to ``CMAKE_INSTALL_PREFIX/dist/bin``.
 
      **Windows**:
 
-     Copy from ``D:/LLVM/19.1.7/build/Release/bin`` to ``CMAKE_INSTALL_PREFIX/dist/bin``.
+     Copy from ``D:/LLVM/20.1.0/build/Release/bin`` to ``CMAKE_INSTALL_PREFIX/dist/bin``.
 
      Alternatively, specify the path to ``FileCheck`` in the ``CMAKE_INSTALL_PREFIX`` option.
 
@@ -281,8 +281,8 @@ Linux testing
 
 On Linux, the following configurations are tested:
 
-* Ubuntu 22-23: LLVM 13.0.0 - 19.1.7, CUDA 7.0 - 12.6.3, cuDNN 8.0.5 - 9.7.1, cuTensor 1.0.1.0 - 2.1.0.9
-* Ubuntu 20-21: LLVM 9.0.0 - 19.1.7, CUDA 7.0 - 12.6.3, cuDNN 5.1.10 - 9.7.1, cuTensor 1.0.1.0 - 2.1.0.9
+* Ubuntu 22-23: LLVM 13.0.0 - 20.1.0, CUDA 7.0 - 12.6.3, cuDNN 8.0.5 - 9.7.1, cuTensor 1.0.1.0 - 2.1.0.9
+* Ubuntu 20-21: LLVM 9.0.0 - 20.1.0, CUDA 7.0 - 12.6.3, cuDNN 5.1.10 - 9.7.1, cuTensor 1.0.1.0 - 2.1.0.9
 * Ubuntu 16-19: LLVM 8.0.0 - 14.0.6, CUDA 7.0 - 10.2, cuDNN 5.1.10 - 8.0.5
 * Ubuntu 14: LLVM 4.0.0 - 7.1.0, CUDA 7.0 - 9.0, cuDNN 5.0.5 - 7.6.5
 
@@ -302,11 +302,11 @@ Here's how to build ``hipify-clang`` with testing support on ``Ubuntu 23.10.01``
   -DHIPIFY_CLANG_TESTS=ON \
   -DCMAKE_BUILD_TYPE=Release \
   -DCMAKE_INSTALL_PREFIX=../dist \
-  -DCMAKE_PREFIX_PATH=/usr/llvm/19.1.7/dist \
+  -DCMAKE_PREFIX_PATH=/usr/llvm/20.1.0/dist \
   -DCUDA_TOOLKIT_ROOT_DIR=/usr/local/cuda-12.6.3 \
   -DCUDA_DNN_ROOT_DIR=/usr/local/cudnn-9.7.1 \
   -DCUDA_TENSOR_ROOT_DIR=/usr/local/cutensor-2.1.0.9 \
-  -DLLVM_EXTERNAL_LIT=/usr/llvm/19.1.7/build/bin/llvm-lit \
+  -DLLVM_EXTERNAL_LIT=/usr/llvm/20.1.0/build/bin/llvm-lit \
   ../hipify
 
 The corresponding successful output is:
@@ -331,11 +331,11 @@ The corresponding successful output is:
   --    - Is part of HIP SDK    : OFF
   --    - Install clang headers : ON
   -- Found ZLIB: /usr/lib/x86_64-linux-gnu/libz.so (found version "1.2.13")
-  -- Found LLVM 19.1.7:
-  --    - CMake module path     : /usr/llvm/19.1.7/dist/lib/cmake/llvm
-  --    - Clang include path    : /usr/llvm/19.1.7/dist/include
-  --    - LLVM Include path     : /usr/llvm/19.1.7/dist/include
-  --    - Binary path           : /usr/llvm/19.1.7/dist/bin
+  -- Found LLVM 20.1.0:
+  --    - CMake module path     : /usr/llvm/20.1.0/dist/lib/cmake/llvm
+  --    - Clang include path    : /usr/llvm/20.1.0/dist/include
+  --    - LLVM Include path     : /usr/llvm/20.1.0/dist/include
+  --    - Binary path           : /usr/llvm/20.1.0/dist/bin
   -- Linker detection: GNU ld
   -- ---- The below configuring for hipify-clang testing only ----
   -- Found Python: /usr/bin/python3.13 (found suitable version "3.13.2", required range is "3.0...3.14") found components: Interpreter
@@ -372,7 +372,7 @@ The corresponding successful output is:
   Running HIPify regression tests
   ===============================================================
   CUDA 12.6.85 - will be used for testing
-  LLVM 19.1.7 - will be used for testing
+  LLVM 20.1.0 - will be used for testing
   x86_64 - Platform architecture
   Linux 6.5.0-15-generic - Platform OS
   64 - hipify-clang binary bitness
@@ -472,7 +472,7 @@ Tested configurations:
     - ``2019.16.11.42, 2022.17.12.3``
     - ``3.31.2``
     - ``3.13.2``
-  * - ``19.1.0 - 19.1.7``
+  * - ``19.1.0 - 20.1.0``
     - ``7.0 - 12.6.3``
     - ``8.0.5  - 9.7.1``
     - ``2019.16.11.42, 2022.17.12.3``
@@ -502,12 +502,12 @@ Building with testing support using ``Visual Studio 17 2022`` on ``Windows 11``:
   -DHIPIFY_CLANG_TESTS=ON \
   -DCMAKE_BUILD_TYPE=Release \
   -DCMAKE_INSTALL_PREFIX=../dist \
-  -DCMAKE_PREFIX_PATH=D:/LLVM/19.1.7/dist \
+  -DCMAKE_PREFIX_PATH=D:/LLVM/20.1.0/dist \
   -DCUDA_TOOLKIT_ROOT_DIR="C:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v12.6" \
   -DCUDA_SDK_ROOT_DIR="C:/ProgramData/NVIDIA Corporation/CUDA Samples/v12.5" \
   -DCUDA_DNN_ROOT_DIR=D:/CUDA/cuDNN/9.7.1 \
   -DCUDA_TENSOR_ROOT_DIR=D:/CUDA/cuTensor/2.1.0.9 \
-  -DLLVM_EXTERNAL_LIT=D:/LLVM/19.1.7/build/Release/bin/llvm-lit.py \
+  -DLLVM_EXTERNAL_LIT=D:/LLVM/20.1.0/build/Release/bin/llvm-lit.py \
   ../hipify
 
 The corresponding successful output is:
@@ -532,15 +532,15 @@ The corresponding successful output is:
   --    - Test hipify-clang     : ON
   --    - Is part of HIP SDK    : OFF
   --    - Install clang headers : ON
-  -- Found LLVM 19.1.7:
-  --    - CMake module path     : D:/LLVM/19.1.7/dist/lib/cmake/llvm
-  --    - Clang include path    : D:/LLVM/19.1.7/dist/include
-  --    - LLVM Include path     : D:/LLVM/19.1.7/dist/include
-  --    - Binary path           : D:/LLVM/19.1.7/dist/bin
+  -- Found LLVM 20.1.0:
+  --    - CMake module path     : D:/LLVM/20.1.0/dist/lib/cmake/llvm
+  --    - Clang include path    : D:/LLVM/20.1.0/dist/include
+  --    - LLVM Include path     : D:/LLVM/20.1.0/dist/include
+  --    - Binary path           : D:/LLVM/20.1.0/dist/bin
   -- ---- The below configuring for hipify-clang testing only ----
   -- Found Python: C:/Users/TT/AppData/Local/Programs/Python/Python313/python.exe (found suitable version "3.13.2", required range is "3.0...3.14") found components: Interpreter
   -- Found lit: C:/Users/TT/AppData/Local/Programs/Python/Python313/Scripts/lit.exe
-  -- Found FileCheck: D:/LLVM/19.1.7/dist/bin/FileCheck.exe
+  -- Found FileCheck: D:/LLVM/20.1.0/dist/bin/FileCheck.exe
   -- Initial CUDA to configure:
   --    - CUDA Toolkit path     : C:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v12.6
   --    - CUDA Samples path     : C:/ProgramData/NVIDIA Corporation/CUDA Samples/v12.5

--- a/docs/how-to/hipify-clang.rst
+++ b/docs/how-to/hipify-clang.rst
@@ -41,7 +41,7 @@ Release Dependencies
 
 * `LLVM+Clang <http://releases.llvm.org>`_ version is determined at least partially by 
   the CUDA version you are using, as shown in the table below. The recommended Clang release 
-  is the latest stable release `19.1.7 <https://github.com/llvm/llvm-project/releases/tag/llvmorg-19.1.7>`_, 
+  is the latest stable release `20.1.0 <https://github.com/llvm/llvm-project/releases/tag/llvmorg-20.1.0>`_, 
   or at least version `4.0.0 <http://releases.llvm.org/download.html#4.0.0>`_.
 
 .. list-table::
@@ -50,7 +50,13 @@ Release Dependencies
     - supported LLVM release versions
     - Windows
     - Linux
-  * - `12.6.3 <https://developer.nvidia.com/cuda-downloads>`_:sup:`1`
+  * 
+    - `12.8.0 <https://developer.nvidia.com/cuda-12-6-3-download-archive>`_
+    - `20.1.0 <https://github.com/llvm/llvm-project/releases/tag/llvmorg-20.1.0>`_:sup:`1`
+    - ✅
+    - ✅
+  * 
+    - `12.6.3 <https://developer.nvidia.com/cuda-12-6-3-download-archive>`_
     - `19.1.0 <https://github.com/llvm/llvm-project/releases/tag/llvmorg-19.1.0>`_,
       `19.1.1 <https://github.com/llvm/llvm-project/releases/tag/llvmorg-19.1.1>`_,
       `19.1.2 <https://github.com/llvm/llvm-project/releases/tag/llvmorg-19.1.2>`_,
@@ -58,7 +64,7 @@ Release Dependencies
       `19.1.4 <https://github.com/llvm/llvm-project/releases/tag/llvmorg-19.1.4>`_,
       `19.1.5 <https://github.com/llvm/llvm-project/releases/tag/llvmorg-19.1.5>`_,
       `19.1.6 <https://github.com/llvm/llvm-project/releases/tag/llvmorg-19.1.6>`_,
-      `19.1.7 <https://github.com/llvm/llvm-project/releases/tag/llvmorg-19.1.7>`_:sup:`1`
+      `19.1.7 <https://github.com/llvm/llvm-project/releases/tag/llvmorg-19.1.7>`_
     - ✅
     - ✅
   * - `12.3.2 <https://developer.nvidia.com/cuda-12-3-2-download-archive>`_ 
@@ -235,7 +241,7 @@ Release Dependencies
 In most cases, you can get a suitable version of ``LLVM+Clang`` with your package manager. However, you can also
 `download a release archive <http://releases.llvm.org/>`_ and build or install it. In case of multiple versions of ``LLVM`` installed, set
 `CMAKE_PREFIX_PATH <https://cmake.org/cmake/help/latest/variable/CMAKE_PREFIX_PATH.html>`_ so that
-``CMake`` can find the desired version of ``LLVM``. For example, ``-DCMAKE_PREFIX_PATH=D:\LLVM\19.1.7\dist``.
+``CMake`` can find the desired version of ``LLVM``. For example, ``-DCMAKE_PREFIX_PATH=D:\LLVM\20.1.0\dist``.
 
 Usage
 =====
@@ -271,7 +277,7 @@ header files used during the hipification process:
 
 .. code:: shell
 
-  ./hipify-clang square.cu --cuda-path=/usr/local/cuda-12.6 --clang-resource-directory=/usr/llvm/19.1.7/dist/lib/clang/19
+  ./hipify-clang square.cu --cuda-path=/usr/local/cuda-12.6 --clang-resource-directory=/usr/llvm/20.1.0/dist/lib/clang/19
 
 For more information, refer to the `Clang manual for compiling CUDA <https://llvm.org/docs/CompileCudaWithLLVM.html#compiling-cuda-code>`_.
 


### PR DESCRIPTION
+ No patches are needed
+ Updated the `README.md` accordingly
+ Tested on `Windows 11` (`VS 2019` and `VS 2022`)  and `Ubuntu 23.10`
