### PR TITLE
[HIPIFY][#2062][feature][partial] Initial support for partially supported HIP APIs - Part 1 - tests breaking change

### DIFF
--- a/src/CUDA2HIP.cpp
+++ b/src/CUDA2HIP.cpp
@@ -142,6 +142,14 @@ const std::map<llvm::StringRef, hipCounter> &CUDA_RENAMES_MAP() {
   return ret;
 };
 
+const std::map<llvm::StringRef, cudaAPIUnsupportedVersions> &CUDA_UNSUPPORTED_VER_MAP() {
+  static std::map<llvm::StringRef, cudaAPIUnsupportedVersions> ret;
+  if (!ret.empty())
+    return ret;
+  ret.insert(CUDA_DRIVER_FUNCTION_UNSUPPORTED_VER_MAP.begin(), CUDA_DRIVER_FUNCTION_UNSUPPORTED_VER_MAP.end());
+  return ret;
+};
+
 const std::map<llvm::StringRef, cudaAPIversions> &CUDA_VERSIONS_MAP() {
   static std::map<llvm::StringRef, cudaAPIversions> ret;
   if (!ret.empty())

--- a/src/CUDA2HIP.h
+++ b/src/CUDA2HIP.h
@@ -129,10 +129,7 @@ extern const std::map<llvm::StringRef, cudaAPIversions> CUDA_SOLVER_FUNCTION_VER
 extern const std::map<llvm::StringRef, cudaAPIversions> CUDA_TENSOR_TYPE_NAME_VER_MAP;
 extern const std::map<llvm::StringRef, cudaAPIversions> CUDA_TENSOR_FUNCTION_VER_MAP;
 
-/**
-  * The union of all the above CUDA maps.
-  *
-  */
+// The union of all the above maps.
 const std::map<llvm::StringRef, cudaAPIversions> &CUDA_VERSIONS_MAP();
 
 extern const std::map<llvm::StringRef, hipAPIversions> HIP_DRIVER_TYPE_NAME_VER_MAP;
@@ -178,10 +175,7 @@ extern const std::map<llvm::StringRef, hipAPIChangedVersions> HIP_TENSOR_FUNCTIO
 extern const std::map<llvm::StringRef, cudaAPIChangedVersions> CUDA_TENSOR_FUNCTION_CHANGED_VER_MAP;
 extern const std::map<llvm::StringRef, cudaAPIChangedVersions> CUDA_TENSOR_TYPE_CHANGED_VER_MAP;
 
-/**
-  * The union of all the above HIP maps.
-  *
-  */
+// The union of all the above maps.
 const std::map<llvm::StringRef, hipAPIversions> &HIP_VERSIONS_MAP();
 
 extern const std::map<unsigned int, llvm::StringRef> CUDA_DRIVER_API_SECTION_MAP;
@@ -197,6 +191,11 @@ extern const std::map<unsigned int, llvm::StringRef> CUDA_RTC_API_SECTION_MAP;
 extern const std::map<unsigned int, llvm::StringRef> CUDA_CUB_API_SECTION_MAP;
 extern const std::map<unsigned int, llvm::StringRef> CUDA_SOLVER_API_SECTION_MAP;
 extern const std::map<unsigned int, llvm::StringRef> CUDA_TENSOR_API_SECTION_MAP;
+
+extern const std::map<llvm::StringRef, cudaAPIUnsupportedVersions> CUDA_DRIVER_FUNCTION_UNSUPPORTED_VER_MAP;
+
+// The union of all the above maps.
+const std::map<llvm::StringRef, cudaAPIUnsupportedVersions> &CUDA_UNSUPPORTED_VER_MAP();
 
 namespace driver {
   enum CUDA_DRIVER_API_SECTIONS {

--- a/src/CUDA2HIP_Driver_API_functions.cpp
+++ b/src/CUDA2HIP_Driver_API_functions.cpp
@@ -97,9 +97,8 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_FUNCTION_MAP {
   {"cuDevicePrimaryCtxSetFlags_v2",                               {"hipDevicePrimaryCtxSetFlags",                                 "", CONV_CONTEXT, API_DRIVER, SEC::PRIMARY_CONTEXT, HIP_DEPRECATED}},
 
   // 8. Context Management
- 
-  // TODO: report unsupported only for CUDA >= 13000
-  {"cuCtxCreate",                                                 {"hipCtxCreate",                                                "", CONV_CONTEXT, API_DRIVER, SEC::CONTEXT, HIP_UNSUPPORTED | HIP_DEPRECATED}},
+
+  {"cuCtxCreate",                                                 {"hipCtxCreate",                                                "", CONV_CONTEXT, API_DRIVER, SEC::CONTEXT, HIP_PARTIALLY_SUPPORTED | HIP_DEPRECATED}},
   // TODO: report unsupported only for CUDA >= 13000
   {"cuCtxCreate_v2",                                              {"hipCtxCreate",                                                "", CONV_CONTEXT, API_DRIVER, SEC::CONTEXT, HIP_UNSUPPORTED | HIP_DEPRECATED}},
   {"cuCtxCreate_v3",                                              {"hipCtxCreate_v3",                                             "", CONV_CONTEXT, API_DRIVER, SEC::CONTEXT, HIP_UNSUPPORTED}},
@@ -1809,6 +1808,10 @@ const std::map<llvm::StringRef, hipAPIChangedVersions> HIP_DRIVER_FUNCTION_CHANG
   {"hipCtxGetApiVersion",                                         {HIP_7000}},
   {"hipDrvGraphAddMemsetNode",                                    {HIP_7000}},
   {"hipDrvGraphExecMemsetNodeSetParams",                          {HIP_7000}},
+};
+
+const std::map<llvm::StringRef, cudaAPIUnsupportedVersions> CUDA_DRIVER_FUNCTION_UNSUPPORTED_VER_MAP {
+  {"cuCtxCreate",                                                 {CUDA_130}},
 };
 
 const std::map<unsigned int, llvm::StringRef> CUDA_DRIVER_API_SECTION_MAP {

--- a/src/HipifyAction.cpp
+++ b/src/HipifyAction.cpp
@@ -2335,6 +2335,24 @@ void HipifyAction::FindAndReplace(StringRef name,
     DE.Report(sl, ID) << found->first << sWarn;
     return;
   }
+  if (Statistics::isHipPartiallySupported(found->second)) {
+    unsigned ver = Statistics::getCudaVersion();
+    bool bPartiallySupported = false;
+    const auto it = CUDA_UNSUPPORTED_VER_MAP().find(name);
+    if (it != CUDA_UNSUPPORTED_VER_MAP().end()) {
+      for (const auto &v : it->second) {
+        if (v == ver) {
+          bPartiallySupported = true;
+          break;
+        }
+      }
+      if (bPartiallySupported) {
+        const auto ID = DE.getCustomDiagID(clang::DiagnosticsEngine::Warning, "'%0' of CUDA version '%1' is not supported.");
+        DE.Report(sl, ID) << found->first << ver;
+        return;
+      }
+    }
+  }
   if (!bReplace) {
     return;
   }

--- a/src/Statistics.cpp
+++ b/src/Statistics.cpp
@@ -384,6 +384,10 @@ bool Statistics::isHipExperimental(const hipCounter &counter) {
   return HIP_EXPERIMENTAL == (counter.supportDegree & HIP_EXPERIMENTAL);
 }
 
+bool Statistics::isHipPartiallySupported(const hipCounter &counter) {
+  return HIP_PARTIALLY_SUPPORTED == (counter.supportDegree & HIP_PARTIALLY_SUPPORTED);
+}
+
 bool Statistics::isHipUnsupported(const hipCounter &counter) {
   return HIP_UNSUPPORTED == (counter.supportDegree & HIP_UNSUPPORTED) ||
     UNSUPPORTED == (counter.supportDegree & UNSUPPORTED);
@@ -394,7 +398,11 @@ bool Statistics::isRocUnsupported(const hipCounter &counter) {
     UNSUPPORTED == (counter.supportDegree & UNSUPPORTED);
 }
 
-bool Statistics::isUnsupported(const hipCounter& counter) {
+bool Statistics::isRocPartiallySupported(const hipCounter &counter) {
+  return ROC_PARTIALLY_SUPPORTED == (counter.supportDegree & ROC_PARTIALLY_SUPPORTED);
+}
+
+bool Statistics::isUnsupported(const hipCounter &counter) {
   if (UNSUPPORTED == (counter.supportDegree & UNSUPPORTED)) return true;
   if (Statistics::isToRoc(counter)) return Statistics::isRocUnsupported(counter);
   else return Statistics::isHipUnsupported(counter);

--- a/src/Statistics.h
+++ b/src/Statistics.h
@@ -207,7 +207,9 @@ enum SupportDegree {
   REMOVED = 0x400,
   HIP_EXPERIMENTAL = 0x800,
   HIP_SUPPORTED_V2_ONLY = 0x1000,
-  CUDA_OVERLOADED = 0x2000
+  CUDA_OVERLOADED = 0x2000,
+  HIP_PARTIALLY_SUPPORTED = 0x4000,
+  ROC_PARTIALLY_SUPPORTED = 0x8000,
 };
 
 enum cudaVersions {
@@ -435,6 +437,7 @@ struct hipAPIversions {
 
 typedef std::list<hipVersions> hipAPIChangedVersions;
 typedef std::list<cudaVersions> cudaAPIChangedVersions;
+typedef std::list<cudaVersions> cudaAPIUnsupportedVersions;
 
 // The names of various fields in in the statistics reports.
 extern const char *counterNames[NUM_CONV_TYPES];
@@ -529,13 +532,17 @@ public:
   // Check the counter and option TranslateToRoc whether it should be translated to Roc or not.
   static bool isToRoc(const hipCounter &counter);
   // Check the counter and option TranslateToMIOpen whether it should be translated to MIOpen or not.
-  static bool isToMIOpen(const hipCounter& counter);
+  static bool isToMIOpen(const hipCounter &counter);
   // Check whether the counter is HIP_EXPERIMENTAL or not.
   static bool isHipExperimental(const hipCounter &counter);
+  // Check whether the counter is HIP_PARTIALLY_SUPPORTED or not.
+  static bool isHipPartiallySupported(const hipCounter &counter);
   // Check whether the counter is HIP_UNSUPPORTED or not.
   static bool isHipUnsupported(const hipCounter &counter);
   // Check whether the counter is ROC_UNSUPPORTED or not.
   static bool isRocUnsupported(const hipCounter &counter);
+  // Check whether the counter is ROC_PARTIALLY_SUPPORTED or not.
+  static bool isRocPartiallySupported(const hipCounter &counter);
   // Check whether the counter is ROC_UNSUPPORTED/HIP_UNSUPPORTED/UNSUPPORTED or not.
   static bool isUnsupported(const hipCounter &counter);
   // Check whether the counter is CUDA_DEPRECATED or not.

--- a/tests/unit_tests/synthetic/driver_functions.cu
+++ b/tests/unit_tests/synthetic/driver_functions.cu
@@ -190,12 +190,12 @@ int main() {
   // CHECK: result = hipDevicePrimaryCtxSetFlags(device, flags);
   result = cuDevicePrimaryCtxSetFlags(device, flags);
 
-  // [TODO][#2062] Rename all DO-NOT-CHECK back
+  // [TODO][#2062] Split into two tests: before 13.0 and after 13.0. Run the below API test only for CUDA versions before 13.0.
 #if CUDA_VERSION < 13000
   // CUDA: CUresult CUDAAPI cuCtxCreate(CUcontext *pctx, unsigned int flags, CUdevice dev);
   // HIP: DEPRECATED(DEPRECATED_MSG) hipError_t hipCtxCreate(hipCtx_t *ctx, unsigned int flags, hipDevice_t device);
-  // DO-NOT-CHECK: result = hipCtxCreate(&context, flags, device);
-  // DO-NOT-CHECK-NEXT: result = hipCtxCreate(&context, flags, device);
+  // CHECK: result = hipCtxCreate(&context, flags, device);
+  // CHECK-NEXT: result = hipCtxCreate(&context, flags, device);
   result = cuCtxCreate(&context, flags, device);
   result = cuCtxCreate_v2(&context, flags, device);
 #endif


### PR DESCRIPTION
+ [IMP] Now, if an API is marked as `HIP_PARTIALLY_SUPPORTED`, like `cuCtxCreate`, `hipify-clang` checks the unsupported CUDA versions for such an API and doesn't hipify it - instead, it emits a warning like the following: `'cuCtxCreate' of CUDA version '13000' is not supported.`
+ [IMP] If such a marked API is used against a supported CUDA version, hipification occurs without any warnings.
+ [ToDo] Do the same for the rest partially supported APIs.
+ [ToDo] Split the corresponding tests with such APIs into two: before 13, and after 13.
+ [ToDo][doc] Reflect such APIs in the autogenerated documentation.
+ [ToDo][perl] Think about implementing a similar behaviour in autogenerated `hipify-perl`.
