### PR TITLE
[HIPIFY][clang][#147835][compatibility][SWDEV-549281][fix][partial] clang `22.0.0git` compatibility fixes - Part 1

### DIFF
--- a/src/LLVMCompat.cpp
+++ b/src/LLVMCompat.cpp
@@ -196,12 +196,17 @@ std::string getNamespaceDeclName(const clang::NestedNameSpecifier *NNS) {
   std::string sEmpty = "";
   if (!NNS) return sEmpty;
 #if LLVM_VERSION_MAJOR >= 22
-  const clang::NamespaceBaseDecl *nsd = NNS->getAsNamespace();
+  if (NNS->getKind() == clang::NestedNameSpecifier::Kind::Namespace) {
+    if (const auto *ND = dyn_cast<clang::NamespaceDecl>(NNS->getAsNamespaceAndPrefix().Namespace)) {
+      return ND->getDeclName().getAsString();
+    }
+  }
 #else
   const clang::NamespaceDecl *nsd = NNS->getAsNamespace();
-#endif
   if (!nsd) return sEmpty;
   return nsd->getDeclName().getAsString();
+#endif
+  return sEmpty;
 }
 
 } // namespace llcompat


### PR DESCRIPTION
+ Part 1: Compatibility issue with getting `NamespaceDecl`

[Root Cause]
+ [LLVM][#147835](https://github.com/llvm/llvm-project/pull/147835)[clang] Improve nested name specifier AST representation
