### PR TITLE
[HIPIFY][SWDEV-514098][RTC] `CUDA 12.8.0` support - Step 26 - RTC

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -7087,6 +7087,7 @@ sub simpleSubstitutions {
     subst("CUuuid_st", "hipUUID_t", "type");
     subst("GLenum", "GLenum", "type");
     subst("GLuint", "GLuint", "type");
+    subst("_nvrtcProgram", "_hiprtcProgram", "type");
     subst("bsric02Info", "bsric02Info", "type");
     subst("bsric02Info_t", "bsric02Info_t", "type");
     subst("bsrilu02Info", "bsrilu02Info", "type");

--- a/docs/reference/tables/CUDA_RTC_API_supported_by_HIP.md
+++ b/docs/reference/tables/CUDA_RTC_API_supported_by_HIP.md
@@ -9,6 +9,7 @@
 |**CUDA**|**A**|**D**|**C**|**R**|**HIP**|**A**|**D**|**C**|**R**|**E**|
 |:--|:-:|:-:|:-:|:-:|:--|:-:|:-:|:-:|:-:|:-:|
 |`NVRTC_ERROR_BUILTIN_OPERATION_FAILURE`| | | | |`HIPRTC_ERROR_BUILTIN_OPERATION_FAILURE`|2.6.0| | | | |
+|`NVRTC_ERROR_CANCELLED`|12.8| | | | | | | | | |
 |`NVRTC_ERROR_COMPILATION`| | | | |`HIPRTC_ERROR_COMPILATION`|2.6.0| | | | |
 |`NVRTC_ERROR_INTERNAL_ERROR`|8.0| | | |`HIPRTC_ERROR_INTERNAL_ERROR`|2.6.0| | | | |
 |`NVRTC_ERROR_INVALID_INPUT`| | | | |`HIPRTC_ERROR_INVALID_INPUT`|2.6.0| | | | |
@@ -17,10 +18,14 @@
 |`NVRTC_ERROR_NAME_EXPRESSION_NOT_VALID`|8.0| | | |`HIPRTC_ERROR_NAME_EXPRESSION_NOT_VALID`|2.6.0| | | | |
 |`NVRTC_ERROR_NO_LOWERED_NAMES_BEFORE_COMPILATION`|8.0| | | |`HIPRTC_ERROR_NO_LOWERED_NAMES_BEFORE_COMPILATION`|2.6.0| | | | |
 |`NVRTC_ERROR_NO_NAME_EXPRESSIONS_AFTER_COMPILATION`|8.0| | | |`HIPRTC_ERROR_NO_NAME_EXPRESSIONS_AFTER_COMPILATION`|2.6.0| | | | |
+|`NVRTC_ERROR_NO_PCH_CREATE_ATTEMPTED`|12.8| | | | | | | | | |
 |`NVRTC_ERROR_OUT_OF_MEMORY`| | | | |`HIPRTC_ERROR_OUT_OF_MEMORY`|2.6.0| | | | |
+|`NVRTC_ERROR_PCH_CREATE`|12.8| | | | | | | | | |
+|`NVRTC_ERROR_PCH_CREATE_HEAP_EXHAUSTED`|12.8| | | | | | | | | |
 |`NVRTC_ERROR_PROGRAM_CREATION_FAILURE`| | | | |`HIPRTC_ERROR_PROGRAM_CREATION_FAILURE`|2.6.0| | | | |
 |`NVRTC_ERROR_TIME_FILE_WRITE_FAILED`|12.1| | | | | | | | | |
 |`NVRTC_SUCCESS`| | | | |`HIPRTC_SUCCESS`|2.6.0| | | | |
+|`_nvrtcProgram`| | | | |`_hiprtcProgram`|2.6.0| | | | |
 |`nvrtcProgram`| | | | |`hiprtcProgram`|2.6.0| | | | |
 |`nvrtcResult`| | | | |`hiprtcResult`|2.6.0| | | | |
 
@@ -43,10 +48,15 @@
 |`nvrtcGetNumSupportedArchs`|11.2| | | | | | | | | |
 |`nvrtcGetOptiXIR`|12.0| | | | | | | | | |
 |`nvrtcGetOptiXIRSize`|12.0| | | | | | | | | |
+|`nvrtcGetPCHCreateStatus`|12.8| | | | | | | | | |
+|`nvrtcGetPCHHeapSize`|12.8| | | | | | | | | |
+|`nvrtcGetPCHHeapSizeRequired`|12.8| | | | | | | | | |
 |`nvrtcGetPTX`| | | | |`hiprtcGetCode`|2.6.0| | | | |
 |`nvrtcGetPTXSize`| | | | |`hiprtcGetCodeSize`|2.6.0| | | | |
 |`nvrtcGetProgramLog`| | | | |`hiprtcGetProgramLog`|2.6.0| | | | |
 |`nvrtcGetProgramLogSize`| | | | |`hiprtcGetProgramLogSize`|2.6.0| | | | |
 |`nvrtcGetSupportedArchs`|11.2| | | | | | | | | |
+|`nvrtcSetFlowCallback`|12.8| | | | | | | | | |
+|`nvrtcSetPCHHeapSize`|12.8| | | | | | | | | |
 |`nvrtcVersion`| | | | |`hiprtcVersion`|2.6.0| | | | |
 

--- a/src/CUDA2HIP_RTC_API_functions.cpp
+++ b/src/CUDA2HIP_RTC_API_functions.cpp
@@ -45,6 +45,11 @@ const std::map<llvm::StringRef, hipCounter> CUDA_RTC_FUNCTION_MAP {
   {"nvrtcGetLTOIR",                               {"hiprtcGetLTOIR",                               "", CONV_LIB_FUNC, API_RTC, 2, HIP_UNSUPPORTED}},
   {"nvrtcGetOptiXIRSize",                         {"hiprtcGetOptiXIRSize",                         "", CONV_LIB_FUNC, API_RTC, 2, HIP_UNSUPPORTED}},
   {"nvrtcGetOptiXIR",                             {"hiprtcGetOptiXIR",                             "", CONV_LIB_FUNC, API_RTC, 2, HIP_UNSUPPORTED}},
+  {"nvrtcGetPCHHeapSize",                         {"hiprtcGetPCHHeapSize",                         "", CONV_LIB_FUNC, API_RTC, 2, UNSUPPORTED}},
+  {"nvrtcSetPCHHeapSize",                         {"hiprtcSetPCHHeapSize",                         "", CONV_LIB_FUNC, API_RTC, 2, UNSUPPORTED}},
+  {"nvrtcGetPCHCreateStatus",                     {"hiprtcGetPCHCreateStatus",                     "", CONV_LIB_FUNC, API_RTC, 2, UNSUPPORTED}},
+  {"nvrtcGetPCHHeapSizeRequired",                 {"hiprtcGetPCHHeapSizeRequired",                 "", CONV_LIB_FUNC, API_RTC, 2, UNSUPPORTED}},
+  {"nvrtcSetFlowCallback",                        {"hiprtcSetFlowCallback",                        "", CONV_LIB_FUNC, API_RTC, 2, UNSUPPORTED}},
 };
 
 const std::map<llvm::StringRef, cudaAPIversions> CUDA_RTC_FUNCTION_VER_MAP {
@@ -60,6 +65,11 @@ const std::map<llvm::StringRef, cudaAPIversions> CUDA_RTC_FUNCTION_VER_MAP {
   {"nvrtcGetLTOIR",                               {CUDA_120, CUDA_0,   CUDA_0  }},
   {"nvrtcGetOptiXIRSize",                         {CUDA_120, CUDA_0,   CUDA_0  }},
   {"nvrtcGetOptiXIR",                             {CUDA_120, CUDA_0,   CUDA_0  }},
+  {"nvrtcGetPCHHeapSize",                         {CUDA_128, CUDA_0,   CUDA_0  }},
+  {"nvrtcSetPCHHeapSize",                         {CUDA_128, CUDA_0,   CUDA_0  }},
+  {"nvrtcGetPCHCreateStatus",                     {CUDA_128, CUDA_0,   CUDA_0  }},
+  {"nvrtcGetPCHHeapSizeRequired",                 {CUDA_128, CUDA_0,   CUDA_0  }},
+  {"nvrtcSetFlowCallback",                        {CUDA_128, CUDA_0,   CUDA_0  }},
 };
 
 const std::map<llvm::StringRef, hipAPIversions> HIP_RTC_FUNCTION_VER_MAP {

--- a/src/CUDA2HIP_RTC_API_types.cpp
+++ b/src/CUDA2HIP_RTC_API_types.cpp
@@ -38,8 +38,13 @@ const std::map<llvm::StringRef, hipCounter> CUDA_RTC_TYPE_NAME_MAP {
   {"NVRTC_ERROR_NAME_EXPRESSION_NOT_VALID",                      {"HIPRTC_ERROR_NAME_EXPRESSION_NOT_VALID",              "", CONV_NUMERIC_LITERAL, API_RTC, 1}}, // 10
   {"NVRTC_ERROR_INTERNAL_ERROR",                                 {"HIPRTC_ERROR_INTERNAL_ERROR",                         "", CONV_NUMERIC_LITERAL, API_RTC, 1}}, // 11
   {"NVRTC_ERROR_TIME_FILE_WRITE_FAILED",                         {"HIPRTC_ERROR_TIME_FILE_WRITE_FAILED",                 "", CONV_NUMERIC_LITERAL, API_RTC, 1, HIP_UNSUPPORTED}}, // 12
+  {"NVRTC_ERROR_NO_PCH_CREATE_ATTEMPTED",                        {"HIPRTC_ERROR_NO_PCH_CREATE_ATTEMPTED",                "", CONV_NUMERIC_LITERAL, API_RTC, 1, UNSUPPORTED}}, // 13
+  {"NVRTC_ERROR_PCH_CREATE_HEAP_EXHAUSTED",                      {"HIPRTC_ERROR_PCH_CREATE_HEAP_EXHAUSTED",              "", CONV_NUMERIC_LITERAL, API_RTC, 1, UNSUPPORTED}}, // 14
+  {"NVRTC_ERROR_PCH_CREATE",                                     {"HIPRTC_ERROR_PCH_CREATE",                             "", CONV_NUMERIC_LITERAL, API_RTC, 1, UNSUPPORTED}}, // 15
+  {"NVRTC_ERROR_CANCELLED",                                      {"HIPRTC_ERROR_CANCELLED",                              "", CONV_NUMERIC_LITERAL, API_RTC, 1, UNSUPPORTED}}, // 16
 
   {"nvrtcProgram",                                               {"hiprtcProgram",                                       "", CONV_TYPE, API_RTC, 1}},
+  {"_nvrtcProgram",                                              {"_hiprtcProgram",                                      "", CONV_TYPE, API_RTC, 1}},
 };
 
 const std::map<llvm::StringRef, cudaAPIversions> CUDA_RTC_TYPE_NAME_VER_MAP {
@@ -48,6 +53,10 @@ const std::map<llvm::StringRef, cudaAPIversions> CUDA_RTC_TYPE_NAME_VER_MAP {
   {"NVRTC_ERROR_NAME_EXPRESSION_NOT_VALID",                      {CUDA_80,  CUDA_0,   CUDA_0  }},
   {"NVRTC_ERROR_INTERNAL_ERROR",                                 {CUDA_80,  CUDA_0,   CUDA_0  }},
   {"NVRTC_ERROR_TIME_FILE_WRITE_FAILED",                         {CUDA_121, CUDA_0,   CUDA_0  }},
+  {"NVRTC_ERROR_NO_PCH_CREATE_ATTEMPTED",                        {CUDA_128, CUDA_0,   CUDA_0  }},
+  {"NVRTC_ERROR_PCH_CREATE_HEAP_EXHAUSTED",                      {CUDA_128, CUDA_0,   CUDA_0  }},
+  {"NVRTC_ERROR_PCH_CREATE",                                     {CUDA_128, CUDA_0,   CUDA_0  }},
+  {"NVRTC_ERROR_CANCELLED",                                      {CUDA_128, CUDA_0,   CUDA_0  }},
 };
 
 const std::map<llvm::StringRef, hipAPIversions> HIP_RTC_TYPE_NAME_VER_MAP {
@@ -65,4 +74,5 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_RTC_TYPE_NAME_VER_MAP {
   {"HIPRTC_ERROR_NAME_EXPRESSION_NOT_VALID",                     {HIP_2060, HIP_0,    HIP_0   }},
   {"HIPRTC_ERROR_INTERNAL_ERROR",                                {HIP_2060, HIP_0,    HIP_0   }},
   {"hiprtcProgram",                                              {HIP_2060, HIP_0,    HIP_0   }},
+  {"_hiprtcProgram",                                             {HIP_2060, HIP_0,    HIP_0   }},
 };


### PR DESCRIPTION
+ Updated the regenerated `hipify-perl` and `RTC` `CUDA2HIP` docs accordingly
+ Added support for the missing opaque struct `_nvrtcProgram`
