### PR TITLE
[HIPIFY][tests][#2090][fix][Linux] The non-existing directory in relative path of the `#include` directive

### DIFF
--- a/tests/unit_tests/headers/local_headers/relative/sub/common2.h
+++ b/tests/unit_tests/headers/local_headers/relative/sub/common2.h
@@ -1,0 +1,12 @@
+// RUN: %run_test hipify "%s" "%t" %hipify_args --local-headers-recursive %clang_args
+
+#ifndef COMMON2_H
+#define COMMON2_H
+// CHECK: #include <hip/hip_runtime.h>
+// CHECK-NOT: #include <cuda_runtime.h>
+#include <cuda_runtime.h>
+inline void w() {
+    // CHECK: hipDeviceSynchronize();
+    cudaDeviceSynchronize();
+}
+#endif

--- a/tests/unit_tests/headers/local_headers/relative_path.cu
+++ b/tests/unit_tests/headers/local_headers/relative_path.cu
@@ -4,4 +4,5 @@
 // CHECK-NOT: #include <cuda_runtime.h>
 #include <cuda_runtime.h>
 #include "relative/./sub/../common1.h"
+#include "relative/sub/common2.h"
 int main(){return 0; }


### PR DESCRIPTION
**[Synopsis]**
+ On Windows with MSVC, the test `relative_path.cu` passes due to the `path canonicalization`, when the relative path `relative/./sub/../common1.h` is simplified by the preprocessor before it searches for the file; thus, after preprocessor, the path is `relative/common1.h`. And because of that `path canonicalization`, the test passes.
+ On Linux with GCC 13.3, the test `relative_path.cu` fails probably due to the missing or switched off by default `path canonicalization`.

**[Solution]**
+ Add the missing `sub` directory with yet another header file to be able to submit the change.
+ [IMP] Now, the include directive after preprocessing always becomes `relative/sub/../common1.h` and the test for `relative path` passes on both OS types.
