### PR TITLE
[HIPIFY][doc][revert] Remove 6.5.0 from `CHANGELOG.md`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,16 +3,6 @@
 Documentation for HIPIFY is available at
 [https://rocmdocs.amd.com/projects/HIPIFY/en/latest/](https://rocmdocs.amd.com/projects/HIPIFY/en/latest/).
 
-## HIPIFY for ROCm 6.5.0
-
-### Added
-
-* CUDA 12.8.0 support
-* cuDNN 9.8.0 support
-* cuTENSOR 2.2.0.0 support
-* cuFFTXt support
-* LLVM 20.1.3 support
-
 ## HIPIFY for ROCm 6.4.0
 
 ### Added


### PR DESCRIPTION
+ [Reason] The next major release is going to be `7.0` 
+ [ToDo] Update the sources accordingly