### PR TITLE
[HIPIFY][doc][fix][rst] Set correct name tags to navigate across the documentation

### DIFF
--- a/docs/building/build-hipify-clang-linux.rst
+++ b/docs/building/build-hipify-clang-linux.rst
@@ -2,7 +2,7 @@
    :description: Tools to automatically translate CUDA source code into portable HIP C++
    :keywords: HIPIFY, ROCm, library, tool, CUDA, CUDA2HIP, hipify-clang, hipify-perl, Linux
 
-.. _linux-instructions:
+.. _build-hipify-clang-linux:
 
 **************************************************************************
 Building hipify-clang on Linux

--- a/docs/building/build-hipify-clang-windows.rst
+++ b/docs/building/build-hipify-clang-windows.rst
@@ -2,7 +2,7 @@
    :description: Tools to automatically translate CUDA source code into portable HIP C++
    :keywords: HIPIFY, ROCm, library, tool, CUDA, CUDA2HIP, hipify-clang, hipify-perl, Windows
 
-.. _windows-instructions:
+.. _build-hipify-clang-windows:
 
 **************************************************************************
 Building hipify-clang on Windows


### PR DESCRIPTION
+ Build instructions for `hipify-clang` were unreachable from the `index.rst`
