### PR TITLE
[HIPIFY][CUDA 13] CUDA 13.0.0 support - Step 3 - Driver - Data Types

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -8771,6 +8771,7 @@ sub simpleSubstitutions {
     subst("CU_MEM_HANDLE_TYPE_WIN32_KMT", "hipMemHandleTypeWin32Kmt", "numeric_literal");
     subst("CU_MEM_LOCATION_TYPE_DEVICE", "hipMemLocationTypeDevice", "numeric_literal");
     subst("CU_MEM_LOCATION_TYPE_INVALID", "hipMemLocationTypeInvalid", "numeric_literal");
+    subst("CU_MEM_LOCATION_TYPE_NONE", "hipMemLocationTypeInvalid", "numeric_literal");
     subst("CU_MEM_OPERATION_TYPE_MAP", "hipMemOperationTypeMap", "numeric_literal");
     subst("CU_MEM_OPERATION_TYPE_UNMAP", "hipMemOperationTypeUnmap", "numeric_literal");
     subst("CU_MEM_RANGE_ATTRIBUTE_ACCESSED_BY", "hipMemRangeAttributeAccessedBy", "numeric_literal");
@@ -12421,9 +12422,13 @@ sub warnRemovedFunctions {
     "CUcheckpointRestoreArgs",
     "CUcheckpointLockArgs_st",
     "CUcheckpointLockArgs",
+    "CUcheckpointGpuPair_st",
+    "CUcheckpointGpuPair",
     "CUcheckpointCheckpointArgs_st",
     "CUcheckpointCheckpointArgs",
     "CUatomicOperation_enum",
+    "CUatomicOperationCapability_enum",
+    "CUatomicOperationCapability",
     "CUatomicOperation",
     "CUasyncNotificationType_enum",
     "CUasyncNotificationType",
@@ -12567,6 +12572,7 @@ sub warnRemovedFunctions {
     "CU_MEM_DECOMPRESS_ALGORITHM_DEFLATE",
     "CU_MEM_CREATE_USAGE_TILE_POOL",
     "CU_MEM_CREATE_USAGE_HW_DECOMPRESS",
+    "CU_MEM_ALLOCATION_TYPE_MANAGED",
     "CU_MEM_ACCESS_FLAGS_PROT_MAX",
     "CU_MEMCPY_SRC_ACCESS_ORDER_STREAM",
     "CU_MEMCPY_SRC_ACCESS_ORDER_MAX",
@@ -12669,6 +12675,7 @@ sub warnRemovedFunctions {
     "CU_EXTERNAL_SEMAPHORE_HANDLE_TYPE_D3D11_KEYED_MUTEX",
     "CU_EXTERNAL_SEMAPHORE_HANDLE_TYPE_D3D11_FENCE",
     "CU_EXTERNAL_MEMORY_HANDLE_TYPE_NVSCIBUF",
+    "CU_EXTERNAL_MEMORY_HANDLE_TYPE_DMABUF_FD",
     "CU_EXEC_AFFINITY_TYPE_SM_COUNT",
     "CU_EXEC_AFFINITY_TYPE_MAX",
     "CU_EVENT_WAIT_EXTERNAL",
@@ -12883,6 +12890,13 @@ sub warnRemovedFunctions {
     "CU_ATOMIC_OPERATION_EXCHANGE",
     "CU_ATOMIC_OPERATION_CAS",
     "CU_ATOMIC_OPERATION_AND",
+    "CU_ATOMIC_CAPABILITY_VECTOR_32x4",
+    "CU_ATOMIC_CAPABILITY_UNSIGNED",
+    "CU_ATOMIC_CAPABILITY_SIGNED",
+    "CU_ATOMIC_CAPABILITY_SCALAR_64",
+    "CU_ATOMIC_CAPABILITY_SCALAR_32",
+    "CU_ATOMIC_CAPABILITY_SCALAR_128",
+    "CU_ATOMIC_CAPABILITY_REDUCTION",
     "CU_ASYNC_NOTIFICATION_TYPE_OVER_BUDGET",
     "CU_ARRAY_SPARSE_PROPERTIES_SINGLE_MIPTAIL",
     "CU_AD_FORMAT_YUY2",

--- a/docs/reference/tables/CUDA_Driver_API_functions_supported_by_HIP.md
+++ b/docs/reference/tables/CUDA_Driver_API_functions_supported_by_HIP.md
@@ -328,6 +328,13 @@
 |`CU_ARRAY_SPARSE_SUBRESOURCE_TYPE_MIPTAIL`|11.1| | | |`hipArraySparseSubresourceTypeMiptail`|5.2.0| | | | |
 |`CU_ARRAY_SPARSE_SUBRESOURCE_TYPE_SPARSE_LEVEL`|11.1| | | |`hipArraySparseSubresourceTypeSparseLevel`|5.2.0| | | | |
 |`CU_ASYNC_NOTIFICATION_TYPE_OVER_BUDGET`|12.4| | | | | | | | | |
+|`CU_ATOMIC_CAPABILITY_REDUCTION`|13.0| | | | | | | | | |
+|`CU_ATOMIC_CAPABILITY_SCALAR_128`|13.0| | | | | | | | | |
+|`CU_ATOMIC_CAPABILITY_SCALAR_32`|13.0| | | | | | | | | |
+|`CU_ATOMIC_CAPABILITY_SCALAR_64`|13.0| | | | | | | | | |
+|`CU_ATOMIC_CAPABILITY_SIGNED`|13.0| | | | | | | | | |
+|`CU_ATOMIC_CAPABILITY_UNSIGNED`|13.0| | | | | | | | | |
+|`CU_ATOMIC_CAPABILITY_VECTOR_32x4`|13.0| | | | | | | | | |
 |`CU_ATOMIC_OPERATION_AND`|13.0| | | | | | | | | |
 |`CU_ATOMIC_OPERATION_CAS`|13.0| | | | | | | | | |
 |`CU_ATOMIC_OPERATION_EXCHANGE`|13.0| | | | | | | | | |
@@ -672,6 +679,7 @@
 |`CU_EXTERNAL_MEMORY_HANDLE_TYPE_D3D11_RESOURCE_KMT`|10.2| | | |`hipExternalMemoryHandleTypeD3D11ResourceKmt`|4.3.0| | | | |
 |`CU_EXTERNAL_MEMORY_HANDLE_TYPE_D3D12_HEAP`|10.0| | | |`hipExternalMemoryHandleTypeD3D12Heap`|4.3.0| | | | |
 |`CU_EXTERNAL_MEMORY_HANDLE_TYPE_D3D12_RESOURCE`|10.0| | | |`hipExternalMemoryHandleTypeD3D12Resource`|4.3.0| | | | |
+|`CU_EXTERNAL_MEMORY_HANDLE_TYPE_DMABUF_FD`|13.0| | | | | | | | | |
 |`CU_EXTERNAL_MEMORY_HANDLE_TYPE_NVSCIBUF`|10.2| | | | | | | | | |
 |`CU_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD`|10.0| | | |`hipExternalMemoryHandleTypeOpaqueFd`|4.3.0| | | | |
 |`CU_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32`|10.0| | | |`hipExternalMemoryHandleTypeOpaqueWin32`|4.3.0| | | | |
@@ -935,6 +943,7 @@
 |`CU_MEM_ADVISE_UNSET_PREFERRED_LOCATION`|8.0| | | |`hipMemAdviseUnsetPreferredLocation`|3.7.0| | | | |
 |`CU_MEM_ADVISE_UNSET_READ_MOSTLY`|8.0| | | |`hipMemAdviseUnsetReadMostly`|3.7.0| | | | |
 |`CU_MEM_ALLOCATION_TYPE_INVALID`|10.2| | | |`hipMemAllocationTypeInvalid`|5.2.0| | | | |
+|`CU_MEM_ALLOCATION_TYPE_MANAGED`|13.0| | | | | | | | | |
 |`CU_MEM_ALLOCATION_TYPE_MAX`|10.2| | | |`hipMemAllocationTypeMax`|5.2.0| | | | |
 |`CU_MEM_ALLOCATION_TYPE_PINNED`|10.2| | | |`hipMemAllocationTypePinned`|5.2.0| | | | |
 |`CU_MEM_ALLOC_GRANULARITY_MINIMUM`|10.2| | | |`hipMemAllocationGranularityMinimum`|5.2.0| | | | |
@@ -961,6 +970,7 @@
 |`CU_MEM_LOCATION_TYPE_HOST_NUMA_CURRENT`|12.2| | | | | | | | | |
 |`CU_MEM_LOCATION_TYPE_INVALID`|10.2| | | |`hipMemLocationTypeInvalid`|5.2.0| | | | |
 |`CU_MEM_LOCATION_TYPE_MAX`|10.2| | | | | | | | | |
+|`CU_MEM_LOCATION_TYPE_NONE`|13.0| | | |`hipMemLocationTypeInvalid`|5.2.0| | | | |
 |`CU_MEM_OPERATION_TYPE_MAP`|11.1| | | |`hipMemOperationTypeMap`|5.2.0| | | | |
 |`CU_MEM_OPERATION_TYPE_UNMAP`|11.1| | | |`hipMemOperationTypeUnmap`|5.2.0| | | | |
 |`CU_MEM_POOL_CREATE_USAGE_HW_DECOMPRESS`|12.8| | | | | | | | | |
@@ -1210,9 +1220,13 @@
 |`CUasyncNotificationType`|12.4| | | | | | | | | |
 |`CUasyncNotificationType_enum`|12.4| | | | | | | | | |
 |`CUatomicOperation`|13.0| | | | | | | | | |
+|`CUatomicOperationCapability`|13.0| | | | | | | | | |
+|`CUatomicOperationCapability_enum`|13.0| | | | | | | | | |
 |`CUatomicOperation_enum`|13.0| | | | | | | | | |
 |`CUcheckpointCheckpointArgs`|12.8| | | | | | | | | |
 |`CUcheckpointCheckpointArgs_st`|12.8| | | | | | | | | |
+|`CUcheckpointGpuPair`|13.0| | | | | | | | | |
+|`CUcheckpointGpuPair_st`|13.0| | | | | | | | | |
 |`CUcheckpointLockArgs`|12.8| | | | | | | | | |
 |`CUcheckpointLockArgs_st`|12.8| | | | | | | | | |
 |`CUcheckpointRestoreArgs`|12.8| | | | | | | | | |

--- a/src/CUDA2HIP_Driver_API_types.cpp
+++ b/src/CUDA2HIP_Driver_API_types.cpp
@@ -488,6 +488,11 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_TYPE_NAME_MAP {
   //
   {"CUcheckpointRestoreArgs",                                          {"hipCheckpointRestoreArgs",                                 "", CONV_TYPE, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
 
+  //
+  {"CUcheckpointGpuPair_st",                                           {"hipCheckpointGpuPair",                                     "", CONV_TYPE, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
+  //
+  {"CUcheckpointGpuPair",                                              {"hipCheckpointGpuPair",                                     "", CONV_TYPE, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
+
   // cudaMemcpyAttributes
   {"CUmemcpyAttributes_st",                                            {"hipMemcpyAttributes",                                      "", CONV_TYPE, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
   // cudaMemcpyAttributes
@@ -1267,6 +1272,8 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_TYPE_NAME_MAP {
   {"CU_EXTERNAL_MEMORY_HANDLE_TYPE_D3D11_RESOURCE_KMT",                {"hipExternalMemoryHandleTypeD3D11ResourceKmt",              "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES}}, // 7
   // cudaExternalMemoryHandleTypeNvSciBuf
   {"CU_EXTERNAL_MEMORY_HANDLE_TYPE_NVSCIBUF",                          {"hipExternalMemoryHandleTypeNvSciBuf",                      "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED}}, // 8
+  //
+  {"CU_EXTERNAL_MEMORY_HANDLE_TYPE_DMABUF_FD",                         {"hipExternalMemoryHandleTypeDmaBufFd",                      "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED}}, // 9
 
   // cudaExternalSemaphoreHandleType
   {"CUexternalSemaphoreHandleType",                                    {"hipExternalSemaphoreHandleType",                           "", CONV_TYPE, API_DRIVER, SEC::DATA_TYPES}},
@@ -2247,6 +2254,8 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_TYPE_NAME_MAP {
   // CUmemLocationType enum values
   // cudaMemLocationTypeInvalid
   {"CU_MEM_LOCATION_TYPE_INVALID",                                     {"hipMemLocationTypeInvalid",                                "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES}}, // 0x0
+  //
+  {"CU_MEM_LOCATION_TYPE_NONE",                                        {"hipMemLocationTypeInvalid",                                "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES}}, // 0x0
   // cudaMemLocationTypeDevice
   {"CU_MEM_LOCATION_TYPE_DEVICE",                                      {"hipMemLocationTypeDevice",                                 "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES}}, // 0x1
   // cudaMemLocationTypeHost
@@ -2266,6 +2275,8 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_TYPE_NAME_MAP {
   {"CU_MEM_ALLOCATION_TYPE_INVALID",                                   {"hipMemAllocationTypeInvalid",                              "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES}}, // 0x0
   // cudaMemAllocationTypePinned
   {"CU_MEM_ALLOCATION_TYPE_PINNED",                                    {"hipMemAllocationTypePinned",                               "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES}}, // 0x1
+  //
+  {"CU_MEM_ALLOCATION_TYPE_MANAGED",                                   {"hipMemAllocationTypeManaged",                              "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED}}, // 0x2
   // cudaMemAllocationTypeMax
   {"CU_MEM_ALLOCATION_TYPE_MAX",                                       {"hipMemAllocationTypeMax",                                  "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES}}, // 0x7FFFFFFF
 
@@ -3063,6 +3074,26 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_TYPE_NAME_MAP {
   {"CU_ATOMIC_OPERATION_FLOAT_MAX",                                    {"HIP_ATOMIC_OPERATION_FLOAT_MAX",                           "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
   //
   {"CU_ATOMIC_OPERATION_MAX",                                          {"HIP_ATOMIC_OPERATION_MAX",                                 "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
+
+  //
+  {"CUatomicOperationCapability",                                      {"hipAtomicOperationCapability",                             "", CONV_TYPE, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
+  //
+  {"CUatomicOperationCapability_enum",                                 {"hipAtomicOperationCapability",                             "", CONV_TYPE, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
+  // CUatomicOperationCapability enum values
+  //
+  {"CU_ATOMIC_CAPABILITY_SIGNED",                                      {"HIP_ATOMIC_CAPABILITY_SIGNED",                             "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
+  //
+  {"CU_ATOMIC_CAPABILITY_UNSIGNED",                                    {"HIP_ATOMIC_CAPABILITY_UNSIGNED",                           "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
+  //
+  {"CU_ATOMIC_CAPABILITY_REDUCTION",                                   {"HIP_ATOMIC_CAPABILITY_REDUCTION",                          "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
+  //
+  {"CU_ATOMIC_CAPABILITY_SCALAR_32",                                   {"HIP_ATOMIC_CAPABILITY_SCALAR_32",                          "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
+  //
+  {"CU_ATOMIC_CAPABILITY_SCALAR_64",                                   {"HIP_ATOMIC_CAPABILITY_SCALAR_64",                          "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
+  //
+  {"CU_ATOMIC_CAPABILITY_SCALAR_128",                                  {"HIP_ATOMIC_CAPABILITY_SCALAR_128",                         "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
+  //
+  {"CU_ATOMIC_CAPABILITY_VECTOR_32x4",                                 {"HIP_ATOMIC_CAPABILITY_VECTOR_32x4",                        "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
 
   // 4. Typedefs
 
@@ -4346,6 +4377,20 @@ const std::map<llvm::StringRef, cudaAPIversions> CUDA_DRIVER_TYPE_NAME_VER_MAP {
   {"CU_ATOMIC_OPERATION_FLOAT_MIN",                                    {CUDA_130, CUDA_0,   CUDA_0  }},
   {"CU_ATOMIC_OPERATION_FLOAT_MAX",                                    {CUDA_130, CUDA_0,   CUDA_0  }},
   {"CU_ATOMIC_OPERATION_MAX",                                          {CUDA_130, CUDA_0,   CUDA_0  }},
+  {"CUatomicOperationCapability",                                      {CUDA_130, CUDA_0,   CUDA_0  }},
+  {"CUatomicOperationCapability_enum",                                 {CUDA_130, CUDA_0,   CUDA_0  }},
+  {"CU_ATOMIC_CAPABILITY_SIGNED",                                      {CUDA_130, CUDA_0,   CUDA_0  }},
+  {"CU_ATOMIC_CAPABILITY_UNSIGNED",                                    {CUDA_130, CUDA_0,   CUDA_0  }},
+  {"CU_ATOMIC_CAPABILITY_REDUCTION",                                   {CUDA_130, CUDA_0,   CUDA_0  }},
+  {"CU_ATOMIC_CAPABILITY_SCALAR_32",                                   {CUDA_130, CUDA_0,   CUDA_0  }},
+  {"CU_ATOMIC_CAPABILITY_SCALAR_64",                                   {CUDA_130, CUDA_0,   CUDA_0  }},
+  {"CU_ATOMIC_CAPABILITY_SCALAR_128",                                  {CUDA_130, CUDA_0,   CUDA_0  }},
+  {"CU_ATOMIC_CAPABILITY_VECTOR_32x4",                                 {CUDA_130, CUDA_0,   CUDA_0  }},
+  {"CU_EXTERNAL_MEMORY_HANDLE_TYPE_DMABUF_FD",                         {CUDA_130, CUDA_0,   CUDA_0  }},
+  {"CU_MEM_LOCATION_TYPE_NONE",                                        {CUDA_130, CUDA_0,   CUDA_0  }},
+  {"CU_MEM_ALLOCATION_TYPE_MANAGED",                                   {CUDA_130, CUDA_0,   CUDA_0  }},
+  {"CUcheckpointGpuPair_st",                                           {CUDA_130, CUDA_0,   CUDA_0  }},
+  {"CUcheckpointGpuPair",                                              {CUDA_130, CUDA_0,   CUDA_0  }},
 };
 
 const std::map<llvm::StringRef, hipAPIversions> HIP_DRIVER_TYPE_NAME_VER_MAP {


### PR DESCRIPTION
+ Updated the regenerated `hipify-perl`, and `Driver` `CUDA2HIP` docs accordingly
