### PR TITLE
[HIPIFY][CUDA 13] CUDA 13.0.0 support - Step 11 - Runtime - Data Types

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -898,6 +898,7 @@ my %deprecated_funcs = (
     "cudaDeviceSetSharedMemConfig" => "12.4",
     "cudaDeviceGetSharedMemConfig" => "12.4",
     "cudaDevAttrMaxTimelineSemaphoreInteropSupported" => "11.5",
+    "cudaDevAttrCooperativeMultiDeviceLaunch" => "11.4",
     "cudaD3D9UnregisterResource" => "10.0",
     "cudaD3D9UnmapResources" => "10.0",
     "cudaD3D9ResourceSetMapFlags" => "10.0",
@@ -1456,7 +1457,11 @@ my %removed_funcs = (
     "cudaGetTextureAlignmentOffset" => "12.0",
     "cudaGetSurfaceReference" => "12.0",
     "cudaDevicePropDontCare" => "12.0",
+    "cudaDevAttrMaxTimelineSemaphoreInteropSupported" => "13.0",
+    "cudaDevAttrCooperativeMultiDeviceLaunch" => "13.0",
     "cudaCreateTextureObject_v2" => "12.0",
+    "cudaCooperativeLaunchMultiDeviceNoPreSync" => "13.0",
+    "cudaCooperativeLaunchMultiDeviceNoPostSync" => "13.0",
     "cudaConfigureCall" => "10.1",
     "cudaCSV" => "12.0",
     "cudaBindTextureToMipmappedArray" => "12.0",
@@ -8982,6 +8987,7 @@ sub simpleSubstitutions {
     subst("cudaDevAttrPciDeviceId", "hipDeviceAttributePciDeviceId", "numeric_literal");
     subst("cudaDevAttrPciDomainId", "hipDeviceAttributePciDomainId", "numeric_literal");
     subst("cudaDevAttrReserved94", "hipDeviceAttributeCanUseStreamWaitValue", "numeric_literal");
+    subst("cudaDevAttrReserved96", "hipDeviceAttributeCooperativeMultiDeviceLaunch", "numeric_literal");
     subst("cudaDevAttrSingleToDoublePrecisionPerfRatio", "hipDeviceAttributeSingleToDoublePrecisionPerfRatio", "numeric_literal");
     subst("cudaDevAttrStreamPrioritiesSupported", "hipDeviceAttributeStreamPrioritiesSupported", "numeric_literal");
     subst("cudaDevAttrSurfaceAlignment", "hipDeviceAttributeSurfaceAlignment", "numeric_literal");
@@ -9195,6 +9201,7 @@ sub simpleSubstitutions {
     subst("cudaMemHandleTypeWin32Kmt", "hipMemHandleTypeWin32Kmt", "numeric_literal");
     subst("cudaMemLocationTypeDevice", "hipMemLocationTypeDevice", "numeric_literal");
     subst("cudaMemLocationTypeInvalid", "hipMemLocationTypeInvalid", "numeric_literal");
+    subst("cudaMemLocationTypeNone", "hipMemLocationTypeInvalid", "numeric_literal");
     subst("cudaMemPoolAttrReleaseThreshold", "hipMemPoolAttrReleaseThreshold", "numeric_literal");
     subst("cudaMemPoolAttrReservedMemCurrent", "hipMemPoolAttrReservedMemCurrent", "numeric_literal");
     subst("cudaMemPoolAttrReservedMemHigh", "hipMemPoolAttrReservedMemHigh", "numeric_literal");
@@ -11312,6 +11319,7 @@ sub warnRemovedFunctions {
     "cudaMemHandleTypeFabric",
     "cudaMemFabricHandle_t",
     "cudaMemFabricHandle_st",
+    "cudaMemAllocationTypeManaged",
     "cudaMemAllocNodeParamsV2",
     "cudaMemAdvise_v2",
     "cudaLimitPersistingL2CacheSize",
@@ -11686,6 +11694,7 @@ sub warnRemovedFunctions {
     "cudaDevAttrReservedSharedMemoryPerBlock",
     "cudaDevAttrReserved93",
     "cudaDevAttrReserved92",
+    "cudaDevAttrReserved145",
     "cudaDevAttrReserved141",
     "cudaDevAttrReserved132",
     "cudaDevAttrReserved129",
@@ -11694,6 +11703,7 @@ sub warnRemovedFunctions {
     "cudaDevAttrReserved124",
     "cudaDevAttrReserved123",
     "cudaDevAttrReserved122",
+    "cudaDevAttrOnlyPartialHostNativeAtomicSupported",
     "cudaDevAttrNumaId",
     "cudaDevAttrNumaConfig",
     "cudaDevAttrMpsEnabled",
@@ -11714,6 +11724,7 @@ sub warnRemovedFunctions {
     "cudaDevAttrHostNumaMultinodeIpcSupported",
     "cudaDevAttrHostNumaMemoryPoolsSupported",
     "cudaDevAttrHostNumaId",
+    "cudaDevAttrHostMemoryPoolsSupported",
     "cudaDevAttrGpuPciSubsystemId",
     "cudaDevAttrGpuPciDeviceId",
     "cudaDevAttrGPUDirectRDMAWritesOrdering",

--- a/docs/reference/tables/CUDA_Runtime_API_functions_supported_by_HIP.md
+++ b/docs/reference/tables/CUDA_Runtime_API_functions_supported_by_HIP.md
@@ -758,8 +758,8 @@
 |`cudaComputeModeExclusiveProcess`| | | | |`hipComputeModeExclusiveProcess`|2.0.0| | | | |
 |`cudaComputeModeProhibited`| | | | |`hipComputeModeProhibited`|1.9.0| | | | |
 |`cudaConditionalNodeParams`|12.3| | | | | | | | | |
-|`cudaCooperativeLaunchMultiDeviceNoPostSync`|9.0| | | |`hipCooperativeLaunchMultiDeviceNoPostSync`|3.2.0| | | | |
-|`cudaCooperativeLaunchMultiDeviceNoPreSync`|9.0| | | |`hipCooperativeLaunchMultiDeviceNoPreSync`|3.2.0| | | | |
+|`cudaCooperativeLaunchMultiDeviceNoPostSync`|9.0| | |13.0|`hipCooperativeLaunchMultiDeviceNoPostSync`|3.2.0| | | | |
+|`cudaCooperativeLaunchMultiDeviceNoPreSync`|9.0| | |13.0|`hipCooperativeLaunchMultiDeviceNoPreSync`|3.2.0| | | | |
 |`cudaCpuDeviceId`|8.0| | | |`hipCpuDeviceId`|3.7.0| | | | |
 |`cudaD3D10DeviceList`| | | | | | | | | | |
 |`cudaD3D10DeviceListAll`| | | | | | | | | | |
@@ -800,7 +800,7 @@
 |`cudaDevAttrConcurrentKernels`| | | | |`hipDeviceAttributeConcurrentKernels`|1.6.0| | | | |
 |`cudaDevAttrConcurrentManagedAccess`|8.0| | | |`hipDeviceAttributeConcurrentManagedAccess`|3.10.0| | | | |
 |`cudaDevAttrCooperativeLaunch`|9.0| | | |`hipDeviceAttributeCooperativeLaunch`|2.6.0| | | | |
-|`cudaDevAttrCooperativeMultiDeviceLaunch`|9.0| | | |`hipDeviceAttributeCooperativeMultiDeviceLaunch`|2.6.0| | | | |
+|`cudaDevAttrCooperativeMultiDeviceLaunch`|9.0|11.4| |13.0|`hipDeviceAttributeCooperativeMultiDeviceLaunch`|2.6.0| | | | |
 |`cudaDevAttrD3D12CigSupported`|12.5| | | | | | | | | |
 |`cudaDevAttrDeferredMappingCudaArraySupported`|11.6| | | | | | | | | |
 |`cudaDevAttrDirectManagedMemAccessFromHost`|9.2| | | |`hipDeviceAttributeDirectManagedMemAccessFromHost`|3.10.0| | | | |
@@ -813,6 +813,7 @@
 |`cudaDevAttrGpuOverlap`| | | | |`hipDeviceAttributeAsyncEngineCount`|4.3.0| | | | |
 |`cudaDevAttrGpuPciDeviceId`|12.8| | | | | | | | | |
 |`cudaDevAttrGpuPciSubsystemId`|12.8| | | | | | | | | |
+|`cudaDevAttrHostMemoryPoolsSupported`|13.0| | | | | | | | | |
 |`cudaDevAttrHostNativeAtomicSupported`|8.0| | | |`hipDeviceAttributeHostNativeAtomicSupported`|4.3.0| | | | |
 |`cudaDevAttrHostNumaId`|12.2| | | | | | | | | |
 |`cudaDevAttrHostNumaMemoryPoolsSupported`|12.9| | | | | | | | | |
@@ -884,7 +885,7 @@
 |`cudaDevAttrMaxTextureCubemapWidth`| | | | |`hipDeviceAttributeMaxTextureCubemap`|4.3.0| | | | |
 |`cudaDevAttrMaxThreadsPerBlock`| | | | |`hipDeviceAttributeMaxThreadsPerBlock`|1.6.0| | | | |
 |`cudaDevAttrMaxThreadsPerMultiProcessor`| | | | |`hipDeviceAttributeMaxThreadsPerMultiProcessor`|1.6.0| | | | |
-|`cudaDevAttrMaxTimelineSemaphoreInteropSupported`|11.2|11.5| | | | | | | | |
+|`cudaDevAttrMaxTimelineSemaphoreInteropSupported`|11.2|11.5| |13.0| | | | | | |
 |`cudaDevAttrMemSyncDomainCount`|12.0| | | | | | | | | |
 |`cudaDevAttrMemoryClockRate`| | | | |`hipDeviceAttributeMemoryClockRate`|1.6.0| | | | |
 |`cudaDevAttrMemoryPoolSupportedHandleTypes`|11.3| | | | | | | | | |
@@ -894,6 +895,7 @@
 |`cudaDevAttrMultiProcessorCount`| | | | |`hipDeviceAttributeMultiprocessorCount`|1.6.0| | | | |
 |`cudaDevAttrNumaConfig`|12.2| | | | | | | | | |
 |`cudaDevAttrNumaId`|12.2| | | | | | | | | |
+|`cudaDevAttrOnlyPartialHostNativeAtomicSupported`|13.0| | | | | | | | | |
 |`cudaDevAttrPageableMemoryAccess`|8.0| | | |`hipDeviceAttributePageableMemoryAccess`|3.10.0| | | | |
 |`cudaDevAttrPageableMemoryAccessUsesHostPageTables`|9.2| | | |`hipDeviceAttributePageableMemoryAccessUsesHostPageTables`|3.10.0| | | | |
 |`cudaDevAttrPciBusId`| | | | |`hipDeviceAttributePciBusId`|1.6.0| | | | |
@@ -907,9 +909,11 @@
 |`cudaDevAttrReserved129`|12.1| | | | | | | | | |
 |`cudaDevAttrReserved132`|12.1| | | | | | | | | |
 |`cudaDevAttrReserved141`|12.9| | | | | | | | | |
+|`cudaDevAttrReserved145`|13.0| | | | | | | | | |
 |`cudaDevAttrReserved92`|9.0| | | | | | | | | |
 |`cudaDevAttrReserved93`|9.0| | | | | | | | | |
 |`cudaDevAttrReserved94`|9.0| | | |`hipDeviceAttributeCanUseStreamWaitValue`|4.3.0| | | | |
+|`cudaDevAttrReserved96`|13.0| | | |`hipDeviceAttributeCooperativeMultiDeviceLaunch`|2.6.0| | | | |
 |`cudaDevAttrReservedSharedMemoryPerBlock`|11.0| | | | | | | | | |
 |`cudaDevAttrSingleToDoublePrecisionPerfRatio`|8.0| | | |`hipDeviceAttributeSingleToDoublePrecisionPerfRatio`|4.3.0| | | | |
 |`cudaDevAttrSparseCudaArraySupported`|11.1| | | | | | | | | |
@@ -1525,6 +1529,7 @@
 |`cudaMemAllocationHandleType`|11.2| | | |`hipMemAllocationHandleType`|5.2.0| | | | |
 |`cudaMemAllocationType`|11.2| | | |`hipMemAllocationType`|5.2.0| | | | |
 |`cudaMemAllocationTypeInvalid`|11.2| | | |`hipMemAllocationTypeInvalid`|5.2.0| | | | |
+|`cudaMemAllocationTypeManaged`|13.0| | | | | | | | | |
 |`cudaMemAllocationTypeMax`|11.2| | | |`hipMemAllocationTypeMax`|5.2.0| | | | |
 |`cudaMemAllocationTypePinned`|11.2| | | |`hipMemAllocationTypePinned`|5.2.0| | | | |
 |`cudaMemAttachGlobal`| | | | |`hipMemAttachGlobal`|2.5.0| | | | |
@@ -1545,6 +1550,7 @@
 |`cudaMemLocationTypeHostNuma`|12.2| | | | | | | | | |
 |`cudaMemLocationTypeHostNumaCurrent`|12.2| | | | | | | | | |
 |`cudaMemLocationTypeInvalid`|11.2| | | |`hipMemLocationTypeInvalid`|5.2.0| | | | |
+|`cudaMemLocationTypeNone`|13.0| | | |`hipMemLocationTypeInvalid`|5.2.0| | | | |
 |`cudaMemPoolAttr`|11.2| | | |`hipMemPoolAttr`|5.2.0| | | | |
 |`cudaMemPoolAttrReleaseThreshold`|11.2| | | |`hipMemPoolAttrReleaseThreshold`|5.2.0| | | | |
 |`cudaMemPoolAttrReservedMemCurrent`|11.3| | | |`hipMemPoolAttrReservedMemCurrent`|5.2.0| | | | |

--- a/src/CUDA2HIP_Runtime_API_types.cpp
+++ b/src/CUDA2HIP_Runtime_API_types.cpp
@@ -615,7 +615,10 @@ const std::map<llvm::StringRef, hipCounter> CUDA_RUNTIME_TYPE_NAME_MAP {
   // CU_DEVICE_ATTRIBUTE_COOPERATIVE_LAUNCH
   {"cudaDevAttrCooperativeLaunch",                                     {"hipDeviceAttributeCooperativeLaunch",                      "", CONV_NUMERIC_LITERAL, API_RUNTIME, SEC::DATA_TYPES}}, // 95
   // CU_DEVICE_ATTRIBUTE_COOPERATIVE_MULTI_DEVICE_LAUNCH
-  {"cudaDevAttrCooperativeMultiDeviceLaunch",                          {"hipDeviceAttributeCooperativeMultiDeviceLaunch",           "", CONV_NUMERIC_LITERAL, API_RUNTIME, SEC::DATA_TYPES}}, // 96
+  {"cudaDevAttrCooperativeMultiDeviceLaunch",                          {"hipDeviceAttributeCooperativeMultiDeviceLaunch",           "", CONV_NUMERIC_LITERAL, API_RUNTIME, SEC::DATA_TYPES, CUDA_DEPRECATED| CUDA_REMOVED}}, // 96
+  //
+  {"cudaDevAttrReserved96",                                            {"hipDeviceAttributeCooperativeMultiDeviceLaunch",           "", CONV_NUMERIC_LITERAL, API_RUNTIME, SEC::DATA_TYPES}}, // 96
+
   // CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_BLOCK_OPTIN
   // CUDA only
   {"cudaDevAttrMaxSharedMemoryPerBlockOptin",                          {"hipDeviceAttributeSharedMemPerBlockOptin",                 "", CONV_NUMERIC_LITERAL, API_RUNTIME, SEC::DATA_TYPES}}, // 97
@@ -641,7 +644,7 @@ const std::map<llvm::StringRef, hipCounter> CUDA_RUNTIME_TYPE_NAME_MAP {
   // CU_DEVICE_ATTRIBUTE_READ_ONLY_HOST_REGISTER_SUPPORTED
   {"cudaDevAttrHostRegisterReadOnlySupported",                         {"hipDeviceAttributeReadOnlyHostRestigerSupported",          "", CONV_NUMERIC_LITERAL, API_RUNTIME, SEC::DATA_TYPES, HIP_UNSUPPORTED}}, // 113
   // CU_DEVICE_ATTRIBUTE_TIMELINE_SEMAPHORE_INTEROP_SUPPORTED
-  {"cudaDevAttrMaxTimelineSemaphoreInteropSupported",                  {"hipDeviceAttributeMaxTimelineSemaphoreInteropSupported",   "", CONV_NUMERIC_LITERAL, API_RUNTIME, SEC::DATA_TYPES, HIP_UNSUPPORTED | CUDA_DEPRECATED}}, // 114
+  {"cudaDevAttrMaxTimelineSemaphoreInteropSupported",                  {"hipDeviceAttributeMaxTimelineSemaphoreInteropSupported",   "", CONV_NUMERIC_LITERAL, API_RUNTIME, SEC::DATA_TYPES, HIP_UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED}}, // 114
   // CU_DEVICE_ATTRIBUTE_TIMELINE_SEMAPHORE_INTEROP_SUPPORTED
   {"cudaDevAttrTimelineSemaphoreInteropSupported",                     {"hipDeviceAttributeTimelineSemaphoreInteropSupported",      "", CONV_NUMERIC_LITERAL, API_RUNTIME, SEC::DATA_TYPES, HIP_UNSUPPORTED}}, // 114
   // CU_DEVICE_ATTRIBUTE_MEMORY_POOLS_SUPPORTED
@@ -698,6 +701,12 @@ const std::map<llvm::StringRef, hipCounter> CUDA_RUNTIME_TYPE_NAME_MAP {
   {"cudaDevAttrHostNumaMemoryPoolsSupported",                          {"hipDevAttrHostNumaMemoryPoolsSupported",                   "", CONV_NUMERIC_LITERAL, API_RUNTIME, SEC::DATA_TYPES, HIP_UNSUPPORTED}}, // 142
   // CU_DEVICE_ATTRIBUTE_HOST_NUMA_MULTINODE_IPC_SUPPORTED
   {"cudaDevAttrHostNumaMultinodeIpcSupported",                         {"hipDeviceAttributeHostNumaMultinodeIpcSupported",          "", CONV_NUMERIC_LITERAL, API_RUNTIME, SEC::DATA_TYPES, HIP_UNSUPPORTED}}, // 143
+  //
+  {"cudaDevAttrHostMemoryPoolsSupported",                              {"hipDevAttrHostMemoryPoolsSupported",                       "", CONV_NUMERIC_LITERAL, API_RUNTIME, SEC::DATA_TYPES, HIP_UNSUPPORTED}}, // 144
+  //
+  {"cudaDevAttrReserved145",                                           {"hipDevAttrReserved145",                                    "", CONV_NUMERIC_LITERAL, API_RUNTIME, SEC::DATA_TYPES, HIP_UNSUPPORTED}}, // 145
+  //
+  {"cudaDevAttrOnlyPartialHostNativeAtomicSupported",                  {"hipDevAttrOnlyPartialHostNativeAtomicSupported",           "", CONV_NUMERIC_LITERAL, API_RUNTIME, SEC::DATA_TYPES, HIP_UNSUPPORTED}}, // 147
   // CU_DEVICE_ATTRIBUTE_MAX
   {"cudaDevAttrMax",                                                   {"hipDeviceAttributeMax",                                    "", CONV_NUMERIC_LITERAL, API_RUNTIME, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
 
@@ -1813,6 +1822,8 @@ const std::map<llvm::StringRef, hipCounter> CUDA_RUNTIME_TYPE_NAME_MAP {
   // cudaMemLocationType enum values
   // CU_MEM_LOCATION_TYPE_INVALID
   {"cudaMemLocationTypeInvalid",                                       {"hipMemLocationTypeInvalid",                                "", CONV_NUMERIC_LITERAL, API_RUNTIME, SEC::DATA_TYPES}}, // 0
+  //
+  {"cudaMemLocationTypeNone",                                          {"hipMemLocationTypeInvalid",                                "", CONV_NUMERIC_LITERAL, API_RUNTIME, SEC::DATA_TYPES}}, // 0
   // CU_MEM_LOCATION_TYPE_DEVICE
   {"cudaMemLocationTypeDevice",                                        {"hipMemLocationTypeDevice",                                 "", CONV_NUMERIC_LITERAL, API_RUNTIME, SEC::DATA_TYPES}}, // 1
   // CU_MEM_LOCATION_TYPE_HOST
@@ -1829,6 +1840,8 @@ const std::map<llvm::StringRef, hipCounter> CUDA_RUNTIME_TYPE_NAME_MAP {
   {"cudaMemAllocationTypeInvalid",                                     {"hipMemAllocationTypeInvalid",                              "", CONV_NUMERIC_LITERAL, API_RUNTIME, SEC::DATA_TYPES}}, // 0x0
   // CU_MEM_ALLOCATION_TYPE_PINNED
   {"cudaMemAllocationTypePinned",                                      {"hipMemAllocationTypePinned",                               "", CONV_NUMERIC_LITERAL, API_RUNTIME, SEC::DATA_TYPES}}, // 0x1
+  //
+  {"cudaMemAllocationTypeManaged",                                     {"hipMemAllocationTypeManaged",                              "", CONV_NUMERIC_LITERAL, API_RUNTIME, SEC::DATA_TYPES, HIP_UNSUPPORTED}}, // 0x2
   // CU_MEM_ALLOCATION_TYPE_MAX
   {"cudaMemAllocationTypeMax",                                         {"hipMemAllocationTypeMax",                                  "", CONV_NUMERIC_LITERAL, API_RUNTIME, SEC::DATA_TYPES}}, // 0x7FFFFFFF
 
@@ -2250,9 +2263,9 @@ const std::map<llvm::StringRef, hipCounter> CUDA_RUNTIME_TYPE_NAME_MAP {
   // CUDA_ARRAY3D_DEFERRED_MAPPING
   {"cudaArrayDeferredMapping",                                         {"hipArrayDeferredMapping",                                  "", CONV_DEFINE, API_RUNTIME, SEC::DATA_TYPES, HIP_UNSUPPORTED}}, // 0x80
   // CUDA_COOPERATIVE_LAUNCH_MULTI_DEVICE_NO_PRE_LAUNCH_SYNC
-  {"cudaCooperativeLaunchMultiDeviceNoPreSync",                        {"hipCooperativeLaunchMultiDeviceNoPreSync",                 "", CONV_DEFINE, API_RUNTIME, SEC::DATA_TYPES}}, // 0x01
+  {"cudaCooperativeLaunchMultiDeviceNoPreSync",                        {"hipCooperativeLaunchMultiDeviceNoPreSync",                 "", CONV_DEFINE, API_RUNTIME, SEC::DATA_TYPES, CUDA_REMOVED}}, // 0x01
   // CUDA_COOPERATIVE_LAUNCH_MULTI_DEVICE_NO_POST_LAUNCH_SYNC
-  {"cudaCooperativeLaunchMultiDeviceNoPostSync",                       {"hipCooperativeLaunchMultiDeviceNoPostSync",                "", CONV_DEFINE, API_RUNTIME, SEC::DATA_TYPES}}, // 0x02
+  {"cudaCooperativeLaunchMultiDeviceNoPostSync",                       {"hipCooperativeLaunchMultiDeviceNoPostSync",                "", CONV_DEFINE, API_RUNTIME, SEC::DATA_TYPES, CUDA_REMOVED}}, // 0x02
   // CU_DEVICE_CPU ((CUdevice)-1)
   {"cudaCpuDeviceId",                                                  {"hipCpuDeviceId",                                           "", CONV_DEFINE, API_RUNTIME, SEC::DATA_TYPES}}, // ((int)-1)
   // CU_DEVICE_INVALID ((CUdevice)-2)
@@ -2538,7 +2551,7 @@ const std::map<llvm::StringRef, cudaAPIversions> CUDA_RUNTIME_TYPE_NAME_VER_MAP 
   {"cudaDevAttrReserved93",                                            {CUDA_90,  CUDA_0,   CUDA_0  }},
   {"cudaDevAttrReserved94",                                            {CUDA_90,  CUDA_0,   CUDA_0  }},
   {"cudaDevAttrCooperativeLaunch",                                     {CUDA_90,  CUDA_0,   CUDA_0  }},
-  {"cudaDevAttrCooperativeMultiDeviceLaunch",                          {CUDA_90,  CUDA_0,   CUDA_0  }},
+  {"cudaDevAttrCooperativeMultiDeviceLaunch",                          {CUDA_90,  CUDA_114, CUDA_130}},
   {"cudaDevAttrMaxSharedMemoryPerBlockOptin",                          {CUDA_90,  CUDA_0,   CUDA_0  }},
   {"cudaDevAttrCanFlushRemoteWrites",                                  {CUDA_92,  CUDA_0,   CUDA_0  }},
   {"cudaDevAttrHostRegisterSupported",                                 {CUDA_92,  CUDA_0,   CUDA_0  }},
@@ -2759,8 +2772,8 @@ const std::map<llvm::StringRef, cudaAPIversions> CUDA_RUNTIME_TYPE_NAME_VER_MAP 
   {"cudaHostFn_t",                                                     {CUDA_100, CUDA_0,   CUDA_0  }},
   {"CUDA_EGL_MAX_PLANES",                                              {CUDA_91,  CUDA_0,   CUDA_0  }},
   {"cudaArrayColorAttachment",                                         {CUDA_100, CUDA_0,   CUDA_0  }},
-  {"cudaCooperativeLaunchMultiDeviceNoPreSync",                        {CUDA_90,  CUDA_0,   CUDA_0  }},
-  {"cudaCooperativeLaunchMultiDeviceNoPostSync",                       {CUDA_90,  CUDA_0,   CUDA_0  }},
+  {"cudaCooperativeLaunchMultiDeviceNoPreSync",                        {CUDA_90,  CUDA_0,   CUDA_130}},
+  {"cudaCooperativeLaunchMultiDeviceNoPostSync",                       {CUDA_90,  CUDA_0,   CUDA_130}},
   {"cudaCpuDeviceId",                                                  {CUDA_80,  CUDA_0,   CUDA_0  }},
   {"cudaInvalidDeviceId",                                              {CUDA_80,  CUDA_0,   CUDA_0  }},
   {"cudaExternalMemoryDedicated",                                      {CUDA_100, CUDA_0,   CUDA_0  }},
@@ -2787,7 +2800,7 @@ const std::map<llvm::StringRef, cudaAPIversions> CUDA_RUNTIME_TYPE_NAME_VER_MAP 
   {"cudaErrorSoftwareValidityNotEstablished",                          {CUDA_112, CUDA_0,   CUDA_0  }},
   {"cudaErrorJitCompilationDisabled",                                  {CUDA_112, CUDA_0,   CUDA_0  }},
   {"cudaChannelFormatKindNV12",                                        {CUDA_112, CUDA_0,   CUDA_0  }},
-  {"cudaDevAttrMaxTimelineSemaphoreInteropSupported",                  {CUDA_112, CUDA_115, CUDA_0  }},
+  {"cudaDevAttrMaxTimelineSemaphoreInteropSupported",                  {CUDA_112, CUDA_115, CUDA_130}},
   {"cudaDevAttrMemoryPoolsSupported",                                  {CUDA_112, CUDA_0,   CUDA_0  }},
   {"cudaMemPoolAttr",                                                  {CUDA_112, CUDA_0,   CUDA_0  }},
   {"cudaMemPoolReuseFollowEventDependencies",                          {CUDA_112, CUDA_0,   CUDA_0  }},
@@ -3178,6 +3191,12 @@ const std::map<llvm::StringRef, cudaAPIversions> CUDA_RUNTIME_TYPE_NAME_VER_MAP 
   {"cudaGraphChildGraphNodeOwnership",                                 {CUDA_129, CUDA_0,   CUDA_0  }},
   {"cudaGraphChildGraphOwnershipClone",                                {CUDA_129, CUDA_0,   CUDA_0  }},
   {"cudaGraphChildGraphOwnershipMove",                                 {CUDA_129, CUDA_0,   CUDA_0  }},
+  {"cudaDevAttrReserved96",                                            {CUDA_130, CUDA_0,   CUDA_0  }},
+  {"cudaDevAttrHostMemoryPoolsSupported",                              {CUDA_130, CUDA_0,   CUDA_0  }},
+  {"cudaDevAttrReserved145",                                           {CUDA_130, CUDA_0,   CUDA_0  }},
+  {"cudaDevAttrOnlyPartialHostNativeAtomicSupported",                  {CUDA_130, CUDA_0,   CUDA_0  }},
+  {"cudaMemLocationTypeNone",                                          {CUDA_130, CUDA_0,   CUDA_0  }},
+  {"cudaMemAllocationTypeManaged",                                     {CUDA_130, CUDA_0,   CUDA_0  }},
 };
 
 const std::map<llvm::StringRef, hipAPIversions> HIP_RUNTIME_TYPE_NAME_VER_MAP {

--- a/tests/unit_tests/synthetic/runtime_defines.cu
+++ b/tests/unit_tests/synthetic/runtime_defines.cu
@@ -396,11 +396,12 @@ int main() {
 #endif
 
 #if CUDA_VERSION >= 9000
+#if CUDA_VERSION < 13000
   // CHECK: int CooperativeLaunchMultiDeviceNoPreSync = hipCooperativeLaunchMultiDeviceNoPreSync;
   // CHECK-NEXT: int CooperativeLaunchMultiDeviceNoPostSync = hipCooperativeLaunchMultiDeviceNoPostSync;
   int CooperativeLaunchMultiDeviceNoPreSync = cudaCooperativeLaunchMultiDeviceNoPreSync;
   int CooperativeLaunchMultiDeviceNoPostSync = cudaCooperativeLaunchMultiDeviceNoPostSync;
-
+#endif
   // CHECK: hipStream_t StreamLegacy = hipStreamLegacy;
   cudaStream_t StreamLegacy = cudaStreamLegacy;
 #endif

--- a/tests/unit_tests/synthetic/runtime_enums.cu
+++ b/tests/unit_tests/synthetic/runtime_enums.cu
@@ -538,12 +538,17 @@ int main() {
 #if CUDA_VERSION >= 9000
   // CHECK: hipDeviceAttribute_t DevAttrReserved94 = hipDeviceAttributeCanUseStreamWaitValue;
   // CHECK-NEXT: hipDeviceAttribute_t DevAttrCooperativeLaunch = hipDeviceAttributeCooperativeLaunch;
-  // CHECK-NEXT: hipDeviceAttribute_t DevAttrCooperativeMultiDeviceLaunch = hipDeviceAttributeCooperativeMultiDeviceLaunch;
   // CHECK-NEXT: hipDeviceAttribute_t DevAttrMaxSharedMemoryPerBlockOptin = hipDeviceAttributeSharedMemPerBlockOptin;
   cudaDeviceAttr DevAttrReserved94 = cudaDevAttrReserved94;
   cudaDeviceAttr DevAttrCooperativeLaunch = cudaDevAttrCooperativeLaunch;
-  cudaDeviceAttr DevAttrCooperativeMultiDeviceLaunch = cudaDevAttrCooperativeMultiDeviceLaunch;
   cudaDeviceAttr DevAttrMaxSharedMemoryPerBlockOptin = cudaDevAttrMaxSharedMemoryPerBlockOptin;
+#if CUDA_VERSION < 13000
+  // CHECK: hipDeviceAttribute_t DevAttrCooperativeMultiDeviceLaunch = hipDeviceAttributeCooperativeMultiDeviceLaunch;
+  cudaDeviceAttr DevAttrCooperativeMultiDeviceLaunch = cudaDevAttrCooperativeMultiDeviceLaunch;
+#elif CUDA_VERSION >= 13000
+  // CHECK: hipDeviceAttribute_t DevAttrReserved96 = hipDeviceAttributeCooperativeMultiDeviceLaunch;
+  cudaDeviceAttr DevAttrReserved96 = cudaDevAttrReserved96;
+#endif
 
   // CHECK: hipError_t ErrorCooperativeLaunchTooLarge = hipErrorCooperativeLaunchTooLarge;
   cudaError_t ErrorCooperativeLaunchTooLarge = cudaErrorCooperativeLaunchTooLarge;
@@ -766,6 +771,11 @@ int main() {
   cudaMemLocationType memLocationType;
   cudaMemLocationType MemLocationTypeInvalid = cudaMemLocationTypeInvalid;
   cudaMemLocationType MemLocationTypeDevice = cudaMemLocationTypeDevice;
+
+#if CUDA_VERSION >= 13000
+  // CHECK: hipMemLocationType MemLocationTypeNone = hipMemLocationTypeInvalid;
+  cudaMemLocationType MemLocationTypeNone = cudaMemLocationTypeNone;
+#endif
 
   // CHECK: hipMemAccessFlags MemAccessFlags;
   // CHECK-NEXT: hipMemAccessFlags MemAccessFlagsProtNone = hipMemAccessFlagsProtNone;


### PR DESCRIPTION
+ Updated synthetic tests, the regenerated `hipify-perl`, and `Runtime` `CUDA2HIP` docs accordingly
