### PR TITLE
[HIPIFY][SWDEV-490433][fix] Add support for cuda-samples helper headers to HIP

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -7045,6 +7045,8 @@ sub simpleSubstitutions {
     subst("device_functions.h", "hip\/device_functions.h", "include");
     subst("device_launch_parameters.h", "", "include");
     subst("driver_types.h", "hip\/driver_types.h", "include");
+    subst("helper_cuda.h", "hip\/hip_runtime_api.h", "include");
+    subst("helper_math.h", "hip\/hip_vector_types.h", "include");
     subst("library_types.h", "hip\/library_types.h", "include");
     subst("math_constants.h", "hip\/hip_math_constants.h", "include");
     subst("texture_fetch_functions.h", "", "include");

--- a/src/CUDA2HIP.cpp
+++ b/src/CUDA2HIP.cpp
@@ -42,6 +42,9 @@ const std::map <llvm::StringRef, hipCounter> CUDA_INCLUDE_MAP {
   {"cooperative_groups.h",                                  {"hip/hip_cooperative_groups.h",                          "",                                                               CONV_INCLUDE,                API_RUNTIME, 0}},
   {"library_types.h",                                       {"hip/library_types.h",                                   "",                                                               CONV_INCLUDE,                API_RUNTIME, 0}},
   {"math_constants.h",                                      {"hip/hip_math_constants.h",                              "",                                                               CONV_INCLUDE,                API_RUNTIME, 0}},
+  // cuda-samples helper includes
+  {"helper_cuda.h",                                         {"hip/hip_runtime_api.h",                                 "",                                                               CONV_INCLUDE,                API_RUNTIME, 0}},
+  {"helper_math.h",                                         {"hip/hip_vector_types.h",                                "",                                                               CONV_INCLUDE,                API_RUNTIME, 0}},
   // cuComplex includes
   {"cuComplex.h",                                           {"hip/hip_complex.h",                                     "",                                                               CONV_INCLUDE_CUDA_MAIN_H,    API_COMPLEX, 0}},
   // cuBLAS includes


### PR DESCRIPTION
cuda-samples/* requires helper header files.
Fixes SWDEV-490433