### PR TITLE
[HIPIFY][#2013][TENSOR] Support for `hipTensor 7.0` - Step 5 - Data Types - final

### DIFF
--- a/docs/reference/tables/CUTENSOR_API_supported_by_HIP.md
+++ b/docs/reference/tables/CUTENSOR_API_supported_by_HIP.md
@@ -149,7 +149,7 @@
 |`CUTENSOR_WORKSPACE_MIN`|1.0.1.0| | | |`HIPTENSOR_WORKSPACE_MIN`|5.7.0| | | | |
 |`CUTENSOR_WORKSPACE_RECOMMENDED`|1.0.1.0| | |2.0.0.0| | | | | | |
 |`cutensorAlgo_t`|1.0.1.0| | | |`hiptensorAlgo_t`|5.7.0| | | | |
-|`cutensorAutotuneMode_t`|1.2.0.0| | | |`hiptensorAutotuneMode_t`|7.0.0| | | |7.0.0|
+|`cutensorAutotuneMode_t`|1.2.0.0| |2.0.0.0| |`hiptensorAutotuneMode_t`|7.0.0| | | |7.0.0|
 |`cutensorCacheMode_t`|1.2.0.0| | | |`hiptensorCacheMode_t`|7.0.0| | | |7.0.0|
 |`cutensorComputeType_t`| | | | |`hiptensorComputeDescriptor_t`|7.0.0| | | |7.0.0|
 |`cutensorContractionPlan_t`|1.0.1.0| | |2.0.0.0|`hiptensorContractionPlan_t`|5.7.0| | | | |
@@ -197,7 +197,7 @@
 |`cutensorContract`|2.0.0.0| | | |`hiptensorContraction`|6.1.0| | | | |
 |`cutensorContractTrinary`|2.2.0.0| | | | | | | | | |
 |`cutensorContraction`|1.0.1.0| | |2.0.0.0|`hiptensorContraction`|6.1.0| | | | |
-|`cutensorCreate`|1.7.0.0| | | |`hiptensorCreate`|5.7.0| | | | |
+|`cutensorCreate`|1.7.0.0| |2.0.0.0| |`hiptensorCreate`|5.7.0| | | | |
 |`cutensorCreateContraction`|2.0.0.0| | | | | | | | | |
 |`cutensorCreateContractionTrinary`|2.2.0.0| | | | | | | | | |
 |`cutensorCreateElementwiseBinary`|2.0.0.0| | | | | | | | | |

--- a/src/CUDA2HIP.h
+++ b/src/CUDA2HIP.h
@@ -173,6 +173,8 @@ extern const std::map<llvm::StringRef, hipAPIversions> HIP_SOLVER_TYPE_NAME_VER_
 extern const std::map<llvm::StringRef, hipAPIversions> HIP_SOLVER_FUNCTION_VER_MAP;
 extern const std::map<llvm::StringRef, hipAPIversions> HIP_TENSOR_TYPE_NAME_VER_MAP;
 extern const std::map<llvm::StringRef, hipAPIversions> HIP_TENSOR_FUNCTION_VER_MAP;
+extern const std::map<llvm::StringRef, cudaAPIChangedVersions> CUDA_TENSOR_FUNCTION_CHANGED_VER_MAP;
+extern const std::map<llvm::StringRef, cudaAPIChangedVersions> CUDA_TENSOR_TYPE_CHANGED_VER_MAP;
 
 /**
   * The union of all the above HIP maps.

--- a/src/CUDA2HIP_Doc.cpp
+++ b/src/CUDA2HIP_Doc.cpp
@@ -202,13 +202,14 @@ namespace doc {
       virtual const hipVersionMap &getHipFunctionVersions() const = 0;
       virtual const hipChangedVersionMap &getHipChangedFunctionVersions() const { return hipChangedVersionMapEmpty; };
       virtual const cudaChangedVersionMap &getCudaChangedFunctionVersions() const { return cudaChangedVersionMapEmpty; };
+      virtual const cudaChangedVersionMap &getCudaChangedTypeVersions() const { return cudaChangedVersionMapEmpty; };
       virtual const versionMap &getTypeVersions() const = 0;
       virtual const hipVersionMap &getHipTypeVersions() const = 0;
       virtual const string &getAPI() const { return sHIP; }
       virtual const string &getSecondAPI() const { return sROC; }
       virtual const string &getJointAPI() const { return sEmpty; }
       virtual bool isJoint() const { return roc == joint && hasROC; }
-      virtual const string& getAdditionalMetaKeywords() const = 0;
+      virtual const string &getAdditionalMetaKeywords() const = 0;
       virtual const string &writeAdditionalMetaKeywords() const { return getAdditionalMetaKeywords(); }
       virtual void writeHeadMeta(const docType doc) {
           *streams[doc].get() << "<head>" << endl_tab;
@@ -269,11 +270,12 @@ namespace doc {
           *streams[doc].get() << endl << (format == full ? "**A** - Added; **D** - Deprecated; **C** - Changed; **R** - Removed; **E** - Experimental" : "**D** - Deprecated; **E** - Experimental") << endl << endl;
           unsigned int compact_only_cur_sec_num = 1;
           for (auto &s : getSections()) {
-            const functionMap &ftMap = isTypeSection(s.first, getSections()) ? getTypes() : getFunctions();
-            const versionMap &vMap = isTypeSection(s.first, getSections()) ? getTypeVersions() : getFunctionVersions();
-            const hipVersionMap &hMap = commonHipVersionMap.empty() ? (isTypeSection(s.first, getSections()) ? getHipTypeVersions() : getHipFunctionVersions()) : commonHipVersionMap;
+            bool isType = isTypeSection(s.first, getSections());
+            const functionMap &ftMap = isType ? getTypes() : getFunctions();
+            const versionMap &vMap = isType ? getTypeVersions() : getFunctionVersions();
+            const hipVersionMap &hMap = commonHipVersionMap.empty() ? ((isType) ? getHipTypeVersions() : getHipFunctionVersions()) : commonHipVersionMap;
             const hipChangedVersionMap &hChangedMap = getHipChangedFunctionVersions();
-            const cudaChangedVersionMap &cudaChangedMap = getCudaChangedFunctionVersions();
+            const cudaChangedVersionMap &cudaChangedMap = isType ? getCudaChangedTypeVersions() : getCudaChangedFunctionVersions();
             functionMap fMap;
             for (auto &f : ftMap) {
               if (f.second.apiSection == s.first) {
@@ -538,7 +540,7 @@ namespace doc {
       const typeMap &getTypes() const override { return CUDA_RUNTIME_TYPE_NAME_MAP; }
       const versionMap &getFunctionVersions() const override { return CUDA_RUNTIME_FUNCTION_VER_MAP; }
       const hipVersionMap &getHipFunctionVersions() const override { return HIP_RUNTIME_FUNCTION_VER_MAP; }
-      const cudaChangedVersionMap& getCudaChangedFunctionVersions() const override { return CUDA_RUNTIME_FUNCTION_CHANGED_VER_MAP; }
+      const cudaChangedVersionMap &getCudaChangedFunctionVersions() const override { return CUDA_RUNTIME_FUNCTION_CHANGED_VER_MAP; }
       const versionMap &getTypeVersions() const override { return CUDA_RUNTIME_TYPE_NAME_VER_MAP; }
       const hipVersionMap &getHipTypeVersions() const override { return HIP_RUNTIME_TYPE_NAME_VER_MAP; }
       const string &getName() const override { return sCUDA_RUNTIME; }
@@ -665,7 +667,7 @@ namespace doc {
     virtual ~ROCSOLVER() {}
   protected:
     const string sMetaKeywords = "SOLVER, cuSOLVER, rocSOLVER";
-    const string& getAdditionalMetaKeywords() const override { return sMetaKeywords; }
+    const string &getAdditionalMetaKeywords() const override { return sMetaKeywords; }
     const string &getAPI() const override { return sROC; }
     const string &getFileName(docType format) const override {
       switch (format) {
@@ -705,13 +707,13 @@ namespace doc {
 
   class ROCRAND : public RAND {
   public:
-      ROCRAND(const string& outDir) : RAND(outDir) { hasROC = false; isROC = true; }
+      ROCRAND(const string &outDir) : RAND(outDir) { hasROC = false; isROC = true; }
       virtual ~ROCRAND() {}
   protected:
       const string sMetaKeywords = "RAND, cuRAND, rocRAND";
       const string &getAdditionalMetaKeywords() const override { return sMetaKeywords; }
-      const string& getAPI() const override { return sROC; }
-      const string& getFileName(docType format) const override {
+      const string &getAPI() const override { return sROC; }
+      const string &getFileName(docType format) const override {
           switch (format) {
           case none:
           default: return sEmpty;
@@ -930,6 +932,8 @@ namespace doc {
       const typeMap &getTypes() const override { return CUDA_TENSOR_TYPE_NAME_MAP; }
       const versionMap &getFunctionVersions() const override { return CUDA_TENSOR_FUNCTION_VER_MAP; }
       const hipVersionMap &getHipFunctionVersions() const override { return HIP_TENSOR_FUNCTION_VER_MAP; }
+      const cudaChangedVersionMap &getCudaChangedFunctionVersions() const override { return CUDA_TENSOR_FUNCTION_CHANGED_VER_MAP; }
+      const cudaChangedVersionMap &getCudaChangedTypeVersions() const override { return CUDA_TENSOR_TYPE_CHANGED_VER_MAP; }
       const versionMap &getTypeVersions() const override { return CUDA_TENSOR_TYPE_NAME_VER_MAP; }
       const hipVersionMap &getHipTypeVersions() const override { return HIP_TENSOR_TYPE_NAME_VER_MAP; }
       const string &getName() const override { return sCUTENSOR; }

--- a/src/CUDA2HIP_TENSOR_API_functions.cpp
+++ b/src/CUDA2HIP_TENSOR_API_functions.cpp
@@ -171,6 +171,10 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_TENSOR_FUNCTION_VER_MAP {
   {"hiptensorLoggerForceDisable",                    {HIP_5070,      HIP_0,         HIP_0         }},
 };
 
+const std::map<llvm::StringRef, cudaAPIChangedVersions> CUDA_TENSOR_FUNCTION_CHANGED_VER_MAP {
+  {"cutensorCreate",                                 {CUTENSOR_2000}},
+};
+
 const std::map<unsigned int, llvm::StringRef> CUDA_TENSOR_API_SECTION_MAP {
   {1, "CUTENSOR Data types"},
   {2, "CUTENSOR Function Reference"},

--- a/src/CUDA2HIP_TENSOR_API_types.cpp
+++ b/src/CUDA2HIP_TENSOR_API_types.cpp
@@ -535,3 +535,7 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_TENSOR_TYPE_NAME_VER_MAP {
   {"hiptensorOperationDescriptor",                     {HIP_7000,      HIP_0,         HIP_0,        HIP_LATEST}},
   {"hiptensorTensorDescriptor",                        {HIP_7000,      HIP_0,         HIP_0,        HIP_LATEST}},
 };
+
+const std::map<llvm::StringRef, cudaAPIChangedVersions> CUDA_TENSOR_TYPE_CHANGED_VER_MAP {
+  {"cutensorAutotuneMode_t",                           {CUTENSOR_2000}},
+};


### PR DESCRIPTION
+ Changed APIs: `cutensorAutotuneMode_t`, `cutensorCreate`
+ Updated the regenerated `TENSOR` `CUDA2HIP` docs accordingly
