### PR TITLE
[HIPIFY][#SWDEV-534480][BLAS] Support for hipBLAS 7.0 - Step 1 - `hipblasDatatype_t` removal - Part 3 - final

### DIFF
--- a/docs/reference/hipify-clang-cmd.rst
+++ b/docs/reference/hipify-clang-cmd.rst
@@ -158,9 +158,6 @@ Options
     * - ``--temp-dir=<directory>``                          
       - Temporary directory
 
-    * - ``--use-hip-data-types``                            
-      - Use ``hipDataType`` instead of ``hipblasDatatype_t`` or ``rocblas_datatype``
-
     * - ``-v``                                              
       - Show commands to run and use verbose output
 

--- a/src/ArgParse.cpp
+++ b/src/ArgParse.cpp
@@ -214,13 +214,6 @@ cl::opt<bool> Versions("versions",
   cl::value_desc("versions"),
   cl::cat(ToolTemplateCategory));
 
-// NOTE: A temporary solution; to remove after fixing https://github.com/ROCm/hipBLAS/issues/366
-cl::opt<bool> UseHipDataType("use-hip-data-types",
-  cl::desc("Use 'hipDataType' instead of 'hipblasDatatype_t' or 'rocblas_datatype'"),
-  cl::value_desc("use-hip-data-types"),
-  cl::init(false),
-  cl::cat(ToolTemplateCategory));
-
 cl::opt<std::string> ClangResourceDir("clang-resource-directory",
   cl::desc("The clang resource path - the path to the parent folder for the 'include' folder, containing '__clang_cuda_runtime_wrapper.h' and other header files used on runtime"),
   cl::value_desc("directory"),

--- a/src/ArgParse.h
+++ b/src/ArgParse.h
@@ -68,5 +68,4 @@ extern const std::vector<std::string> hipifyOptionsWithTwoArgs;
 extern cl::opt<bool> Versions;
 extern cl::opt<bool> NoUndocumented;
 extern cl::opt<bool> NoWarningsUndocumented;
-extern cl::opt<bool> UseHipDataType;
 extern cl::opt<bool> HipifyAMAP;

--- a/src/HipifyAction.cpp
+++ b/src/HipifyAction.cpp
@@ -3349,6 +3349,5 @@ void HipifyAction::run(const mat::MatchFinder::MatchResult &Result) {
   if (cubNamespacePrefix(Result)) return;
   if (cubFunctionTemplateDecl(Result)) return;
   if (cubUsingNamespaceDecl(Result)) return;
-  if (UseHipDataType && dataTypeSelection(Result)) return;
   if (!NoUndocumented && half2Member(Result)) return;
 }

--- a/tests/unit_tests/synthetic/libraries/cusparse2hipsparse.cu
+++ b/tests/unit_tests/synthetic/libraries/cusparse2hipsparse.cu
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %hipify_args 4 --amap --skip-excluded-preprocessor-conditional-blocks --experimental --use-hip-data-types %clang_args -ferror-limit=500
+// RUN: %run_test hipify "%s" "%t" %hipify_args 3 --amap --skip-excluded-preprocessor-conditional-blocks --experimental %clang_args -ferror-limit=500
 
 // CHECK: #include <hip/hip_runtime.h>
 #include <cuda_runtime.h>

--- a/tests/unit_tests/synthetic/libraries/cusparse2hipsparse_11030_12000.cu
+++ b/tests/unit_tests/synthetic/libraries/cusparse2hipsparse_11030_12000.cu
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %hipify_args 3 --skip-excluded-preprocessor-conditional-blocks --experimental --use-hip-data-types %clang_args -ferror-limit=500
+// RUN: %run_test hipify "%s" "%t" %hipify_args 2 --skip-excluded-preprocessor-conditional-blocks --experimental %clang_args -ferror-limit=500
 
 // CHECK: #include <hip/hip_runtime.h>
 #include <cuda_runtime.h>

--- a/tests/unit_tests/synthetic/libraries/cusparse2hipsparse_12000.cu
+++ b/tests/unit_tests/synthetic/libraries/cusparse2hipsparse_12000.cu
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %hipify_args 3 --skip-excluded-preprocessor-conditional-blocks --experimental --use-hip-data-types %clang_args -ferror-limit=500
+// RUN: %run_test hipify "%s" "%t" %hipify_args 2 --skip-excluded-preprocessor-conditional-blocks --experimental %clang_args -ferror-limit=500
 
 // CHECK: #include <hip/hip_runtime.h>
 #include <cuda_runtime.h>

--- a/tests/unit_tests/synthetic/libraries/cusparse2rocsparse.cu
+++ b/tests/unit_tests/synthetic/libraries/cusparse2rocsparse.cu
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %hipify_args 5 --amap --skip-excluded-preprocessor-conditional-blocks --experimental --roc --use-hip-data-types %clang_args -ferror-limit=500
+// RUN: %run_test hipify "%s" "%t" %hipify_args 4 --amap --skip-excluded-preprocessor-conditional-blocks --experimental --roc %clang_args -ferror-limit=500
 
 // CHECK: #include <hip/hip_runtime.h>
 #include <cuda_runtime.h>

--- a/tests/unit_tests/synthetic/libraries/cusparse2rocsparse_10000.cu
+++ b/tests/unit_tests/synthetic/libraries/cusparse2rocsparse_10000.cu
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %hipify_args 4 --skip-excluded-preprocessor-conditional-blocks --experimental --roc --use-hip-data-types %clang_args -ferror-limit=500
+// RUN: %run_test hipify "%s" "%t" %hipify_args 3 --skip-excluded-preprocessor-conditional-blocks --experimental --roc %clang_args -ferror-limit=500
 
 // CHECK: #include <hip/hip_runtime.h>
 #include <cuda_runtime.h>

--- a/tests/unit_tests/synthetic/libraries/cusparse2rocsparse_10010.cu
+++ b/tests/unit_tests/synthetic/libraries/cusparse2rocsparse_10010.cu
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %hipify_args 4 --skip-excluded-preprocessor-conditional-blocks --experimental --roc --use-hip-data-types %clang_args -ferror-limit=500
+// RUN: %run_test hipify "%s" "%t" %hipify_args 3 --skip-excluded-preprocessor-conditional-blocks --experimental --roc %clang_args -ferror-limit=500
 
 // CHECK: #include <hip/hip_runtime.h>
 #include <cuda_runtime.h>

--- a/tests/unit_tests/synthetic/libraries/cusparse2rocsparse_10010_12000.cu
+++ b/tests/unit_tests/synthetic/libraries/cusparse2rocsparse_10010_12000.cu
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %hipify_args 5 --skip-excluded-preprocessor-conditional-blocks --experimental --roc --use-hip-data-types --amap %clang_args -ferror-limit=500
+// RUN: %run_test hipify "%s" "%t" %hipify_args 4 --skip-excluded-preprocessor-conditional-blocks --experimental --roc --amap %clang_args -ferror-limit=500
 
 // CHECK: #include <hip/hip_runtime.h>
 #include <cuda_runtime.h>

--- a/tests/unit_tests/synthetic/libraries/cusparse2rocsparse_11010_12000.cu
+++ b/tests/unit_tests/synthetic/libraries/cusparse2rocsparse_11010_12000.cu
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %hipify_args 4 --skip-excluded-preprocessor-conditional-blocks --experimental --roc --use-hip-data-types %clang_args -ferror-limit=500
+// RUN: %run_test hipify "%s" "%t" %hipify_args 3 --skip-excluded-preprocessor-conditional-blocks --experimental --roc %clang_args -ferror-limit=500
 
 // CHECK: #include <hip/hip_runtime.h>
 #include <cuda_runtime.h>

--- a/tests/unit_tests/synthetic/libraries/cusparse2rocsparse_11030_12000.cu
+++ b/tests/unit_tests/synthetic/libraries/cusparse2rocsparse_11030_12000.cu
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %hipify_args 4 --skip-excluded-preprocessor-conditional-blocks --experimental --roc --use-hip-data-types %clang_args -ferror-limit=500
+// RUN: %run_test hipify "%s" "%t" %hipify_args 3 --skip-excluded-preprocessor-conditional-blocks --experimental --roc %clang_args -ferror-limit=500
 
 // CHECK: #include <hip/hip_runtime.h>
 #include <cuda_runtime.h>

--- a/tests/unit_tests/synthetic/libraries/cusparse2rocsparse_12000.cu
+++ b/tests/unit_tests/synthetic/libraries/cusparse2rocsparse_12000.cu
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %hipify_args 4 --skip-excluded-preprocessor-conditional-blocks --experimental --roc --use-hip-data-types %clang_args -ferror-limit=500
+// RUN: %run_test hipify "%s" "%t" %hipify_args 3 --skip-excluded-preprocessor-conditional-blocks --experimental --roc %clang_args -ferror-limit=500
 
 // CHECK: #include <hip/hip_runtime.h>
 #include <cuda_runtime.h>

--- a/tests/unit_tests/synthetic/libraries/cusparse2rocsparse_7050.cu
+++ b/tests/unit_tests/synthetic/libraries/cusparse2rocsparse_7050.cu
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %hipify_args 4 --skip-excluded-preprocessor-conditional-blocks --experimental --roc --use-hip-data-types %clang_args -ferror-limit=500
+// RUN: %run_test hipify "%s" "%t" %hipify_args 3 --skip-excluded-preprocessor-conditional-blocks --experimental --roc %clang_args -ferror-limit=500
 
 // CHECK: #include <hip/hip_runtime.h>
 #include <cuda_runtime.h>

--- a/tests/unit_tests/synthetic/libraries/cusparse2rocsparse_9020.cu
+++ b/tests/unit_tests/synthetic/libraries/cusparse2rocsparse_9020.cu
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %hipify_args 4 --skip-excluded-preprocessor-conditional-blocks --experimental --roc --use-hip-data-types %clang_args -ferror-limit=500
+// RUN: %run_test hipify "%s" "%t" %hipify_args 3 --skip-excluded-preprocessor-conditional-blocks --experimental --roc %clang_args -ferror-limit=500
 
 // CHECK: #include <hip/hip_runtime.h>
 #include <cuda_runtime.h>

--- a/tests/unit_tests/synthetic/libraries/cusparse2rocsparse_9020_12000.cu
+++ b/tests/unit_tests/synthetic/libraries/cusparse2rocsparse_9020_12000.cu
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %hipify_args 4 --skip-excluded-preprocessor-conditional-blocks --experimental --roc --use-hip-data-types %clang_args -ferror-limit=500
+// RUN: %run_test hipify "%s" "%t" %hipify_args 3 --skip-excluded-preprocessor-conditional-blocks --experimental --roc %clang_args -ferror-limit=500
 
 // CHECK: #include <hip/hip_runtime.h>
 #include <cuda_runtime.h>

--- a/tests/unit_tests/synthetic/libraries/cusparse2rocsparse_before_11000.cu
+++ b/tests/unit_tests/synthetic/libraries/cusparse2rocsparse_before_11000.cu
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %hipify_args 4 --skip-excluded-preprocessor-conditional-blocks --experimental --roc --use-hip-data-types %clang_args -ferror-limit=500
+// RUN: %run_test hipify "%s" "%t" %hipify_args 3 --skip-excluded-preprocessor-conditional-blocks --experimental --roc %clang_args -ferror-limit=500
 
 // CHECK: #include <hip/hip_runtime.h>
 #include <cuda_runtime.h>

--- a/tests/unit_tests/synthetic/libraries/cusparse2rocsparse_before_12000.cu
+++ b/tests/unit_tests/synthetic/libraries/cusparse2rocsparse_before_12000.cu
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %hipify_args 4 --skip-excluded-preprocessor-conditional-blocks --experimental --roc --use-hip-data-types %clang_args -ferror-limit=500
+// RUN: %run_test hipify "%s" "%t" %hipify_args 3 --skip-excluded-preprocessor-conditional-blocks --experimental --roc %clang_args -ferror-limit=500
 
 // CHECK: #include <hip/hip_runtime.h>
 #include <cuda_runtime.h>


### PR DESCRIPTION
+ Actually, `hipDatatype_t` is already used instead
+ Removed the `--use-hip-data-types` option
+ Updated the documentation accordingly
+ Updated the `hipBLAS` and `rocBLAS` tests accordingly
+ [ToDo][hipBLASLt] `hipblasLtMatmulDescCreate` the only hipBLAS API still contains `hipblasDatatype_t` in tests
+ [ToDo] Rename the rest `_v2` functions