### PR TITLE
[HIPIFY][CUDA 13] CUDA 13.0.0 support - Step 10 - Runtime - Functions

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -1443,9 +1443,12 @@ my %removed_funcs = (
     "cudaThreadGetCacheConfig" => "13.0",
     "cudaThreadExit" => "13.0",
     "cudaSetupArgument" => "10.1",
+    "cudaSetDoubleForHost" => "13.0",
+    "cudaSetDoubleForDevice" => "13.0",
     "cudaProfilerInitialize" => "12.0",
     "cudaOutputMode_t" => "12.0",
     "cudaOutputMode" => "12.0",
+    "cudaLaunchCooperativeKernelMultiDevice" => "13.0",
     "cudaLaunch" => "10.1",
     "cudaKeyValuePair" => "12.0",
     "cudaGetTextureReference" => "12.0",
@@ -4496,13 +4499,11 @@ sub simpleSubstitutions {
     subst("cudaStreamCreateWithPriority", "hipStreamCreateWithPriority", "stream");
     subst("cudaStreamDestroy", "hipStreamDestroy", "stream");
     subst("cudaStreamEndCapture", "hipStreamEndCapture", "stream");
-    subst("cudaStreamGetCaptureInfo", "hipStreamGetCaptureInfo", "stream");
     subst("cudaStreamGetFlags", "hipStreamGetFlags", "stream");
     subst("cudaStreamGetPriority", "hipStreamGetPriority", "stream");
     subst("cudaStreamIsCapturing", "hipStreamIsCapturing", "stream");
     subst("cudaStreamQuery", "hipStreamQuery", "stream");
     subst("cudaStreamSynchronize", "hipStreamSynchronize", "stream");
-    subst("cudaStreamUpdateCaptureDependencies", "hipStreamUpdateCaptureDependencies", "stream");
     subst("cudaStreamWaitEvent", "hipStreamWaitEvent", "stream");
     subst("cudaThreadExchangeStreamCaptureMode", "hipThreadExchangeStreamCaptureMode", "stream");
     subst("cuEventCreate", "hipEventCreateWithFlags", "event");
@@ -11240,10 +11241,12 @@ sub warnRemovedFunctions {
     "cudaSyncPolicyAuto",
     "cudaSurfaceFormatMode",
     "cudaStreamUpdateCaptureDependencies_v2",
+    "cudaStreamUpdateCaptureDependencies",
     "cudaStreamSetAttribute",
     "cudaStreamGetId",
     "cudaStreamGetDevice",
     "cudaStreamGetCaptureInfo_v3",
+    "cudaStreamGetCaptureInfo",
     "cudaStreamGetAttribute",
     "cudaStreamCopyAttributes",
     "cudaStreamAttributeSynchronizationPolicy",
@@ -11672,7 +11675,9 @@ sub warnRemovedFunctions {
     "cudaDeviceNumaConfigNone",
     "cudaDeviceNumaConfig",
     "cudaDeviceMask",
+    "cudaDeviceGetP2PAtomicCapabilities",
     "cudaDeviceGetNvSciSyncAttributes",
+    "cudaDeviceGetHostAtomicCapabilities",
     "cudaDeviceFlushGPUDirectRDMAWrites",
     "cudaDevAttrVulkanCigSupported",
     "cudaDevAttrTimelineSemaphoreInteropSupported",

--- a/docs/reference/tables/CUDA_Runtime_API_functions_supported_by_HIP.md
+++ b/docs/reference/tables/CUDA_Runtime_API_functions_supported_by_HIP.md
@@ -20,9 +20,11 @@
 |`cudaDeviceGetByPCIBusId`| | | | |`hipDeviceGetByPCIBusId`|1.6.0| | | | |
 |`cudaDeviceGetCacheConfig`| | | | |`hipDeviceGetCacheConfig`|1.6.0| | | | |
 |`cudaDeviceGetDefaultMemPool`|11.2| | | |`hipDeviceGetDefaultMemPool`|5.2.0| | | | |
+|`cudaDeviceGetHostAtomicCapabilities`|13.0| | | | | | | | | |
 |`cudaDeviceGetLimit`| | | | |`hipDeviceGetLimit`|1.6.0| | | | |
 |`cudaDeviceGetMemPool`|11.2| | | |`hipDeviceGetMemPool`|5.2.0| | | | |
 |`cudaDeviceGetNvSciSyncAttributes`|10.2| | | | | | | | | |
+|`cudaDeviceGetP2PAtomicCapabilities`|13.0| | | | | | | | | |
 |`cudaDeviceGetP2PAttribute`|8.0| | | |`hipDeviceGetP2PAttribute`|3.8.0| | | | |
 |`cudaDeviceGetPCIBusId`| | | | |`hipDeviceGetPCIBusId`|1.6.0| | | | |
 |`cudaDeviceGetStreamPriorityRange`| | | | |`hipDeviceGetStreamPriorityRange`|2.0.0| | | | |
@@ -78,7 +80,7 @@
 |`cudaStreamDestroy`| | | | |`hipStreamDestroy`|1.6.0| | | | |
 |`cudaStreamEndCapture`|10.0| | | |`hipStreamEndCapture`|4.3.0| | | | |
 |`cudaStreamGetAttribute`|11.0| | | | | | | | | |
-|`cudaStreamGetCaptureInfo`|10.1| | | |`hipStreamGetCaptureInfo`|5.0.0| | | | |
+|`cudaStreamGetCaptureInfo`|10.1| |13.0| | | | | | | |
 |`cudaStreamGetCaptureInfo_v3`|12.3| | | | | | | | | |
 |`cudaStreamGetDevice`|12.8| | | | | | | | | |
 |`cudaStreamGetFlags`| | | | |`hipStreamGetFlags`|1.6.0| | | | |
@@ -88,7 +90,7 @@
 |`cudaStreamQuery`| | | | |`hipStreamQuery`|1.6.0| | | | |
 |`cudaStreamSetAttribute`|11.0| | | | | | | | | |
 |`cudaStreamSynchronize`| | | | |`hipStreamSynchronize`|1.6.0| | | | |
-|`cudaStreamUpdateCaptureDependencies`|11.3| | | |`hipStreamUpdateCaptureDependencies`|5.0.0| | | | |
+|`cudaStreamUpdateCaptureDependencies`|11.3| |13.0| | | | | | | |
 |`cudaStreamUpdateCaptureDependencies_v2`|12.3| | | | | | | | | |
 |`cudaStreamWaitEvent`| | | | |`hipStreamWaitEvent`|1.6.0| | | | |
 |`cudaThreadExchangeStreamCaptureMode`|10.1| | | |`hipThreadExchangeStreamCaptureMode`|5.2.0| | | | |
@@ -132,12 +134,12 @@
 |`cudaGetParameterBuffer`| | | | | | | | | | |
 |`cudaGetParameterBufferV2`| | | | | | | | | | |
 |`cudaLaunchCooperativeKernel`|9.0| | | |`hipLaunchCooperativeKernel`|2.6.0| | | | |
-|`cudaLaunchCooperativeKernelMultiDevice`|9.0|11.3| | |`hipLaunchCooperativeKernelMultiDevice`|2.6.0| | | | |
+|`cudaLaunchCooperativeKernelMultiDevice`|9.0|11.3| |13.0|`hipLaunchCooperativeKernelMultiDevice`|2.6.0| | | | |
 |`cudaLaunchHostFunc`|10.0| | | |`hipLaunchHostFunc`|5.2.0| | | | |
 |`cudaLaunchKernel`| | | | |`hipLaunchKernel`|1.6.0| | | | |
 |`cudaLaunchKernelExC`|11.8| | | |`hipLaunchKernelExC`|7.0.0| | | |7.0.0|
-|`cudaSetDoubleForDevice`| |10.0| | | | | | | | |
-|`cudaSetDoubleForHost`| |10.0| | | | | | | | |
+|`cudaSetDoubleForDevice`| |10.0| |13.0| | | | | | |
+|`cudaSetDoubleForHost`| |10.0| |13.0| | | | | | |
 
 ## **8. Execution Control [DEPRECATED]**
 

--- a/src/CUDA2HIP_Driver_API_functions.cpp
+++ b/src/CUDA2HIP_Driver_API_functions.cpp
@@ -75,7 +75,7 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_FUNCTION_MAP {
   {"cuDeviceGetExecAffinitySupport",                              {"hipDeviceGetExecAffinitySupport",                             "", CONV_DEVICE, API_DRIVER, SEC::DEVICE, HIP_UNSUPPORTED}},
   // cudaDeviceFlushGPUDirectRDMAWrites
   {"cuFlushGPUDirectRDMAWrites",                                  {"hipDeviceFlushGPUDirectRDMAWrites",                           "", CONV_DEVICE, API_DRIVER, SEC::DEVICE, HIP_UNSUPPORTED}},
-  //
+  // cudaDeviceGetHostAtomicCapabilities
   {"cuDeviceGetHostAtomicCapabilities",                           {"hipDeviceGetHostAtomicCapabilities",                          "", CONV_DEVICE, API_DRIVER, SEC::DEVICE, HIP_UNSUPPORTED}},
 
   // 6. Device Management [DEPRECATED]
@@ -986,7 +986,7 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_FUNCTION_MAP {
   {"cuDeviceCanAccessPeer",                                       {"hipDeviceCanAccessPeer",                                      "", CONV_PEER, API_DRIVER, SEC::PEER}},
   // cudaDeviceGetP2PAttribute
   {"cuDeviceGetP2PAttribute",                                     {"hipDeviceGetP2PAttribute",                                    "", CONV_PEER, API_DRIVER, SEC::PEER}},
-  //
+  // cudaDeviceGetP2PAtomicCapabilities
   {"cuDeviceGetP2PAtomicCapabilities",                            {"hipDeviceGetP2PAtomicCapabilities",                           "", CONV_PEER, API_DRIVER, SEC::PEER, HIP_UNSUPPORTED}},
 
   // 32. Graphics Interoperability

--- a/src/CUDA2HIP_Runtime_API_functions.cpp
+++ b/src/CUDA2HIP_Runtime_API_functions.cpp
@@ -91,6 +91,10 @@ const std::map<llvm::StringRef, hipCounter> CUDA_RUNTIME_FUNCTION_MAP {
   {"cudaDeviceGetMemPool",                                    {"hipDeviceGetMemPool",                                    "", CONV_DEVICE, API_RUNTIME, SEC::DEVICE}},
   //
   {"cudaInitDevice",                                          {"hipInitDevice",                                          "", CONV_DEVICE, API_RUNTIME, SEC::DEVICE, HIP_UNSUPPORTED}},
+  // cuDeviceGetHostAtomicCapabilities
+  {"cudaDeviceGetHostAtomicCapabilities",                     {"hipDeviceGetHostAtomicCapabilities",                     "", CONV_DEVICE, API_RUNTIME, SEC::DEVICE, HIP_UNSUPPORTED}},
+  // cuDeviceGetP2PAtomicCapabilities
+  {"cudaDeviceGetP2PAtomicCapabilities",                      {"hipDeviceGetP2PAtomicCapabilities",                      "", CONV_DEVICE, API_RUNTIME, SEC::DEVICE, HIP_UNSUPPORTED}},
 
   // 2. Device Management [DEPRECATED]
   // cuCtxGetSharedMemConfig -> hipCtxGetSharedMemConfig
@@ -145,11 +149,13 @@ const std::map<llvm::StringRef, hipCounter> CUDA_RUNTIME_FUNCTION_MAP {
   // cuStreamIsCapturing
   {"cudaStreamIsCapturing",                                   {"hipStreamIsCapturing",                                   "", CONV_STREAM, API_RUNTIME, SEC::STREAM}},
   // cuStreamGetCaptureInfo
-  {"cudaStreamGetCaptureInfo",                                {"hipStreamGetCaptureInfo",                                "", CONV_STREAM, API_RUNTIME, SEC::STREAM}},
+  // TODO: report unsupported only for CUDA >= 13000
+  {"cudaStreamGetCaptureInfo",                                {"hipStreamGetCaptureInfo",                                "", CONV_STREAM, API_RUNTIME, SEC::STREAM, HIP_UNSUPPORTED}},
   // cuStreamGetCaptureInfo_v3
   {"cudaStreamGetCaptureInfo_v3",                             {"hipStreamGetCaptureInfo_v3",                             "", CONV_STREAM, API_RUNTIME, SEC::STREAM, HIP_UNSUPPORTED}},
   // cuStreamUpdateCaptureDependencies
-  {"cudaStreamUpdateCaptureDependencies",                     {"hipStreamUpdateCaptureDependencies",                     "", CONV_STREAM, API_RUNTIME, SEC::STREAM}},
+  // TODO: report unsupported only for CUDA >= 13000
+  {"cudaStreamUpdateCaptureDependencies",                     {"hipStreamUpdateCaptureDependencies",                     "", CONV_STREAM, API_RUNTIME, SEC::STREAM, HIP_UNSUPPORTED}},
   // cuStreamUpdateCaptureDependencies_v2
   {"cudaStreamUpdateCaptureDependencies_v2",                  {"hipStreamUpdateCaptureDependencies_v2",                  "", CONV_STREAM, API_RUNTIME, SEC::STREAM, HIP_UNSUPPORTED}},
   // cuStreamQuery
@@ -222,16 +228,16 @@ const std::map<llvm::StringRef, hipCounter> CUDA_RUNTIME_FUNCTION_MAP {
   {"cudaLaunchCooperativeKernel",                             {"hipLaunchCooperativeKernel",                             "", CONV_EXECUTION, API_RUNTIME, SEC::EXECUTION}},
   // no analogue
   // NOTE: Not equal to cuLaunchCooperativeKernelMultiDevice due to different signatures
-  {"cudaLaunchCooperativeKernelMultiDevice",                  {"hipLaunchCooperativeKernelMultiDevice",                  "", CONV_EXECUTION, API_RUNTIME, SEC::EXECUTION, CUDA_DEPRECATED}},
+  {"cudaLaunchCooperativeKernelMultiDevice",                  {"hipLaunchCooperativeKernelMultiDevice",                  "", CONV_EXECUTION, API_RUNTIME, SEC::EXECUTION, CUDA_DEPRECATED | CUDA_REMOVED}},
   // cuLaunchHostFunc
   {"cudaLaunchHostFunc",                                      {"hipLaunchHostFunc",                                      "", CONV_EXECUTION, API_RUNTIME, SEC::EXECUTION}},
   // no analogue
   // NOTE: Not equal to cuLaunchKernel due to different signatures
   {"cudaLaunchKernel",                                        {"hipLaunchKernel",                                        "", CONV_EXECUTION, API_RUNTIME, SEC::EXECUTION}},
   // no analogue
-  {"cudaSetDoubleForDevice",                                  {"hipSetDoubleForDevice",                                  "", CONV_EXECUTION, API_RUNTIME, SEC::EXECUTION, HIP_UNSUPPORTED | CUDA_DEPRECATED}},
+  {"cudaSetDoubleForDevice",                                  {"hipSetDoubleForDevice",                                  "", CONV_EXECUTION, API_RUNTIME, SEC::EXECUTION, HIP_UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED}},
   // no analogue
-  {"cudaSetDoubleForHost",                                    {"hipSetDoubleForHost",                                    "", CONV_EXECUTION, API_RUNTIME, SEC::EXECUTION, HIP_UNSUPPORTED | CUDA_DEPRECATED}},
+  {"cudaSetDoubleForHost",                                    {"hipSetDoubleForHost",                                    "", CONV_EXECUTION, API_RUNTIME, SEC::EXECUTION, HIP_UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED}},
   // no analogue
   // NOTE: Not equal to cuLaunchKernelEx due to different signatures
   {"cudaLaunchKernelExC",                                     {"hipLaunchKernelExC",                                     "", CONV_EXECUTION, API_RUNTIME, SEC::EXECUTION, HIP_EXPERIMENTAL}},
@@ -996,10 +1002,10 @@ const std::map<llvm::StringRef, cudaAPIversions> CUDA_RUNTIME_FUNCTION_VER_MAP {
   {"cudaWaitExternalSemaphoresAsync",                         {CUDA_100, CUDA_0,   CUDA_0  }},
   {"cudaFuncSetAttribute",                                    {CUDA_90,  CUDA_0,   CUDA_0  }},
   {"cudaLaunchCooperativeKernel",                             {CUDA_90,  CUDA_0,   CUDA_0  }},
-  {"cudaLaunchCooperativeKernelMultiDevice",                  {CUDA_90,  CUDA_113, CUDA_0  }},
+  {"cudaLaunchCooperativeKernelMultiDevice",                  {CUDA_90,  CUDA_113, CUDA_130}},
   {"cudaLaunchHostFunc",                                      {CUDA_100, CUDA_0,   CUDA_0  }},
-  {"cudaSetDoubleForDevice",                                  {CUDA_0,   CUDA_100, CUDA_0  }},
-  {"cudaSetDoubleForHost",                                    {CUDA_0,   CUDA_100, CUDA_0  }},
+  {"cudaSetDoubleForDevice",                                  {CUDA_0,   CUDA_100, CUDA_130}},
+  {"cudaSetDoubleForHost",                                    {CUDA_0,   CUDA_100, CUDA_130}},
   {"cudaOccupancyAvailableDynamicSMemPerBlock",               {CUDA_110, CUDA_0,   CUDA_0  }},
   {"cudaMemAdvise",                                           {CUDA_80,  CUDA_0,   CUDA_0  }},
   {"cudaMemPrefetchAsync",                                    {CUDA_80,  CUDA_0,   CUDA_0  }},
@@ -1221,6 +1227,8 @@ const std::map<llvm::StringRef, cudaAPIversions> CUDA_RUNTIME_FUNCTION_VER_MAP {
   {"cudaKernelSetAttributeForDevice",                         {CUDA_128, CUDA_0,   CUDA_0  }},
   {"cudaLibraryGetKernelCount",                               {CUDA_128, CUDA_0,   CUDA_0  }},
   {"cudaLibraryEnumerateKernels",                             {CUDA_128, CUDA_0,   CUDA_0  }},
+  {"cudaDeviceGetHostAtomicCapabilities",                     {CUDA_130, CUDA_0,   CUDA_0  }},
+  {"cudaDeviceGetP2PAtomicCapabilities",                      {CUDA_130, CUDA_0,   CUDA_0  }},
 };
 
 const std::map<llvm::StringRef, hipAPIversions> HIP_RUNTIME_FUNCTION_VER_MAP {
@@ -1489,6 +1497,10 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_RUNTIME_FUNCTION_VER_MAP {
 
 const std::map<llvm::StringRef, cudaAPIChangedVersions> CUDA_RUNTIME_FUNCTION_CHANGED_VER_MAP {
   {"cudaGetDriverEntryPoint",                                 {CUDA_120}},
+  {"cudaStreamGetCaptureInfo",                                {CUDA_130}},
+  {"cudaStreamUpdateCaptureDependencies",                     {CUDA_130}},
+  {"cudaMemcpyBatchAsync",                                    {CUDA_130}},
+  {"cudaMemcpy3DBatchAsync",                                  {CUDA_130}},
 };
 
 const std::map<unsigned int, llvm::StringRef> CUDA_RUNTIME_API_SECTION_MAP {

--- a/tests/unit_tests/synthetic/runtime_functions.cu
+++ b/tests/unit_tests/synthetic/runtime_functions.cu
@@ -883,10 +883,12 @@ int main() {
   // CHECK: hipLaunchParams LaunchParams;
   cudaLaunchParams LaunchParams;
 
+#if CUDA_VERSION < 13000
   // CUDA: extern __CUDA_DEPRECATED __host__ cudaError_t CUDARTAPI cudaLaunchCooperativeKernelMultiDevice(struct cudaLaunchParams *launchParamsList, unsigned int numDevices, unsigned int flags __dv(0));
   // HIP: hipError_t hipLaunchCooperativeKernelMultiDevice(hipLaunchParams* launchParamsList, int numDevices, unsigned int flags);
   // CHECK: result = hipLaunchCooperativeKernelMultiDevice(&LaunchParams, intVal, flags);
   result = cudaLaunchCooperativeKernelMultiDevice(&LaunchParams, intVal, flags);
+#endif
 #endif
 
 #if CUDA_VERSION <= 10000
@@ -1122,10 +1124,13 @@ int main() {
   // CHECK: result = hipThreadExchangeStreamCaptureMode(&streamCaptureMode);
   result = cudaThreadExchangeStreamCaptureMode(&streamCaptureMode);
 
+  // [TODO][#2062] Rename all DO-NOT-CHECK back
+#if CUDA_VERSION < 13000
   // CUDA: extern __host__ cudaError_t CUDARTAPI cudaStreamGetCaptureInfo(cudaStream_t stream, enum cudaStreamCaptureStatus *pCaptureStatus, unsigned long long *pId);
   // HIP: hipError_t hipStreamGetCaptureInfo(hipStream_t stream, hipStreamCaptureStatus* pCaptureStatus, unsigned long long* pId);
-  // CHECK: result = hipStreamGetCaptureInfo(stream, &StreamCaptureStatus, &ull_2);
+  // DO-NOT-CHECK: result = hipStreamGetCaptureInfo(stream, &StreamCaptureStatus, &ull_2);
   result = cudaStreamGetCaptureInfo(stream, &StreamCaptureStatus, &ull_2);
+#endif
 
   // CUDA: extern __host__ cudaError_t CUDARTAPI cudaThreadExchangeStreamCaptureMode(enum cudaStreamCaptureMode *mode);
   // HIP: hipError_t hipThreadExchangeStreamCaptureMode(hipStreamCaptureMode* mode);
@@ -1516,10 +1521,13 @@ int main() {
   // CHECK: result = hipGraphDebugDotPrint(Graph_t, name.c_str(), flags);
   result = cudaGraphDebugDotPrint(Graph_t, name.c_str(), flags);
 
+  // [TODO][#2062] Rename all DO-NOT-CHECK back
+#if CUDA_VERSION < 13000
   // CUDA: extern __host__ cudaError_t CUDARTAPI cudaStreamUpdateCaptureDependencies(cudaStream_t stream, cudaGraphNode_t *dependencies, size_t numDependencies, unsigned int flags __dv(0));
   // HIP: hipError_t hipStreamUpdateCaptureDependencies(hipStream_t stream, hipGraphNode_t* dependencies, size_t numDependencies, unsigned int flags __dparm(0));
-  // CHECK: result = hipStreamUpdateCaptureDependencies(stream, &graphNode, bytes, flags);
+  // DO-NOT-CHECK: result = hipStreamUpdateCaptureDependencies(stream, &graphNode, bytes, flags);
   result = cudaStreamUpdateCaptureDependencies(stream, &graphNode, bytes, flags);
+#endif
 #endif
 
 #if CUDA_VERSION >= 11040


### PR DESCRIPTION
+ Updated synthetic tests, the regenerated `hipify-perl`, and `Runtime` `CUDA2HIP` docs accordingly

[IMP]
+ `cudaStreamGetCaptureInfo` and `cudaStreamUpdateCaptureDependencies` changed their ABI, hence are not supported by HIP anymore
