### PR TITLE
[HIPIFY][CUDA 13] CUDA 13.0.0 support - Step 5 - Driver - Functions - Unified Addressing

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -4457,8 +4457,6 @@ sub simpleSubstitutions {
     subst("cuMemPoolSetAccess", "hipMemPoolSetAccess", "ordered_memory");
     subst("cuMemPoolSetAttribute", "hipMemPoolSetAttribute", "ordered_memory");
     subst("cuMemPoolTrimTo", "hipMemPoolTrimTo", "ordered_memory");
-    subst("cuMemAdvise", "hipMemAdvise", "unified");
-    subst("cuMemPrefetchAsync", "hipMemPrefetchAsync", "unified");
     subst("cuMemRangeGetAttribute", "hipMemRangeGetAttribute", "unified");
     subst("cuMemRangeGetAttributes", "hipMemRangeGetAttributes", "unified");
     subst("cuPointerGetAttribute", "hipPointerGetAttribute", "unified");
@@ -12035,11 +12033,16 @@ sub warnRemovedFunctions {
     "cuMemcpy3DBatchAsync",
     "cuMemcpy",
     "cuMemSetMemPool",
+    "cuMemPrefetchBatchAsync",
     "cuMemPrefetchAsync_v2",
+    "cuMemPrefetchAsync",
     "cuMemGetMemPool",
     "cuMemGetDefaultMemPool",
+    "cuMemDiscardBatchAsync",
+    "cuMemDiscardAndPrefetchBatchAsync",
     "cuMemBatchDecompressAsync",
     "cuMemAdvise_v2",
+    "cuMemAdvise",
     "cuLogsUnregisterCallback",
     "cuLogsRegisterCallback",
     "cuLogsDumpToMemory",

--- a/docs/reference/tables/CUDA_Driver_API_functions_supported_by_HIP.md
+++ b/docs/reference/tables/CUDA_Driver_API_functions_supported_by_HIP.md
@@ -1940,10 +1940,13 @@
 
 |**CUDA**|**A**|**D**|**C**|**R**|**HIP**|**A**|**D**|**C**|**R**|**E**|
 |:--|:-:|:-:|:-:|:-:|:--|:-:|:-:|:-:|:-:|:-:|
-|`cuMemAdvise`|8.0| | | |`hipMemAdvise`|3.7.0| | | | |
+|`cuMemAdvise`|8.0| |13.0| | | | | | | |
 |`cuMemAdvise_v2`|12.2| | | | | | | | | |
-|`cuMemPrefetchAsync`|8.0| | | |`hipMemPrefetchAsync`|3.7.0| | | | |
+|`cuMemDiscardAndPrefetchBatchAsync`|13.0| | | | | | | | | |
+|`cuMemDiscardBatchAsync`|13.0| | | | | | | | | |
+|`cuMemPrefetchAsync`|8.0| |13.0| | | | | | | |
 |`cuMemPrefetchAsync_v2`|12.2| | | | | | | | | |
+|`cuMemPrefetchBatchAsync`|13.0| | | | | | | | | |
 |`cuMemRangeGetAttribute`|8.0| | | |`hipMemRangeGetAttribute`|3.7.0| | | | |
 |`cuMemRangeGetAttributes`|8.0| | | |`hipMemRangeGetAttributes`|3.7.0| | | | |
 |`cuPointerGetAttribute`| | | | |`hipPointerGetAttribute`|5.0.0| | | | |

--- a/src/CUDA2HIP_Driver_API_functions.cpp
+++ b/src/CUDA2HIP_Driver_API_functions.cpp
@@ -474,12 +474,16 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_FUNCTION_MAP {
 
   // 17. Unified Addressing
   // cudaMemAdvise
-  {"cuMemAdvise",                                                 {"hipMemAdvise",                                                "", CONV_UNIFIED, API_DRIVER, SEC::UNIFIED}},
+  // TODO: report unsupported only for CUDA >= 13000
+  {"cuMemAdvise",                                                 {"hipMemAdvise",                                                "", CONV_UNIFIED, API_DRIVER, SEC::UNIFIED, HIP_UNSUPPORTED}},
   // cudaMemAdvise_v2
+  // TODO: report unsupported only for CUDA >= 13000
   {"cuMemAdvise_v2",                                              {"hipMemAdvise_v2",                                             "", CONV_UNIFIED, API_DRIVER, SEC::UNIFIED, HIP_UNSUPPORTED}},
   // cudaMemPrefetchAsync
-  {"cuMemPrefetchAsync",                                          {"hipMemPrefetchAsync",                                         "", CONV_UNIFIED, API_DRIVER, SEC::UNIFIED}},
+  // TODO: report unsupported only for CUDA >= 13000
+  {"cuMemPrefetchAsync",                                          {"hipMemPrefetchAsync",                                         "", CONV_UNIFIED, API_DRIVER, SEC::UNIFIED, HIP_UNSUPPORTED}},
   // cudaMemPrefetchAsync_v2
+  // TODO: report unsupported only for CUDA >= 13000
   {"cuMemPrefetchAsync_v2",                                       {"hipMemPrefetchAsync_v2",                                      "", CONV_UNIFIED, API_DRIVER, SEC::UNIFIED, HIP_UNSUPPORTED}},
   // cudaMemRangeGetAttribute
   {"cuMemRangeGetAttribute",                                      {"hipMemRangeGetAttribute",                                     "", CONV_UNIFIED, API_DRIVER, SEC::UNIFIED}},
@@ -492,6 +496,12 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_FUNCTION_MAP {
   {"cuPointerGetAttributes",                                      {"hipDrvPointerGetAttributes",                                  "", CONV_UNIFIED, API_DRIVER, SEC::UNIFIED}},
   // no analogue
   {"cuPointerSetAttribute",                                       {"hipPointerSetAttribute",                                      "", CONV_UNIFIED, API_DRIVER, SEC::UNIFIED}},
+  //
+  {"cuMemPrefetchBatchAsync",                                     {"hipMemPrefetchBatchAsync",                                    "", CONV_UNIFIED, API_DRIVER, SEC::UNIFIED, HIP_UNSUPPORTED}},
+  //
+  {"cuMemDiscardBatchAsync",                                      {"hipMemDiscardBatchAsync",                                     "", CONV_UNIFIED, API_DRIVER, SEC::UNIFIED, HIP_UNSUPPORTED}},
+  //
+  {"cuMemDiscardAndPrefetchBatchAsync",                           {"hipMemDiscardAndPrefetchBatchAsync",                          "", CONV_UNIFIED, API_DRIVER, SEC::UNIFIED, HIP_UNSUPPORTED}},
 
   // 18. Stream Management
   // cudaStreamAddCallback
@@ -1590,6 +1600,9 @@ const std::map<llvm::StringRef, cudaAPIversions> CUDA_DRIVER_FUNCTION_VER_MAP {
   {"cuMemGetDefaultMemPool",                                      {CUDA_130, CUDA_0,   CUDA_0  }},
   {"cuMemGetMemPool",                                             {CUDA_130, CUDA_0,   CUDA_0  }},
   {"cuMemSetMemPool",                                             {CUDA_130, CUDA_0,   CUDA_0  }},
+  {"cuMemPrefetchBatchAsync",                                     {CUDA_130, CUDA_0,   CUDA_0  }},
+  {"cuMemDiscardBatchAsync",                                      {CUDA_130, CUDA_0,   CUDA_0  }},
+  {"cuMemDiscardAndPrefetchBatchAsync",                           {CUDA_130, CUDA_0,   CUDA_0  }},
 };
 
 const std::map<llvm::StringRef, hipAPIversions> HIP_DRIVER_FUNCTION_VER_MAP {
@@ -1768,6 +1781,8 @@ const std::map<llvm::StringRef, cudaAPIChangedVersions> CUDA_DRIVER_FUNCTION_CHA
   {"cuCtxCreate",                                                 {CUDA_130}},
   {"cuMemcpyBatchAsync",                                          {CUDA_130}},
   {"cuMemcpy3DBatchAsync",                                        {CUDA_130}},
+  {"cuMemPrefetchAsync",                                          {CUDA_130}},
+  {"cuMemAdvise",                                                 {CUDA_130}},
 };
 
 const std::map<llvm::StringRef, hipAPIChangedVersions> HIP_DRIVER_FUNCTION_CHANGED_VER_MAP {

--- a/tests/unit_tests/synthetic/driver_functions.cu
+++ b/tests/unit_tests/synthetic/driver_functions.cu
@@ -1039,6 +1039,7 @@ int main() {
   CUmem_range_attribute MemoryRangeAttribute;
   CUmem_advise MemoryAdvise;
 
+#if CUDA_VERSION < 13000
   // CUDA: CUresult CUDAAPI cuMemAdvise(CUdeviceptr devPtr, size_t count, CUmem_advise advice, CUdevice device);
   // HIP: hipError_t hipMemAdvise(const void* dev_ptr, size_t count, hipMemoryAdvise advice, int device);
   // CHECK: result = hipMemAdvise(deviceptr, bytes, MemoryAdvise, device);
@@ -1048,6 +1049,7 @@ int main() {
   // HIP: hipError_t hipMemPrefetchAsync(const void* dev_ptr, size_t count, int device, hipStream_t stream __dparm(0));
   // CHECK: result = hipMemPrefetchAsync(deviceptr, bytes, device, stream);
   result = cuMemPrefetchAsync(deviceptr, bytes, device, stream);
+#endif
 
   // CUDA: CUresult CUDAAPI cuMemRangeGetAttribute(void *data, size_t dataSize, CUmem_range_attribute attribute, CUdeviceptr devPtr, size_t count);
   // HIP: hipError_t hipMemRangeGetAttribute(void* data, size_t data_size, hipMemRangeAttribute attribute, const void* dev_ptr, size_t count);


### PR DESCRIPTION
+ Updated synthetic tests, the regenerated `hipify-perl`, and `Driver` `CUDA2HIP` docs accordingly

[IMP]
+ `cuMemAdvise` and `cuMemPrefetchAsync` changed their ABI, hence not supported by HIP anymore