### PR TITLE
[HIPIFY][CUDA 13] CUDA 13.0.0 support - Step 15 - Runtime - Functions

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -4404,7 +4404,6 @@ sub simpleSubstitutions {
     subst("cudaMallocManaged", "hipMallocManaged", "memory");
     subst("cudaMallocMipmappedArray", "hipMallocMipmappedArray", "memory");
     subst("cudaMallocPitch", "hipMallocPitch", "memory");
-    subst("cudaMemAdvise", "hipMemAdvise", "memory");
     subst("cudaMemGetInfo", "hipMemGetInfo", "memory");
     subst("cudaMemPoolCreate", "hipMemPoolCreate", "memory");
     subst("cudaMemPoolDestroy", "hipMemPoolDestroy", "memory");
@@ -4417,7 +4416,6 @@ sub simpleSubstitutions {
     subst("cudaMemPoolSetAccess", "hipMemPoolSetAccess", "memory");
     subst("cudaMemPoolSetAttribute", "hipMemPoolSetAttribute", "memory");
     subst("cudaMemPoolTrimTo", "hipMemPoolTrimTo", "memory");
-    subst("cudaMemPrefetchAsync", "hipMemPrefetchAsync", "memory");
     subst("cudaMemRangeGetAttribute", "hipMemRangeGetAttribute", "memory");
     subst("cudaMemRangeGetAttributes", "hipMemRangeGetAttributes", "memory");
     subst("cudaMemcpy", "hipMemcpy", "memory");
@@ -11312,21 +11310,28 @@ sub warnRemovedFunctions {
     "cudaMemcpy3DOperand",
     "cudaMemcpy3DBatchOp",
     "cudaMemcpy3DBatchAsync",
+    "cudaMemSetMemPool",
     "cudaMemRangeAttributePreferredLocationType",
     "cudaMemRangeAttributePreferredLocationId",
     "cudaMemRangeAttributeLastPrefetchLocationType",
     "cudaMemRangeAttributeLastPrefetchLocationId",
     "cudaMemPrefetchAsync_v2",
+    "cudaMemPrefetchAsync",
     "cudaMemPoolCreateUsageHwDecompress",
     "cudaMemLocationTypeHostNumaCurrent",
     "cudaMemLocationTypeHostNuma",
     "cudaMemLocationTypeHost",
     "cudaMemHandleTypeFabric",
+    "cudaMemGetMemPool",
+    "cudaMemGetDefaultMemPool",
     "cudaMemFabricHandle_t",
     "cudaMemFabricHandle_st",
+    "cudaMemDiscardBatchAsync",
+    "cudaMemDiscardAndPrefetchBatchAsync",
     "cudaMemAllocationTypeManaged",
     "cudaMemAllocNodeParamsV2",
     "cudaMemAdvise_v2",
+    "cudaMemAdvise",
     "cudaLogsCallbackHandle",
     "cudaLogLevelWarning",
     "cudaLogLevelError",

--- a/docs/reference/tables/CUDA_Runtime_API_functions_supported_by_HIP.md
+++ b/docs/reference/tables/CUDA_Runtime_API_functions_supported_by_HIP.md
@@ -191,10 +191,12 @@
 |`cudaMallocManaged`| | | | |`hipMallocManaged`|2.5.0| | | | |
 |`cudaMallocMipmappedArray`| | | | |`hipMallocMipmappedArray`|3.5.0| | | | |
 |`cudaMallocPitch`| | | | |`hipMallocPitch`|1.6.0| | | | |
-|`cudaMemAdvise`|8.0| | | |`hipMemAdvise`|3.7.0| | | | |
+|`cudaMemAdvise`|8.0| |13.0| | | | | | | |
 |`cudaMemAdvise_v2`|12.2| | | | | | | | | |
+|`cudaMemDiscardAndPrefetchBatchAsync`|13.0| | | | | | | | | |
+|`cudaMemDiscardBatchAsync`|13.0| | | | | | | | | |
 |`cudaMemGetInfo`| | | | |`hipMemGetInfo`|1.6.0| | | | |
-|`cudaMemPrefetchAsync`|8.0| | | |`hipMemPrefetchAsync`|3.7.0| | | | |
+|`cudaMemPrefetchAsync`|8.0| |13.0| | | | | | | |
 |`cudaMemPrefetchAsync_v2`|12.2| | | | | | | | | |
 |`cudaMemRangeGetAttribute`|8.0| | | |`hipMemRangeGetAttribute`|3.7.0| | | | |
 |`cudaMemRangeGetAttributes`|8.0| | | |`hipMemRangeGetAttributes`|3.7.0| | | | |
@@ -246,6 +248,8 @@
 |`cudaFreeAsync`|11.2| | | |`hipFreeAsync`|5.2.0| | | | |
 |`cudaMallocAsync`|11.2| | | |`hipMallocAsync`|5.2.0| | | | |
 |`cudaMallocFromPoolAsync`|11.2| | | |`hipMallocFromPoolAsync`|5.2.0| | | | |
+|`cudaMemGetDefaultMemPool`|13.0| | | | | | | | | |
+|`cudaMemGetMemPool`|13.0| | | | | | | | | |
 |`cudaMemPoolCreate`|11.2| | | |`hipMemPoolCreate`|5.2.0| | | | |
 |`cudaMemPoolDestroy`|11.2| | | |`hipMemPoolDestroy`|5.2.0| | | | |
 |`cudaMemPoolExportPointer`|11.2| | | |`hipMemPoolExportPointer`|5.2.0| | | | |
@@ -257,6 +261,7 @@
 |`cudaMemPoolSetAccess`|11.2| | | |`hipMemPoolSetAccess`|5.2.0| | | | |
 |`cudaMemPoolSetAttribute`|11.2| | | |`hipMemPoolSetAttribute`|5.2.0| | | | |
 |`cudaMemPoolTrimTo`|11.2| | | |`hipMemPoolTrimTo`|5.2.0| | | | |
+|`cudaMemSetMemPool`|13.0| | | | | | | | | |
 
 ## **13. Unified Addressing**
 

--- a/src/CUDA2HIP_Runtime_API_functions.cpp
+++ b/src/CUDA2HIP_Runtime_API_functions.cpp
@@ -319,7 +319,8 @@ const std::map<llvm::StringRef, hipCounter> CUDA_RUNTIME_FUNCTION_MAP {
   // NOTE: Not equal to cuMemAllocPitch due to different signatures
   {"cudaMallocPitch",                                         {"hipMallocPitch",                                         "", CONV_MEMORY, API_RUNTIME, SEC::MEMORY}},
   // cuMemAdvise
-  {"cudaMemAdvise",                                           {"hipMemAdvise",                                           "", CONV_MEMORY, API_RUNTIME, SEC::MEMORY}},
+  // TODO: report unsupported only for CUDA >= 13000
+  {"cudaMemAdvise",                                           {"hipMemAdvise",                                           "", CONV_MEMORY, API_RUNTIME, SEC::MEMORY, HIP_UNSUPPORTED}},
   // cuMemAdvise_v2
   {"cudaMemAdvise_v2",                                        {"hipMemAdvise_v2",                                        "", CONV_MEMORY, API_RUNTIME, SEC::MEMORY, HIP_UNSUPPORTED}},
   // no analogue
@@ -377,7 +378,8 @@ const std::map<llvm::StringRef, hipCounter> CUDA_RUNTIME_FUNCTION_MAP {
   // cuMemGetInfo
   {"cudaMemGetInfo",                                          {"hipMemGetInfo",                                          "", CONV_MEMORY, API_RUNTIME, SEC::MEMORY}},
   // cuMemPrefetchAsync
-  {"cudaMemPrefetchAsync",                                    {"hipMemPrefetchAsync",                                    "", CONV_MEMORY, API_RUNTIME, SEC::MEMORY}},
+  // TODO: report unsupported only for CUDA >= 13000
+  {"cudaMemPrefetchAsync",                                    {"hipMemPrefetchAsync",                                    "", CONV_MEMORY, API_RUNTIME, SEC::MEMORY, HIP_UNSUPPORTED}},
   // cuMemPrefetchAsync_v2
   {"cudaMemPrefetchAsync_v2",                                 {"hipMemPrefetchAsync_v2",                                 "", CONV_MEMORY, API_RUNTIME, SEC::MEMORY, HIP_UNSUPPORTED}},
   // cuMemRangeGetAttribute
@@ -412,6 +414,10 @@ const std::map<llvm::StringRef, hipCounter> CUDA_RUNTIME_FUNCTION_MAP {
   {"cudaDeviceRegisterAsyncNotification",                     {"hipDeviceRegisterAsyncNotification",                     "", CONV_MEMORY, API_RUNTIME, SEC::MEMORY, HIP_UNSUPPORTED}},
   // cuDeviceUnregisterAsyncNotification
   {"cudaDeviceUnregisterAsyncNotification",                   {"hipDeviceUnregisterAsyncNotification",                   "", CONV_MEMORY, API_RUNTIME, SEC::MEMORY, HIP_UNSUPPORTED}},
+  //
+  {"cudaMemDiscardBatchAsync",                                {"hipMemDiscardBatchAsync",                                "", CONV_MEMORY, API_RUNTIME, SEC::MEMORY, HIP_UNSUPPORTED}},
+  //
+  {"cudaMemDiscardAndPrefetchBatchAsync",                     {"hipMemDiscardAndPrefetchBatchAsync",                     "", CONV_MEMORY, API_RUNTIME, SEC::MEMORY, HIP_UNSUPPORTED}},
 
   // 11. Memory Management [DEPRECATED]
   // no analogue
@@ -456,6 +462,12 @@ const std::map<llvm::StringRef, hipCounter> CUDA_RUNTIME_FUNCTION_MAP {
   {"cudaMemPoolExportPointer",                                {"hipMemPoolExportPointer",                                "", CONV_MEMORY, API_RUNTIME, SEC::ORDERED_MEMORY}},
   // cuMemPoolImportPointer
   {"cudaMemPoolImportPointer",                                {"hipMemPoolImportPointer",                                "", CONV_MEMORY, API_RUNTIME, SEC::ORDERED_MEMORY}},
+  //
+  {"cudaMemGetDefaultMemPool",                                {"hipMemGetDefaultMemPool",                                "", CONV_MEMORY, API_RUNTIME, SEC::ORDERED_MEMORY, HIP_UNSUPPORTED}},
+  //
+  {"cudaMemGetMemPool",                                       {"hipMemGetMemPool",                                       "", CONV_MEMORY, API_RUNTIME, SEC::ORDERED_MEMORY, HIP_UNSUPPORTED}},
+  //
+  {"cudaMemSetMemPool",                                       {"hipMemSetMemPool",                                       "", CONV_MEMORY, API_RUNTIME, SEC::ORDERED_MEMORY, HIP_UNSUPPORTED}},
 
   // 13. Unified Addressing
   // no analogue
@@ -1229,6 +1241,11 @@ const std::map<llvm::StringRef, cudaAPIversions> CUDA_RUNTIME_FUNCTION_VER_MAP {
   {"cudaLibraryEnumerateKernels",                             {CUDA_128, CUDA_0,   CUDA_0  }},
   {"cudaDeviceGetHostAtomicCapabilities",                     {CUDA_130, CUDA_0,   CUDA_0  }},
   {"cudaDeviceGetP2PAtomicCapabilities",                      {CUDA_130, CUDA_0,   CUDA_0  }},
+  {"cudaMemDiscardBatchAsync",                                {CUDA_130, CUDA_0,   CUDA_0  }},
+  {"cudaMemDiscardAndPrefetchBatchAsync",                     {CUDA_130, CUDA_0,   CUDA_0  }},
+  {"cudaMemGetDefaultMemPool",                                {CUDA_130, CUDA_0,   CUDA_0  }},
+  {"cudaMemGetMemPool",                                       {CUDA_130, CUDA_0,   CUDA_0  }},
+  {"cudaMemSetMemPool",                                       {CUDA_130, CUDA_0,   CUDA_0  }},
 };
 
 const std::map<llvm::StringRef, hipAPIversions> HIP_RUNTIME_FUNCTION_VER_MAP {
@@ -1501,6 +1518,8 @@ const std::map<llvm::StringRef, cudaAPIChangedVersions> CUDA_RUNTIME_FUNCTION_CH
   {"cudaStreamUpdateCaptureDependencies",                     {CUDA_130}},
   {"cudaMemcpyBatchAsync",                                    {CUDA_130}},
   {"cudaMemcpy3DBatchAsync",                                  {CUDA_130}},
+  {"cudaMemPrefetchAsync",                                    {CUDA_130}},
+  {"cudaMemAdvise",                                           {CUDA_130}},
 };
 
 const std::map<unsigned int, llvm::StringRef> CUDA_RUNTIME_API_SECTION_MAP {

--- a/tests/unit_tests/synthetic/runtime_functions.cu
+++ b/tests/unit_tests/synthetic/runtime_functions.cu
@@ -852,6 +852,7 @@ int main() {
   // CHECK: result = hipDeviceGetP2PAttribute(&intVal, DeviceP2PAttr, device, deviceId);
   result = cudaDeviceGetP2PAttribute(&intVal, DeviceP2PAttr, device, deviceId);
 
+#if CUDA_VERSION < 13000
   // CUDA: extern __host__ cudaError_t CUDARTAPI cudaMemAdvise(const void *devPtr, size_t count, enum cudaMemoryAdvise advice, int device);
   // HIP: hipError_t hipMemAdvise(const void* dev_ptr, size_t count, hipMemoryAdvise advice, int device);
   // CHECK: result = hipMemAdvise(deviceptr, bytes, MemoryAdvise, device);
@@ -861,7 +862,7 @@ int main() {
   // HIP: hipError_t hipMemPrefetchAsync(const void* dev_ptr, size_t count, int device, hipStream_t stream __dparm(0));
   // CHECK: result = hipMemPrefetchAsync(deviceptr, bytes, device, stream);
   result = cudaMemPrefetchAsync(deviceptr, bytes, device, stream);
-
+#endif
   // CHECK: hipMemRangeAttribute MemRangeAttribute;
   cudaMemRangeAttribute MemRangeAttribute;
 


### PR DESCRIPTION
+ Updated synthetic tests, the regenerated `hipify-perl`, and `Runtime` `CUDA2HIP` docs accordingly

[IMP]
+ `cudaMemAdvise` and `cudaMemPrefetchAsync` changed their ABI, hence not supported by HIP anymore
