### PR TITLE
[HIPIFY][doc][fix] Introduced multilevel tree for `Supported APIs`: `HIP`, `ROC`, and `HIP+ROC`

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -44,6 +44,9 @@ The documentation is structured as follows:
     * :doc:`hipify-clang commands <./reference/hipify-clang-cmd>`
     * :doc:`hipify-perl commands <./reference/hipify-perl-cmd>`
     * :doc:`Supported APIs <./reference/supported_apis>`
+    * :doc:`HIP supported APIs <./reference/hip_supported_apis>`
+    * :doc:`ROC supported APIs <./reference/roc_supported_apis>`
+    * :doc:`HIP and ROC supported APIs <./reference/hip_roc_supported_apis>`
 
 To contribute to the documentation, refer to
 `Contributing to ROCm  <https://rocm.docs.amd.com/en/latest/contribute/contributing.html>`_.

--- a/docs/reference/hip_roc_supported_apis.md
+++ b/docs/reference/hip_roc_supported_apis.md
@@ -1,0 +1,16 @@
+<head>
+  <meta charset="UTF-8">
+  <meta name="description" content="NVIDIA CUDA APIs supported by HIPIFY">
+
+  <meta name="keywords" content="HIPIFY, ROCm, NVIDIA, CUDA, CUDA2HIP, hipify-clang, hipify-perl">
+</head>
+
+# Supported NVIDIA CUDA APIs
+
+|     **CUDA**     |                            **HIP & ROC**                                |
+|:-----------------|:------------------------------------------------------------------------|
+| CUBLAS API       | [HIP + ROC BLAS API](tables/CUBLAS_API_supported_by_HIP_and_ROC.md)     |
+| CUSPARSE API     | [HIP + ROC SPARSE API](tables/CUSPARSE_API_supported_by_HIP_and_ROC.md) |
+| CURAND API       | [HIP + ROC RAND API](tables/CURAND_API_supported_by_HIP_and_ROC.md)     |
+
+To generate the above documentation with the information about all supported CUDA APIs in Markdown format, run `hipify-clang --md --doc-format=full` with or without specifying the output directory (`-o`), for HIP and ROC separately `--doc-roc=separate` or in the joint format (HIP & ROC) `--doc-roc=joint`.

--- a/docs/reference/hip_supported_apis.md
+++ b/docs/reference/hip_supported_apis.md
@@ -1,0 +1,25 @@
+<head>
+  <meta charset="UTF-8">
+  <meta name="description" content="NVIDIA CUDA APIs supported by HIPIFY">
+
+  <meta name="keywords" content="HIPIFY, ROCm, NVIDIA, CUDA, CUDA2HIP, hipify-clang, hipify-perl">
+</head>
+
+# HIP supported NVIDIA CUDA APIs
+
+|     **CUDA**     | **HIP**                                                           |
+|:-----------------|:------------------------------------------------------------------|
+| CUDA Runtime API | [HIP API](tables/CUDA_Runtime_API_functions_supported_by_HIP.md)  |
+| CUDA Driver API  | [HIP API](tables/CUDA_Driver_API_functions_supported_by_HIP.md)   |
+| CUComplex API    | [HIP API](tables/cuComplex_API_supported_by_HIP.md)               |
+| CUDA Device API  | [HIP Device API](tables/CUDA_Device_API_supported_by_HIP.md)      |
+| CUDA RTC API     | [HIP RTC API](tables/CUDA_RTC_API_supported_by_HIP.md)            |
+| CUBLAS API       | [HIP BLAS API](tables/CUBLAS_API_supported_by_HIP.md)             |
+| CUSPARSE API     | [HIP SPARSE API](tables/CUSPARSE_API_supported_by_HIP.md)         |
+| CUSOLVER API     | [HIP SOLVER API](tables/CUSOLVER_API_supported_by_HIP.md)         |
+| CURAND API       | [HIP RAND API](tables/CURAND_API_supported_by_HIP.md)             |
+| CUFFT API        | [HIP FFT API](tables/CUFFT_API_supported_by_HIP.md)               |
+| CUTENSOR API     | [HIP TENSOR API](tables/CUTENSOR_API_supported_by_HIP.md)         |
+| CUB API          | [HIP CUB API](tables/CUB_API_supported_by_HIP.md)                 |
+
+To generate the above documentation with the information about all supported CUDA APIs in Markdown format, run `hipify-clang --md --doc-format=full` with or without specifying the output directory (`-o`), for HIP and ROC separately `--doc-roc=separate` or in the joint format (HIP & ROC) `--doc-roc=joint`.

--- a/docs/reference/roc_supported_apis.md
+++ b/docs/reference/roc_supported_apis.md
@@ -1,0 +1,17 @@
+<head>
+  <meta charset="UTF-8">
+  <meta name="description" content="NVIDIA CUDA APIs supported by HIPIFY">
+
+  <meta name="keywords" content="HIPIFY, ROCm, NVIDIA, CUDA, CUDA2HIP, hipify-clang, hipify-perl">
+</head>
+
+# Supported NVIDIA CUDA APIs
+
+|     **CUDA**     |                            **ROC**                        |
+|:-----------------|:----------------------------------------------------------|
+| CUBLAS API       | [ROC BLAS API](tables/CUBLAS_API_supported_by_ROC.md)     |
+| CUSPARSE API     | [ROC SPARSE API](tables/CUSPARSE_API_supported_by_ROC.md) |
+| CURAND API       | [ROC RAND API](tables/CURAND_API_supported_by_ROC.md)     |
+| CUDNN API        | [MIOPEN API](tables/CUDNN_API_supported_by_MIOPEN.md)     |
+
+To generate the above documentation with the information about all supported CUDA APIs in Markdown format, run `hipify-clang --md --doc-format=full` with or without specifying the output directory (`-o`), for HIP and ROC separately `--doc-roc=separate` or in the joint format (HIP & ROC) `--doc-roc=joint`.

--- a/docs/sphinx/_toc.yml.in
+++ b/docs/sphinx/_toc.yml.in
@@ -20,9 +20,9 @@ subtrees:
   - file: reference/hipify-clang-cmd
   - file: reference/hipify-perl-cmd
   - file: reference/supported_apis
+  - file: reference/hip_supported_apis
     subtrees:
-    - caption: HIP
-      entries:
+    - entries:
       - file: reference/tables/CUDA_Runtime_API_functions_supported_by_HIP
         title: CUDA Runtime API
       - file: reference/tables/CUDA_Driver_API_functions_supported_by_HIP
@@ -47,8 +47,9 @@ subtrees:
         title: cuTENSOR API
       - file: reference/tables/CUB_API_supported_by_HIP
         title: CUB API
-    - caption: ROC
-      entries:
+  - file: reference/roc_supported_apis
+    subtrees:
+    - entries:
       - file: reference/tables/CUBLAS_API_supported_by_ROC
         title: cuBLAS API
       - file: reference/tables/CUSPARSE_API_supported_by_ROC
@@ -57,8 +58,9 @@ subtrees:
         title: cuRAND API
       - file: reference/tables/CUDNN_API_supported_by_MIOPEN
         title: cuDNN API
-    - caption: HIP and ROC
-      entries:
+  - file: reference/hip_roc_supported_apis
+    subtrees:
+    - entries:
       - file: reference/tables/CUBLAS_API_supported_by_HIP_and_ROC
         title: cuBLAS API
       - file: reference/tables/CUSPARSE_API_supported_by_HIP_and_ROC


### PR DESCRIPTION
+ Plus corresponding Markdown tables
