### PR TITLE
[HIPIFY][doc] Update hipify-clang.rst (on behalf of randyh62)

### DIFF
--- a/docs/how-to/hipify-clang.rst
+++ b/docs/how-to/hipify-clang.rst
@@ -317,7 +317,7 @@ To provide Clang options, use ``compile_commands.json`` file, whereas to provide
   provided before the separator.
 
 Here's an
-`example <https://github.com/ROCm/HIPIFY/blob/amd-staging/tests/unit_tests/compilation_database/compile_commands.json.in>`_
+`example <https://github.com/ROCm/HIPIFY/blob/amd-staging/tests/unit_tests/compilation_database/compilation_database_before_13000/compile_commands.json.in>`_
 demonstrating the ``compile_commands.json`` usage:
 
 .. code:: json


### PR DESCRIPTION
## Motivation

To fix the broken URL to the JSON file

P.S. Instead of cherry-picking, the original commit is a4cdb8210e160769ae4080bd7ceb17f2ea2d715d