### PR TITLE
[HIPIFY][tests][Windows][fix] Fix the test harness running script

### DIFF
--- a/tests/run_test.bat
+++ b/tests/run_test.bat
@@ -30,7 +30,7 @@ if %NUM% EQU 1 (
   shift
   call set HIPIFY_OPTS=%%5 %%6 %%7 %%8 %%9
 ) else (
-  set clang_args=%%all_args:*%6=%%
+  call set clang_args=%%all_args:*%5=%%
   set NUM=0
 )
 if %NUM% EQU 4 (


### PR DESCRIPTION
+ Fixed the case with no hipify arguments presented
+ [IMP][Windows] Currently,  `run_test.bat` supports up to 5 hipify-specific options, so for more options support this script should be changed
+ [ToDo] Rewrite this script to Python and make it cross-platform (`run_test.py` instead of `run_test.bat` and `run_test.sh`)
