### PR TITLE
[HIPIFY][JIT][fix] Revise JIT-related APIs - Part 1

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -8241,6 +8241,8 @@ sub simpleSubstitutions {
     subst("CU_EVENT_DEFAULT", "hipEventDefault", "numeric_literal");
     subst("CU_EVENT_DISABLE_TIMING", "hipEventDisableTiming", "numeric_literal");
     subst("CU_EVENT_INTERPROCESS", "hipEventInterprocess", "numeric_literal");
+    subst("CU_EVENT_RECORD_DEFAULT", "hipEventRecordDefault", "numeric_literal");
+    subst("CU_EVENT_RECORD_EXTERNAL", "hipEventRecordExternal", "numeric_literal");
     subst("CU_EXTERNAL_MEMORY_HANDLE_TYPE_D3D11_RESOURCE", "hipExternalMemoryHandleTypeD3D11Resource", "numeric_literal");
     subst("CU_EXTERNAL_MEMORY_HANDLE_TYPE_D3D11_RESOURCE_KMT", "hipExternalMemoryHandleTypeD3D11ResourceKmt", "numeric_literal");
     subst("CU_EXTERNAL_MEMORY_HANDLE_TYPE_D3D12_HEAP", "hipExternalMemoryHandleTypeD3D12Heap", "numeric_literal");
@@ -8324,31 +8326,43 @@ sub simpleSubstitutions {
     subst("CU_GRAPH_NODE_TYPE_WAIT_EVENT", "hipGraphNodeTypeWaitEvent", "numeric_literal");
     subst("CU_GRAPH_USER_OBJECT_MOVE", "hipGraphUserObjectMove", "numeric_literal");
     subst("CU_IPC_MEM_LAZY_ENABLE_PEER_ACCESS", "hipIpcMemLazyEnablePeerAccess", "numeric_literal");
-    subst("CU_JIT_CACHE_MODE", "HIPRTC_JIT_CACHE_MODE", "numeric_literal");
-    subst("CU_JIT_ERROR_LOG_BUFFER", "HIPRTC_JIT_ERROR_LOG_BUFFER", "numeric_literal");
-    subst("CU_JIT_ERROR_LOG_BUFFER_SIZE_BYTES", "HIPRTC_JIT_ERROR_LOG_BUFFER_SIZE_BYTES", "numeric_literal");
-    subst("CU_JIT_FALLBACK_STRATEGY", "HIPRTC_JIT_FALLBACK_STRATEGY", "numeric_literal");
-    subst("CU_JIT_FAST_COMPILE", "HIPRTC_JIT_FAST_COMPILE", "numeric_literal");
-    subst("CU_JIT_GENERATE_DEBUG_INFO", "HIPRTC_JIT_GENERATE_DEBUG_INFO", "numeric_literal");
-    subst("CU_JIT_GENERATE_LINE_INFO", "HIPRTC_JIT_GENERATE_LINE_INFO", "numeric_literal");
-    subst("CU_JIT_INFO_LOG_BUFFER", "HIPRTC_JIT_INFO_LOG_BUFFER", "numeric_literal");
-    subst("CU_JIT_INFO_LOG_BUFFER_SIZE_BYTES", "HIPRTC_JIT_INFO_LOG_BUFFER_SIZE_BYTES", "numeric_literal");
+    subst("CU_JIT_CACHE_MODE", "hipJitOptionCacheMode", "numeric_literal");
+    subst("CU_JIT_ERROR_LOG_BUFFER", "hipJitOptionErrorLogBuffer", "numeric_literal");
+    subst("CU_JIT_ERROR_LOG_BUFFER_SIZE_BYTES", "hipJitOptionErrorLogBufferSizeBytes", "numeric_literal");
+    subst("CU_JIT_FALLBACK_STRATEGY", "hipJitOptionFallbackStrategy", "numeric_literal");
+    subst("CU_JIT_FAST_COMPILE", "hipJitOptionFastCompile", "numeric_literal");
+    subst("CU_JIT_FMA", "hipJitOptionFma", "numeric_literal");
+    subst("CU_JIT_FTZ", "hipJitOptionFtz", "numeric_literal");
+    subst("CU_JIT_GENERATE_DEBUG_INFO", "hipJitOptionGenerateDebugInfo", "numeric_literal");
+    subst("CU_JIT_GENERATE_LINE_INFO", "hipJitOptionGenerateLineInfo", "numeric_literal");
+    subst("CU_JIT_GLOBAL_SYMBOL_ADDRESSES", "hipJitOptionGlobalSymbolAddresses", "numeric_literal");
+    subst("CU_JIT_GLOBAL_SYMBOL_COUNT", "hipJitOptionGlobalSymbolCount", "numeric_literal");
+    subst("CU_JIT_GLOBAL_SYMBOL_NAMES", "hipJitOptionGlobalSymbolNames", "numeric_literal");
+    subst("CU_JIT_INFO_LOG_BUFFER", "hipJitOptionInfoLogBuffer", "numeric_literal");
+    subst("CU_JIT_INFO_LOG_BUFFER_SIZE_BYTES", "hipJitOptionInfoLogBufferSizeBytes", "numeric_literal");
     subst("CU_JIT_INPUT_CUBIN", "HIPRTC_JIT_INPUT_CUBIN", "numeric_literal");
     subst("CU_JIT_INPUT_FATBINARY", "HIPRTC_JIT_INPUT_FATBINARY", "numeric_literal");
     subst("CU_JIT_INPUT_LIBRARY", "HIPRTC_JIT_INPUT_LIBRARY", "numeric_literal");
     subst("CU_JIT_INPUT_NVVM", "HIPRTC_JIT_INPUT_NVVM", "numeric_literal");
     subst("CU_JIT_INPUT_OBJECT", "HIPRTC_JIT_INPUT_OBJECT", "numeric_literal");
     subst("CU_JIT_INPUT_PTX", "HIPRTC_JIT_INPUT_PTX", "numeric_literal");
-    subst("CU_JIT_LOG_VERBOSE", "HIPRTC_JIT_LOG_VERBOSE", "numeric_literal");
-    subst("CU_JIT_MAX_REGISTERS", "HIPRTC_JIT_MAX_REGISTERS", "numeric_literal");
-    subst("CU_JIT_NEW_SM3X_OPT", "HIPRTC_JIT_NEW_SM3X_OPT", "numeric_literal");
+    subst("CU_JIT_LOG_VERBOSE", "hipJitOptionLogVerbose", "numeric_literal");
+    subst("CU_JIT_LTO", "hipJitOptionLto", "numeric_literal");
+    subst("CU_JIT_MAX_REGISTERS", "hipJitOptionMaxRegisters", "numeric_literal");
+    subst("CU_JIT_MAX_THREADS_PER_BLOCK", "hipJitOptionMaxThreadsPerBlock", "numeric_literal");
+    subst("CU_JIT_MIN_CTA_PER_SM", "hipJitOptionMinCTAPerSM", "numeric_literal");
+    subst("CU_JIT_NEW_SM3X_OPT", "hipJitOptionSm3xOpt", "numeric_literal");
     subst("CU_JIT_NUM_INPUT_TYPES", "HIPRTC_JIT_NUM_LEGACY_INPUT_TYPES", "numeric_literal");
-    subst("CU_JIT_NUM_OPTIONS", "HIPRTC_JIT_NUM_OPTIONS", "numeric_literal");
-    subst("CU_JIT_OPTIMIZATION_LEVEL", "HIPRTC_JIT_OPTIMIZATION_LEVEL", "numeric_literal");
-    subst("CU_JIT_TARGET", "HIPRTC_JIT_TARGET", "numeric_literal");
-    subst("CU_JIT_TARGET_FROM_CUCONTEXT", "HIPRTC_JIT_TARGET_FROM_HIPCONTEXT", "numeric_literal");
-    subst("CU_JIT_THREADS_PER_BLOCK", "HIPRTC_JIT_THREADS_PER_BLOCK", "numeric_literal");
-    subst("CU_JIT_WALL_TIME", "HIPRTC_JIT_WALL_TIME", "numeric_literal");
+    subst("CU_JIT_NUM_OPTIONS", "hipJitOptionNumOptions", "numeric_literal");
+    subst("CU_JIT_OPTIMIZATION_LEVEL", "hipJitOptionOptimizationLevel", "numeric_literal");
+    subst("CU_JIT_OVERRIDE_DIRECTIVE_VALUES", "hipJitOptionOverrideDirectiveValues", "numeric_literal");
+    subst("CU_JIT_POSITION_INDEPENDENT_CODE", "hipJitOptionPositionIndependentCode", "numeric_literal");
+    subst("CU_JIT_PREC_DIV", "hipJitOptionPrecDiv", "numeric_literal");
+    subst("CU_JIT_PREC_SQRT", "hipJitOptionPrecSqrt", "numeric_literal");
+    subst("CU_JIT_TARGET", "hipJitOptionTarget", "numeric_literal");
+    subst("CU_JIT_TARGET_FROM_CUCONTEXT", "hipJitOptionTargetFromContext", "numeric_literal");
+    subst("CU_JIT_THREADS_PER_BLOCK", "hipJitOptionThreadsPerBlock", "numeric_literal");
+    subst("CU_JIT_WALL_TIME", "hipJitOptionWallTime", "numeric_literal");
     subst("CU_KERNEL_NODE_ATTRIBUTE_ACCESS_POLICY_WINDOW", "hipKernelNodeAttributeAccessPolicyWindow", "numeric_literal");
     subst("CU_KERNEL_NODE_ATTRIBUTE_COOPERATIVE", "hipKernelNodeAttributeCooperative", "numeric_literal");
     subst("CU_KERNEL_NODE_ATTRIBUTE_PRIORITY", "hipKernelNodeAttributePriority", "numeric_literal");
@@ -8776,19 +8790,23 @@ sub simpleSubstitutions {
     subst("cudaGraphicsRegisterFlagsSurfaceLoadStore", "hipGraphicsRegisterFlagsSurfaceLoadStore", "numeric_literal");
     subst("cudaGraphicsRegisterFlagsTextureGather", "hipGraphicsRegisterFlagsTextureGather", "numeric_literal");
     subst("cudaGraphicsRegisterFlagsWriteDiscard", "hipGraphicsRegisterFlagsWriteDiscard", "numeric_literal");
-    subst("cudaJitCacheMode", "HIPRTC_JIT_CACHE_MODE", "numeric_literal");
-    subst("cudaJitErrorLogBuffer", "HIPRTC_JIT_ERROR_LOG_BUFFER", "numeric_literal");
-    subst("cudaJitErrorLogBufferSizeBytes", "HIPRTC_JIT_ERROR_LOG_BUFFER_SIZE_BYTES", "numeric_literal");
-    subst("cudaJitFallbackStrategy", "HIPRTC_JIT_FALLBACK_STRATEGY", "numeric_literal");
-    subst("cudaJitGenerateDebugInfo", "HIPRTC_JIT_GENERATE_DEBUG_INFO", "numeric_literal");
-    subst("cudaJitGenerateLineInfo", "HIPRTC_JIT_GENERATE_LINE_INFO", "numeric_literal");
-    subst("cudaJitInfoLogBuffer", "HIPRTC_JIT_INFO_LOG_BUFFER", "numeric_literal");
-    subst("cudaJitInfoLogBufferSizeBytes", "HIPRTC_JIT_INFO_LOG_BUFFER_SIZE_BYTES", "numeric_literal");
-    subst("cudaJitLogVerbose", "HIPRTC_JIT_LOG_VERBOSE", "numeric_literal");
-    subst("cudaJitMaxRegisters", "HIPRTC_JIT_MAX_REGISTERS", "numeric_literal");
-    subst("cudaJitOptimizationLevel", "HIPRTC_JIT_OPTIMIZATION_LEVEL", "numeric_literal");
-    subst("cudaJitThreadsPerBlock", "HIPRTC_JIT_THREADS_PER_BLOCK", "numeric_literal");
-    subst("cudaJitWallTime", "HIPRTC_JIT_WALL_TIME", "numeric_literal");
+    subst("cudaJitCacheMode", "hipJitOptionCacheMode", "numeric_literal");
+    subst("cudaJitErrorLogBuffer", "hipJitOptionErrorLogBuffer", "numeric_literal");
+    subst("cudaJitErrorLogBufferSizeBytes", "hipJitOptionErrorLogBufferSizeBytes", "numeric_literal");
+    subst("cudaJitFallbackStrategy", "hipJitOptionFallbackStrategy", "numeric_literal");
+    subst("cudaJitGenerateDebugInfo", "hipJitOptionGenerateDebugInfo", "numeric_literal");
+    subst("cudaJitGenerateLineInfo", "hipJitOptionGenerateLineInfo", "numeric_literal");
+    subst("cudaJitInfoLogBuffer", "hipJitOptionInfoLogBuffer", "numeric_literal");
+    subst("cudaJitInfoLogBufferSizeBytes", "hipJitOptionInfoLogBufferSizeBytes", "numeric_literal");
+    subst("cudaJitLogVerbose", "hipJitOptionLogVerbose", "numeric_literal");
+    subst("cudaJitMaxRegisters", "hipJitOptionMaxRegisters", "numeric_literal");
+    subst("cudaJitMaxThreadsPerBlock", "hipJitOptionMaxThreadsPerBlock", "numeric_literal");
+    subst("cudaJitMinCtaPerSm", "hipJitOptionMinCTAPerSM", "numeric_literal");
+    subst("cudaJitOptimizationLevel", "hipJitOptionOptimizationLevel", "numeric_literal");
+    subst("cudaJitOverrideDirectiveValues", "hipJitOptionOverrideDirectiveValues", "numeric_literal");
+    subst("cudaJitPositionIndependentCode", "hipJitOptionPositionIndependentCode", "numeric_literal");
+    subst("cudaJitThreadsPerBlock", "hipJitOptionThreadsPerBlock", "numeric_literal");
+    subst("cudaJitWallTime", "hipJitOptionWallTime", "numeric_literal");
     subst("cudaKernelNodeAttributeAccessPolicyWindow", "hipKernelNodeAttributeAccessPolicyWindow", "numeric_literal");
     subst("cudaKernelNodeAttributeCooperative", "hipKernelNodeAttributeCooperative", "numeric_literal");
     subst("cudaKernelNodeAttributePriority", "hipKernelNodeAttributePriority", "numeric_literal");
@@ -9050,6 +9068,8 @@ sub simpleSubstitutions {
     subst("cudaEventDefault", "hipEventDefault", "define");
     subst("cudaEventDisableTiming", "hipEventDisableTiming", "define");
     subst("cudaEventInterprocess", "hipEventInterprocess", "define");
+    subst("cudaEventRecordDefault", "hipEventRecordDefault", "define");
+    subst("cudaEventRecordExternal", "hipEventRecordExternal", "define");
     subst("cudaExternalMemoryDedicated", "hipExternalMemoryDedicated", "define");
     subst("cudaGraphKernelNodePortDefault", "hipGraphKernelNodePortDefault", "define");
     subst("cudaGraphKernelNodePortLaunchCompletion", "hipGraphKernelNodePortLaunchCompletion", "define");
@@ -11008,10 +11028,6 @@ sub warnRemovedFunctions {
     "cudaKernelNodeAttributeClusterDimension",
     "cudaJit_Fallback",
     "cudaJit_CacheMode",
-    "cudaJitPositionIndependentCode",
-    "cudaJitOverrideDirectiveValues",
-    "cudaJitMinCtaPerSm",
-    "cudaJitMaxThreadsPerBlock",
     "cudaJitCacheOptionNone",
     "cudaJitCacheOptionCG",
     "cudaJitCacheOptionCA",
@@ -11112,8 +11128,6 @@ sub warnRemovedFunctions {
     "cudaExternalMemoryGetMappedMipmappedArray",
     "cudaEventWaitExternal",
     "cudaEventWaitDefault",
-    "cudaEventRecordExternal",
-    "cudaEventRecordDefault",
     "cudaEventElapsedTime_v2",
     "cudaEventCreateFromEGLSync",
     "cudaErrorUnsupportedPtxVersion",
@@ -12248,19 +12262,7 @@ sub warnRemovedFunctions {
     "CU_JIT_REFERENCED_VARIABLE_COUNT",
     "CU_JIT_REFERENCED_KERNEL_NAMES",
     "CU_JIT_REFERENCED_KERNEL_COUNT",
-    "CU_JIT_PREC_SQRT",
-    "CU_JIT_PREC_DIV",
-    "CU_JIT_POSITION_INDEPENDENT_CODE",
-    "CU_JIT_OVERRIDE_DIRECTIVE_VALUES",
     "CU_JIT_OPTIMIZE_UNUSED_DEVICE_VARIABLES",
-    "CU_JIT_MIN_CTA_PER_SM",
-    "CU_JIT_MAX_THREADS_PER_BLOCK",
-    "CU_JIT_LTO",
-    "CU_JIT_GLOBAL_SYMBOL_NAMES",
-    "CU_JIT_GLOBAL_SYMBOL_COUNT",
-    "CU_JIT_GLOBAL_SYMBOL_ADDRESSES",
-    "CU_JIT_FTZ",
-    "CU_JIT_FMA",
     "CU_JIT_CACHE_OPTION_NONE",
     "CU_JIT_CACHE_OPTION_CG",
     "CU_JIT_CACHE_OPTION_CA",
@@ -12312,8 +12314,6 @@ sub warnRemovedFunctions {
     "CU_EVENT_SCHED_SPIN",
     "CU_EVENT_SCHED_BLOCKING_SYNC",
     "CU_EVENT_SCHED_AUTO",
-    "CU_EVENT_RECORD_EXTERNAL",
-    "CU_EVENT_RECORD_DEFAULT",
     "CU_EGL_RESOURCE_LOCATION_VIDMEM",
     "CU_EGL_RESOURCE_LOCATION_SYSMEM",
     "CU_EGL_FRAME_TYPE_PITCH",

--- a/docs/reference/tables/CUDA_Driver_API_functions_supported_by_HIP.md
+++ b/docs/reference/tables/CUDA_Driver_API_functions_supported_by_HIP.md
@@ -627,8 +627,8 @@
 |`CU_EVENT_DEFAULT`| | | | |`hipEventDefault`|1.6.0| | | | |
 |`CU_EVENT_DISABLE_TIMING`| | | | |`hipEventDisableTiming`|1.6.0| | | | |
 |`CU_EVENT_INTERPROCESS`| | | | |`hipEventInterprocess`|1.6.0| | | | |
-|`CU_EVENT_RECORD_DEFAULT`|11.1| | | | | | | | | |
-|`CU_EVENT_RECORD_EXTERNAL`|11.1| | | | | | | | | |
+|`CU_EVENT_RECORD_DEFAULT`|11.1| | | |`hipEventRecordDefault`|6.4.0| | | | |
+|`CU_EVENT_RECORD_EXTERNAL`|11.1| | | |`hipEventRecordExternal`|6.4.0| | | | |
 |`CU_EVENT_SCHED_AUTO`|11.8| | | | | | | | | |
 |`CU_EVENT_SCHED_BLOCKING_SYNC`|11.8| | | | | | | | | |
 |`CU_EVENT_SCHED_SPIN`|11.8| | | | | | | | | |
@@ -764,51 +764,51 @@
 |`CU_GREEN_CTX_DEFAULT_STREAM`|12.4| | | | | | | | | |
 |`CU_IPC_HANDLE_SIZE`| | | | |`HIP_IPC_HANDLE_SIZE`|1.6.0| | | | |
 |`CU_IPC_MEM_LAZY_ENABLE_PEER_ACCESS`| | | | |`hipIpcMemLazyEnablePeerAccess`|1.6.0| | | | |
-|`CU_JIT_CACHE_MODE`| | | | |`HIPRTC_JIT_CACHE_MODE`|1.6.0| | | | |
+|`CU_JIT_CACHE_MODE`| | | | |`hipJitOptionCacheMode`|6.4.0| | | | |
 |`CU_JIT_CACHE_OPTION_CA`| | | | | | | | | | |
 |`CU_JIT_CACHE_OPTION_CG`| | | | | | | | | | |
 |`CU_JIT_CACHE_OPTION_NONE`| | | | | | | | | | |
-|`CU_JIT_ERROR_LOG_BUFFER`| | | | |`HIPRTC_JIT_ERROR_LOG_BUFFER`|1.6.0| | | | |
-|`CU_JIT_ERROR_LOG_BUFFER_SIZE_BYTES`| | | | |`HIPRTC_JIT_ERROR_LOG_BUFFER_SIZE_BYTES`|1.6.0| | | | |
-|`CU_JIT_FALLBACK_STRATEGY`| | | | |`HIPRTC_JIT_FALLBACK_STRATEGY`|1.6.0| | | | |
-|`CU_JIT_FAST_COMPILE`| | | | |`HIPRTC_JIT_FAST_COMPILE`|1.6.0| | | | |
-|`CU_JIT_FMA`|11.4|12.0| | | | | | | | |
-|`CU_JIT_FTZ`|11.4|12.0| | | | | | | | |
-|`CU_JIT_GENERATE_DEBUG_INFO`| | | | |`HIPRTC_JIT_GENERATE_DEBUG_INFO`|1.6.0| | | | |
-|`CU_JIT_GENERATE_LINE_INFO`| | | | |`HIPRTC_JIT_GENERATE_LINE_INFO`|1.6.0| | | | |
-|`CU_JIT_GLOBAL_SYMBOL_ADDRESSES`| | | | | | | | | | |
-|`CU_JIT_GLOBAL_SYMBOL_COUNT`| | | | | | | | | | |
-|`CU_JIT_GLOBAL_SYMBOL_NAMES`| | | | | | | | | | |
-|`CU_JIT_INFO_LOG_BUFFER`| | | | |`HIPRTC_JIT_INFO_LOG_BUFFER`|1.6.0| | | | |
-|`CU_JIT_INFO_LOG_BUFFER_SIZE_BYTES`| | | | |`HIPRTC_JIT_INFO_LOG_BUFFER_SIZE_BYTES`|1.6.0| | | | |
+|`CU_JIT_ERROR_LOG_BUFFER`| | | | |`hipJitOptionErrorLogBuffer`|6.4.0| | | | |
+|`CU_JIT_ERROR_LOG_BUFFER_SIZE_BYTES`| | | | |`hipJitOptionErrorLogBufferSizeBytes`|6.4.0| | | | |
+|`CU_JIT_FALLBACK_STRATEGY`| | | | |`hipJitOptionFallbackStrategy`|6.4.0| | | | |
+|`CU_JIT_FAST_COMPILE`|8.0| | | |`hipJitOptionFastCompile`|6.4.0| | | | |
+|`CU_JIT_FMA`|11.4|12.0| | |`hipJitOptionFma`|6.4.0| | | | |
+|`CU_JIT_FTZ`|11.4|12.0| | |`hipJitOptionFtz`|6.4.0| | | | |
+|`CU_JIT_GENERATE_DEBUG_INFO`| | | | |`hipJitOptionGenerateDebugInfo`|6.4.0| | | | |
+|`CU_JIT_GENERATE_LINE_INFO`| | | | |`hipJitOptionGenerateLineInfo`|6.4.0| | | | |
+|`CU_JIT_GLOBAL_SYMBOL_ADDRESSES`|10.0| | | |`hipJitOptionGlobalSymbolAddresses`|6.4.0| | | | |
+|`CU_JIT_GLOBAL_SYMBOL_COUNT`|10.0| | | |`hipJitOptionGlobalSymbolCount`|6.4.0| | | | |
+|`CU_JIT_GLOBAL_SYMBOL_NAMES`|10.0| | | |`hipJitOptionGlobalSymbolNames`|6.4.0| | | | |
+|`CU_JIT_INFO_LOG_BUFFER`| | | | |`hipJitOptionInfoLogBuffer`|6.4.0| | | | |
+|`CU_JIT_INFO_LOG_BUFFER_SIZE_BYTES`| | | | |`hipJitOptionInfoLogBufferSizeBytes`|6.4.0| | | | |
 |`CU_JIT_INPUT_CUBIN`| | | | |`HIPRTC_JIT_INPUT_CUBIN`|5.3.0| | | | |
 |`CU_JIT_INPUT_FATBINARY`| | | | |`HIPRTC_JIT_INPUT_FATBINARY`|5.3.0| | | | |
 |`CU_JIT_INPUT_LIBRARY`| | | | |`HIPRTC_JIT_INPUT_LIBRARY`|5.3.0| | | | |
 |`CU_JIT_INPUT_NVVM`|11.4|12.0| | |`HIPRTC_JIT_INPUT_NVVM`|5.3.0| | | | |
 |`CU_JIT_INPUT_OBJECT`| | | | |`HIPRTC_JIT_INPUT_OBJECT`|5.3.0| | | | |
 |`CU_JIT_INPUT_PTX`| | | | |`HIPRTC_JIT_INPUT_PTX`|5.3.0| | | | |
-|`CU_JIT_LOG_VERBOSE`| | | | |`HIPRTC_JIT_LOG_VERBOSE`|1.6.0| | | | |
-|`CU_JIT_LTO`|11.4|12.0| | | | | | | | |
-|`CU_JIT_MAX_REGISTERS`| | | | |`HIPRTC_JIT_MAX_REGISTERS`|1.6.0| | | | |
-|`CU_JIT_MAX_THREADS_PER_BLOCK`|12.4| | | | | | | | | |
-|`CU_JIT_MIN_CTA_PER_SM`|12.3| | | | | | | | | |
-|`CU_JIT_NEW_SM3X_OPT`| | | | |`HIPRTC_JIT_NEW_SM3X_OPT`|1.6.0| | | | |
+|`CU_JIT_LOG_VERBOSE`| | | | |`hipJitOptionLogVerbose`|6.4.0| | | | |
+|`CU_JIT_LTO`|11.4|12.0| | |`hipJitOptionLto`|6.4.0| | | | |
+|`CU_JIT_MAX_REGISTERS`| | | | |`hipJitOptionMaxRegisters`|6.4.0| | | | |
+|`CU_JIT_MAX_THREADS_PER_BLOCK`|12.4| | | |`hipJitOptionMaxThreadsPerBlock`|6.4.0| | | | |
+|`CU_JIT_MIN_CTA_PER_SM`|12.3| | | |`hipJitOptionMinCTAPerSM`|6.4.0| | | | |
+|`CU_JIT_NEW_SM3X_OPT`|8.0| | | |`hipJitOptionSm3xOpt`|6.4.0| | | | |
 |`CU_JIT_NUM_INPUT_TYPES`| | | | |`HIPRTC_JIT_NUM_LEGACY_INPUT_TYPES`|5.3.0| | | | |
-|`CU_JIT_NUM_OPTIONS`| | | | |`HIPRTC_JIT_NUM_OPTIONS`|1.6.0| | | | |
-|`CU_JIT_OPTIMIZATION_LEVEL`| | | | |`HIPRTC_JIT_OPTIMIZATION_LEVEL`|1.6.0| | | | |
+|`CU_JIT_NUM_OPTIONS`| | | | |`hipJitOptionNumOptions`|6.4.0| | | | |
+|`CU_JIT_OPTIMIZATION_LEVEL`| | | | |`hipJitOptionOptimizationLevel`|6.4.0| | | | |
 |`CU_JIT_OPTIMIZE_UNUSED_DEVICE_VARIABLES`|11.7|12.0| | | | | | | | |
-|`CU_JIT_OVERRIDE_DIRECTIVE_VALUES`|12.4| | | | | | | | | |
-|`CU_JIT_POSITION_INDEPENDENT_CODE`|12.0| | | | | | | | | |
-|`CU_JIT_PREC_DIV`|11.4|12.0| | | | | | | | |
-|`CU_JIT_PREC_SQRT`|11.4|12.0| | | | | | | | |
+|`CU_JIT_OVERRIDE_DIRECTIVE_VALUES`|12.4| | | |`hipJitOptionOverrideDirectiveValues`|6.4.0| | | | |
+|`CU_JIT_POSITION_INDEPENDENT_CODE`|12.0| | | |`hipJitOptionPositionIndependentCode`|6.4.0| | | | |
+|`CU_JIT_PREC_DIV`|11.4|12.0| | |`hipJitOptionPrecDiv`|6.4.0| | | | |
+|`CU_JIT_PREC_SQRT`|11.4|12.0| | |`hipJitOptionPrecSqrt`|6.4.0| | | | |
 |`CU_JIT_REFERENCED_KERNEL_COUNT`|11.7|12.0| | | | | | | | |
 |`CU_JIT_REFERENCED_KERNEL_NAMES`|11.7|12.0| | | | | | | | |
 |`CU_JIT_REFERENCED_VARIABLE_COUNT`|11.7|12.0| | | | | | | | |
 |`CU_JIT_REFERENCED_VARIABLE_NAMES`|11.7|12.0| | | | | | | | |
-|`CU_JIT_TARGET`| | | | |`HIPRTC_JIT_TARGET`|1.6.0| | | | |
-|`CU_JIT_TARGET_FROM_CUCONTEXT`| | | | |`HIPRTC_JIT_TARGET_FROM_HIPCONTEXT`|1.6.0| | | | |
-|`CU_JIT_THREADS_PER_BLOCK`| | | | |`HIPRTC_JIT_THREADS_PER_BLOCK`|1.6.0| | | | |
-|`CU_JIT_WALL_TIME`| | | | |`HIPRTC_JIT_WALL_TIME`|1.6.0| | | | |
+|`CU_JIT_TARGET`| | | | |`hipJitOptionTarget`|6.4.0| | | | |
+|`CU_JIT_TARGET_FROM_CUCONTEXT`| | | | |`hipJitOptionTargetFromContext`|6.4.0| | | | |
+|`CU_JIT_THREADS_PER_BLOCK`| | | | |`hipJitOptionThreadsPerBlock`|6.4.0| | | | |
+|`CU_JIT_WALL_TIME`| | | | |`hipJitOptionWallTime`|6.4.0| | | | |
 |`CU_KERNEL_NODE_ATTRIBUTE_ACCESS_POLICY_WINDOW`|11.0| | | |`hipKernelNodeAttributeAccessPolicyWindow`|5.2.0| | | | |
 |`CU_KERNEL_NODE_ATTRIBUTE_CLUSTER_DIMENSION`|11.8| | | | | | | | | |
 |`CU_KERNEL_NODE_ATTRIBUTE_CLUSTER_SCHEDULING_POLICY_PREFERENCE`|11.8| | | | | | | | | |

--- a/docs/reference/tables/CUDA_Runtime_API_functions_supported_by_HIP.md
+++ b/docs/reference/tables/CUDA_Runtime_API_functions_supported_by_HIP.md
@@ -1218,8 +1218,8 @@
 |`cudaEventDefault`| | | | |`hipEventDefault`|1.6.0| | | | |
 |`cudaEventDisableTiming`| | | | |`hipEventDisableTiming`|1.6.0| | | | |
 |`cudaEventInterprocess`| | | | |`hipEventInterprocess`|1.6.0| | | | |
-|`cudaEventRecordDefault`|11.1| | | | | | | | | |
-|`cudaEventRecordExternal`|11.1| | | | | | | | | |
+|`cudaEventRecordDefault`|11.1| | | |`hipEventRecordDefault`|6.4.0| | | | |
+|`cudaEventRecordExternal`|11.1| | | |`hipEventRecordExternal`|6.4.0| | | | |
 |`cudaEventRecordNodeParams`|12.2| | | |`hipEventRecordNodeParams`|6.1.0| | | | |
 |`cudaEventWaitDefault`|11.1| | | | | | | | | |
 |`cudaEventWaitExternal`| | | | | | | | | | |
@@ -1429,27 +1429,27 @@
 |`cudaIpcMemHandle_st`| | | | |`hipIpcMemHandle_st`|1.6.0| | | | |
 |`cudaIpcMemHandle_t`| | | | |`hipIpcMemHandle_t`|1.6.0| | | | |
 |`cudaIpcMemLazyEnablePeerAccess`| | | | |`hipIpcMemLazyEnablePeerAccess`|1.6.0| | | | |
-|`cudaJitCacheMode`|12.8| | | |`HIPRTC_JIT_CACHE_MODE`|1.6.0| | | | |
+|`cudaJitCacheMode`|12.8| | | |`hipJitOptionCacheMode`|6.4.0| | | | |
 |`cudaJitCacheOptionCA`|12.8| | | | | | | | | |
 |`cudaJitCacheOptionCG`|12.8| | | | | | | | | |
 |`cudaJitCacheOptionNone`|12.8| | | | | | | | | |
-|`cudaJitErrorLogBuffer`|12.8| | | |`HIPRTC_JIT_ERROR_LOG_BUFFER`|1.6.0| | | | |
-|`cudaJitErrorLogBufferSizeBytes`|12.8| | | |`HIPRTC_JIT_ERROR_LOG_BUFFER_SIZE_BYTES`|1.6.0| | | | |
-|`cudaJitFallbackStrategy`|12.8| | | |`HIPRTC_JIT_FALLBACK_STRATEGY`|1.6.0| | | | |
-|`cudaJitGenerateDebugInfo`|12.8| | | |`HIPRTC_JIT_GENERATE_DEBUG_INFO`|1.6.0| | | | |
-|`cudaJitGenerateLineInfo`|12.8| | | |`HIPRTC_JIT_GENERATE_LINE_INFO`|1.6.0| | | | |
-|`cudaJitInfoLogBuffer`|12.8| | | |`HIPRTC_JIT_INFO_LOG_BUFFER`|1.6.0| | | | |
-|`cudaJitInfoLogBufferSizeBytes`|12.8| | | |`HIPRTC_JIT_INFO_LOG_BUFFER_SIZE_BYTES`|1.6.0| | | | |
-|`cudaJitLogVerbose`|12.8| | | |`HIPRTC_JIT_LOG_VERBOSE`|1.6.0| | | | |
-|`cudaJitMaxRegisters`|12.8| | | |`HIPRTC_JIT_MAX_REGISTERS`|1.6.0| | | | |
-|`cudaJitMaxThreadsPerBlock`|12.8| | | | | | | | | |
-|`cudaJitMinCtaPerSm`|12.8| | | | | | | | | |
-|`cudaJitOptimizationLevel`|12.8| | | |`HIPRTC_JIT_OPTIMIZATION_LEVEL`|1.6.0| | | | |
+|`cudaJitErrorLogBuffer`|12.8| | | |`hipJitOptionErrorLogBuffer`|6.4.0| | | | |
+|`cudaJitErrorLogBufferSizeBytes`|12.8| | | |`hipJitOptionErrorLogBufferSizeBytes`|6.4.0| | | | |
+|`cudaJitFallbackStrategy`|12.8| | | |`hipJitOptionFallbackStrategy`|6.4.0| | | | |
+|`cudaJitGenerateDebugInfo`|12.8| | | |`hipJitOptionGenerateDebugInfo`|6.4.0| | | | |
+|`cudaJitGenerateLineInfo`|12.8| | | |`hipJitOptionGenerateLineInfo`|6.4.0| | | | |
+|`cudaJitInfoLogBuffer`|12.8| | | |`hipJitOptionInfoLogBuffer`|6.4.0| | | | |
+|`cudaJitInfoLogBufferSizeBytes`|12.8| | | |`hipJitOptionInfoLogBufferSizeBytes`|6.4.0| | | | |
+|`cudaJitLogVerbose`|12.8| | | |`hipJitOptionLogVerbose`|6.4.0| | | | |
+|`cudaJitMaxRegisters`|12.8| | | |`hipJitOptionMaxRegisters`|6.4.0| | | | |
+|`cudaJitMaxThreadsPerBlock`|12.8| | | |`hipJitOptionMaxThreadsPerBlock`|6.4.0| | | | |
+|`cudaJitMinCtaPerSm`|12.8| | | |`hipJitOptionMinCTAPerSM`|6.4.0| | | | |
+|`cudaJitOptimizationLevel`|12.8| | | |`hipJitOptionOptimizationLevel`|6.4.0| | | | |
 |`cudaJitOption`|12.8| | | |`hipJitOption`|1.6.0| | | | |
-|`cudaJitOverrideDirectiveValues`|12.8| | | | | | | | | |
-|`cudaJitPositionIndependentCode`|12.8| | | | | | | | | |
-|`cudaJitThreadsPerBlock`|12.8| | | |`HIPRTC_JIT_THREADS_PER_BLOCK`|1.6.0| | | | |
-|`cudaJitWallTime`|12.8| | | |`HIPRTC_JIT_WALL_TIME`|1.6.0| | | | |
+|`cudaJitOverrideDirectiveValues`|12.8| | | |`hipJitOptionOverrideDirectiveValues`|6.4.0| | | | |
+|`cudaJitPositionIndependentCode`|12.8| | | |`hipJitOptionPositionIndependentCode`|6.4.0| | | | |
+|`cudaJitThreadsPerBlock`|12.8| | | |`hipJitOptionThreadsPerBlock`|6.4.0| | | | |
+|`cudaJitWallTime`|12.8| | | |`hipJitOptionWallTime`|6.4.0| | | | |
 |`cudaJit_CacheMode`|12.8| | | | | | | | | |
 |`cudaJit_Fallback`|12.8| | | | | | | | | |
 |`cudaKernelNodeAttrID`|11.0| | | |`hipKernelNodeAttrID`|5.2.0| | | | |

--- a/src/CUDA2HIP_Driver_API_types.cpp
+++ b/src/CUDA2HIP_Driver_API_types.cpp
@@ -1453,55 +1453,55 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_TYPE_NAME_MAP {
   {"CUjit_option_enum",                                                {"hipJitOption",                                             "", CONV_TYPE, API_DRIVER, SEC::DATA_TYPES}},
   // CUjit_option enum values
   // cudaJitMaxRegisters
-  {"CU_JIT_MAX_REGISTERS",                                             {"HIPRTC_JIT_MAX_REGISTERS",                                 "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES}}, // 0
+  {"CU_JIT_MAX_REGISTERS",                                             {"hipJitOptionMaxRegisters",                                 "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES}}, // 0
   // cudaJitThreadsPerBlock
-  {"CU_JIT_THREADS_PER_BLOCK",                                         {"HIPRTC_JIT_THREADS_PER_BLOCK",                             "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES}}, // 1
+  {"CU_JIT_THREADS_PER_BLOCK",                                         {"hipJitOptionThreadsPerBlock",                              "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES}}, // 1
   // cudaJitWallTime
-  {"CU_JIT_WALL_TIME",                                                 {"HIPRTC_JIT_WALL_TIME",                                     "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES}}, // 2
+  {"CU_JIT_WALL_TIME",                                                 {"hipJitOptionWallTime",                                     "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES}}, // 2
   // cudaJitInfoLogBuffer
-  {"CU_JIT_INFO_LOG_BUFFER",                                           {"HIPRTC_JIT_INFO_LOG_BUFFER",                               "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES}}, // 3
+  {"CU_JIT_INFO_LOG_BUFFER",                                           {"hipJitOptionInfoLogBuffer",                                "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES}}, // 3
   // cudaJitInfoLogBufferSizeBytes
-  {"CU_JIT_INFO_LOG_BUFFER_SIZE_BYTES",                                {"HIPRTC_JIT_INFO_LOG_BUFFER_SIZE_BYTES",                    "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES}}, // 4
+  {"CU_JIT_INFO_LOG_BUFFER_SIZE_BYTES",                                {"hipJitOptionInfoLogBufferSizeBytes",                       "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES}}, // 4
   // cudaJitErrorLogBuffer
-  {"CU_JIT_ERROR_LOG_BUFFER",                                          {"HIPRTC_JIT_ERROR_LOG_BUFFER",                              "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES}}, // 5
+  {"CU_JIT_ERROR_LOG_BUFFER",                                          {"hipJitOptionErrorLogBuffer",                               "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES}}, // 5
   // cudaJitErrorLogBufferSizeBytes
-  {"CU_JIT_ERROR_LOG_BUFFER_SIZE_BYTES",                               {"HIPRTC_JIT_ERROR_LOG_BUFFER_SIZE_BYTES",                   "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES}}, // 6
+  {"CU_JIT_ERROR_LOG_BUFFER_SIZE_BYTES",                               {"hipJitOptionErrorLogBufferSizeBytes",                      "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES}}, // 6
   // cudaJitOptimizationLevel
-  {"CU_JIT_OPTIMIZATION_LEVEL",                                        {"HIPRTC_JIT_OPTIMIZATION_LEVEL",                            "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES}}, // 7
+  {"CU_JIT_OPTIMIZATION_LEVEL",                                        {"hipJitOptionOptimizationLevel",                            "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES}}, // 7
   //
-  {"CU_JIT_TARGET_FROM_CUCONTEXT",                                     {"HIPRTC_JIT_TARGET_FROM_HIPCONTEXT",                        "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES}},
+  {"CU_JIT_TARGET_FROM_CUCONTEXT",                                     {"hipJitOptionTargetFromContext",                            "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES}},
   //
-  {"CU_JIT_TARGET",                                                    {"HIPRTC_JIT_TARGET",                                        "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES}},
+  {"CU_JIT_TARGET",                                                    {"hipJitOptionTarget",                                       "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES}},
   // cudaJitFallbackStrategy
-  {"CU_JIT_FALLBACK_STRATEGY",                                         {"HIPRTC_JIT_FALLBACK_STRATEGY",                             "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES}}, // 10
+  {"CU_JIT_FALLBACK_STRATEGY",                                         {"hipJitOptionFallbackStrategy",                             "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES}}, // 10
   // cudaJitGenerateDebugInfo
-  {"CU_JIT_GENERATE_DEBUG_INFO",                                       {"HIPRTC_JIT_GENERATE_DEBUG_INFO",                           "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES}}, // 11
+  {"CU_JIT_GENERATE_DEBUG_INFO",                                       {"hipJitOptionGenerateDebugInfo",                            "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES}}, // 11
   // cudaJitLogVerbose
-  {"CU_JIT_LOG_VERBOSE",                                               {"HIPRTC_JIT_LOG_VERBOSE",                                   "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES}}, // 12
+  {"CU_JIT_LOG_VERBOSE",                                               {"hipJitOptionLogVerbose",                                   "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES}}, // 12
   // cudaJitGenerateLineInfo
-  {"CU_JIT_GENERATE_LINE_INFO",                                        {"HIPRTC_JIT_GENERATE_LINE_INFO",                            "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES}}, // 13
+  {"CU_JIT_GENERATE_LINE_INFO",                                        {"hipJitOptionGenerateLineInfo",                             "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES}}, // 13
   // cudaJitCacheMode
-  {"CU_JIT_CACHE_MODE",                                                {"HIPRTC_JIT_CACHE_MODE",                                    "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES}}, // 14
+  {"CU_JIT_CACHE_MODE",                                                {"hipJitOptionCacheMode",                                    "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES}}, // 14
   //
-  {"CU_JIT_NEW_SM3X_OPT",                                              {"HIPRTC_JIT_NEW_SM3X_OPT",                                  "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES}},
+  {"CU_JIT_NEW_SM3X_OPT",                                              {"hipJitOptionSm3xOpt",                                      "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES}},
   //
-  {"CU_JIT_FAST_COMPILE",                                              {"HIPRTC_JIT_FAST_COMPILE",                                  "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES}},
+  {"CU_JIT_FAST_COMPILE",                                              {"hipJitOptionFastCompile",                                  "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES}},
   //
-  {"CU_JIT_GLOBAL_SYMBOL_NAMES",                                       {"hipJitGlobalSymbolNames",                                  "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
+  {"CU_JIT_GLOBAL_SYMBOL_NAMES",                                       {"hipJitOptionGlobalSymbolNames",                            "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES}},
   //
-  {"CU_JIT_GLOBAL_SYMBOL_ADDRESSES",                                   {"hipJitGlobalSymbolAddresses",                              "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
+  {"CU_JIT_GLOBAL_SYMBOL_ADDRESSES",                                   {"hipJitOptionGlobalSymbolAddresses",                        "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES}},
   //
-  {"CU_JIT_GLOBAL_SYMBOL_COUNT",                                       {"hipJitGlobalSymbolCount",                                  "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
+  {"CU_JIT_GLOBAL_SYMBOL_COUNT",                                       {"hipJitOptionGlobalSymbolCount",                            "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES}},
   //
-  {"CU_JIT_LTO",                                                       {"hipJitLto",                                                "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED | CUDA_DEPRECATED}},
+  {"CU_JIT_LTO",                                                       {"hipJitOptionLto",                                          "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES, CUDA_DEPRECATED}},
   //
-  {"CU_JIT_FTZ",                                                       {"hipJitFtz",                                                "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED | CUDA_DEPRECATED}},
+  {"CU_JIT_FTZ",                                                       {"hipJitOptionFtz",                                          "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES, CUDA_DEPRECATED}},
   //
-  {"CU_JIT_PREC_DIV",                                                  {"hipJitPrecDiv",                                            "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED | CUDA_DEPRECATED}},
+  {"CU_JIT_PREC_DIV",                                                  {"hipJitOptionPrecDiv",                                      "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES, CUDA_DEPRECATED}},
   //
-  {"CU_JIT_PREC_SQRT",                                                 {"hipJitPrecSqrt",                                           "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED | CUDA_DEPRECATED}},
+  {"CU_JIT_PREC_SQRT",                                                 {"hipJitOptionPrecSqrt",                                     "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES, CUDA_DEPRECATED}},
   //
-  {"CU_JIT_FMA",                                                       {"hipJitFma",                                                "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED | CUDA_DEPRECATED}},
+  {"CU_JIT_FMA",                                                       {"hipJitOptionFma",                                          "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES, CUDA_DEPRECATED}},
   //
   {"CU_JIT_REFERENCED_KERNEL_NAMES",                                   {"hipJitReferencedKernelNames",                              "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED | CUDA_DEPRECATED}},
   //
@@ -1513,15 +1513,15 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_TYPE_NAME_MAP {
   //
   {"CU_JIT_OPTIMIZE_UNUSED_DEVICE_VARIABLES",                          {"hipJitOptimizeUnusedDeviceVariables",                      "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED | CUDA_DEPRECATED}},
   // cudaJitPositionIndependentCode
-  {"CU_JIT_POSITION_INDEPENDENT_CODE",                                 {"hipJitPositionIndependentCode",                            "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED}}, // 30
+  {"CU_JIT_POSITION_INDEPENDENT_CODE",                                 {"hipJitOptionPositionIndependentCode",                      "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES}}, // 30
   // cudaJitMinCtaPerSm
-  {"CU_JIT_MIN_CTA_PER_SM",                                            {"hipJitMinCtaPerSm",                                        "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED}}, // 31
+  {"CU_JIT_MIN_CTA_PER_SM",                                            {"hipJitOptionMinCTAPerSM",                                  "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES}}, // 31
   // cudaJitMaxThreadsPerBlock
-  {"CU_JIT_MAX_THREADS_PER_BLOCK",                                     {"hipJitMaxThreadsPerBlock",                                 "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED}}, // 32
+  {"CU_JIT_MAX_THREADS_PER_BLOCK",                                     {"hipJitOptionMaxThreadsPerBlock",                           "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES}}, // 32
   // cudaJitOverrideDirectiveValues
-  {"CU_JIT_OVERRIDE_DIRECTIVE_VALUES",                                 {"hipJitOverrideDerectiveValues",                            "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED}}, // 33
+  {"CU_JIT_OVERRIDE_DIRECTIVE_VALUES",                                 {"hipJitOptionOverrideDirectiveValues",                      "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES}}, // 33
   //
-  {"CU_JIT_NUM_OPTIONS",                                               {"HIPRTC_JIT_NUM_OPTIONS",                                   "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES}},
+  {"CU_JIT_NUM_OPTIONS",                                               {"hipJitOptionNumOptions",                                   "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES}},
 
   // no analogue
   {"CUjit_target",                                                     {"hipJitTarget",                                             "", CONV_TYPE, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
@@ -2304,9 +2304,9 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_TYPE_NAME_MAP {
   {"CUevent_record_flags_enum",                                        {"hipEvent_record_flags",                                    "", CONV_TYPE, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
   // CUevent_record_flags enum values
   // cudaEventRecordDefault
-  {"CU_EVENT_RECORD_DEFAULT",                                          {"hipEventRecordDefault",                                    "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED}}, // 0x0
+  {"CU_EVENT_RECORD_DEFAULT",                                          {"hipEventRecordDefault",                                    "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES}}, // 0x0
   // cudaEventRecordExternal
-  {"CU_EVENT_RECORD_EXTERNAL",                                         {"hipEventRecordExternal",                                   "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED}}, // 0x1
+  {"CU_EVENT_RECORD_EXTERNAL",                                         {"hipEventRecordExternal",                                   "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES}}, // 0x1
 
   // no analogue
   {"CUevent_wait_flags",                                               {"hipEvent_wait_flags",                                      "", CONV_TYPE, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
@@ -4180,6 +4180,11 @@ const std::map<llvm::StringRef, cudaAPIversions> CUDA_DRIVER_TYPE_NAME_VER_MAP {
   {"CU_MEM_DECOMPRESS_ALGORITHM_SNAPPY",                               {CUDA_128, CUDA_0,   CUDA_0  }},
   {"CUmemDecompressParams_st",                                         {CUDA_128, CUDA_0,   CUDA_0  }},
   {"CUmemDecompressParams",                                            {CUDA_128, CUDA_0,   CUDA_0  }},
+  {"CU_JIT_GLOBAL_SYMBOL_NAMES",                                       {CUDA_100, CUDA_0,   CUDA_0  }},
+  {"CU_JIT_GLOBAL_SYMBOL_ADDRESSES",                                   {CUDA_100, CUDA_0,   CUDA_0  }},
+  {"CU_JIT_GLOBAL_SYMBOL_COUNT",                                       {CUDA_100, CUDA_0,   CUDA_0  }},
+  {"CU_JIT_NEW_SM3X_OPT",                                              {CUDA_80,  CUDA_0,   CUDA_0  }},
+  {"CU_JIT_FAST_COMPILE",                                              {CUDA_80,  CUDA_0,   CUDA_0  }},
 };
 
 const std::map<llvm::StringRef, hipAPIversions> HIP_DRIVER_TYPE_NAME_VER_MAP {
@@ -4258,24 +4263,24 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_DRIVER_TYPE_NAME_VER_MAP {
   {"hipMemRangeAttributeAccessedBy",                                   {HIP_3070, HIP_0,    HIP_0   }},
   {"hipMemRangeAttributeLastPrefetchLocation",                         {HIP_3070, HIP_0,    HIP_0   }},
   {"hipJitOption",                                                     {HIP_1060, HIP_0,    HIP_0   }},
-  {"HIPRTC_JIT_MAX_REGISTERS",                                         {HIP_1060, HIP_0,    HIP_0   }},
-  {"HIPRTC_JIT_THREADS_PER_BLOCK",                                     {HIP_1060, HIP_0,    HIP_0   }},
-  {"HIPRTC_JIT_WALL_TIME",                                             {HIP_1060, HIP_0,    HIP_0   }},
-  {"HIPRTC_JIT_INFO_LOG_BUFFER",                                       {HIP_1060, HIP_0,    HIP_0   }},
-  {"HIPRTC_JIT_INFO_LOG_BUFFER_SIZE_BYTES",                            {HIP_1060, HIP_0,    HIP_0   }},
-  {"HIPRTC_JIT_ERROR_LOG_BUFFER",                                      {HIP_1060, HIP_0,    HIP_0   }},
-  {"HIPRTC_JIT_ERROR_LOG_BUFFER_SIZE_BYTES",                           {HIP_1060, HIP_0,    HIP_0   }},
-  {"HIPRTC_JIT_OPTIMIZATION_LEVEL",                                    {HIP_1060, HIP_0,    HIP_0   }},
-  {"HIPRTC_JIT_TARGET_FROM_HIPCONTEXT",                                {HIP_1060, HIP_0,    HIP_0   }},
-  {"HIPRTC_JIT_TARGET",                                                {HIP_1060, HIP_0,    HIP_0   }},
-  {"HIPRTC_JIT_FALLBACK_STRATEGY",                                     {HIP_1060, HIP_0,    HIP_0   }},
-  {"HIPRTC_JIT_GENERATE_DEBUG_INFO",                                   {HIP_1060, HIP_0,    HIP_0   }},
-  {"HIPRTC_JIT_LOG_VERBOSE",                                           {HIP_1060, HIP_0,    HIP_0   }},
-  {"HIPRTC_JIT_GENERATE_LINE_INFO",                                    {HIP_1060, HIP_0,    HIP_0   }},
-  {"HIPRTC_JIT_CACHE_MODE",                                            {HIP_1060, HIP_0,    HIP_0   }},
-  {"HIPRTC_JIT_NEW_SM3X_OPT",                                          {HIP_1060, HIP_0,    HIP_0   }},
-  {"HIPRTC_JIT_FAST_COMPILE",                                          {HIP_1060, HIP_0,    HIP_0   }},
-  {"HIPRTC_JIT_NUM_OPTIONS",                                           {HIP_1060, HIP_0,    HIP_0   }},
+  {"hipJitOptionMaxRegisters",                                         {HIP_6040, HIP_0,    HIP_0   }},
+  {"hipJitOptionThreadsPerBlock",                                      {HIP_6040, HIP_0,    HIP_0   }},
+  {"hipJitOptionWallTime",                                             {HIP_6040, HIP_0,    HIP_0   }},
+  {"hipJitOptionInfoLogBuffer",                                        {HIP_6040, HIP_0,    HIP_0   }},
+  {"hipJitOptionInfoLogBufferSizeBytes",                               {HIP_6040, HIP_0,    HIP_0   }},
+  {"hipJitOptionErrorLogBuffer",                                       {HIP_6040, HIP_0,    HIP_0   }},
+  {"hipJitOptionErrorLogBufferSizeBytes",                              {HIP_6040, HIP_0,    HIP_0   }},
+  {"hipJitOptionOptimizationLevel",                                    {HIP_6040, HIP_0,    HIP_0   }},
+  {"hipJitOptionTargetFromContext",                                    {HIP_6040, HIP_0,    HIP_0   }},
+  {"hipJitOptionTarget",                                               {HIP_6040, HIP_0,    HIP_0   }},
+  {"hipJitOptionFallbackStrategy",                                     {HIP_6040, HIP_0,    HIP_0   }},
+  {"hipJitOptionGenerateDebugInfo",                                    {HIP_6040, HIP_0,    HIP_0   }},
+  {"hipJitOptionLogVerbose",                                           {HIP_6040, HIP_0,    HIP_0   }},
+  {"hipJitOptionGenerateLineInfo",                                     {HIP_6040, HIP_0,    HIP_0   }},
+  {"hipJitOptionCacheMode",                                            {HIP_6040, HIP_0,    HIP_0   }},
+  {"hipJitOptionSm3xOpt",                                              {HIP_6040, HIP_0,    HIP_0   }},
+  {"hipJitOptionFastCompile",                                          {HIP_6040, HIP_0,    HIP_0   }},
+  {"hipJitOptionNumOptions",                                           {HIP_6040, HIP_0,    HIP_0   }},
   {"hipFuncCache_t",                                                   {HIP_1060, HIP_0,    HIP_0   }},
   {"hipFuncCachePreferNone",                                           {HIP_1060, HIP_0,    HIP_0   }},
   {"hipFuncCachePreferShared",                                         {HIP_1060, HIP_0,    HIP_0   }},
@@ -4641,4 +4646,16 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_DRIVER_TYPE_NAME_VER_MAP {
   {"hipStreamMemOpWriteValue64",                                       {HIP_6040, HIP_0,    HIP_0   }},
   {"hipStreamMemOpBarrier",                                            {HIP_6040, HIP_0,    HIP_0   }},
   {"hipGraphNodeTypeBatchMemOp",                                       {HIP_6040, HIP_0,    HIP_0   }},
+  {"hipJitOptionGlobalSymbolNames",                                    {HIP_6040, HIP_0,    HIP_0   }},
+  {"hipJitOptionGlobalSymbolAddresses",                                {HIP_6040, HIP_0,    HIP_0   }},
+  {"hipJitOptionGlobalSymbolCount",                                    {HIP_6040, HIP_0,    HIP_0   }},
+  {"hipJitOptionLto",                                                  {HIP_6040, HIP_0,    HIP_0   }},
+  {"hipJitOptionFtz",                                                  {HIP_6040, HIP_0,    HIP_0   }},
+  {"hipJitOptionPrecDiv",                                              {HIP_6040, HIP_0,    HIP_0   }},
+  {"hipJitOptionPrecSqrt",                                             {HIP_6040, HIP_0,    HIP_0   }},
+  {"hipJitOptionFma",                                                  {HIP_6040, HIP_0,    HIP_0   }},
+  {"hipJitOptionPositionIndependentCode",                              {HIP_6040, HIP_0,    HIP_0   }},
+  {"hipJitOptionMinCTAPerSM",                                          {HIP_6040, HIP_0,    HIP_0   }},
+  {"hipJitOptionMaxThreadsPerBlock",                                   {HIP_6040, HIP_0,    HIP_0   }},
+  {"hipJitOptionOverrideDirectiveValues",                              {HIP_6040, HIP_0,    HIP_0   }},
 };

--- a/src/CUDA2HIP_Runtime_API_types.cpp
+++ b/src/CUDA2HIP_Runtime_API_types.cpp
@@ -2120,39 +2120,39 @@ const std::map<llvm::StringRef, hipCounter> CUDA_RUNTIME_TYPE_NAME_MAP {
   {"cudaJitOption",                                                    {"hipJitOption",                                             "", CONV_TYPE, API_RUNTIME, SEC::DATA_TYPES}},
   // cudaJitOption enum values
   // CU_JIT_MAX_REGISTERS
-  {"cudaJitMaxRegisters",                                              {"HIPRTC_JIT_MAX_REGISTERS",                                 "", CONV_NUMERIC_LITERAL, API_RUNTIME, SEC::DATA_TYPES}}, // 0
+  {"cudaJitMaxRegisters",                                              {"hipJitOptionMaxRegisters",                                 "", CONV_NUMERIC_LITERAL, API_RUNTIME, SEC::DATA_TYPES}}, // 0
   // CU_JIT_THREADS_PER_BLOCK
-  {"cudaJitThreadsPerBlock",                                           {"HIPRTC_JIT_THREADS_PER_BLOCK",                             "", CONV_NUMERIC_LITERAL, API_RUNTIME, SEC::DATA_TYPES}}, // 1
+  {"cudaJitThreadsPerBlock",                                           {"hipJitOptionThreadsPerBlock",                              "", CONV_NUMERIC_LITERAL, API_RUNTIME, SEC::DATA_TYPES}}, // 1
   // CU_JIT_WALL_TIME
-  {"cudaJitWallTime",                                                  {"HIPRTC_JIT_WALL_TIME",                                     "", CONV_NUMERIC_LITERAL, API_RUNTIME, SEC::DATA_TYPES}}, // 2
+  {"cudaJitWallTime",                                                  {"hipJitOptionWallTime",                                     "", CONV_NUMERIC_LITERAL, API_RUNTIME, SEC::DATA_TYPES}}, // 2
   // CU_JIT_INFO_LOG_BUFFER
-  {"cudaJitInfoLogBuffer",                                             {"HIPRTC_JIT_INFO_LOG_BUFFER",                               "", CONV_NUMERIC_LITERAL, API_RUNTIME, SEC::DATA_TYPES}}, // 3
+  {"cudaJitInfoLogBuffer",                                             {"hipJitOptionInfoLogBuffer",                                "", CONV_NUMERIC_LITERAL, API_RUNTIME, SEC::DATA_TYPES}}, // 3
   // CU_JIT_INFO_LOG_BUFFER_SIZE_BYTES
-  {"cudaJitInfoLogBufferSizeBytes",                                    {"HIPRTC_JIT_INFO_LOG_BUFFER_SIZE_BYTES",                    "", CONV_NUMERIC_LITERAL, API_RUNTIME, SEC::DATA_TYPES}}, // 4
+  {"cudaJitInfoLogBufferSizeBytes",                                    {"hipJitOptionInfoLogBufferSizeBytes",                       "", CONV_NUMERIC_LITERAL, API_RUNTIME, SEC::DATA_TYPES}}, // 4
   // CU_JIT_ERROR_LOG_BUFFER
-  {"cudaJitErrorLogBuffer",                                            {"HIPRTC_JIT_ERROR_LOG_BUFFER",                              "", CONV_NUMERIC_LITERAL, API_RUNTIME, SEC::DATA_TYPES}}, // 5
+  {"cudaJitErrorLogBuffer",                                            {"hipJitOptionErrorLogBuffer",                               "", CONV_NUMERIC_LITERAL, API_RUNTIME, SEC::DATA_TYPES}}, // 5
   // CU_JIT_ERROR_LOG_BUFFER_SIZE_BYTES
-  {"cudaJitErrorLogBufferSizeBytes",                                   {"HIPRTC_JIT_ERROR_LOG_BUFFER_SIZE_BYTES",                   "", CONV_NUMERIC_LITERAL, API_RUNTIME, SEC::DATA_TYPES}}, // 6
+  {"cudaJitErrorLogBufferSizeBytes",                                   {"hipJitOptionErrorLogBufferSizeBytes",                      "", CONV_NUMERIC_LITERAL, API_RUNTIME, SEC::DATA_TYPES}}, // 6
   // CU_JIT_OPTIMIZATION_LEVEL
-  {"cudaJitOptimizationLevel",                                         {"HIPRTC_JIT_OPTIMIZATION_LEVEL",                            "", CONV_NUMERIC_LITERAL, API_RUNTIME, SEC::DATA_TYPES}}, // 7
+  {"cudaJitOptimizationLevel",                                         {"hipJitOptionOptimizationLevel",                            "", CONV_NUMERIC_LITERAL, API_RUNTIME, SEC::DATA_TYPES}}, // 7
   // CU_JIT_FALLBACK_STRATEGY
-  {"cudaJitFallbackStrategy",                                          {"HIPRTC_JIT_FALLBACK_STRATEGY",                             "", CONV_NUMERIC_LITERAL, API_RUNTIME, SEC::DATA_TYPES}}, // 10
+  {"cudaJitFallbackStrategy",                                          {"hipJitOptionFallbackStrategy",                             "", CONV_NUMERIC_LITERAL, API_RUNTIME, SEC::DATA_TYPES}}, // 10
   // CU_JIT_GENERATE_DEBUG_INFO
-  {"cudaJitGenerateDebugInfo",                                         {"HIPRTC_JIT_GENERATE_DEBUG_INFO",                           "", CONV_NUMERIC_LITERAL, API_RUNTIME, SEC::DATA_TYPES}}, // 11
+  {"cudaJitGenerateDebugInfo",                                         {"hipJitOptionGenerateDebugInfo",                            "", CONV_NUMERIC_LITERAL, API_RUNTIME, SEC::DATA_TYPES}}, // 11
   // CU_JIT_LOG_VERBOSE
-  {"cudaJitLogVerbose",                                                {"HIPRTC_JIT_LOG_VERBOSE",                                   "", CONV_NUMERIC_LITERAL, API_RUNTIME, SEC::DATA_TYPES}}, // 12
+  {"cudaJitLogVerbose",                                                {"hipJitOptionLogVerbose",                                   "", CONV_NUMERIC_LITERAL, API_RUNTIME, SEC::DATA_TYPES}}, // 12
   // CU_JIT_GENERATE_LINE_INFO
-  {"cudaJitGenerateLineInfo",                                          {"HIPRTC_JIT_GENERATE_LINE_INFO",                            "", CONV_NUMERIC_LITERAL, API_RUNTIME, SEC::DATA_TYPES}}, // 13
+  {"cudaJitGenerateLineInfo",                                          {"hipJitOptionGenerateLineInfo",                             "", CONV_NUMERIC_LITERAL, API_RUNTIME, SEC::DATA_TYPES}}, // 13
   // CU_JIT_CACHE_MODE
-  {"cudaJitCacheMode",                                                 {"HIPRTC_JIT_CACHE_MODE",                                    "", CONV_NUMERIC_LITERAL, API_RUNTIME, SEC::DATA_TYPES}}, // 14
+  {"cudaJitCacheMode",                                                 {"hipJitOptionCacheMode",                                    "", CONV_NUMERIC_LITERAL, API_RUNTIME, SEC::DATA_TYPES}}, // 14
   // CU_JIT_POSITION_INDEPENDENT_CODE
-  {"cudaJitPositionIndependentCode",                                   {"hipJitPositionIndependentCode",                            "", CONV_NUMERIC_LITERAL, API_RUNTIME, SEC::DATA_TYPES, HIP_UNSUPPORTED}}, // 30
+  {"cudaJitPositionIndependentCode",                                   {"hipJitOptionPositionIndependentCode",                      "", CONV_NUMERIC_LITERAL, API_RUNTIME, SEC::DATA_TYPES}}, // 30
   // CU_JIT_MIN_CTA_PER_SM
-  {"cudaJitMinCtaPerSm",                                               {"hipJitMinCtaPerSm",                                        "", CONV_NUMERIC_LITERAL, API_RUNTIME, SEC::DATA_TYPES, HIP_UNSUPPORTED}}, // 31
+  {"cudaJitMinCtaPerSm",                                               {"hipJitOptionMinCTAPerSM",                                  "", CONV_NUMERIC_LITERAL, API_RUNTIME, SEC::DATA_TYPES}}, // 31
   // CU_JIT_MAX_THREADS_PER_BLOCK
-  {"cudaJitMaxThreadsPerBlock",                                        {"hipJitMaxThreadsPerBlock",                                 "", CONV_NUMERIC_LITERAL, API_RUNTIME, SEC::DATA_TYPES, HIP_UNSUPPORTED}}, // 32
+  {"cudaJitMaxThreadsPerBlock",                                        {"hipJitOptionMaxThreadsPerBlock",                           "", CONV_NUMERIC_LITERAL, API_RUNTIME, SEC::DATA_TYPES}}, // 32
   // CU_JIT_OVERRIDE_DIRECTIVE_VALUES
-  {"cudaJitOverrideDirectiveValues",                                   {"hipJitOverrideDerectiveValues",                            "", CONV_NUMERIC_LITERAL, API_RUNTIME, SEC::DATA_TYPES, HIP_UNSUPPORTED}}, // 33
+  {"cudaJitOverrideDirectiveValues",                                   {"hipJitOptionOverrideDirectiveValues",                      "", CONV_NUMERIC_LITERAL, API_RUNTIME, SEC::DATA_TYPES}}, // 33
 
   // CUlibraryOption
   {"cudaLibraryOption",                                                {"hipLibraryOption",                                         "", CONV_TYPE, API_RUNTIME, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
@@ -2276,9 +2276,9 @@ const std::map<llvm::StringRef, hipCounter> CUDA_RUNTIME_TYPE_NAME_MAP {
   // CU_EVENT_INTERPROCESS
   {"cudaEventInterprocess",                                            {"hipEventInterprocess",                                     "", CONV_DEFINE, API_RUNTIME, SEC::DATA_TYPES}}, // 0x04
   // CU_EVENT_RECORD_DEFAULT
-  {"cudaEventRecordDefault",                                           {"hipEventRecordDefault",                                    "", CONV_DEFINE, API_RUNTIME, SEC::DATA_TYPES, HIP_UNSUPPORTED}}, // 0x00
+  {"cudaEventRecordDefault",                                           {"hipEventRecordDefault",                                    "", CONV_DEFINE, API_RUNTIME, SEC::DATA_TYPES}}, // 0x00
   // CU_EVENT_RECORD_EXTERNAL
-  {"cudaEventRecordExternal",                                          {"hipEventRecordExternal",                                   "", CONV_DEFINE, API_RUNTIME, SEC::DATA_TYPES, HIP_UNSUPPORTED}}, // 0x01
+  {"cudaEventRecordExternal",                                          {"hipEventRecordExternal",                                   "", CONV_DEFINE, API_RUNTIME, SEC::DATA_TYPES}}, // 0x01
   // CU_EVENT_WAIT_DEFAULT
   {"cudaEventWaitDefault",                                             {"hipEventWaitDefault",                                      "", CONV_DEFINE, API_RUNTIME, SEC::DATA_TYPES, HIP_UNSUPPORTED}}, // 0x00
   // CU_EVENT_WAIT_EXTERNAL
@@ -2759,7 +2759,6 @@ const std::map<llvm::StringRef, cudaAPIversions> CUDA_RUNTIME_TYPE_NAME_VER_MAP 
   {"cudaEventRecordDefault",                                           {CUDA_111, CUDA_0,   CUDA_0  }},
   {"cudaEventRecordExternal",                                          {CUDA_111, CUDA_0,   CUDA_0  }},
   {"cudaEventWaitDefault",                                             {CUDA_111, CUDA_0,   CUDA_0  }},
-  {"cudaEventRecordExternal",                                          {CUDA_111, CUDA_0,   CUDA_0  }},
   {"cudaArraySparse",                                                  {CUDA_111, CUDA_0,   CUDA_0  }},
   {"cudaErrorStubLibrary",                                             {CUDA_111, CUDA_0,   CUDA_0  }},
   {"cudaErrorCallRequiresNewerDriver",                                 {CUDA_111, CUDA_0,   CUDA_0  }},
@@ -3527,4 +3526,6 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_RUNTIME_TYPE_NAME_VER_MAP {
   {"HIP_DBL2INT_CVT",                                                  {HIP_5070, HIP_0,    HIP_0   }},
   {"hipErrorInvalidChannelDescriptor",                                 {HIP_6040, HIP_0,    HIP_0   }},
   {"hipErrorInvalidTexture",                                           {HIP_6040, HIP_0,    HIP_0   }},
+  {"hipEventRecordDefault",                                            {HIP_6040, HIP_0,    HIP_0   }},
+  {"hipEventRecordExternal",                                           {HIP_6040, HIP_0,    HIP_0   }},
 };

--- a/tests/unit_tests/synthetic/driver_enums.cu
+++ b/tests/unit_tests/synthetic/driver_enums.cu
@@ -315,21 +315,22 @@ int main() {
 
   // CHECK: hipJitOption jit_option;
   // CHECK-NEXT: hipJitOption jit_option_enum;
-  // CHECK-NEXT: hipJitOption JIT_MAX_REGISTERS = HIPRTC_JIT_MAX_REGISTERS;
-  // CHECK-NEXT: hipJitOption JIT_THREADS_PER_BLOCK = HIPRTC_JIT_THREADS_PER_BLOCK;
-  // CHECK-NEXT: hipJitOption JIT_WALL_TIME = HIPRTC_JIT_WALL_TIME;
-  // CHECK-NEXT: hipJitOption JIT_INFO_LOG_BUFFER = HIPRTC_JIT_INFO_LOG_BUFFER;
-  // CHECK-NEXT: hipJitOption JIT_INFO_LOG_BUFFER_SIZE_BYTES = HIPRTC_JIT_INFO_LOG_BUFFER_SIZE_BYTES;
-  // CHECK-NEXT: hipJitOption JIT_ERROR_LOG_BUFFER = HIPRTC_JIT_ERROR_LOG_BUFFER;
-  // CHECK-NEXT: hipJitOption JIT_ERROR_LOG_BUFFER_SIZE_BYTES = HIPRTC_JIT_ERROR_LOG_BUFFER_SIZE_BYTES;
-  // CHECK-NEXT: hipJitOption JIT_OPTIMIZATION_LEVEL = HIPRTC_JIT_OPTIMIZATION_LEVEL;
-  // CHECK-NEXT: hipJitOption JIT_TARGET_FROM_CUCONTEXT = HIPRTC_JIT_TARGET_FROM_HIPCONTEXT;
-  // CHECK-NEXT: hipJitOption JIT_TARGET = HIPRTC_JIT_TARGET;
-  // CHECK-NEXT: hipJitOption JIT_FALLBACK_STRATEGY = HIPRTC_JIT_FALLBACK_STRATEGY;
-  // CHECK-NEXT: hipJitOption JIT_GENERATE_DEBUG_INFO = HIPRTC_JIT_GENERATE_DEBUG_INFO;
-  // CHECK-NEXT: hipJitOption JIT_LOG_VERBOSE = HIPRTC_JIT_LOG_VERBOSE;
-  // CHECK-NEXT: hipJitOption JIT_GENERATE_LINE_INFO = HIPRTC_JIT_GENERATE_LINE_INFO;
-  // CHECK-NEXT: hipJitOption JIT_CACHE_MODE = HIPRTC_JIT_CACHE_MODE;
+  // CHECK-NEXT: hipJitOption JIT_MAX_REGISTERS = hipJitOptionMaxRegisters;
+  // CHECK-NEXT: hipJitOption JIT_THREADS_PER_BLOCK = hipJitOptionThreadsPerBlock;
+  // CHECK-NEXT: hipJitOption JIT_WALL_TIME = hipJitOptionWallTime;
+  // CHECK-NEXT: hipJitOption JIT_INFO_LOG_BUFFER = hipJitOptionInfoLogBuffer;
+  // CHECK-NEXT: hipJitOption JIT_INFO_LOG_BUFFER_SIZE_BYTES = hipJitOptionInfoLogBufferSizeBytes;
+  // CHECK-NEXT: hipJitOption JIT_ERROR_LOG_BUFFER = hipJitOptionErrorLogBuffer;
+  // CHECK-NEXT: hipJitOption JIT_ERROR_LOG_BUFFER_SIZE_BYTES = hipJitOptionErrorLogBufferSizeBytes;
+  // CHECK-NEXT: hipJitOption JIT_OPTIMIZATION_LEVEL = hipJitOptionOptimizationLevel;
+  // CHECK-NEXT: hipJitOption JIT_TARGET_FROM_CUCONTEXT = hipJitOptionTargetFromContext;
+  // CHECK-NEXT: hipJitOption JIT_TARGET = hipJitOptionTarget;
+  // CHECK-NEXT: hipJitOption JIT_FALLBACK_STRATEGY = hipJitOptionFallbackStrategy;
+  // CHECK-NEXT: hipJitOption JIT_GENERATE_DEBUG_INFO = hipJitOptionGenerateDebugInfo;
+  // CHECK-NEXT: hipJitOption JIT_LOG_VERBOSE = hipJitOptionLogVerbose;
+  // CHECK-NEXT: hipJitOption JIT_GENERATE_LINE_INFO = hipJitOptionGenerateLineInfo;
+  // CHECK-NEXT: hipJitOption JIT_CACHE_MODE = hipJitOptionCacheMode;
+  // CHECK-NEXT: hipJitOption JIT_NUM_OPTIONS = hipJitOptionNumOptions;
   CUjit_option jit_option;
   CUjit_option_enum jit_option_enum;
   CUjit_option JIT_MAX_REGISTERS = CU_JIT_MAX_REGISTERS;
@@ -347,8 +348,6 @@ int main() {
   CUjit_option JIT_LOG_VERBOSE = CU_JIT_LOG_VERBOSE;
   CUjit_option JIT_GENERATE_LINE_INFO = CU_JIT_GENERATE_LINE_INFO;
   CUjit_option JIT_CACHE_MODE = CU_JIT_CACHE_MODE;
-
-  // CHECK: hipJitOption JIT_NUM_OPTIONS = HIPRTC_JIT_NUM_OPTIONS;
   CUjit_option JIT_NUM_OPTIONS = CU_JIT_NUM_OPTIONS;
 
   // CHECK: hipLimit_t limit;
@@ -646,8 +645,8 @@ int main() {
   CUdevice_P2PAttribute DEVICE_P2P_ATTRIBUTE_ACCESS_SUPPORTED = CU_DEVICE_P2P_ATTRIBUTE_ACCESS_SUPPORTED;
   CUdevice_P2PAttribute DEVICE_P2P_ATTRIBUTE_NATIVE_ATOMIC_SUPPORTED = CU_DEVICE_P2P_ATTRIBUTE_NATIVE_ATOMIC_SUPPORTED;
 
-  // CHECK: hipJitOption JIT_NEW_SM3X_OPT = HIPRTC_JIT_NEW_SM3X_OPT;
-  // CHECK-NEXT: hipJitOption JIT_FAST_COMPILE = HIPRTC_JIT_FAST_COMPILE;
+  // CHECK: hipJitOption JIT_NEW_SM3X_OPT = hipJitOptionSm3xOpt;
+  // CHECK-NEXT: hipJitOption JIT_FAST_COMPILE = hipJitOptionFastCompile;
   CUjit_option JIT_NEW_SM3X_OPT = CU_JIT_NEW_SM3X_OPT;
   CUjit_option JIT_FAST_COMPILE = CU_JIT_FAST_COMPILE;
 
@@ -817,6 +816,13 @@ int main() {
   CUstreamCaptureStatus STREAM_CAPTURE_STATUS_NONE = CU_STREAM_CAPTURE_STATUS_NONE;
   CUstreamCaptureStatus STREAM_CAPTURE_STATUS_ACTIVE = CU_STREAM_CAPTURE_STATUS_ACTIVE;
   CUstreamCaptureStatus STREAM_CAPTURE_STATUS_INVALIDATED = CU_STREAM_CAPTURE_STATUS_INVALIDATED;
+
+  // CHECK: hipJitOption JIT_GLOBAL_SYMBOL_NAMES = hipJitOptionGlobalSymbolNames;
+  // CHECK-NEXT: hipJitOption JIT_GLOBAL_SYMBOL_ADDRESSES = hipJitOptionGlobalSymbolAddresses;
+  // CHECK-NEXT: hipJitOption JIT_GLOBAL_SYMBOL_COUNT = hipJitOptionGlobalSymbolCount;
+  CUjit_option JIT_GLOBAL_SYMBOL_NAMES = CU_JIT_GLOBAL_SYMBOL_NAMES;
+  CUjit_option JIT_GLOBAL_SYMBOL_ADDRESSES = CU_JIT_GLOBAL_SYMBOL_ADDRESSES;
+  CUjit_option JIT_GLOBAL_SYMBOL_COUNT = CU_JIT_GLOBAL_SYMBOL_COUNT;
 #endif
 
 #if CUDA_VERSION == 10010
@@ -995,6 +1001,11 @@ int main() {
   CUarraySparseSubresourceType_enum arraySparseSubresourceType_enum;
   CUarraySparseSubresourceType ARRAY_SPARSE_SUBRESOURCE_TYPE_SPARSE_LEVEL = CU_ARRAY_SPARSE_SUBRESOURCE_TYPE_SPARSE_LEVEL;
   CUarraySparseSubresourceType ARRAY_SPARSE_SUBRESOURCE_TYPE_MIPTAIL = CU_ARRAY_SPARSE_SUBRESOURCE_TYPE_MIPTAIL;
+
+  // CHECK: int EventRecordDefault = hipEventRecordDefault;
+  // CHECK-NEXT: int EventRecordExternal = hipEventRecordExternal;
+  int EventRecordDefault = CU_EVENT_RECORD_DEFAULT;
+  int EventRecordExternal = CU_EVENT_RECORD_EXTERNAL;
 #endif
 
 #if CUDA_VERSION >= 11020
@@ -1133,6 +1144,17 @@ int main() {
   // CHECK-NEXT: hipGraphNodeType GRAPH_NODE_TYPE_MEM_FREE = hipGraphNodeTypeMemFree;
   CUgraphNodeType GRAPH_NODE_TYPE_MEM_ALLOC = CU_GRAPH_NODE_TYPE_MEM_ALLOC;
   CUgraphNodeType GRAPH_NODE_TYPE_MEM_FREE = CU_GRAPH_NODE_TYPE_MEM_FREE;
+
+  // CHECK: hipJitOption JIT_LTO = hipJitOptionLto;
+  // CHECK-NEXT: hipJitOption JIT_FTZ = hipJitOptionFtz;
+  // CHECK-NEXT: hipJitOption JIT_PREC_DIV = hipJitOptionPrecDiv;
+  // CHECK-NEXT: hipJitOption JIT_PREC_SQRT = hipJitOptionPrecSqrt;
+  // CHECK-NEXT: hipJitOption JIT_FMA = hipJitOptionFma;
+  CUjit_option JIT_LTO = CU_JIT_LTO;
+  CUjit_option JIT_FTZ = CU_JIT_FTZ;
+  CUjit_option JIT_PREC_DIV = CU_JIT_PREC_DIV;
+  CUjit_option JIT_PREC_SQRT = CU_JIT_PREC_SQRT;
+  CUjit_option JIT_FMA = CU_JIT_FMA;
 #endif
 
 #if CUDA_VERSION >= 11070
@@ -1196,6 +1218,9 @@ int main() {
   CUdriverProcAddressQueryResult GET_PROC_ADDRESS_SUCCESS = CU_GET_PROC_ADDRESS_SUCCESS;
   CUdriverProcAddressQueryResult GET_PROC_ADDRESS_SYMBOL_NOT_FOUND = CU_GET_PROC_ADDRESS_SYMBOL_NOT_FOUND;
   CUdriverProcAddressQueryResult GET_PROC_ADDRESS_VERSION_NOT_SUFFICIENT = CU_GET_PROC_ADDRESS_VERSION_NOT_SUFFICIENT;
+
+  // CHECK: hipJitOption JIT_MIN_CTA_PER_SM = hipJitOptionMinCTAPerSM;
+  CUjit_option JIT_MIN_CTA_PER_SM = CU_JIT_MIN_CTA_PER_SM;
 #endif
 
 #if CUDA_VERSION >= 12030
@@ -1207,6 +1232,16 @@ int main() {
   CUgraphDependencyType_enum graphDependencyType_enum;
   CUgraphDependencyType GRAPH_DEPENDENCY_TYPE_DEFAULT = CU_GRAPH_DEPENDENCY_TYPE_DEFAULT;
   CUgraphDependencyType GRAPH_DEPENDENCY_TYPE_PROGRAMMATIC = CU_GRAPH_DEPENDENCY_TYPE_PROGRAMMATIC;
+
+  // CHECK: hipJitOption JIT_POSITION_INDEPENDENT_CODE = hipJitOptionPositionIndependentCode;
+  CUjit_option JIT_POSITION_INDEPENDENT_CODE = CU_JIT_POSITION_INDEPENDENT_CODE;
+#endif
+
+#if CUDA_VERSION >= 12040
+  // CHECK: hipJitOption JIT_MAX_THREADS_PER_BLOCK = hipJitOptionMaxThreadsPerBlock;
+  // CHECK-NEXT: hipJitOption JIT_OVERRIDE_DIRECTIVE_VALUES = hipJitOptionOverrideDirectiveValues;
+  CUjit_option JIT_MAX_THREADS_PER_BLOCK = CU_JIT_MAX_THREADS_PER_BLOCK;
+  CUjit_option JIT_OVERRIDE_DIRECTIVE_VALUES = CU_JIT_OVERRIDE_DIRECTIVE_VALUES;
 #endif
 
   return 0;

--- a/tests/unit_tests/synthetic/runtime_enums.cu
+++ b/tests/unit_tests/synthetic/runtime_enums.cu
@@ -735,6 +735,11 @@ int main() {
   // CHECK-NEXT: hipGraphNodeType GraphNodeTypeEventRecord = hipGraphNodeTypeEventRecord;
   cudaGraphNodeType GraphNodeTypeWaitEvent = cudaGraphNodeTypeWaitEvent;
   cudaGraphNodeType GraphNodeTypeEventRecord = cudaGraphNodeTypeEventRecord;
+
+  // CHECK: int EventRecordDefault = hipEventRecordDefault;
+  // CHECK-NEXT: int EventRecordExternal = hipEventRecordExternal;
+  int EventRecordDefault = cudaEventRecordDefault;
+  int EventRecordExternal = cudaEventRecordExternal;
 #endif
 
 #if CUDA_VERSION >= 11020
@@ -949,19 +954,23 @@ int main() {
 
 #if CUDA_VERSION >= 12080
   // CHECK: hipJitOption jit_option;
-  // CHECK-NEXT: hipJitOption JIT_MAX_REGISTERS = HIPRTC_JIT_MAX_REGISTERS;
-  // CHECK-NEXT: hipJitOption JIT_THREADS_PER_BLOCK = HIPRTC_JIT_THREADS_PER_BLOCK;
-  // CHECK-NEXT: hipJitOption JIT_WALL_TIME = HIPRTC_JIT_WALL_TIME;
-  // CHECK-NEXT: hipJitOption JIT_INFO_LOG_BUFFER = HIPRTC_JIT_INFO_LOG_BUFFER;
-  // CHECK-NEXT: hipJitOption JIT_INFO_LOG_BUFFER_SIZE_BYTES = HIPRTC_JIT_INFO_LOG_BUFFER_SIZE_BYTES;
-  // CHECK-NEXT: hipJitOption JIT_ERROR_LOG_BUFFER = HIPRTC_JIT_ERROR_LOG_BUFFER;
-  // CHECK-NEXT: hipJitOption JIT_ERROR_LOG_BUFFER_SIZE_BYTES = HIPRTC_JIT_ERROR_LOG_BUFFER_SIZE_BYTES;
-  // CHECK-NEXT: hipJitOption JIT_OPTIMIZATION_LEVEL = HIPRTC_JIT_OPTIMIZATION_LEVEL;
-  // CHECK-NEXT: hipJitOption JIT_FALLBACK_STRATEGY = HIPRTC_JIT_FALLBACK_STRATEGY;
-  // CHECK-NEXT: hipJitOption JIT_GENERATE_DEBUG_INFO = HIPRTC_JIT_GENERATE_DEBUG_INFO;
-  // CHECK-NEXT: hipJitOption JIT_LOG_VERBOSE = HIPRTC_JIT_LOG_VERBOSE;
-  // CHECK-NEXT: hipJitOption JIT_GENERATE_LINE_INFO = HIPRTC_JIT_GENERATE_LINE_INFO;
-  // CHECK-NEXT: hipJitOption JIT_CACHE_MODE = HIPRTC_JIT_CACHE_MODE;
+  // CHECK-NEXT: hipJitOption JIT_MAX_REGISTERS = hipJitOptionMaxRegisters;
+  // CHECK-NEXT: hipJitOption JIT_THREADS_PER_BLOCK = hipJitOptionThreadsPerBlock;
+  // CHECK-NEXT: hipJitOption JIT_WALL_TIME = hipJitOptionWallTime;
+  // CHECK-NEXT: hipJitOption JIT_INFO_LOG_BUFFER = hipJitOptionInfoLogBuffer;
+  // CHECK-NEXT: hipJitOption JIT_INFO_LOG_BUFFER_SIZE_BYTES = hipJitOptionInfoLogBufferSizeBytes;
+  // CHECK-NEXT: hipJitOption JIT_ERROR_LOG_BUFFER = hipJitOptionErrorLogBuffer;
+  // CHECK-NEXT: hipJitOption JIT_ERROR_LOG_BUFFER_SIZE_BYTES = hipJitOptionErrorLogBufferSizeBytes;
+  // CHECK-NEXT: hipJitOption JIT_OPTIMIZATION_LEVEL = hipJitOptionOptimizationLevel;
+  // CHECK-NEXT: hipJitOption JIT_FALLBACK_STRATEGY = hipJitOptionFallbackStrategy;
+  // CHECK-NEXT: hipJitOption JIT_GENERATE_DEBUG_INFO = hipJitOptionGenerateDebugInfo;
+  // CHECK-NEXT: hipJitOption JIT_LOG_VERBOSE = hipJitOptionLogVerbose;
+  // CHECK-NEXT: hipJitOption JIT_GENERATE_LINE_INFO = hipJitOptionGenerateLineInfo;
+  // CHECK-NEXT: hipJitOption JIT_CACHE_MODE = hipJitOptionCacheMode;
+  // CHECK-NEXT: hipJitOption JIT_POSITION_INDEPENDENT_CODE = hipJitOptionPositionIndependentCode;
+  // CHECK-NEXT: hipJitOption JIT_MIN_CTA_PER_SM = hipJitOptionMinCTAPerSM;
+  // CHECK-NEXT: hipJitOption JIT_MAX_THREADS_PER_BLOCK = hipJitOptionMaxThreadsPerBlock;
+  // CHECK-NEXT: hipJitOption JIT_OVERRIDE_DIRECTIVE_VALUES = hipJitOptionOverrideDirectiveValues;
   cudaJitOption jit_option;
   cudaJitOption JIT_MAX_REGISTERS = cudaJitMaxRegisters;
   cudaJitOption JIT_THREADS_PER_BLOCK = cudaJitThreadsPerBlock;
@@ -976,6 +985,11 @@ int main() {
   cudaJitOption JIT_LOG_VERBOSE = cudaJitLogVerbose;
   cudaJitOption JIT_GENERATE_LINE_INFO = cudaJitGenerateLineInfo;
   cudaJitOption JIT_CACHE_MODE = cudaJitCacheMode;
+  cudaJitOption JIT_POSITION_INDEPENDENT_CODE = cudaJitPositionIndependentCode;
+  cudaJitOption JIT_MIN_CTA_PER_SM = cudaJitMinCtaPerSm;
+  cudaJitOption JIT_MAX_THREADS_PER_BLOCK = cudaJitMaxThreadsPerBlock;
+  cudaJitOption JIT_OVERRIDE_DIRECTIVE_VALUES = cudaJitOverrideDirectiveValues;
 #endif
+
   return 0;
 }


### PR DESCRIPTION
+ Added missing Data Types
+ Renamed HIP Data types, which were redefined in 6.4
+ Fixed versioning
+ Updated synthetic tests, the regenerated `hipify-perl`, and `CUDA2HIP` documentation
