### PR TITLE
[HIPIFY][CUDA 13] CUDA 13.0.0 support - Step 17 - Runtime - Functions - Graph - Part 1

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -4652,7 +4652,6 @@ sub simpleSubstitutions {
     subst("cudaDeviceGraphMemTrim", "hipDeviceGraphMemTrim", "graph");
     subst("cudaDeviceSetGraphMemAttribute", "hipDeviceSetGraphMemAttribute", "graph");
     subst("cudaGraphAddChildGraphNode", "hipGraphAddChildGraphNode", "graph");
-    subst("cudaGraphAddDependencies", "hipGraphAddDependencies", "graph");
     subst("cudaGraphAddEmptyNode", "hipGraphAddEmptyNode", "graph");
     subst("cudaGraphAddEventRecordNode", "hipGraphAddEventRecordNode", "graph");
     subst("cudaGraphAddEventWaitNode", "hipGraphAddEventWaitNode", "graph");
@@ -4698,7 +4697,6 @@ sub simpleSubstitutions {
     subst("cudaGraphExternalSemaphoresSignalNodeSetParams", "hipGraphExternalSemaphoresSignalNodeSetParams", "graph");
     subst("cudaGraphExternalSemaphoresWaitNodeGetParams", "hipGraphExternalSemaphoresWaitNodeGetParams", "graph");
     subst("cudaGraphExternalSemaphoresWaitNodeSetParams", "hipGraphExternalSemaphoresWaitNodeSetParams", "graph");
-    subst("cudaGraphGetEdges", "hipGraphGetEdges", "graph");
     subst("cudaGraphGetNodes", "hipGraphGetNodes", "graph");
     subst("cudaGraphGetRootNodes", "hipGraphGetRootNodes", "graph");
     subst("cudaGraphHostNodeGetParams", "hipGraphHostNodeGetParams", "graph");
@@ -4722,8 +4720,6 @@ sub simpleSubstitutions {
     subst("cudaGraphMemsetNodeGetParams", "hipGraphMemsetNodeGetParams", "graph");
     subst("cudaGraphMemsetNodeSetParams", "hipGraphMemsetNodeSetParams", "graph");
     subst("cudaGraphNodeFindInClone", "hipGraphNodeFindInClone", "graph");
-    subst("cudaGraphNodeGetDependencies", "hipGraphNodeGetDependencies", "graph");
-    subst("cudaGraphNodeGetDependentNodes", "hipGraphNodeGetDependentNodes", "graph");
     subst("cudaGraphNodeGetEnabled", "hipGraphNodeGetEnabled", "graph");
     subst("cudaGraphNodeGetType", "hipGraphNodeGetType", "graph");
     subst("cudaGraphNodeSetEnabled", "hipGraphNodeSetEnabled", "graph");
@@ -11420,7 +11416,9 @@ sub warnRemovedFunctions {
     "cudaGraphicsCubeFace",
     "cudaGraphRemoveDependencies_v2",
     "cudaGraphNodeGetDependentNodes_v2",
+    "cudaGraphNodeGetDependentNodes",
     "cudaGraphNodeGetDependencies_v2",
+    "cudaGraphNodeGetDependencies",
     "cudaGraphKernelNodeUpdate",
     "cudaGraphKernelNodeFieldParam",
     "cudaGraphKernelNodeFieldInvalid",
@@ -11429,6 +11427,7 @@ sub warnRemovedFunctions {
     "cudaGraphKernelNodeField",
     "cudaGraphInstantiateConditionalHandleUnused",
     "cudaGraphGetEdges_v2",
+    "cudaGraphGetEdges",
     "cudaGraphExecUpdateResultInfo_st",
     "cudaGraphExecUpdateResultInfo",
     "cudaGraphExecUpdateErrorAttributesChanged",
@@ -11447,6 +11446,7 @@ sub warnRemovedFunctions {
     "cudaGraphChildGraphNodeOwnership",
     "cudaGraphAddNode_v2",
     "cudaGraphAddDependencies_v2",
+    "cudaGraphAddDependencies",
     "cudaGetTextureObjectTextureDesc_v2",
     "cudaGetSurfaceReference",
     "cudaGetSurfaceObjectResourceDesc",

--- a/docs/reference/tables/CUDA_Runtime_API_functions_supported_by_HIP.md
+++ b/docs/reference/tables/CUDA_Runtime_API_functions_supported_by_HIP.md
@@ -449,7 +449,7 @@
 |`cudaDeviceGraphMemTrim`|11.4| | | |`hipDeviceGraphMemTrim`|5.3.0| | | | |
 |`cudaDeviceSetGraphMemAttribute`|11.4| | | |`hipDeviceSetGraphMemAttribute`|5.3.0| | | | |
 |`cudaGraphAddChildGraphNode`|10.0| | | |`hipGraphAddChildGraphNode`|5.0.0| | | | |
-|`cudaGraphAddDependencies`|10.0| | | |`hipGraphAddDependencies`|4.5.0| | | | |
+|`cudaGraphAddDependencies`|10.0| |13.0| | | | | | | |
 |`cudaGraphAddDependencies_v2`|12.3| | | | | | | | | |
 |`cudaGraphAddEmptyNode`|10.0| | | |`hipGraphAddEmptyNode`|4.5.0| | | | |
 |`cudaGraphAddEventRecordNode`|11.1| | | |`hipGraphAddEventRecordNode`|5.0.0| | | | |
@@ -498,7 +498,7 @@
 |`cudaGraphExternalSemaphoresSignalNodeSetParams`|11.2| | | |`hipGraphExternalSemaphoresSignalNodeSetParams`|5.7.0| | | | |
 |`cudaGraphExternalSemaphoresWaitNodeGetParams`|11.2| | | |`hipGraphExternalSemaphoresWaitNodeGetParams`|5.7.0| | | | |
 |`cudaGraphExternalSemaphoresWaitNodeSetParams`|11.2| | | |`hipGraphExternalSemaphoresWaitNodeSetParams`|5.7.0| | | | |
-|`cudaGraphGetEdges`|10.0| | | |`hipGraphGetEdges`|5.0.0| | | | |
+|`cudaGraphGetEdges`|10.0| |13.0| | | | | | | |
 |`cudaGraphGetEdges_v2`|12.3| | | | | | | | | |
 |`cudaGraphGetNodes`|10.0| | | |`hipGraphGetNodes`|4.5.0| | | | |
 |`cudaGraphGetRootNodes`|10.0| | | |`hipGraphGetRootNodes`|4.5.0| | | | |
@@ -507,7 +507,7 @@
 |`cudaGraphInstantiate`|10.0| | | |`hipGraphInstantiate`|4.3.0| | | | |
 |`cudaGraphInstantiateWithFlags`|11.4| | | |`hipGraphInstantiateWithFlags`|5.0.0| | | | |
 |`cudaGraphInstantiateWithParams`|12.0| | | |`hipGraphInstantiateWithParams`|6.2.0| | | | |
-|`cudaGraphKernelNodeCopyAttributes`|11.0| | | |`hipGraphKernelNodeCopyAttributes`|5.5.0| | | | |
+|`cudaGraphKernelNodeCopyAttributes`|11.0| |13.0| |`hipGraphKernelNodeCopyAttributes`|5.5.0| | | | |
 |`cudaGraphKernelNodeGetAttribute`|11.0| | | |`hipGraphKernelNodeGetAttribute`|5.2.0| | | | |
 |`cudaGraphKernelNodeGetParams`|11.0| | | |`hipGraphKernelNodeGetParams`|4.5.0| | | | |
 |`cudaGraphKernelNodeSetAttribute`|11.0| | | |`hipGraphKernelNodeSetAttribute`|5.2.0| | | | |
@@ -523,9 +523,9 @@
 |`cudaGraphMemsetNodeGetParams`|11.0| | | |`hipGraphMemsetNodeGetParams`|4.5.0| | | | |
 |`cudaGraphMemsetNodeSetParams`|11.0| | | |`hipGraphMemsetNodeSetParams`|4.5.0| | | | |
 |`cudaGraphNodeFindInClone`|11.0| | | |`hipGraphNodeFindInClone`|5.0.0| | | | |
-|`cudaGraphNodeGetDependencies`|11.0| | | |`hipGraphNodeGetDependencies`|5.0.0| | | | |
+|`cudaGraphNodeGetDependencies`|11.0| |13.0| | | | | | | |
 |`cudaGraphNodeGetDependencies_v2`|12.3| | | | | | | | | |
-|`cudaGraphNodeGetDependentNodes`|11.0| | | |`hipGraphNodeGetDependentNodes`|5.0.0| | | | |
+|`cudaGraphNodeGetDependentNodes`|11.0| |13.0| | | | | | | |
 |`cudaGraphNodeGetDependentNodes_v2`|12.3| | | | | | | | | |
 |`cudaGraphNodeGetEnabled`|11.6| | | |`hipGraphNodeGetEnabled`|5.5.0| | | | |
 |`cudaGraphNodeGetType`|11.0| | | |`hipGraphNodeGetType`|5.0.0| | | | |

--- a/src/CUDA2HIP_Runtime_API_functions.cpp
+++ b/src/CUDA2HIP_Runtime_API_functions.cpp
@@ -704,7 +704,8 @@ const std::map<llvm::StringRef, hipCounter> CUDA_RUNTIME_FUNCTION_MAP {
   // cuGraphAddChildGraphNode
   {"cudaGraphAddChildGraphNode",                              {"hipGraphAddChildGraphNode",                              "", CONV_GRAPH, API_RUNTIME, SEC::GRAPH}},
   // cuGraphAddDependencies
-  {"cudaGraphAddDependencies",                                {"hipGraphAddDependencies",                                "", CONV_GRAPH, API_RUNTIME, SEC::GRAPH}},
+  // TODO: report unsupported only for CUDA >= 13000
+  {"cudaGraphAddDependencies",                                {"hipGraphAddDependencies",                                "", CONV_GRAPH, API_RUNTIME, SEC::GRAPH, HIP_UNSUPPORTED}},
   // cuGraphAddDependencies_v2
   {"cudaGraphAddDependencies_v2",                             {"hipGraphAddDependencies_v2",                             "", CONV_GRAPH, API_RUNTIME, SEC::GRAPH, HIP_UNSUPPORTED}},
   // cuGraphAddEmptyNode
@@ -738,7 +739,8 @@ const std::map<llvm::StringRef, hipCounter> CUDA_RUNTIME_FUNCTION_MAP {
   // cuGraphExecDestroy
   {"cudaGraphExecDestroy",                                    {"hipGraphExecDestroy",                                    "", CONV_GRAPH, API_RUNTIME, SEC::GRAPH}},
   // cuGraphGetEdges
-  {"cudaGraphGetEdges",                                       {"hipGraphGetEdges",                                       "", CONV_GRAPH, API_RUNTIME, SEC::GRAPH}},
+  // TODO: report unsupported only for CUDA >= 13000
+  {"cudaGraphGetEdges",                                       {"hipGraphGetEdges",                                       "", CONV_GRAPH, API_RUNTIME, SEC::GRAPH, HIP_UNSUPPORTED}},
   // cuGraphGetEdges_v2
   {"cudaGraphGetEdges_v2",                                    {"hipGraphGetEdges_v2",                                    "", CONV_GRAPH, API_RUNTIME, SEC::GRAPH, HIP_UNSUPPORTED}},
   // cuGraphGetNodes
@@ -786,11 +788,13 @@ const std::map<llvm::StringRef, hipCounter> CUDA_RUNTIME_FUNCTION_MAP {
   // cuGraphNodeFindInClone
   {"cudaGraphNodeFindInClone",                                {"hipGraphNodeFindInClone",                                "", CONV_GRAPH, API_RUNTIME, SEC::GRAPH}},
   // cuGraphNodeGetDependencies
-  {"cudaGraphNodeGetDependencies",                            {"hipGraphNodeGetDependencies",                            "", CONV_GRAPH, API_RUNTIME, SEC::GRAPH}},
+  // TODO: report unsupported only for CUDA >= 13000
+  {"cudaGraphNodeGetDependencies",                            {"hipGraphNodeGetDependencies",                            "", CONV_GRAPH, API_RUNTIME, SEC::GRAPH, HIP_UNSUPPORTED}},
   // cuGraphNodeGetDependencies_v2
   {"cudaGraphNodeGetDependencies_v2",                         {"hipGraphNodeGetDependencies_v2",                         "", CONV_GRAPH, API_RUNTIME, SEC::GRAPH, HIP_UNSUPPORTED}},
   // cuGraphNodeGetDependentNodes
-  {"cudaGraphNodeGetDependentNodes",                          {"hipGraphNodeGetDependentNodes",                          "", CONV_GRAPH, API_RUNTIME, SEC::GRAPH}},
+  // TODO: report unsupported only for CUDA >= 13000
+  {"cudaGraphNodeGetDependentNodes",                          {"hipGraphNodeGetDependentNodes",                          "", CONV_GRAPH, API_RUNTIME, SEC::GRAPH, HIP_UNSUPPORTED}},
   // cuGraphNodeGetDependentNodes_v2
   {"cudaGraphNodeGetDependentNodes_v2",                       {"hipGraphNodeGetDependentNodes_v2",                       "", CONV_GRAPH, API_RUNTIME, SEC::GRAPH, HIP_UNSUPPORTED}},
   // cuGraphNodeGetEnabled
@@ -1535,6 +1539,12 @@ const std::map<llvm::StringRef, cudaAPIChangedVersions> CUDA_RUNTIME_FUNCTION_CH
   {"cudaMemcpy3DBatchAsync",                                  {CUDA_130}},
   {"cudaMemPrefetchAsync",                                    {CUDA_130}},
   {"cudaMemAdvise",                                           {CUDA_130}},
+  {"cudaGraphGetEdges",                                       {CUDA_130}},
+  {"cudaGraphNodeGetDependencies",                            {CUDA_130}},
+  {"cudaGraphNodeGetDependentNodes",                          {CUDA_130}},
+  {"cudaGraphAddDependencies",                                {CUDA_130}},
+  // [IMP] Changed semantics: Dst <-> Src
+  {"cudaGraphKernelNodeCopyAttributes",                       {CUDA_130}},
 };
 
 const std::map<unsigned int, llvm::StringRef> CUDA_RUNTIME_API_SECTION_MAP {

--- a/tests/unit_tests/graph/simple_mechs.cu
+++ b/tests/unit_tests/graph/simple_mechs.cu
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %hipify_args 1 --experimental %clang_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args 3 --experimental --amap --skip-excluded-preprocessor-conditional-blocks %clang_args
 
 // CHECK: #include <hip/hip_runtime.h>
 #include <stdio.h>
@@ -110,11 +110,14 @@ void init(void) {
       printf("Failed to create kernel node\n");
   }
   for (i = 0; i < (NUM_NODES - 1); ++i)
-    // CHECK: hipGraphAddDependencies(graph,
+ // [TODO][#2062] Rename all DO-NOT-CHECK back
+#if CUDA_VERSION < 13000
+    // DO-NOT-CHECK: hipGraphAddDependencies(graph,
     cudaGraphAddDependencies(graph,
                               &node[i],
                               &node[i+1],
                               1);
+#endif
   // CHECK: hipGraphInstantiate(&graphExec,
   cudaGraphInstantiate(&graphExec,
                         graph,
@@ -123,10 +126,10 @@ void init(void) {
                         0);
   /* Same input for dataplane every frame */
   // CHECK: hipMemcpy(dev_in_p,
-  // CHECK-NEXT: hipMemcpyHostToDevice);
   cudaMemcpy(dev_in_p,
              host_in_p,
              WORK_BUFFER_SIZE,
+  // CHECK: hipMemcpyHostToDevice);
              cudaMemcpyHostToDevice);
 }
 
@@ -162,20 +165,20 @@ int main (void) {
     }
     /* One copy for all data needed to execute one frame, queued in same stream as the rest */
     // CHECK: hipMemcpyAsync(dev_gc_p,
-    // CHECK-NEXT: hipMemcpyHostToDevice,
     cudaMemcpyAsync(dev_gc_p,
                     host_gc_p,
                     sizeof(graph_control_t),
+    // CHECK: hipMemcpyHostToDevice,
                     cudaMemcpyHostToDevice,
                     stream);
     /* Kick graph */
     graph_launch();
     /*  One read-out for all data produced this frame, queued in same stream as the rest.   */
     // CHECK: hipMemcpyAsync(host_out_p,
-    // CHECK-NEXT: hipMemcpyDeviceToHost,
     cudaMemcpyAsync(host_out_p,
                         dev_out_p,
                         WORK_BUFFER_SIZE,
+    // CHECK: hipMemcpyDeviceToHost,
                         cudaMemcpyDeviceToHost,
                         stream);
 

--- a/tests/unit_tests/synthetic/runtime_functions.cu
+++ b/tests/unit_tests/synthetic/runtime_functions.cu
@@ -1003,10 +1003,12 @@ int main() {
   // CHECK: result = hipGraphAddChildGraphNode(&graphNode, Graph_t, &graphNode_2, bytes, Graph_t_2);
   result = cudaGraphAddChildGraphNode(&graphNode, Graph_t, &graphNode_2, bytes, Graph_t_2);
 
+#if CUDA_VERSION < 13000
   // CUDA: extern __host__ cudaError_t CUDARTAPI cudaGraphAddDependencies(cudaGraph_t graph, const cudaGraphNode_t *from, const cudaGraphNode_t *to, size_t numDependencies);
   // HIP: hipError_t hipGraphAddDependencies(hipGraph_t graph, const hipGraphNode_t* from, const hipGraphNode_t* to, size_t numDependencies);
   // CHECK: result = hipGraphAddDependencies(Graph_t, &graphNode, &graphNode_2, bytes);
   result = cudaGraphAddDependencies(Graph_t, &graphNode, &graphNode_2, bytes);
+#endif
 
   // CUDA: extern __host__ cudaError_t CUDARTAPI cudaGraphAddEmptyNode(cudaGraphNode_t *pGraphNode, cudaGraph_t graph, const cudaGraphNode_t *pDependencies, size_t numDependencies);
   // HIP: hipError_t hipGraphAddEmptyNode(hipGraphNode_t* pGraphNode, hipGraph_t graph, const hipGraphNode_t* pDependencies, size_t numDependencies);
@@ -1075,10 +1077,12 @@ int main() {
   // CHECK: result = hipGraphExecDestroy(GraphExec_t);
   result = cudaGraphExecDestroy(GraphExec_t);
 
+#if CUDA_VERSION < 13000
   // CUDA: extern __host__ cudaError_t CUDARTAPI cudaGraphGetEdges(cudaGraph_t graph, cudaGraphNode_t *from, cudaGraphNode_t *to, size_t *numEdges);
   // HIP: hipError_t hipGraphGetEdges(hipGraph_t graph, hipGraphNode_t* from, hipGraphNode_t* to, size_t* numEdges);
   // CHECK: result = hipGraphGetEdges(Graph_t, &graphNode, &graphNode_2, &bytes);
   result = cudaGraphGetEdges(Graph_t, &graphNode, &graphNode_2, &bytes);
+#endif
 
   // CUDA: extern __host__ cudaError_t CUDARTAPI cudaGraphGetNodes(cudaGraph_t graph, cudaGraphNode_t *nodes, size_t *numNodes);
   // HIP: hipError_t hipGraphGetNodes(hipGraph_t graph, hipGraphNode_t* nodes, size_t* numNodes);
@@ -1229,6 +1233,7 @@ int main() {
   // CHECK: result = hipGraphNodeFindInClone(&graphNode, graphNode_2, Graph_t);
   result = cudaGraphNodeFindInClone(&graphNode, graphNode_2, Graph_t);
 
+#if CUDA_VERSION < 13000
   // CUDA: extern __host__ cudaError_t CUDARTAPI cudaGraphNodeGetDependencies(cudaGraphNode_t node, cudaGraphNode_t *pDependencies, size_t *pNumDependencies);
   // HIP: hipError_t hipGraphNodeGetDependencies(hipGraphNode_t node, hipGraphNode_t* pDependencies, size_t* pNumDependencies);
   // CHECK: result = hipGraphNodeGetDependencies(graphNode, &graphNode_2, &bytes);
@@ -1238,6 +1243,7 @@ int main() {
   // HIP: hipError_t hipGraphNodeGetDependentNodes(hipGraphNode_t node, hipGraphNode_t* pDependentNodes, size_t* pNumDependentNodes);
   // CHECK: result = hipGraphNodeGetDependentNodes(graphNode, &graphNode_2, &bytes);
   result = cudaGraphNodeGetDependentNodes(graphNode, &graphNode_2, &bytes);
+#endif
 
   // CUDA: extern __host__ cudaError_t CUDARTAPI cudaGraphNodeGetType(cudaGraphNode_t node, enum cudaGraphNodeType *pType);
   // HIP: hipError_t hipGraphNodeGetType(hipGraphNode_t node, hipGraphNodeType* pType);


### PR DESCRIPTION
+ Updated tests, the regenerated `hipify-perl`, and `Runtime` `CUDA2HIP` docs accordingly
+ [TODO][#2062] Rename all DO-NOT-CHECK back

[IMP]
+ `cudaMemAdvise`, `cudaGraphGetEdges`, `cudaGraphNodeGetDependencies`, `cudaGraphNodeGetDependentNodes`, `cudaGraphAddDependencies` changed their ABI, hence not supported by HIP anymore
+ `cudaGraphKernelNodeCopyAttributes` changed its semantics: Dst <-> Src
