### PR TITLE
[HIPIFY][#2073][feature] `CUDA` version detection - Part 1

### DIFF
--- a/src/HipifyAction.cpp
+++ b/src/HipifyAction.cpp
@@ -2295,6 +2295,11 @@ void HipifyAction::FindAndReplace(StringRef name,
     return;
   Statistics::current().incrementCounter(found->second, name.str());
   clang::DiagnosticsEngine &DE = getCompilerInstance().getDiagnostics();
+
+  // [ToDo] Remove after final implementing #2073
+  // const auto ID = DE.getCustomDiagID(clang::DiagnosticsEngine::Warning, "'%0' is the CUDA version, used by clang");
+  // DE.Report(sl, ID) << Statistics::getCudaVersion(Statistics::getCudaVersionUsedByClang());
+
   // Warn about the deprecated identifier in CUDA but hipify it.
   if (Statistics::isCudaDeprecated(found->second)) {
     const auto ID = DE.getCustomDiagID(clang::DiagnosticsEngine::Warning, "'%0' is deprecated in CUDA.");
@@ -3292,6 +3297,10 @@ void HipifyAction::ExecuteAction() {
   clang::Preprocessor &PP = getCompilerInstance().getPreprocessor();
   // Register yourself as the preprocessor callback, by proxy.
   PP.addPPCallbacks(std::unique_ptr<PPCallbackProxy>(new PPCallbackProxy(*this)));
+#if LLVM_VERSION_MAJOR > 3
+  Statistics::cudaVersionUsedByClang = Statistics::convertCudaToolkitVersion(clang::ToCudaVersion(PP.getTargetInfo().getSDKVersion()));
+  llvm::errs() << " !!!!!!! CUDA SDK version detected: " << int(clang::ToCudaVersion(PP.getTargetInfo().getSDKVersion())) << "\n";
+#endif
   // Now we're done futzing with the lexer, have the subclass proceeed with Sema and AST matching.
   clang::ASTFrontendAction::ExecuteAction();
   auto &SM = getCompilerInstance().getSourceManager();

--- a/src/Statistics.cpp
+++ b/src/Statistics.cpp
@@ -663,5 +663,71 @@ std::string Statistics::getHipVersion(const hipVersions &ver) {
   return "";
 }
 
+#if LLVM_VERSION_MAJOR > 3
+cudaVersions Statistics::convertCudaToolkitVersion(const clang::CudaVersion &ver) {
+  switch (ver) {
+    default:
+    case clang::CudaVersion::UNKNOWN: return CUDA_0;
+    case clang::CudaVersion::CUDA_70: return CUDA_70;
+    case clang::CudaVersion::CUDA_75: return CUDA_75;
+    case clang::CudaVersion::CUDA_80: return CUDA_80;
+#if LLVM_VERSION_MAJOR > 5
+    case clang::CudaVersion::CUDA_90: return CUDA_90;
+#if LLVM_VERSION_MAJOR > 6
+    case clang::CudaVersion::CUDA_91: return CUDA_91;
+    case clang::CudaVersion::CUDA_92: return CUDA_92;
+#if LLVM_VERSION_MAJOR > 7
+    case clang::CudaVersion::CUDA_100: return CUDA_100;
+#if LLVM_VERSION_MAJOR > 8
+    case clang::CudaVersion::CUDA_101: return CUDA_101;
+#if LLVM_VERSION_MAJOR > 9
+    case clang::CudaVersion::CUDA_102: return CUDA_102;
+    case clang::CudaVersion::CUDA_110: return CUDA_110;
+#if LLVM_VERSION_MAJOR > 12
+    case clang::CudaVersion::CUDA_111: return CUDA_111;
+    case clang::CudaVersion::CUDA_112: return CUDA_112;
+#if LLVM_VERSION_MAJOR > 13
+    case clang::CudaVersion::CUDA_113: return CUDA_113;
+    case clang::CudaVersion::CUDA_114: return CUDA_114;
+    case clang::CudaVersion::CUDA_115: return CUDA_115;
+    case clang::CudaVersion::NEW: return CUDA_PARTIALLY_SUPPORTED;
+#if LLVM_VERSION_MAJOR > 15
+    case clang::CudaVersion::CUDA_116: return CUDA_116;
+    case clang::CudaVersion::CUDA_117: return CUDA_117;
+    case clang::CudaVersion::CUDA_118: return CUDA_118;
+#if LLVM_VERSION_MAJOR > 16
+    case clang::CudaVersion::CUDA_120: return CUDA_120;
+    case clang::CudaVersion::CUDA_121: return CUDA_121;
+#if LLVM_VERSION_MAJOR > 17
+    case clang::CudaVersion::CUDA_122: return CUDA_122;
+    case clang::CudaVersion::CUDA_123: return CUDA_123;
+#if LLVM_VERSION_MAJOR > 18
+    case clang::CudaVersion::CUDA_124: return CUDA_124;
+    case clang::CudaVersion::CUDA_125: return CUDA_125;
+#if LLVM_VERSION_MAJOR > 19
+    case clang::CudaVersion::CUDA_126: return CUDA_126;
+    case clang::CudaVersion::CUDA_128: return CUDA_128;
+#if LLVM_VERSION_MAJOR > 21
+    case clang::CudaVersion::CUDA_129: return CUDA_129;
+#endif
+#endif
+#endif
+#endif
+#endif
+#endif
+#endif
+#endif
+#endif
+#endif
+#endif
+#endif
+#endif
+  }
+  return CUDA_0;
+}
+#endif
+
 std::map<std::string, Statistics> Statistics::stats = {};
 Statistics *Statistics::currentStatistics = nullptr;
+cudaVersions Statistics::cudaVersionUsedByClang = CUDA_0;
+

--- a/src/Statistics.h
+++ b/src/Statistics.h
@@ -30,7 +30,9 @@ THE SOFTWARE.
 #include <list>
 #include <llvm/ADT/StringRef.h>
 #include <llvm/Support/raw_ostream.h>
-
+#if LLVM_VERSION_MAJOR > 3
+#include "clang/Basic/Cuda.h"
+#endif
 namespace chr = std::chrono;
 
 enum ConvTypes {
@@ -253,6 +255,7 @@ enum cudaVersions {
   CUDA_129 = 12090,
   CUDA_130 = 13000,
   CUDA_LATEST = CUDA_129,
+  CUDA_PARTIALLY_SUPPORTED = CUDA_130,
   CUDNN_10 = 100,
   CUDNN_20 = 200,
   CUDNN_30 = 300,
@@ -466,6 +469,7 @@ public:
   * Tracks the statistics for a single input file.
   */
 class Statistics {
+  friend class HipifyAction;
   StatCounter supported;
   StatCounter unsupported;
   std::string fileName;
@@ -476,6 +480,8 @@ class Statistics {
   unsigned totalBytes = 0;
   chr::steady_clock::time_point startTime;
   chr::steady_clock::time_point completionTime;
+  // CUDA Toolkit version provided by clang at runtime and converted to HIPIFY cudaVersions enum.
+  static cudaVersions cudaVersionUsedByClang;
 
 public:
   Statistics(const std::string &name);
@@ -553,4 +559,10 @@ public:
   static std::string getHipVersion(const hipVersions &ver);
   // Set this flag in case of hipification errors.
   bool hasErrors = false;
+#if LLVM_VERSION_MAJOR > 3
+  // Converts CUDA version used by clang to CUDA version HIPIFY type.
+  static cudaVersions convertCudaToolkitVersion(const clang::CudaVersion &ver);
+#endif
+  // Get CUDA version used by clang in HIPIFY CUDA version format.
+  static cudaVersions getCudaVersionUsedByClang() { return cudaVersionUsedByClang; }
 };


### PR DESCRIPTION
+ [Part 1] Detect the CUDA version chosen by clang to be compiled against
+ [IMP]
  - clang doesn't report unsupported CUDA versions; moreover never reports even `NEW`
  - That is why clang's CUDA version is not always an actual CUDA Toolkit version, which is provided for compilation; it is always the CUDA version chosen by clang for compilation (even in case of a newer yet unsupported CUDA version explicitly provided)
  - clang CUDA version is insufficient for implementing #2062
  - `hipify-clang` must detect the real CUDA version for #2062
+ [ToDo]
  - [HIPIFY] Detect the real CUDA version by `hipify-clang` itself
  - [clang] Fix empty version reporting for any yet unsupported CUDA version; the current report is incorrect, for instance: `Found CUDA installation: C:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v13.0.1, version`
    + Report a detected CUDA version even if it is unsupported
    + Explicitly report CUDA version chosen by clang for compilation - otherwise it can be found only in verbose mode (`-target-sdk-version=12.9`, for instance)
