### PR TITLE
[HIPIFY][TENSOR][doc] `cuTensor 2.3.1.0` is the latest supported version

### DIFF
--- a/docs/building/build-hipify-clang-linux.rst
+++ b/docs/building/build-hipify-clang-linux.rst
@@ -134,8 +134,8 @@ Linux testing
 
 On Linux, the following configurations are tested:
 
-* Ubuntu 22-24: LLVM 13.0.0 - 21.1.2, CUDA 7.0 - 12.9.1, cuDNN 8.0.5 - 9.13.0, cuTensor 1.0.1.0 - 2.3.0.0
-* Ubuntu 20-21: LLVM 9.0.0 - 20.1.8, CUDA 7.0 - 12.8.1, cuDNN 5.1.10 - 9.13.0, cuTensor 1.0.1.0 - 2.3.0.0
+* Ubuntu 22-24: LLVM 13.0.0 - 21.1.2, CUDA 7.0 - 12.9.1, cuDNN 8.0.5 - 9.13.0, cuTensor 1.0.1.0 - 2.3.1.0
+* Ubuntu 20-21: LLVM 9.0.0 - 20.1.8, CUDA 7.0 - 12.8.1, cuDNN 5.1.10 - 9.13.0, cuTensor 1.0.1.0 - 2.3.1.0
 * Ubuntu 16-19: LLVM 8.0.0 - 14.0.6, CUDA 7.0 - 10.2, cuDNN 5.1.10 - 8.0.5
 * Ubuntu 14: LLVM 4.0.0 - 7.1.0, CUDA 7.0 - 9.0, cuDNN 5.0.5 - 7.6.5
 
@@ -160,7 +160,7 @@ Here's how to build ``hipify-clang`` with testing support on ``Ubuntu 24.04.02``
     -DCMAKE_PREFIX_PATH=$ROOT_DIR/dist \
     -DCUDA_TOOLKIT_ROOT_DIR=/usr/local/cuda-12.9.1 \
     -DCUDA_DNN_ROOT_DIR=/usr/local/cudnn-9.13.0 \
-    -DCUDA_TENSOR_ROOT_DIR=/usr/local/cutensor-2.3.0.0 \
+    -DCUDA_TENSOR_ROOT_DIR=/usr/local/cutensor-2.3.1.0 \
     -DLLVM_EXTERNAL_LIT=$ROOT_DIR/build/bin/llvm-lit \
     ../hipify
 
@@ -200,7 +200,7 @@ The corresponding successful output is (assuming ROOT_DIR is ``/usr/llvm/21.1.2`
   --    - CUDA Toolkit path     : /usr/local/cuda-12.9.1
   --    - CUDA Samples path     :
   --    - cuDNN path            : /usr/local/cudnn-9.13.0
-  --    - cuTENSOR path         : /usr/local/cuTensor/2.3.0.0
+  --    - cuTENSOR path         : /usr/local/cuTensor/2.3.1.0
   --    - CUB path              :
   -- Found CUDAToolkit: /usr/local/cuda-12.9.1/targets/x86_64-linux/include (found version "12.9.86")
   -- Performing Test CMAKE_HAVE_LIBC_PTHREAD
@@ -211,7 +211,7 @@ The corresponding successful output is (assuming ROOT_DIR is ``/usr/llvm/21.1.2`
   --    - CUDA Samples path     : OFF
   --    - cuDNN path            : /usr/local/cudnn-9.13.0
   --    - CUB path              : /usr/local/cuda-12.9.1/include/cub
-  --    - cuTENSOR path         : /usr/local/cuTensor/2.3.0.0
+  --    - cuTENSOR path         : /usr/local/cuTensor/2.3.1.0
   -- Configuring done (0.6s)
   -- Generating done (0.0s)
   -- Build files have been written to: /usr/hipify/build

--- a/docs/building/build-hipify-clang-windows.rst
+++ b/docs/building/build-hipify-clang-windows.rst
@@ -92,7 +92,7 @@ We recommend that you build ``LLVM+Clang`` from sources, as prebuilt binaries ar
 
   .. code-block:: bash
 
-   -DCUDA_TENSOR_ROOT_DIR=D:/CUDA/cuTensor/2.3.0.0
+   -DCUDA_TENSOR_ROOT_DIR=D:/CUDA/cuTensor/2.3.1.0
 
 - [Optional] Install `cuDNN <https://developer.nvidia.com/rdp/cudnn-archive>`_ belonging to the version corresponding to the CUDA version:
 
@@ -264,7 +264,7 @@ Building with testing support using ``Visual Studio 17 2022`` on ``Windows 11``:
   -DCUDA_TOOLKIT_ROOT_DIR="C:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v12.9" \
   -DCUDA_SDK_ROOT_DIR="C:/ProgramData/NVIDIA Corporation/CUDA Samples/v12.9" \
   -DCUDA_DNN_ROOT_DIR=D:/CUDA/cuDNN/9.13.0 \
-  -DCUDA_TENSOR_ROOT_DIR=D:/CUDA/cuTensor/2.3.0.0 \
+  -DCUDA_TENSOR_ROOT_DIR=D:/CUDA/cuTensor/2.3.1.0 \
   -DLLVM_EXTERNAL_LIT=%ROOT_DIR%/build/Release/bin/llvm-lit.py \
   ../hipify
 
@@ -302,14 +302,14 @@ The corresponding successful output is (assuming %ROOT_DIR% is ``D:/LLVM/21.1.2`
   --    - CUDA Toolkit path     : C:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v12.9
   --    - CUDA Samples path     : C:/ProgramData/NVIDIA Corporation/CUDA Samples/v12.9
   --    - cuDNN path            : D:/CUDA/cuDNN/9.13.0
-  --    - cuTENSOR path         : D:/CUDA/cuTensor/2.3.0.0
+  --    - cuTENSOR path         : D:/CUDA/cuTensor/2.3.1.0
   --    - CUB path              :
   -- Found CUDAToolkit: C:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v12.9/include (found version "12.9.86")
   -- Found CUDA config:
   --    - CUDA Toolkit path     : C:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v12.9
   --    - CUDA Samples path     : C:/ProgramData/NVIDIA Corporation/CUDA Samples/v12.9
   --    - cuDNN path            : D:/CUDA/cuDNN/9.13.0
-  --    - cuTENSOR path         : D:/CUDA/cuTensor/2.3.0.0
+  --    - cuTENSOR path         : D:/CUDA/cuTensor/2.3.1.0
   --    - CUB path              : C:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v12.9/include/cub
   -- Configuring done (4.4s)
   -- Generating done (0.1s)


### PR DESCRIPTION
+ No API changes since `2.3.0.0`
