### PR TITLE
[HIPIFY][#SWDEV-534480][BLAS] Support for `hipBLAS 7.0` - Step 2 - renaming `v2` APIs - Part 40 - `hipblas(Nrm2|Scal|Rot)Ex_v2(_64)?` - final

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -5191,10 +5191,10 @@ sub simpleSubstitutions {
     subst("cublasLtMatrixTransformDescDestroy", "hipblasLtMatrixTransformDescDestroy", "library");
     subst("cublasLtMatrixTransformDescGetAttribute", "hipblasLtMatrixTransformDescGetAttribute", "library");
     subst("cublasLtMatrixTransformDescSetAttribute", "hipblasLtMatrixTransformDescSetAttribute", "library");
-    subst("cublasNrm2Ex", "hipblasNrm2Ex_v2", "library");
-    subst("cublasNrm2Ex_64", "hipblasNrm2Ex_v2_64", "library");
-    subst("cublasRotEx", "hipblasRotEx_v2", "library");
-    subst("cublasRotEx_64", "hipblasRotEx_v2_64", "library");
+    subst("cublasNrm2Ex", "hipblasNrm2Ex", "library");
+    subst("cublasNrm2Ex_64", "hipblasNrm2Ex_64", "library");
+    subst("cublasRotEx", "hipblasRotEx", "library");
+    subst("cublasRotEx_64", "hipblasRotEx_64", "library");
     subst("cublasSasum", "hipblasSasum", "library");
     subst("cublasSasum_64", "hipblasSasum_64", "library");
     subst("cublasSasum_v2", "hipblasSasum", "library");
@@ -5203,8 +5203,8 @@ sub simpleSubstitutions {
     subst("cublasSaxpy_64", "hipblasSaxpy_64", "library");
     subst("cublasSaxpy_v2", "hipblasSaxpy", "library");
     subst("cublasSaxpy_v2_64", "hipblasSaxpy_64", "library");
-    subst("cublasScalEx", "hipblasScalEx_v2", "library");
-    subst("cublasScalEx_64", "hipblasScalEx_v2_64", "library");
+    subst("cublasScalEx", "hipblasScalEx", "library");
+    subst("cublasScalEx_64", "hipblasScalEx_64", "library");
     subst("cublasScasum", "hipblasScasum", "library");
     subst("cublasScasum_64", "hipblasScasum_64", "library");
     subst("cublasScasum_v2", "hipblasScasum", "library");

--- a/docs/reference/tables/CUBLAS_API_supported_by_HIP.md
+++ b/docs/reference/tables/CUBLAS_API_supported_by_HIP.md
@@ -1276,8 +1276,8 @@
 |`cublasIzamin_64`|12.0| | | |`hipblasIzamin_64`|6.1.0| |7.0.0| | |
 |`cublasIzamin_v2`| | | | |`hipblasIzamin`|3.0.0| |7.0.0| | |
 |`cublasIzamin_v2_64`|12.0| | | |`hipblasIzamin_64`|6.1.0| |7.0.0| | |
-|`cublasNrm2Ex`|8.0| | | |`hipblasNrm2Ex_v2`|6.0.0| | | | |
-|`cublasNrm2Ex_64`|12.0| | | |`hipblasNrm2Ex_v2_64`|6.2.0| | | | |
+|`cublasNrm2Ex`|8.0| | | |`hipblasNrm2Ex`|4.1.0| |7.0.0| | |
+|`cublasNrm2Ex_64`|12.0| | | |`hipblasNrm2Ex_64`|6.2.0| |7.0.0| | |
 |`cublasSasum`| | | | |`hipblasSasum`|1.8.2| | | | |
 |`cublasSasum_64`|12.0| | | |`hipblasSasum_64`|6.1.0| | | | |
 |`cublasSasum_v2`| | | | |`hipblasSasum`|1.8.2| | | | |
@@ -1927,14 +1927,14 @@
 |`cublasIamaxEx_64`|12.0| | | | | | | | | |
 |`cublasIaminEx`|10.1| | | | | | | | | |
 |`cublasIaminEx_64`|12.0| | | | | | | | | |
-|`cublasRotEx`|10.1| | | |`hipblasRotEx_v2`|6.0.0| | | | |
-|`cublasRotEx_64`|12.0| | | |`hipblasRotEx_v2_64`|6.2.0| | | | |
+|`cublasRotEx`|10.1| | | |`hipblasRotEx`|4.1.0| |7.0.0| | |
+|`cublasRotEx_64`|12.0| | | |`hipblasRotEx_64`|6.2.0| |7.0.0| | |
 |`cublasRotgEx`|10.1| | | | | | | | | |
 |`cublasRotmEx`|10.1| | | | | | | | | |
 |`cublasRotmEx_64`|12.0| | | | | | | | | |
 |`cublasRotmgEx`|10.1| | | | | | | | | |
-|`cublasScalEx`|8.0| | | |`hipblasScalEx_v2`|6.0.0| | | | |
-|`cublasScalEx_64`|12.0| | | |`hipblasScalEx_v2_64`|6.2.0| | | | |
+|`cublasScalEx`|8.0| | | |`hipblasScalEx`|4.1.0| |7.0.0| | |
+|`cublasScalEx_64`|12.0| | | |`hipblasScalEx_64`|6.2.0| |7.0.0| | |
 |`cublasSdgmm`| | | | |`hipblasSdgmm`|3.6.0| | | | |
 |`cublasSdgmm_64`|12.0| | | |`hipblasSdgmm_64`|6.3.0| | | | |
 |`cublasSgeam`| | | | |`hipblasSgeam`|1.8.2| | | | |

--- a/docs/reference/tables/CUBLAS_API_supported_by_HIP_and_ROC.md
+++ b/docs/reference/tables/CUBLAS_API_supported_by_HIP_and_ROC.md
@@ -1276,8 +1276,8 @@
 |`cublasIzamin_64`|12.0| | | |`hipblasIzamin_64`|6.1.0| |7.0.0| | |`rocblas_izamin_64`|6.1.0| | | | |
 |`cublasIzamin_v2`| | | | |`hipblasIzamin`|3.0.0| |7.0.0| | |`rocblas_izamin`|3.5.0| | | | |
 |`cublasIzamin_v2_64`|12.0| | | |`hipblasIzamin_64`|6.1.0| |7.0.0| | |`rocblas_izamin_64`|6.1.0| | | | |
-|`cublasNrm2Ex`|8.0| | | |`hipblasNrm2Ex_v2`|6.0.0| | | | |`rocblas_nrm2_ex`|4.1.0| | | | |
-|`cublasNrm2Ex_64`|12.0| | | |`hipblasNrm2Ex_v2_64`|6.2.0| | | | |`rocblas_nrm2_ex_64`|6.1.0| | | | |
+|`cublasNrm2Ex`|8.0| | | |`hipblasNrm2Ex`|4.1.0| |7.0.0| | |`rocblas_nrm2_ex`|4.1.0| | | | |
+|`cublasNrm2Ex_64`|12.0| | | |`hipblasNrm2Ex_64`|6.2.0| |7.0.0| | |`rocblas_nrm2_ex_64`|6.1.0| | | | |
 |`cublasSasum`| | | | |`hipblasSasum`|1.8.2| | | | |`rocblas_sasum`|1.5.0| | | | |
 |`cublasSasum_64`|12.0| | | |`hipblasSasum_64`|6.1.0| | | | |`rocblas_sasum_64`|6.1.0| | | | |
 |`cublasSasum_v2`| | | | |`hipblasSasum`|1.8.2| | | | |`rocblas_sasum`|1.5.0| | | | |
@@ -1927,14 +1927,14 @@
 |`cublasIamaxEx_64`|12.0| | | | | | | | | | | | | | | |
 |`cublasIaminEx`|10.1| | | | | | | | | | | | | | | |
 |`cublasIaminEx_64`|12.0| | | | | | | | | | | | | | | |
-|`cublasRotEx`|10.1| | | |`hipblasRotEx_v2`|6.0.0| | | | |`rocblas_rot_ex`|4.1.0| | | | |
-|`cublasRotEx_64`|12.0| | | |`hipblasRotEx_v2_64`|6.2.0| | | | |`rocblas_rot_ex_64`|6.1.0| | | | |
+|`cublasRotEx`|10.1| | | |`hipblasRotEx`|4.1.0| |7.0.0| | |`rocblas_rot_ex`|4.1.0| | | | |
+|`cublasRotEx_64`|12.0| | | |`hipblasRotEx_64`|6.2.0| |7.0.0| | |`rocblas_rot_ex_64`|6.1.0| | | | |
 |`cublasRotgEx`|10.1| | | | | | | | | | | | | | | |
 |`cublasRotmEx`|10.1| | | | | | | | | | | | | | | |
 |`cublasRotmEx_64`|12.0| | | | | | | | | | | | | | | |
 |`cublasRotmgEx`|10.1| | | | | | | | | | | | | | | |
-|`cublasScalEx`|8.0| | | |`hipblasScalEx_v2`|6.0.0| | | | |`rocblas_scal_ex`|4.0.0| | | | |
-|`cublasScalEx_64`|12.0| | | |`hipblasScalEx_v2_64`|6.2.0| | | | |`rocblas_scal_ex_64`|6.1.0| | | | |
+|`cublasScalEx`|8.0| | | |`hipblasScalEx`|4.1.0| |7.0.0| | |`rocblas_scal_ex`|4.0.0| | | | |
+|`cublasScalEx_64`|12.0| | | |`hipblasScalEx_64`|6.2.0| |7.0.0| | |`rocblas_scal_ex_64`|6.1.0| | | | |
 |`cublasSdgmm`| | | | |`hipblasSdgmm`|3.6.0| | | | |`rocblas_sdgmm`|3.5.0| | | | |
 |`cublasSdgmm_64`|12.0| | | |`hipblasSdgmm_64`|6.3.0| | | | |`rocblas_sdgmm_64`|6.3.0| | | | |
 |`cublasSgeam`| | | | |`hipblasSgeam`|1.8.2| | | | |`rocblas_sgeam`|1.6.4| | | | |

--- a/src/CUDA2HIP_BLAS_API_functions.cpp
+++ b/src/CUDA2HIP_BLAS_API_functions.cpp
@@ -98,8 +98,8 @@ const std::map<llvm::StringRef, hipCounter> CUDA_BLAS_FUNCTION_MAP {
   {"cublasScnrm2_64",                                      {"hipblasScnrm2_64",                                          "rocblas_scnrm2_64",                                  CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_1}},
   {"cublasDznrm2",                                         {"hipblasDznrm2",                                             "rocblas_dznrm2",                                     CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_1, HIP_SUPPORTED_V2_ONLY}},
   {"cublasDznrm2_64",                                      {"hipblasDznrm2_64",                                          "rocblas_dznrm2_64",                                  CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_1}},
-  {"cublasNrm2Ex",                                         {"hipblasNrm2Ex_v2",                                          "rocblas_nrm2_ex",                                    CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_1}},
-  {"cublasNrm2Ex_64",                                      {"hipblasNrm2Ex_v2_64",                                       "rocblas_nrm2_ex_64",                                 CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_1}},
+  {"cublasNrm2Ex",                                         {"hipblasNrm2Ex",                                             "rocblas_nrm2_ex",                                    CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_1}},
+  {"cublasNrm2Ex_64",                                      {"hipblasNrm2Ex_64",                                          "rocblas_nrm2_ex_64",                                 CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_1}},
 
   // DOT
   // DOT functions' signatures differ from _v2 ones, hipblas and rocblas DOT functions have mapping to DOT_v2 functions only
@@ -958,8 +958,8 @@ const std::map<llvm::StringRef, hipCounter> CUDA_BLAS_FUNCTION_MAP {
   {"cublasZdotc_v2_64",                                    {"hipblasZdotc_64",                                           "rocblas_zdotc_64",                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_1}},
 
   // SCAL
-  {"cublasScalEx",                                         {"hipblasScalEx_v2",                                          "rocblas_scal_ex",                                    CONV_LIB_FUNC, API_BLAS, SEC::BLAS_EXT}},
-  {"cublasScalEx_64",                                      {"hipblasScalEx_v2_64",                                       "rocblas_scal_ex_64",                                 CONV_LIB_FUNC, API_BLAS, SEC::BLAS_EXT}},
+  {"cublasScalEx",                                         {"hipblasScalEx",                                             "rocblas_scal_ex",                                    CONV_LIB_FUNC, API_BLAS, SEC::BLAS_EXT}},
+  {"cublasScalEx_64",                                      {"hipblasScalEx_64",                                          "rocblas_scal_ex_64",                                 CONV_LIB_FUNC, API_BLAS, SEC::BLAS_EXT}},
   {"cublasSscal_v2",                                       {"hipblasSscal",                                              "rocblas_sscal",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_1}},
   {"cublasSscal_v2_64",                                    {"hipblasSscal_64",                                           "rocblas_sscal_64",                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_1}},
   {"cublasDscal_v2",                                       {"hipblasDscal",                                              "rocblas_dscal",                                      CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_1}},
@@ -1046,8 +1046,8 @@ const std::map<llvm::StringRef, hipCounter> CUDA_BLAS_FUNCTION_MAP {
   {"cublasDzasum_v2_64",                                   {"hipblasDzasum_64",                                          "rocblas_dzasum_64",                                  CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_1}},
 
   // ROT
-  {"cublasRotEx",                                          {"hipblasRotEx_v2",                                           "rocblas_rot_ex",                                     CONV_LIB_FUNC, API_BLAS, SEC::BLAS_EXT}},
-  {"cublasRotEx_64",                                       {"hipblasRotEx_v2_64",                                        "rocblas_rot_ex_64",                                  CONV_LIB_FUNC, API_BLAS, SEC::BLAS_EXT}},
+  {"cublasRotEx",                                          {"hipblasRotEx",                                              "rocblas_rot_ex",                                     CONV_LIB_FUNC, API_BLAS, SEC::BLAS_EXT}},
+  {"cublasRotEx_64",                                       {"hipblasRotEx_64",                                           "rocblas_rot_ex_64",                                  CONV_LIB_FUNC, API_BLAS, SEC::BLAS_EXT}},
   {"cublasSrot_v2",                                        {"hipblasSrot",                                               "rocblas_srot",                                       CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_1}},
   {"cublasSrot_v2_64",                                     {"hipblasSrot_64",                                            "rocblas_srot_64",                                    CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_1}},
   {"cublasDrot_v2",                                        {"hipblasDrot",                                               "rocblas_drot",                                       CONV_LIB_FUNC, API_BLAS, SEC::BLAS_LEVEL_1}},
@@ -1862,9 +1862,9 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_BLAS_FUNCTION_VER_MAP {
   {"hipblasAxpyEx",                                        {HIP_4010, HIP_0,    HIP_0   }},
   {"hipblasDotEx",                                         {HIP_4010, HIP_0,    HIP_0   }},
   {"hipblasDotcEx",                                        {HIP_4010, HIP_0,    HIP_0   }},
-  {"hipblasNrm2Ex_v2",                                     {HIP_6000, HIP_0,    HIP_0   }},
-  {"hipblasRotEx_v2",                                      {HIP_6000, HIP_0,    HIP_0   }},
-  {"hipblasScalEx_v2",                                     {HIP_6000, HIP_0,    HIP_0   }},
+  {"hipblasNrm2Ex",                                        {HIP_4010, HIP_0,    HIP_0   }},
+  {"hipblasRotEx",                                         {HIP_4010, HIP_0,    HIP_0   }},
+  {"hipblasScalEx",                                        {HIP_4010, HIP_0,    HIP_0   }},
   {"hipblasSetMathMode",                                   {HIP_6010, HIP_0,    HIP_0   }},
   {"hipblasGetMathMode",                                   {HIP_6010, HIP_0,    HIP_0   }},
   {"hipblasIsamax_64",                                     {HIP_6010, HIP_0,    HIP_0   }},
@@ -2023,9 +2023,9 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_BLAS_FUNCTION_VER_MAP {
   {"hipblasAxpyEx_64",                                     {HIP_6020, HIP_0,    HIP_0   }},
   {"hipblasDotEx_64",                                      {HIP_6020, HIP_0,    HIP_0   }},
   {"hipblasDotcEx_64",                                     {HIP_6020, HIP_0,    HIP_0   }},
-  {"hipblasNrm2Ex_v2_64",                                  {HIP_6020, HIP_0,    HIP_0   }},
-  {"hipblasRotEx_v2_64",                                   {HIP_6020, HIP_0,    HIP_0   }},
-  {"hipblasScalEx_v2_64",                                  {HIP_6020, HIP_0,    HIP_0   }},
+  {"hipblasNrm2Ex_64",                                     {HIP_6020, HIP_0,    HIP_0   }},
+  {"hipblasRotEx_64",                                      {HIP_6020, HIP_0,    HIP_0   }},
+  {"hipblasScalEx_64",                                     {HIP_6020, HIP_0,    HIP_0   }},
   {"hipblasHgemm_64",                                      {HIP_6030, HIP_0,    HIP_0   }},
   {"hipblasSgemm_64",                                      {HIP_6030, HIP_0,    HIP_0   }},
   {"hipblasDgemm_64",                                      {HIP_6030, HIP_0,    HIP_0   }},
@@ -2763,6 +2763,12 @@ const std::map<llvm::StringRef, hipAPIChangedVersions> HIP_BLAS_FUNCTION_CHANGED
   {"hipblasDotEx_64",                                      {HIP_7000}},
   {"hipblasDotcEx",                                        {HIP_7000}},
   {"hipblasDotcEx_64",                                     {HIP_7000}},
+  {"hipblasNrm2Ex",                                        {HIP_7000}},
+  {"hipblasNrm2Ex_64",                                     {HIP_7000}},
+  {"hipblasRotEx",                                         {HIP_7000}},
+  {"hipblasRotEx_64",                                      {HIP_7000}},
+  {"hipblasScalEx",                                        {HIP_7000}},
+  {"hipblasScalEx_64",                                     {HIP_7000}},
 
   {"rocblas_strmm",                                        {HIP_6000}},
   {"rocblas_dtrmm",                                        {HIP_6000}},

--- a/tests/unit_tests/synthetic/libraries/cublas2hipblas.cu
+++ b/tests/unit_tests/synthetic/libraries/cublas2hipblas.cu
@@ -1558,8 +1558,8 @@ int main() {
   cublasGemmAlgo_t BLAS_GEMM_DFALT = CUBLAS_GEMM_DFALT;
 
   // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasNrm2Ex(cublasHandle_t handle, int n, const void* x, cudaDataType xType, int incx, void* result, cudaDataType resultType, cudaDataType executionType);
-  // HIP: HIPBLAS_EXPORT hipblasStatus_t hipblasNrm2Ex_v2(hipblasHandle_t handle, int n, const void* x, hipDataType xType, int incx, void* result, hipDataType resultType, hipDataType executionType);
-  // CHECK: blasStatus = hipblasNrm2Ex_v2(blasHandle, n, image, DataType, incx, image_2, DataType_2, DataType_3);
+  // HIP: HIPBLAS_EXPORT hipblasStatus_t hipblasNrm2Ex(hipblasHandle_t handle, int n, const void* x, hipDataType xType, int incx, void* result, hipDataType resultType, hipDataType executionType);
+  // CHECK: blasStatus = hipblasNrm2Ex(blasHandle, n, image, DataType, incx, image_2, DataType_2, DataType_3);
   blasStatus = cublasNrm2Ex(blasHandle, n, image, DataType, incx, image_2, DataType_2, DataType_3);
 
   // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasSgemmStridedBatched(cublasHandle_t handle, cublasOperation_t transa, cublasOperation_t transb, int m, int n, int k, const float* alpha, const float* A, int lda, long long int strideA, const float* B, int ldb, long long int strideB, const float* beta, float* C, int ldc, long long int strideC, int batchCount);
@@ -1613,8 +1613,8 @@ int main() {
   cudaDataType Executiontype;
 
   // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasScalEx(cublasHandle_t handle, int n, const void* alpha, cudaDataType alphaType, void* x, cudaDataType xType, int incx, cudaDataType executionType);
-  // HIP: HIPBLAS_EXPORT hipblasStatus_t hipblasScalEx_v2(hipblasHandle_t handle, int n, const void* alpha, hipDataType alphaType, void* x, hipDataType xType, int incx, hipDataType executionType);
-  // CHECK: blasStatus = hipblasScalEx_v2(blasHandle, n, aptr, Atype, xptr, Xtype, incx, Executiontype);
+  // HIP: HIPBLAS_EXPORT hipblasStatus_t hipblasScalEx(hipblasHandle_t handle, int n, const void* alpha, hipDataType alphaType, void* x, hipDataType xType, int incx, hipDataType executionType);
+  // CHECK: blasStatus = hipblasScalEx(blasHandle, n, aptr, Atype, xptr, Xtype, incx, Executiontype);
   blasStatus = cublasScalEx(blasHandle, n, aptr, Atype, xptr, Xtype, incx, Executiontype);
 
   // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasAxpyEx(cublasHandle_t handle, int n, const void* alpha, cudaDataType alphaType, const void* x, cudaDataType xType, int incx, void* y, cudaDataType yType, int incy, cudaDataType executiontype);
@@ -1668,8 +1668,8 @@ int main() {
   cublasFillMode_t BLAS_FILL_MODE_FULL = CUBLAS_FILL_MODE_FULL;
 
   // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasRotEx(cublasHandle_t handle, int n, void* x, cudaDataType xType, int incx, void* y, cudaDataType yType, int incy, const void* c, const void* s, cudaDataType csType, cudaDataType executiontype);
-  // HIP: HIPBLAS_EXPORT hipblasStatus_t hipblasRotEx_v2(hipblasHandle_t handle, int n, void* x, hipDataType xType, int incx, void* y, hipDataType yType, int incy, const void* c, const void* s, hipDataType csType, hipDataType executionType);
-  // CHECK: blasStatus = hipblasRotEx_v2(blasHandle, n, xptr, Xtype, incx, yptr, Ytype, incy, cptr, sptr, CStype, Executiontype);
+  // HIP: HIPBLAS_EXPORT hipblasStatus_t hipblasRotEx(hipblasHandle_t handle, int n, void* x, hipDataType xType, int incx, void* y, hipDataType yType, int incy, const void* c, const void* s, hipDataType csType, hipDataType executionType);
+  // CHECK: blasStatus = hipblasRotEx(blasHandle, n, xptr, Xtype, incx, yptr, Ytype, incy, cptr, sptr, CStype, Executiontype);
   blasStatus = cublasRotEx(blasHandle, n, xptr, Xtype, incx, yptr, Ytype, incy, cptr, sptr, CStype, Executiontype);
 #endif
 

--- a/tests/unit_tests/synthetic/libraries/cublas2hipblas_v2.cu
+++ b/tests/unit_tests/synthetic/libraries/cublas2hipblas_v2.cu
@@ -1767,8 +1767,8 @@ int main() {
   cublasGemmAlgo_t BLAS_GEMM_DFALT = CUBLAS_GEMM_DFALT;
 
   // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasNrm2Ex(cublasHandle_t handle, int n, const void* x, cudaDataType xType, int incx, void* result, cudaDataType resultType, cudaDataType executionType);
-  // HIP: HIPBLAS_EXPORT hipblasStatus_t hipblasNrm2Ex_v2(hipblasHandle_t handle, int n, const void* x, hipDataType xType, int incx, void* result, hipDataType resultType, hipDataType executionType);
-  // CHECK: blasStatus = hipblasNrm2Ex_v2(blasHandle, n, image, DataType, incx, image_2, DataType_2, DataType_3);
+  // HIP: HIPBLAS_EXPORT hipblasStatus_t hipblasNrm2Ex(hipblasHandle_t handle, int n, const void* x, hipDataType xType, int incx, void* result, hipDataType resultType, hipDataType executionType);
+  // CHECK: blasStatus = hipblasNrm2Ex(blasHandle, n, image, DataType, incx, image_2, DataType_2, DataType_3);
   blasStatus = cublasNrm2Ex(blasHandle, n, image, DataType, incx, image_2, DataType_2, DataType_3);
 
   // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasSgemmStridedBatched(cublasHandle_t handle, cublasOperation_t transa, cublasOperation_t transb, int m, int n, int k, const float* alpha, const float* A, int lda, long long int strideA, const float* B, int ldb, long long int strideB, const float* beta, float* C, int ldc, long long int strideC, int batchCount);
@@ -1822,8 +1822,8 @@ int main() {
   cudaDataType Executiontype;
 
   // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasScalEx(cublasHandle_t handle, int n, const void* alpha, cudaDataType alphaType, void* x, cudaDataType xType, int incx, cudaDataType executionType);
-  // HIP: HIPBLAS_EXPORT hipblasStatus_t hipblasScalEx_v2(hipblasHandle_t handle, int n, const void* alpha, hipDataType alphaType, void* x, hipDataType xType, int incx, hipDataType executionType);
-  // CHECK: blasStatus = hipblasScalEx_v2(blasHandle, n, aptr, Atype, xptr, Xtype, incx, Executiontype);
+  // HIP: HIPBLAS_EXPORT hipblasStatus_t hipblasScalEx(hipblasHandle_t handle, int n, const void* alpha, hipDataType alphaType, void* x, hipDataType xType, int incx, hipDataType executionType);
+  // CHECK: blasStatus = hipblasScalEx(blasHandle, n, aptr, Atype, xptr, Xtype, incx, Executiontype);
   blasStatus = cublasScalEx(blasHandle, n, aptr, Atype, xptr, Xtype, incx, Executiontype);
 
   // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasAxpyEx(cublasHandle_t handle, int n, const void* alpha, cudaDataType alphaType, const void* x, cudaDataType xType, int incx, void* y, cudaDataType yType, int incy, cudaDataType executiontype);
@@ -1860,8 +1860,8 @@ int main() {
   cublasFillMode_t BLAS_FILL_MODE_FULL = CUBLAS_FILL_MODE_FULL;
 
   // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasRotEx(cublasHandle_t handle, int n, void* x, cudaDataType xType, int incx, void* y, cudaDataType yType, int incy, const void* c, const void* s, cudaDataType csType, cudaDataType executiontype);
-  // HIP: HIPBLAS_EXPORT hipblasStatus_t hipblasRotEx_v2(hipblasHandle_t handle, int n, void* x, hipDataType xType, int incx, void* y, hipDataType yType, int incy, const void* c, const void* s, hipDataType csType, hipDataType executionType);
-  // CHECK: blasStatus = hipblasRotEx_v2(blasHandle, n, xptr, Xtype, incx, yptr, Ytype, incy, cptr, sptr, CStype, Executiontype);
+  // HIP: HIPBLAS_EXPORT hipblasStatus_t hipblasRotEx(hipblasHandle_t handle, int n, void* x, hipDataType xType, int incx, void* y, hipDataType yType, int incy, const void* c, const void* s, hipDataType csType, hipDataType executionType);
+  // CHECK: blasStatus = hipblasRotEx(blasHandle, n, xptr, Xtype, incx, yptr, Ytype, incy, cptr, sptr, CStype, Executiontype);
   blasStatus = cublasRotEx(blasHandle, n, xptr, Xtype, incx, yptr, Ytype, incy, cptr, sptr, CStype, Executiontype);
 #endif
 
@@ -2896,18 +2896,18 @@ int main() {
   blasStatus = cublasDotcEx_64(blasHandle, n_64, xptr, Xtype, incx_64, yptr, Ytype, incy_64, image, DataType, Executiontype);
 
   // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasNrm2Ex_64(cublasHandle_t handle, int64_t n, const void* x, cudaDataType xType, int64_t incx, void* result, cudaDataType resultType, cudaDataType executionType);
-  // HIP: HIPBLAS_EXPORT hipblasStatus_t hipblasNrm2Ex_v2_64(hipblasHandle_t handle, int64_t n, const void* x, hipDataType xType, int64_t incx, void* result, hipDataType resultType, hipDataType executionType);
-  // CHECK: blasStatus = hipblasNrm2Ex_v2_64(blasHandle, n_64, xptr, Xtype, incx_64, image, DataType, Executiontype);
+  // HIP: HIPBLAS_EXPORT hipblasStatus_t hipblasNrm2Ex_64(hipblasHandle_t handle, int64_t n, const void* x, hipDataType xType, int64_t incx, void* result, hipDataType resultType, hipDataType executionType);
+  // CHECK: blasStatus = hipblasNrm2Ex_64(blasHandle, n_64, xptr, Xtype, incx_64, image, DataType, Executiontype);
   blasStatus = cublasNrm2Ex_64(blasHandle, n_64, xptr, Xtype, incx_64, image, DataType, Executiontype);
 
   // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasRotEx_64(cublasHandle_t handle, int64_t n, void* x, cudaDataType xType, int64_t incx, void* y, cudaDataType yType, int64_t incy, const void* c, const void* s, cudaDataType csType, cudaDataType executiontype);
-  // HIP: HIPBLAS_EXPORT hipblasStatus_t hipblasRotEx_v2_64(hipblasHandle_t handle, int64_t n, void* x, hipDataType xType, int64_t incx, void* y, hipDataType yType, int64_t incy, const void* c, const void* s, hipDataType csType, hipDataType executionType);
-  // CHECK: blasStatus = hipblasRotEx_v2_64(blasHandle, n_64, xptr, Xtype, incx_64, yptr, Ytype, incy_64, cptr, sptr, CStype, Executiontype);
+  // HIP: HIPBLAS_EXPORT hipblasStatus_t hipblasRotEx_64(hipblasHandle_t handle, int64_t n, void* x, hipDataType xType, int64_t incx, void* y, hipDataType yType, int64_t incy, const void* c, const void* s, hipDataType csType, hipDataType executionType);
+  // CHECK: blasStatus = hipblasRotEx_64(blasHandle, n_64, xptr, Xtype, incx_64, yptr, Ytype, incy_64, cptr, sptr, CStype, Executiontype);
   blasStatus = cublasRotEx_64(blasHandle, n_64, xptr, Xtype, incx_64, yptr, Ytype, incy_64, cptr, sptr, CStype, Executiontype);
 
   // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasScalEx_64(cublasHandle_t handle, int64_t n, const void* alpha, cudaDataType alphaType, void* x, cudaDataType xType, int64_t incx, cudaDataType executionType);
-  // HIP: HIPBLAS_EXPORT hipblasStatus_t hipblasScalEx_v2_64(hipblasHandle_t handle, int64_t n, const void* alpha, hipDataType alphaType, void* x, hipDataType xType, int64_t incx, hipDataType executionType);
-  // CHECK: blasStatus = hipblasScalEx_v2_64(blasHandle, n_64, aptr, Atype, xptr, Xtype, incx_64, Executiontype);
+  // HIP: HIPBLAS_EXPORT hipblasStatus_t hipblasScalEx_64(hipblasHandle_t handle, int64_t n, const void* alpha, hipDataType alphaType, void* x, hipDataType xType, int64_t incx, hipDataType executionType);
+  // CHECK: blasStatus = hipblasScalEx_64(blasHandle, n_64, aptr, Atype, xptr, Xtype, incx_64, Executiontype);
   blasStatus = cublasScalEx_64(blasHandle, n_64, aptr, Atype, xptr, Xtype, incx_64, Executiontype);
 
   // CUDA: CUBLASAPI cublasStatus_t CUBLASWINAPI cublasSgemm_v2_64(cublasHandle_t handle, cublasOperation_t transa, cublasOperation_t transb, int64_t m, int64_t n, int64_t k, const float* alpha, const float* A, int64_t lda, const float* B, int64_t ldb, const float* beta, float* C, int64_t ldc);


### PR DESCRIPTION
+ Updated the `hipBLAS` tests, the regenerated `hipify-perl`, and `BLAS` `CUDA2HIP` docs accordingly
