### PR TITLE
[HIPIFY][doc] `CUDA 12.8.1` is the latest supported CUDA release (`LLVM 20.1.x`)

### DIFF
--- a/docs/building/building-hipify.rst
+++ b/docs/building/building-hipify.rst
@@ -281,8 +281,8 @@ Linux testing
 
 On Linux, the following configurations are tested:
 
-* Ubuntu 22-23: LLVM 13.0.0 - 20.1.4, CUDA 7.0 - 12.8.0, cuDNN 8.0.5 - 9.9.0, cuTensor 1.0.1.0 - 2.2.0.0
-* Ubuntu 20-21: LLVM 9.0.0 - 20.1.4, CUDA 7.0 - 12.8.0, cuDNN 5.1.10 - 9.9.0, cuTensor 1.0.1.0 - 2.2.0.0
+* Ubuntu 22-23: LLVM 13.0.0 - 20.1.4, CUDA 7.0 - 12.8.1, cuDNN 8.0.5 - 9.9.0, cuTensor 1.0.1.0 - 2.2.0.0
+* Ubuntu 20-21: LLVM 9.0.0 - 20.1.4, CUDA 7.0 - 12.8.1, cuDNN 5.1.10 - 9.9.0, cuTensor 1.0.1.0 - 2.2.0.0
 * Ubuntu 16-19: LLVM 8.0.0 - 14.0.6, CUDA 7.0 - 10.2, cuDNN 5.1.10 - 8.0.5
 * Ubuntu 14: LLVM 4.0.0 - 7.1.0, CUDA 7.0 - 9.0, cuDNN 5.0.5 - 7.6.5
 
@@ -303,7 +303,7 @@ Here's how to build ``hipify-clang`` with testing support on ``Ubuntu 23.10.01``
   -DCMAKE_BUILD_TYPE=Release \
   -DCMAKE_INSTALL_PREFIX=../dist \
   -DCMAKE_PREFIX_PATH=/usr/llvm/20.1.4/dist \
-  -DCUDA_TOOLKIT_ROOT_DIR=/usr/local/cuda-12.8.0 \
+  -DCUDA_TOOLKIT_ROOT_DIR=/usr/local/cuda-12.8.1 \
   -DCUDA_DNN_ROOT_DIR=/usr/local/cudnn-9.9.0 \
   -DCUDA_TENSOR_ROOT_DIR=/usr/local/cutensor-2.2.0.0 \
   -DLLVM_EXTERNAL_LIT=/usr/llvm/20.1.4/build/bin/llvm-lit \
@@ -342,20 +342,20 @@ The corresponding successful output is:
   -- Found lit: /usr/local/bin/lit
   -- Found FileCheck: /GIT/LLVM/trunk/dist/FileCheck
   -- Initial CUDA to configure:
-  --    - CUDA Toolkit path     : /usr/local/cuda-12.8.0
+  --    - CUDA Toolkit path     : /usr/local/cuda-12.8.1
   --    - CUDA Samples path     :
   --    - cuDNN path            : /usr/local/cudnn-9.9.0
   --    - cuTENSOR path         : /usr/local/cuTensor/2.2.0.0
   --    - CUB path              :
-  -- Found CUDAToolkit: /usr/local/cuda-12.8.0/targets/x86_64-linux/include (found version "12.8.61")
+  -- Found CUDAToolkit: /usr/local/cuda-12.8.1/targets/x86_64-linux/include (found version "12.8.93")
   -- Performing Test CMAKE_HAVE_LIBC_PTHREAD
   -- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Success
   -- Found Threads: TRUE
   -- Found CUDA config:
-  --    - CUDA Toolkit path     : /usr/local/cuda-12.8.0
+  --    - CUDA Toolkit path     : /usr/local/cuda-12.8.1
   --    - CUDA Samples path     : OFF
   --    - cuDNN path            : /usr/local/cudnn-9.9.0
-  --    - CUB path              : /usr/local/cuda-12.8.0/include/cub
+  --    - CUB path              : /usr/local/cuda-12.8.1/include/cub
   --    - cuTENSOR path         : /usr/local/cuTensor/2.2.0.0
   -- Configuring done (0.6s)
   -- Generating done (0.0s)
@@ -371,7 +371,7 @@ The corresponding successful output is:
 
   Running HIPify regression tests
   ===============================================================
