### PR TITLE
[HIPIFY][CLR][6.5] Sync with `ROCm HIP 6.5.0` - Part 5 - `Device API` - function defines

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -1527,6 +1527,13 @@ my %experimental_funcs = (
     "CUDA_R_6F_E3M2" => "6.5.0",
     "CUDA_R_6F_E2M3" => "6.5.0",
     "CUDA_R_4F_E2M1" => "6.5.0",
+    "CUDART_ZERO_FP16" => "6.5.0",
+    "CUDART_ONE_FP16" => "6.5.0",
+    "CUDART_NEG_ZERO_FP16" => "6.5.0",
+    "CUDART_NAN_FP16" => "6.5.0",
+    "CUDART_MIN_DENORM_FP16" => "6.5.0",
+    "CUDART_MAX_NORMAL_FP16" => "6.5.0",
+    "CUDART_INF_FP16" => "6.5.0",
     "CUBLASLT_MATMUL_MATRIX_SCALE_VEC32_UE8M0" => "6.5.0",
     "CUBLASLT_MATMUL_MATRIX_SCALE_VEC16_UE4M3" => "6.5.0",
     "CUBLASLT_MATMUL_MATRIX_SCALE_SCALAR_32F" => "6.5.0",
@@ -1670,6 +1677,13 @@ sub subst {
 sub experimentalSubstitutions {
     subst("cuLaunchKernelEx", "hipDrvLaunchKernelEx", "execution");
     subst("cudaLaunchKernelExC", "hipLaunchKernelExC", "execution");
+    subst("CUDART_INF_FP16", "HIPRT_INF_FP16", "device_type");
+    subst("CUDART_MAX_NORMAL_FP16", "HIPRT_MAX_NORMAL_FP16", "device_type");
+    subst("CUDART_MIN_DENORM_FP16", "HIPRT_MIN_DENORM_FP16", "device_type");
+    subst("CUDART_NAN_FP16", "HIPRT_NAN_FP16", "device_type");
+    subst("CUDART_NEG_ZERO_FP16", "HIPRT_NEG_ZERO_FP16", "device_type");
+    subst("CUDART_ONE_FP16", "HIPRT_ONE_FP16", "device_type");
+    subst("CUDART_ZERO_FP16", "HIPRT_ZERO_FP16", "device_type");
     subst("cublasLtMatmulMatrixScale_t", "hipblasLtMatmulMatrixScale_t", "type");
     subst("cudaLaunchAttribute", "hipLaunchAttribute", "type");
     subst("cudaLaunchAttribute_st", "hipLaunchAttribute_st", "type");
@@ -10196,7 +10210,14 @@ sub warnUnsupportedDeviceFunctions {
     "__NV_SATFINITE",
     "__NV_NOSAT",
     "__NV_E5M2",
-    "__NV_E4M3"
+    "__NV_E4M3",
+    "CUDART_ZERO_FP16",
+    "CUDART_ONE_FP16",
+    "CUDART_NEG_ZERO_FP16",
+    "CUDART_NAN_FP16",
+    "CUDART_MIN_DENORM_FP16",
+    "CUDART_MAX_NORMAL_FP16",
+    "CUDART_INF_FP16"
 );
 
 sub countSupportedDeviceDataTypes {

--- a/docs/reference/tables/CUDA_Device_API_supported_by_HIP.md
+++ b/docs/reference/tables/CUDA_Device_API_supported_by_HIP.md
@@ -894,6 +894,13 @@
 
 |**CUDA**|**A**|**D**|**C**|**R**|**HIP**|**A**|**D**|**C**|**R**|**E**|
 |:--|:-:|:-:|:-:|:-:|:--|:-:|:-:|:-:|:-:|:-:|
+|`CUDART_INF_FP16`|12.2| | | |`HIPRT_INF_FP16`|6.5.0| | | |6.5.0|
+|`CUDART_MAX_NORMAL_FP16`|12.2| | | |`HIPRT_MAX_NORMAL_FP16`|6.5.0| | | |6.5.0|
+|`CUDART_MIN_DENORM_FP16`|12.2| | | |`HIPRT_MIN_DENORM_FP16`|6.5.0| | | |6.5.0|
+|`CUDART_NAN_FP16`|12.2| | | |`HIPRT_NAN_FP16`|6.5.0| | | |6.5.0|
+|`CUDART_NEG_ZERO_FP16`|12.2| | | |`HIPRT_NEG_ZERO_FP16`|6.5.0| | | |6.5.0|
+|`CUDART_ONE_FP16`|12.2| | | |`HIPRT_ONE_FP16`|6.5.0| | | |6.5.0|
+|`CUDART_ZERO_FP16`|12.2| | | |`HIPRT_ZERO_FP16`|6.5.0| | | |6.5.0|
 |`__NV_E2M1`|12.8| | | | | | | | | |
 |`__NV_E2M3`|12.8| | | | | | | | | |
 |`__NV_E3M2`|12.8| | | | | | | | | |

--- a/src/CUDA2HIP_Device_types.cpp
+++ b/src/CUDA2HIP_Device_types.cpp
@@ -77,6 +77,14 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DEVICE_TYPE_NAME_MAP {
   {"__nv_fp4_e2m1",                        {"__hip_fp4_e2m1",                        "",                                        CONV_DEVICE_TYPE, API_RUNTIME, 2, UNSUPPORTED}},
   {"__nv_fp4x2_e2m1",                      {"__hip_fp4x2_e2m1",                      "",                                        CONV_DEVICE_TYPE, API_RUNTIME, 2, UNSUPPORTED}},
   {"__nv_fp4x4_e2m1",                      {"__hip_fp4x4_e2m1",                      "",                                        CONV_DEVICE_TYPE, API_RUNTIME, 2, UNSUPPORTED}},
+  // defines
+  {"CUDART_INF_FP16",                      {"HIPRT_INF_FP16",                        "",                                        CONV_DEVICE_TYPE, API_RUNTIME, 2, HIP_EXPERIMENTAL}},
+  {"CUDART_MAX_NORMAL_FP16",               {"HIPRT_MAX_NORMAL_FP16",                 "",                                        CONV_DEVICE_TYPE, API_RUNTIME, 2, HIP_EXPERIMENTAL}},
+  {"CUDART_MIN_DENORM_FP16",               {"HIPRT_MIN_DENORM_FP16",                 "",                                        CONV_DEVICE_TYPE, API_RUNTIME, 2, HIP_EXPERIMENTAL}},
+  {"CUDART_NAN_FP16",                      {"HIPRT_NAN_FP16",                        "",                                        CONV_DEVICE_TYPE, API_RUNTIME, 2, HIP_EXPERIMENTAL}},
+  {"CUDART_NEG_ZERO_FP16",                 {"HIPRT_NEG_ZERO_FP16",                   "",                                        CONV_DEVICE_TYPE, API_RUNTIME, 2, HIP_EXPERIMENTAL}},
+  {"CUDART_ONE_FP16",                      {"HIPRT_ONE_FP16",                        "",                                        CONV_DEVICE_TYPE, API_RUNTIME, 2, HIP_EXPERIMENTAL}},
+  {"CUDART_ZERO_FP16",                     {"HIPRT_ZERO_FP16",                       "",                                        CONV_DEVICE_TYPE, API_RUNTIME, 2, HIP_EXPERIMENTAL}},
 };
 
 const std::map<llvm::StringRef, cudaAPIversions> CUDA_DEVICE_TYPE_NAME_VER_MAP {
@@ -124,6 +132,13 @@ const std::map<llvm::StringRef, cudaAPIversions> CUDA_DEVICE_TYPE_NAME_VER_MAP {
   {"__nv_fp8_e8m0",                        {CUDA_128, CUDA_0,   CUDA_0  }},
   {"__nv_fp8x2_e8m0",                      {CUDA_128, CUDA_0,   CUDA_0  }},
   {"__nv_fp8x4_e8m0",                      {CUDA_128, CUDA_0,   CUDA_0  }},
+  {"CUDART_INF_FP16",                      {CUDA_122, CUDA_0,   CUDA_0  }},
+  {"CUDART_MAX_NORMAL_FP16",               {CUDA_122, CUDA_0,   CUDA_0  }},
+  {"CUDART_MIN_DENORM_FP16",               {CUDA_122, CUDA_0,   CUDA_0  }},
+  {"CUDART_NAN_FP16",                      {CUDA_122, CUDA_0,   CUDA_0  }},
+  {"CUDART_NEG_ZERO_FP16",                 {CUDA_122, CUDA_0,   CUDA_0  }},
+  {"CUDART_ONE_FP16",                      {CUDA_122, CUDA_0,   CUDA_0  }},
+  {"CUDART_ZERO_FP16",                     {CUDA_122, CUDA_0,   CUDA_0  }},
 };
 
 const std::map<llvm::StringRef, hipAPIversions> HIP_DEVICE_TYPE_NAME_VER_MAP {
@@ -151,6 +166,13 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_DEVICE_TYPE_NAME_VER_MAP {
   {"__hip_bfloat162_raw",                  {HIP_6020, HIP_0,    HIP_0   }},
   {"__hip_bfloat162",                      {HIP_5070, HIP_0,    HIP_0   }},
   {"hip_bfloat16",                         {HIP_3050, HIP_0,    HIP_0   }},
+  {"HIPRT_INF_FP16",                       {HIP_6050, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"HIPRT_MAX_NORMAL_FP16",                {HIP_6050, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"HIPRT_MIN_DENORM_FP16",                {HIP_6050, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"HIPRT_NAN_FP16",                       {HIP_6050, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"HIPRT_NEG_ZERO_FP16",                  {HIP_6050, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"HIPRT_ONE_FP16",                       {HIP_6050, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"HIPRT_ZERO_FP16",                      {HIP_6050, HIP_0,    HIP_0,  HIP_LATEST}},
 
   {"rocblas_half",                         {HIP_1050, HIP_0,    HIP_0   }},
   {"rocblas_bfloat16",                     {HIP_3050, HIP_0,    HIP_0   }},

--- a/tests/unit_tests/synthetic/libraries/cudevice2hipdevice.cu
+++ b/tests/unit_tests/synthetic/libraries/cudevice2hipdevice.cu
@@ -173,6 +173,21 @@ int main() {
   // HIP: __HOST_DEVICE__ __half2 make_half2(__half x, __half y);
   // CHECK: h2 = make_half2(hx, hy);
   h2 = make_half2(hx, hy);
+
+  // CHECK: __half _INF_FP16 = HIPRT_INF_FP16;
+  // CHECK-NEXT: __half _MAX_NORMAL_FP16 = HIPRT_MAX_NORMAL_FP16;
+  // CHECK-NEXT: __half _MIN_DENORM_FP16 = HIPRT_MIN_DENORM_FP16;
+  // CHECK-NEXT: __half _NAN_FP16 = HIPRT_NAN_FP16;
+  // CHECK-NEXT: __half _NEG_ZERO_FP16 = HIPRT_NEG_ZERO_FP16;
+  // CHECK-NEXT: __half _ONE_FP16 = HIPRT_ONE_FP16;
+  // CHECK-NEXT: __half _ZERO_FP16 = HIPRT_ZERO_FP16;
+  __half _INF_FP16 = CUDART_INF_FP16;
+  __half _MAX_NORMAL_FP16 = CUDART_MAX_NORMAL_FP16;
+  __half _MIN_DENORM_FP16 = CUDART_MIN_DENORM_FP16;
+  __half _NAN_FP16 = CUDART_NAN_FP16;
+  __half _NEG_ZERO_FP16 = CUDART_NEG_ZERO_FP16;
+  __half _ONE_FP16 = CUDART_ONE_FP16;
+  __half _ZERO_FP16 = CUDART_ZERO_FP16;
 #endif
 
   return 0;


### PR DESCRIPTION
+ Updated synthetic tests, the regenerated `hipify-perl`, and `Device` `CUDA2HIP` documentation
