### PR TITLE
[HIPIFY][SWDEV-514098] `CUDA 12.8.0` support - Step 24 - `fp8` Functions

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -6752,6 +6752,7 @@ sub simpleSubstitutions {
     subst("__nv_fp8x2_e5m2", "__hip_fp8x2_e5m2_fnuz", "device_type");
     subst("__nv_fp8x2_storage_t", "__hip_fp8x2_storage_t", "device_type");
     subst("__nv_fp8x4_e4m3", "__hip_fp8x4_e4m3_fnuz", "device_type");
+    subst("__nv_fp8x4_e5m2", "__hip_fp8x4_e5m2_fnuz", "device_type");
     subst("__nv_fp8x4_storage_t", "__hip_fp8x4_storage_t", "device_type");
     subst("__nv_saturation_t", "__hip_saturation_t", "device_type");
     subst("nv_bfloat16", "hip_bfloat16", "device_type");
@@ -8370,7 +8371,6 @@ sub simpleSubstitutions {
     subst("__NV_E5M2", "__HIP_E5M2_FNUZ", "numeric_literal");
     subst("__NV_NOSAT", "__HIP_NOSAT", "numeric_literal");
     subst("__NV_SATFINITE", "__HIP_SATFINITE", "numeric_literal");
-    subst("__nv_fp8x4_e5m2", "__hip_fp8x4_e5m2_fnuz", "numeric_literal");
     subst("cublasLtOrder_t", "hipblasLtOrder_t", "numeric_literal");
     subst("cudaAccessPropertyNormal", "hipAccessPropertyNormal", "numeric_literal");
     subst("cudaAccessPropertyPersisting", "hipAccessPropertyPersisting", "numeric_literal");
@@ -9825,16 +9825,24 @@ sub countSupportedDeviceFunctions {
     "__nv_cvt_fp4_to_halfraw",
     "__nv_cvt_float_to_fp6",
     "__nv_cvt_float_to_fp4",
+    "__nv_cvt_float_to_e8m0",
     "__nv_cvt_float2_to_fp6x2",
     "__nv_cvt_float2_to_fp4x2",
+    "__nv_cvt_float2_to_e8m0x2",
+    "__nv_cvt_e8m0x2_to_bf162raw",
+    "__nv_cvt_e8m0_to_bf16raw",
     "__nv_cvt_double_to_fp6",
     "__nv_cvt_double_to_fp4",
+    "__nv_cvt_double_to_e8m0",
     "__nv_cvt_double2_to_fp6x2",
     "__nv_cvt_double2_to_fp4x2",
+    "__nv_cvt_double2_to_e8m0x2",
     "__nv_cvt_bfloat16raw_to_fp6",
     "__nv_cvt_bfloat16raw_to_fp4",
+    "__nv_cvt_bfloat16raw_to_e8m0",
     "__nv_cvt_bfloat16raw2_to_fp6x2",
     "__nv_cvt_bfloat16raw2_to_fp4x2",
+    "__nv_cvt_bfloat162raw_to_e8m0x2",
     "__ll2bfloat16_rz",
     "__ll2bfloat16_ru",
     "__ll2bfloat16_rn",
@@ -10016,6 +10024,9 @@ sub countSupportedDeviceDataTypes {
 
 @UnsupportedDeviceDataTypes = (
     "nv_bfloat162",
+    "__nv_fp8x4_e8m0",
+    "__nv_fp8x2_e8m0",
+    "__nv_fp8_e8m0",
     "__nv_fp6x4_storage_t",
     "__nv_fp6x4_e3m2",
     "__nv_fp6x4_e2m3",

--- a/docs/reference/tables/CUDA_Device_API_supported_by_HIP.md
+++ b/docs/reference/tables/CUDA_Device_API_supported_by_HIP.md
@@ -374,21 +374,29 @@
 |`__mul24`| | | | |`__mul24`|1.6.0| | | | |
 |`__mul64hi`| | | | |`__mul64hi`|1.6.0| | | | |
 |`__mulhi`| | | | |`__mulhi`|1.6.0| | | | |
+|`__nv_cvt_bfloat162raw_to_e8m0x2`|12.8| | | | | | | | | |
 |`__nv_cvt_bfloat16raw2_to_fp4x2`|12.8| | | | | | | | | |
 |`__nv_cvt_bfloat16raw2_to_fp6x2`|12.8| | | | | | | | | |
 |`__nv_cvt_bfloat16raw2_to_fp8x2`|11.8| | | |`__hip_cvt_bfloat16raw2_to_fp8x2`|6.2.0| | | | |
+|`__nv_cvt_bfloat16raw_to_e8m0`|12.8| | | | | | | | | |
 |`__nv_cvt_bfloat16raw_to_fp4`|12.8| | | | | | | | | |
 |`__nv_cvt_bfloat16raw_to_fp6`|12.8| | | | | | | | | |
 |`__nv_cvt_bfloat16raw_to_fp8`|11.8| | | |`__hip_cvt_bfloat16raw_to_fp8`|6.2.0| | | | |
+|`__nv_cvt_double2_to_e8m0x2`|12.8| | | | | | | | | |
 |`__nv_cvt_double2_to_fp4x2`|12.8| | | | | | | | | |
 |`__nv_cvt_double2_to_fp6x2`|12.8| | | | | | | | | |
 |`__nv_cvt_double2_to_fp8x2`|11.8| | | |`__hip_cvt_double2_to_fp8x2`|6.2.0| | | | |
+|`__nv_cvt_double_to_e8m0`|12.8| | | | | | | | | |
 |`__nv_cvt_double_to_fp4`|12.8| | | | | | | | | |
 |`__nv_cvt_double_to_fp6`|12.8| | | | | | | | | |
 |`__nv_cvt_double_to_fp8`|11.8| | | |`__hip_cvt_double_to_fp8`|6.2.0| | | | |
+|`__nv_cvt_e8m0_to_bf16raw`|12.8| | | | | | | | | |
+|`__nv_cvt_e8m0x2_to_bf162raw`|12.8| | | | | | | | | |
+|`__nv_cvt_float2_to_e8m0x2`|12.8| | | | | | | | | |
 |`__nv_cvt_float2_to_fp4x2`|12.8| | | | | | | | | |
 |`__nv_cvt_float2_to_fp6x2`|12.8| | | | | | | | | |
 |`__nv_cvt_float2_to_fp8x2`|11.8| | | |`__hip_cvt_float2_to_fp8x2`|6.2.0| | | | |
+|`__nv_cvt_float_to_e8m0`|12.8| | | | | | | | | |
 |`__nv_cvt_float_to_fp4`|12.8| | | | | | | | | |
 |`__nv_cvt_float_to_fp6`|12.8| | | | | | | | | |
 |`__nv_cvt_float_to_fp8`|11.8| | | |`__hip_cvt_float_to_fp8`|6.2.0| | | | |
@@ -917,13 +925,16 @@
 |`__nv_fp6x4_storage_t`|12.8| | | | | | | | | |
 |`__nv_fp8_e4m3`|11.8| | | |`__hip_fp8_e4m3_fnuz`|6.2.0| | | | |
 |`__nv_fp8_e5m2`|11.8| | | |`__hip_fp8_e5m2_fnuz`|6.2.0| | | | |
+|`__nv_fp8_e8m0`|12.8| | | | | | | | | |
 |`__nv_fp8_interpretation_t`|11.8| | | |`__hip_fp8_interpretation_t`|6.2.0| | | | |
 |`__nv_fp8_storage_t`|11.8| | | |`__hip_fp8_storage_t`|6.2.0| | | | |
 |`__nv_fp8x2_e4m3`|11.8| | | |`__hip_fp8x2_e4m3_fnuz`|6.2.0| | | | |
 |`__nv_fp8x2_e5m2`|11.8| | | |`__hip_fp8x2_e5m2_fnuz`|6.2.0| | | | |
+|`__nv_fp8x2_e8m0`|12.8| | | | | | | | | |
 |`__nv_fp8x2_storage_t`|11.8| | | |`__hip_fp8x2_storage_t`|6.2.0| | | | |
 |`__nv_fp8x4_e4m3`|11.8| | | |`__hip_fp8x4_e4m3_fnuz`|6.2.0| | | | |
 |`__nv_fp8x4_e5m2`|11.8| | | |`__hip_fp8x4_e5m2_fnuz`|6.2.0| | | | |
+|`__nv_fp8x4_e8m0`|12.8| | | | | | | | | |
 |`__nv_fp8x4_storage_t`|11.8| | | |`__hip_fp8x4_storage_t`|6.2.0| | | | |
 |`__nv_saturation_t`|11.8| | | |`__hip_saturation_t`|6.2.0| | | | |
 |`nv_bfloat16`|11.0| | | |`hip_bfloat16`|3.5.0| | | | |

--- a/src/CUDA2HIP_Device_functions.cpp
+++ b/src/CUDA2HIP_Device_functions.cpp
@@ -880,6 +880,14 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DEVICE_FUNCTION_MAP {
   {"__nv_cvt_bfloat16raw2_to_fp8x2",    {"__hip_cvt_bfloat16raw2_to_fp8x2",    "", CONV_DEVICE_FUNC, API_RUNTIME, 1}},
   {"__nv_cvt_fp8_to_halfraw",           {"__hip_cvt_fp8_to_halfraw",           "", CONV_DEVICE_FUNC, API_RUNTIME, 1}},
   {"__nv_cvt_fp8x2_to_halfraw2",        {"__hip_cvt_fp8x2_to_halfraw2",        "", CONV_DEVICE_FUNC, API_RUNTIME, 1}},
+  {"__nv_cvt_bfloat16raw_to_e8m0",      {"__hip_cvt_bfloat16raw_to_e8m0",      "", CONV_DEVICE_FUNC, API_RUNTIME, 1, UNSUPPORTED}},
+  {"__nv_cvt_bfloat162raw_to_e8m0x2",   {"__hip_cvt_bfloat162raw_to_e8m0x2",   "", CONV_DEVICE_FUNC, API_RUNTIME, 1, UNSUPPORTED}},
+  {"__nv_cvt_float_to_e8m0",            {"__hip_cvt_float_to_e8m0",            "", CONV_DEVICE_FUNC, API_RUNTIME, 1, UNSUPPORTED}},
+  {"__nv_cvt_float2_to_e8m0x2",         {"__hip_cvt_float2_to_e8m0x2",         "", CONV_DEVICE_FUNC, API_RUNTIME, 1, UNSUPPORTED}},
+  {"__nv_cvt_double_to_e8m0",           {"__hip_cvt_double_to_e8m0",           "", CONV_DEVICE_FUNC, API_RUNTIME, 1, UNSUPPORTED}},
+  {"__nv_cvt_double2_to_e8m0x2",        {"__hip_cvt_double2_to_e8m0x2",        "", CONV_DEVICE_FUNC, API_RUNTIME, 1, UNSUPPORTED}},
+  {"__nv_cvt_e8m0_to_bf16raw",          {"__hip_cvt_e8m0_to_bf16raw",          "", CONV_DEVICE_FUNC, API_RUNTIME, 1, UNSUPPORTED}},
+  {"__nv_cvt_e8m0x2_to_bf162raw",       {"__hip_cvt_e8m0x2_to_bf162raw",       "", CONV_DEVICE_FUNC, API_RUNTIME, 1, UNSUPPORTED}},
   // fp6 functions
   {"__nv_cvt_double_to_fp6",            {"__hip_cvt_double_to_fp6",            "", CONV_DEVICE_FUNC, API_RUNTIME, 1, UNSUPPORTED}},
   {"__nv_cvt_double2_to_fp6x2",         {"__hip_cvt_double2_to_fp6x2",         "", CONV_DEVICE_FUNC, API_RUNTIME, 1, UNSUPPORTED}},
@@ -1120,6 +1128,14 @@ const std::map<llvm::StringRef, cudaAPIversions> CUDA_DEVICE_FUNCTION_VER_MAP {
   {"h2tanh",                            {CUDA_128, CUDA_0,   CUDA_0  }},
   {"htanh_approx",                      {CUDA_128, CUDA_0,   CUDA_0  }},
   {"h2tanh_approx",                     {CUDA_128, CUDA_0,   CUDA_0  }},
+  {"__nv_cvt_bfloat16raw_to_e8m0",      {CUDA_128, CUDA_0,   CUDA_0  }},
+  {"__nv_cvt_bfloat162raw_to_e8m0x2",   {CUDA_128, CUDA_0,   CUDA_0  }},
+  {"__nv_cvt_float_to_e8m0",            {CUDA_128, CUDA_0,   CUDA_0  }},
+  {"__nv_cvt_float2_to_e8m0x2",         {CUDA_128, CUDA_0,   CUDA_0  }},
+  {"__nv_cvt_double_to_e8m0",           {CUDA_128, CUDA_0,   CUDA_0  }},
+  {"__nv_cvt_double2_to_e8m0x2",        {CUDA_128, CUDA_0,   CUDA_0  }},
+  {"__nv_cvt_e8m0_to_bf16raw",          {CUDA_128, CUDA_0,   CUDA_0  }},
+  {"__nv_cvt_e8m0x2_to_bf162raw",       {CUDA_128, CUDA_0,   CUDA_0  }},
 };
 
 const std::map<llvm::StringRef, hipAPIversions> HIP_DEVICE_FUNCTION_VER_MAP {

--- a/src/CUDA2HIP_Device_types.cpp
+++ b/src/CUDA2HIP_Device_types.cpp
@@ -51,7 +51,10 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DEVICE_TYPE_NAME_MAP {
   {"__nv_fp8_interpretation_t",            {"__hip_fp8_interpretation_t",            "",                                        CONV_DEVICE_TYPE, API_RUNTIME, 2}},
   {"__NV_E4M3",                            {"__HIP_E4M3_FNUZ",                       "",                                        CONV_NUMERIC_LITERAL, API_RUNTIME, 2}},
   {"__NV_E5M2",                            {"__HIP_E5M2_FNUZ",                       "",                                        CONV_NUMERIC_LITERAL, API_RUNTIME, 2}},
-  {"__nv_fp8x4_e5m2",                      {"__hip_fp8x4_e5m2_fnuz",                 "",                                        CONV_NUMERIC_LITERAL, API_RUNTIME, 2}},
+  {"__nv_fp8x4_e5m2",                      {"__hip_fp8x4_e5m2_fnuz",                 "",                                        CONV_DEVICE_TYPE, API_RUNTIME, 2}},
+  {"__nv_fp8_e8m0",                        {"__hip_fp8_e8m0",                        "",                                        CONV_DEVICE_TYPE, API_RUNTIME, 2, UNSUPPORTED}},
+  {"__nv_fp8x2_e8m0",                      {"__hip_fp8x2_e8m0",                      "",                                        CONV_DEVICE_TYPE, API_RUNTIME, 2, UNSUPPORTED}},
+  {"__nv_fp8x4_e8m0",                      {"__hip_fp8x4_e8m0",                      "",                                        CONV_DEVICE_TYPE, API_RUNTIME, 2, UNSUPPORTED}},
   // float6 Precision Device types
   {"__nv_fp6_storage_t",                   {"__hip_fp6_storage_t",                   "",                                        CONV_DEVICE_TYPE, API_RUNTIME, 2, UNSUPPORTED}},
   {"__nv_fp6x2_storage_t",                 {"__hip_fp6x2_storage_t",                 "",                                        CONV_DEVICE_TYPE, API_RUNTIME, 2, UNSUPPORTED}},
@@ -118,6 +121,9 @@ const std::map<llvm::StringRef, cudaAPIversions> CUDA_DEVICE_TYPE_NAME_VER_MAP {
   {"__nv_fp4_e2m1",                        {CUDA_128, CUDA_0,   CUDA_0  }},
   {"__nv_fp4x2_e2m1",                      {CUDA_128, CUDA_0,   CUDA_0  }},
   {"__nv_fp4x4_e2m1",                      {CUDA_128, CUDA_0,   CUDA_0  }},
+  {"__nv_fp8_e8m0",                        {CUDA_128, CUDA_0,   CUDA_0  }},
+  {"__nv_fp8x2_e8m0",                      {CUDA_128, CUDA_0,   CUDA_0  }},
+  {"__nv_fp8x4_e8m0",                      {CUDA_128, CUDA_0,   CUDA_0  }},
 };
 
 const std::map<llvm::StringRef, hipAPIversions> HIP_DEVICE_TYPE_NAME_VER_MAP {


### PR DESCRIPTION
+ Updated the regenerated `hipify-perl` and `DEVICE` `CUDA2HIP` docs accordingly
