### PR TITLE
[HIPIFY][CLR][6.5] Sync with `ROCm HIP 6.5.0` - Part 2 - `Driver API`

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -7115,6 +7115,8 @@ sub simpleSubstitutions {
     subst("CUlaunchAttributeID_enum", "hipLaunchAttributeID", "type");
     subst("CUlaunchAttributeValue", "hipLaunchAttributeValue", "type");
     subst("CUlaunchAttributeValue_union", "hipLaunchAttributeValue", "type");
+    subst("CUlaunchConfig", "HIP_LAUNCH_CONFIG", "type");
+    subst("CUlaunchConfig_st", "HIP_LAUNCH_CONFIG_st", "type");
     subst("CUlimit", "hipLimit_t", "type");
     subst("CUlimit_enum", "hipLimit_t", "type");
     subst("CUlinkState", "hiprtcLinkState", "type");
@@ -7331,8 +7333,10 @@ sub simpleSubstitutions {
     subst("cudaKernelNodeAttrID", "hipKernelNodeAttrID", "type");
     subst("cudaKernelNodeAttrValue", "hipKernelNodeAttrValue", "type");
     subst("cudaKernelNodeParams", "hipKernelNodeParams", "type");
+    subst("cudaLaunchAttribute", "hipLaunchAttribute", "type");
     subst("cudaLaunchAttributeID", "hipLaunchAttributeID", "type");
     subst("cudaLaunchAttributeValue", "hipLaunchAttributeValue", "type");
+    subst("cudaLaunchAttribute_st", "hipLaunchAttribute_st", "type");
     subst("cudaLaunchParams", "hipLaunchParams", "type");
     subst("cudaLibXtDesc", "hipLibXtDesc", "type");
     subst("cudaLibXtDesc_t", "hipLibXtDesc_t", "type");
@@ -8225,7 +8229,7 @@ sub simpleSubstitutions {
     subst("CU_DEVICE_ATTRIBUTE_PAGEABLE_MEMORY_ACCESS_USES_HOST_PAGE_TABLES", "hipDeviceAttributePageableMemoryAccessUsesHostPageTables", "numeric_literal");
     subst("CU_DEVICE_ATTRIBUTE_PCI_BUS_ID", "hipDeviceAttributePciBusId", "numeric_literal");
     subst("CU_DEVICE_ATTRIBUTE_PCI_DEVICE_ID", "hipDeviceAttributePciDeviceId", "numeric_literal");
-    subst("CU_DEVICE_ATTRIBUTE_PCI_DOMAIN_ID", "hipDeviceAttributePciDomainID", "numeric_literal");
+    subst("CU_DEVICE_ATTRIBUTE_PCI_DOMAIN_ID", "hipDeviceAttributePciDomainId", "numeric_literal");
     subst("CU_DEVICE_ATTRIBUTE_REGISTERS_PER_BLOCK", "hipDeviceAttributeMaxRegistersPerBlock", "numeric_literal");
     subst("CU_DEVICE_ATTRIBUTE_SHARED_MEMORY_PER_BLOCK", "hipDeviceAttributeMaxSharedMemoryPerBlock", "numeric_literal");
     subst("CU_DEVICE_ATTRIBUTE_SINGLE_TO_DOUBLE_PRECISION_PERF_RATIO", "hipDeviceAttributeSingleToDoublePrecisionPerfRatio", "numeric_literal");
@@ -8626,7 +8630,7 @@ sub simpleSubstitutions {
     subst("cudaDevAttrPageableMemoryAccessUsesHostPageTables", "hipDeviceAttributePageableMemoryAccessUsesHostPageTables", "numeric_literal");
     subst("cudaDevAttrPciBusId", "hipDeviceAttributePciBusId", "numeric_literal");
     subst("cudaDevAttrPciDeviceId", "hipDeviceAttributePciDeviceId", "numeric_literal");
-    subst("cudaDevAttrPciDomainId", "hipDeviceAttributePciDomainID", "numeric_literal");
+    subst("cudaDevAttrPciDomainId", "hipDeviceAttributePciDomainId", "numeric_literal");
     subst("cudaDevAttrReserved94", "hipDeviceAttributeCanUseStreamWaitValue", "numeric_literal");
     subst("cudaDevAttrSingleToDoublePrecisionPerfRatio", "hipDeviceAttributeSingleToDoublePrecisionPerfRatio", "numeric_literal");
     subst("cudaDevAttrStreamPrioritiesSupported", "hipDeviceAttributeStreamPrioritiesSupported", "numeric_literal");
@@ -11007,9 +11011,6 @@ sub warnRemovedFunctions {
     "cudaLaunchMemSyncDomainDefault",
     "cudaLaunchMemSyncDomain",
     "cudaLaunchKernelExC",
-    "cudaLaunchConfig_t",
-    "cudaLaunchConfig_st",
-    "cudaLaunchAttribute_st",
     "cudaLaunchAttributeSynchronizationPolicy",
     "cudaLaunchAttributeProgrammaticStreamSerialization",
     "cudaLaunchAttributeProgrammaticEvent",
@@ -11022,7 +11023,6 @@ sub warnRemovedFunctions {
     "cudaLaunchAttributeDeviceUpdatableKernelNode",
     "cudaLaunchAttributeClusterSchedulingPolicyPreference",
     "cudaLaunchAttributeClusterDimension",
-    "cudaLaunchAttribute",
     "cudaKeyValuePair",
     "cudaKernel_t",
     "cudaKernelSetAttributeForDevice",
@@ -11972,8 +11972,6 @@ sub warnRemovedFunctions {
     "CUlaunchMemSyncDomainMap_st",
     "CUlaunchMemSyncDomainMap",
     "CUlaunchMemSyncDomain",
-    "CUlaunchConfig_st",
-    "CUlaunchConfig",
     "CUlaunchAttribute_st",
     "CUlaunchAttribute",
     "CUkernel",

--- a/docs/reference/tables/CUDA_Driver_API_functions_supported_by_HIP.md
+++ b/docs/reference/tables/CUDA_Driver_API_functions_supported_by_HIP.md
@@ -511,7 +511,7 @@
 |`CU_DEVICE_ATTRIBUTE_PAGEABLE_MEMORY_ACCESS_USES_HOST_PAGE_TABLES`|9.2| | | |`hipDeviceAttributePageableMemoryAccessUsesHostPageTables`|3.10.0| | | | |
 |`CU_DEVICE_ATTRIBUTE_PCI_BUS_ID`| | | | |`hipDeviceAttributePciBusId`|1.6.0| | | | |
 |`CU_DEVICE_ATTRIBUTE_PCI_DEVICE_ID`| | | | |`hipDeviceAttributePciDeviceId`|1.6.0| | | | |
-|`CU_DEVICE_ATTRIBUTE_PCI_DOMAIN_ID`| | | | |`hipDeviceAttributePciDomainID`|4.3.0| | | | |
+|`CU_DEVICE_ATTRIBUTE_PCI_DOMAIN_ID`| | | | |`hipDeviceAttributePciDomainId`|4.3.0| | | | |
 |`CU_DEVICE_ATTRIBUTE_READ_ONLY_HOST_REGISTER_SUPPORTED`|11.1| | | | | | | | | |
 |`CU_DEVICE_ATTRIBUTE_REGISTERS_PER_BLOCK`| |5.0| | |`hipDeviceAttributeMaxRegistersPerBlock`|1.6.0| | | | |
 |`CU_DEVICE_ATTRIBUTE_RESERVED_SHARED_MEMORY_PER_BLOCK`|11.0| | | | | | | | | |
@@ -1348,8 +1348,8 @@
 |`CUlaunchAttributeValue`|11.8| | | |`hipLaunchAttributeValue`|6.2.0| | | | |
 |`CUlaunchAttributeValue_union`|11.8| | | |`hipLaunchAttributeValue`|6.2.0| | | | |
 |`CUlaunchAttribute_st`|11.8| | | | | | | | | |
-|`CUlaunchConfig`|11.8| | | | | | | | | |
-|`CUlaunchConfig_st`|11.8| | | | | | | | | |
+|`CUlaunchConfig`|11.8| | | |`HIP_LAUNCH_CONFIG`|6.5.0| | | | |
+|`CUlaunchConfig_st`|11.8| | | |`HIP_LAUNCH_CONFIG_st`|6.5.0| | | | |
 |`CUlaunchMemSyncDomain`|12.0| | | | | | | | | |
 |`CUlaunchMemSyncDomainMap`|12.0| | | | | | | | | |
 |`CUlaunchMemSyncDomainMap_st`|12.0| | | | | | | | | |

--- a/docs/reference/tables/CUDA_Runtime_API_functions_supported_by_HIP.md
+++ b/docs/reference/tables/CUDA_Runtime_API_functions_supported_by_HIP.md
@@ -900,7 +900,7 @@
 |`cudaDevAttrPageableMemoryAccessUsesHostPageTables`|9.2| | | |`hipDeviceAttributePageableMemoryAccessUsesHostPageTables`|3.10.0| | | | |
 |`cudaDevAttrPciBusId`| | | | |`hipDeviceAttributePciBusId`|1.6.0| | | | |
 |`cudaDevAttrPciDeviceId`| | | | |`hipDeviceAttributePciDeviceId`|1.6.0| | | | |
-|`cudaDevAttrPciDomainId`| | | | |`hipDeviceAttributePciDomainID`|4.3.0| | | | |
+|`cudaDevAttrPciDomainId`| | | | |`hipDeviceAttributePciDomainId`|4.3.0| | | | |
 |`cudaDevAttrReserved122`|12.0| | | | | | | | | |
 |`cudaDevAttrReserved123`|12.0| | | | | | | | | |
 |`cudaDevAttrReserved124`|12.0| | | | | | | | | |
@@ -1467,7 +1467,7 @@
 |`cudaKernelNodeParamsV2`|12.2| | | | | | | | | |
 |`cudaKernel_t`|12.1| | | | | | | | | |
 |`cudaKeyValuePair`| | | |12.0| | | | | | |
-|`cudaLaunchAttribute`|11.8| | | | | | | | | |
+|`cudaLaunchAttribute`|11.8| | | |`hipLaunchAttribute`|6.5.0| | | | |
 |`cudaLaunchAttributeAccessPolicyWindow`|11.8| | | |`hipLaunchAttributeAccessPolicyWindow`|6.2.0| | | | |
 |`cudaLaunchAttributeClusterDimension`|11.8| | | | | | | | | |
 |`cudaLaunchAttributeClusterSchedulingPolicyPreference`|11.8| | | | | | | | | |
@@ -1485,9 +1485,7 @@
 |`cudaLaunchAttributeProgrammaticStreamSerialization`|11.8| | | | | | | | | |
 |`cudaLaunchAttributeSynchronizationPolicy`|11.8| | | | | | | | | |
 |`cudaLaunchAttributeValue`|11.8| | | |`hipLaunchAttributeValue`|6.2.0| | | | |
-|`cudaLaunchAttribute_st`|11.8| | | | | | | | | |
-|`cudaLaunchConfig_st`|11.8| | | | | | | | | |
-|`cudaLaunchConfig_t`|11.8| | | | | | | | | |
+|`cudaLaunchAttribute_st`|11.8| | | |`hipLaunchAttribute_st`|6.5.0| | | | |
 |`cudaLaunchMemSyncDomain`|12.0| | | | | | | | | |
 |`cudaLaunchMemSyncDomainDefault`|12.0| | | | | | | | | |
 |`cudaLaunchMemSyncDomainMap`|12.0| | | | | | | | | |

--- a/src/CUDA2HIP_Driver_API_types.cpp
+++ b/src/CUDA2HIP_Driver_API_types.cpp
@@ -369,10 +369,10 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_TYPE_NAME_MAP {
   // cudaLaunchAttribute
   {"CUlaunchAttribute",                                                {"hipLaunchAttribute",                                       "", CONV_TYPE, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
 
-  // cudaLaunchConfig_st
-  {"CUlaunchConfig_st",                                                {"hipLaunchConfig",                                          "", CONV_TYPE, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
-  // cudaLaunchConfig_t
-  {"CUlaunchConfig",                                                   {"hipLaunchConfig",                                          "", CONV_TYPE, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
+  // NOTE: cudaLaunchConfig_st struct differs
+  {"CUlaunchConfig_st",                                                {"HIP_LAUNCH_CONFIG_st",                                     "", CONV_TYPE, API_DRIVER, SEC::DATA_TYPES}},
+  // NOTE: cudaLaunchConfig_t struct differs
+  {"CUlaunchConfig",                                                   {"HIP_LAUNCH_CONFIG",                                        "", CONV_TYPE, API_DRIVER, SEC::DATA_TYPES}},
 
   // CUlib_st
   {"CUlib_st",                                                         {"hipLibraty",                                               "", CONV_TYPE, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
@@ -811,7 +811,7 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_TYPE_NAME_MAP {
   // CUDA only
   {"CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE3D_DEPTH_ALTERNATE",            {"hipDeviceAttributeMaxTexture3DAlt",                        "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES}}, // 49
   // cudaDevAttrPciDomainId
-  {"CU_DEVICE_ATTRIBUTE_PCI_DOMAIN_ID",                                {"hipDeviceAttributePciDomainID",                            "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES}}, // 50
+  {"CU_DEVICE_ATTRIBUTE_PCI_DOMAIN_ID",                                {"hipDeviceAttributePciDomainId",                            "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES}}, // 50
   // cudaDevAttrTexturePitchAlignment
   {"CU_DEVICE_ATTRIBUTE_TEXTURE_PITCH_ALIGNMENT",                      {"hipDeviceAttributeTexturePitchAlignment",                  "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES}}, // 51
   // cudaDevAttrMaxTextureCubemapWidth
@@ -4522,7 +4522,7 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_DRIVER_TYPE_NAME_VER_MAP {
   {"hipDeviceAttributeTccDriver",                                      {HIP_4030, HIP_0,    HIP_0   }},
   {"hipDeviceAttributeUnifiedAddressing",                              {HIP_4030, HIP_0,    HIP_0   }},
   {"hipDeviceAttributeMaxTexture1DLayered",                            {HIP_4030, HIP_0,    HIP_0   }},
-  {"hipDeviceAttributePciDomainID",                                    {HIP_4030, HIP_0,    HIP_0   }},
+  {"hipDeviceAttributePciDomainId",                                    {HIP_4030, HIP_0,    HIP_0   }},
   {"hipDeviceAttributeTexturePitchAlignment",                          {HIP_3020, HIP_0,    HIP_0   }},
   {"hipDeviceAttributeMaxSurface1D",                                   {HIP_4030, HIP_0,    HIP_0   }},
   {"hipDeviceAttributeMaxSurface2D",                                   {HIP_4030, HIP_0,    HIP_0   }},
@@ -4658,4 +4658,6 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_DRIVER_TYPE_NAME_VER_MAP {
   {"hipJitOptionMinCTAPerSM",                                          {HIP_6040, HIP_0,    HIP_0   }},
   {"hipJitOptionMaxThreadsPerBlock",                                   {HIP_6040, HIP_0,    HIP_0   }},
   {"hipJitOptionOverrideDirectiveValues",                              {HIP_6040, HIP_0,    HIP_0   }},
+  {"HIP_LAUNCH_CONFIG_st",                                             {HIP_6050, HIP_0,    HIP_0   }},
+  {"HIP_LAUNCH_CONFIG",                                                {HIP_6050, HIP_0,    HIP_0   }},
 };

--- a/src/CUDA2HIP_Runtime_API_types.cpp
+++ b/src/CUDA2HIP_Runtime_API_types.cpp
@@ -285,14 +285,14 @@ const std::map<llvm::StringRef, hipCounter> CUDA_RUNTIME_TYPE_NAME_MAP {
   {"cudaLaunchAttributeValue",                                         {"hipLaunchAttributeValue",                                  "", CONV_TYPE, API_RUNTIME, SEC::DATA_TYPES}},
 
   // CUlaunchAttribute_st
-  {"cudaLaunchAttribute_st",                                           {"hipLaunchAttribute",                                       "", CONV_TYPE, API_RUNTIME, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
+  {"cudaLaunchAttribute_st",                                           {"hipLaunchAttribute_st",                                    "", CONV_TYPE, API_RUNTIME, SEC::DATA_TYPES}},
   // CUlaunchAttribute
-  {"cudaLaunchAttribute",                                              {"hipLaunchAttribute",                                       "", CONV_TYPE, API_RUNTIME, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
+  {"cudaLaunchAttribute",                                              {"hipLaunchAttribute",                                       "", CONV_TYPE, API_RUNTIME, SEC::DATA_TYPES}},
 
-  // CUlaunchConfig_st
-  {"cudaLaunchConfig_st",                                              {"hipLaunchConfig",                                          "", CONV_TYPE, API_RUNTIME, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
-  // CUlaunchConfig
-  {"cudaLaunchConfig_t",                                               {"hipLaunchConfig",                                          "", CONV_TYPE, API_RUNTIME, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
+  // NOTE: CUlaunchConfig_st struct differs
+  {"cudaLaunchConfig_st",                                              {"hipLaunchConfig_st",                                       "", CONV_TYPE, API_RUNTIME, SEC::DATA_TYPES}},
+  // NOTE: CUlaunchConfig struct differs
+  {"cudaLaunchConfig_t",                                               {"hipLaunchConfig_t",                                        "", CONV_TYPE, API_RUNTIME, SEC::DATA_TYPES}},
 
   // CUDA_GRAPH_INSTANTIATE_PARAMS_st
   {"cudaGraphInstantiateParams_st",                                    {"hipGraphInstantiateParams",                                "", CONV_TYPE, API_RUNTIME, SEC::DATA_TYPES}},
@@ -503,7 +503,7 @@ const std::map<llvm::StringRef, hipCounter> CUDA_RUNTIME_TYPE_NAME_MAP {
   // CUDA only
   {"cudaDevAttrMaxTexture3DDepthAlt",                                  {"hipDeviceAttributeMaxTexture3DAlt",                        "", CONV_NUMERIC_LITERAL, API_RUNTIME, SEC::DATA_TYPES}}, // 49
   // CU_DEVICE_ATTRIBUTE_PCI_DOMAIN_ID
-  {"cudaDevAttrPciDomainId",                                           {"hipDeviceAttributePciDomainID",                            "", CONV_NUMERIC_LITERAL, API_RUNTIME, SEC::DATA_TYPES}}, // 50
+  {"cudaDevAttrPciDomainId",                                           {"hipDeviceAttributePciDomainId",                            "", CONV_NUMERIC_LITERAL, API_RUNTIME, SEC::DATA_TYPES}}, // 50
   // CU_DEVICE_ATTRIBUTE_TEXTURE_PITCH_ALIGNMENT
   {"cudaDevAttrTexturePitchAlignment",                                 {"hipDeviceAttributeTexturePitchAlignment",                  "", CONV_NUMERIC_LITERAL, API_RUNTIME, SEC::DATA_TYPES}}, // 51
   // CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURECUBEMAP_WIDTH
@@ -3528,4 +3528,8 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_RUNTIME_TYPE_NAME_VER_MAP {
   {"hipErrorInvalidTexture",                                           {HIP_6040, HIP_0,    HIP_0   }},
   {"hipEventRecordDefault",                                            {HIP_6040, HIP_0,    HIP_0   }},
   {"hipEventRecordExternal",                                           {HIP_6040, HIP_0,    HIP_0   }},
+  {"hipLaunchAttribute_st",                                            {HIP_6050, HIP_0,    HIP_0   }},
+  {"hipLaunchAttribute",                                               {HIP_6050, HIP_0,    HIP_0   }},
+  {"hipLaunchConfig_st",                                               {HIP_6050, HIP_0,    HIP_0   }},
+  {"hipLaunchConfig_t",                                                {HIP_6050, HIP_0,    HIP_0   }},
 };

--- a/tests/unit_tests/synthetic/driver_enums.cu
+++ b/tests/unit_tests/synthetic/driver_enums.cu
@@ -121,7 +121,7 @@ int main() {
   // CHECK-NEXT: hipDeviceAttribute_t DEVICE_ATTRIBUTE_ASYNC_ENGINE_COUNT = hipDeviceAttributeAsyncEngineCount;
   // CHECK-NEXT: hipDeviceAttribute_t DEVICE_ATTRIBUTE_UNIFIED_ADDRESSING = hipDeviceAttributeUnifiedAddressing;
   // CHECK-NEXT: hipDeviceAttribute_t DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE1D_LAYERED_WIDTH = hipDeviceAttributeMaxTexture1DLayered;
-  // CHECK-NEXT: hipDeviceAttribute_t DEVICE_ATTRIBUTE_PCI_DOMAIN_ID = hipDeviceAttributePciDomainID;
+  // CHECK-NEXT: hipDeviceAttribute_t DEVICE_ATTRIBUTE_PCI_DOMAIN_ID = hipDeviceAttributePciDomainId;
   // CHECK-NEXT: hipDeviceAttribute_t DEVICE_ATTRIBUTE_TEXTURE_PITCH_ALIGNMENT = hipDeviceAttributeTexturePitchAlignment;
   // CHECK-NEXT: hipDeviceAttribute_t DEVICE_ATTRIBUTE_MAXIMUM_TEXTURECUBEMAP_WIDTH = hipDeviceAttributeMaxTextureCubemap;
   // CHECK-NEXT: hipDeviceAttribute_t DEVICE_ATTRIBUTE_MAXIMUM_SURFACE1D_WIDTH = hipDeviceAttributeMaxSurface1D;

--- a/tests/unit_tests/synthetic/driver_structs.cu
+++ b/tests/unit_tests/synthetic/driver_structs.cu
@@ -318,6 +318,13 @@ int main() {
   CUDA_BATCH_MEM_OP_NODE_PARAMS_st BATCH_MEM_OP_NODE_PARAMS_st;
 #endif
 
+#if CUDA_VERSION >= 11080
+  // CHECK: HIP_LAUNCH_CONFIG_st LaunchConfig_st;
+  // CHECK-NEXT: HIP_LAUNCH_CONFIG launchConfig;
+  CUlaunchConfig_st LaunchConfig_st;
+  CUlaunchConfig launchConfig;
+#endif
+
 #if CUDA_VERSION >= 12000
   // CHECK: hipGraphInstantiateParams GRAPH_INSTANTIATE_PARAMS_st;
   // CHECK-NEXT: hipGraphInstantiateParams GRAPH_INSTANTIATE_PARAMS;

--- a/tests/unit_tests/synthetic/runtime_enums.cu
+++ b/tests/unit_tests/synthetic/runtime_enums.cu
@@ -80,7 +80,7 @@ int main() {
   // CHECK-NEXT: hipDeviceAttribute_t DevAttrMaxTexture3DWidthAlt = hipDeviceAttributeMaxTexture3DAlt;
   // CHECK-NEXT: hipDeviceAttribute_t DevAttrMaxTexture3DHeightAlt = hipDeviceAttributeMaxTexture3DAlt;
   // CHECK-NEXT: hipDeviceAttribute_t DevAttrMaxTexture3DDepthAlt = hipDeviceAttributeMaxTexture3DAlt;
-  // CHECK-NEXT: hipDeviceAttribute_t DevAttrPciDomainId = hipDeviceAttributePciDomainID;
+  // CHECK-NEXT: hipDeviceAttribute_t DevAttrPciDomainId = hipDeviceAttributePciDomainId;
   // CHECK-NEXT: hipDeviceAttribute_t DevAttrTexturePitchAlignment = hipDeviceAttributeTexturePitchAlignment;
   // CHECK-NEXT: hipDeviceAttribute_t DevAttrMaxTextureCubemapWidth = hipDeviceAttributeMaxTextureCubemap;
   // CHECK-NEXT: hipDeviceAttribute_t DevAttrMaxTextureCubemapLayeredWidth = hipDeviceAttributeMaxTextureCubemapLayered;

--- a/tests/unit_tests/synthetic/runtime_structs.cu
+++ b/tests/unit_tests/synthetic/runtime_structs.cu
@@ -184,6 +184,18 @@ int main() {
   cudaMemAllocNodeParams MemAllocNodeParams;
 #endif
 
+#if CUDA_VERSION >= 11080
+  // CHECK: hipLaunchConfig_st LaunchConfig_st;
+  // CHECK-NEXT: hipLaunchConfig_t launchConfig;
+  cudaLaunchConfig_st LaunchConfig_st;
+  cudaLaunchConfig_t launchConfig;
+
+  // CHECK: hipLaunchAttribute_st LaunchAttribute_st;
+  // CHECK-NEXT: hipLaunchAttribute LaunchAttribute;
+  cudaLaunchAttribute_st LaunchAttribute_st;
+  cudaLaunchAttribute LaunchAttribute;
+#endif
+
 #if CUDA_VERSION < 12000
   // CHECK: surfaceReference surfaceRef;
   surfaceReference surfaceRef;


### PR DESCRIPTION
+ Updated synthetic tests, the regenerated `hipify-perl`, and `Driver` `CUDA2HIP` documentation