### PR TITLE
[HIPIFY][doc] `LLVM 21.1.1` is the latest stable supported version

### DIFF
--- a/docs/building/build-hipify-clang-linux.rst
+++ b/docs/building/build-hipify-clang-linux.rst
@@ -134,7 +134,7 @@ Linux testing
 
 On Linux, the following configurations are tested:
 
-* Ubuntu 22-24: LLVM 13.0.0 - 21.1.0, CUDA 7.0 - 12.9.1, cuDNN 8.0.5 - 9.13.0, cuTensor 1.0.1.0 - 2.2.0.0
+* Ubuntu 22-24: LLVM 13.0.0 - 21.1.1, CUDA 7.0 - 12.9.1, cuDNN 8.0.5 - 9.13.0, cuTensor 1.0.1.0 - 2.2.0.0
 * Ubuntu 20-21: LLVM 9.0.0 - 20.1.8, CUDA 7.0 - 12.8.1, cuDNN 5.1.10 - 9.13.0, cuTensor 1.0.1.0 - 2.2.0.0
 * Ubuntu 16-19: LLVM 8.0.0 - 14.0.6, CUDA 7.0 - 10.2, cuDNN 5.1.10 - 8.0.5
 * Ubuntu 14: LLVM 4.0.0 - 7.1.0, CUDA 7.0 - 9.0, cuDNN 5.0.5 - 7.6.5
@@ -164,7 +164,7 @@ Here's how to build ``hipify-clang`` with testing support on ``Ubuntu 24.04.02``
     -DLLVM_EXTERNAL_LIT=$ROOT_DIR/build/bin/llvm-lit \
     ../hipify
 
-The corresponding successful output is (assuming ROOT_DIR is ``/usr/llvm/21.1.0``):
+The corresponding successful output is (assuming ROOT_DIR is ``/usr/llvm/21.1.1``):
 
 .. code-block:: shell
 
