### PR TITLE
[HIPIFY][bug] Missing support of `cuda_bf16.h` import

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -7248,6 +7248,7 @@ sub simpleSubstitutions {
     subst("cooperative_groups.h", "hip\/hip_cooperative_groups.h", "include");
     subst("cublasLt.h", "hipblaslt.h", "include");
     subst("cublas_api.h", "hipblas.h", "include");
+    subst("cuda_bf16.h", "hip\/hip_bf16.h", "include");
     subst("cuda_fp16.h", "hip\/hip_fp16.h", "include");
     subst("cuda_fp4.h", "hip\/hip_fp4.h", "include");
     subst("cuda_fp8.h", "hip\/hip_fp8.h", "include");


### PR DESCRIPTION
I have a CUDA header file with these includes:
```
#include <cuda.h>
#include <cuda_bf16.h>
#include <cuda_fp16.h>
```
I call ROCm 6.4 HIPify on it like this
```
$ lib/rocm-6.4.1/bin/hipify-perl in.cuh -o out.h
```
HIP-ify converts two of the imports correctly, but seems to miss one entirely
```
#include <hip/hip_runtime.h>
#include <cuda_bf16.h>
#include <hip/hip_fp16.h>
```
This is because hipify-perl does not have any include directive substitutions for cuda_bf16.h. This PR fixes this issue.