### PR TITLE
[HIPIFY][TENSOR] Support for `hipTensor 7.0` - Step 4 - Data Types

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -1520,10 +1520,20 @@ my %removed_funcs = (
 );
 
 my %experimental_funcs = (
+    "cutensorTensorDescriptor" => "7.0.0",
+    "cutensorPlan_t" => "7.0.0",
+    "cutensorPlanPreference_t" => "7.0.0",
     "cutensorPlanPreferenceAttribute_t" => "7.0.0",
+    "cutensorPlanPreference" => "7.0.0",
     "cutensorPlanAttribute_t" => "7.0.0",
+    "cutensorPlan" => "7.0.0",
+    "cutensorOperationDescriptor_t" => "7.0.0",
     "cutensorOperationDescriptorAttribute_t" => "7.0.0",
+    "cutensorOperationDescriptor" => "7.0.0",
+    "cutensorJitMode_t" => "7.0.0",
+    "cutensorHandle" => "7.0.0",
     "cutensorDataType_t" => "7.0.0",
+    "cutensorCacheMode_t" => "7.0.0",
     "cutensorAutotuneMode_t" => "7.0.0",
     "cudaRoundZero" => "7.0.0",
     "cudaRoundPosInf" => "7.0.0",
@@ -1608,6 +1618,8 @@ my %experimental_funcs = (
     "CUTENSOR_OPERATION_DESCRIPTOR_PADDING_LEFT" => "7.0.0",
     "CUTENSOR_OPERATION_DESCRIPTOR_MOVED_BYTES" => "7.0.0",
     "CUTENSOR_OPERATION_DESCRIPTOR_FLOPS" => "7.0.0",
+    "CUTENSOR_JIT_MODE_NONE" => "7.0.0",
+    "CUTENSOR_JIT_MODE_DEFAULT" => "7.0.0",
     "CUTENSOR_C_8U" => "7.0.0",
     "CUTENSOR_C_8I" => "7.0.0",
     "CUTENSOR_C_64U" => "7.0.0",
@@ -1630,6 +1642,8 @@ my %experimental_funcs = (
     "CUTENSOR_COMPUTE_32F" => "7.0.0",
     "CUTENSOR_COMPUTE_16F" => "7.0.0",
     "CUTENSOR_COMPUTE_16BF" => "7.0.0",
+    "CUTENSOR_CACHE_MODE_PEDANTIC" => "7.0.0",
+    "CUTENSOR_CACHE_MODE_NONE" => "7.0.0",
     "CUTENSOR_AUTOTUNE_NONE" => "7.0.0",
     "CUTENSOR_AUTOTUNE_MODE_NONE" => "7.0.0",
     "CUTENSOR_AUTOTUNE_MODE_INCREMENTAL" => "7.0.0",
@@ -1824,10 +1838,20 @@ sub experimentalSubstitutions {
     subst("cudaLaunchConfig_st", "hipLaunchConfig_st", "type");
     subst("cudaLaunchConfig_t", "hipLaunchConfig_t", "type");
     subst("cutensorAutotuneMode_t", "hiptensorAutotuneMode_t", "type");
+    subst("cutensorCacheMode_t", "hiptensorCacheMode_t", "type");
     subst("cutensorDataType_t", "hiptensorDataType_t", "type");
+    subst("cutensorHandle", "hiptensorHandle", "type");
+    subst("cutensorJitMode_t", "hiptensorJitMode_t", "type");
+    subst("cutensorOperationDescriptor", "hiptensorOperationDescriptor", "type");
     subst("cutensorOperationDescriptorAttribute_t", "hiptensorOperationDescriptorAttribute_t", "type");
+    subst("cutensorOperationDescriptor_t", "hiptensorOperationDescriptor_t", "type");
+    subst("cutensorPlan", "hiptensorPlan", "type");
     subst("cutensorPlanAttribute_t", "hiptensorPlanAttribute_t", "type");
+    subst("cutensorPlanPreference", "hiptensorPlanPreference", "type");
     subst("cutensorPlanPreferenceAttribute_t", "hiptensorPlanPreferenceAttribute_t", "type");
+    subst("cutensorPlanPreference_t", "hiptensorPlanPreference_t", "type");
+    subst("cutensorPlan_t", "hiptensorPlan_t", "type");
+    subst("cutensorTensorDescriptor", "hiptensorTensorDescriptor", "type");
     subst("CUBLASLT_MATMUL_MATRIX_SCALE_BLK128x128_32F", "HIPBLASLT_MATMUL_MATRIX_SCALE_BLK128x128_32F", "numeric_literal");
     subst("CUBLASLT_MATMUL_MATRIX_SCALE_END", "HIPBLASLT_MATMUL_MATRIX_SCALE_END", "numeric_literal");
     subst("CUBLASLT_MATMUL_MATRIX_SCALE_OUTER_VEC_32F", "HIPBLASLT_MATMUL_MATRIX_SCALE_OUTER_VEC_32F", "numeric_literal");
@@ -1843,6 +1867,8 @@ sub experimentalSubstitutions {
     subst("CUTENSOR_AUTOTUNE_MODE_INCREMENTAL", "HIPTENSOR_AUTOTUNE_MODE_INCREMENTAL", "numeric_literal");
     subst("CUTENSOR_AUTOTUNE_MODE_NONE", "HIPTENSOR_AUTOTUNE_MODE_NONE", "numeric_literal");
     subst("CUTENSOR_AUTOTUNE_NONE", "HIPTENSOR_AUTOTUNE_MODE_NONE", "numeric_literal");
+    subst("CUTENSOR_CACHE_MODE_NONE", "HIPTENSOR_CACHE_MODE_NONE", "numeric_literal");
+    subst("CUTENSOR_CACHE_MODE_PEDANTIC", "HIPTENSOR_CACHE_MODE_PEDANTIC", "numeric_literal");
     subst("CUTENSOR_COMPUTE_16BF", "HIPTENSOR_COMPUTE_DESC_16BF", "numeric_literal");
     subst("CUTENSOR_COMPUTE_16F", "HIPTENSOR_COMPUTE_DESC_16F", "numeric_literal");
     subst("CUTENSOR_COMPUTE_32F", "HIPTENSOR_COMPUTE_DESC_32F", "numeric_literal");
@@ -1865,6 +1891,8 @@ sub experimentalSubstitutions {
     subst("CUTENSOR_C_64U", "HIPTENSOR_C_64U", "numeric_literal");
     subst("CUTENSOR_C_8I", "HIPTENSOR_C_8I", "numeric_literal");
     subst("CUTENSOR_C_8U", "HIPTENSOR_C_8U", "numeric_literal");
+    subst("CUTENSOR_JIT_MODE_DEFAULT", "HIPTENSOR_JIT_MODE_DEFAULT", "numeric_literal");
+    subst("CUTENSOR_JIT_MODE_NONE", "HIPTENSOR_JIT_MODE_NONE", "numeric_literal");
     subst("CUTENSOR_OPERATION_DESCRIPTOR_FLOPS", "HIPTENSOR_OPERATION_DESCRIPTOR_FLOPS", "numeric_literal");
     subst("CUTENSOR_OPERATION_DESCRIPTOR_MOVED_BYTES", "HIPTENSOR_OPERATION_DESCRIPTOR_MOVED_BYTES", "numeric_literal");
     subst("CUTENSOR_OPERATION_DESCRIPTOR_PADDING_LEFT", "HIPTENSOR_OPERATION_DESCRIPTOR_PADDING_LEFT", "numeric_literal");
@@ -7814,7 +7842,6 @@ sub simpleSubstitutions {
     subst("cutensorHandle_t", "hiptensorHandle_t", "type");
     subst("cutensorLoggerCallback_t", "hiptensorLoggerCallback_t", "type");
     subst("cutensorOperator_t", "hiptensorOperator_t", "type");
-    subst("cutensorPlan_t", "hiptensorContractionPlan_t", "type");
     subst("cutensorStatus_t", "hiptensorStatus_t", "type");
     subst("cutensorTensorDescriptor_t", "hiptensorTensorDescriptor_t", "type");
     subst("cutensorWorksizePreference_t", "hiptensorWorksizePreference_t", "type");
@@ -10562,12 +10589,10 @@ sub warnRemovedFunctions {
     "libraryPropertyType",
     "gesvdjInfo",
     "cutensorWriteKernelCacheToFile",
-    "cutensorTensorDescriptor",
     "cutensorReduce",
     "cutensorReadKernelCacheFromFile",
     "cutensorPlanPreferenceSetAttribute",
     "cutensorPlanGetAttribute",
-    "cutensorPlan",
     "cutensorPermute",
     "cutensorOperationDescriptorSetAttribute",
     "cutensorOperationDescriptorGetAttribute",
@@ -10607,11 +10632,9 @@ sub warnRemovedFunctions {
     "cutensorMgContractionDescriptor_s",
     "cutensorMgContraction",
     "cutensorMgAlgo_t",
-    "cutensorJitMode_t",
     "cutensorHandleWritePlanCacheToFile",
     "cutensorHandleResizePlanCache",
     "cutensorHandleReadPlanCacheFromFile",
-    "cutensorHandle",
     "cutensorGetVersion",
     "cutensorEstimateWorkspaceSize",
     "cutensorElementwiseTrinaryExecute",
@@ -10630,7 +10653,6 @@ sub warnRemovedFunctions {
     "cutensorCreateContractionTrinary",
     "cutensorCreateContraction",
     "cutensorContractTrinary",
-    "cutensorCacheMode_t",
     "cusparseZhybsv_solve",
     "cusparseZhybsv_analysis",
     "cusparseZhyb2dense",
@@ -12858,16 +12880,12 @@ sub warnRemovedFunctions {
     "CUTENSOR_OP_MISH",
     "CUTENSOR_MG_DEVICE_HOST_PINNED",
     "CUTENSOR_MG_DEVICE_HOST",
-    "CUTENSOR_JIT_MODE_NONE",
-    "CUTENSOR_JIT_MODE_DEFAULT",
     "CUTENSOR_C_MIN_TF32",
     "CUTENSOR_C_MIN_64F",
     "CUTENSOR_C_MIN_32F",
     "CUTENSOR_C_MIN_16F",
     "CUTENSOR_COMPUTE_TF32",
     "CUTENSOR_COMPUTE_3XTF32",
-    "CUTENSOR_CACHE_MODE_PEDANTIC",
-    "CUTENSOR_CACHE_MODE_NONE",
     "CUTENSOR_ALGO_TTGT",
     "CUTENSOR_ALGO_TGETT",
     "CUTENSOR_ALGO_GETT",
@@ -14013,12 +14031,10 @@ sub warnHipOnlyUnsupportedFunctions {
 
 @RocOnlyUnsupportedFunctions = (
     "cutensorWriteKernelCacheToFile",
-    "cutensorTensorDescriptor",
     "cutensorReduce",
     "cutensorReadKernelCacheFromFile",
     "cutensorPlanPreferenceSetAttribute",
     "cutensorPlanGetAttribute",
-    "cutensorPlan",
     "cutensorPermute",
     "cutensorOperationDescriptorSetAttribute",
     "cutensorOperationDescriptorGetAttribute",
@@ -14058,11 +14074,9 @@ sub warnHipOnlyUnsupportedFunctions {
     "cutensorMgContractionDescriptor_s",
     "cutensorMgContraction",
     "cutensorMgAlgo_t",
-    "cutensorJitMode_t",
     "cutensorHandleWritePlanCacheToFile",
     "cutensorHandleResizePlanCache",
     "cutensorHandleReadPlanCacheFromFile",
-    "cutensorHandle",
     "cutensorGetVersion",
     "cutensorEstimateWorkspaceSize",
     "cutensorElementwiseTrinaryExecute",
@@ -14081,7 +14095,6 @@ sub warnHipOnlyUnsupportedFunctions {
     "cutensorCreateContractionTrinary",
     "cutensorCreateContraction",
     "cutensorContractTrinary",
-    "cutensorCacheMode_t",
     "cusparseZhybsv_solve",
     "cusparseZhybsv_analysis",
     "cusparseZhyb2dense",
@@ -14505,16 +14518,12 @@ sub warnHipOnlyUnsupportedFunctions {
     "CUTENSOR_OP_MISH",
     "CUTENSOR_MG_DEVICE_HOST_PINNED",
     "CUTENSOR_MG_DEVICE_HOST",
-    "CUTENSOR_JIT_MODE_NONE",
-    "CUTENSOR_JIT_MODE_DEFAULT",
     "CUTENSOR_C_MIN_TF32",
     "CUTENSOR_C_MIN_64F",
     "CUTENSOR_C_MIN_32F",
     "CUTENSOR_C_MIN_16F",
     "CUTENSOR_COMPUTE_TF32",
     "CUTENSOR_COMPUTE_3XTF32",
-    "CUTENSOR_CACHE_MODE_PEDANTIC",
-    "CUTENSOR_CACHE_MODE_NONE",
     "CUTENSOR_ALGO_TTGT",
     "CUTENSOR_ALGO_TGETT",
     "CUTENSOR_ALGO_GETT",

--- a/docs/reference/tables/CUTENSOR_API_supported_by_HIP.md
+++ b/docs/reference/tables/CUTENSOR_API_supported_by_HIP.md
@@ -25,8 +25,8 @@
 |`CUTENSOR_AUTOTUNE_MODE_INCREMENTAL`|2.0.0.0| | | |`HIPTENSOR_AUTOTUNE_MODE_INCREMENTAL`|7.0.0| | | |7.0.0|
 |`CUTENSOR_AUTOTUNE_MODE_NONE`|2.0.0.0| | | |`HIPTENSOR_AUTOTUNE_MODE_NONE`|7.0.0| | | |7.0.0|
 |`CUTENSOR_AUTOTUNE_NONE`|1.2.0.0| | |2.0.0.0|`HIPTENSOR_AUTOTUNE_MODE_NONE`|7.0.0| | | |7.0.0|
-|`CUTENSOR_CACHE_MODE_NONE`|1.2.0.0| | | | | | | | | |
-|`CUTENSOR_CACHE_MODE_PEDANTIC`|1.2.0.0| | | | | | | | | |
+|`CUTENSOR_CACHE_MODE_NONE`|1.2.0.0| | | |`HIPTENSOR_CACHE_MODE_NONE`|7.0.0| | | |7.0.0|
+|`CUTENSOR_CACHE_MODE_PEDANTIC`|1.2.0.0| | | |`HIPTENSOR_CACHE_MODE_PEDANTIC`|7.0.0| | | |7.0.0|
 |`CUTENSOR_COMPUTE_16BF`|1.0.1.0| | |2.0.0.0|`HIPTENSOR_COMPUTE_DESC_16BF`|7.0.0| | | |7.0.0|
 |`CUTENSOR_COMPUTE_16F`|1.0.1.0| | |2.0.0.0|`HIPTENSOR_COMPUTE_DESC_16F`|7.0.0| | | |7.0.0|
 |`CUTENSOR_COMPUTE_32F`|1.0.1.0| | |2.0.0.0|`HIPTENSOR_COMPUTE_DESC_32F`|7.0.0| | | |7.0.0|
@@ -55,8 +55,8 @@
 |`CUTENSOR_C_MIN_32F`|1.0.1.0|1.2.0.0| |2.0.0.0| | | | | | |
 |`CUTENSOR_C_MIN_64F`|1.0.1.0|1.2.0.0| |2.0.0.0| | | | | | |
 |`CUTENSOR_C_MIN_TF32`|1.0.1.0|1.2.0.0| |2.0.0.0| | | | | | |
-|`CUTENSOR_JIT_MODE_DEFAULT`|2.0.0.0| | | | | | | | | |
-|`CUTENSOR_JIT_MODE_NONE`|2.0.0.0| | | | | | | | | |
+|`CUTENSOR_JIT_MODE_DEFAULT`|2.0.0.0| | | |`HIPTENSOR_JIT_MODE_DEFAULT`|7.0.0| | | |7.0.0|
+|`CUTENSOR_JIT_MODE_NONE`|2.0.0.0| | | |`HIPTENSOR_JIT_MODE_NONE`|7.0.0| | | |7.0.0|
 |`CUTENSOR_MG_DEVICE_HOST`|1.4.0.0| | | | | | | | | |
 |`CUTENSOR_MG_DEVICE_HOST_PINNED`|1.4.0.0| | | | | | | | | |
 |`CUTENSOR_OPERATION_DESCRIPTOR_FLOPS`|2.0.0.0| | | |`HIPTENSOR_OPERATION_DESCRIPTOR_FLOPS`|7.0.0| | | |7.0.0|
@@ -150,13 +150,13 @@
 |`CUTENSOR_WORKSPACE_RECOMMENDED`|1.0.1.0| | |2.0.0.0| | | | | | |
 |`cutensorAlgo_t`|1.0.1.0| | | |`hiptensorAlgo_t`|5.7.0| | | | |
 |`cutensorAutotuneMode_t`|1.2.0.0| | | |`hiptensorAutotuneMode_t`|7.0.0| | | |7.0.0|
-|`cutensorCacheMode_t`|1.2.0.0| | | | | | | | | |
+|`cutensorCacheMode_t`|1.2.0.0| | | |`hiptensorCacheMode_t`|7.0.0| | | |7.0.0|
 |`cutensorComputeType_t`| | | | |`hiptensorComputeDescriptor_t`|7.0.0| | | |7.0.0|
 |`cutensorContractionPlan_t`|1.0.1.0| | |2.0.0.0|`hiptensorContractionPlan_t`|5.7.0| | | | |
 |`cutensorDataType_t`|2.0.0.0| | | |`hiptensorDataType_t`|7.0.0| | | |7.0.0|
-|`cutensorHandle`|2.0.0.0| | | | | | | | | |
+|`cutensorHandle`|2.0.0.0| | | |`hiptensorHandle`|7.0.0| | | |7.0.0|
 |`cutensorHandle_t`|1.0.1.0| | | |`hiptensorHandle_t`|5.7.0| | | | |
-|`cutensorJitMode_t`|2.0.0.0| | | | | | | | | |
+|`cutensorJitMode_t`|2.0.0.0| | | |`hiptensorJitMode_t`|7.0.0| | | |7.0.0|
 |`cutensorLoggerCallback_t`|1.3.2.0| | | |`hiptensorLoggerCallback_t`|5.7.0| | | | |
 |`cutensorMgAlgo_t`|1.4.0.0| | | | | | | | | |
 |`cutensorMgContractionDescriptor_s`|1.4.0.0| | | | | | | | | |
@@ -175,14 +175,18 @@
 |`cutensorMgHostDevice_t`|1.4.0.0| | | | | | | | | |
 |`cutensorMgTensorDescriptor_s`|1.4.0.0| | | | | | | | | |
 |`cutensorMgTensorDescriptor_t`|1.4.0.0| | | | | | | | | |
+|`cutensorOperationDescriptor`|2.0.0.0| | | |`hiptensorOperationDescriptor`|7.0.0| | | |7.0.0|
 |`cutensorOperationDescriptorAttribute_t`|2.0.0.0| | | |`hiptensorOperationDescriptorAttribute_t`|7.0.0| | | |7.0.0|
+|`cutensorOperationDescriptor_t`|2.0.0.0| | | |`hiptensorOperationDescriptor_t`|7.0.0| | | |7.0.0|
 |`cutensorOperator_t`|1.0.1.0| | | |`hiptensorOperator_t`|5.7.0| | | | |
-|`cutensorPlan`|2.0.0.0| | | | | | | | | |
+|`cutensorPlan`|2.0.0.0| | | |`hiptensorPlan`|7.0.0| | | |7.0.0|
 |`cutensorPlanAttribute_t`|2.0.0.0| | | |`hiptensorPlanAttribute_t`|7.0.0| | | |7.0.0|
+|`cutensorPlanPreference`|2.0.0.0| | | |`hiptensorPlanPreference`|7.0.0| | | |7.0.0|
 |`cutensorPlanPreferenceAttribute_t`|2.0.0.0| | | |`hiptensorPlanPreferenceAttribute_t`|7.0.0| | | |7.0.0|
-|`cutensorPlan_t`|2.0.0.0| | | |`hiptensorContractionPlan_t`|5.7.0| | | | |
+|`cutensorPlanPreference_t`|2.0.0.0| | | |`hiptensorPlanPreference_t`|7.0.0| | | |7.0.0|
+|`cutensorPlan_t`|2.0.0.0| | | |`hiptensorPlan_t`|7.0.0| | | |7.0.0|
 |`cutensorStatus_t`|1.0.1.0| | | |`hiptensorStatus_t`|5.7.0| | | | |
-|`cutensorTensorDescriptor`|2.0.0.0| | | | | | | | | |
+|`cutensorTensorDescriptor`|2.0.0.0| | | |`hiptensorTensorDescriptor`|7.0.0| | | |7.0.0|
 |`cutensorTensorDescriptor_t`|1.0.1.0| | | |`hiptensorTensorDescriptor_t`|5.7.0| | | | |
 |`cutensorWorksizePreference_t`|1.0.1.0| | | |`hiptensorWorksizePreference_t`|5.7.0| | | | |
 

--- a/src/CUDA2HIP_TENSOR_API_types.cpp
+++ b/src/CUDA2HIP_TENSOR_API_types.cpp
@@ -168,13 +168,13 @@ const std::map<llvm::StringRef, hipCounter> CUDA_TENSOR_TYPE_NAME_MAP {
   {"CUTENSOR_AUTOTUNE_MODE_INCREMENTAL",               {"HIPTENSOR_AUTOTUNE_MODE_INCREMENTAL",                      "", CONV_NUMERIC_LITERAL, API_TENSOR, 1, HIP_EXPERIMENTAL}},
   {"CUTENSOR_AUTOTUNE_INCREMENTAL",                    {"HIPTENSOR_AUTOTUNE_MODE_INCREMENTAL",                      "", CONV_NUMERIC_LITERAL, API_TENSOR, 1, HIP_EXPERIMENTAL | CUDA_REMOVED}},
 
-  {"cutensorJitMode_t",                                {"",                                                         "", CONV_TYPE, API_TENSOR, 1, UNSUPPORTED}},
-  {"CUTENSOR_JIT_MODE_NONE",                           {"",                                                         "", CONV_NUMERIC_LITERAL, API_TENSOR, 1, UNSUPPORTED}},
-  {"CUTENSOR_JIT_MODE_DEFAULT",                        {"",                                                         "", CONV_NUMERIC_LITERAL, API_TENSOR, 1, UNSUPPORTED}},
+  {"cutensorJitMode_t",                                {"hiptensorJitMode_t",                                       "", CONV_TYPE, API_TENSOR, 1, HIP_EXPERIMENTAL}},
+  {"CUTENSOR_JIT_MODE_NONE",                           {"HIPTENSOR_JIT_MODE_NONE",                                  "", CONV_NUMERIC_LITERAL, API_TENSOR, 1, HIP_EXPERIMENTAL}},
+  {"CUTENSOR_JIT_MODE_DEFAULT",                        {"HIPTENSOR_JIT_MODE_DEFAULT",                               "", CONV_NUMERIC_LITERAL, API_TENSOR, 1, HIP_EXPERIMENTAL}},
 
-  {"cutensorCacheMode_t",                              {"",                                                         "", CONV_TYPE, API_TENSOR, 1, UNSUPPORTED}},
-  {"CUTENSOR_CACHE_MODE_NONE",                         {"",                                                         "", CONV_NUMERIC_LITERAL, API_TENSOR, 1, UNSUPPORTED}},
-  {"CUTENSOR_CACHE_MODE_PEDANTIC",                     {"",                                                         "", CONV_NUMERIC_LITERAL, API_TENSOR, 1, UNSUPPORTED}},
+  {"cutensorCacheMode_t",                              {"hiptensorCacheMode_t",                                     "", CONV_TYPE, API_TENSOR, 1, HIP_EXPERIMENTAL}},
+  {"CUTENSOR_CACHE_MODE_NONE",                         {"HIPTENSOR_CACHE_MODE_NONE",                                "", CONV_NUMERIC_LITERAL, API_TENSOR, 1, HIP_EXPERIMENTAL}},
+  {"CUTENSOR_CACHE_MODE_PEDANTIC",                     {"HIPTENSOR_CACHE_MODE_PEDANTIC",                            "", CONV_NUMERIC_LITERAL, API_TENSOR, 1, HIP_EXPERIMENTAL}},
 
   {"cutensorPlanAttribute_t",                          {"hiptensorPlanAttribute_t",                                 "", CONV_TYPE, API_TENSOR, 1, HIP_EXPERIMENTAL}},
   {"CUTENSOR_PLAN_REQUIRED_WORKSPACE",                 {"HIPTENSOR_PLAN_REQUIRED_WORKSPACE",                        "", CONV_NUMERIC_LITERAL, API_TENSOR, 1, HIP_EXPERIMENTAL}},
@@ -190,27 +190,44 @@ const std::map<llvm::StringRef, hipCounter> CUDA_TENSOR_TYPE_NAME_MAP {
   {"CUTENSORMG_CONTRACTION_FIND_ATTRIBUTE_MAX",        {"",                                                         "", CONV_NUMERIC_LITERAL, API_TENSOR, 1, UNSUPPORTED}},
 
   {"cutensorHandle_t",                                 {"hiptensorHandle_t",                                        "", CONV_TYPE, API_TENSOR, 1}},
-  {"cutensorHandle",                                   {"",                                                         "", CONV_TYPE, API_TENSOR, 1, UNSUPPORTED}},
+  {"cutensorHandle",                                   {"hiptensorHandle",                                          "", CONV_TYPE, API_TENSOR, 1, HIP_EXPERIMENTAL}},
+
   {"cutensorTensorDescriptor_t",                       {"hiptensorTensorDescriptor_t",                              "", CONV_TYPE, API_TENSOR, 1}},
-  {"cutensorTensorDescriptor",                         {"",                                                         "", CONV_TYPE, API_TENSOR, 1, UNSUPPORTED}},
+  {"cutensorTensorDescriptor",                         {"hiptensorTensorDescriptor",                                "", CONV_TYPE, API_TENSOR, 1, HIP_EXPERIMENTAL}},
+
+  {"cutensorOperationDescriptor_t",                    {"hiptensorOperationDescriptor_t",                           "", CONV_TYPE, API_TENSOR, 1, HIP_EXPERIMENTAL}},
+  {"cutensorOperationDescriptor",                      {"hiptensorOperationDescriptor",                             "", CONV_TYPE, API_TENSOR, 1, HIP_EXPERIMENTAL}},
+
   {"cutensorContractionPlan_t",                        {"hiptensorContractionPlan_t",                               "", CONV_TYPE, API_TENSOR, 1}},
-  {"cutensorPlan_t",                                   {"hiptensorContractionPlan_t",                               "", CONV_TYPE, API_TENSOR, 1}},
-  {"cutensorPlan",                                     {"",                                                         "", CONV_TYPE, API_TENSOR, 1, UNSUPPORTED}},
+
+  {"cutensorPlan_t",                                   {"hiptensorPlan_t",                                          "", CONV_TYPE, API_TENSOR, 1, HIP_EXPERIMENTAL}},
+  {"cutensorPlan",                                     {"hiptensorPlan",                                            "", CONV_TYPE, API_TENSOR, 1, HIP_EXPERIMENTAL}},
+
   {"cutensorLoggerCallback_t",                         {"hiptensorLoggerCallback_t",                                "", CONV_TYPE, API_TENSOR, 1}},
+
   {"cutensorMgHandle_t",                               {"",                                                         "", CONV_TYPE, API_TENSOR, 1, UNSUPPORTED}},
   {"cutensorMgHandle_s",                               {"",                                                         "", CONV_TYPE, API_TENSOR, 1, UNSUPPORTED}},
+
   {"cutensorMgTensorDescriptor_t",                     {"",                                                         "", CONV_TYPE, API_TENSOR, 1, UNSUPPORTED}},
   {"cutensorMgTensorDescriptor_s",                     {"",                                                         "", CONV_TYPE, API_TENSOR, 1, UNSUPPORTED}},
+
   {"cutensorMgCopyDescriptor_t",                       {"",                                                         "", CONV_TYPE, API_TENSOR, 1, UNSUPPORTED}},
   {"cutensorMgCopyDescriptor_s",                       {"",                                                         "", CONV_TYPE, API_TENSOR, 1, UNSUPPORTED}},
+
   {"cutensorMgCopyPlan_t",                             {"",                                                         "", CONV_TYPE, API_TENSOR, 1, UNSUPPORTED}},
   {"cutensorMgCopyPlan_s",                             {"",                                                         "", CONV_TYPE, API_TENSOR, 1, UNSUPPORTED}},
+
   {"cutensorMgContractionDescriptor_t",                {"",                                                         "", CONV_TYPE, API_TENSOR, 1, UNSUPPORTED}},
   {"cutensorMgContractionDescriptor_s",                {"",                                                         "", CONV_TYPE, API_TENSOR, 1, UNSUPPORTED}},
+
   {"cutensorMgContractionFind_t",                      {"",                                                         "", CONV_TYPE, API_TENSOR, 1, UNSUPPORTED}},
   {"cutensorMgContractionFind_s",                      {"",                                                         "", CONV_TYPE, API_TENSOR, 1, UNSUPPORTED}},
+
   {"cutensorMgContractionPlan_t",                      {"",                                                         "", CONV_TYPE, API_TENSOR, 1, UNSUPPORTED}},
   {"cutensorMgContractionPlan_s",                      {"",                                                         "", CONV_TYPE, API_TENSOR, 1, UNSUPPORTED}},
+
+  {"cutensorPlanPreference_t",                         {"hiptensorPlanPreference_t",                                "", CONV_TYPE, API_TENSOR, 1, HIP_EXPERIMENTAL}},
+  {"cutensorPlanPreference",                           {"hiptensorPlanPreference",                                  "", CONV_TYPE, API_TENSOR, 1, HIP_EXPERIMENTAL}},
 };
 
 const std::map<llvm::StringRef, cudaAPIversions> CUDA_TENSOR_TYPE_NAME_VER_MAP {
@@ -384,6 +401,10 @@ const std::map<llvm::StringRef, cudaAPIversions> CUDA_TENSOR_TYPE_NAME_VER_MAP {
   {"CUTENSORMG_ALGO_DEFAULT",                          {CUTENSOR_1400, CUDA_0,        CUDA_0        }},
   {"cutensorMgContractionFindAttribute_t",             {CUTENSOR_1500, CUDA_0,        CUDA_0        }},
   {"CUTENSORMG_CONTRACTION_FIND_ATTRIBUTE_MAX",        {CUTENSOR_1500, CUDA_0,        CUDA_0        }},
+  {"cutensorPlanPreference",                           {CUTENSOR_2000, CUDA_0,        CUDA_0        }},
+  {"cutensorPlanPreference_t",                         {CUTENSOR_2000, CUDA_0,        CUDA_0        }},
+  {"cutensorOperationDescriptor_t",                    {CUTENSOR_2000, CUDA_0,        CUDA_0        }},
+  {"cutensorOperationDescriptor",                      {CUTENSOR_2000, CUDA_0,        CUDA_0        }},
 };
 
 const std::map<llvm::StringRef, hipAPIversions> HIP_TENSOR_TYPE_NAME_VER_MAP {
@@ -499,4 +520,18 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_TENSOR_TYPE_NAME_VER_MAP {
   {"hiptensorAutotuneMode_t",                          {HIP_7000,      HIP_0,         HIP_0,        HIP_LATEST}},
   {"HIPTENSOR_AUTOTUNE_MODE_NONE",                     {HIP_7000,      HIP_0,         HIP_0,        HIP_LATEST}},
   {"HIPTENSOR_AUTOTUNE_MODE_INCREMENTAL",              {HIP_7000,      HIP_0,         HIP_0,        HIP_LATEST}},
+  {"hiptensorCacheMode_t",                             {HIP_7000,      HIP_0,         HIP_0,        HIP_LATEST}},
+  {"HIPTENSOR_CACHE_MODE_NONE",                        {HIP_7000,      HIP_0,         HIP_0,        HIP_LATEST}},
+  {"HIPTENSOR_CACHE_MODE_PEDANTIC",                    {HIP_7000,      HIP_0,         HIP_0,        HIP_LATEST}},
+  {"hiptensorJitMode_t",                               {HIP_7000,      HIP_0,         HIP_0,        HIP_LATEST}},
+  {"HIPTENSOR_JIT_MODE_NONE",                          {HIP_7000,      HIP_0,         HIP_0,        HIP_LATEST}},
+  {"HIPTENSOR_JIT_MODE_DEFAULT",                       {HIP_7000,      HIP_0,         HIP_0,        HIP_LATEST}},
+  {"hiptensorPlan_t",                                  {HIP_7000,      HIP_0,         HIP_0,        HIP_LATEST}},
+  {"hiptensorPlan",                                    {HIP_7000,      HIP_0,         HIP_0,        HIP_LATEST}},
+  {"hiptensorPlanPreference_t",                        {HIP_7000,      HIP_0,         HIP_0,        HIP_LATEST}},
+  {"hiptensorPlanPreference",                          {HIP_7000,      HIP_0,         HIP_0,        HIP_LATEST}},
+  {"hiptensorHandle",                                  {HIP_7000,      HIP_0,         HIP_0,        HIP_LATEST}},
+  {"hiptensorOperationDescriptor_t",                   {HIP_7000,      HIP_0,         HIP_0,        HIP_LATEST}},
+  {"hiptensorOperationDescriptor",                     {HIP_7000,      HIP_0,         HIP_0,        HIP_LATEST}},
+  {"hiptensorTensorDescriptor",                        {HIP_7000,      HIP_0,         HIP_0,        HIP_LATEST}},
 };

--- a/tests/unit_tests/synthetic/libraries/cutensor2hiptensor.cu
+++ b/tests/unit_tests/synthetic/libraries/cutensor2hiptensor.cu
@@ -10,9 +10,11 @@
 int main() {
   printf("25. cuTensor API to hipTensor API synthetic test\n");
 
-  // CHECK: hiptensorHandle_t handle;
+  // CHECK: hiptensorHandle *handle_p = nullptr;
+  // CHECK-NEXT: hiptensorHandle_t handle;
   // CHECK-NEXT: const hiptensorHandle_t *handle_c = nullptr;
   // CHECK-NEXT: hiptensorHandle_t *handle2 = nullptr;
+  cutensorHandle *handle_p = nullptr;
   cutensorHandle_t handle;
   const cutensorHandle_t *handle_c = nullptr;
   cutensorHandle_t *handle2 = nullptr;
@@ -155,6 +157,13 @@ int main() {
   cutensorPlanPreferenceAttribute_t TENSOR_PLAN_PREFERENCE_KERNEL_RANK = CUTENSOR_PLAN_PREFERENCE_KERNEL_RANK;
   cutensorPlanPreferenceAttribute_t TENSOR_PLAN_PREFERENCE_JIT = CUTENSOR_PLAN_PREFERENCE_JIT;
 
+  // CHECK: hiptensorJitMode_t tensorJitMode_t;
+  // CHECK-NEXT hiptensorJitMode_t TENSOR_JIT_MODE_NONE = HIPTENSOR_JIT_MODE_NONE;
+  // CHECK-NEXT hiptensorJitMode_t TENSOR_JIT_MODE_DEFAULT = HIPTENSOR_JIT_MODE_DEFAULT;
+  cutensorJitMode_t tensorJitMode_t;
+  cutensorJitMode_t TENSOR_JIT_MODE_NONE = CUTENSOR_JIT_MODE_NONE;
+  cutensorJitMode_t TENSOR_JIT_MODE_DEFAULT = CUTENSOR_JIT_MODE_DEFAULT;
+
   // CHECK: hiptensorPlanAttribute_t tensorPlanAttribute_t;
   // CHECK-NEXT hiptensorPlanAttribute_t TENSOR_PLAN_REQUIRED_WORKSPACE = HIPTENSOR_PLAN_REQUIRED_WORKSPACE;
   cutensorPlanAttribute_t tensorPlanAttribute_t;
@@ -165,13 +174,25 @@ int main() {
   cutensorAutotuneMode_t TENSOR_AUTOTUNE_MODE_NONE = CUTENSOR_AUTOTUNE_MODE_NONE;
   cutensorAutotuneMode_t TENSOR_AUTOTUNE_MODE_INCREMENTAL = CUTENSOR_AUTOTUNE_MODE_INCREMENTAL;
 
-  // CHECK: hiptensorContractionPlan_t tensorPlan2_t;
-  cutensorPlan_t tensorPlan2_t;
+  // CHECK: hiptensorPlan *tensorPlan_p = nullptr;
+  // CHECK-NEXT: hiptensorPlan_t tensorPlan_t;
+  cutensorPlan *tensorPlan_p = nullptr;
+  cutensorPlan_t tensorPlan_t;
+
+  // CHECK: hiptensorPlanPreference *tensorPlanRef_p = nullptr;
+  // CHECK-NEXT: hiptensorPlanPreference_t tensorPlanPreference_t;
+  cutensorPlanPreference *tensorPlanRef_p = nullptr;
+  cutensorPlanPreference_t tensorPlanPreference_t;
+
+  // CHECK: hiptensorOperationDescriptor *tensorOperationDescriptor_p = nullptr;
+  // CHECK-NEXT: hiptensorOperationDescriptor_t tensorOperationDescriptor_t;
+  cutensorOperationDescriptor *tensorOperationDescriptor_p = nullptr;
+  cutensorOperationDescriptor_t tensorOperationDescriptor_t;
 
   // CUDA: cutensorStatus_t cutensorContract(const cutensorHandle_t handle, const cutensorPlan_t plan, const void* alpha, const void *A, const void *B, const void* beta, const void *C, void *D, void* workspace, uint64_t workspaceSize, cudaStream_t stream);
   // HIP: hiptensorStatus_t hiptensorContraction(const hiptensorHandle_t* handle, const hiptensorContractionPlan_t* plan, const void* alpha, const void* A, const void* B, const void* beta, const void* C, void* D, void* workspace, uint64_t workspaceSize, hipStream_t stream);
-  // CHECK: status = hiptensorContraction(handle, tensorPlan2_t, alpha, A, B_1, beta, C, D, workspace,  workspaceSize2, stream_t);
-  status = cutensorContract(handle, tensorPlan2_t, alpha, A, B_1, beta, C, D, workspace, workspaceSize2, stream_t);
+  // CHECK: status = hiptensorContraction(handle, tensorPlan_t, alpha, A, B_1, beta, C, D, workspace,  workspaceSize2, stream_t);
+  status = cutensorContract(handle, tensorPlan_t, alpha, A, B_1, beta, C, D, workspace, workspaceSize2, stream_t);
 
    // CUDA: cutensorStatus_t cutensorCreate(cutensorHandle_t* handle);
    // HIP: hiptensorStatus_t hiptensorCreate(hiptensorHandle_t** handle);
@@ -301,6 +322,9 @@ int main() {
   // CHECK: hiptensorComputeDescriptor_t tensorComputeType_t;
   cutensorComputeType_t tensorComputeType_t;
 
+  // CHECK: hiptensorContractionPlan_t tensorPlan2_t;
+  cutensorContractionPlan_t tensorPlan2_t;
+
 #if CUTENSOR_MINOR >= 2
   // CHECK: hiptensorAutotuneMode_t tensorAutotuneMode_t;
   cutensorAutotuneMode_t tensorAutotuneMode_t;
@@ -324,6 +348,13 @@ int main() {
   cutensorComputeType_t TENSOR_COMPUTE_8I = CUTENSOR_COMPUTE_8I;
   cutensorComputeType_t TENSOR_COMPUTE_32U = CUTENSOR_COMPUTE_32U;
   cutensorComputeType_t TENSOR_COMPUTE_32I = CUTENSOR_COMPUTE_32I;
+
+  // CHECK: hiptensorCacheMode_t tensorCacheMode_t;
+  // CHECK-NEXT hiptensorCacheMode_t TENSOR_CACHE_MODE_NONE = HIPTENSOR_CACHE_MODE_NONE;
+  // CHECK-NEXT hiptensorCacheMode_t TENSOR_CACHE_MODE_PEDANTIC = HIPTENSOR_CACHE_MODE_PEDANTIC;
+  cutensorCacheMode_t tensorCacheMode_t;
+  cutensorCacheMode_t TENSOR_CACHE_MODE_NONE = CUTENSOR_CACHE_MODE_NONE;
+  cutensorCacheMode_t TENSOR_CACHE_MODE_PEDANTIC = CUTENSOR_CACHE_MODE_PEDANTIC;
 #endif
 
   // CHECK: const hiptensorContractionPlan_t *plan_c = nullptr;


### PR DESCRIPTION
+ Updated the `hipTensor` tests, the regenerated `hipify-perl`, and `TENSOR` `CUDA2HIP` docs accordingly
+ [ToDo] Changed API revision (`cutensorAutotuneMode_t`, `cutensorCreate`, etc.)
