### PR TITLE
[HIPIFY][doc] `LLVM 21.1.0` and `CUDA 12.9.1` are the latest stable supported versions

### DIFF
--- a/docs/building/build-hipify-clang-linux.rst
+++ b/docs/building/build-hipify-clang-linux.rst
@@ -134,7 +134,7 @@ Linux testing
 
 On Linux, the following configurations are tested:
 
-* Ubuntu 22-24: LLVM 13.0.0 - 20.1.8, CUDA 7.0 - 12.8.1, cuDNN 8.0.5 - 9.12.0, cuTensor 1.0.1.0 - 2.2.0.0
+* Ubuntu 22-24: LLVM 13.0.0 - 21.1.0, CUDA 7.0 - 12.9.1, cuDNN 8.0.5 - 9.12.0, cuTensor 1.0.1.0 - 2.2.0.0
 * Ubuntu 20-21: LLVM 9.0.0 - 20.1.8, CUDA 7.0 - 12.8.1, cuDNN 5.1.10 - 9.12.0, cuTensor 1.0.1.0 - 2.2.0.0
 * Ubuntu 16-19: LLVM 8.0.0 - 14.0.6, CUDA 7.0 - 10.2, cuDNN 5.1.10 - 8.0.5
 * Ubuntu 14: LLVM 4.0.0 - 7.1.0, CUDA 7.0 - 9.0, cuDNN 5.0.5 - 7.6.5
@@ -158,13 +158,13 @@ Here's how to build ``hipify-clang`` with testing support on ``Ubuntu 24.04.02``
     -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_INSTALL_PREFIX=../dist \
     -DCMAKE_PREFIX_PATH=$ROOT_DIR/dist \
-    -DCUDA_TOOLKIT_ROOT_DIR=/usr/local/cuda-12.8.1 \
+    -DCUDA_TOOLKIT_ROOT_DIR=/usr/local/cuda-12.9.1 \
     -DCUDA_DNN_ROOT_DIR=/usr/local/cudnn-9.12.0 \
     -DCUDA_TENSOR_ROOT_DIR=/usr/local/cutensor-2.2.0.0 \
     -DLLVM_EXTERNAL_LIT=$ROOT_DIR/build/bin/llvm-lit \
     ../hipify
 
-The corresponding successful output is (assuming ROOT_DIR is ``/usr/llvm/20.1.8``):
+The corresponding successful output is (assuming ROOT_DIR is ``/usr/llvm/21.1.0``):
 
 .. code-block:: shell
 
