### PR TITLE
[HIPIFY][clang][#147835][compatibility][SWDEV-549281][fix][partial] clang `22.0.0git` compatibility fixes - Part 2 - final

### DIFF
--- a/src/HipifyAction.cpp
+++ b/src/HipifyAction.cpp
@@ -2628,12 +2628,7 @@ bool HipifyAction::cudaDeviceFuncCall(const mat::MatchFinder::MatchResult &Resul
 
 bool HipifyAction::cubNamespacePrefix(const mat::MatchFinder::MatchResult &Result) {
   if (auto *decl = Result.Nodes.getNodeAs<clang::TypedefNameDecl>(sCubNamespacePrefix)) {
-    clang::QualType QT = decl->getUnderlyingType();
-    auto *t = QT.getTypePtr();
-    if (!t) return false;
-    const clang::ElaboratedType *et = t->getAs<clang::ElaboratedType>();
-    if (!et) return false;
-    std::string name = llcompat::getNamespaceDeclName(et->getQualifier());
+    std::string name = llcompat::getNamespaceDeclName(decl->getUnderlyingType());
     if (name.empty()) return false;
     const clang::TypeSourceInfo *si = decl->getTypeSourceInfo();
     const clang::TypeLoc tloc = si->getTypeLoc();
@@ -2656,18 +2651,15 @@ bool HipifyAction::cubUsingNamespaceDecl(const mat::MatchFinder::MatchResult &Re
 
 bool HipifyAction::cubFunctionTemplateDecl(const mat::MatchFinder::MatchResult &Result) {
   if (auto *decl = Result.Nodes.getNodeAs<clang::FunctionTemplateDecl>(sCubFunctionTemplateDecl)) {
-    auto *Tparams = decl->getTemplateParameters();
+    const auto *Tparams = decl->getTemplateParameters();
     bool ret = false;
     for (size_t I = 0; I < Tparams->size(); ++I) {
-      const clang::ValueDecl *valueDecl = dyn_cast<clang::ValueDecl>(Tparams->getParam(I));
+      const clang::NamedDecl *Param = Tparams->getParam(I);
+      if (!Param->getIdentifier()) continue;
+      const clang::ValueDecl *valueDecl = dyn_cast<clang::ValueDecl>(Param);
       if (!valueDecl) continue;
-      clang::QualType QT = valueDecl->getType();
-      auto *t = QT.getTypePtr();
-      if (!t) continue;
-      const clang::ElaboratedType *et = t->getAs<clang::ElaboratedType>();
-      if (!et) continue;
-      std::string name = llcompat::getNamespaceDeclName(et->getQualifier());
-      if (name.empty()) return false;
+      std::string name = llcompat::getNamespaceDeclName(valueDecl->getType());
+      if (name.empty()) ret = false;
       const clang::SourceRange sr = valueDecl->getSourceRange();
       FindAndReplace(name, GetSubstrLocation(name, sr), CUDA_CUB_NAMESPACE_MAP);
       ret = true;
@@ -3154,18 +3146,22 @@ std::unique_ptr<clang::ASTConsumer> HipifyAction::CreateASTConsumer(clang::Compi
     mat::typedefDecl(
       mat::isExpansionInMainFile(),
       mat::hasType(
+#if LLVM_VERSION_MAJOR < 22
         mat::elaboratedType(
+#endif
           mat::hasQualifier(
             mat::specifiesNamespace(
               mat::hasName(sCub)
             )
           )
+#if LLVM_VERSION_MAJOR < 22
         )
-       )
+#endif
+      )
     ).bind(sCubNamespacePrefix),
     this
   );
-  // TODO: Maybe worth to make it more concrete based on final cubFunctionTemplateDecl
+  // TODO: Maybe worth making it more concrete based on the final cubFunctionTemplateDecl
   Finder->addMatcher(
     mat::functionTemplateDecl(
       mat::isExpansionInMainFile()

--- a/src/LLVMCompat.cpp
+++ b/src/LLVMCompat.cpp
@@ -192,16 +192,22 @@ const clang::IdentifierInfo *getControllingMacro(clang::CompilerInstance &CI) {
 #endif
 }
 
-std::string getNamespaceDeclName(const clang::NestedNameSpecifier *NNS) {
+std::string getNamespaceDeclName(const clang::QualType &QT) {
   std::string sEmpty = "";
-  if (!NNS) return sEmpty;
+  auto *t = QT.getTypePtr();
+  if (!t) return sEmpty;
 #if LLVM_VERSION_MAJOR >= 22
-  if (NNS->getKind() == clang::NestedNameSpecifier::Kind::Namespace) {
-    if (const auto *ND = dyn_cast<clang::NamespaceDecl>(NNS->getAsNamespaceAndPrefix().Namespace)) {
+  const auto NNS = t->getPrefix();
+  if (NNS.getKind() == clang::NestedNameSpecifier::Kind::Namespace) {
+    if (const auto *ND = dyn_cast<clang::NamespaceDecl>(NNS.getAsNamespaceAndPrefix().Namespace)) {
       return ND->getDeclName().getAsString();
     }
   }
 #else
+  const clang::ElaboratedType *et = t->getAs<clang::ElaboratedType>();
+  if (!et) return sEmpty;
+  auto *NNS = et->getQualifier();
+  if (!NNS) return sEmpty;
   const clang::NamespaceDecl *nsd = NNS->getAsNamespace();
   if (!nsd) return sEmpty;
   return nsd->getDeclName().getAsString();

--- a/src/LLVMCompat.h
+++ b/src/LLVMCompat.h
@@ -103,6 +103,6 @@ void addTargetIfNeeded(ct::RefactoringTool &Tool);
 
 const clang::IdentifierInfo *getControllingMacro(clang::CompilerInstance &CI);
 
-std::string getNamespaceDeclName(const clang::NestedNameSpecifier *NNS);
+std::string getNamespaceDeclName(const clang::QualType &QT);
 
 } // namespace llcompat


### PR DESCRIPTION
+ Part 2: Compatibility issue with removal of the `ElaboratedType` from `clang` - final; Part 1 was #2061

**[Root Cause]**
+ [LLVM][#147835](https://github.com/llvm/llvm-project/pull/147835)[clang] Improve nested name specifier AST representation

**[Testing]**
+ `Win 11`, `VS 17.14.12`
+ Linux Ubuntu `24.04.2`, `GNU 13.3.0`
+ `CUDA 7.0.0` - `13.0.0`
+ `LLVM` `19.1.6`, `20.1.8`, `21.1.0-rc3`, `22.0.0git` (SHA-1: 0f6d3ad0feb42fbe36e1878fe9ffff67195c50d2, 2025.08.13)
+ all **PASSED**, except only CUDA 13.0.0 vs LLVM releases; CUDA 13.0.0 vs LLVM 22.0.0git partially passed (due to other reasons)

**[ToDo]**
+ Move `Matchers` to functions to simplify further support and fix compatibility issues in them
