### PR TITLE
[HIPIFY][doc][#2072][fix] Fix `ref:`s and `toc` in the `rst` documentation

### DIFF
--- a/docs/how-to/hipify-clang.rst
+++ b/docs/how-to/hipify-clang.rst
@@ -257,7 +257,7 @@ Usage
 =====
 
 .. note::
-  For additional details on the following ``hipify-clang`` command options, see :ref:`hipify_clang-command`
+  For additional details on the following ``hipify-clang`` command options, see :ref:`hipify-clang-command`
 
 To process a file, ``hipify-clang`` needs access to the same headers that are required to compile it
 with ``Clang``:

--- a/docs/how-to/hipify-perl.rst
+++ b/docs/how-to/hipify-perl.rst
@@ -34,7 +34,7 @@ Using hipify-perl
 Example
 =======
 
-For additional details on the following ``hipify-perl`` command options, see :ref:`hipify_perl-command`. For more advanced translation needs use ``hipify-clang`` as it is more comprehensive and accurate. 
+For additional details on the following ``hipify-perl`` command options, see :ref:`hipify-perl-command`. For more advanced translation needs use ``hipify-clang`` as it is more comprehensive and accurate. 
 
 Convert a simple CUDA file (``square.cu``) to HIP using ``hipify-perl``:
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -30,20 +30,21 @@ The documentation is structured as follows:
 
   .. grid-item-card:: Building
 
-    * :ref:`build-hipify-clang`
+    * :ref:`build-hipify-clang-linux`
+    * :ref:`build-hipify-clang-windows`
     * :ref:`build-hipify-perl`
-    
+
   .. grid-item-card:: How to
 
     * :doc:`Use hipify-clang <./how-to/hipify-clang>`
     * :doc:`Use hipify-perl <./how-to/hipify-perl>`
-    
+
   .. grid-item-card:: API reference
 
-    * :ref:`hipify_clang-command`
-    * :ref:`hipify_perl-command`
+    * :ref:`hipify-clang-cmd`
+    * :ref:`hipify-perl-cmd`
     * :doc:`Supported APIs <./reference/supported_apis>`
-     
+
 To contribute to the documentation, refer to
 `Contributing to ROCm  <https://rocm.docs.amd.com/en/latest/contribute/contributing.html>`_.
 

--- a/docs/sphinx/_toc.yml.in
+++ b/docs/sphinx/_toc.yml.in
@@ -6,7 +6,8 @@ root: index
 subtrees:
 - caption: Building
   entries:
-  - file: building/building-hipify
+  - file: building/build-hipify-clang-linux
+  - file: building/build-hipify-clang-windows
   - file: building/build-hipify-perl
 - caption: How to
   entries:
@@ -21,7 +22,7 @@ subtrees:
   - file: reference/supported_apis
     subtrees:
     - entries:
-      - file: reference/tables/CUDA_Runtime_API_functions_supported_by_HIP     
+      - file: reference/tables/CUDA_Runtime_API_functions_supported_by_HIP
         title: CUDA Runtime functions
       - file: reference/tables/CUDA_Driver_API_functions_supported_by_HIP
         title: CUDA Driver functions
@@ -37,13 +38,13 @@ subtrees:
         title: cuSPARSE
       - file: reference/tables/CUSOLVER_API_supported_by_HIP
         title: cuSOLVER API
-      - file: reference/tables/CURAND_API_supported_by_HIP      
+      - file: reference/tables/CURAND_API_supported_by_HIP
         title: cuRAND API
       - file: reference/tables/CUFFT_API_supported_by_HIP
         title: cuFFT API
-      - file: reference/tables/CUDNN_API_supported_by_HIP     
+      - file: reference/tables/CUDNN_API_supported_by_HIP
         title: cuDNN API
-      - file: reference/tables/CUTENSOR_API_supported_by_HIP     
+      - file: reference/tables/CUTENSOR_API_supported_by_HIP
         title: cuTENSOR API
       - file: reference/tables/CUB_API_supported_by_HIP
         title: CUB API


### PR DESCRIPTION
+ Broken `toc` structure, missing newly added `rst` files, typos, formatting
