### PR TITLE
[HIPIFY][CUDA 13] CUDA 13.0.0 support - Step 6 - Driver - Functions - Streams, Graphs

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -4473,14 +4473,12 @@ sub simpleSubstitutions {
     subst("cuStreamDestroy", "hipStreamDestroy", "stream");
     subst("cuStreamDestroy_v2", "hipStreamDestroy", "stream");
     subst("cuStreamEndCapture", "hipStreamEndCapture", "stream");
-    subst("cuStreamGetCaptureInfo", "hipStreamGetCaptureInfo", "stream");
     subst("cuStreamGetCaptureInfo_v2", "hipStreamGetCaptureInfo_v2", "stream");
     subst("cuStreamGetFlags", "hipStreamGetFlags", "stream");
     subst("cuStreamGetPriority", "hipStreamGetPriority", "stream");
     subst("cuStreamIsCapturing", "hipStreamIsCapturing", "stream");
     subst("cuStreamQuery", "hipStreamQuery", "stream");
     subst("cuStreamSynchronize", "hipStreamSynchronize", "stream");
-    subst("cuStreamUpdateCaptureDependencies", "hipStreamUpdateCaptureDependencies", "stream");
     subst("cuStreamWaitEvent", "hipStreamWaitEvent", "stream");
     subst("cuThreadExchangeStreamCaptureMode", "hipThreadExchangeStreamCaptureMode", "stream");
     subst("cudaStreamAddCallback", "hipStreamAddCallback", "stream");
@@ -4505,6 +4503,7 @@ sub simpleSubstitutions {
     subst("cuEventDestroy", "hipEventDestroy", "event");
     subst("cuEventDestroy_v2", "hipEventDestroy", "event");
     subst("cuEventElapsedTime", "hipEventElapsedTime", "event");
+    subst("cuEventElapsedTime_v2", "hipEventElapsedTime", "event");
     subst("cuEventQuery", "hipEventQuery", "event");
     subst("cuEventRecord", "hipEventRecord", "event");
     subst("cuEventRecordWithFlags", "hipEventRecordWithFlags", "event");
@@ -4604,7 +4603,6 @@ sub simpleSubstitutions {
     subst("cuGraphExternalSemaphoresSignalNodeSetParams", "hipGraphExternalSemaphoresSignalNodeSetParams", "graph");
     subst("cuGraphExternalSemaphoresWaitNodeGetParams", "hipGraphExternalSemaphoresWaitNodeGetParams", "graph");
     subst("cuGraphExternalSemaphoresWaitNodeSetParams", "hipGraphExternalSemaphoresWaitNodeSetParams", "graph");
-    subst("cuGraphGetEdges", "hipGraphGetEdges", "graph");
     subst("cuGraphGetNodes", "hipGraphGetNodes", "graph");
     subst("cuGraphGetRootNodes", "hipGraphGetRootNodes", "graph");
     subst("cuGraphHostNodeGetParams", "hipGraphHostNodeGetParams", "graph");
@@ -4626,8 +4624,6 @@ sub simpleSubstitutions {
     subst("cuGraphMemsetNodeGetParams", "hipGraphMemsetNodeGetParams", "graph");
     subst("cuGraphMemsetNodeSetParams", "hipGraphMemsetNodeSetParams", "graph");
     subst("cuGraphNodeFindInClone", "hipGraphNodeFindInClone", "graph");
-    subst("cuGraphNodeGetDependencies", "hipGraphNodeGetDependencies", "graph");
-    subst("cuGraphNodeGetDependentNodes", "hipGraphNodeGetDependentNodes", "graph");
     subst("cuGraphNodeGetEnabled", "hipGraphNodeGetEnabled", "graph");
     subst("cuGraphNodeGetType", "hipGraphNodeGetType", "graph");
     subst("cuGraphNodeSetEnabled", "hipGraphNodeSetEnabled", "graph");
@@ -11984,6 +11980,7 @@ sub warnRemovedFunctions {
     "cuSurfObjectDestroy",
     "cuSurfObjectCreate",
     "cuStreamUpdateCaptureDependencies_v2",
+    "cuStreamUpdateCaptureDependencies",
     "cuStreamSetAttribute",
     "cuStreamGetId",
     "cuStreamGetGreenCtx",
@@ -11991,6 +11988,7 @@ sub warnRemovedFunctions {
     "cuStreamGetCtx_v2",
     "cuStreamGetCtx",
     "cuStreamGetCaptureInfo_v3",
+    "cuStreamGetCaptureInfo",
     "cuStreamGetAttribute",
     "cuStreamCopyAttributes",
     "cuStreamBeginCapture_ptsz",
@@ -12086,8 +12084,11 @@ sub warnRemovedFunctions {
     "cuGraphicsD3D10RegisterResource",
     "cuGraphRemoveDependencies_v2",
     "cuGraphNodeGetDependentNodes_v2",
+    "cuGraphNodeGetDependentNodes",
     "cuGraphNodeGetDependencies_v2",
+    "cuGraphNodeGetDependencies",
     "cuGraphGetEdges_v2",
+    "cuGraphGetEdges",
     "cuGraphConditionalHandleCreate",
     "cuGraphAddNode_v2",
     "cuGraphAddNode",
@@ -12113,7 +12114,6 @@ sub warnRemovedFunctions {
     "cuFuncGetModule",
     "cuFlushGPUDirectRDMAWrites",
     "cuExternalMemoryGetMappedMipmappedArray",
-    "cuEventElapsedTime_v2",
     "cuEventCreateFromEGLSync",
     "cuEGLStreamProducerReturnFrame",
     "cuEGLStreamProducerPresentFrame",

--- a/docs/reference/tables/CUDA_Driver_API_functions_supported_by_HIP.md
+++ b/docs/reference/tables/CUDA_Driver_API_functions_supported_by_HIP.md
@@ -1970,7 +1970,7 @@
 |`cuStreamDestroy_v2`| | | | |`hipStreamDestroy`|1.6.0| | | | |
 |`cuStreamEndCapture`|10.0| | | |`hipStreamEndCapture`|4.3.0| | | | |
 |`cuStreamGetAttribute`|11.0| | | | | | | | | |
-|`cuStreamGetCaptureInfo`|10.1| | | |`hipStreamGetCaptureInfo`|5.0.0| | | | |
+|`cuStreamGetCaptureInfo`|10.1| |13.0| | | | | | | |
 |`cuStreamGetCaptureInfo_v2`|11.3| | | |`hipStreamGetCaptureInfo_v2`|5.0.0| | | | |
 |`cuStreamGetCaptureInfo_v3`|12.3| | | | | | | | | |
 |`cuStreamGetCtx`|9.2| | | | | | | | | |
@@ -1983,7 +1983,7 @@
 |`cuStreamQuery`| | | | |`hipStreamQuery`|1.6.0| | | | |
 |`cuStreamSetAttribute`|11.0| | | | | | | | | |
 |`cuStreamSynchronize`| | | | |`hipStreamSynchronize`|1.6.0| | | | |
-|`cuStreamUpdateCaptureDependencies`|11.3| | | |`hipStreamUpdateCaptureDependencies`|5.0.0| | | | |
+|`cuStreamUpdateCaptureDependencies`|11.3| |13.0| | | | | | | |
 |`cuStreamUpdateCaptureDependencies_v2`|12.3| | | | | | | | | |
 |`cuStreamWaitEvent`| | | | |`hipStreamWaitEvent`|1.6.0| | | | |
 |`cuThreadExchangeStreamCaptureMode`|10.1| | | |`hipThreadExchangeStreamCaptureMode`|5.2.0| | | | |
@@ -1996,7 +1996,7 @@
 |`cuEventDestroy`| | | | |`hipEventDestroy`|1.6.0| | | | |
 |`cuEventDestroy_v2`| | | | |`hipEventDestroy`|1.6.0| | | | |
 |`cuEventElapsedTime`| | | | |`hipEventElapsedTime`|1.6.0| | | | |
-|`cuEventElapsedTime_v2`|12.8| | | | | | | | | |
+|`cuEventElapsedTime_v2`|12.8| | | |`hipEventElapsedTime`|1.6.0| | | | |
 |`cuEventQuery`| | | | |`hipEventQuery`|1.6.0| | | | |
 |`cuEventRecord`| | | | |`hipEventRecord`|1.6.0| | | | |
 |`cuEventRecordWithFlags`|11.1| | | |`hipEventRecordWithFlags`|6.4.0| | | | |
@@ -2119,7 +2119,7 @@
 |`cuGraphExternalSemaphoresSignalNodeSetParams`|11.2| | | |`hipGraphExternalSemaphoresSignalNodeSetParams`|5.7.0| | | | |
 |`cuGraphExternalSemaphoresWaitNodeGetParams`|11.2| | | |`hipGraphExternalSemaphoresWaitNodeGetParams`|5.7.0| | | | |
 |`cuGraphExternalSemaphoresWaitNodeSetParams`|11.2| | | |`hipGraphExternalSemaphoresWaitNodeSetParams`|5.7.0| | | | |
-|`cuGraphGetEdges`|10.0| | | |`hipGraphGetEdges`|5.0.0| | | | |
+|`cuGraphGetEdges`|10.0| |13.0| | | | | | | |
 |`cuGraphGetEdges_v2`|12.3| | | | | | | | | |
 |`cuGraphGetNodes`|10.0| | | |`hipGraphGetNodes`|4.5.0| | | | |
 |`cuGraphGetRootNodes`|10.0| | | |`hipGraphGetRootNodes`|4.5.0| | | | |
@@ -2142,9 +2142,9 @@
 |`cuGraphMemsetNodeGetParams`|10.0| | | |`hipGraphMemsetNodeGetParams`|4.5.0| | | | |
 |`cuGraphMemsetNodeSetParams`|10.0| | | |`hipGraphMemsetNodeSetParams`|4.5.0| | | | |
 |`cuGraphNodeFindInClone`|10.0| | | |`hipGraphNodeFindInClone`|5.0.0| | | | |
-|`cuGraphNodeGetDependencies`|10.0| | | |`hipGraphNodeGetDependencies`|5.0.0| | | | |
+|`cuGraphNodeGetDependencies`|10.0| |13.0| | | | | | | |
 |`cuGraphNodeGetDependencies_v2`|12.3| | | | | | | | | |
-|`cuGraphNodeGetDependentNodes`|10.0| | | |`hipGraphNodeGetDependentNodes`|5.0.0| | | | |
+|`cuGraphNodeGetDependentNodes`|10.0| |13.0| | | | | | | |
 |`cuGraphNodeGetDependentNodes_v2`|12.3| | | | | | | | | |
 |`cuGraphNodeGetEnabled`|11.6| | | |`hipGraphNodeGetEnabled`|5.5.0| | | | |
 |`cuGraphNodeGetType`|10.0| | | |`hipGraphNodeGetType`|5.0.0| | | | |

--- a/src/CUDA2HIP_Driver_API_functions.cpp
+++ b/src/CUDA2HIP_Driver_API_functions.cpp
@@ -528,12 +528,14 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_FUNCTION_MAP {
   // cudaStreamGetAttribute
   {"cuStreamGetAttribute",                                        {"hipStreamGetAttribute",                                       "", CONV_STREAM, API_DRIVER, SEC::STREAM, HIP_UNSUPPORTED}},
   // cudaStreamGetCaptureInfo
-  {"cuStreamGetCaptureInfo",                                      {"hipStreamGetCaptureInfo",                                     "", CONV_STREAM, API_DRIVER, SEC::STREAM}},
+  // TODO: report unsupported only for CUDA >= 13000
+  {"cuStreamGetCaptureInfo",                                      {"hipStreamGetCaptureInfo",                                     "", CONV_STREAM, API_DRIVER, SEC::STREAM, HIP_UNSUPPORTED}},
   {"cuStreamGetCaptureInfo_v2",                                   {"hipStreamGetCaptureInfo_v2",                                  "", CONV_STREAM, API_DRIVER, SEC::STREAM}},
   // cudaStreamGetCaptureInfo_v3
   {"cuStreamGetCaptureInfo_v3",                                   {"hipStreamGetCaptureInfo_v3",                                  "", CONV_STREAM, API_DRIVER, SEC::STREAM, HIP_UNSUPPORTED}},
   // cudaStreamUpdateCaptureDependencies
-  {"cuStreamUpdateCaptureDependencies",                           {"hipStreamUpdateCaptureDependencies",                          "", CONV_STREAM, API_DRIVER, SEC::STREAM}},
+  // TODO: report unsupported only for CUDA >= 13000
+  {"cuStreamUpdateCaptureDependencies",                           {"hipStreamUpdateCaptureDependencies",                          "", CONV_STREAM, API_DRIVER, SEC::STREAM, HIP_UNSUPPORTED}},
   // cudaStreamUpdateCaptureDependencies_v2
   {"cuStreamUpdateCaptureDependencies_v2",                        {"hipStreamUpdateCaptureDependencies_v2",                       "", CONV_STREAM, API_DRIVER, SEC::STREAM, HIP_UNSUPPORTED}},
   // no analogue
@@ -570,7 +572,7 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_FUNCTION_MAP {
   // cudaEventElapsedTime
   {"cuEventElapsedTime",                                          {"hipEventElapsedTime",                                         "", CONV_EVENT, API_DRIVER, SEC::EVENT}},
   //
-  {"cuEventElapsedTime_v2",                                       {"hipEventElapsedTime_v2",                                      "", CONV_EVENT, API_DRIVER, SEC::EVENT, HIP_UNSUPPORTED}},
+  {"cuEventElapsedTime_v2",                                       {"hipEventElapsedTime",                                         "", CONV_EVENT, API_DRIVER, SEC::EVENT}},
   // cudaEventQuery
   {"cuEventQuery",                                                {"hipEventQuery",                                               "", CONV_EVENT, API_DRIVER, SEC::EVENT}},
   // cudaEventRecord
@@ -725,7 +727,8 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_FUNCTION_MAP {
   // cudaGraphExecDestroy
   {"cuGraphExecDestroy",                                          {"hipGraphExecDestroy",                                         "", CONV_GRAPH, API_DRIVER, SEC::GRAPH}},
   // cudaGraphGetEdges
-  {"cuGraphGetEdges",                                             {"hipGraphGetEdges",                                            "", CONV_GRAPH, API_DRIVER, SEC::GRAPH}},
+  // TODO: report unsupported only for CUDA >= 13000
+  {"cuGraphGetEdges",                                             {"hipGraphGetEdges",                                            "", CONV_GRAPH, API_DRIVER, SEC::GRAPH, HIP_UNSUPPORTED}},
   // cudaGraphGetEdges_v2
   {"cuGraphGetEdges_v2",                                          {"hipGraphGetEdges_v2",                                         "", CONV_GRAPH, API_DRIVER, SEC::GRAPH, HIP_UNSUPPORTED}},
   // cudaGraphGetNodes
@@ -764,11 +767,13 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_FUNCTION_MAP {
   // cudaGraphNodeFindInClone
   {"cuGraphNodeFindInClone",                                      {"hipGraphNodeFindInClone",                                     "", CONV_GRAPH, API_DRIVER, SEC::GRAPH}},
   // cudaGraphNodeGetDependencies
-  {"cuGraphNodeGetDependencies",                                  {"hipGraphNodeGetDependencies",                                 "", CONV_GRAPH, API_DRIVER, SEC::GRAPH}},
+  // TODO: report unsupported only for CUDA >= 13000
+  {"cuGraphNodeGetDependencies",                                  {"hipGraphNodeGetDependencies",                                 "", CONV_GRAPH, API_DRIVER, SEC::GRAPH, HIP_UNSUPPORTED}},
   // cudaGraphNodeGetDependencies_v2
   {"cuGraphNodeGetDependencies_v2",                               {"hipGraphNodeGetDependencies_v2",                              "", CONV_GRAPH, API_DRIVER, SEC::GRAPH, HIP_UNSUPPORTED}},
   // cudaGraphNodeGetDependentNodes
-  {"cuGraphNodeGetDependentNodes",                                {"hipGraphNodeGetDependentNodes",                               "", CONV_GRAPH, API_DRIVER, SEC::GRAPH}},
+  // TODO: report unsupported only for CUDA >= 13000
+  {"cuGraphNodeGetDependentNodes",                                {"hipGraphNodeGetDependentNodes",                               "", CONV_GRAPH, API_DRIVER, SEC::GRAPH, HIP_UNSUPPORTED}},
   // cudaGraphNodeGetDependentNodes_v2
   {"cuGraphNodeGetDependentNodes_v2",                             {"hipGraphNodeGetDependentNodes_v2",                            "", CONV_GRAPH, API_DRIVER, SEC::GRAPH, HIP_UNSUPPORTED}},
   // cudaGraphNodeGetEnabled
@@ -1783,6 +1788,11 @@ const std::map<llvm::StringRef, cudaAPIChangedVersions> CUDA_DRIVER_FUNCTION_CHA
   {"cuMemcpy3DBatchAsync",                                        {CUDA_130}},
   {"cuMemPrefetchAsync",                                          {CUDA_130}},
   {"cuMemAdvise",                                                 {CUDA_130}},
+  {"cuStreamGetCaptureInfo",                                      {CUDA_130}},
+  {"cuStreamUpdateCaptureDependencies",                           {CUDA_130}},
+  {"cuGraphGetEdges",                                             {CUDA_130}},
+  {"cuGraphNodeGetDependencies",                                  {CUDA_130}},
+  {"cuGraphNodeGetDependentNodes",                                {CUDA_130}},
 };
 
 const std::map<llvm::StringRef, hipAPIChangedVersions> HIP_DRIVER_FUNCTION_CHANGED_VER_MAP {

--- a/tests/unit_tests/synthetic/driver_functions.cu
+++ b/tests/unit_tests/synthetic/driver_functions.cu
@@ -1287,6 +1287,7 @@ int main() {
   // CHECK: result = hipGraphMemsetNodeSetParams(graphNode, &MEMSET_NODE_PARAMS);
   result = cuGraphMemsetNodeSetParams(graphNode, &MEMSET_NODE_PARAMS);
 
+#if CUDA_VERSION < 13000
   // CUDA: CUresult CUDAAPI cuGraphGetEdges(CUgraph hGraph, CUgraphNode *from, CUgraphNode *to, size_t *numEdges);
   // HIP: hipError_t hipGraphGetEdges(hipGraph_t graph, hipGraphNode_t* from, hipGraphNode_t* to, size_t* numEdges);
   // CHECK: result = hipGraphGetEdges(graph, &graphNode, &graphNode2, &bytes);
@@ -1297,15 +1298,16 @@ int main() {
   // CHECK: result = hipGraphNodeGetDependencies(graphNode, &graphNode2, &bytes);
   result = cuGraphNodeGetDependencies(graphNode, &graphNode2, &bytes);
 
-  // CUDA: CUresult CUDAAPI cuGraphRemoveDependencies(CUgraph hGraph, const CUgraphNode *from, const CUgraphNode *to, size_t numDependencies);
-  // HIP: hipError_t hipGraphRemoveDependencies(hipGraph_t graph, const hipGraphNode_t* from, const hipGraphNode_t* to, size_t numDependencies);
-  // CHECK: result = hipGraphRemoveDependencies(graph, &graphNode, &graphNode2, bytes);
-  result = cuGraphRemoveDependencies(graph, &graphNode, &graphNode2, bytes);
-
   // CUDA: CUresult CUDAAPI cuGraphNodeGetDependentNodes(CUgraphNode hNode, CUgraphNode *dependentNodes, size_t *numDependentNodes);
   // HIP: hipError_t hipGraphNodeGetDependentNodes(hipGraphNode_t node, hipGraphNode_t* pDependentNodes, size_t* pNumDependentNodes);
   // CHECK: result = hipGraphNodeGetDependentNodes(graphNode, &graphNode2, &bytes);
   result = cuGraphNodeGetDependentNodes(graphNode, &graphNode2, &bytes);
+#endif
+
+  // CUDA: CUresult CUDAAPI cuGraphRemoveDependencies(CUgraph hGraph, const CUgraphNode *from, const CUgraphNode *to, size_t numDependencies);
+  // HIP: hipError_t hipGraphRemoveDependencies(hipGraph_t graph, const hipGraphNode_t* from, const hipGraphNode_t* to, size_t numDependencies);
+  // CHECK: result = hipGraphRemoveDependencies(graph, &graphNode, &graphNode2, bytes);
+  result = cuGraphRemoveDependencies(graph, &graphNode, &graphNode2, bytes);
 
   // CUDA: CUresult CUDAAPI cuGraphNodeGetType(CUgraphNode hNode, CUgraphNodeType *type);
   // HIP: hipError_t hipGraphNodeGetType(hipGraphNode_t node, hipGraphNodeType* pType);
@@ -1763,16 +1765,13 @@ int main() {
 #endif
 
 #if CUDA_VERSION >= 11030
-  // CUDA < 12000: CUresult CUDAAPI cuStreamGetCaptureInfo(CUstream hStream, CUstreamCaptureStatus *captureStatus_out, cuuint64_t *id_out);
-  // CUDA:         CUresult CUDAAPI cuStreamGetCaptureInfo_v2(CUstream hStream, CUstreamCaptureStatus *captureStatus_out, cuuint64_t *id_out, CUgraph *graph_out, const CUgraphNode **dependencies_out, size_t *numDependencies_out);
-  // HIP: hipError_t hipStreamGetCaptureInfo_v2(hipStream_t stream, hipStreamCaptureStatus* captureStatus_out, unsigned long long* id_out __dparm(0), hipGraph_t* graph_out __dparm(0), const hipGraphNode_t** dependencies_out __dparm(0), size_t* numDependencies_out __dparm(0));
-  // CHECK: result = hipStreamGetCaptureInfo_v2(stream, &streamCaptureStatus, &ull, &graph, &pGraphNode, &bytes);
-  result = cuStreamGetCaptureInfo_v2(stream, &streamCaptureStatus, &ull, &graph, &pGraphNode, &bytes);
 
+#if CUDA_VERSION < 13000
   // CUDA: CUresult CUDAAPI cuStreamUpdateCaptureDependencies(CUstream hStream, CUgraphNode *dependencies, size_t numDependencies, unsigned int flags);
   // HIP: hipError_t hipStreamUpdateCaptureDependencies(hipStream_t stream, hipGraphNode_t* dependencies, size_t numDependencies, unsigned int flags __dparm(0));
   // CHECK: result = hipStreamUpdateCaptureDependencies(stream, &graphNode, bytes, flags);
   result = cuStreamUpdateCaptureDependencies(stream, &graphNode, bytes, flags);
+#endif
 
   // CHECK: hipUserObject_t userObject;
   CUuserObject userObject;
@@ -1963,6 +1962,7 @@ int main() {
   CUDA_GRAPH_INSTANTIATE_PARAMS_st GRAPH_INSTANTIATE_PARAMS_st;
   CUDA_GRAPH_INSTANTIATE_PARAMS GRAPH_INSTANTIATE_PARAMS;
 
+#if CUDA_VERSION < 13000
   // TODO: https://github.com/ROCm/HIPIFY/issues/782 - Introduce 1-to-N conditional matcher
   //       Implement "conditional" matching in hipify-clang, based on CUDA_VERSION first;
   //       below the transformation cuStreamGetCaptureInfo -> hipStreamGetCaptureInfo_v2 should be applied for CUDA_VERSION >= 12000,
@@ -1972,6 +1972,7 @@ int main() {
   // HIP: hipError_t hipStreamGetCaptureInfo_v2(hipStream_t stream, hipStreamCaptureStatus* captureStatus_out, unsigned long long* id_out __dparm(0), hipGraph_t* graph_out __dparm(0), const hipGraphNode_t** dependencies_out __dparm(0), size_t* numDependencies_out __dparm(0));
   //
   result = cuStreamGetCaptureInfo(stream, &streamCaptureStatus, &ull, &graph, &pGraphNode, &bytes);
+#endif
 
   // NOTE: not implemented yet in HIP
   // CUDA < 12000: CUresult CUDAAPI cuGraphExecUpdate(CUgraphExec hGraphExec, CUgraph hGraph, CUgraphNode *hErrorNode_out, CUgraphExecUpdateResult *updateResult_out);
@@ -2034,6 +2035,13 @@ int main() {
   // HIP: hipError_t hipStreamBeginCaptureToGraph(hipStream_t stream, hipGraph_t graph, const hipGraphNode_t* dependencies, const hipGraphEdgeData* dependencyData, size_t numDependencies, hipStreamCaptureMode mode);
   // CHECK: result = hipStreamBeginCaptureToGraph(stream, graph, &graphNode2, &graphEdgeData, bytes, streamCaptureMode);
   result = cuStreamBeginCaptureToGraph(stream, graph, &graphNode2, &graphEdgeData, bytes, streamCaptureMode);
+#endif
+
+#if CUDA_VERSION >= 12080
+  // CUDA: CUresult CUDAAPI cuEventElapsedTime_v2(float *pMilliseconds, CUevent hStart, CUevent hEnd);
+  // HIP: hipError_t hipEventElapsedTime(float* ms, hipEvent_t start, hipEvent_t stop);
+  // CHECK: result = hipEventElapsedTime(&ms, event_start, event_end);
+  result = cuEventElapsedTime_v2(&ms, event_start, event_end);
 #endif
 
   return 0;

--- a/tests/unit_tests/synthetic/driver_functions_internal.cu
+++ b/tests/unit_tests/synthetic/driver_functions_internal.cu
@@ -15,19 +15,43 @@
 int main() {
   printf("13. CUDA Driver API Internal Functions synthetic test\n");
 
+#if defined(_WIN32)
+  unsigned long long ull = 0;
+#else
+  unsigned long ull = 0;
+#endif
   size_t bytes = 0;
 
   // CHECK: hipTexRef texref;
   // CHECK-NEXT: HIP_ARRAY_DESCRIPTOR ARRAY_DESCRIPTOR;
   // CHECK-NEXT: hipDeviceptr_t deviceptr;
+  // CHECK-NEXT: hipStream_t stream;
   CUtexref texref;
   CUDA_ARRAY_DESCRIPTOR ARRAY_DESCRIPTOR;
   CUdeviceptr deviceptr;
+  CUstream stream;
 
   // CUDA: CUresult CUDAAPI cuTexRefSetAddress2D_v2(CUtexref hTexRef, const CUDA_ARRAY_DESCRIPTOR *desc, CUdeviceptr dptr, size_t Pitch);
   // HIP: DEPRECATED(DEPRECATED_MSG) hipError_t hipTexRefSetAddress2D(textureReference* texRef, const HIP_ARRAY_DESCRIPTOR* desc, hipDeviceptr_t dptr, size_t Pitch);
   // CHECK: hipError_t result = hipTexRefSetAddress2D(texref, &ARRAY_DESCRIPTOR, deviceptr, bytes);
   CUresult result = cuTexRefSetAddress2D_v2(texref, &ARRAY_DESCRIPTOR, deviceptr, bytes);
+
+#if CUDA_VERSION >= 10000
+  // CHECK: hipStreamCaptureStatus streamCaptureStatus;
+  // CHECK-NEXT: hipGraph_t graph;
+  // CHECK-NEXT: const hipGraphNode_t *pGraphNode = nullptr;
+  CUstreamCaptureStatus streamCaptureStatus;
+  CUgraph graph;
+  const CUgraphNode *pGraphNode = nullptr;
+#endif
+
+#if CUDA_VERSION >= 11030
+  // CUDA < 12000: CUresult CUDAAPI cuStreamGetCaptureInfo(CUstream hStream, CUstreamCaptureStatus *captureStatus_out, cuuint64_t *id_out);
+  // CUDA:         CUresult CUDAAPI cuStreamGetCaptureInfo_v2(CUstream hStream, CUstreamCaptureStatus *captureStatus_out, cuuint64_t *id_out, CUgraph *graph_out, const CUgraphNode **dependencies_out, size_t *numDependencies_out);
+  // HIP: hipError_t hipStreamGetCaptureInfo_v2(hipStream_t stream, hipStreamCaptureStatus* captureStatus_out, unsigned long long* id_out __dparm(0), hipGraph_t* graph_out __dparm(0), const hipGraphNode_t** dependencies_out __dparm(0), size_t* numDependencies_out __dparm(0));
+  // CHECK: result = hipStreamGetCaptureInfo_v2(stream, &streamCaptureStatus, &ull, &graph, &pGraphNode, &bytes);
+  result = cuStreamGetCaptureInfo_v2(stream, &streamCaptureStatus, &ull, &graph, &pGraphNode, &bytes);
+#endif
 
   return 0;
 }


### PR DESCRIPTION
+ Updated synthetic tests, the regenerated `hipify-perl`, and `Driver` `CUDA2HIP` docs accordingly

[IMP]
+ `cuStreamGetCaptureInfo`, `cuStreamUpdateCaptureDependencies`, `cuGraphGetEdges`, `cuGraphNodeGetDependencies`, and `cuGraphNodeGetDependentNodes` changed their ABI, hence are not supported by HIP anymore
