### PR TITLE
[HIPIFY][SWDEV-430220][#1838][LRT][fix] Remove `const_cast<const char**>` in `hiprtcCreateProgram` and `hiprtcCompileProgram`

### DIFF
--- a/docs/reference/tables/CUDA_RTC_API_supported_by_HIP.md
+++ b/docs/reference/tables/CUDA_RTC_API_supported_by_HIP.md
@@ -40,8 +40,8 @@
 |**CUDA**|**A**|**D**|**C**|**R**|**HIP**|**A**|**D**|**C**|**R**|**E**|
 |:--|:-:|:-:|:-:|:-:|:--|:-:|:-:|:-:|:-:|:-:|
 |`nvrtcAddNameExpression`|8.0| | | |`hiprtcAddNameExpression`|2.6.0| | | | |
-|`nvrtcCompileProgram`| | |8.0| |`hiprtcCompileProgram`|2.6.0| | | | |
-|`nvrtcCreateProgram`| | |8.0| |`hiprtcCreateProgram`|2.6.0| | | | |
+|`nvrtcCompileProgram`| | |8.0| |`hiprtcCompileProgram`|2.6.0| |7.0.0| | |
+|`nvrtcCreateProgram`| | |8.0| |`hiprtcCreateProgram`|2.6.0| |7.0.0| | |
 |`nvrtcDestroyProgram`| | | | |`hiprtcDestroyProgram`|2.6.0| | | | |
 |`nvrtcGetCUBIN`|11.1| | | |`hiprtcGetBitcode`|5.3.0| | | | |
 |`nvrtcGetCUBINSize`|11.1| | | |`hiprtcGetBitcodeSize`|5.3.0| | | | |

--- a/src/CUDA2HIP.h
+++ b/src/CUDA2HIP.h
@@ -167,6 +167,7 @@ extern const std::map<llvm::StringRef, hipAPIversions> HIP_CUB_TYPE_NAME_VER_MAP
 extern const std::map<llvm::StringRef, hipAPIversions> HIP_CUB_FUNCTION_VER_MAP;
 extern const std::map<llvm::StringRef, hipAPIversions> HIP_RTC_TYPE_NAME_VER_MAP;
 extern const std::map<llvm::StringRef, hipAPIversions> HIP_RTC_FUNCTION_VER_MAP;
+extern const std::map<llvm::StringRef, hipAPIChangedVersions> HIP_RTC_FUNCTION_CHANGED_VER_MAP;
 extern const std::map<llvm::StringRef, cudaAPIChangedVersions> CUDA_RTC_FUNCTION_CHANGED_VER_MAP;
 extern const std::map<llvm::StringRef, hipAPIversions> HIP_SOLVER_TYPE_NAME_VER_MAP;
 extern const std::map<llvm::StringRef, hipAPIversions> HIP_SOLVER_FUNCTION_VER_MAP;

--- a/src/CUDA2HIP_Doc.cpp
+++ b/src/CUDA2HIP_Doc.cpp
@@ -878,7 +878,8 @@ namespace doc {
       const typeMap &getTypes() const override { return CUDA_RTC_TYPE_NAME_MAP; }
       const versionMap &getFunctionVersions() const override { return CUDA_RTC_FUNCTION_VER_MAP; }
       const hipVersionMap &getHipFunctionVersions() const override { return HIP_RTC_FUNCTION_VER_MAP; }
-      const cudaChangedVersionMap& getCudaChangedFunctionVersions() const override { return CUDA_RTC_FUNCTION_CHANGED_VER_MAP; }
+      const hipChangedVersionMap &getHipChangedFunctionVersions() const override { return HIP_RTC_FUNCTION_CHANGED_VER_MAP; }
+      const cudaChangedVersionMap &getCudaChangedFunctionVersions() const override { return CUDA_RTC_FUNCTION_CHANGED_VER_MAP; }
       const versionMap &getTypeVersions() const override { return CUDA_RTC_TYPE_NAME_VER_MAP; }
       const hipVersionMap &getHipTypeVersions() const override { return HIP_RTC_TYPE_NAME_VER_MAP; }
       const string &getName() const override { return sCURTC; }

--- a/src/CUDA2HIP_RTC_API_functions.cpp
+++ b/src/CUDA2HIP_RTC_API_functions.cpp
@@ -93,6 +93,11 @@ const std::map<llvm::StringRef, cudaAPIChangedVersions> CUDA_RTC_FUNCTION_CHANGE
   {"nvrtcCompileProgram",                         {CUDA_80}},
 };
 
+const std::map<llvm::StringRef, hipAPIChangedVersions> HIP_RTC_FUNCTION_CHANGED_VER_MAP {
+  {"hiprtcCreateProgram",                         {HIP_7000}},
+  {"hiprtcCompileProgram",                        {HIP_7000}},
+};
+
 const std::map<unsigned int, llvm::StringRef> CUDA_RTC_API_SECTION_MAP {
   {1, "RTC Data types"},
   {2, "RTC API functions"},

--- a/src/HipifyAction.cpp
+++ b/src/HipifyAction.cpp
@@ -234,8 +234,6 @@ const std::string sCusparseSpMV_bufferSize = "cusparseSpMV_bufferSize";
 const std::string sCusparseSpMM_preprocess = "cusparseSpMM_preprocess";
 const std::string sCusparseSpSV_bufferSize = "cusparseSpSV_bufferSize";
 const std::string sCudaGetDriverEntryPoint = "cudaGetDriverEntryPoint";
-const std::string sNvrtcCompileProgram = "nvrtcCompileProgram";
-const std::string sNvrtcCreateProgram = "nvrtcCreateProgram";
 
 // CUDA_OVERLOADED
 const std::string sCudaEventCreate = "cudaEventCreate";
@@ -295,25 +293,6 @@ std::map<std::string, hipify::FuncOverloadsStruct> FuncOverloads {
 };
 
 std::map<std::string, std::vector<ArgCastStruct>> FuncArgCasts {
-  {sNvrtcCompileProgram,
-    {
-      {
-        {
-          {2, {e_const_cast_char_pp, cw_None}}
-        }
-      }
-    }
-  },
-  {sNvrtcCreateProgram,
-    {
-      {
-        {
-          {4, {e_const_cast_char_pp, cw_None}},
-          {5, {e_const_cast_char_pp, cw_None}}
-        }
-      }
-    }
-  },
   {sCudaGetDriverEntryPoint,
     {
       {
@@ -3135,9 +3114,7 @@ std::unique_ptr<clang::ASTConsumer> HipifyAction::CreateASTConsumer(clang::Compi
             sCusparseSpMV_bufferSize,
             sCusparseSpMM_preprocess,
             sCusparseSpSV_bufferSize,
-            sCudaGetDriverEntryPoint,
-            sNvrtcCompileProgram,
-            sNvrtcCreateProgram
+            sCudaGetDriverEntryPoint
           )
         )
       )

--- a/tests/unit_tests/synthetic/nvrtc2hiprtc.cu
+++ b/tests/unit_tests/synthetic/nvrtc2hiprtc.cu
@@ -27,12 +27,12 @@ int main() {
 
   // CUDA: nvrtcResult nvrtcCompileProgram(nvrtcProgram prog, int numOptions, const char* const* options);
   // HIP: hiprtcResult hiprtcCompileProgram(hiprtcProgram prog, int numOptions, const char** options);
-  // CHECK: rtcResult = hiprtcCompileProgram(rtcProgram, numOptions, const_cast<const char**>(&pOptions));
+  // CHECK: rtcResult = hiprtcCompileProgram(rtcProgram, numOptions, &pOptions);
   rtcResult = nvrtcCompileProgram(rtcProgram, numOptions, &pOptions);
 
   // CUDA: nvrtcResult nvrtcCreateProgram(nvrtcProgram *prog, const char* src, const char* name, int numHeaders, const char* const* headers, const char* const* includeNames);
-  // HIP: hiprtcResult hiprtcCreateProgram(hiprtcProgram* prog, const char* src, const char* name, int numHeaders, const char** headers, const char** includeNames);
-  // CHECK: rtcResult = hiprtcCreateProgram(&rtcProgram, pchSrc, pchName, numHeaders, const_cast<const char**>(&pHeadedrs), const_cast<const char**>(&pIncludeNames));
+  // HIP: hiprtcResult hiprtcCreateProgram(hiprtcProgram* prog, const char* src, const char* name, int numHeaders, const char* const* headers, const char* const* includeNames);
+  // CHECK: rtcResult = hiprtcCreateProgram(&rtcProgram, pchSrc, pchName, numHeaders, &pHeadedrs, &pIncludeNames);
   rtcResult = nvrtcCreateProgram(&rtcProgram, pchSrc, pchName, numHeaders, &pHeadedrs, &pIncludeNames);
 
   return 0;


### PR DESCRIPTION
+ [Reason] Since `7.0`, those `RTC` APIs are compatible with the corresponding CUDA counterparts (ABI-changed)
+ Updated synthetic tests, the regenerated `hipify-perl`, and `RTC` `CUDA2HIP` docs accordingly