@@ -186,31 +186,31 @@ The corresponding successful output is (assuming ROOT_DIR is ``/usr/llvm/20.1.8`
   --    - Is part of HIP SDK    : OFF
   --    - Install clang headers : ON
   -- Found ZLIB: /usr/lib/x86_64-linux-gnu/libz.so (found version "1.3")
-  -- Found LLVM 20.1.8:
-  --    - CMake module path     : /usr/llvm/20.1.8/dist/lib/cmake/llvm
-  --    - Clang include path    : /usr/llvm/20.1.8/dist/include
-  --    - LLVM Include path     : /usr/llvm/20.1.8/dist/include
-  --    - Binary path           : /usr/llvm/20.1.8/dist/bin
+  -- Found LLVM 21.1.0:
+  --    - CMake module path     : /usr/llvm/21.1.0/dist/lib/cmake/llvm
+  --    - Clang include path    : /usr/llvm/21.1.0/dist/include
+  --    - LLVM Include path     : /usr/llvm/21.1.0/dist/include
+  --    - Binary path           : /usr/llvm/21.1.0/dist/bin
   -- Linker detection: GNU ld
   -- ---- The below configuring for hipify-clang testing only ----
   -- Found Python: /usr/bin/python3.13 (found suitable version "3.13.6", required range is "3.0...3.14") found components: Interpreter
   -- Found lit: /usr/local/bin/lit
   -- Found FileCheck: /GIT/LLVM/trunk/dist/FileCheck
   -- Initial CUDA to configure:
-  --    - CUDA Toolkit path     : /usr/local/cuda-12.8.1
+  --    - CUDA Toolkit path     : /usr/local/cuda-12.9.1
   --    - CUDA Samples path     :
   --    - cuDNN path            : /usr/local/cudnn-9.12.0
   --    - cuTENSOR path         : /usr/local/cuTensor/2.2.0.0
   --    - CUB path              :
-  -- Found CUDAToolkit: /usr/local/cuda-12.8.1/targets/x86_64-linux/include (found version "12.8.93")
+  -- Found CUDAToolkit: /usr/local/cuda-12.9.1/targets/x86_64-linux/include (found version "12.9.86")
   -- Performing Test CMAKE_HAVE_LIBC_PTHREAD
   -- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Success
   -- Found Threads: TRUE
   -- Found CUDA config:
-  --    - CUDA Toolkit path     : /usr/local/cuda-12.8.1
+  --    - CUDA Toolkit path     : /usr/local/cuda-12.9.1
   --    - CUDA Samples path     : OFF
   --    - cuDNN path            : /usr/local/cudnn-9.12.0
-  --    - CUB path              : /usr/local/cuda-12.8.1/include/cub
+  --    - CUB path              : /usr/local/cuda-12.9.1/include/cub
   --    - cuTENSOR path         : /usr/local/cuTensor/2.2.0.0
   -- Configuring done (0.6s)
   -- Generating done (0.0s)
@@ -226,8 +226,8 @@ The corresponding successful output is:
 
   Running HIPify regression tests
   ===============================================================
-  CUDA 12.8.93 - will be used for testing
-  LLVM 20.1.8 - will be used for testing
+  CUDA 12.9.86 - will be used for testing
+  LLVM 21.1.0 - will be used for testing
   x86_64 - Platform architecture
   Linux 6.5.0-15-generic - Platform OS
   64 - hipify-clang binary bitness

--- a/docs/building/build-hipify-clang-windows.rst
+++ b/docs/building/build-hipify-clang-windows.rst
@@ -82,9 +82,9 @@ We recommend that you build ``LLVM+Clang`` from sources, as prebuilt binaries ar
   
   .. code-block:: bash
   
-    -DCUDA_TOOLKIT_ROOT_DIR="C:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v12.8"
+    -DCUDA_TOOLKIT_ROOT_DIR="C:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v12.9"
 
-    -DCUDA_SDK_ROOT_DIR="C:/ProgramData/NVIDIA Corporation/CUDA Samples/v12.8"
+    -DCUDA_SDK_ROOT_DIR="C:/ProgramData/NVIDIA Corporation/CUDA Samples/v12.9"
 
 - [Optional] Install `cuTensor <https://developer.nvidia.com/cutensor-downloads>`_:
 
@@ -230,6 +230,12 @@ Tested configurations:
     - ``2019.16.11.50, 2022.17.14.12``
     - ``4.1.0``
     - ``3.13.6``
+  * - ``21.1.0``
+    - ``7.0 - 12.9.1``
+    - ``8.0.5  - 9.12.0``
+    - ``2019.16.11.50, 2022.17.14.12``
+    - ``4.1.0``
+    - ``3.13.6``
 
 :sup:`5` LLVM 14.x.x is the latest major release supporting Visual Studio 2017.
 
@@ -255,14 +261,14 @@ Building with testing support using ``Visual Studio 17 2022`` on ``Windows 11``:
   -DCMAKE_BUILD_TYPE=Release \
   -DCMAKE_INSTALL_PREFIX=../dist \
   -DCMAKE_PREFIX_PATH=%ROOT_DIR%/dist \
-  -DCUDA_TOOLKIT_ROOT_DIR="C:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v12.8" \
-  -DCUDA_SDK_ROOT_DIR="C:/ProgramData/NVIDIA Corporation/CUDA Samples/v12.8" \
+  -DCUDA_TOOLKIT_ROOT_DIR="C:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v12.9" \
+  -DCUDA_SDK_ROOT_DIR="C:/ProgramData/NVIDIA Corporation/CUDA Samples/v12.9" \
   -DCUDA_DNN_ROOT_DIR=D:/CUDA/cuDNN/9.12.0 \
   -DCUDA_TENSOR_ROOT_DIR=D:/CUDA/cuTensor/2.2.0.0 \
   -DLLVM_EXTERNAL_LIT=%ROOT_DIR%/build/Release/bin/llvm-lit.py \
   ../hipify
 
-The corresponding successful output is (assuming %ROOT_DIR% is ``D:/LLVM/20.1.8``):
+The corresponding successful output is (assuming %ROOT_DIR% is ``D:/LLVM/21.1.0``):
 
 .. code-block:: shell
 
@@ -284,28 +290,28 @@ The corresponding successful output is (assuming %ROOT_DIR% is ``D:/LLVM/20.1.8`
   --    - Test hipify-clang     : ON
   --    - Is part of HIP SDK    : OFF
   --    - Install clang headers : ON
-  -- Found LLVM 20.1.8:
-  --    - CMake module path     : D:/LLVM/20.1.8/dist/lib/cmake/llvm
-  --    - Clang include path    : D:/LLVM/20.1.8/dist/include
-  --    - LLVM Include path     : D:/LLVM/20.1.8/dist/include
-  --    - Binary path           : D:/LLVM/20.1.8/dist/bin
+  -- Found LLVM 21.1.0:
+  --    - CMake module path     : D:/LLVM/21.1.0/dist/lib/cmake/llvm
+  --    - Clang include path    : D:/LLVM/21.1.0/dist/include
+  --    - LLVM Include path     : D:/LLVM/21.1.0/dist/include
+  --    - Binary path           : D:/LLVM/21.1.0/dist/bin
   -- ---- The below configuring for hipify-clang testing only ----
   -- Found Python: C:/Users/TT/AppData/Local/Programs/Python/Python313/python.exe (found suitable version "3.13.6", required range is "3.0...3.14") found components: Interpreter
   -- Found lit: C:/Users/TT/AppData/Local/Programs/Python/Python313/Scripts/lit.exe
-  -- Found FileCheck: D:/LLVM/20.1.8/dist/bin/FileCheck.exe
+  -- Found FileCheck: D:/LLVM/21.1.0/dist/bin/FileCheck.exe
   -- Initial CUDA to configure:
-  --    - CUDA Toolkit path     : C:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v12.8
-  --    - CUDA Samples path     : C:/ProgramData/NVIDIA Corporation/CUDA Samples/v12.8
+  --    - CUDA Toolkit path     : C:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v12.9
+  --    - CUDA Samples path     : C:/ProgramData/NVIDIA Corporation/CUDA Samples/v12.9
   --    - cuDNN path            : D:/CUDA/cuDNN/9.12.0
   --    - cuTENSOR path         : D:/CUDA/cuTensor/2.2.0.0
   --    - CUB path              :
-  -- Found CUDAToolkit: C:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v12.8/include (found version "12.8.93")
+  -- Found CUDAToolkit: C:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v12.9/include (found version "12.9.86")
   -- Found CUDA config:
-  --    - CUDA Toolkit path     : C:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v12.8
-  --    - CUDA Samples path     : C:/ProgramData/NVIDIA Corporation/CUDA Samples/v12.8
+  --    - CUDA Toolkit path     : C:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v12.9
+  --    - CUDA Samples path     : C:/ProgramData/NVIDIA Corporation/CUDA Samples/v12.9
   --    - cuDNN path            : D:/CUDA/cuDNN/9.12.0
   --    - cuTENSOR path         : D:/CUDA/cuTensor/2.2.0.0
-  --    - CUB path              : C:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v12.8/include/cub
+  --    - CUB path              : C:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v12.9/include/cub
   -- Configuring done (4.4s)
   -- Generating done (0.1s)
   -- Build files have been written to: D:/HIPIFY/build

--- a/docs/how-to/hipify-clang.rst
+++ b/docs/how-to/hipify-clang.rst
@@ -36,12 +36,12 @@ Release Dependencies
 ``hipify-clang`` requires:
 
 * `CUDA <https://developer.nvidia.com/cuda-downloads>`_, the latest supported version is
-  `12.8.1 <https://developer.nvidia.com/cuda-12-8-1-download-archive>`_, but requires at least version
+  `12.9.1 <https://developer.nvidia.com/cuda-12-9-1-download-archive>`_, but requires at least version
   `7.0 <https://developer.nvidia.com/cuda-toolkit-70>`_.
 
 * `LLVM+Clang <http://releases.llvm.org>`_ version is determined at least partially by 
   the CUDA version you are using, as shown in the table below. The recommended Clang release 
-  is the latest stable release `20.1.8 <https://github.com/llvm/llvm-project/releases/tag/llvmorg-20.1.8>`_, 
+  is the latest stable release `21.1.0 <https://github.com/llvm/llvm-project/releases/tag/llvmorg-21.1.0>`_, 
   or at least version `4.0.0 <http://releases.llvm.org/download.html#4.0.0>`_.
 
 .. list-table::
@@ -50,11 +50,11 @@ Release Dependencies
     - supported LLVM release versions
     - Windows
     - Linux
-  * - `12.9.0 <https://developer.nvidia.com/cuda-downloads>`_
-    - `21.0.0git <https://github.com/llvm/llvm-project>`_
+  * - `12.9.1 <https://developer.nvidia.com/cuda-12-9-1-download-archive>`_:sup:`1`
+    - `21.1.0 <https://github.com/llvm/llvm-project/releases/tag/llvmorg-21.1.0>`_:sup:`1`
     - ✅
     - ✅
-  * - `12.8.1 <https://developer.nvidia.com/cuda-12-8-1-download-archive>`_:sup:`1`
+  * - `12.8.1 <https://developer.nvidia.com/cuda-12-8-1-download-archive>`_
     - `20.1.0 <https://github.com/llvm/llvm-project/releases/tag/llvmorg-20.1.0>`_,
       `20.1.1 <https://github.com/llvm/llvm-project/releases/tag/llvmorg-20.1.1>`_,
       `20.1.2 <https://github.com/llvm/llvm-project/releases/tag/llvmorg-20.1.2>`_,
@@ -63,7 +63,7 @@ Release Dependencies
       `20.1.5 <https://github.com/llvm/llvm-project/releases/tag/llvmorg-20.1.5>`_,
       `20.1.6 <https://github.com/llvm/llvm-project/releases/tag/llvmorg-20.1.6>`_,
       `20.1.7 <https://github.com/llvm/llvm-project/releases/tag/llvmorg-20.1.7>`_,
-      `20.1.8 <https://github.com/llvm/llvm-project/releases/tag/llvmorg-20.1.8>`_:sup:`1`
+      `20.1.8 <https://github.com/llvm/llvm-project/releases/tag/llvmorg-20.1.8>`_
     - ✅
     - ✅
   * - `12.6.3 <https://developer.nvidia.com/cuda-12-6-3-download-archive>`_
@@ -251,7 +251,7 @@ Release Dependencies
 In most cases, you can get a suitable version of ``LLVM+Clang`` with your package manager. However, you can also
 `download a release archive <http://releases.llvm.org/>`_ and build or install it. In case of multiple versions of ``LLVM`` installed, set
 `CMAKE_PREFIX_PATH <https://cmake.org/cmake/help/latest/variable/CMAKE_PREFIX_PATH.html>`_ so that
-``CMake`` can find the desired version of ``LLVM``. For example, ``-DCMAKE_PREFIX_PATH=D:\LLVM\20.1.8\dist``.
+``CMake`` can find the desired version of ``LLVM``. For example, ``-DCMAKE_PREFIX_PATH=D:\LLVM\21.1.0\dist``.
 
 Usage
 =====
@@ -264,21 +264,21 @@ with ``Clang``:
 
 .. code:: shell
 
-  ./hipify-clang square.cu --cuda-path=/usr/local/cuda-12.8 -I /usr/local/cuda-12.8/samples/common/inc
+  ./hipify-clang square.cu --cuda-path=/usr/local/cuda-12.9 -I /usr/local/cuda-12.9/samples/common/inc
 
 ``hipify-clang`` arguments are supplied first, followed by a separator ``--`` and the arguments to be
 passed to Clang for compiling the input file:
 
 .. code:: shell
 
-  ./hipify-clang cpp17.cu --cuda-path=/usr/local/cuda-12.8 -- -std=c++17
+  ./hipify-clang cpp17.cu --cuda-path=/usr/local/cuda-12.9 -- -std=c++17
 
 ``hipify-clang`` also supports the hipification of multiple files that can be specified in a single
 command with absolute or relative paths:
 
 .. code:: shell
 
-  ./hipify-clang cpp17.cu ../../square.cu /home/user/cuda/intro.cu --cuda-path=/usr/local/cuda-12.8 -- -std=c++17
+  ./hipify-clang cpp17.cu ../../square.cu /home/user/cuda/intro.cu --cuda-path=/usr/local/cuda-12.9 -- -std=c++17
 
 To use a specific version of LLVM during hipification, specify the ``hipify-clang`` option
 ``--clang-resource-directory=`` to point to the Clang resource directory, which is the
@@ -287,7 +287,7 @@ header files used during the hipification process:
 
 .. code:: shell
 
-  ./hipify-clang square.cu --cuda-path=/usr/local/cuda-12.8 --clang-resource-directory=/usr/llvm/20.1.8/dist/lib/clang/20
+  ./hipify-clang square.cu --cuda-path=/usr/local/cuda-12.9 --clang-resource-directory=/usr/llvm/21.1.0/dist/lib/clang/21
 
 For more information, refer to the `Clang manual for compiling CUDA <https://llvm.org/docs/CompileCudaWithLLVM.html#compiling-cuda-code>`_.
 
@@ -345,7 +345,7 @@ Print statistics
 
 .. code:: cpp
 
-  hipify-clang intro.cu -cuda-path="C:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v12.8" --print-stats
+  hipify-clang intro.cu -cuda-path="C:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v12.9" --print-stats
 
 .. code:: cpp
 
@@ -403,7 +403,7 @@ Print CSV statistics
 
 .. code-block:: cpp
 
-  hipify-clang intro.cu -cuda-path="C:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v12.8" --print-stats-csv
+  hipify-clang intro.cu -cuda-path="C:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v12.9" --print-stats-csv
 
 This generates ``intro.cu.csv`` file with statistics:
 


### PR DESCRIPTION
+ No patches are needed
+ Updated the `README.md` accordingly
+ Tested on `Windows 11` (latest `VS 2019` and `VS 2022`)  and `Ubuntu 24.04.2` (`GNU C/C++ 13.3`)
