### PR TITLE
[HIPIFY][RAND][fix] Added the missing `rocrand_state_xorwow` type

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -3344,6 +3344,8 @@ sub rocSubstitutions {
     subst("curandStateSobol32_t", "rocrand_state_sobol32", "type");
     subst("curandStateSobol64", "rocrand_device::sobol64_engine<false>", "type");
     subst("curandStateSobol64_t", "rocrand_state_sobol64", "type");
+    subst("curandStateXORWOW", "rocrand_device::xorwow_engine", "type");
+    subst("curandStateXORWOW_t", "rocrand_state_xorwow", "type");
     subst("curandStatus", "rocrand_status", "type");
     subst("curandStatus_t", "rocrand_status", "type");
     subst("cusolverDnHandle_t", "rocblas_handle", "type");
@@ -14312,8 +14314,6 @@ sub warnHipOnlyUnsupportedFunctions {
     "curand_mtgp32_single",
     "curand_Philox4x32_10",
     "curandState_t",
-    "curandStateXORWOW_t",
-    "curandStateXORWOW",
     "curandState",
     "curandMethod_t",
     "curandMethod",

--- a/docs/reference/tables/CURAND_API_supported_by_HIP_and_ROC.md
+++ b/docs/reference/tables/CURAND_API_supported_by_HIP_and_ROC.md
@@ -104,8 +104,8 @@
 |`curandStateSobol32_t`| | | | |`hiprandStateSobol32_t`|1.5.0| | | | |`rocrand_state_sobol32`|1.5.0| | | | |
 |`curandStateSobol64`| | | | |`hiprandStateSobol64`|6.2.0| | | | |`rocrand_device::sobol64_engine<false>`|4.5.0| | | | |
 |`curandStateSobol64_t`| | | | |`hiprandStateSobol64_t`|6.2.0| | | | |`rocrand_state_sobol64`|4.5.0| | | | |
-|`curandStateXORWOW`| | | | |`hiprandStateXORWOW`|1.8.0| | | | | | | | | | |
-|`curandStateXORWOW_t`| | | | |`hiprandStateXORWOW_t`|1.5.0| | | | | | | | | | |
+|`curandStateXORWOW`| | | | |`hiprandStateXORWOW`|1.8.0| | | | |`rocrand_device::xorwow_engine`|1.5.0| | | | |
+|`curandStateXORWOW_t`| | | | |`hiprandStateXORWOW_t`|1.5.0| | | | |`rocrand_state_xorwow`|1.5.0| | | | |
 |`curandState_t`| | | | |`hiprandState_t`|1.5.0| | | | | | | | | | |
 |`curandStatus`| | | | |`hiprandStatus`|1.5.0| | | | |`rocrand_status`|1.5.0| | | | |
 |`curandStatus_t`| | | | |`hiprandStatus_t`|1.5.0| | | | |`rocrand_status`|1.5.0| | | | |

--- a/docs/reference/tables/CURAND_API_supported_by_ROC.md
+++ b/docs/reference/tables/CURAND_API_supported_by_ROC.md
@@ -104,8 +104,8 @@
 |`curandStateSobol32_t`| | | | |`rocrand_state_sobol32`|1.5.0| | | | |
 |`curandStateSobol64`| | | | |`rocrand_device::sobol64_engine<false>`|4.5.0| | | | |
 |`curandStateSobol64_t`| | | | |`rocrand_state_sobol64`|4.5.0| | | | |
-|`curandStateXORWOW`| | | | | | | | | | |
-|`curandStateXORWOW_t`| | | | | | | | | | |
+|`curandStateXORWOW`| | | | |`rocrand_device::xorwow_engine`|1.5.0| | | | |
+|`curandStateXORWOW_t`| | | | |`rocrand_state_xorwow`|1.5.0| | | | |
 |`curandState_t`| | | | | | | | | | |
 |`curandStatus`| | | | |`rocrand_status`|1.5.0| | | | |
 |`curandStatus_t`| | | | |`rocrand_status`|1.5.0| | | | |

--- a/src/CUDA2HIP_RAND_API_types.cpp
+++ b/src/CUDA2HIP_RAND_API_types.cpp
@@ -116,8 +116,8 @@ const std::map<llvm::StringRef, hipCounter> CUDA_RAND_TYPE_NAME_MAP {
   {"curandStateMRG32k3a_t",                            {"hiprandStateMRG32k3a_t",                         "rocrand_state_mrg32k3a",                                         CONV_TYPE, API_RAND, 1}},
   {"curandStatePhilox4_32_10",                         {"hiprandStatePhilox4_32_10",                      "rocrand_device::philox4x32_10_engine",                           CONV_TYPE, API_RAND, 1}},
   {"curandStatePhilox4_32_10_t",                       {"hiprandStatePhilox4_32_10_t",                    "rocrand_state_philox4x32_10",                                    CONV_TYPE, API_RAND, 1}},
-  {"curandStateXORWOW",                                {"hiprandStateXORWOW",                             "",                                                               CONV_TYPE, API_RAND, 1, ROC_UNSUPPORTED}},
-  {"curandStateXORWOW_t",                              {"hiprandStateXORWOW_t",                           "",                                                               CONV_TYPE, API_RAND, 1, ROC_UNSUPPORTED}},
+  {"curandStateXORWOW",                                {"hiprandStateXORWOW",                             "rocrand_device::xorwow_engine",                                  CONV_TYPE, API_RAND, 1}},
+  {"curandStateXORWOW_t",                              {"hiprandStateXORWOW_t",                           "rocrand_state_xorwow",                                           CONV_TYPE, API_RAND, 1}},
   {"curandState",                                      {"hiprandState",                                   "",                                                               CONV_TYPE, API_RAND, 1, ROC_UNSUPPORTED}},
   {"curandState_t",                                    {"hiprandState_t",                                 "",                                                               CONV_TYPE, API_RAND, 1, ROC_UNSUPPORTED}},
 
@@ -263,4 +263,6 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_RAND_TYPE_NAME_VER_MAP {
   {"rocrand_state_sobol64",                            {HIP_4050, HIP_0,    HIP_0   }},
   {"rocrand_device::mrg32k3a_engine",                  {HIP_1050, HIP_0,    HIP_0   }},
   {"rocrand_state_mrg32k3a",                           {HIP_1050, HIP_0,    HIP_0   }},
+  {"rocrand_device::xorwow_engine",                    {HIP_1050, HIP_0,    HIP_0   }},
+  {"rocrand_state_xorwow",                             {HIP_1050, HIP_0,    HIP_0   }},
 };

--- a/tests/unit_tests/synthetic/libraries/curand2rocrand.cu
+++ b/tests/unit_tests/synthetic/libraries/curand2rocrand.cu
@@ -153,6 +153,11 @@ int main() {
   curandStatePhilox4_32_10 statePhilox4_32_10;
   curandStatePhilox4_32_10_t statePhilox4_32_10_t;
 
+  // CHECK: rocrand_device::xorwow_engine stateXORWOW;
+  // CHECK-NEXT: rocrand_state_xorwow stateXORWOW_t;
+  curandStateXORWOW stateXORWOW;
+  curandStateXORWOW_t stateXORWOW_t;
+
   // CUDA: curandStatus_t CURANDAPI curandCreateGenerator(curandGenerator_t *generator, curandRngType_t rng_type);
   // ROC: rocrand_status ROCRANDAPI rocrand_create_generator(rocrand_generator * generator, rocrand_rng_type rng_type);
   // CHECK: status = rocrand_create_generator(&randGenerator, randRngType_t);


### PR DESCRIPTION
+ Updated synthetic tests, the regenerated `hipify-perl`, and `rocRAND` `CUDA2HIP` docs accordingly
