### PR TITLE
[HIPIFY][CUDA 13][tests][fix] Fix the `headers_test_09_rocrand.cu` test

### DIFF
--- a/tests/lit.cfg
+++ b/tests/lit.cfg
@@ -182,6 +182,7 @@ if config.cuda_version_major >= 12:
 if config.cuda_version_major >= 13:
     config.excludes.append('cd_intro_before_13000.cu')
     config.excludes.append('intro_before_13000.cu')
+    config.excludes.append('headers_test_09_rocrand_before_13000.cu')
 
 if config.cuda_version_major < 13:
     config.excludes.append('cd_intro.cu')

--- a/tests/unit_tests/headers/headers_test_09_rocrand_before_13000.cu
+++ b/tests/unit_tests/headers/headers_test_09_rocrand_before_13000.cu
@@ -11,6 +11,7 @@
 // CHECK: #include "hip/device_functions.h"
 // CHECK: #include "hip/driver_types.h"
 // CHECK: #include "hip/hip_complex.h"
+// CHECK: #include "hip/hip_texture_types.h"
 // CHECK: #include "hip/hip_vector_types.h"
 
 // CHECK: #include <iostream>
@@ -74,6 +75,9 @@
 #include "device_functions.h"
 #include "driver_types.h"
 #include "cuComplex.h"
+#if CUDA_VERSION < 13000
+#include "cuda_texture_types.h"
+#endif
 #include "vector_types.h"
 
 #include <iostream>


### PR DESCRIPTION
+ Split `headers_test_09_rocrand.cu` into two with introducing `headers_test_09_rocrand_before_13000.cu`
+ [Reason] The `cuda_texture_types.h` is excluded from `CUDA 13.0.0`
