### PR TITLE
[HIPIFY][CLR][6.5] Sync with `ROCm HIP 6.5.0` - Part 7 - `Device API` - `fp4` - Step 2 - final

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -1529,9 +1529,16 @@ my %experimental_funcs = (
     "cublasLtMatmulMatrixScale_t" => "6.5.0",
     "cuLaunchKernelEx" => "6.5.0",
     "__nv_fp4x4_storage_t" => "6.5.0",
+    "__nv_fp4x4_e2m1" => "6.5.0",
     "__nv_fp4x2_storage_t" => "6.5.0",
+    "__nv_fp4x2_e2m1" => "6.5.0",
     "__nv_fp4_storage_t" => "6.5.0",
     "__nv_fp4_interpretation_t" => "6.5.0",
+    "__nv_fp4_e2m1" => "6.5.0",
+    "__nv_cvt_halfraw_to_fp4" => "6.5.0",
+    "__nv_cvt_halfraw2_to_fp4x2" => "6.5.0",
+    "__nv_cvt_fp4x2_to_halfraw2" => "6.5.0",
+    "__nv_cvt_fp4_to_halfraw" => "6.5.0",
     "__nv_cvt_float_to_fp4" => "6.5.0",
     "__nv_cvt_float2_to_fp4x2" => "6.5.0",
     "__nv_cvt_double_to_fp4" => "6.5.0",
@@ -1699,6 +1706,10 @@ sub experimentalSubstitutions {
     subst("__nv_cvt_double_to_fp4", "__hip_cvt_double_to_fp4", "device_function");
     subst("__nv_cvt_float2_to_fp4x2", "__hip_cvt_float2_to_fp4x2", "device_function");
     subst("__nv_cvt_float_to_fp4", "__hip_cvt_float_to_fp4", "device_function");
+    subst("__nv_cvt_fp4_to_halfraw", "__hip_cvt_fp4_to_halfraw", "device_function");
+    subst("__nv_cvt_fp4x2_to_halfraw2", "__hip_cvt_fp4x2_to_halfraw2", "device_function");
+    subst("__nv_cvt_halfraw2_to_fp4x2", "__hip_cvt_halfraw2_to_fp4x2", "device_function");
+    subst("__nv_cvt_halfraw_to_fp4", "__hip_cvt_halfraw_to_fp4", "device_function");
     subst("CUDART_INF_FP16", "HIPRT_INF_FP16", "device_type");
     subst("CUDART_MAX_NORMAL_FP16", "HIPRT_MAX_NORMAL_FP16", "device_type");
     subst("CUDART_MIN_DENORM_FP16", "HIPRT_MIN_DENORM_FP16", "device_type");
@@ -1706,9 +1717,12 @@ sub experimentalSubstitutions {
     subst("CUDART_NEG_ZERO_FP16", "HIPRT_NEG_ZERO_FP16", "device_type");
     subst("CUDART_ONE_FP16", "HIPRT_ONE_FP16", "device_type");
     subst("CUDART_ZERO_FP16", "HIPRT_ZERO_FP16", "device_type");
+    subst("__nv_fp4_e2m1", "__hip_fp4_e2m1", "device_type");
     subst("__nv_fp4_interpretation_t", "__hip_fp4_interpretation_t", "device_type");
     subst("__nv_fp4_storage_t", "__hip_fp4_storage_t", "device_type");
+    subst("__nv_fp4x2_e2m1", "__hip_fp4x2_e2m1", "device_type");
     subst("__nv_fp4x2_storage_t", "__hip_fp4x2_storage_t", "device_type");
+    subst("__nv_fp4x4_e2m1", "__hip_fp4x4_e2m1", "device_type");
     subst("__nv_fp4x4_storage_t", "__hip_fp4x4_storage_t", "device_type");
     subst("cudaRoundMode", "hipRoundMode", "device_type");
     subst("cublasLtMatmulMatrixScale_t", "hipblasLtMatmulMatrixScale_t", "type");
@@ -9595,9 +9609,13 @@ sub transformHostFunctions {
     "__popcll",
     "__popc",
     "__nv_cvt_halfraw_to_fp8",
+    "__nv_cvt_halfraw_to_fp4",
     "__nv_cvt_halfraw2_to_fp8x2",
+    "__nv_cvt_halfraw2_to_fp4x2",
     "__nv_cvt_fp8x2_to_halfraw2",
     "__nv_cvt_fp8_to_halfraw",
+    "__nv_cvt_fp4x2_to_halfraw2",
+    "__nv_cvt_fp4_to_halfraw",
     "__nv_cvt_float_to_fp8",
     "__nv_cvt_float_to_fp4",
     "__nv_cvt_float2_to_fp8x2",
@@ -10055,13 +10073,9 @@ sub countSupportedDeviceFunctions {
     "__nv_fp128_acosh",
     "__nv_fp128_acos",
     "__nv_cvt_halfraw_to_fp6",
-    "__nv_cvt_halfraw_to_fp4",
     "__nv_cvt_halfraw2_to_fp6x2",
-    "__nv_cvt_halfraw2_to_fp4x2",
     "__nv_cvt_fp6x2_to_halfraw2",
     "__nv_cvt_fp6_to_halfraw",
-    "__nv_cvt_fp4x2_to_halfraw2",
-    "__nv_cvt_fp4_to_halfraw",
     "__nv_cvt_float_to_fp6",
     "__nv_cvt_float_to_e8m0",
     "__nv_cvt_float2_to_fp6x2",
@@ -10238,9 +10252,12 @@ sub warnUnsupportedDeviceFunctions {
     "__nv_fp8_e5m2",
     "__nv_fp8_e4m3",
     "__nv_fp4x4_storage_t",
+    "__nv_fp4x4_e2m1",
     "__nv_fp4x2_storage_t",
+    "__nv_fp4x2_e2m1",
     "__nv_fp4_storage_t",
     "__nv_fp4_interpretation_t",
+    "__nv_fp4_e2m1",
     "__nv_bfloat16_raw",
     "__nv_bfloat162_raw",
     "__nv_bfloat162",
@@ -10290,9 +10307,6 @@ sub countSupportedDeviceDataTypes {
     "__nv_fp6_interpretation_t",
     "__nv_fp6_e3m2",
     "__nv_fp6_e2m3",
-    "__nv_fp4x4_e2m1",
-    "__nv_fp4x2_e2m1",
-    "__nv_fp4_e2m1",
     "__NV_E3M2",
     "__NV_E2M3"
 );

--- a/docs/reference/tables/CUDA_Device_API_supported_by_HIP.md
+++ b/docs/reference/tables/CUDA_Device_API_supported_by_HIP.md
@@ -403,16 +403,16 @@
 |`__nv_cvt_float_to_fp4`|12.8| | | |`__hip_cvt_float_to_fp4`|6.5.0| | | |6.5.0|
 |`__nv_cvt_float_to_fp6`|12.8| | | | | | | | | |
 |`__nv_cvt_float_to_fp8`|11.8| | | |`__hip_cvt_float_to_fp8`|6.2.0| | | | |
-|`__nv_cvt_fp4_to_halfraw`|12.8| | | | | | | | | |
-|`__nv_cvt_fp4x2_to_halfraw2`|12.8| | | | | | | | | |
+|`__nv_cvt_fp4_to_halfraw`|12.8| | | |`__hip_cvt_fp4_to_halfraw`|6.5.0| | | |6.5.0|
+|`__nv_cvt_fp4x2_to_halfraw2`|12.8| | | |`__hip_cvt_fp4x2_to_halfraw2`|6.5.0| | | |6.5.0|
 |`__nv_cvt_fp6_to_halfraw`|12.8| | | | | | | | | |
 |`__nv_cvt_fp6x2_to_halfraw2`|12.8| | | | | | | | | |
 |`__nv_cvt_fp8_to_halfraw`|11.8| | | |`__hip_cvt_fp8_to_halfraw`|6.2.0| | | | |
 |`__nv_cvt_fp8x2_to_halfraw2`|11.8| | | |`__hip_cvt_fp8x2_to_halfraw2`|6.2.0| | | | |
-|`__nv_cvt_halfraw2_to_fp4x2`|12.8| | | | | | | | | |
+|`__nv_cvt_halfraw2_to_fp4x2`|12.8| | | |`__hip_cvt_halfraw2_to_fp4x2`|6.5.0| | | |6.5.0|
 |`__nv_cvt_halfraw2_to_fp6x2`|12.8| | | | | | | | | |
 |`__nv_cvt_halfraw2_to_fp8x2`|11.8| | | |`__hip_cvt_halfraw2_to_fp8x2`|6.2.0| | | | |
-|`__nv_cvt_halfraw_to_fp4`|12.8| | | | | | | | | |
+|`__nv_cvt_halfraw_to_fp4`|12.8| | | |`__hip_cvt_halfraw_to_fp4`|6.5.0| | | |6.5.0|
 |`__nv_cvt_halfraw_to_fp6`|12.8| | | | | | | | | |
 |`__nv_cvt_halfraw_to_fp8`|11.8| | | |`__hip_cvt_halfraw_to_fp8`|6.2.0| | | | |
 |`__nv_fp128_acos`|12.8| | | | | | | | | |
@@ -916,12 +916,12 @@
 |`__nv_bfloat162`|11.0| | | |`__hip_bfloat162`|5.7.0| | | | |
 |`__nv_bfloat162_raw`|11.0| | | |`__hip_bfloat162_raw`|6.2.0| | | | |
 |`__nv_bfloat16_raw`|11.0| | | |`__hip_bfloat16_raw`|6.2.0| | | | |
-|`__nv_fp4_e2m1`|12.8| | | | | | | | | |
+|`__nv_fp4_e2m1`|12.8| | | |`__hip_fp4_e2m1`|6.5.0| | | |6.5.0|
 |`__nv_fp4_interpretation_t`|12.8| | | |`__hip_fp4_interpretation_t`|6.5.0| | | |6.5.0|
 |`__nv_fp4_storage_t`|12.8| | | |`__hip_fp4_storage_t`|6.5.0| | | |6.5.0|
-|`__nv_fp4x2_e2m1`|12.8| | | | | | | | | |
+|`__nv_fp4x2_e2m1`|12.8| | | |`__hip_fp4x2_e2m1`|6.5.0| | | |6.5.0|
 |`__nv_fp4x2_storage_t`|12.8| | | |`__hip_fp4x2_storage_t`|6.5.0| | | |6.5.0|
-|`__nv_fp4x4_e2m1`|12.8| | | | | | | | | |
+|`__nv_fp4x4_e2m1`|12.8| | | |`__hip_fp4x4_e2m1`|6.5.0| | | |6.5.0|
 |`__nv_fp4x4_storage_t`|12.8| | | |`__hip_fp4x4_storage_t`|6.5.0| | | |6.5.0|
 |`__nv_fp6_e2m3`|12.8| | | | | | | | | |
 |`__nv_fp6_e3m2`|12.8| | | | | | | | | |

--- a/src/CUDA2HIP_Device_functions.cpp
+++ b/src/CUDA2HIP_Device_functions.cpp
@@ -904,12 +904,12 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DEVICE_FUNCTION_MAP {
   {"__nv_cvt_double2_to_fp4x2",         {"__hip_cvt_double2_to_fp4x2",         "", CONV_DEVICE_FUNC, API_RUNTIME, 1, HIP_EXPERIMENTAL}},
   {"__nv_cvt_float_to_fp4",             {"__hip_cvt_float_to_fp4",             "", CONV_DEVICE_FUNC, API_RUNTIME, 1, HIP_EXPERIMENTAL}},
   {"__nv_cvt_float2_to_fp4x2",          {"__hip_cvt_float2_to_fp4x2",          "", CONV_DEVICE_FUNC, API_RUNTIME, 1, HIP_EXPERIMENTAL}},
-  {"__nv_cvt_halfraw_to_fp4",           {"__hip_cvt_halfraw_to_fp4",           "", CONV_DEVICE_FUNC, API_RUNTIME, 1, UNSUPPORTED}},
-  {"__nv_cvt_halfraw2_to_fp4x2",        {"__hip_cvt_halfraw2_to_fp4x2",        "", CONV_DEVICE_FUNC, API_RUNTIME, 1, UNSUPPORTED}},
+  {"__nv_cvt_halfraw_to_fp4",           {"__hip_cvt_halfraw_to_fp4",           "", CONV_DEVICE_FUNC, API_RUNTIME, 1, HIP_EXPERIMENTAL}},
+  {"__nv_cvt_halfraw2_to_fp4x2",        {"__hip_cvt_halfraw2_to_fp4x2",        "", CONV_DEVICE_FUNC, API_RUNTIME, 1, HIP_EXPERIMENTAL}},
   {"__nv_cvt_bfloat16raw_to_fp4",       {"__hip_cvt_bfloat16raw_to_fp4",       "", CONV_DEVICE_FUNC, API_RUNTIME, 1, HIP_EXPERIMENTAL}},
   {"__nv_cvt_bfloat16raw2_to_fp4x2",    {"__hip_cvt_bfloat16raw2_to_fp4x2",    "", CONV_DEVICE_FUNC, API_RUNTIME, 1, HIP_EXPERIMENTAL}},
-  {"__nv_cvt_fp4_to_halfraw",           {"__hip_cvt_fp4_to_halfraw",           "", CONV_DEVICE_FUNC, API_RUNTIME, 1, UNSUPPORTED}},
-  {"__nv_cvt_fp4x2_to_halfraw2",        {"__hip_cvt_fp4x2_to_halfraw2",        "", CONV_DEVICE_FUNC, API_RUNTIME, 1, UNSUPPORTED}},
+  {"__nv_cvt_fp4_to_halfraw",           {"__hip_cvt_fp4_to_halfraw",           "", CONV_DEVICE_FUNC, API_RUNTIME, 1, HIP_EXPERIMENTAL}},
+  {"__nv_cvt_fp4x2_to_halfraw2",        {"__hip_cvt_fp4x2_to_halfraw2",        "", CONV_DEVICE_FUNC, API_RUNTIME, 1, HIP_EXPERIMENTAL}},
   // intrinsics
   {"__all_sync",                        {"__all_sync",                         "", CONV_DEVICE_FUNC, API_RUNTIME, 1}},
   {"__any_sync",                        {"__any_sync",                         "", CONV_DEVICE_FUNC, API_RUNTIME, 1}},
@@ -1699,6 +1699,10 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_DEVICE_FUNCTION_VER_MAP {
   {"__hip_cvt_double2_to_fp4x2",        {HIP_6050, HIP_0,    HIP_0,  HIP_LATEST}},
   {"__hip_cvt_float_to_fp4",            {HIP_6050, HIP_0,    HIP_0,  HIP_LATEST}},
   {"__hip_cvt_float2_to_fp4x2",         {HIP_6050, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"__hip_cvt_fp4_to_halfraw",          {HIP_6050, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"__hip_cvt_fp4x2_to_halfraw2",       {HIP_6050, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"__hip_cvt_halfraw_to_fp4",          {HIP_6050, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"__hip_cvt_halfraw2_to_fp4x2",       {HIP_6050, HIP_0,    HIP_0,  HIP_LATEST}},
 };
 
 const std::map<llvm::StringRef, cudaAPIChangedVersions> CUDA_DEVICE_FUNCTION_CHANGED_VER_MAP {

--- a/src/CUDA2HIP_Device_types.cpp
+++ b/src/CUDA2HIP_Device_types.cpp
@@ -74,9 +74,9 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DEVICE_TYPE_NAME_MAP {
   {"__nv_fp4x4_storage_t",                 {"__hip_fp4x4_storage_t",                 "",                                        CONV_DEVICE_TYPE, API_RUNTIME, 2, HIP_EXPERIMENTAL}},
   {"__nv_fp4_interpretation_t",            {"__hip_fp4_interpretation_t",            "",                                        CONV_DEVICE_TYPE, API_RUNTIME, 2, HIP_EXPERIMENTAL}},
   {"__NV_E2M1",                            {"__HIP_E2M1",                            "",                                        CONV_NUMERIC_LITERAL, API_RUNTIME, 2, HIP_EXPERIMENTAL}},
-  {"__nv_fp4_e2m1",                        {"__hip_fp4_e2m1",                        "",                                        CONV_DEVICE_TYPE, API_RUNTIME, 2, UNSUPPORTED}},
-  {"__nv_fp4x2_e2m1",                      {"__hip_fp4x2_e2m1",                      "",                                        CONV_DEVICE_TYPE, API_RUNTIME, 2, UNSUPPORTED}},
-  {"__nv_fp4x4_e2m1",                      {"__hip_fp4x4_e2m1",                      "",                                        CONV_DEVICE_TYPE, API_RUNTIME, 2, UNSUPPORTED}},
+  {"__nv_fp4_e2m1",                        {"__hip_fp4_e2m1",                        "",                                        CONV_DEVICE_TYPE, API_RUNTIME, 2, HIP_EXPERIMENTAL}},
+  {"__nv_fp4x2_e2m1",                      {"__hip_fp4x2_e2m1",                      "",                                        CONV_DEVICE_TYPE, API_RUNTIME, 2, HIP_EXPERIMENTAL}},
+  {"__nv_fp4x4_e2m1",                      {"__hip_fp4x4_e2m1",                      "",                                        CONV_DEVICE_TYPE, API_RUNTIME, 2, HIP_EXPERIMENTAL}},
   // defines
   {"CUDART_INF_FP16",                      {"HIPRT_INF_FP16",                        "",                                        CONV_DEVICE_TYPE, API_RUNTIME, 2, HIP_EXPERIMENTAL}},
   {"CUDART_MAX_NORMAL_FP16",               {"HIPRT_MAX_NORMAL_FP16",                 "",                                        CONV_DEVICE_TYPE, API_RUNTIME, 2, HIP_EXPERIMENTAL}},
@@ -189,6 +189,9 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_DEVICE_TYPE_NAME_VER_MAP {
   {"hipRoundZero",                         {HIP_6050, HIP_0,    HIP_0,  HIP_LATEST}},
   {"hipRoundPosInf",                       {HIP_6050, HIP_0,    HIP_0,  HIP_LATEST}},
   {"hipRoundMinInf",                       {HIP_6050, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"__hip_fp4_e2m1",                       {HIP_6050, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"__hip_fp4x2_e2m1",                     {HIP_6050, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"__hip_fp4x4_e2m1",                     {HIP_6050, HIP_0,    HIP_0,  HIP_LATEST}},
 
   {"rocblas_half",                         {HIP_1050, HIP_0,    HIP_0   }},
   {"rocblas_bfloat16",                     {HIP_3050, HIP_0,    HIP_0   }},

--- a/tests/unit_tests/synthetic/libraries/cudevice2hipdevice.cu
+++ b/tests/unit_tests/synthetic/libraries/cudevice2hipdevice.cu
@@ -206,11 +206,17 @@ int main() {
   // CHECK-NEXT: __hip_fp4x4_storage_t fp4x4_storage_t;
   // CHECK-NEXT: __hip_fp4_interpretation_t fp4_interpretation_t;
   // CHECK-NEXT: __hip_fp4_interpretation_t fp4_interpretation = __HIP_E2M1;
+  // CHECK-NEXT: __hip_fp4_e2m1 fp4_e2m1;
+  // CHECK-NEXT: __hip_fp4x2_e2m1 fp4x2_e2m1;
+  // CHECK-NEXT: __hip_fp4x4_e2m1 fp4x4_e2m1;
   __nv_fp4_storage_t fp4_storage_t;
   __nv_fp4x2_storage_t fp4x2_storage_t;
   __nv_fp4x4_storage_t fp4x4_storage_t;
   __nv_fp4_interpretation_t fp4_interpretation_t;
   __nv_fp4_interpretation_t fp4_interpretation = __NV_E2M1;
+  __nv_fp4_e2m1 fp4_e2m1;
+  __nv_fp4x2_e2m1 fp4x2_e2m1;
+  __nv_fp4x4_e2m1 fp4x4_e2m1;
 
   // CUDA: __CUDA_HOSTDEVICE_FP4_DECL__ __nv_fp4_storage_t __nv_cvt_double_to_fp4(const double x, const __nv_fp4_interpretation_t fp4_interpretation, const enum cudaRoundMode rounding);
   // HIP: __FP4_HOST_DEVICE_STATIC__ __hip_fp4_storage_t __hip_cvt_double_to_fp4(const double x, const __hip_fp4_interpretation_t, const enum hipRoundMode);
@@ -241,6 +247,26 @@ int main() {
   // HIP: __FP4_HOST_DEVICE_STATIC__ __hip_fp4x2_storage_t __hip_cvt_bfloat16raw2_to_fp4x2(const __hip_bfloat162_raw x, const __hip_fp4_interpretation_t, const enum hipRoundMode);
   // CHECK: fp4x2_storage_t = __hip_cvt_bfloat16raw2_to_fp4x2(bf162r, fp4_interpretation_t, RoundMode);
   fp4x2_storage_t = __nv_cvt_bfloat16raw2_to_fp4x2(bf162r, fp4_interpretation_t, RoundMode);
+
+  // CUDA: __CUDA_HOSTDEVICE_FP4_DECL__ __nv_fp4_storage_t __nv_cvt_halfraw_to_fp4(const __half_raw x, const __nv_fp4_interpretation_t fp4_interpretation, const enum cudaRoundMode rounding);
+  // HIP: __FP4_HOST_DEVICE_STATIC__ __hip_fp4_storage_t __hip_cvt_halfraw_to_fp4(const __half_raw x, const __hip_fp4_interpretation_t, const enum hipRoundMode );
+  // CHECK: fp4_storage_t = __hip_cvt_halfraw_to_fp4(hrx, fp4_interpretation_t, RoundMode);
+  fp4_storage_t = __nv_cvt_halfraw_to_fp4(hrx, fp4_interpretation_t, RoundMode);
+
+  // CUDA: __CUDA_HOSTDEVICE_FP4_DECL__ __nv_fp4x2_storage_t __nv_cvt_halfraw2_to_fp4x2(const __half2_raw x, const __nv_fp4_interpretation_t fp4_interpretation, const enum cudaRoundMode rounding);
+  // HIP: __FP4_HOST_DEVICE_STATIC__ __hip_fp4x2_storage_t __hip_cvt_halfraw2_to_fp4x2(const __half2_raw x, const __hip_fp4_interpretation_t, const enum hipRoundMode);
+  // CHECK: fp4x2_storage_t = __hip_cvt_halfraw2_to_fp4x2(h2rx, fp4_interpretation_t, RoundMode);
+  fp4x2_storage_t = __nv_cvt_halfraw2_to_fp4x2(h2rx, fp4_interpretation_t, RoundMode);
+
+  // CUDA: __CUDA_HOSTDEVICE_FP4_DECL__ __half_raw __nv_cvt_fp4_to_halfraw(const __nv_fp4_storage_t x, const __nv_fp4_interpretation_t fp4_interpretation);
+  // HIP: __FP4_HOST_DEVICE_STATIC__ __half_raw __hip_cvt_fp4_to_halfraw(const __hip_fp4_storage_t x, const __hip_fp4_interpretation_t);
+  // CHECK: hrx = __hip_cvt_fp4_to_halfraw(fp4_storage_t, fp4_interpretation_t);
+  hrx = __nv_cvt_fp4_to_halfraw(fp4_storage_t, fp4_interpretation_t);
+
+  // CUDA: __CUDA_HOSTDEVICE_FP4_DECL__ __half2_raw __nv_cvt_fp4x2_to_halfraw2(const __nv_fp4x2_storage_t x, const __nv_fp4_interpretation_t fp4_interpretation);
+  // HIP: __FP4_HOST_DEVICE_STATIC__ __half2_raw __hip_cvt_fp4x2_to_halfraw2(const __hip_fp4x2_storage_t x, const __hip_fp4_interpretation_t);
+  // CHECK: h2rx = __hip_cvt_fp4x2_to_halfraw2(fp4x2_storage_t, fp4_interpretation_t);
+  h2rx = __nv_cvt_fp4x2_to_halfraw2(fp4x2_storage_t, fp4_interpretation_t);
 #endif
 
   return 0;


### PR DESCRIPTION
+ Updated synthetic tests, the regenerated `hipify-perl`, and `Device` `CUDA2HIP` documentation
