### PR TITLE
[HIPIFY][CUDA 13] CUDA 13.0.0 support - Step 4 - Driver - Functions

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -4233,8 +4233,6 @@ sub simpleSubstitutions {
     subst("cudaSetDevice", "hipSetDevice", "device");
     subst("cudaSetDeviceFlags", "hipSetDeviceFlags", "device");
     subst("cudaSetValidDevices", "hipSetValidDevices", "device");
-    subst("cuCtxCreate", "hipCtxCreate", "context");
-    subst("cuCtxCreate_v2", "hipCtxCreate", "context");
     subst("cuCtxDestroy", "hipCtxDestroy", "context");
     subst("cuCtxDestroy_v2", "hipCtxDestroy", "context");
     subst("cuCtxGetApiVersion", "hipCtxGetApiVersion", "context");
@@ -4578,7 +4576,6 @@ sub simpleSubstitutions {
     subst("cuGraphAddMemFreeNode", "hipDrvGraphAddMemFreeNode", "graph");
     subst("cuGraphAddMemcpyNode", "hipDrvGraphAddMemcpyNode", "graph");
     subst("cuGraphAddMemsetNode", "hipDrvGraphAddMemsetNode", "graph");
-    subst("cuGraphAddNode", "hipGraphAddNode", "graph");
     subst("cuGraphBatchMemOpNodeGetParams", "hipGraphBatchMemOpNodeGetParams", "graph");
     subst("cuGraphBatchMemOpNodeSetParams", "hipGraphBatchMemOpNodeSetParams", "graph");
     subst("cuGraphChildGraphNodeGetGraph", "hipGraphChildGraphNodeGetGraph", "graph");
@@ -12037,7 +12034,10 @@ sub warnRemovedFunctions {
     "cuMemcpy3DPeer",
     "cuMemcpy3DBatchAsync",
     "cuMemcpy",
+    "cuMemSetMemPool",
     "cuMemPrefetchAsync_v2",
+    "cuMemGetMemPool",
+    "cuMemGetDefaultMemPool",
     "cuMemBatchDecompressAsync",
     "cuMemAdvise_v2",
     "cuLogsUnregisterCallback",
@@ -12087,6 +12087,7 @@ sub warnRemovedFunctions {
     "cuGraphGetEdges_v2",
     "cuGraphConditionalHandleCreate",
     "cuGraphAddNode_v2",
+    "cuGraphAddNode",
     "cuGraphAddDependencies_v2",
     "cuGLUnregisterBufferObject",
     "cuGLUnmapBufferObjectAsync",
@@ -12125,6 +12126,7 @@ sub warnRemovedFunctions {
     "cuDeviceGetProperties",
     "cuDeviceGetNvSciSyncAttributes",
     "cuDeviceGetLuid",
+    "cuDeviceGetHostAtomicCapabilities",
     "cuDeviceGetExecAffinitySupport",
     "cuDeviceGetDevResource",
     "cuDevSmResourceSplitByCount",
@@ -12165,15 +12167,19 @@ sub warnRemovedFunctions {
     "cuD3D10CtxCreateOnDevice",
     "cuD3D10CtxCreate",
     "cuCtxWaitEvent",
+    "cuCtxSynchronize_v2",
     "cuCtxSetFlags",
     "cuCtxResetPersistingL2Cache",
     "cuCtxGetId",
     "cuCtxGetExecAffinity",
+    "cuCtxGetDevice_v2",
     "cuCtxGetDevResource",
     "cuCtxFromGreenCtx",
     "cuCtxDetach",
     "cuCtxCreate_v4",
     "cuCtxCreate_v3",
+    "cuCtxCreate_v2",
+    "cuCtxCreate",
     "cuCtxAttach",
     "cuCoredumpSetAttributeGlobal",
     "cuCoredumpSetAttribute",

--- a/docs/reference/tables/CUDA_Driver_API_functions_supported_by_HIP.md
+++ b/docs/reference/tables/CUDA_Driver_API_functions_supported_by_HIP.md
@@ -1641,6 +1641,7 @@
 |`cuDeviceGetCount`| | | | |`hipGetDeviceCount`|1.6.0| | | | |
 |`cuDeviceGetDefaultMemPool`|11.2| | | |`hipDeviceGetDefaultMemPool`|5.2.0| | | | |
 |`cuDeviceGetExecAffinitySupport`|11.4| | | | | | | | | |
+|`cuDeviceGetHostAtomicCapabilities`|13.0| | | | | | | | | |
 |`cuDeviceGetLuid`|10.0| | | | | | | | | |
 |`cuDeviceGetMemPool`|11.2| | | |`hipDeviceGetMemPool`|5.2.0| | | | |
 |`cuDeviceGetName`| | | | |`hipDeviceGetName`|1.6.0| | | | |
@@ -1677,8 +1678,8 @@
 
 |**CUDA**|**A**|**D**|**C**|**R**|**HIP**|**A**|**D**|**C**|**R**|**E**|
 |:--|:-:|:-:|:-:|:-:|:--|:-:|:-:|:-:|:-:|:-:|
-|`cuCtxCreate`| | | | |`hipCtxCreate`|1.6.0|1.9.0| | | |
-|`cuCtxCreate_v2`| | | | |`hipCtxCreate`|1.6.0|1.9.0| | | |
+|`cuCtxCreate`| | |13.0| | | | | | | |
+|`cuCtxCreate_v2`| | | | | | | | | | |
 |`cuCtxCreate_v3`|11.4| | | | | | | | | |
 |`cuCtxCreate_v4`|12.5| | | | | | | | | |
 |`cuCtxDestroy`| | | | |`hipCtxDestroy`|1.6.0|1.9.0| | | |
@@ -1687,6 +1688,7 @@
 |`cuCtxGetCacheConfig`| | | | |`hipCtxGetCacheConfig`|1.9.0|1.9.0| | | |
 |`cuCtxGetCurrent`| | | | |`hipCtxGetCurrent`|1.6.0|1.9.0| | | |
 |`cuCtxGetDevice`| | | | |`hipCtxGetDevice`|1.6.0|1.9.0| | | |
+|`cuCtxGetDevice_v2`|13.0| | | | | | | | | |
 |`cuCtxGetExecAffinity`|11.4| | | | | | | | | |
 |`cuCtxGetFlags`| | | | |`hipCtxGetFlags`|1.9.0|1.9.0| | | |
 |`cuCtxGetId`|12.0| | | | | | | | | |
@@ -1704,6 +1706,7 @@
 |`cuCtxSetLimit`| | | | |`hipDeviceSetLimit`|5.3.0| | | | |
 |`cuCtxSetSharedMemConfig`| | | |12.4|`hipCtxSetSharedMemConfig`|1.9.0|1.9.0| | | |
 |`cuCtxSynchronize`| | | | |`hipCtxSynchronize`|1.9.0|1.9.0| | | |
+|`cuCtxSynchronize_v2`|13.0| | | | | | | | | |
 |`cuCtxWaitEvent`|12.5| | | | | | | | | |
 
 ## **9. Context Management [DEPRECATED]**
@@ -1824,7 +1827,7 @@
 |`cuMemcpy3D`| | | | |`hipDrvMemcpy3D`|3.5.0| | | | |
 |`cuMemcpy3DAsync`| | | | |`hipDrvMemcpy3DAsync`|3.5.0| | | | |
 |`cuMemcpy3DAsync_v2`| | | | |`hipDrvMemcpy3DAsync`|3.5.0| | | | |
-|`cuMemcpy3DBatchAsync`|12.8| | | | | | | | | |
+|`cuMemcpy3DBatchAsync`|12.8| |13.0| | | | | | | |
 |`cuMemcpy3DPeer`| | | | | | | | | | |
 |`cuMemcpy3DPeerAsync`| | | | | | | | | | |
 |`cuMemcpy3D_v2`| | | | |`hipDrvMemcpy3D`|3.5.0| | | | |
@@ -1837,7 +1840,7 @@
 |`cuMemcpyAtoHAsync`| | | | |`hipMemcpyAtoHAsync`|6.2.0| | | | |
 |`cuMemcpyAtoHAsync_v2`| | | | |`hipMemcpyAtoHAsync`|6.2.0| | | | |
 |`cuMemcpyAtoH_v2`| | | | |`hipMemcpyAtoH`|1.9.0| | | | |
-|`cuMemcpyBatchAsync`|12.8| | | | | | | | | |
+|`cuMemcpyBatchAsync`|12.8| |13.0| | | | | | | |
 |`cuMemcpyDtoA`| | | | |`hipMemcpyDtoA`|6.2.0| | | | |
 |`cuMemcpyDtoA_v2`| | | | |`hipMemcpyDtoA`|6.2.0| | | | |
 |`cuMemcpyDtoD`| | | | |`hipMemcpyDtoD`|1.6.0| | | | |
@@ -1907,6 +1910,8 @@
 |`cuMemAllocAsync`|11.2| | | |`hipMallocAsync`|5.2.0| | | | |
 |`cuMemAllocFromPoolAsync`|11.2| | | |`hipMallocFromPoolAsync`|5.2.0| | | | |
 |`cuMemFreeAsync`|11.2| | | |`hipFreeAsync`|5.2.0| | | | |
+|`cuMemGetDefaultMemPool`|13.0| | | | | | | | | |
+|`cuMemGetMemPool`|13.0| | | | | | | | | |
 |`cuMemPoolCreate`|11.2| | | |`hipMemPoolCreate`|5.2.0| | | | |
 |`cuMemPoolDestroy`|11.2| | | |`hipMemPoolDestroy`|5.2.0| | | | |
 |`cuMemPoolExportPointer`|11.2| | | |`hipMemPoolExportPointer`|5.2.0| | | | |
@@ -1918,6 +1923,7 @@
 |`cuMemPoolSetAccess`|11.2| | | |`hipMemPoolSetAccess`|5.2.0| | | | |
 |`cuMemPoolSetAttribute`|11.2| | | |`hipMemPoolSetAttribute`|5.2.0| | | | |
 |`cuMemPoolTrimTo`|11.2| | | |`hipMemPoolTrimTo`|5.2.0| | | | |
+|`cuMemSetMemPool`|13.0| | | | | | | | | |
 
 ## **16. Multicast Object Management**
 
@@ -2077,7 +2083,7 @@
 |`cuGraphAddMemFreeNode`|11.4| | | |`hipDrvGraphAddMemFreeNode`|6.3.0| | | | |
 |`cuGraphAddMemcpyNode`|10.0| | | |`hipDrvGraphAddMemcpyNode`|6.0.0| | | | |
 |`cuGraphAddMemsetNode`|10.0| | | |`hipDrvGraphAddMemsetNode`|6.1.0| |7.0.0| | |
-|`cuGraphAddNode`|12.2| | | |`hipGraphAddNode`|6.2.0| | | | |
+|`cuGraphAddNode`|12.2| |13.0| | | | | | | |
 |`cuGraphAddNode_v2`|12.3| | | | | | | | | |
 |`cuGraphBatchMemOpNodeGetParams`|11.7| | | |`hipGraphBatchMemOpNodeGetParams`|6.4.0| | | | |
 |`cuGraphBatchMemOpNodeSetParams`|11.7| | | |`hipGraphBatchMemOpNodeSetParams`|6.4.0| | | | |

--- a/src/CUDA2HIP_Driver_API_functions.cpp
+++ b/src/CUDA2HIP_Driver_API_functions.cpp
@@ -75,6 +75,8 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_FUNCTION_MAP {
   {"cuDeviceGetExecAffinitySupport",                              {"hipDeviceGetExecAffinitySupport",                             "", CONV_DEVICE, API_DRIVER, SEC::DEVICE, HIP_UNSUPPORTED}},
   // cudaDeviceFlushGPUDirectRDMAWrites
   {"cuFlushGPUDirectRDMAWrites",                                  {"hipDeviceFlushGPUDirectRDMAWrites",                           "", CONV_DEVICE, API_DRIVER, SEC::DEVICE, HIP_UNSUPPORTED}},
+  //
+  {"cuDeviceGetHostAtomicCapabilities",                           {"hipDeviceGetHostAtomicCapabilities",                          "", CONV_DEVICE, API_DRIVER, SEC::DEVICE, HIP_UNSUPPORTED}},
 
   // 6. Device Management [DEPRECATED]
   //
@@ -95,10 +97,13 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_FUNCTION_MAP {
   {"cuDevicePrimaryCtxSetFlags_v2",                               {"hipDevicePrimaryCtxSetFlags",                                 "", CONV_CONTEXT, API_DRIVER, SEC::PRIMARY_CONTEXT, HIP_DEPRECATED}},
 
   // 8. Context Management
-  // no analogues, except a few
-  {"cuCtxCreate",                                                 {"hipCtxCreate",                                                "", CONV_CONTEXT, API_DRIVER, SEC::CONTEXT, HIP_DEPRECATED}},
-  {"cuCtxCreate_v2",                                              {"hipCtxCreate",                                                "", CONV_CONTEXT, API_DRIVER, SEC::CONTEXT, HIP_DEPRECATED}},
+ 
+  // TODO: report unsupported only for CUDA >= 13000
+  {"cuCtxCreate",                                                 {"hipCtxCreate",                                                "", CONV_CONTEXT, API_DRIVER, SEC::CONTEXT, HIP_UNSUPPORTED | HIP_DEPRECATED}},
+  // TODO: report unsupported only for CUDA >= 13000
+  {"cuCtxCreate_v2",                                              {"hipCtxCreate",                                                "", CONV_CONTEXT, API_DRIVER, SEC::CONTEXT, HIP_UNSUPPORTED | HIP_DEPRECATED}},
   {"cuCtxCreate_v3",                                              {"hipCtxCreate_v3",                                             "", CONV_CONTEXT, API_DRIVER, SEC::CONTEXT, HIP_UNSUPPORTED}},
+  // NOTE: cuCtxCreate_v4 equals cuCtxCreate since CUDA 13.0.0
   {"cuCtxCreate_v4",                                              {"hipCtxCreate_v4",                                             "", CONV_CONTEXT, API_DRIVER, SEC::CONTEXT, HIP_UNSUPPORTED}},
   {"cuCtxDestroy",                                                {"hipCtxDestroy",                                               "", CONV_CONTEXT, API_DRIVER, SEC::CONTEXT, HIP_DEPRECATED}},
   {"cuCtxDestroy_v2",                                             {"hipCtxDestroy",                                               "", CONV_CONTEXT, API_DRIVER, SEC::CONTEXT, HIP_DEPRECATED}},
@@ -106,6 +111,7 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_FUNCTION_MAP {
   {"cuCtxGetCacheConfig",                                         {"hipCtxGetCacheConfig",                                        "", CONV_CONTEXT, API_DRIVER, SEC::CONTEXT, HIP_DEPRECATED}},
   {"cuCtxGetCurrent",                                             {"hipCtxGetCurrent",                                            "", CONV_CONTEXT, API_DRIVER, SEC::CONTEXT, HIP_DEPRECATED}},
   {"cuCtxGetDevice",                                              {"hipCtxGetDevice",                                             "", CONV_CONTEXT, API_DRIVER, SEC::CONTEXT, HIP_DEPRECATED}},
+  {"cuCtxGetDevice_v2",                                           {"hipCtxGetDevice_v2",                                          "", CONV_CONTEXT, API_DRIVER, SEC::CONTEXT, HIP_UNSUPPORTED}},
   // cudaGetDeviceFlags
   // TODO: rename to hipGetDeviceFlags
   {"cuCtxGetFlags",                                               {"hipCtxGetFlags",                                              "", CONV_CONTEXT, API_DRIVER, SEC::CONTEXT, HIP_DEPRECATED}},
@@ -133,6 +139,8 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_FUNCTION_MAP {
   // cudaDeviceSynchronize
   // TODO: rename to hipDeviceSynchronize
   {"cuCtxSynchronize",                                            {"hipCtxSynchronize",                                           "", CONV_CONTEXT, API_DRIVER, SEC::CONTEXT, HIP_DEPRECATED}},
+  //
+  {"cuCtxSynchronize_v2",                                         {"hipCtxSynchronize_v2",                                        "", CONV_CONTEXT, API_DRIVER, SEC::CONTEXT, HIP_UNSUPPORTED}},
   //
   {"cuCtxGetExecAffinity",                                        {"hipCtxGetExecAffinity",                                       "", CONV_CONTEXT, API_DRIVER, SEC::CONTEXT, HIP_UNSUPPORTED}},
   //
@@ -443,6 +451,12 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_FUNCTION_MAP {
   {"cuMemPoolExportPointer",                                      {"hipMemPoolExportPointer",                                     "", CONV_ORDERED_MEMORY, API_DRIVER, SEC::ORDERED_MEMORY}},
   // cudaMemPoolImportPointer
   {"cuMemPoolImportPointer",                                      {"hipMemPoolImportPointer",                                     "", CONV_ORDERED_MEMORY, API_DRIVER, SEC::ORDERED_MEMORY}},
+  //
+  {"cuMemGetDefaultMemPool",                                      {"hipMemGetDefaultMemPool",                                     "", CONV_ORDERED_MEMORY, API_DRIVER, SEC::ORDERED_MEMORY, HIP_UNSUPPORTED}},
+  //
+  {"cuMemGetMemPool",                                             {"hipMemGetMemPool",                                            "", CONV_ORDERED_MEMORY, API_DRIVER, SEC::ORDERED_MEMORY, HIP_UNSUPPORTED}},
+  //
+  {"cuMemSetMemPool",                                             {"hipMemSetMemPool",                                            "", CONV_ORDERED_MEMORY, API_DRIVER, SEC::ORDERED_MEMORY, HIP_UNSUPPORTED}},
 
   // 16. Multicast Object Management
   //
@@ -841,8 +855,10 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_FUNCTION_MAP {
   // cudaGraphExecGetFlags
   {"cuGraphExecGetFlags",                                         {"hipGraphExecGetFlags",                                        "", CONV_GRAPH, API_DRIVER, SEC::GRAPH}},
   // cudaGraphAddNode
-  {"cuGraphAddNode",                                              {"hipGraphAddNode",                                             "", CONV_GRAPH, API_DRIVER, SEC::GRAPH}},
+  // TODO: report unsupported only for CUDA >= 13000
+  {"cuGraphAddNode",                                              {"hipGraphAddNode",                                             "", CONV_GRAPH, API_DRIVER, SEC::GRAPH, HIP_UNSUPPORTED}},
   // cudaGraphAddNode_v2
+  // NOTE: cuGraphAddNode_v2 equals cuGraphAddNode since CUDA 13.0.0
   {"cuGraphAddNode_v2",                                           {"hipGraphAddNode_v2",                                          "", CONV_GRAPH, API_DRIVER, SEC::GRAPH, HIP_UNSUPPORTED}},
   // cudaGraphNodeSetParams
   {"cuGraphNodeSetParams",                                        {"hipGraphNodeSetParams",                                       "", CONV_GRAPH, API_DRIVER, SEC::GRAPH}},
@@ -1568,6 +1584,12 @@ const std::map<llvm::StringRef, cudaAPIversions> CUDA_DRIVER_FUNCTION_VER_MAP {
   {"cuLogsCurrent",                                               {CUDA_129, CUDA_0,   CUDA_0  }},
   {"cuLogsDumpToFile",                                            {CUDA_129, CUDA_0,   CUDA_0  }},
   {"cuLogsDumpToMemory",                                          {CUDA_129, CUDA_0,   CUDA_0  }},
+  {"cuDeviceGetHostAtomicCapabilities",                           {CUDA_130, CUDA_0,   CUDA_0  }},
+  {"cuCtxGetDevice_v2",                                           {CUDA_130, CUDA_0,   CUDA_0  }},
+  {"cuCtxSynchronize_v2",                                         {CUDA_130, CUDA_0,   CUDA_0  }},
+  {"cuMemGetDefaultMemPool",                                      {CUDA_130, CUDA_0,   CUDA_0  }},
+  {"cuMemGetMemPool",                                             {CUDA_130, CUDA_0,   CUDA_0  }},
+  {"cuMemSetMemPool",                                             {CUDA_130, CUDA_0,   CUDA_0  }},
 };
 
 const std::map<llvm::StringRef, hipAPIversions> HIP_DRIVER_FUNCTION_VER_MAP {
@@ -1742,6 +1764,10 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_DRIVER_FUNCTION_VER_MAP {
 
 const std::map<llvm::StringRef, cudaAPIChangedVersions> CUDA_DRIVER_FUNCTION_CHANGED_VER_MAP {
   {"cuGetProcAddress",                                            {CUDA_120}},
+  {"cuGraphAddNode",                                              {CUDA_130}},
+  {"cuCtxCreate",                                                 {CUDA_130}},
+  {"cuMemcpyBatchAsync",                                          {CUDA_130}},
+  {"cuMemcpy3DBatchAsync",                                        {CUDA_130}},
 };
 
 const std::map<llvm::StringRef, hipAPIChangedVersions> HIP_DRIVER_FUNCTION_CHANGED_VER_MAP {

--- a/tests/unit_tests/synthetic/driver_functions.cu
+++ b/tests/unit_tests/synthetic/driver_functions.cu
@@ -190,12 +190,14 @@ int main() {
   // CHECK: result = hipDevicePrimaryCtxSetFlags(device, flags);
   result = cuDevicePrimaryCtxSetFlags(device, flags);
 
+#if CUDA_VERSION < 13000
   // CUDA: CUresult CUDAAPI cuCtxCreate(CUcontext *pctx, unsigned int flags, CUdevice dev);
   // HIP: DEPRECATED(DEPRECATED_MSG) hipError_t hipCtxCreate(hipCtx_t *ctx, unsigned int flags, hipDevice_t device);
   // CHECK: result = hipCtxCreate(&context, flags, device);
   // CHECK-NEXT: result = hipCtxCreate(&context, flags, device);
   result = cuCtxCreate(&context, flags, device);
   result = cuCtxCreate_v2(&context, flags, device);
+#endif
 
   // CUDA: CUresult CUDAAPI cuCtxDestroy(CUcontext ctx);
   // HIP: DEPRECATED(DEPRECATED_MSG) hipError_t hipCtxDestroy(hipCtx_t ctx);
@@ -1850,11 +1852,19 @@ int main() {
   // HIP: hipError_t hipGraphMemFreeNodeGetParams(hipGraphNode_t node, void* dev_ptr);
   // CHECK: result = hipGraphMemFreeNodeGetParams(graphNode, &deviceptr);
   result = cuGraphMemFreeNodeGetParams(graphNode, &deviceptr);
-#endif
 
-#if CUDA_VERSION >= 11040 && CUDA_VERSION < 12020
+#if CUDA_VERSION < 12020
   // CHECK: hipMemAllocNodeParams MEM_ALLOC_NODE_PARAMS_st;
   CUDA_MEM_ALLOC_NODE_PARAMS_st MEM_ALLOC_NODE_PARAMS_st;
+#endif
+
+#if CUDA_VERSION < 13000
+  // CUDA: CUresult CUDAAPI cuDeviceGetUuid_v2(CUuuid *uuid, CUdevice dev);
+  // HIP: hipError_t hipDeviceGetUuid(hipUUID* uuid, hipDevice_t device);
+  // CHECK: result = hipDeviceGetUuid(&uuid, device);
+  result = cuDeviceGetUuid_v2(&uuid, device);
+#endif
+
 #endif
 
 #if CUDA_VERSION >= 11060
@@ -1994,10 +2004,12 @@ int main() {
   // CHECK: hipGraphNodeParams graphNodeParams;
   CUgraphNodeParams graphNodeParams;
 
+#if CUDA_VERSION < 13000
   // CUDA: CUresult CUDAAPI cuGraphAddNode(CUgraphNode *phGraphNode, CUgraph hGraph, const CUgraphNode *dependencies, size_t numDependencies, CUgraphNodeParams *nodeParams);
   // HIP: hipError_t hipGraphAddNode(hipGraphNode_t *pGraphNode, hipGraph_t graph, const hipGraphNode_t *pDependencies, size_t numDependencies, hipGraphNodeParams *nodeParams);
   // CHECK: result = hipGraphAddNode(&graphNode, graph, &graphNode2, bytes, &graphNodeParams);
   result = cuGraphAddNode(&graphNode, graph, &graphNode2, bytes, &graphNodeParams);
+#endif
 
   // CUDA: CUresult CUDAAPI cuGraphNodeSetParams(CUgraphNode hNode, CUgraphNodeParams *nodeParams);
   // HIP: hipError_t hipGraphNodeSetParams(hipGraphNode_t node, hipGraphNodeParams *nodeParams);


### PR DESCRIPTION
+ Updated synthetic tests, the regenerated `hipify-perl`, and `Driver` `CUDA2HIP` docs accordingly

[IMP]
+ `cuCtxCreate` and `cuGraphAddNode` changed their ABI, hence not supported by HIP anymore