### PR TITLE
[HIPIFY][CLR][6.5][fix] Sync with `ROCm HIP 6.5.0` - Part 8 - `Driver API` - `CUlaunchAttribute(_st)` support

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -1546,6 +1546,8 @@ my %experimental_funcs = (
     "__nv_cvt_bfloat16raw_to_fp4" => "6.5.0",
     "__nv_cvt_bfloat16raw2_to_fp4x2" => "6.5.0",
     "__NV_E2M1" => "6.5.0",
+    "CUlaunchAttribute_st" => "6.5.0",
+    "CUlaunchAttribute" => "6.5.0",
     "CUDA_R_8F_UE8M0" => "6.5.0",
     "CUDA_R_6F_E3M2" => "6.5.0",
     "CUDA_R_6F_E2M3" => "6.5.0",
@@ -1725,6 +1727,8 @@ sub experimentalSubstitutions {
     subst("__nv_fp4x4_e2m1", "__hip_fp4x4_e2m1", "device_type");
     subst("__nv_fp4x4_storage_t", "__hip_fp4x4_storage_t", "device_type");
     subst("cudaRoundMode", "hipRoundMode", "device_type");
+    subst("CUlaunchAttribute", "hipLaunchAttribute", "type");
+    subst("CUlaunchAttribute_st", "hipLaunchAttribute_st", "type");
     subst("cublasLtMatmulMatrixScale_t", "hipblasLtMatmulMatrixScale_t", "type");
     subst("cudaLaunchAttribute", "hipLaunchAttribute", "type");
     subst("cudaLaunchAttribute_st", "hipLaunchAttribute_st", "type");
@@ -12064,8 +12068,6 @@ sub warnRemovedFunctions {
     "CUlaunchMemSyncDomainMap_st",
     "CUlaunchMemSyncDomainMap",
     "CUlaunchMemSyncDomain",
-    "CUlaunchAttribute_st",
-    "CUlaunchAttribute",
     "CUkernel",
     "CUkern_st",
     "CUjit_target_enum",

--- a/docs/reference/tables/CUDA_Driver_API_functions_supported_by_HIP.md
+++ b/docs/reference/tables/CUDA_Driver_API_functions_supported_by_HIP.md
@@ -1342,12 +1342,12 @@
 |`CUkernelNodeAttrValue`|11.0| | | |`hipKernelNodeAttrValue`|5.2.0| | | | |
 |`CUkernelNodeAttrValue_union`|11.0| | |11.8|`hipKernelNodeAttrValue`|5.2.0| | | | |
 |`CUkernelNodeAttrValue_v1`|11.3| | | |`hipKernelNodeAttrValue`|5.2.0| | | | |
-|`CUlaunchAttribute`|11.8| | | | | | | | | |
+|`CUlaunchAttribute`|11.8| | | |`hipLaunchAttribute`|6.5.0| | | |6.5.0|
 |`CUlaunchAttributeID`|11.8| | | |`hipLaunchAttributeID`|6.2.0| | | | |
 |`CUlaunchAttributeID_enum`|11.8| | | |`hipLaunchAttributeID`|6.2.0| | | | |
 |`CUlaunchAttributeValue`|11.8| | | |`hipLaunchAttributeValue`|6.2.0| | | | |
 |`CUlaunchAttributeValue_union`|11.8| | | |`hipLaunchAttributeValue`|6.2.0| | | | |
-|`CUlaunchAttribute_st`|11.8| | | | | | | | | |
+|`CUlaunchAttribute_st`|11.8| | | |`hipLaunchAttribute_st`|6.5.0| | | |6.5.0|
 |`CUlaunchConfig`|11.8| | | |`HIP_LAUNCH_CONFIG`|6.5.0| | | |6.5.0|
 |`CUlaunchConfig_st`|11.8| | | |`HIP_LAUNCH_CONFIG_st`|6.5.0| | | |6.5.0|
 |`CUlaunchMemSyncDomain`|12.0| | | | | | | | | |

--- a/src/CUDA2HIP_Driver_API_types.cpp
+++ b/src/CUDA2HIP_Driver_API_types.cpp
@@ -365,9 +365,9 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_TYPE_NAME_MAP {
   {"CUDA_BATCH_MEM_OP_NODE_PARAMS_v2",                                 {"hipBatchMemOpNodeParams",                                  "", CONV_TYPE, API_DRIVER, SEC::DATA_TYPES}},
 
   // cudaLaunchAttribute_st
-  {"CUlaunchAttribute_st",                                             {"hipLaunchAttribute",                                       "", CONV_TYPE, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
+  {"CUlaunchAttribute_st",                                             {"hipLaunchAttribute_st",                                    "", CONV_TYPE, API_DRIVER, SEC::DATA_TYPES, HIP_EXPERIMENTAL}},
   // cudaLaunchAttribute
-  {"CUlaunchAttribute",                                                {"hipLaunchAttribute",                                       "", CONV_TYPE, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
+  {"CUlaunchAttribute",                                                {"hipLaunchAttribute",                                       "", CONV_TYPE, API_DRIVER, SEC::DATA_TYPES, HIP_EXPERIMENTAL}},
 
   // NOTE: cudaLaunchConfig_st struct differs
   {"CUlaunchConfig_st",                                                {"HIP_LAUNCH_CONFIG_st",                                     "", CONV_TYPE, API_DRIVER, SEC::DATA_TYPES}},

--- a/tests/unit_tests/synthetic/driver_structs.cu
+++ b/tests/unit_tests/synthetic/driver_structs.cu
@@ -323,6 +323,11 @@ int main() {
   // CHECK-NEXT: HIP_LAUNCH_CONFIG launchConfig;
   CUlaunchConfig_st LaunchConfig_st;
   CUlaunchConfig launchConfig;
+
+  // CHECK: hipLaunchAttribute_st LaunchAttribute_st;
+  // CHECK-NEXT: hipLaunchAttribute LaunchAttribute;
+  CUlaunchAttribute_st LaunchAttribute_st;
+  CUlaunchAttribute LaunchAttribute;
 #endif
 
 #if CUDA_VERSION >= 12000


### PR DESCRIPTION
+ Updated synthetic tests, the regenerated `hipify-perl`, and `Driver` `CUDA2HIP` documentation
