### PR TITLE
[HIPIFY][CUDA 13][tests][fix] Fix the `headers_test_09_12000.cu` test

### DIFF
--- a/tests/unit_tests/headers/headers_test_09_12000.cu
+++ b/tests/unit_tests/headers/headers_test_09_12000.cu
@@ -12,7 +12,6 @@
 // CHECK: #include "hip/driver_types.h"
 // CHECK: #include "hip/hip_complex.h"
 // CHECK: #include "hip/hip_fp16.h"
-// CHECK: #include "hip/hip_texture_types.h"
 // CHECK: #include "hip/hip_vector_types.h"
 
 // CHECK: #include <iostream>
@@ -67,7 +66,6 @@
 #include "driver_types.h"
 #include "cuComplex.h"
 #include "cuda_fp16.h"
-#include "cuda_texture_types.h"
 #include "vector_types.h"
 
 #include <iostream>


### PR DESCRIPTION
+ [Reason] The `cuda_texture_types.h` is excluded from `CUDA 13.0.0`, and this fact is already being tested by another test [#2092].
