### PR TITLE
[HIPIFY][CUDA 13] CUDA 13.0.0 support - Step 7 - Driver - Functions (final)

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -4561,7 +4561,6 @@ sub simpleSubstitutions {
     subst("cuDeviceSetGraphMemAttribute", "hipDeviceSetGraphMemAttribute", "graph");
     subst("cuGraphAddBatchMemOpNode", "hipGraphAddBatchMemOpNode", "graph");
     subst("cuGraphAddChildGraphNode", "hipGraphAddChildGraphNode", "graph");
-    subst("cuGraphAddDependencies", "hipGraphAddDependencies", "graph");
     subst("cuGraphAddEmptyNode", "hipGraphAddEmptyNode", "graph");
     subst("cuGraphAddEventRecordNode", "hipGraphAddEventRecordNode", "graph");
     subst("cuGraphAddEventWaitNode", "hipGraphAddEventWaitNode", "graph");
@@ -4629,7 +4628,6 @@ sub simpleSubstitutions {
     subst("cuGraphNodeSetEnabled", "hipGraphNodeSetEnabled", "graph");
     subst("cuGraphNodeSetParams", "hipGraphNodeSetParams", "graph");
     subst("cuGraphReleaseUserObject", "hipGraphReleaseUserObject", "graph");
-    subst("cuGraphRemoveDependencies", "hipGraphRemoveDependencies", "graph");
     subst("cuGraphRetainUserObject", "hipGraphRetainUserObject", "graph");
     subst("cuGraphUpload", "hipGraphUpload", "graph");
     subst("cuUserObjectCreate", "hipUserObjectCreate", "graph");
@@ -12069,6 +12067,7 @@ sub warnRemovedFunctions {
     "cuGreenCtxWaitEvent",
     "cuGreenCtxStreamCreate",
     "cuGreenCtxRecordEvent",
+    "cuGreenCtxGetId",
     "cuGreenCtxGetDevResource",
     "cuGreenCtxDestroy",
     "cuGreenCtxCreate",
@@ -12083,6 +12082,7 @@ sub warnRemovedFunctions {
     "cuGraphicsD3D11RegisterResource",
     "cuGraphicsD3D10RegisterResource",
     "cuGraphRemoveDependencies_v2",
+    "cuGraphRemoveDependencies",
     "cuGraphNodeGetDependentNodes_v2",
     "cuGraphNodeGetDependentNodes",
     "cuGraphNodeGetDependencies_v2",
@@ -12093,6 +12093,7 @@ sub warnRemovedFunctions {
     "cuGraphAddNode_v2",
     "cuGraphAddNode",
     "cuGraphAddDependencies_v2",
+    "cuGraphAddDependencies",
     "cuGLUnregisterBufferObject",
     "cuGLUnmapBufferObjectAsync",
     "cuGLUnmapBufferObject",
@@ -12127,6 +12128,7 @@ sub warnRemovedFunctions {
     "cuDeviceUnregisterAsyncNotification",
     "cuDeviceRegisterAsyncNotification",
     "cuDeviceGetProperties",
+    "cuDeviceGetP2PAtomicCapabilities",
     "cuDeviceGetNvSciSyncAttributes",
     "cuDeviceGetLuid",
     "cuDeviceGetHostAtomicCapabilities",

--- a/docs/reference/tables/CUDA_Driver_API_functions_supported_by_HIP.md
+++ b/docs/reference/tables/CUDA_Driver_API_functions_supported_by_HIP.md
@@ -2073,7 +2073,7 @@
 |`cuDeviceSetGraphMemAttribute`|11.4| | | |`hipDeviceSetGraphMemAttribute`|5.3.0| | | | |
 |`cuGraphAddBatchMemOpNode`|11.7| | | |`hipGraphAddBatchMemOpNode`|6.4.0| | | | |
 |`cuGraphAddChildGraphNode`|10.0| | | |`hipGraphAddChildGraphNode`|5.0.0| | | | |
-|`cuGraphAddDependencies`|10.0| | | |`hipGraphAddDependencies`|4.5.0| | | | |
+|`cuGraphAddDependencies`|10.0| |13.0| | | | | | | |
 |`cuGraphAddDependencies_v2`|12.3| | | | | | | | | |
 |`cuGraphAddEmptyNode`|10.0| | | |`hipGraphAddEmptyNode`|4.5.0| | | | |
 |`cuGraphAddEventRecordNode`|11.1| | | |`hipGraphAddEventRecordNode`|5.0.0| | | | |
@@ -2151,7 +2151,7 @@
 |`cuGraphNodeSetEnabled`|11.6| | | |`hipGraphNodeSetEnabled`|5.5.0| | | | |
 |`cuGraphNodeSetParams`|12.2| | | |`hipGraphNodeSetParams`|6.3.0| | | | |
 |`cuGraphReleaseUserObject`|11.3| | | |`hipGraphReleaseUserObject`|5.3.0| | | | |
-|`cuGraphRemoveDependencies`|10.0| | | |`hipGraphRemoveDependencies`|5.0.0| | | | |
+|`cuGraphRemoveDependencies`|10.0| |13.0| | | | | | | |
 |`cuGraphRemoveDependencies_v2`|12.3| | | | | | | | | |
 |`cuGraphRetainUserObject`|11.3| | | |`hipGraphRetainUserObject`|5.3.0| | | | |
 |`cuGraphUpload`|11.1| | | |`hipGraphUpload`|5.3.0| | | | |
@@ -2248,6 +2248,7 @@
 |`cuCtxDisablePeerAccess`| | | | |`hipCtxDisablePeerAccess`|1.6.0|1.9.0| | | |
 |`cuCtxEnablePeerAccess`| | | | |`hipCtxEnablePeerAccess`|1.6.0|1.9.0| | | |
 |`cuDeviceCanAccessPeer`| | | | |`hipDeviceCanAccessPeer`|1.9.0| | | | |
+|`cuDeviceGetP2PAtomicCapabilities`|13.0| | | | | | | | | |
 |`cuDeviceGetP2PAttribute`|8.0| | | |`hipDeviceGetP2PAttribute`|3.8.0| | | | |
 
 ## **32. Graphics Interoperability**
@@ -2291,6 +2292,7 @@
 |`cuGreenCtxCreate`|12.4| | | | | | | | | |
 |`cuGreenCtxDestroy`|12.4| | | | | | | | | |
 |`cuGreenCtxGetDevResource`|12.4| | | | | | | | | |
+|`cuGreenCtxGetId`|13.0| | | | | | | | | |
 |`cuGreenCtxRecordEvent`|12.4| | | | | | | | | |
 |`cuGreenCtxStreamCreate`|12.5| | | | | | | | | |
 |`cuGreenCtxWaitEvent`|12.4| | | | | | | | | |

--- a/src/CUDA2HIP_Driver_API_functions.cpp
+++ b/src/CUDA2HIP_Driver_API_functions.cpp
@@ -693,7 +693,8 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_FUNCTION_MAP {
   // cudaGraphAddChildGraphNode
   {"cuGraphAddChildGraphNode",                                    {"hipGraphAddChildGraphNode",                                   "", CONV_GRAPH, API_DRIVER, SEC::GRAPH}},
   // cudaGraphAddDependencies
-  {"cuGraphAddDependencies",                                      {"hipGraphAddDependencies",                                     "", CONV_GRAPH, API_DRIVER, SEC::GRAPH}},
+  // TODO: report unsupported only for CUDA >= 13000
+  {"cuGraphAddDependencies",                                      {"hipGraphAddDependencies",                                     "", CONV_GRAPH, API_DRIVER, SEC::GRAPH, HIP_UNSUPPORTED}},
   // cudaGraphAddDependencies_v2
   {"cuGraphAddDependencies_v2",                                   {"hipGraphAddDependencies_v2",                                  "", CONV_GRAPH, API_DRIVER, SEC::GRAPH, HIP_UNSUPPORTED}},
   // cudaGraphAddEmptyNode
@@ -783,7 +784,8 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_FUNCTION_MAP {
   // cudaGraphNodeSetEnabled
   {"cuGraphNodeSetEnabled",                                       {"hipGraphNodeSetEnabled",                                      "", CONV_GRAPH, API_DRIVER, SEC::GRAPH}},
   // cudaGraphRemoveDependencies
-  {"cuGraphRemoveDependencies",                                   {"hipGraphRemoveDependencies",                                  "", CONV_GRAPH, API_DRIVER, SEC::GRAPH}},
+  // TODO: report unsupported only for CUDA >= 13000
+  {"cuGraphRemoveDependencies",                                   {"hipGraphRemoveDependencies",                                  "", CONV_GRAPH, API_DRIVER, SEC::GRAPH, HIP_UNSUPPORTED}},
   // cudaGraphRemoveDependencies_v2
   {"cuGraphRemoveDependencies_v2",                                {"hipGraphRemoveDependencies_v2",                               "", CONV_GRAPH, API_DRIVER, SEC::GRAPH, HIP_UNSUPPORTED}},
   // no analogue
@@ -984,6 +986,8 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_FUNCTION_MAP {
   {"cuDeviceCanAccessPeer",                                       {"hipDeviceCanAccessPeer",                                      "", CONV_PEER, API_DRIVER, SEC::PEER}},
   // cudaDeviceGetP2PAttribute
   {"cuDeviceGetP2PAttribute",                                     {"hipDeviceGetP2PAttribute",                                    "", CONV_PEER, API_DRIVER, SEC::PEER}},
+  //
+  {"cuDeviceGetP2PAtomicCapabilities",                            {"hipDeviceGetP2PAtomicCapabilities",                           "", CONV_PEER, API_DRIVER, SEC::PEER, HIP_UNSUPPORTED}},
 
   // 32. Graphics Interoperability
   // cudaGraphicsMapResources
@@ -1044,6 +1048,8 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_FUNCTION_MAP {
   {"cuStreamGetGreenCtx",                                         {"hipStreamGetGreenCtx",                                        "", CONV_GREEN_CONTEXT, API_DRIVER, SEC::GREEN_CONTEXT, HIP_UNSUPPORTED}},
   //
   {"cuGreenCtxStreamCreate",                                      {"hipGreenCtxStreamCreate",                                     "", CONV_GREEN_CONTEXT, API_DRIVER, SEC::GREEN_CONTEXT, HIP_UNSUPPORTED}},
+  //
+  {"cuGreenCtxGetId",                                             {"hipGreenCtxGetId",                                            "", CONV_GREEN_CONTEXT, API_DRIVER, SEC::GREEN_CONTEXT, HIP_UNSUPPORTED}},
 
   // 36. Error Log Management Functions
   //
@@ -1608,6 +1614,8 @@ const std::map<llvm::StringRef, cudaAPIversions> CUDA_DRIVER_FUNCTION_VER_MAP {
   {"cuMemPrefetchBatchAsync",                                     {CUDA_130, CUDA_0,   CUDA_0  }},
   {"cuMemDiscardBatchAsync",                                      {CUDA_130, CUDA_0,   CUDA_0  }},
   {"cuMemDiscardAndPrefetchBatchAsync",                           {CUDA_130, CUDA_0,   CUDA_0  }},
+  {"cuGreenCtxGetId",                                             {CUDA_130, CUDA_0,   CUDA_0  }},
+  {"cuDeviceGetP2PAtomicCapabilities",                            {CUDA_130, CUDA_0,   CUDA_0  }},
 };
 
 const std::map<llvm::StringRef, hipAPIversions> HIP_DRIVER_FUNCTION_VER_MAP {
@@ -1793,6 +1801,8 @@ const std::map<llvm::StringRef, cudaAPIChangedVersions> CUDA_DRIVER_FUNCTION_CHA
   {"cuGraphGetEdges",                                             {CUDA_130}},
   {"cuGraphNodeGetDependencies",                                  {CUDA_130}},
   {"cuGraphNodeGetDependentNodes",                                {CUDA_130}},
+  {"cuGraphAddDependencies",                                      {CUDA_130}},
+  {"cuGraphRemoveDependencies",                                   {CUDA_130}},
 };
 
 const std::map<llvm::StringRef, hipAPIChangedVersions> HIP_DRIVER_FUNCTION_CHANGED_VER_MAP {

--- a/tests/unit_tests/synthetic/driver_functions.cu
+++ b/tests/unit_tests/synthetic/driver_functions.cu
@@ -1212,10 +1212,32 @@ int main() {
   // CHECK: result = hipWaitExternalSemaphoresAsync(&externalSemaphore, &EXTERNAL_SEMAPHORE_WAIT_PARAMS, flags, stream);
   result = cuWaitExternalSemaphoresAsync(&externalSemaphore, &EXTERNAL_SEMAPHORE_WAIT_PARAMS, flags, stream);
 
+#if CUDA_VERSION < 13000
   // CUDA: CUresult CUDAAPI cuGraphAddDependencies(CUgraph hGraph, const CUgraphNode *from, const CUgraphNode *to, size_t numDependencies);
   // HIP: hipError_t hipGraphAddDependencies(hipGraph_t graph, const hipGraphNode_t* from, const hipGraphNode_t* to, size_t numDependencies);
   // CHECK: result = hipGraphAddDependencies(graph, &graphNode, &graphNode2, bytes);
   result = cuGraphAddDependencies(graph, &graphNode, &graphNode2, bytes);
+
+  // CUDA: CUresult CUDAAPI cuGraphRemoveDependencies(CUgraph hGraph, const CUgraphNode *from, const CUgraphNode *to, size_t numDependencies);
+  // HIP: hipError_t hipGraphRemoveDependencies(hipGraph_t graph, const hipGraphNode_t* from, const hipGraphNode_t* to, size_t numDependencies);
+  // CHECK: result = hipGraphRemoveDependencies(graph, &graphNode, &graphNode2, bytes);
+  result = cuGraphRemoveDependencies(graph, &graphNode, &graphNode2, bytes);
+
+  // CUDA: CUresult CUDAAPI cuGraphGetEdges(CUgraph hGraph, CUgraphNode *from, CUgraphNode *to, size_t *numEdges);
+  // HIP: hipError_t hipGraphGetEdges(hipGraph_t graph, hipGraphNode_t* from, hipGraphNode_t* to, size_t* numEdges);
+  // CHECK: result = hipGraphGetEdges(graph, &graphNode, &graphNode2, &bytes);
+  result = cuGraphGetEdges(graph, &graphNode, &graphNode2, &bytes);
+
+  // CUDA: CUresult CUDAAPI cuGraphNodeGetDependencies(CUgraphNode hNode, CUgraphNode *dependencies, size_t *numDependencies);
+  // HIP: hipError_t hipGraphNodeGetDependencies(hipGraphNode_t node, hipGraphNode_t* pDependencies, size_t* pNumDependencies);
+  // CHECK: result = hipGraphNodeGetDependencies(graphNode, &graphNode2, &bytes);
+  result = cuGraphNodeGetDependencies(graphNode, &graphNode2, &bytes);
+
+  // CUDA: CUresult CUDAAPI cuGraphNodeGetDependentNodes(CUgraphNode hNode, CUgraphNode *dependentNodes, size_t *numDependentNodes);
+  // HIP: hipError_t hipGraphNodeGetDependentNodes(hipGraphNode_t node, hipGraphNode_t* pDependentNodes, size_t* pNumDependentNodes);
+  // CHECK: result = hipGraphNodeGetDependentNodes(graphNode, &graphNode2, &bytes);
+  result = cuGraphNodeGetDependentNodes(graphNode, &graphNode2, &bytes);
+#endif
 
   // CUDA: CUresult CUDAAPI cuGraphAddEmptyNode(CUgraphNode *phGraphNode, CUgraph hGraph, const CUgraphNode *dependencies, size_t numDependencies);
   // HIP: hipError_t hipGraphAddEmptyNode(hipGraphNode_t* pGraphNode, hipGraph_t graph, const hipGraphNode_t* pDependencies, size_t numDependencies);
@@ -1286,28 +1308,6 @@ int main() {
   // HIP: hipError_t hipGraphMemsetNodeSetParams(hipGraphNode_t node, const hipMemsetParams* pNodeParams);
   // CHECK: result = hipGraphMemsetNodeSetParams(graphNode, &MEMSET_NODE_PARAMS);
   result = cuGraphMemsetNodeSetParams(graphNode, &MEMSET_NODE_PARAMS);
-
-#if CUDA_VERSION < 13000
-  // CUDA: CUresult CUDAAPI cuGraphGetEdges(CUgraph hGraph, CUgraphNode *from, CUgraphNode *to, size_t *numEdges);
-  // HIP: hipError_t hipGraphGetEdges(hipGraph_t graph, hipGraphNode_t* from, hipGraphNode_t* to, size_t* numEdges);
-  // CHECK: result = hipGraphGetEdges(graph, &graphNode, &graphNode2, &bytes);
-  result = cuGraphGetEdges(graph, &graphNode, &graphNode2, &bytes);
-
-  // CUDA: CUresult CUDAAPI cuGraphNodeGetDependencies(CUgraphNode hNode, CUgraphNode *dependencies, size_t *numDependencies);
-  // HIP: hipError_t hipGraphNodeGetDependencies(hipGraphNode_t node, hipGraphNode_t* pDependencies, size_t* pNumDependencies);
-  // CHECK: result = hipGraphNodeGetDependencies(graphNode, &graphNode2, &bytes);
-  result = cuGraphNodeGetDependencies(graphNode, &graphNode2, &bytes);
-
-  // CUDA: CUresult CUDAAPI cuGraphNodeGetDependentNodes(CUgraphNode hNode, CUgraphNode *dependentNodes, size_t *numDependentNodes);
-  // HIP: hipError_t hipGraphNodeGetDependentNodes(hipGraphNode_t node, hipGraphNode_t* pDependentNodes, size_t* pNumDependentNodes);
-  // CHECK: result = hipGraphNodeGetDependentNodes(graphNode, &graphNode2, &bytes);
-  result = cuGraphNodeGetDependentNodes(graphNode, &graphNode2, &bytes);
-#endif
-
-  // CUDA: CUresult CUDAAPI cuGraphRemoveDependencies(CUgraph hGraph, const CUgraphNode *from, const CUgraphNode *to, size_t numDependencies);
-  // HIP: hipError_t hipGraphRemoveDependencies(hipGraph_t graph, const hipGraphNode_t* from, const hipGraphNode_t* to, size_t numDependencies);
-  // CHECK: result = hipGraphRemoveDependencies(graph, &graphNode, &graphNode2, bytes);
-  result = cuGraphRemoveDependencies(graph, &graphNode, &graphNode2, bytes);
 
   // CUDA: CUresult CUDAAPI cuGraphNodeGetType(CUgraphNode hNode, CUgraphNodeType *type);
   // HIP: hipError_t hipGraphNodeGetType(hipGraphNode_t node, hipGraphNodeType* pType);


### PR DESCRIPTION
+ Updated synthetic tests, the regenerated `hipify-perl`, and `Driver` `CUDA2HIP` docs accordingly

**[IMP]**
+ `cuGraphAddDependencies` and `cuGraphRemoveDependencies` changed their ABI, hence are not supported by HIP anymore

**[TODO]**
+ [feature] Report unsupported only for `CUDA (>|<|==) CUDA_VERSION`; for the supported version(s), no warning should be thrown, and hipification must take place instead:
  - The implementation should fix some existing failures with still unconditionally `HIP_UNSUPPORTED` APIs, which are not hipified for the supported CUDA version yet
+ [feature][doc] Find a way to reflect partial HIP support for particular CUDA version(s)
