### PR TITLE
[HIPIFY][SWDEV-529096][Tensor][DNN][tests] Get `MAJOR` version from header files by regex

### DIFF
--- a/tests/lit.site.cfg.in
+++ b/tests/lit.site.cfg.in
@@ -1,5 +1,6 @@
 import sys
 import os
+import re
 
 config.hipify_install_path = "@CMAKE_INSTALL_PREFIX@"
 config.hipify_clang_tests_only = "@HIPIFY_CLANG_TESTS_ONLY@"
@@ -23,21 +24,37 @@ if sys.platform in ['win32']:
     if not config.build_type:
         config.build_type = "Debug"
 
-config.cudnn_version_major = int("0")
-if config.cuda_dnn_root and config.cuda_dnn_root != "OFF":
-    cudnn_ver_file = config.cuda_dnn_root + '/include/cudnn_version.h';
-    if os.path.isfile(cudnn_ver_file):
-        with open(cudnn_ver_file) as f:
-            if 'CUDNN_MAJOR 9' in f.read():
-                config.cudnn_version_major = int("9")
+pattern_major = r'_MAJOR ([1-9]|1[0-9])'
 
-config.cutensor_version_major = int("1")
+def get_lib_major_ver(file_name):
+    if os.path.isfile(file_name):
+        with open(file_name, 'r') as f:
+            match = re.search(pattern_major, f.read())
+        if match:
+            s = match.group(0)[7:]
+            return int(s)
+    return 0
+
+def get_cudnn_major_ver():
+    ver_file = config.cuda_dnn_root + '/include/cudnn_version.h'
+    ver = get_lib_major_ver(ver_file)
+    if ver == 0:
+        ver_file = config.cuda_dnn_root + '/include/cudnn_version_v9.h'
+        ver = get_lib_major_ver(ver_file)
+    return int(ver)
+
+def get_cutensor_major_ver():
+    ver_file = config.cuda_tensor_root + '/include/cutensor.h'
+    ver = get_lib_major_ver(ver_file)
+    if ver == 0:
+        ver = 1
+    return ver
+
+if config.cuda_dnn_root and config.cuda_dnn_root != "OFF":
+    config.cudnn_version_major = get_cudnn_major_ver()
+
 if config.cuda_tensor_root and config.cuda_tensor_root != "OFF":
-    cuda_tensor_file = config.cuda_tensor_root + '/include/cutensor.h';
-    if os.path.isfile(cuda_tensor_file):
-        with open(cuda_tensor_file) as f:
-            if 'CUTENSOR_MAJOR 2' in f.read():
-                config.cutensor_version_major = int("2")
+    config.cutensor_version_major = get_cutensor_major_ver()
 
 # Support substitution of the tools and libs dirs with user parameters. This is
 # used when we can't determine the tool dir at configuration time.


### PR DESCRIPTION
+ [ToDo] Get all other versions the same way
+ [ToDo] Implement exact version detection in `hipify-clang` itself, because `clang`'s detection is insufficient
