### PR TITLE
[HIPIFY][Runtime][Driver][7.0][fix] The missing HIP functions and types

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -3991,7 +3991,6 @@ sub simpleSubstitutions {
     subst("cuDeviceGetDefaultMemPool", "hipDeviceGetDefaultMemPool", "device");
     subst("cuDeviceGetMemPool", "hipDeviceGetMemPool", "device");
     subst("cuDeviceGetName", "hipDeviceGetName", "device");
-    subst("cuDeviceGetTexture1DLinearMaxWidth", "hipDeviceGetTexture1DLinearMaxWidth", "device");
     subst("cuDeviceGetUuid", "hipDeviceGetUuid", "device");
     subst("cuDeviceGetUuid_v2", "hipDeviceGetUuid", "device");
     subst("cuDeviceSetMemPool", "hipDeviceSetMemPool", "device");
@@ -8824,6 +8823,7 @@ sub simpleSubstitutions {
     subst("CU_KERNEL_NODE_ATTRIBUTE_PRIORITY", "hipKernelNodeAttributePriority", "numeric_literal");
     subst("CU_LAUNCH_ATTRIBUTE_ACCESS_POLICY_WINDOW", "hipLaunchAttributeAccessPolicyWindow", "numeric_literal");
     subst("CU_LAUNCH_ATTRIBUTE_COOPERATIVE", "hipLaunchAttributeCooperative", "numeric_literal");
+    subst("CU_LAUNCH_ATTRIBUTE_MAX", "hipLaunchAttributeMax", "numeric_literal");
     subst("CU_LAUNCH_ATTRIBUTE_PRIORITY", "hipLaunchAttributePriority", "numeric_literal");
     subst("CU_LIMIT_MALLOC_HEAP_SIZE", "hipLimitMallocHeapSize", "numeric_literal");
     subst("CU_LIMIT_PRINTF_FIFO_SIZE", "hipLimitPrintfFifoSize", "numeric_literal");
@@ -12413,6 +12413,7 @@ sub warnRemovedFunctions {
     "cuEGLStreamConsumerAcquireFrame",
     "cuDeviceUnregisterAsyncNotification",
     "cuDeviceRegisterAsyncNotification",
+    "cuDeviceGetTexture1DLinearMaxWidth",
     "cuDeviceGetProperties",
     "cuDeviceGetP2PAtomicCapabilities",
     "cuDeviceGetNvSciSyncAttributes",
@@ -12905,7 +12906,6 @@ sub warnRemovedFunctions {
     "CU_LAUNCH_ATTRIBUTE_NVLINK_UTIL_CENTRIC_SCHEDULING",
     "CU_LAUNCH_ATTRIBUTE_MEM_SYNC_DOMAIN_MAP",
     "CU_LAUNCH_ATTRIBUTE_MEM_SYNC_DOMAIN",
-    "CU_LAUNCH_ATTRIBUTE_MAX",
     "CU_LAUNCH_ATTRIBUTE_LAUNCH_COMPLETION_EVENT",
     "CU_LAUNCH_ATTRIBUTE_IGNORE",
     "CU_LAUNCH_ATTRIBUTE_DEVICE_UPDATABLE_KERNEL_NODE",

--- a/docs/reference/tables/CUDA_Driver_API_functions_supported_by_HIP.md
+++ b/docs/reference/tables/CUDA_Driver_API_functions_supported_by_HIP.md
@@ -868,7 +868,7 @@
 |`CU_LAUNCH_ATTRIBUTE_DEVICE_UPDATABLE_KERNEL_NODE`|12.4| | | | | | | | | | |
 |`CU_LAUNCH_ATTRIBUTE_IGNORE`|11.8| | | | | | | | | | |
 |`CU_LAUNCH_ATTRIBUTE_LAUNCH_COMPLETION_EVENT`|12.3| | | | | | | | | | |
-|`CU_LAUNCH_ATTRIBUTE_MAX`|12.1| | | | | | | | | | |
+|`CU_LAUNCH_ATTRIBUTE_MAX`|12.1| | | |`hipLaunchAttributeMax`|7.0.0| | | | | |
 |`CU_LAUNCH_ATTRIBUTE_MEM_SYNC_DOMAIN`|12.0| | | | | | | | | | |
 |`CU_LAUNCH_ATTRIBUTE_MEM_SYNC_DOMAIN_MAP`|12.0| | | | | | | | | | |
 |`CU_LAUNCH_ATTRIBUTE_NVLINK_UTIL_CENTRIC_SCHEDULING`|13.0| | | | | | | | | | |
@@ -1646,7 +1646,7 @@
 |`cuDeviceGetMemPool`|11.2| | | |`hipDeviceGetMemPool`|5.2.0| | | | | |
 |`cuDeviceGetName`| | | | |`hipDeviceGetName`|1.6.0| | | | | |
 |`cuDeviceGetNvSciSyncAttributes`|10.2| | | | | | | | | | |
-|`cuDeviceGetTexture1DLinearMaxWidth`|11.1| | | |`hipDeviceGetTexture1DLinearMaxWidth`|6.4.0| | | | | |
+|`cuDeviceGetTexture1DLinearMaxWidth`|11.1| | | | | | | | | | |
 |`cuDeviceGetUuid`|9.2| | | |`hipDeviceGetUuid`|5.2.0| | | | | |
 |`cuDeviceGetUuid_v2`|11.4| | | |`hipDeviceGetUuid`|5.2.0| | | | | |
 |`cuDeviceSetMemPool`|11.2| | | |`hipDeviceSetMemPool`|5.2.0| | | | | |
@@ -1855,10 +1855,10 @@
 |`cuMemcpyHtoAAsync`| | | | |`hipMemcpyHtoAAsync`|6.2.0| | | | | |
 |`cuMemcpyHtoAAsync_v2`| | | | |`hipMemcpyHtoAAsync`|6.2.0| | | | | |
 |`cuMemcpyHtoA_v2`| | | | |`hipMemcpyHtoA`|1.9.0| | | | | |
-|`cuMemcpyHtoD`| | | | |`hipMemcpyHtoD`|1.6.0| | | | | |
-|`cuMemcpyHtoDAsync`| | | | |`hipMemcpyHtoDAsync`|1.6.0| | | | | |
-|`cuMemcpyHtoDAsync_v2`| | | | |`hipMemcpyHtoDAsync`|1.6.0| | | | | |
-|`cuMemcpyHtoD_v2`| | | | |`hipMemcpyHtoD`|1.6.0| | | | | |
+|`cuMemcpyHtoD`| | | | |`hipMemcpyHtoD`|1.6.0| |7.0.0| | | |
+|`cuMemcpyHtoDAsync`| | | | |`hipMemcpyHtoDAsync`|1.6.0| |7.0.0| | | |
+|`cuMemcpyHtoDAsync_v2`| | | | |`hipMemcpyHtoDAsync`|1.6.0| |7.0.0| | | |
+|`cuMemcpyHtoD_v2`| | | | |`hipMemcpyHtoD`|1.6.0| |7.0.0| | | |
 |`cuMemcpyPeer`| | | | | | | | | | | |
 |`cuMemcpyPeerAsync`| | | | | | | | | | | |
 |`cuMemsetD16`| | | | |`hipMemsetD16`|3.0.0| | | | | |

--- a/docs/reference/tables/CUDA_Runtime_API_functions_supported_by_HIP.md
+++ b/docs/reference/tables/CUDA_Runtime_API_functions_supported_by_HIP.md
@@ -28,7 +28,7 @@
 |`cudaDeviceGetP2PAttribute`|8.0| | | |`hipDeviceGetP2PAttribute`|3.8.0| | | | | |
 |`cudaDeviceGetPCIBusId`| | | | |`hipDeviceGetPCIBusId`|1.6.0| | | | | |
 |`cudaDeviceGetStreamPriorityRange`| | | | |`hipDeviceGetStreamPriorityRange`|2.0.0| | | | | |
-|`cudaDeviceGetTexture1DLinearMaxWidth`|11.1| | | |`hipDeviceGetTexture1DLinearMaxWidth`|6.4.0| | | | | |
+|`cudaDeviceGetTexture1DLinearMaxWidth`|11.1| | | |`hipDeviceGetTexture1DLinearMaxWidth`|6.4.0| |7.0.0| | | |
 |`cudaDeviceReset`| | | | |`hipDeviceReset`|1.6.0| | | | | |
 |`cudaDeviceSetCacheConfig`| | | | |`hipDeviceSetCacheConfig`|1.6.0| | | | | |
 |`cudaDeviceSetLimit`| | | | |`hipDeviceSetLimit`|5.3.0| | | | | |

--- a/src/CUDA2HIP.h
+++ b/src/CUDA2HIP.h
@@ -138,6 +138,7 @@ extern const std::map<llvm::StringRef, hipAPIChangedVersions> HIP_DRIVER_FUNCTIO
 extern const std::map<llvm::StringRef, cudaAPIChangedVersions> CUDA_DRIVER_FUNCTION_CHANGED_VER_MAP;
 extern const std::map<llvm::StringRef, hipAPIversions> HIP_RUNTIME_TYPE_NAME_VER_MAP;
 extern const std::map<llvm::StringRef, hipAPIversions> HIP_RUNTIME_FUNCTION_VER_MAP;
+extern const std::map<llvm::StringRef, hipAPIChangedVersions> HIP_RUNTIME_FUNCTION_CHANGED_VER_MAP;
 extern const std::map<llvm::StringRef, cudaAPIChangedVersions> CUDA_RUNTIME_FUNCTION_CHANGED_VER_MAP;
 extern const std::map<llvm::StringRef, cudaAPIChangedVersions> CUDA_RUNTIME_TYPE_CHANGED_VER_MAP;
 extern const std::map<llvm::StringRef, hipAPIversions> HIP_COMPLEX_TYPE_NAME_VER_MAP;

--- a/src/CUDA2HIP_Doc.cpp
+++ b/src/CUDA2HIP_Doc.cpp
@@ -552,6 +552,7 @@ namespace doc {
       const typeMap &getTypes() const override { return CUDA_RUNTIME_TYPE_NAME_MAP; }
       const versionMap &getFunctionVersions() const override { return CUDA_RUNTIME_FUNCTION_VER_MAP; }
       const hipVersionMap &getHipFunctionVersions() const override { return HIP_RUNTIME_FUNCTION_VER_MAP; }
+      const hipChangedVersionMap &getHipChangedFunctionVersions() const override { return HIP_RUNTIME_FUNCTION_CHANGED_VER_MAP; }
       const cudaChangedVersionMap &getCudaChangedFunctionVersions() const override { return CUDA_RUNTIME_FUNCTION_CHANGED_VER_MAP; }
       const cudaChangedVersionMap &getCudaChangedTypeVersions() const override { return CUDA_RUNTIME_TYPE_CHANGED_VER_MAP; }
       const cudaUnsupportedVersionMap &getCudaUnsupportedFunctionVersions() const override { return CUDA_RUNTIME_FUNCTION_UNSUPPORTED_VER_MAP; };

--- a/src/CUDA2HIP_Driver_API_functions.cpp
+++ b/src/CUDA2HIP_Driver_API_functions.cpp
@@ -64,7 +64,7 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_FUNCTION_MAP {
   {"cuDeviceTotalMem",                                            {"hipDeviceTotalMem",                                           "", CONV_DEVICE, API_DRIVER, SEC::DEVICE}},
   {"cuDeviceTotalMem_v2",                                         {"hipDeviceTotalMem",                                           "", CONV_DEVICE, API_DRIVER, SEC::DEVICE}},
   // NOTE: incompatible with cudaDeviceGetTexture1DLinearMaxWidth
-  {"cuDeviceGetTexture1DLinearMaxWidth",                          {"hipDeviceGetTexture1DLinearMaxWidth",                         "", CONV_DEVICE, API_DRIVER, SEC::DEVICE}},
+  {"cuDeviceGetTexture1DLinearMaxWidth",                          {"hipDeviceGetTexture1DLinearMaxWidth",                         "", CONV_DEVICE, API_DRIVER, SEC::DEVICE, HIP_UNSUPPORTED}},
   // cudaDeviceSetMemPool
   {"cuDeviceSetMemPool",                                          {"hipDeviceSetMemPool",                                         "", CONV_DEVICE, API_DRIVER, SEC::DEVICE}},
   // cudaDeviceGetMemPool
@@ -1769,7 +1769,6 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_DRIVER_FUNCTION_VER_MAP {
   {"hipGraphBatchMemOpNodeSetParams",                             {HIP_6040, HIP_0,    HIP_0   }},
   {"hipGraphExecBatchMemOpNodeSetParams",                         {HIP_6040, HIP_0,    HIP_0   }},
   {"hipEventRecordWithFlags",                                     {HIP_6040, HIP_0,    HIP_0   }},
-  {"hipDeviceGetTexture1DLinearMaxWidth",                         {HIP_6040, HIP_0,    HIP_0   }},
   {"hipDrvLaunchKernelEx",                                        {HIP_7000, HIP_0,    HIP_0   }},
   {"hipMemGetHandleForAddressRange",                              {HIP_7000, HIP_0,    HIP_0   }},
 };
@@ -1795,6 +1794,8 @@ const std::map<llvm::StringRef, hipAPIChangedVersions> HIP_DRIVER_FUNCTION_CHANG
   {"hipCtxGetApiVersion",                                         {HIP_7000}},
   {"hipDrvGraphAddMemsetNode",                                    {HIP_7000}},
   {"hipDrvGraphExecMemsetNodeSetParams",                          {HIP_7000}},
+  {"hipMemcpyHtoD",                                               {HIP_7000}},
+  {"hipMemcpyHtoDAsync",                                          {HIP_7000}},
 };
 
 const std::map<llvm::StringRef, cudaAPIUnsupportedVersions> CUDA_DRIVER_FUNCTION_UNSUPPORTED_VER_MAP {

--- a/src/CUDA2HIP_Driver_API_types.cpp
+++ b/src/CUDA2HIP_Driver_API_types.cpp
@@ -2662,7 +2662,7 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_TYPE_NAME_MAP {
   // cudaKernelNodeAttributeNvlinkUtilCentricScheduling
   {"CU_LAUNCH_ATTRIBUTE_NVLINK_UTIL_CENTRIC_SCHEDULING",               {"hipLaunchAttributeNvlinkUtilCentricScheduling",            "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
   // no analogue
-  {"CU_LAUNCH_ATTRIBUTE_MAX",                                          {"hipLaunchAttributeMax",                                    "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
+  {"CU_LAUNCH_ATTRIBUTE_MAX",                                          {"hipLaunchAttributeMax",                                    "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES}},
 
   // cudaGraphInstantiateResult
   {"CUgraphInstantiateResult",                                         {"hipGraphInstantiateResult",                                "", CONV_TYPE, API_DRIVER, SEC::DATA_TYPES}},
@@ -4871,4 +4871,5 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_DRIVER_TYPE_NAME_VER_MAP {
   {"hipMemRangeHandleTypeMax",                                         {HIP_7000, HIP_0,    HIP_0   }},
   {"hipMemRangeFlags",                                                 {HIP_7000, HIP_0,    HIP_0   }},
   {"hipMemRangeFlagDmaBufMappingTypePcie",                             {HIP_7000, HIP_0,    HIP_0   }},
+  {"hipLaunchAttributeMax",                                            {HIP_7000, HIP_0,    HIP_0   }},
 };

--- a/src/CUDA2HIP_Runtime_API_functions.cpp
+++ b/src/CUDA2HIP_Runtime_API_functions.cpp
@@ -1524,6 +1524,7 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_RUNTIME_FUNCTION_VER_MAP {
   {"hipGraphNodeSetParams",                                   {HIP_6030, HIP_0,    HIP_0   }},
   {"hipGraphExecNodeSetParams",                               {HIP_6030, HIP_0,    HIP_0   }},
   {"hipLaunchKernelExC",                                      {HIP_7000, HIP_0,    HIP_0   }},
+  {"hipDeviceGetTexture1DLinearMaxWidth",                     {HIP_6040, HIP_0,    HIP_0   }},
 };
 
 const std::map<llvm::StringRef, cudaAPIChangedVersions> CUDA_RUNTIME_FUNCTION_CHANGED_VER_MAP {
@@ -1542,6 +1543,10 @@ const std::map<llvm::StringRef, cudaAPIChangedVersions> CUDA_RUNTIME_FUNCTION_CH
   {"cudaGraphAddNode",                                        {CUDA_130}},
   // [IMP] Changed semantics: Dst <-> Src
   {"cudaGraphKernelNodeCopyAttributes",                       {CUDA_130}},
+};
+
+const std::map<llvm::StringRef, hipAPIChangedVersions> HIP_RUNTIME_FUNCTION_CHANGED_VER_MAP {
+  {"hipDeviceGetTexture1DLinearMaxWidth",                     {HIP_7000}},
 };
 
 const std::map<llvm::StringRef, cudaAPIUnsupportedVersions> CUDA_RUNTIME_FUNCTION_UNSUPPORTED_VER_MAP {

--- a/tests/unit_tests/synthetic/driver_enums.cu
+++ b/tests/unit_tests/synthetic/driver_enums.cu
@@ -1249,7 +1249,12 @@ int main() {
   CUdriverProcAddressQueryResult GET_PROC_ADDRESS_VERSION_NOT_SUFFICIENT = CU_GET_PROC_ADDRESS_VERSION_NOT_SUFFICIENT;
 #endif
 
-#if CUDA_VERSION >= 12030
+#if CUDA_VERSION >= 12010
+  // CHECK: hipLaunchAttributeID LAUNCH_ATTRIBUTE_MAX = hipLaunchAttributeMax;
+  CUlaunchAttributeID LAUNCH_ATTRIBUTE_MAX = CU_LAUNCH_ATTRIBUTE_MAX;
+#endif
+
+#if CUDA_VERSION >= 12030 
   // CHECK: hipGraphDependencyType graphDependencyType;
   // CHECK-NEXT: hipGraphDependencyType graphDependencyType_enum;
   // CHECK-NEXT: hipGraphDependencyType GRAPH_DEPENDENCY_TYPE_DEFAULT = hipGraphDependencyTypeDefault;

--- a/tests/unit_tests/synthetic/driver_functions.cu
+++ b/tests/unit_tests/synthetic/driver_functions.cu
@@ -478,14 +478,14 @@ int main() {
   result = cuMemcpyHtoA_v2(array_, offset, dsthost, bytes);
 
   // CUDA: CUresult CUDAAPI cuMemcpyHtoD(CUdeviceptr dstDevice, const void *srcHost, size_t ByteCount);
-  // HIP: hipError_t hipMemcpyHtoD(hipDeviceptr_t dst, void* src, size_t sizeBytes);
+  // HIP: hipError_t hipMemcpyHtoD(hipDeviceptr_t dst, const void* src, size_t sizeBytes);
   // CHECK: result = hipMemcpyHtoD(deviceptr, dsthost, bytes);
   // CHECK-NEXT: result = hipMemcpyHtoD(deviceptr, dsthost, bytes);
   result = cuMemcpyHtoD(deviceptr, dsthost, bytes);
   result = cuMemcpyHtoD_v2(deviceptr, dsthost, bytes);
 
   // CUDA: CUresult CUDAAPI cuMemcpyHtoDAsync(CUdeviceptr dstDevice, const void *srcHost, size_t ByteCount, CUstream hStream);
-  // HIP: hipError_t hipMemcpyHtoDAsync(hipDeviceptr_t dst, void* src, size_t sizeBytes, hipStream_t stream);
+  // HIP: hipError_t hipMemcpyHtoDAsync(hipDeviceptr_t dst, const void* src, size_t sizeBytes, hipStream_t stream);
   // CHECK: result = hipMemcpyHtoDAsync(deviceptr, dsthost, bytes, stream);
   // CHECK-NEXT: result = hipMemcpyHtoDAsync(deviceptr, dsthost, bytes, stream);
   result = cuMemcpyHtoDAsync(deviceptr, dsthost, bytes, stream);

--- a/tests/unit_tests/synthetic/runtime_functions.cu
+++ b/tests/unit_tests/synthetic/runtime_functions.cu
@@ -1290,10 +1290,10 @@ int main() {
   // CHECK: result = hipEventRecordWithFlags(Event_t, stream, flags);
   result = cudaEventRecordWithFlags(Event_t, stream, flags);
 
-  // TODO [LRT]: make hipDeviceGetTexture1DLinearMaxWidth compatible with cudaDeviceGetTexture1DLinearMaxWidth
   // CUDA:extern __host__ __cudart_builtin__ cudaError_t CUDARTAPI cudaDeviceGetTexture1DLinearMaxWidth(size_t *maxWidthInElements, const struct cudaChannelFormatDesc *fmtDesc, int device);
-  // HIP: hipError_t hipDeviceGetTexture1DLinearMaxWidth(hipMemPool_t* mem_pool, int device);
-  result = cudaDeviceGetTexture1DLinearMaxWidth(&bytes, &ChannelFormatDesc, device);
+  // HIP: hipError_t hipDeviceGetTexture1DLinearMaxWidth(size_t* max_width, const hipChannelFormatDesc* desc, int device);
+  // CHECK: result = hipDeviceGetTexture1DLinearMaxWidth(&width, &ChannelFormatDesc, device);
+  result = cudaDeviceGetTexture1DLinearMaxWidth(&width, &ChannelFormatDesc, device);
 #endif
 
 #if CUDA_VERSION >= 11020

--- a/tests/unit_tests/synthetic/runtime_functions_before_13000.cu
+++ b/tests/unit_tests/synthetic/runtime_functions_before_13000.cu
@@ -1330,10 +1330,10 @@ int main() {
   // CHECK: result = hipEventRecordWithFlags(Event_t, stream, flags);
   result = cudaEventRecordWithFlags(Event_t, stream, flags);
 
-  // TODO [LRT]: make hipDeviceGetTexture1DLinearMaxWidth compatible with cudaDeviceGetTexture1DLinearMaxWidth
   // CUDA:extern __host__ __cudart_builtin__ cudaError_t CUDARTAPI cudaDeviceGetTexture1DLinearMaxWidth(size_t *maxWidthInElements, const struct cudaChannelFormatDesc *fmtDesc, int device);
-  // HIP: hipError_t hipDeviceGetTexture1DLinearMaxWidth(hipMemPool_t* mem_pool, int device);
-  result = cudaDeviceGetTexture1DLinearMaxWidth(&bytes, &ChannelFormatDesc, device);
+  // HIP: hipError_t hipDeviceGetTexture1DLinearMaxWidth(size_t* max_width, const hipChannelFormatDesc* desc, int device);
+  // CHECK: result = hipDeviceGetTexture1DLinearMaxWidth(&width, &ChannelFormatDesc, device);
+  result = cudaDeviceGetTexture1DLinearMaxWidth(&width, &ChannelFormatDesc, device);
 #endif
 
 #if CUDA_VERSION >= 11020


### PR DESCRIPTION
+ Updated the corresponding tests, regenerated `hipify-perl`, and `Runtime` and `Driver` `CUDA2HIP` docs accordingly
+ [IMP][fix] `hipMemcpyHtoD`, `hipMemcpyHtoDAsync`, and `hipDeviceGetTexture1DLinearMaxWidth` APIs has been changed in `7.0`
+ [fix] `cuDeviceGetTexture1DLinearMaxWidth` is actually unsupported as incompatible with `cudaDeviceGetTexture1DLinearMaxWidth`
+ [ToDo] Revise and add missing tests
