### PR TITLE
[HIPIFY][CUDA 13] CUDA 13.0.0 support - Step 19 - Sync `Driver` and `Runtime` APIs in `HIPIFY` - Part 1

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -11310,6 +11310,7 @@ sub warnRemovedFunctions {
     "cudaMemRangeAttributePreferredLocationId",
     "cudaMemRangeAttributeLastPrefetchLocationType",
     "cudaMemRangeAttributeLastPrefetchLocationId",
+    "cudaMemPrefetchBatchAsync",
     "cudaMemPrefetchAsync_v2",
     "cudaMemPrefetchAsync",
     "cudaMemPoolCreateUsageHwDecompress",

--- a/docs/reference/tables/CUDA_Runtime_API_functions_supported_by_HIP.md
+++ b/docs/reference/tables/CUDA_Runtime_API_functions_supported_by_HIP.md
@@ -198,6 +198,7 @@
 |`cudaMemGetInfo`| | | | |`hipMemGetInfo`|1.6.0| | | | |
 |`cudaMemPrefetchAsync`|8.0| |13.0| | | | | | | |
 |`cudaMemPrefetchAsync_v2`|12.2| | | | | | | | | |
+|`cudaMemPrefetchBatchAsync`|13.0| | | | | | | | | |
 |`cudaMemRangeGetAttribute`|8.0| | | |`hipMemRangeGetAttribute`|3.7.0| | | | |
 |`cudaMemRangeGetAttributes`|8.0| | | |`hipMemRangeGetAttributes`|3.7.0| | | | |
 |`cudaMemcpy`| | | | |`hipMemcpy`|1.5.0| | | | |

--- a/src/CUDA2HIP_Driver_API_functions.cpp
+++ b/src/CUDA2HIP_Driver_API_functions.cpp
@@ -451,11 +451,11 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_FUNCTION_MAP {
   {"cuMemPoolExportPointer",                                      {"hipMemPoolExportPointer",                                     "", CONV_ORDERED_MEMORY, API_DRIVER, SEC::ORDERED_MEMORY}},
   // cudaMemPoolImportPointer
   {"cuMemPoolImportPointer",                                      {"hipMemPoolImportPointer",                                     "", CONV_ORDERED_MEMORY, API_DRIVER, SEC::ORDERED_MEMORY}},
-  //
+  // cudaMemGetDefaultMemPool
   {"cuMemGetDefaultMemPool",                                      {"hipMemGetDefaultMemPool",                                     "", CONV_ORDERED_MEMORY, API_DRIVER, SEC::ORDERED_MEMORY, HIP_UNSUPPORTED}},
-  //
+  // cudaMemGetMemPool
   {"cuMemGetMemPool",                                             {"hipMemGetMemPool",                                            "", CONV_ORDERED_MEMORY, API_DRIVER, SEC::ORDERED_MEMORY, HIP_UNSUPPORTED}},
-  //
+  // cudaMemSetMemPool
   {"cuMemSetMemPool",                                             {"hipMemSetMemPool",                                            "", CONV_ORDERED_MEMORY, API_DRIVER, SEC::ORDERED_MEMORY, HIP_UNSUPPORTED}},
 
   // 16. Multicast Object Management
@@ -496,11 +496,11 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_FUNCTION_MAP {
   {"cuPointerGetAttributes",                                      {"hipDrvPointerGetAttributes",                                  "", CONV_UNIFIED, API_DRIVER, SEC::UNIFIED}},
   // no analogue
   {"cuPointerSetAttribute",                                       {"hipPointerSetAttribute",                                      "", CONV_UNIFIED, API_DRIVER, SEC::UNIFIED}},
-  //
+  // cudaMemPrefetchBatchAsync
   {"cuMemPrefetchBatchAsync",                                     {"hipMemPrefetchBatchAsync",                                    "", CONV_UNIFIED, API_DRIVER, SEC::UNIFIED, HIP_UNSUPPORTED}},
-  //
+  // cudaMemDiscardBatchAsync
   {"cuMemDiscardBatchAsync",                                      {"hipMemDiscardBatchAsync",                                     "", CONV_UNIFIED, API_DRIVER, SEC::UNIFIED, HIP_UNSUPPORTED}},
-  //
+  // cudaMemDiscardAndPrefetchBatchAsync
   {"cuMemDiscardAndPrefetchBatchAsync",                           {"hipMemDiscardAndPrefetchBatchAsync",                          "", CONV_UNIFIED, API_DRIVER, SEC::UNIFIED, HIP_UNSUPPORTED}},
 
   // 18. Stream Management
@@ -1052,15 +1052,15 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_FUNCTION_MAP {
   {"cuGreenCtxGetId",                                             {"hipGreenCtxGetId",                                            "", CONV_GREEN_CONTEXT, API_DRIVER, SEC::GREEN_CONTEXT, HIP_UNSUPPORTED}},
 
   // 36. Error Log Management Functions
-  //
+  // cudaLogsRegisterCallback
   {"cuLogsRegisterCallback",                                      {"hipLogsRegisterCallback",                                     "", CONV_ERROR_LOG, API_DRIVER, SEC::ERROR_LOG, HIP_UNSUPPORTED}},
-  //
+  // cudaLogsUnregisterCallback
   {"cuLogsUnregisterCallback",                                    {"hipLogsUnregisterCallback",                                   "", CONV_ERROR_LOG, API_DRIVER, SEC::ERROR_LOG, HIP_UNSUPPORTED}},
-  //
+  // cudaLogsCurrent
   {"cuLogsCurrent",                                               {"hipLogsCurrent",                                              "", CONV_ERROR_LOG, API_DRIVER, SEC::ERROR_LOG, HIP_UNSUPPORTED}},
-  //
+  // cudaLogsDumpToFile
   {"cuLogsDumpToFile",                                            {"hipLogsDumpToFile",                                           "", CONV_ERROR_LOG, API_DRIVER, SEC::ERROR_LOG, HIP_UNSUPPORTED}},
-  //
+  // cudaLogsDumpToMemory
   {"cuLogsDumpToMemory",                                          {"hipLogsDumpToMemory",                                         "", CONV_ERROR_LOG, API_DRIVER, SEC::ERROR_LOG, HIP_UNSUPPORTED}},
 
   // 37. Checkpointing

--- a/src/CUDA2HIP_Driver_API_types.cpp
+++ b/src/CUDA2HIP_Driver_API_types.cpp
@@ -528,9 +528,9 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_TYPE_NAME_MAP {
   //
   {"CUmemDecompressParams",                                            {"hipMemDecompressParams",                                   "", CONV_TYPE, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
 
-  //
+  // CUlogsCallbackEntry_st
   {"CUlogsCallbackEntry_st",                                           {"hipLogsCallbackEntry_st",                                  "", CONV_TYPE, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
-  //
+  // cudaLogsCallbackHandle
   {"CUlogsCallbackHandle",                                             {"hipLogsCallbackHandle",                                    "", CONV_TYPE, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
 
   // 2. Unions
@@ -2254,7 +2254,7 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_TYPE_NAME_MAP {
   // CUmemLocationType enum values
   // cudaMemLocationTypeInvalid
   {"CU_MEM_LOCATION_TYPE_INVALID",                                     {"hipMemLocationTypeInvalid",                                "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES}}, // 0x0
-  //
+  // cudaMemLocationTypeNone
   {"CU_MEM_LOCATION_TYPE_NONE",                                        {"hipMemLocationTypeInvalid",                                "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES}}, // 0x0
   // cudaMemLocationTypeDevice
   {"CU_MEM_LOCATION_TYPE_DEVICE",                                      {"hipMemLocationTypeDevice",                                 "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES}}, // 0x1
@@ -2275,7 +2275,7 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_TYPE_NAME_MAP {
   {"CU_MEM_ALLOCATION_TYPE_INVALID",                                   {"hipMemAllocationTypeInvalid",                              "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES}}, // 0x0
   // cudaMemAllocationTypePinned
   {"CU_MEM_ALLOCATION_TYPE_PINNED",                                    {"hipMemAllocationTypePinned",                               "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES}}, // 0x1
-  //
+  // cudaMemAllocationTypeManaged
   {"CU_MEM_ALLOCATION_TYPE_MANAGED",                                   {"hipMemAllocationTypeManaged",                              "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED}}, // 0x2
   // cudaMemAllocationTypeMax
   {"CU_MEM_ALLOCATION_TYPE_MAX",                                       {"hipMemAllocationTypeMax",                                  "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES}}, // 0x7FFFFFFF
@@ -2659,9 +2659,9 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_TYPE_NAME_MAP {
   {"CU_LAUNCH_ATTRIBUTE_DEVICE_UPDATABLE_KERNEL_NODE",                 {"hipLaunchAttributeDeviceUpdatableKernelNode",              "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
   // cudaLaunchAttributePreferredSharedMemoryCarveout
   {"CU_LAUNCH_ATTRIBUTE_PREFERRED_SHARED_MEMORY_CARVEOUT",             {"hipLaunchAttributePreferredSharedMemoryCarveout",          "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
-  //
+  // cudaKernelNodeAttributeNvlinkUtilCentricScheduling
   {"CU_LAUNCH_ATTRIBUTE_NVLINK_UTIL_CENTRIC_SCHEDULING",               {"hipLaunchAttributeNvlinkUtilCentricScheduling",            "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
-  //
+  // no analogue
   {"CU_LAUNCH_ATTRIBUTE_MAX",                                          {"hipLaunchAttributeMax",                                    "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
 
   // cudaGraphInstantiateResult
@@ -3041,39 +3041,39 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_TYPE_NAME_MAP {
   //
   {"CU_LOG_LEVEL_WARNING",                                             {"HIP_LOG_LEVEL_WARNING",                                    "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
 
-  //
+  // cudaAtomicOperation
   {"CUatomicOperation",                                                {"hipAtomicOperation",                                       "", CONV_TYPE, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
-  //
+  // cudaAtomicOperation
   {"CUatomicOperation_enum",                                           {"hipAtomicOperation",                                       "", CONV_TYPE, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
   // CUatomicOperation enum values
-  //
-  {"CU_ATOMIC_OPERATION_INTEGER_ADD",                                  {"HIP_ATOMIC_OPERATION_INTEGER_ADD",                         "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
-  //
-  {"CU_ATOMIC_OPERATION_INTEGER_MIN",                                  {"HIP_ATOMIC_OPERATION_INTEGER_MIN",                         "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
-  //
-  {"CU_ATOMIC_OPERATION_INTEGER_MAX",                                  {"HIP_ATOMIC_OPERATION_INTEGER_MAX",                         "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
-  //
-  {"CU_ATOMIC_OPERATION_INTEGER_INCREMENT",                            {"HIP_ATOMIC_OPERATION_INTEGER_INCREMENT",                   "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
-  //
-  {"CU_ATOMIC_OPERATION_INTEGER_DECREMENT",                            {"HIP_ATOMIC_OPERATION_INTEGER_DECREMENT",                   "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
-  //
-  {"CU_ATOMIC_OPERATION_AND",                                          {"HIP_ATOMIC_OPERATION_AND",                                 "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
-  //
-  {"CU_ATOMIC_OPERATION_OR",                                           {"HIP_ATOMIC_OPERATION_OR",                                  "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
-  //
-  {"CU_ATOMIC_OPERATION_XOR",                                          {"HIP_ATOMIC_OPERATION_XOR",                                 "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
-  //
-  {"CU_ATOMIC_OPERATION_EXCHANGE",                                     {"HIP_ATOMIC_OPERATION_EXCHANGE",                            "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
-  //
-  {"CU_ATOMIC_OPERATION_CAS",                                          {"HIP_ATOMIC_OPERATION_CAS",                                 "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
-  //
-  {"CU_ATOMIC_OPERATION_FLOAT_ADD",                                    {"HIP_ATOMIC_OPERATION_FLOAT_ADD",                           "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
-  //
-  {"CU_ATOMIC_OPERATION_FLOAT_MIN",                                    {"HIP_ATOMIC_OPERATION_FLOAT_MIN",                           "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
-  //
-  {"CU_ATOMIC_OPERATION_FLOAT_MAX",                                    {"HIP_ATOMIC_OPERATION_FLOAT_MAX",                           "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
-  //
-  {"CU_ATOMIC_OPERATION_MAX",                                          {"HIP_ATOMIC_OPERATION_MAX",                                 "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
+  // cudaAtomicOperationIntegerAdd
+  {"CU_ATOMIC_OPERATION_INTEGER_ADD",                                  {"hipAtomicOperationIntegerAdd",                             "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
+  // cudaAtomicOperationIntegerMin
+  {"CU_ATOMIC_OPERATION_INTEGER_MIN",                                  {"hipAtomicOperationIntegerMin",                             "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
+  // cudaAtomicOperationIntegerMax
+  {"CU_ATOMIC_OPERATION_INTEGER_MAX",                                  {"hipAtomicOperationIntegerMax",                             "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
+  // cudaAtomicOperationIntegerIncrement
+  {"CU_ATOMIC_OPERATION_INTEGER_INCREMENT",                            {"hipAtomicOperationIntegerIncrement",                       "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
+  // cudaAtomicOperationIntegerDecrement
+  {"CU_ATOMIC_OPERATION_INTEGER_DECREMENT",                            {"hipAtomicOperationIntegerDecrement",                       "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
+  // cudaAtomicOperationAnd
+  {"CU_ATOMIC_OPERATION_AND",                                          {"hipAtomicOperationAnd",                                    "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
+  // cudaAtomicOperationOr
+  {"CU_ATOMIC_OPERATION_OR",                                           {"hipAtomicOperationOr",                                     "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
+  // cudaAtomicOperationXOR
+  {"CU_ATOMIC_OPERATION_XOR",                                          {"hipAtomicOperationXOR",                                    "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
+  // cudaAtomicOperationExchange
+  {"CU_ATOMIC_OPERATION_EXCHANGE",                                     {"hipAtomicOperationExchange",                               "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
+  // cudaAtomicOperationCAS
+  {"CU_ATOMIC_OPERATION_CAS",                                          {"hipAtomicOperationCAS",                                    "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
+  // cudaAtomicOperationFloatAdd
+  {"CU_ATOMIC_OPERATION_FLOAT_ADD",                                    {"hipAtomicOperationFloatAdd",                               "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
+  // cudaAtomicOperationFloatMin
+  {"CU_ATOMIC_OPERATION_FLOAT_MIN",                                    {"hipAtomicOperationFloatMin",                               "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
+  // cudaAtomicOperationFloatMax
+  {"CU_ATOMIC_OPERATION_FLOAT_MAX",                                    {"hipAtomicOperationFloatMax",                               "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
+  // no analogue
+  {"CU_ATOMIC_OPERATION_MAX",                                          {"hipAtomicOperationMax",                                    "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
 
   //
   {"CUatomicOperationCapability",                                      {"hipAtomicOperationCapability",                             "", CONV_TYPE, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
@@ -3267,7 +3267,7 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_TYPE_NAME_MAP {
   {"CU_COMPUTE_FAMILY_TARGET_BASE",                                    {"HIP_COMPUTE_FAMILY_TARGET_BASE",                           "", CONV_DEFINE, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED}}, // 0x20000
   //
   {"CU_LAUNCH_KERNEL_REQUIRED_BLOCK_DIM",                              {"HIP_LAUNCH_KERNEL_REQUIRED_BLOCK_DIM",                     "", CONV_DEFINE, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED}}, // 1
-  //
+  // cudaLogIterator
   {"CUlogIterator",                                                    {"hipLogIterator",                                           "", CONV_DEFINE, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
 };
 

--- a/src/CUDA2HIP_Runtime_API_functions.cpp
+++ b/src/CUDA2HIP_Runtime_API_functions.cpp
@@ -414,10 +414,12 @@ const std::map<llvm::StringRef, hipCounter> CUDA_RUNTIME_FUNCTION_MAP {
   {"cudaDeviceRegisterAsyncNotification",                     {"hipDeviceRegisterAsyncNotification",                     "", CONV_MEMORY, API_RUNTIME, SEC::MEMORY, HIP_UNSUPPORTED}},
   // cuDeviceUnregisterAsyncNotification
   {"cudaDeviceUnregisterAsyncNotification",                   {"hipDeviceUnregisterAsyncNotification",                   "", CONV_MEMORY, API_RUNTIME, SEC::MEMORY, HIP_UNSUPPORTED}},
-  //
+  // cuMemDiscardBatchAsync
   {"cudaMemDiscardBatchAsync",                                {"hipMemDiscardBatchAsync",                                "", CONV_MEMORY, API_RUNTIME, SEC::MEMORY, HIP_UNSUPPORTED}},
-  //
+  // cuMemDiscardAndPrefetchBatchAsync
   {"cudaMemDiscardAndPrefetchBatchAsync",                     {"hipMemDiscardAndPrefetchBatchAsync",                     "", CONV_MEMORY, API_RUNTIME, SEC::MEMORY, HIP_UNSUPPORTED}},
+  // cuMemPrefetchBatchAsync
+  {"cudaMemPrefetchBatchAsync",                               {"hipMemPrefetchBatchAsync",                               "", CONV_MEMORY, API_RUNTIME, SEC::MEMORY, HIP_UNSUPPORTED}},
 
   // 11. Memory Management [DEPRECATED]
   // no analogue
@@ -462,11 +464,11 @@ const std::map<llvm::StringRef, hipCounter> CUDA_RUNTIME_FUNCTION_MAP {
   {"cudaMemPoolExportPointer",                                {"hipMemPoolExportPointer",                                "", CONV_MEMORY, API_RUNTIME, SEC::ORDERED_MEMORY}},
   // cuMemPoolImportPointer
   {"cudaMemPoolImportPointer",                                {"hipMemPoolImportPointer",                                "", CONV_MEMORY, API_RUNTIME, SEC::ORDERED_MEMORY}},
-  //
+  // cuMemGetDefaultMemPool
   {"cudaMemGetDefaultMemPool",                                {"hipMemGetDefaultMemPool",                                "", CONV_MEMORY, API_RUNTIME, SEC::ORDERED_MEMORY, HIP_UNSUPPORTED}},
-  //
+  // cuMemGetMemPool
   {"cudaMemGetMemPool",                                       {"hipMemGetMemPool",                                       "", CONV_MEMORY, API_RUNTIME, SEC::ORDERED_MEMORY, HIP_UNSUPPORTED}},
-  //
+  // cuMemSetMemPool
   {"cudaMemSetMemPool",                                       {"hipMemSetMemPool",                                       "", CONV_MEMORY, API_RUNTIME, SEC::ORDERED_MEMORY, HIP_UNSUPPORTED}},
 
   // 13. Unified Addressing
@@ -689,15 +691,15 @@ const std::map<llvm::StringRef, hipCounter> CUDA_RUNTIME_FUNCTION_MAP {
   {"cudaRuntimeGetVersion",                                   {"hipRuntimeGetVersion",                                   "", CONV_VERSION, API_RUNTIME, SEC::VERSION}},
 
   // 29. Log Management Functions
-  //
+  // cuLogsRegisterCallback
   {"cudaLogsRegisterCallback",                                {"hipLogsRegisterCallback",                                "", CONV_ERROR_LOG, API_RUNTIME, SEC::ERROR_LOG, HIP_UNSUPPORTED}},
-  //
+  // cuLogsUnregisterCallback
   {"cudaLogsUnregisterCallback",                              {"hipLogsUnregisterCallback",                              "", CONV_ERROR_LOG, API_RUNTIME, SEC::ERROR_LOG, HIP_UNSUPPORTED}},
-  //
+  // cuLogsCurrent
   {"cudaLogsCurrent",                                         {"hipLogsCurrent",                                         "", CONV_ERROR_LOG, API_RUNTIME, SEC::ERROR_LOG, HIP_UNSUPPORTED}},
-  //
+  // cuLogsDumpToFile
   {"cudaLogsDumpToFile",                                      {"hipLogsDumpToFile",                                      "", CONV_ERROR_LOG, API_RUNTIME, SEC::ERROR_LOG, HIP_UNSUPPORTED}},
-  //
+  // cuLogsDumpToMemory
   {"cudaLogsDumpToMemory",                                    {"hipLogsDumpToMemory",                                    "", CONV_ERROR_LOG, API_RUNTIME, SEC::ERROR_LOG, HIP_UNSUPPORTED}},
 
   // 30. Graph Management
@@ -1259,6 +1261,7 @@ const std::map<llvm::StringRef, cudaAPIversions> CUDA_RUNTIME_FUNCTION_VER_MAP {
   {"cudaDeviceGetP2PAtomicCapabilities",                      {CUDA_130, CUDA_0,   CUDA_0  }},
   {"cudaMemDiscardBatchAsync",                                {CUDA_130, CUDA_0,   CUDA_0  }},
   {"cudaMemDiscardAndPrefetchBatchAsync",                     {CUDA_130, CUDA_0,   CUDA_0  }},
+  {"cudaMemPrefetchBatchAsync",                               {CUDA_130, CUDA_0,   CUDA_0  }},
   {"cudaMemGetDefaultMemPool",                                {CUDA_130, CUDA_0,   CUDA_0  }},
   {"cudaMemGetMemPool",                                       {CUDA_130, CUDA_0,   CUDA_0  }},
   {"cudaMemSetMemPool",                                       {CUDA_130, CUDA_0,   CUDA_0  }},

--- a/src/CUDA2HIP_Runtime_API_types.cpp
+++ b/src/CUDA2HIP_Runtime_API_types.cpp
@@ -1824,7 +1824,7 @@ const std::map<llvm::StringRef, hipCounter> CUDA_RUNTIME_TYPE_NAME_MAP {
   // cudaMemLocationType enum values
   // CU_MEM_LOCATION_TYPE_INVALID
   {"cudaMemLocationTypeInvalid",                                       {"hipMemLocationTypeInvalid",                                "", CONV_NUMERIC_LITERAL, API_RUNTIME, SEC::DATA_TYPES}}, // 0
-  //
+  // CU_MEM_LOCATION_TYPE_NONE
   {"cudaMemLocationTypeNone",                                          {"hipMemLocationTypeInvalid",                                "", CONV_NUMERIC_LITERAL, API_RUNTIME, SEC::DATA_TYPES}}, // 0
   // CU_MEM_LOCATION_TYPE_DEVICE
   {"cudaMemLocationTypeDevice",                                        {"hipMemLocationTypeDevice",                                 "", CONV_NUMERIC_LITERAL, API_RUNTIME, SEC::DATA_TYPES}}, // 1
@@ -1842,7 +1842,7 @@ const std::map<llvm::StringRef, hipCounter> CUDA_RUNTIME_TYPE_NAME_MAP {
   {"cudaMemAllocationTypeInvalid",                                     {"hipMemAllocationTypeInvalid",                              "", CONV_NUMERIC_LITERAL, API_RUNTIME, SEC::DATA_TYPES}}, // 0x0
   // CU_MEM_ALLOCATION_TYPE_PINNED
   {"cudaMemAllocationTypePinned",                                      {"hipMemAllocationTypePinned",                               "", CONV_NUMERIC_LITERAL, API_RUNTIME, SEC::DATA_TYPES}}, // 0x1
-  //
+  // CU_MEM_ALLOCATION_TYPE_MANAGED
   {"cudaMemAllocationTypeManaged",                                     {"hipMemAllocationTypeManaged",                              "", CONV_NUMERIC_LITERAL, API_RUNTIME, SEC::DATA_TYPES, HIP_UNSUPPORTED}}, // 0x2
   // CU_MEM_ALLOCATION_TYPE_MAX
   {"cudaMemAllocationTypeMax",                                         {"hipMemAllocationTypeMax",                                  "", CONV_NUMERIC_LITERAL, API_RUNTIME, SEC::DATA_TYPES}}, // 0x7FFFFFFF
@@ -2220,34 +2220,34 @@ const std::map<llvm::StringRef, hipCounter> CUDA_RUNTIME_TYPE_NAME_MAP {
   // CU_GRAPH_CHILD_GRAPH_OWNERSHIP_MOVE
   {"cudaGraphChildGraphOwnershipMove",                                 {"hipGraphChildGraphOwnershipMove",                          "", CONV_NUMERIC_LITERAL, API_RUNTIME, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
 
-  //
+  // CUatomicOperation
   {"cudaAtomicOperation",                                              {"hipAtomicOperation",                                       "", CONV_TYPE, API_RUNTIME, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
   // cudaAtomicOperation enum values
-  //
+  // CU_ATOMIC_OPERATION_INTEGER_ADD
   {"cudaAtomicOperationIntegerAdd",                                    {"hipAtomicOperationIntegerAdd",                             "", CONV_NUMERIC_LITERAL, API_RUNTIME, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
-  //
+  // CU_ATOMIC_OPERATION_INTEGER_MIN
   {"cudaAtomicOperationIntegerMin",                                    {"hipAtomicOperationIntegerMin",                             "", CONV_NUMERIC_LITERAL, API_RUNTIME, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
-  //
+  // CU_ATOMIC_OPERATION_INTEGER_MAX
   {"cudaAtomicOperationIntegerMax",                                    {"hipAtomicOperationIntegerMax",                             "", CONV_NUMERIC_LITERAL, API_RUNTIME, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
-  //
+  // CU_ATOMIC_OPERATION_INTEGER_INCREMENT
   {"cudaAtomicOperationIntegerIncrement",                              {"hipAtomicOperationIntegerIncrement",                       "", CONV_NUMERIC_LITERAL, API_RUNTIME, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
-  //
+  // CU_ATOMIC_OPERATION_INTEGER_DECREMENT
   {"cudaAtomicOperationIntegerDecrement",                              {"hipAtomicOperationIntegerDecrement",                       "", CONV_NUMERIC_LITERAL, API_RUNTIME, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
-  //
+  // CU_ATOMIC_OPERATION_AND
   {"cudaAtomicOperationAnd",                                           {"hipAtomicOperationAnd",                                    "", CONV_NUMERIC_LITERAL, API_RUNTIME, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
-  //
+  // CU_ATOMIC_OPERATION_OR
   {"cudaAtomicOperationOr",                                            {"hipAtomicOperationOr",                                     "", CONV_NUMERIC_LITERAL, API_RUNTIME, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
-  //
+  // CU_ATOMIC_OPERATION_XOR
   {"cudaAtomicOperationXOR",                                           {"hipAtomicOperationXOR",                                    "", CONV_NUMERIC_LITERAL, API_RUNTIME, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
-  //
+  // CU_ATOMIC_OPERATION_EXCHANGE
   {"cudaAtomicOperationExchange",                                      {"hipAtomicOperationExchange",                               "", CONV_NUMERIC_LITERAL, API_RUNTIME, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
-  //
+  // CU_ATOMIC_OPERATION_CAS
   {"cudaAtomicOperationCAS",                                           {"hipAtomicOperationCAS",                                    "", CONV_NUMERIC_LITERAL, API_RUNTIME, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
-  //
+  // CU_ATOMIC_OPERATION_FLOAT_ADD
   {"cudaAtomicOperationFloatAdd",                                      {"hipAtomicOperationFloatAdd",                               "", CONV_NUMERIC_LITERAL, API_RUNTIME, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
-  //
+  // CU_ATOMIC_OPERATION_FLOAT_MIN
   {"cudaAtomicOperationFloatMin",                                      {"hipAtomicOperationFloatMin",                               "", CONV_NUMERIC_LITERAL, API_RUNTIME, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
-  //
+  // CU_ATOMIC_OPERATION_FLOAT_MAX
   {"cudaAtomicOperationFloatMax",                                      {"hipAtomicOperationFloatMax",                               "", CONV_NUMERIC_LITERAL, API_RUNTIME, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
 
   //
@@ -2301,12 +2301,12 @@ const std::map<llvm::StringRef, hipCounter> CUDA_RUNTIME_TYPE_NAME_MAP {
   // CUasyncCallback
   {"cudaAsyncCallback",                                                {"hipAsyncCallback",                                         "", CONV_TYPE, API_RUNTIME, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
 
-  //
+  // CUlogsCallbackHandle
   {"cudaLogsCallbackHandle",                                           {"hipLogsCallbackHandle",                                    "", CONV_TYPE, API_RUNTIME, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
-  //
+  // CUlogsCallbackEntry_st
   {"CUlogsCallbackEntry_st",                                           {"hipLogsCallbackEntry_st",                                  "", CONV_TYPE, API_RUNTIME, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
 
-  //
+  // no analogue
   {"cudaLogsCallback_t",                                               {"hipLogsCallback_t",                                        "", CONV_TYPE, API_RUNTIME, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
 
   // 5. Defines
@@ -2475,9 +2475,9 @@ const std::map<llvm::StringRef, hipCounter> CUDA_RUNTIME_TYPE_NAME_MAP {
   {"cudaGraphKernelNodePortLaunchCompletion",                          {"hipGraphKernelNodePortLaunchCompletion",                   "", CONV_DEFINE, API_RUNTIME, SEC::DATA_TYPES}}, // 2
   // CU_KERNEL_NODE_ATTRIBUTE_DEVICE_UPDATABLE_KERNEL_NODE
   {"cudaKernelNodeAttributeDeviceUpdatableKernelNode",                 {"hipKernelNodeAttributeDeviceUpdatableKernelNode",          "", CONV_DEFINE, API_RUNTIME, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
-  //
+  // CU_LAUNCH_ATTRIBUTE_NVLINK_UTIL_CENTRIC_SCHEDULING
   {"cudaKernelNodeAttributeNvlinkUtilCentricScheduling",               {"hipLaunchAttributeNvlinkUtilCentricScheduling",            "", CONV_DEFINE, API_RUNTIME, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
-  //
+  // CUlogIterator
   {"cudaLogIterator",                                                  {"hipLogIterator",                                           "", CONV_DEFINE, API_RUNTIME, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
 
   {"CUDART_INF_F",                                                     {"HIP_INF_F",                                                "", CONV_DEFINE, API_RUNTIME, SEC::DATA_TYPES}},


### PR DESCRIPTION
+ Updated the regenerated `hipify-perl` and `Runtime` `CUDA2HIP` docs accordingly