-  CUDA 12.8.61 - will be used for testing
+  CUDA 12.8.93 - will be used for testing
   LLVM 20.1.4 - will be used for testing
   x86_64 - Platform architecture
   Linux 6.5.0-15-generic - Platform OS
@@ -473,7 +473,7 @@ Tested configurations:
     - ``4.0.0``
     - ``3.13.2``
   * - ``19.1.0 - 20.1.4``
-    - ``7.0 - 12.8.0``
+    - ``7.0 - 12.8.1``
     - ``8.0.5  - 9.9.0``
     - ``2019.16.11.42, 2022.17.12.3``
     - ``4.0.0``
@@ -504,7 +504,7 @@ Building with testing support using ``Visual Studio 17 2022`` on ``Windows 11``:
   -DCMAKE_INSTALL_PREFIX=../dist \
   -DCMAKE_PREFIX_PATH=D:/LLVM/20.1.4/dist \
   -DCUDA_TOOLKIT_ROOT_DIR="C:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v12.8" \
-  -DCUDA_SDK_ROOT_DIR="C:/ProgramData/NVIDIA Corporation/CUDA Samples/v12.5" \
+  -DCUDA_SDK_ROOT_DIR="C:/ProgramData/NVIDIA Corporation/CUDA Samples/v12.8" \
   -DCUDA_DNN_ROOT_DIR=D:/CUDA/cuDNN/9.9.0 \
   -DCUDA_TENSOR_ROOT_DIR=D:/CUDA/cuTensor/2.2.0.0 \
   -DLLVM_EXTERNAL_LIT=D:/LLVM/20.1.4/build/Release/bin/llvm-lit.py \
@@ -543,11 +543,11 @@ The corresponding successful output is:
   -- Found FileCheck: D:/LLVM/20.1.4/dist/bin/FileCheck.exe
   -- Initial CUDA to configure:
   --    - CUDA Toolkit path     : C:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v12.8
-  --    - CUDA Samples path     : C:/ProgramData/NVIDIA Corporation/CUDA Samples/v12.5
+  --    - CUDA Samples path     : C:/ProgramData/NVIDIA Corporation/CUDA Samples/v12.8
   --    - cuDNN path            : D:/CUDA/cuDNN/9.9.0
   --    - cuTENSOR path         : D:/CUDA/cuTensor/2.2.0.0
   --    - CUB path              :
-  -- Found CUDAToolkit: C:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v12.8/include (found version "12.8.61")
+  -- Found CUDAToolkit: C:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v12.8/include (found version "12.8.93")
   -- Found CUDA config:
   --    - CUDA Toolkit path     : C:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v12.8
   --    - CUDA Samples path     : C:/ProgramData/NVIDIA Corporation/CUDA Samples/v12.8

--- a/docs/how-to/hipify-clang.rst
+++ b/docs/how-to/hipify-clang.rst
@@ -36,7 +36,7 @@ Release Dependencies
 ``hipify-clang`` requires:
 
 * `CUDA <https://developer.nvidia.com/cuda-downloads>`_, the latest supported version is
-  `12.8.0 <https://developer.nvidia.com/cuda-12-8-0-download-archive>`_, but requires at least version
+  `12.8.1 <https://developer.nvidia.com/cuda-12-8-1-download-archive>`_, but requires at least version
   `7.0 <https://developer.nvidia.com/cuda-toolkit-70>`_.
 
 * `LLVM+Clang <http://releases.llvm.org>`_ version is determined at least partially by 
@@ -51,7 +51,7 @@ Release Dependencies
     - Windows
     - Linux
   * 
-    - `12.8.0 <https://developer.nvidia.com/cuda-12-8-0-download-archive>`_:sup:`1`
+    - `12.8.1 <https://developer.nvidia.com/cuda-12-8-1-download-archive>`_:sup:`1`
     - `20.1.0 <https://github.com/llvm/llvm-project/releases/tag/llvmorg-20.1.0>`_,
       `20.1.1 <https://github.com/llvm/llvm-project/releases/tag/llvmorg-20.1.1>`_,
       `20.1.2 <https://github.com/llvm/llvm-project/releases/tag/llvmorg-20.1.2>`_,


### PR DESCRIPTION
+ No API changes since `12.8.0`
+ Updated the `README.md` accordingly
+ Tested on Windows 11 and Ubuntu 23.10