### PR TITLE
[HIPIFY][CUDA 13] CUDA 13.0.0 support - Step 18 - Runtime - Functions - Graph - Part 2

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -872,6 +872,7 @@ my %deprecated_funcs = (
     "cudaMemcpyFromArray" => "10.1",
     "cudaMemcpyArrayToArray" => "10.1",
     "cudaLaunchCooperativeKernelMultiDevice" => "11.3",
+    "cudaGetDriverEntryPoint" => "13.0",
     "cudaGLUnregisterBufferObject" => "10.0",
     "cudaGLUnmapBufferObjectAsync" => "10.0",
     "cudaGLUnmapBufferObject" => "10.0",
@@ -4666,7 +4667,6 @@ sub simpleSubstitutions {
     subst("cudaGraphAddMemcpyNodeFromSymbol", "hipGraphAddMemcpyNodeFromSymbol", "graph");
     subst("cudaGraphAddMemcpyNodeToSymbol", "hipGraphAddMemcpyNodeToSymbol", "graph");
     subst("cudaGraphAddMemsetNode", "hipGraphAddMemsetNode", "graph");
-    subst("cudaGraphAddNode", "hipGraphAddNode", "graph");
     subst("cudaGraphChildGraphNodeGetGraph", "hipGraphChildGraphNodeGetGraph", "graph");
     subst("cudaGraphClone", "hipGraphClone", "graph");
     subst("cudaGraphCreate", "hipGraphCreate", "graph");
@@ -4725,7 +4725,6 @@ sub simpleSubstitutions {
     subst("cudaGraphNodeSetEnabled", "hipGraphNodeSetEnabled", "graph");
     subst("cudaGraphNodeSetParams", "hipGraphNodeSetParams", "graph");
     subst("cudaGraphReleaseUserObject", "hipGraphReleaseUserObject", "graph");
-    subst("cudaGraphRemoveDependencies", "hipGraphRemoveDependencies", "graph");
     subst("cudaGraphRetainUserObject", "hipGraphRetainUserObject", "graph");
     subst("cudaGraphUpload", "hipGraphUpload", "graph");
     subst("cudaUserObjectCreate", "hipUserObjectCreate", "graph");
@@ -11415,6 +11414,7 @@ sub warnRemovedFunctions {
     "cudaGraphicsCubeFaceNegativeX",
     "cudaGraphicsCubeFace",
     "cudaGraphRemoveDependencies_v2",
+    "cudaGraphRemoveDependencies",
     "cudaGraphNodeGetDependentNodes_v2",
     "cudaGraphNodeGetDependentNodes",
     "cudaGraphNodeGetDependencies_v2",
@@ -11445,6 +11445,7 @@ sub warnRemovedFunctions {
     "cudaGraphChildGraphOwnershipClone",
     "cudaGraphChildGraphNodeOwnership",
     "cudaGraphAddNode_v2",
+    "cudaGraphAddNode",
     "cudaGraphAddDependencies_v2",
     "cudaGraphAddDependencies",
     "cudaGetTextureObjectTextureDesc_v2",

--- a/docs/reference/tables/CUDA_Runtime_API_functions_supported_by_HIP.md
+++ b/docs/reference/tables/CUDA_Runtime_API_functions_supported_by_HIP.md
@@ -465,7 +465,7 @@
 |`cudaGraphAddMemcpyNodeFromSymbol`|11.1| | | |`hipGraphAddMemcpyNodeFromSymbol`|5.0.0| | | | |
 |`cudaGraphAddMemcpyNodeToSymbol`|11.1| | | |`hipGraphAddMemcpyNodeToSymbol`|5.0.0| | | | |
 |`cudaGraphAddMemsetNode`|10.0| | | |`hipGraphAddMemsetNode`|4.3.0| | | | |
-|`cudaGraphAddNode`|12.2| | | |`hipGraphAddNode`|6.2.0| | | | |
+|`cudaGraphAddNode`|12.2| |13.0| | | | | | | |
 |`cudaGraphAddNode_v2`|12.3| | | | | | | | | |
 |`cudaGraphChildGraphNodeGetGraph`|10.0| | | |`hipGraphChildGraphNodeGetGraph`|5.0.0| | | | |
 |`cudaGraphClone`|10.0| | | |`hipGraphClone`|5.0.0| | | | |
@@ -532,7 +532,7 @@
 |`cudaGraphNodeSetEnabled`|11.6| | | |`hipGraphNodeSetEnabled`|5.5.0| | | | |
 |`cudaGraphNodeSetParams`|12.2| | | |`hipGraphNodeSetParams`|6.3.0| | | | |
 |`cudaGraphReleaseUserObject`|11.3| | | |`hipGraphReleaseUserObject`|5.3.0| | | | |
-|`cudaGraphRemoveDependencies`|11.0| | | |`hipGraphRemoveDependencies`|5.0.0| | | | |
+|`cudaGraphRemoveDependencies`|11.0| |13.0| | | | | | | |
 |`cudaGraphRemoveDependencies_v2`|12.3| | | | | | | | | |
 |`cudaGraphRetainUserObject`|11.3| | | |`hipGraphRetainUserObject`|5.3.0| | | | |
 |`cudaGraphUpload`|11.1| | | |`hipGraphUpload`|5.3.0| | | | |
@@ -544,7 +544,7 @@
 
 |**CUDA**|**A**|**D**|**C**|**R**|**HIP**|**A**|**D**|**C**|**R**|**E**|
 |:--|:-:|:-:|:-:|:-:|:--|:-:|:-:|:-:|:-:|:-:|
-|`cudaGetDriverEntryPoint`|11.3| |12.0| |`hipGetProcAddress`|6.2.0| | | | |
+|`cudaGetDriverEntryPoint`|11.3|13.0|12.0| |`hipGetProcAddress`|6.2.0| | | | |
 |`cudaGetDriverEntryPointByVersion`|12.5| | | | | | | | | |
 
 ## **32. Library Management**

--- a/src/CUDA2HIP_Runtime_API_functions.cpp
+++ b/src/CUDA2HIP_Runtime_API_functions.cpp
@@ -802,7 +802,8 @@ const std::map<llvm::StringRef, hipCounter> CUDA_RUNTIME_FUNCTION_MAP {
   // cuGraphNodeGetType
   {"cudaGraphNodeGetType",                                    {"hipGraphNodeGetType",                                    "", CONV_GRAPH, API_RUNTIME, SEC::GRAPH}},
   // cuGraphRemoveDependencies
-  {"cudaGraphRemoveDependencies",                             {"hipGraphRemoveDependencies",                             "", CONV_GRAPH, API_RUNTIME, SEC::GRAPH}},
+  // TODO: report unsupported only for CUDA >= 13000
+  {"cudaGraphRemoveDependencies",                             {"hipGraphRemoveDependencies",                             "", CONV_GRAPH, API_RUNTIME, SEC::GRAPH, HIP_UNSUPPORTED}},
   // cuGraphRemoveDependencies_v2
   {"cudaGraphRemoveDependencies_v2",                          {"hipGraphRemoveDependencies_v2",                          "", CONV_GRAPH, API_RUNTIME, SEC::GRAPH, HIP_UNSUPPORTED}},
   // no analogue
@@ -893,7 +894,8 @@ const std::map<llvm::StringRef, hipCounter> CUDA_RUNTIME_FUNCTION_MAP {
   // cuGraphExecGetFlags
   {"cudaGraphExecGetFlags",                                   {"hipGraphExecGetFlags",                                   "", CONV_GRAPH, API_RUNTIME, SEC::GRAPH}},
   // cuGraphAddNode
-  {"cudaGraphAddNode",                                        {"hipGraphAddNode",                                        "", CONV_GRAPH, API_RUNTIME, SEC::GRAPH}},
+  // TODO: report unsupported only for CUDA >= 13000
+  {"cudaGraphAddNode",                                        {"hipGraphAddNode",                                        "", CONV_GRAPH, API_RUNTIME, SEC::GRAPH, HIP_UNSUPPORTED}},
   // cuGraphAddNode_v2
   {"cudaGraphAddNode_v2",                                     {"hipGraphAddNode_v2",                                     "", CONV_GRAPH, API_RUNTIME, SEC::GRAPH, HIP_UNSUPPORTED}},
   // cuGraphNodeSetParams
@@ -905,7 +907,7 @@ const std::map<llvm::StringRef, hipCounter> CUDA_RUNTIME_FUNCTION_MAP {
 
   // 31. Driver Entry Point Access
   // cuGetProcAddress
-  {"cudaGetDriverEntryPoint",                                 {"hipGetProcAddress",                                      "", CONV_DRIVER_ENTRY_POINT, API_RUNTIME, SEC::DRIVER_ENTRY_POINT}},
+  {"cudaGetDriverEntryPoint",                                 {"hipGetProcAddress",                                      "", CONV_DRIVER_ENTRY_POINT, API_RUNTIME, SEC::DRIVER_ENTRY_POINT, CUDA_DEPRECATED}},
   //
   {"cudaGetDriverEntryPointByVersion",                        {"hipGetDriverEntryPointByVersion",                        "", CONV_DRIVER_ENTRY_POINT, API_RUNTIME, SEC::DRIVER_ENTRY_POINT, HIP_UNSUPPORTED}},
 
@@ -1193,7 +1195,7 @@ const std::map<llvm::StringRef, cudaAPIversions> CUDA_RUNTIME_FUNCTION_VER_MAP {
   {"cudaUserObjectRelease",                                   {CUDA_113, CUDA_0,   CUDA_0  }},
   {"cudaGraphRetainUserObject",                               {CUDA_113, CUDA_0,   CUDA_0  }},
   {"cudaGraphReleaseUserObject",                              {CUDA_113, CUDA_0,   CUDA_0  }},
-  {"cudaGetDriverEntryPoint",                                 {CUDA_113, CUDA_0,   CUDA_0  }},
+  {"cudaGetDriverEntryPoint",                                 {CUDA_113, CUDA_130, CUDA_0  }},
   {"cudaGraphAddMemAllocNode",                                {CUDA_114, CUDA_0,   CUDA_0  }},
   {"cudaGraphMemAllocNodeGetParams",                          {CUDA_114, CUDA_0,   CUDA_0  }},
   {"cudaGraphAddMemFreeNode",                                 {CUDA_114, CUDA_0,   CUDA_0  }},
@@ -1543,6 +1545,8 @@ const std::map<llvm::StringRef, cudaAPIChangedVersions> CUDA_RUNTIME_FUNCTION_CH
   {"cudaGraphNodeGetDependencies",                            {CUDA_130}},
   {"cudaGraphNodeGetDependentNodes",                          {CUDA_130}},
   {"cudaGraphAddDependencies",                                {CUDA_130}},
+  {"cudaGraphRemoveDependencies",                             {CUDA_130}},
+  {"cudaGraphAddNode",                                        {CUDA_130}},
   // [IMP] Changed semantics: Dst <-> Src
   {"cudaGraphKernelNodeCopyAttributes",                       {CUDA_130}},
 };

--- a/tests/unit_tests/synthetic/runtime_functions.cu
+++ b/tests/unit_tests/synthetic/runtime_functions.cu
@@ -852,15 +852,16 @@ int main() {
   // CHECK: result = hipDeviceGetP2PAttribute(&intVal, DeviceP2PAttr, device, deviceId);
   result = cudaDeviceGetP2PAttribute(&intVal, DeviceP2PAttr, device, deviceId);
 
+  // [TODO][#2062] Rename all DO-NOT-CHECK back
 #if CUDA_VERSION < 13000
   // CUDA: extern __host__ cudaError_t CUDARTAPI cudaMemAdvise(const void *devPtr, size_t count, enum cudaMemoryAdvise advice, int device);
   // HIP: hipError_t hipMemAdvise(const void* dev_ptr, size_t count, hipMemoryAdvise advice, int device);
-  // CHECK: result = hipMemAdvise(deviceptr, bytes, MemoryAdvise, device);
+  // DO-NOT-CHECK: result = hipMemAdvise(deviceptr, bytes, MemoryAdvise, device);
   result = cudaMemAdvise(deviceptr, bytes, MemoryAdvise, device);
 
   // CUDA: extern __host__ cudaError_t CUDARTAPI cudaMemPrefetchAsync(const void *devPtr, size_t count, int dstDevice, cudaStream_t stream __dv(0));
   // HIP: hipError_t hipMemPrefetchAsync(const void* dev_ptr, size_t count, int device, hipStream_t stream __dparm(0));
-  // CHECK: result = hipMemPrefetchAsync(deviceptr, bytes, device, stream);
+  // DO-NOT-CHECK: result = hipMemPrefetchAsync(deviceptr, bytes, device, stream);
   result = cudaMemPrefetchAsync(deviceptr, bytes, device, stream);
 #endif
   // CHECK: hipMemRangeAttribute MemRangeAttribute;
@@ -881,10 +882,10 @@ int main() {
   // CHECK: hipFuncAttribute FuncAttribute;
   cudaFuncAttribute FuncAttribute;
 
+#if CUDA_VERSION < 13000
   // CHECK: hipLaunchParams LaunchParams;
   cudaLaunchParams LaunchParams;
 
-#if CUDA_VERSION < 13000
   // CUDA: extern __CUDA_DEPRECATED __host__ cudaError_t CUDARTAPI cudaLaunchCooperativeKernelMultiDevice(struct cudaLaunchParams *launchParamsList, unsigned int numDevices, unsigned int flags __dv(0));
   // HIP: hipError_t hipLaunchCooperativeKernelMultiDevice(hipLaunchParams* launchParamsList, int numDevices, unsigned int flags);
   // CHECK: result = hipLaunchCooperativeKernelMultiDevice(&LaunchParams, intVal, flags);
@@ -1003,11 +1004,17 @@ int main() {
   // CHECK: result = hipGraphAddChildGraphNode(&graphNode, Graph_t, &graphNode_2, bytes, Graph_t_2);
   result = cudaGraphAddChildGraphNode(&graphNode, Graph_t, &graphNode_2, bytes, Graph_t_2);
 
+  // [TODO][#2062] Rename all DO-NOT-CHECK back
 #if CUDA_VERSION < 13000
   // CUDA: extern __host__ cudaError_t CUDARTAPI cudaGraphAddDependencies(cudaGraph_t graph, const cudaGraphNode_t *from, const cudaGraphNode_t *to, size_t numDependencies);
   // HIP: hipError_t hipGraphAddDependencies(hipGraph_t graph, const hipGraphNode_t* from, const hipGraphNode_t* to, size_t numDependencies);
-  // CHECK: result = hipGraphAddDependencies(Graph_t, &graphNode, &graphNode_2, bytes);
+  // DO-NOT-CHECK: result = hipGraphAddDependencies(Graph_t, &graphNode, &graphNode_2, bytes);
   result = cudaGraphAddDependencies(Graph_t, &graphNode, &graphNode_2, bytes);
+
+  // CUDA: extern __host__ cudaError_t CUDARTAPI cudaGraphGetEdges(cudaGraph_t graph, cudaGraphNode_t *from, cudaGraphNode_t *to, size_t *numEdges);
+  // HIP: hipError_t hipGraphGetEdges(hipGraph_t graph, hipGraphNode_t* from, hipGraphNode_t* to, size_t* numEdges);
+  // DO-NOT-CHECK: result = hipGraphGetEdges(Graph_t, &graphNode, &graphNode_2, &bytes);
+  result = cudaGraphGetEdges(Graph_t, &graphNode, &graphNode_2, &bytes);
 #endif
 
   // CUDA: extern __host__ cudaError_t CUDARTAPI cudaGraphAddEmptyNode(cudaGraphNode_t *pGraphNode, cudaGraph_t graph, const cudaGraphNode_t *pDependencies, size_t numDependencies);
@@ -1076,13 +1083,6 @@ int main() {
   // HIP: hipError_t hipGraphExecDestroy(hipGraphExec_t graphExec);
   // CHECK: result = hipGraphExecDestroy(GraphExec_t);
   result = cudaGraphExecDestroy(GraphExec_t);
-
-#if CUDA_VERSION < 13000
-  // CUDA: extern __host__ cudaError_t CUDARTAPI cudaGraphGetEdges(cudaGraph_t graph, cudaGraphNode_t *from, cudaGraphNode_t *to, size_t *numEdges);
-  // HIP: hipError_t hipGraphGetEdges(hipGraph_t graph, hipGraphNode_t* from, hipGraphNode_t* to, size_t* numEdges);
-  // CHECK: result = hipGraphGetEdges(Graph_t, &graphNode, &graphNode_2, &bytes);
-  result = cudaGraphGetEdges(Graph_t, &graphNode, &graphNode_2, &bytes);
-#endif
 
   // CUDA: extern __host__ cudaError_t CUDARTAPI cudaGraphGetNodes(cudaGraph_t graph, cudaGraphNode_t *nodes, size_t *numNodes);
   // HIP: hipError_t hipGraphGetNodes(hipGraph_t graph, hipGraphNode_t* nodes, size_t* numNodes);
@@ -1233,32 +1233,33 @@ int main() {
   // CHECK: result = hipGraphNodeFindInClone(&graphNode, graphNode_2, Graph_t);
   result = cudaGraphNodeFindInClone(&graphNode, graphNode_2, Graph_t);
 
+  // [TODO][#2062] Rename all DO-NOT-CHECK back
 #if CUDA_VERSION < 13000
   // CUDA: extern __host__ cudaError_t CUDARTAPI cudaGraphNodeGetDependencies(cudaGraphNode_t node, cudaGraphNode_t *pDependencies, size_t *pNumDependencies);
   // HIP: hipError_t hipGraphNodeGetDependencies(hipGraphNode_t node, hipGraphNode_t* pDependencies, size_t* pNumDependencies);
-  // CHECK: result = hipGraphNodeGetDependencies(graphNode, &graphNode_2, &bytes);
+  // DO-NOT-CHECK: result = hipGraphNodeGetDependencies(graphNode, &graphNode_2, &bytes);
   result = cudaGraphNodeGetDependencies(graphNode, &graphNode_2, &bytes);
 
   // CUDA: extern __host__ cudaError_t CUDARTAPI cudaGraphNodeGetDependentNodes(cudaGraphNode_t node, cudaGraphNode_t *pDependentNodes, size_t *pNumDependentNodes);
   // HIP: hipError_t hipGraphNodeGetDependentNodes(hipGraphNode_t node, hipGraphNode_t* pDependentNodes, size_t* pNumDependentNodes);
-  // CHECK: result = hipGraphNodeGetDependentNodes(graphNode, &graphNode_2, &bytes);
+  // DO-NOT-CHECK: result = hipGraphNodeGetDependentNodes(graphNode, &graphNode_2, &bytes);
   result = cudaGraphNodeGetDependentNodes(graphNode, &graphNode_2, &bytes);
+
+  // CUDA: extern __host__ cudaError_t CUDARTAPI cudaGraphKernelNodeCopyAttributes(cudaGraphNode_t hSrc, cudaGraphNode_t hDst);
+  // HIP: hipError_t hipGraphKernelNodeCopyAttributes(hipGraphNode_t hSrc, hipGraphNode_t hDst);
+  // DO-NOT-CHECK: result = hipGraphKernelNodeCopyAttributes(graphNode, graphNode_2);
+  result = cudaGraphKernelNodeCopyAttributes(graphNode, graphNode_2);
+
+  // CUDA: extern __host__ cudaError_t CUDARTAPI cudaGraphRemoveDependencies(cudaGraph_t graph, const cudaGraphNode_t *from, const cudaGraphNode_t *to, size_t numDependencies);
+  // HIP: hipError_t hipGraphRemoveDependencies(hipGraph_t graph, const hipGraphNode_t* from, const hipGraphNode_t* to, size_t numDependencies);
+  // DO-NOT-CHECK: result = hipGraphRemoveDependencies(Graph_t, &graphNode, &graphNode, bytes);
+  result = cudaGraphRemoveDependencies(Graph_t, &graphNode, &graphNode, bytes);
 #endif
 
   // CUDA: extern __host__ cudaError_t CUDARTAPI cudaGraphNodeGetType(cudaGraphNode_t node, enum cudaGraphNodeType *pType);
   // HIP: hipError_t hipGraphNodeGetType(hipGraphNode_t node, hipGraphNodeType* pType);
   // CHECK: result = hipGraphNodeGetType(graphNode, &GraphNodeType);
   result = cudaGraphNodeGetType(graphNode, &GraphNodeType);
-
-  // CUDA: extern __host__ cudaError_t CUDARTAPI cudaGraphRemoveDependencies(cudaGraph_t graph, const cudaGraphNode_t *from, const cudaGraphNode_t *to, size_t numDependencies);
-  // HIP: hipError_t hipGraphRemoveDependencies(hipGraph_t graph, const hipGraphNode_t* from, const hipGraphNode_t* to, size_t numDependencies);
-  // CHECK: result = hipGraphRemoveDependencies(Graph_t, &graphNode, &graphNode, bytes);
-  result = cudaGraphRemoveDependencies(Graph_t, &graphNode, &graphNode, bytes);
-
-  // CUDA: extern __host__ cudaError_t CUDARTAPI cudaGraphKernelNodeCopyAttributes(cudaGraphNode_t hSrc, cudaGraphNode_t hDst);
-  // HIP: hipError_t hipGraphKernelNodeCopyAttributes(hipGraphNode_t hSrc, hipGraphNode_t hDst);
-  // CHECK: result = hipGraphKernelNodeCopyAttributes(graphNode, graphNode_2);
-  result = cudaGraphKernelNodeCopyAttributes(graphNode, graphNode_2);
 
   // CUDA: extern __host__ cudaError_t cudaGetFuncBySymbol(cudaFunction_t* functionPtr, const void* symbolPtr);
   // HIP: hipError_t hipGetFuncBySymbol(hipFunction_t* functionPtr, const void* symbolPtr);
@@ -1657,10 +1658,13 @@ int main() {
   // CHECK: hipGraphNodeParams *graphNodeParams = nullptr;
   cudaGraphNodeParams *graphNodeParams = nullptr;
 
+  // [TODO][#2062] Rename all DO-NOT-CHECK back
+#if CUDA_VERSION < 13000
   // CUDA: extern __host__ cudaError_t CUDARTAPI cudaGraphAddNode(cudaGraphNode_t *pGraphNode, cudaGraph_t graph, const cudaGraphNode_t *pDependencies, size_t numDependencies, struct cudaGraphNodeParams *nodeParams);
   // HIP: hipError_t hipGraphAddNode(hipGraphNode_t *pGraphNode, hipGraph_t graph, const hipGraphNode_t *pDependencies, size_t numDependencies, hipGraphNodeParams *nodeParams);
-  // CHECK: result = hipGraphAddNode(&graphNode, Graph_t, &graphNode_2, bytes, graphNodeParams);
+  // DO-NOT-CHECK: result = hipGraphAddNode(&graphNode, Graph_t, &graphNode_2, bytes, graphNodeParams);
   result = cudaGraphAddNode(&graphNode, Graph_t, &graphNode_2, bytes, graphNodeParams);
+#endif
 
   // CUDA: extern __host__ cudaError_t CUDARTAPI cudaGraphNodeSetParams(cudaGraphNode_t node, struct cudaGraphNodeParams *nodeParams);
   // HIP: hipError_t hipGraphNodeSetParams(hipGraphNode_t node, hipGraphNodeParams *nodeParams);


### PR DESCRIPTION
+ Updated tests, the regenerated `hipify-perl`, and `Runtime` `CUDA2HIP` docs accordingly
+ [ToDo] Sync `Driver` and `Runtime` APIs in `HIPIFY` after finishing with their separate support
+ [TODO][#2062] Rename all DO-NOT-CHECK back

[IMP]
+ `cudaGraphRemoveDependencies` and `cudaGraphAddNode` changed their ABI, hence not supported by HIP anymore