@@ -186,11 +186,11 @@ The corresponding successful output is (assuming ROOT_DIR is ``/usr/llvm/21.1.0`
   --    - Is part of HIP SDK    : OFF
   --    - Install clang headers : ON
   -- Found ZLIB: /usr/lib/x86_64-linux-gnu/libz.so (found version "1.3")
-  -- Found LLVM 21.1.0:
-  --    - CMake module path     : /usr/llvm/21.1.0/dist/lib/cmake/llvm
-  --    - Clang include path    : /usr/llvm/21.1.0/dist/include
-  --    - LLVM Include path     : /usr/llvm/21.1.0/dist/include
-  --    - Binary path           : /usr/llvm/21.1.0/dist/bin
+  -- Found LLVM 21.1.1:
+  --    - CMake module path     : /usr/llvm/21.1.1/dist/lib/cmake/llvm
+  --    - Clang include path    : /usr/llvm/21.1.1/dist/include
+  --    - LLVM Include path     : /usr/llvm/21.1.1/dist/include
+  --    - Binary path           : /usr/llvm/21.1.1/dist/bin
   -- Linker detection: GNU ld
   -- ---- The below configuring for hipify-clang testing only ----
   -- Found Python: /usr/bin/python3.13 (found suitable version "3.13.6", required range is "3.0...3.14") found components: Interpreter
@@ -227,7 +227,7 @@ The corresponding successful output is:
   Running HIPify regression tests
   ===============================================================
   CUDA 12.9.86 - will be used for testing
-  LLVM 21.1.0 - will be used for testing
+  LLVM 21.1.1 - will be used for testing
   x86_64 - Platform architecture
   Linux 6.5.0-15-generic - Platform OS
   64 - hipify-clang binary bitness

--- a/docs/building/build-hipify-clang-windows.rst
+++ b/docs/building/build-hipify-clang-windows.rst
@@ -230,7 +230,7 @@ Tested configurations:
     - ``2019.16.11.50, 2022.17.14.12``
     - ``4.1.0``
     - ``3.13.6``
-  * - ``21.1.0``
+  * - ``21.1.0 - 21.1.1``
     - ``7.0 - 12.9.1``
     - ``8.0.5  - 9.13.0``
     - ``2019.16.11.50, 2022.17.14.12``
@@ -268,7 +268,7 @@ Building with testing support using ``Visual Studio 17 2022`` on ``Windows 11``:
   -DLLVM_EXTERNAL_LIT=%ROOT_DIR%/build/Release/bin/llvm-lit.py \
   ../hipify
 
-The corresponding successful output is (assuming %ROOT_DIR% is ``D:/LLVM/21.1.0``):
+The corresponding successful output is (assuming %ROOT_DIR% is ``D:/LLVM/21.1.1``):
 
 .. code-block:: shell
 
@@ -290,15 +290,15 @@ The corresponding successful output is (assuming %ROOT_DIR% is ``D:/LLVM/21.1.0`
   --    - Test hipify-clang     : ON
   --    - Is part of HIP SDK    : OFF
   --    - Install clang headers : ON
-  -- Found LLVM 21.1.0:
-  --    - CMake module path     : D:/LLVM/21.1.0/dist/lib/cmake/llvm
-  --    - Clang include path    : D:/LLVM/21.1.0/dist/include
-  --    - LLVM Include path     : D:/LLVM/21.1.0/dist/include
-  --    - Binary path           : D:/LLVM/21.1.0/dist/bin
+  -- Found LLVM 21.1.1:
+  --    - CMake module path     : D:/LLVM/21.1.1/dist/lib/cmake/llvm
+  --    - Clang include path    : D:/LLVM/21.1.1/dist/include
+  --    - LLVM Include path     : D:/LLVM/21.1.1/dist/include
+  --    - Binary path           : D:/LLVM/21.1.1/dist/bin
   -- ---- The below configuring for hipify-clang testing only ----
   -- Found Python: C:/Users/TT/AppData/Local/Programs/Python/Python313/python.exe (found suitable version "3.13.6", required range is "3.0...3.14") found components: Interpreter
   -- Found lit: C:/Users/TT/AppData/Local/Programs/Python/Python313/Scripts/lit.exe
-  -- Found FileCheck: D:/LLVM/21.1.0/dist/bin/FileCheck.exe
+  -- Found FileCheck: D:/LLVM/21.1.1/dist/bin/FileCheck.exe
   -- Initial CUDA to configure:
   --    - CUDA Toolkit path     : C:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v12.9
   --    - CUDA Samples path     : C:/ProgramData/NVIDIA Corporation/CUDA Samples/v12.9

--- a/docs/how-to/hipify-clang.rst
+++ b/docs/how-to/hipify-clang.rst
@@ -41,7 +41,7 @@ Release Dependencies
 
 * `LLVM+Clang <http://releases.llvm.org>`_ version is determined at least partially by 
   the CUDA version you are using, as shown in the table below. The recommended Clang release 
-  is the latest stable release `21.1.0 <https://github.com/llvm/llvm-project/releases/tag/llvmorg-21.1.0>`_, 
+  is the latest stable release `21.1.1 <https://github.com/llvm/llvm-project/releases/tag/llvmorg-21.1.1>`_, 
   or at least version `4.0.0 <http://releases.llvm.org/download.html#4.0.0>`_.
 
 .. list-table::
@@ -51,7 +51,8 @@ Release Dependencies
     - Windows
     - Linux
   * - `12.9.1 <https://developer.nvidia.com/cuda-12-9-1-download-archive>`_:sup:`1`
-    - `21.1.0 <https://github.com/llvm/llvm-project/releases/tag/llvmorg-21.1.0>`_:sup:`1`
+    - `21.1.0 <https://github.com/llvm/llvm-project/releases/tag/llvmorg-21.1.0>`_,
+      `21.1.1 <https://github.com/llvm/llvm-project/releases/tag/llvmorg-21.1.1>`_:sup:`1`
     - ✅
     - ✅
   * - `12.8.1 <https://developer.nvidia.com/cuda-12-8-1-download-archive>`_
@@ -251,7 +252,7 @@ Release Dependencies
 In most cases, you can get a suitable version of ``LLVM+Clang`` with your package manager. However, you can also
 `download a release archive <http://releases.llvm.org/>`_ and build or install it. In case of multiple versions of ``LLVM`` installed, set
 `CMAKE_PREFIX_PATH <https://cmake.org/cmake/help/latest/variable/CMAKE_PREFIX_PATH.html>`_ so that
-``CMake`` can find the desired version of ``LLVM``. For example, ``-DCMAKE_PREFIX_PATH=D:\LLVM\21.1.0\dist``.
+``CMake`` can find the desired version of ``LLVM``. For example, ``-DCMAKE_PREFIX_PATH=D:\LLVM\21.1.1\dist``.
 
 Usage
 =====
@@ -287,7 +288,7 @@ header files used during the hipification process:
 
 .. code:: shell
 
-  ./hipify-clang square.cu --cuda-path=/usr/local/cuda-12.9 --clang-resource-directory=/usr/llvm/21.1.0/dist/lib/clang/21
+  ./hipify-clang square.cu --cuda-path=/usr/local/cuda-12.9 --clang-resource-directory=/usr/llvm/21.1.1/dist/lib/clang/21
 
 For more information, refer to the `Clang manual for compiling CUDA <https://llvm.org/docs/CompileCudaWithLLVM.html#compiling-cuda-code>`_.
 


### PR DESCRIPTION
+ No patches are needed
+ Updated the `README.md` accordingly
+ Tested on `Windows 11` (latest `VS 2019` and `VS 2022`)  and `Ubuntu 24.04.2` (`GNU C/C++ 13.3`)
