### PR TITLE
[HIPIFY][clang][compatibility][fix] clang `21.0.0git` compatibility fix

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -81,9 +81,15 @@ void cleanupHipifyOptions(std::vector<const char*> &args) {
 
 void sortInputFiles(int argc, const char **argv, std::vector<std::string> &files) {
   if (files.size() < 2) return;
+#if LLVM_VERSION_MAJOR >= 21
+  clang::DiagnosticOptions diagOpts;
+  clang::TextDiagnosticPrinter diagClient(llvm::errs(), diagOpts);
+  clang::DiagnosticsEngine Diagnostics(IntrusiveRefCntPtr<clang::DiagnosticIDs>(new clang::DiagnosticIDs()), diagOpts, &diagClient, false);
+#else
   IntrusiveRefCntPtr<clang::DiagnosticOptions> diagOpts(new clang::DiagnosticOptions());
   clang::TextDiagnosticPrinter diagClient(llvm::errs(), &*diagOpts);
   clang::DiagnosticsEngine Diagnostics(IntrusiveRefCntPtr<clang::DiagnosticIDs>(new clang::DiagnosticIDs()), &*diagOpts, &diagClient, false);
+#endif
   std::unique_ptr<clang::driver::Driver> driver(new clang::driver::Driver("", "nvptx64-nvidia-cuda", Diagnostics));
   std::vector<const char*> Args(argv, argv + argc);
   cleanupHipifyOptions(Args);


### PR DESCRIPTION
**[Root Cause]**
+ [LLVM][#139584](https://github.com/llvm/llvm-project/pull/139584)[clang] Remove intrusive reference count from `DiagnosticOptions`

**[IMP]**
+ `LLVM < 21` is also supported, but `LLVM 21` should be newer than [671cd5acb49f9fae274f66cd71464d4afed914e3](https://github.com/llvm/llvm-project/pull/139584/commits/671cd5acb49f9fae274f66cd71464d4afed914e3) (2025-05-20) to build `hipify-clang` correctly

**[Note]**
+ Unfortunately, the class `DiagnosticsEngine` has assignment operator and copy ctor both marked as `delete`, thus the compatibility patch can't be implemented as a separate function in the `llcompat` namespace