### PR TITLE
[HIPIFY][IMP] Switch hipification to `C++17` by default

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -189,7 +189,7 @@ bool appendArgumentsAdjusters(ct::RefactoringTool &Tool, const std::string &sSou
     }
   }
   // Standard c++14 by default
-  Tool.appendArgumentsAdjuster(ct::getInsertArgumentAdjuster("-std=c++14", ct::ArgumentInsertPosition::BEGIN));
+  Tool.appendArgumentsAdjuster(ct::getInsertArgumentAdjuster("-std=c++17", ct::ArgumentInsertPosition::BEGIN));
   std::string sInclude = "-I" + sys::path::parent_path(sSourceAbsPath).str();
   Tool.appendArgumentsAdjuster(ct::getInsertArgumentAdjuster(sInclude.c_str(), ct::ArgumentInsertPosition::BEGIN));
   Tool.appendArgumentsAdjuster(ct::getInsertArgumentAdjuster("-fno-delayed-template-parsing", ct::ArgumentInsertPosition::BEGIN));


### PR DESCRIPTION
**[Reasons]**
+ clang has already switched to `C++17` by default
+ `hipify-clang` is built with `C++17` by default
+ CUDA 13.0.0 has switched to `C++17` by default, too

**[IMP]** To override the default C++ version value, set the `-std=c++XX` option in `hipify-clang`'s command line

**[Testing]** All is good for now; the extensive testing to finish

**[ToDo]**[compatibility] Make conditional setting the default C++ based on clang version

