### PR TITLE
[HIPIFY][fix] Fix `cleanupHipifyOptions`

### DIFF
--- a/src/ArgParse.cpp
+++ b/src/ArgParse.cpp
@@ -253,7 +253,6 @@ const std::vector<std::string> hipifyOptions {
   std::string(NoUndocumented.ArgStr),
   std::string(NoWarningsUndocumented.ArgStr),
   std::string(HipifyAMAP.ArgStr),
-  std::string(ClangResourceDir.ArgStr),
   std::string(HipDnnSupport.ArgStr),
 };
 
@@ -263,4 +262,5 @@ const std::vector<std::string> hipifyOptionsWithTwoArgs {
   std::string(OutputPythonMapDir.ArgStr),
   std::string(OutputStatsFilename.ArgStr),
   std::string(TemporaryDir.ArgStr),
+  std::string(ClangResourceDir.ArgStr),
 };


### PR DESCRIPTION
+ `ClangResourceDir` option (`--clang-resource-directory=`) is a HIPIFY-only option and must be filtered correctly before passing options to `clang`
+ The fix eliminates the following Custom Build error: 

```cmd
CUSTOMBUILD : # | error : unknown argument: '--clang-resource-directory=D:/GIT/LLVM/trunk-for-submit/llvm-64-release-vs2022/dist/lib/clang/22'
```