### PR TITLE
[HIPIFY][doc][#1944][merge] Cherry-pick the Header MetaData for all CUDA2HIP docs into docs/6.4.1 

### DIFF
--- a/docs/reference/tables/CUBLAS_API_supported_by_HIP.md
+++ b/docs/reference/tables/CUBLAS_API_supported_by_HIP.md
@@ -1,3 +1,9 @@
+<head>
+    <meta charset="UTF-8">
+    <meta name="description" content="NVIDIA CUDA APIs supported by HIPIFY">
+    <meta name="keywords" content="HIPIFY, HIP, ROCm, NVIDIA, CUDA, CUDA2HIP, hipification, hipify-clang, hipify-perl, BLAS, cuBLAS, hipBLAS">
+</head>
+
 # CUBLAS API supported by HIP
 
 

--- a/docs/reference/tables/CUBLAS_API_supported_by_HIP_and_ROC.md
+++ b/docs/reference/tables/CUBLAS_API_supported_by_HIP_and_ROC.md
@@ -1,3 +1,9 @@
+<head>
+    <meta charset="UTF-8">
+    <meta name="description" content="NVIDIA CUDA APIs supported by HIPIFY">
+    <meta name="keywords" content="HIPIFY, HIP, ROCm, NVIDIA, CUDA, CUDA2HIP, hipification, hipify-clang, hipify-perl, BLAS, cuBLAS, hipBLAS, rocBLAS">
+</head>
+
 # CUBLAS API supported by HIP and ROC
 
 

--- a/docs/reference/tables/CUBLAS_API_supported_by_ROC.md
+++ b/docs/reference/tables/CUBLAS_API_supported_by_ROC.md
@@ -1,3 +1,9 @@
+<head>
+    <meta charset="UTF-8">
+    <meta name="description" content="NVIDIA CUDA APIs supported by HIPIFY">
+    <meta name="keywords" content="HIPIFY, HIP, ROCm, NVIDIA, CUDA, CUDA2HIP, hipification, hipify-clang, hipify-perl, BLAS, cuBLAS, rocBLAS">
+</head>
+
 # CUBLAS API supported by ROC
 
 

--- a/docs/reference/tables/CUB_API_supported_by_HIP.md
+++ b/docs/reference/tables/CUB_API_supported_by_HIP.md
@@ -1,3 +1,9 @@
+<head>
+    <meta charset="UTF-8">
+    <meta name="description" content="NVIDIA CUDA APIs supported by HIPIFY">
+    <meta name="keywords" content="HIPIFY, HIP, ROCm, NVIDIA, CUDA, CUDA2HIP, hipification, hipify-clang, hipify-perl, CUB, hipCUB">
+</head>
+
 # CUB API supported by HIP
 
 

--- a/docs/reference/tables/CUDA_Device_API_supported_by_HIP.md
+++ b/docs/reference/tables/CUDA_Device_API_supported_by_HIP.md
@@ -1,3 +1,9 @@
+<head>
+    <meta charset="UTF-8">
+    <meta name="description" content="NVIDIA CUDA APIs supported by HIPIFY">
+    <meta name="keywords" content="HIPIFY, HIP, ROCm, NVIDIA, CUDA, CUDA2HIP, hipification, hipify-clang, hipify-perl, Device API">
+</head>
+
 # CUDA DEVICE API supported by HIP
 
 

--- a/docs/reference/tables/CUDA_Driver_API_functions_supported_by_HIP.md
+++ b/docs/reference/tables/CUDA_Driver_API_functions_supported_by_HIP.md
@@ -1,3 +1,9 @@
+<head>
+    <meta charset="UTF-8">
+    <meta name="description" content="NVIDIA CUDA APIs supported by HIPIFY">
+    <meta name="keywords" content="HIPIFY, HIP, ROCm, NVIDIA, CUDA, CUDA2HIP, hipification, hipify-clang, hipify-perl, Driver API">
+</head>
+
 # CUDA Driver API supported by HIP
 
 

--- a/docs/reference/tables/CUDA_RTC_API_supported_by_HIP.md
+++ b/docs/reference/tables/CUDA_RTC_API_supported_by_HIP.md
@@ -1,3 +1,9 @@
+<head>
+    <meta charset="UTF-8">
+    <meta name="description" content="NVIDIA CUDA APIs supported by HIPIFY">
+    <meta name="keywords" content="HIPIFY, HIP, ROCm, NVIDIA, CUDA, CUDA2HIP, hipification, hipify-clang, hipify-perl, RTC, Runtime Compilation">
+</head>
+
 # CUDA RTC API supported by HIP
 
 

--- a/docs/reference/tables/CUDA_Runtime_API_functions_supported_by_HIP.md
+++ b/docs/reference/tables/CUDA_Runtime_API_functions_supported_by_HIP.md
@@ -1,3 +1,9 @@
+<head>
+    <meta charset="UTF-8">
+    <meta name="description" content="NVIDIA CUDA APIs supported by HIPIFY">
+    <meta name="keywords" content="HIPIFY, HIP, ROCm, NVIDIA, CUDA, CUDA2HIP, hipification, hipify-clang, hipify-perl, Runtime API">
+</head>
+
 # CUDA Runtime API supported by HIP
 
 

--- a/docs/reference/tables/CUDNN_API_supported_by_HIP.md
+++ b/docs/reference/tables/CUDNN_API_supported_by_HIP.md
@@ -1,3 +1,9 @@
+<head>
+    <meta charset="UTF-8">
+    <meta name="description" content="NVIDIA CUDA APIs supported by HIPIFY">
+    <meta name="keywords" content="HIPIFY, HIP, ROCm, NVIDIA, CUDA, CUDA2HIP, hipification, hipify-clang, hipify-perl, DNN, cuDNN, hipDNN">
+</head>
+
 # CUDNN API supported by HIP
 
 

--- a/docs/reference/tables/CUDNN_API_supported_by_HIP_and_MIOPEN.md
+++ b/docs/reference/tables/CUDNN_API_supported_by_HIP_and_MIOPEN.md
@@ -1,3 +1,9 @@
+<head>
+    <meta charset="UTF-8">
+    <meta name="description" content="NVIDIA CUDA APIs supported by HIPIFY">
+    <meta name="keywords" content="HIPIFY, HIP, ROCm, NVIDIA, CUDA, CUDA2HIP, hipification, hipify-clang, hipify-perl, DNN, cuDNN, hipDNN, MIOpen">
+</head>
+
 # CUDNN API supported by HIP and MIOPEN
 
 

--- a/docs/reference/tables/CUDNN_API_supported_by_MIOPEN.md
+++ b/docs/reference/tables/CUDNN_API_supported_by_MIOPEN.md
@@ -1,3 +1,9 @@
+<head>
+    <meta charset="UTF-8">
+    <meta name="description" content="NVIDIA CUDA APIs supported by HIPIFY">
+    <meta name="keywords" content="HIPIFY, HIP, ROCm, NVIDIA, CUDA, CUDA2HIP, hipification, hipify-clang, hipify-perl, DNN, cuDNN, MIOpen">
+</head>
+
 # CUDNN API supported by MIOPEN
 
 

--- a/docs/reference/tables/CUFFT_API_supported_by_HIP.md
+++ b/docs/reference/tables/CUFFT_API_supported_by_HIP.md
@@ -1,3 +1,9 @@
+<head>
+    <meta charset="UTF-8">
+    <meta name="description" content="NVIDIA CUDA APIs supported by HIPIFY">
+    <meta name="keywords" content="HIPIFY, HIP, ROCm, NVIDIA, CUDA, CUDA2HIP, hipification, hipify-clang, hipify-perl, FFT, cuFFT, cuFFTXt, hipFFT, hipFFTXt">
+</head>
+
 # CUFFT API supported by HIP
 
 

--- a/docs/reference/tables/CURAND_API_supported_by_HIP.md
+++ b/docs/reference/tables/CURAND_API_supported_by_HIP.md
@@ -1,3 +1,9 @@
+<head>
+    <meta charset="UTF-8">
+    <meta name="description" content="NVIDIA CUDA APIs supported by HIPIFY">
+    <meta name="keywords" content="HIPIFY, HIP, ROCm, NVIDIA, CUDA, CUDA2HIP, hipification, hipify-clang, hipify-perl, RAND, cuRAND, hipRAND">
+</head>
+
 # CURAND API supported by HIP
 
 

--- a/docs/reference/tables/CURAND_API_supported_by_HIP_and_ROC.md
+++ b/docs/reference/tables/CURAND_API_supported_by_HIP_and_ROC.md
@@ -1,3 +1,9 @@
+<head>
+    <meta charset="UTF-8">
+    <meta name="description" content="NVIDIA CUDA APIs supported by HIPIFY">
+    <meta name="keywords" content="HIPIFY, HIP, ROCm, NVIDIA, CUDA, CUDA2HIP, hipification, hipify-clang, hipify-perl, RAND, cuRAND, hipRAND, rocRAND">
+</head>
+
 # CURAND API supported by 
 
 

--- a/docs/reference/tables/CURAND_API_supported_by_ROC.md
+++ b/docs/reference/tables/CURAND_API_supported_by_ROC.md
@@ -1,3 +1,9 @@
+<head>
+    <meta charset="UTF-8">
+    <meta name="description" content="NVIDIA CUDA APIs supported by HIPIFY">
+    <meta name="keywords" content="HIPIFY, HIP, ROCm, NVIDIA, CUDA, CUDA2HIP, hipification, hipify-clang, hipify-perl, RAND, cuRAND, rocRAND">
+</head>
+
 # CURAND API supported by ROC
 
 

--- a/docs/reference/tables/CUSOLVER_API_supported_by_HIP.md
+++ b/docs/reference/tables/CUSOLVER_API_supported_by_HIP.md
@@ -1,3 +1,9 @@
+<head>
+    <meta charset="UTF-8">
+    <meta name="description" content="NVIDIA CUDA APIs supported by HIPIFY">
+    <meta name="keywords" content="HIPIFY, HIP, ROCm, NVIDIA, CUDA, CUDA2HIP, hipification, hipify-clang, hipify-perl, SOLVER, cuSOLVER, hipSOLVER">
+</head>
+
 # CUSOLVER API supported by HIP
 
 

--- a/docs/reference/tables/CUSOLVER_API_supported_by_HIP_and_ROC.md
+++ b/docs/reference/tables/CUSOLVER_API_supported_by_HIP_and_ROC.md
@@ -1,3 +1,9 @@
+<head>
+    <meta charset="UTF-8">
+    <meta name="description" content="NVIDIA CUDA APIs supported by HIPIFY">
+    <meta name="keywords" content="HIPIFY, HIP, ROCm, NVIDIA, CUDA, CUDA2HIP, hipification, hipify-clang, hipify-perl, SOLVER, cuSOLVER, hipSOLVER, rocSOLVER">
+</head>
+
 # CUSOLVER API supported by HIP and ROC
 
 

--- a/docs/reference/tables/CUSOLVER_API_supported_by_ROC.md
+++ b/docs/reference/tables/CUSOLVER_API_supported_by_ROC.md
@@ -1,3 +1,9 @@
+<head>
+    <meta charset="UTF-8">
+    <meta name="description" content="NVIDIA CUDA APIs supported by HIPIFY">
+    <meta name="keywords" content="HIPIFY, HIP, ROCm, NVIDIA, CUDA, CUDA2HIP, hipification, hipify-clang, hipify-perl, SOLVER, cuSOLVER, rocSOLVER">
+</head>
+
 # CUSOLVER API supported by ROC
 
 

--- a/docs/reference/tables/CUSPARSE_API_supported_by_HIP.md
+++ b/docs/reference/tables/CUSPARSE_API_supported_by_HIP.md
@@ -1,3 +1,9 @@
+<head>
+    <meta charset="UTF-8">
+    <meta name="description" content="NVIDIA CUDA APIs supported by HIPIFY">
+    <meta name="keywords" content="HIPIFY, HIP, ROCm, NVIDIA, CUDA, CUDA2HIP, hipification, hipify-clang, hipify-perl, SPARSE, cuSPARSE, hipSPARSE">
+</head>
+
 # CUSPARSE API supported by HIP
 
 

--- a/docs/reference/tables/CUSPARSE_API_supported_by_HIP_and_ROC.md
+++ b/docs/reference/tables/CUSPARSE_API_supported_by_HIP_and_ROC.md
@@ -1,3 +1,9 @@
+<head>
+    <meta charset="UTF-8">
+    <meta name="description" content="NVIDIA CUDA APIs supported by HIPIFY">
+    <meta name="keywords" content="HIPIFY, HIP, ROCm, NVIDIA, CUDA, CUDA2HIP, hipification, hipify-clang, hipify-perl, SPARSE, cuSPARSE, hipSPARSE, rocSPARSE">
+</head>
+
 # CUSPARSE API supported by HIP and ROC
 
 

--- a/docs/reference/tables/CUSPARSE_API_supported_by_ROC.md
+++ b/docs/reference/tables/CUSPARSE_API_supported_by_ROC.md
@@ -1,3 +1,9 @@
+<head>
+    <meta charset="UTF-8">
+    <meta name="description" content="NVIDIA CUDA APIs supported by HIPIFY">
+    <meta name="keywords" content="HIPIFY, HIP, ROCm, NVIDIA, CUDA, CUDA2HIP, hipification, hipify-clang, hipify-perl, SPARSE, cuSPARSE, rocSPARSE">
+</head>
+
 # CUSPARSE API supported by ROC
 
 

--- a/docs/reference/tables/CUTENSOR_API_supported_by_HIP.md
+++ b/docs/reference/tables/CUTENSOR_API_supported_by_HIP.md
@@ -1,3 +1,9 @@
+<head>
+    <meta charset="UTF-8">
+    <meta name="description" content="NVIDIA CUDA APIs supported by HIPIFY">
+    <meta name="keywords" content="HIPIFY, HIP, ROCm, NVIDIA, CUDA, CUDA2HIP, hipification, hipify-clang, hipify-perl, TENSOR, cuTENSOR, hipTENSOR">
+</head>
+
 # CUTENSOR API supported by HIP
 
 

--- a/docs/reference/tables/cuComplex_API_supported_by_HIP.md
+++ b/docs/reference/tables/cuComplex_API_supported_by_HIP.md
@@ -1,3 +1,9 @@
+<head>
+    <meta charset="UTF-8">
+    <meta name="description" content="NVIDIA CUDA APIs supported by HIPIFY">
+    <meta name="keywords" content="HIPIFY, HIP, ROCm, NVIDIA, CUDA, CUDA2HIP, hipification, hipify-clang, hipify-perl, Runtime API, Complex">
+</head>
+
 # CUCOMPLEX API supported by HIP
 
 


### PR DESCRIPTION
+ [IMP] All docs have a common set of keywords, plus it has specific keywords based on the library or libraries supported
+ [IMP] For joint tables containing HIP and ROC analogues set of keywords is the sum of the sets of keywords for each of them
+ Updated the regenerated `CUDA2HIP` documentation