### PR TITLE
[HIPIFY][7.1][FFTw] Sync with `ROCm HIP 7.1` - Part 2 - `fftw` - Step 2 - Functions

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -1682,6 +1682,17 @@ my %removed_funcs = (
 my %experimental_funcs = (
     "fftwf_plan" => "7.1.0",
     "fftwf_complex" => "7.1.0",
+    "fftw_plan_dft_r2c_3d" => "7.1.0",
+    "fftw_plan_dft_r2c_2d" => "7.1.0",
+    "fftw_plan_dft_r2c_1d" => "7.1.0",
+    "fftw_plan_dft_r2c" => "7.1.0",
+    "fftw_plan_dft_c2r_3d" => "7.1.0",
+    "fftw_plan_dft_c2r_2d" => "7.1.0",
+    "fftw_plan_dft_c2r" => "7.1.0",
+    "fftw_plan_dft_3d" => "7.1.0",
+    "fftw_plan_dft_2d" => "7.1.0",
+    "fftw_plan_dft_1d" => "7.1.0",
+    "fftw_plan_dft" => "7.1.0",
     "fftw_plan" => "7.1.0",
     "fftw_complex" => "7.1.0",
     "FFTW_WISDOM_ONLY" => "7.1.0",
@@ -1833,6 +1844,18 @@ sub subst {
 }
 
 sub experimentalSubstitutions {
+    subst("fftw_plan_dft", "fftw_plan_dft", "library");
+    subst("fftw_plan_dft_1d", "fftw_plan_dft_1d", "library");
+    subst("fftw_plan_dft_2d", "fftw_plan_dft_2d", "library");
+    subst("fftw_plan_dft_3d", "fftw_plan_dft_3d", "library");
+    subst("fftw_plan_dft_c2r", "fftw_plan_dft_c2r", "library");
+    subst("fftw_plan_dft_c2r_1d", "fftw_plan_dft_c2r_1d", "library");
+    subst("fftw_plan_dft_c2r_2d", "fftw_plan_dft_c2r_2d", "library");
+    subst("fftw_plan_dft_c2r_3d", "fftw_plan_dft_c2r_3d", "library");
+    subst("fftw_plan_dft_r2c", "fftw_plan_dft_r2c", "library");
+    subst("fftw_plan_dft_r2c_1d", "fftw_plan_dft_r2c_1d", "library");
+    subst("fftw_plan_dft_r2c_2d", "fftw_plan_dft_r2c_2d", "library");
+    subst("fftw_plan_dft_r2c_3d", "fftw_plan_dft_r2c_3d", "library");
     subst("fftw_complex", "fftw_complex", "type");
     subst("fftw_plan", "fftw_plan", "type");
     subst("fftwf_complex", "fftwf_complex", "type");

--- a/docs/reference/tables/CUFFT_API_supported_by_HIP.md
+++ b/docs/reference/tables/CUFFT_API_supported_by_HIP.md
@@ -191,4 +191,16 @@
 |`cufftXtSetGPUs`| | | | |`hipfftXtSetGPUs`|6.0.0| | | | | |
 |`cufftXtSetWorkArea`| | | | | | | | | | | |
 |`cufftXtSetWorkAreaPolicy`|9.2| | | | | | | | | | |
+|`fftw_plan_dft`| | | | |`fftw_plan_dft`|7.1.0| | | | |7.1.0|
+|`fftw_plan_dft_1d`| | | | |`fftw_plan_dft_1d`|7.1.0| | | | |7.1.0|
+|`fftw_plan_dft_2d`| | | | |`fftw_plan_dft_2d`|7.1.0| | | | |7.1.0|
+|`fftw_plan_dft_3d`| | | | |`fftw_plan_dft_3d`|7.1.0| | | | |7.1.0|
+|`fftw_plan_dft_c2r`| | | | |`fftw_plan_dft_c2r`|7.1.0| | | | |7.1.0|
+|`fftw_plan_dft_c2r_1d`| | | | |`fftw_plan_dft_c2r_1d`| | | | | | |
+|`fftw_plan_dft_c2r_2d`| | | | |`fftw_plan_dft_c2r_2d`|7.1.0| | | | |7.1.0|
+|`fftw_plan_dft_c2r_3d`| | | | |`fftw_plan_dft_c2r_3d`|7.1.0| | | | |7.1.0|
+|`fftw_plan_dft_r2c`| | | | |`fftw_plan_dft_r2c`|7.1.0| | | | |7.1.0|
+|`fftw_plan_dft_r2c_1d`| | | | |`fftw_plan_dft_r2c_1d`|7.1.0| | | | |7.1.0|
+|`fftw_plan_dft_r2c_2d`| | | | |`fftw_plan_dft_r2c_2d`|7.1.0| | | | |7.1.0|
+|`fftw_plan_dft_r2c_3d`| | | | |`fftw_plan_dft_r2c_3d`|7.1.0| | | | |7.1.0|
 

--- a/src/CUDA2HIP_FFT_API_functions.cpp
+++ b/src/CUDA2HIP_FFT_API_functions.cpp
@@ -88,6 +88,18 @@ const std::map<llvm::StringRef, hipCounter> CUDA_FFT_FUNCTION_MAP {
   {"cufftSetPlanPropertyInt64",                           {"hipfftSetPlanPropertyInt64",                           "", CONV_LIB_FUNC, API_FFT, 2, UNSUPPORTED}},
   {"cufftGetPlanPropertyInt64",                           {"hipfftGetPlanPropertyInt64",                           "", CONV_LIB_FUNC, API_FFT, 2, UNSUPPORTED}},
   {"cufftResetPlanProperty",                              {"hipfftResetPlanProperty",                              "", CONV_LIB_FUNC, API_FFT, 2, UNSUPPORTED}},
+  {"fftw_plan_dft_1d",                                    {"fftw_plan_dft_1d",                                     "", CONV_LIB_FUNC, API_FFT, 2, HIP_EXPERIMENTAL}},
+  {"fftw_plan_dft_2d",                                    {"fftw_plan_dft_2d",                                     "", CONV_LIB_FUNC, API_FFT, 2, HIP_EXPERIMENTAL}},
+  {"fftw_plan_dft_3d",                                    {"fftw_plan_dft_3d",                                     "", CONV_LIB_FUNC, API_FFT, 2, HIP_EXPERIMENTAL}},
+  {"fftw_plan_dft",                                       {"fftw_plan_dft",                                        "", CONV_LIB_FUNC, API_FFT, 2, HIP_EXPERIMENTAL}},
+  {"fftw_plan_dft_r2c_1d",                                {"fftw_plan_dft_r2c_1d",                                 "", CONV_LIB_FUNC, API_FFT, 2, HIP_EXPERIMENTAL}},
+  {"fftw_plan_dft_r2c_2d",                                {"fftw_plan_dft_r2c_2d",                                 "", CONV_LIB_FUNC, API_FFT, 2, HIP_EXPERIMENTAL}},
+  {"fftw_plan_dft_r2c_3d",                                {"fftw_plan_dft_r2c_3d",                                 "", CONV_LIB_FUNC, API_FFT, 2, HIP_EXPERIMENTAL}},
+  {"fftw_plan_dft_r2c",                                   {"fftw_plan_dft_r2c",                                    "", CONV_LIB_FUNC, API_FFT, 2, HIP_EXPERIMENTAL}},
+  {"fftw_plan_dft_c2r_1d",                                {"fftw_plan_dft_c2r_1d",                                 "", CONV_LIB_FUNC, API_FFT, 2, HIP_EXPERIMENTAL}},
+  {"fftw_plan_dft_c2r_2d",                                {"fftw_plan_dft_c2r_2d",                                 "", CONV_LIB_FUNC, API_FFT, 2, HIP_EXPERIMENTAL}},
+  {"fftw_plan_dft_c2r_3d",                                {"fftw_plan_dft_c2r_3d",                                 "", CONV_LIB_FUNC, API_FFT, 2, HIP_EXPERIMENTAL}},
+  {"fftw_plan_dft_c2r",                                   {"fftw_plan_dft_c2r",                                    "", CONV_LIB_FUNC, API_FFT, 2, HIP_EXPERIMENTAL}},
 };
 
 const std::map<llvm::StringRef, cudaAPIversions> CUDA_FFT_FUNCTION_VER_MAP {
@@ -163,6 +175,17 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_FFT_FUNCTION_VER_MAP {
   {"hipfftXtGetSizeMany",                                 {HIP_5060, HIP_0,    HIP_0   }},
   {"hipfftXtExec",                                        {HIP_5060, HIP_0,    HIP_0   }},
   {"hipfftXtExecDescriptor",                              {HIP_6000, HIP_0,    HIP_0   }},
+  {"fftw_plan_dft_1d",                                    {HIP_7010, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"fftw_plan_dft_2d",                                    {HIP_7010, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"fftw_plan_dft_3d",                                    {HIP_7010, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"fftw_plan_dft",                                       {HIP_7010, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"fftw_plan_dft_r2c_1d",                                {HIP_7010, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"fftw_plan_dft_r2c_2d",                                {HIP_7010, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"fftw_plan_dft_r2c_3d",                                {HIP_7010, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"fftw_plan_dft_r2c",                                   {HIP_7010, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"fftw_plan_dft_c2r_2d",                                {HIP_7010, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"fftw_plan_dft_c2r_3d",                                {HIP_7010, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"fftw_plan_dft_c2r",                                   {HIP_7010, HIP_0,    HIP_0,  HIP_LATEST}},
 };
 
 const std::map<unsigned int, llvm::StringRef> CUDA_FFT_API_SECTION_MAP {

--- a/tests/unit_tests/synthetic/libraries/cufftw2hipfftw.cu
+++ b/tests/unit_tests/synthetic/libraries/cufftw2hipfftw.cu
@@ -31,9 +31,9 @@ int main() {
   int W_PRESERVE_INPUT = FFTW_PRESERVE_INPUT;
   int W_UNALIGNED = FFTW_UNALIGNED;
 
-  // CHECK: fftw_complex w_complex;
+  // CHECK: fftw_complex w_complex, w_complex_in, w_complex_out;
   // CHECK-NEXT: fftwf_complex wf_complex;
-  fftw_complex w_complex;
+  fftw_complex w_complex, w_complex_in, w_complex_out;
   fftwf_complex wf_complex;
 
   // CHECK: fftw_plan w_plan = nullptr;
@@ -41,5 +41,75 @@ int main() {
   fftw_plan w_plan = nullptr;
   fftwf_plan twf_plan = nullptr;
 
+  int n = 0;
+  int n0 = 0;
+  int n1 = 0;
+  int n2 = 0;
+  int sign = 0;
+  int rank = 0;
+  unsigned int flags = 0;
+  double d_in = 0.0f;
+  double d_out = 0.0f;
+
+  // CUDA: fftw_plan CUFFTAPI fftw_plan_dft_1d(int n, fftw_complex* in, fftw_complex* out, int sign, unsigned flags);
+  // HIP: HIPFFT_EXPORT fftw_plan fftw_plan_dft_1d(int n, fftw_complex * in, fftw_complex * out, int sign, unsigned flags);
+  // CHECK: w_plan = fftw_plan_dft_1d(n, &w_complex_in, &w_complex_out, sign, flags);
+  w_plan = fftw_plan_dft_1d(n, &w_complex_in, &w_complex_out, sign, flags);
+
+  // CUDA: fftw_plan CUFFTAPI fftw_plan_dft_2d(int n0, int n1, fftw_complex* in, fftw_complex* out, int sign, unsigned flags);
+  // HIP: HIPFFT_EXPORT fftw_plan fftw_plan_dft_2d(int n0, int n1, fftw_complex * in, fftw_complex * out, int sign, unsigned flags);
+  // CHECK: w_plan = fftw_plan_dft_2d(n0, n1, &w_complex_in, &w_complex_out, sign, flags);
+  w_plan = fftw_plan_dft_2d(n0, n1, &w_complex_in, &w_complex_out, sign, flags);
+
+  // CUDA: fftw_plan CUFFTAPI fftw_plan_dft_3d(int n0, int n1, int n2, fftw_complex* in, fftw_complex* out, int sign, unsigned flags);
+  // HIP: HIPFFT_EXPORT fftw_plan fftw_plan_dft_3d(int n0, int n1, int n2, fftw_complex* in, fftw_complex* out, int sign, unsigned flags);
+  // CHECK: w_plan = fftw_plan_dft_3d(n0, n1, n2, &w_complex_in, &w_complex_out, sign, flags);
+  w_plan = fftw_plan_dft_3d(n0, n1, n2, &w_complex_in, &w_complex_out, sign, flags);
+
+  // CUDA: fftw_plan CUFFTAPI fftw_plan_dft(int rank, const int* n, fftw_complex* in, fftw_complex* out, int sign, unsigned flags);
+  // HIP: HIPFFT_EXPORT fftw_plan fftw_plan_dft(int rank, const int* n, fftw_cBomplex* in, fftw_complex* out, int sign, unsigned flags);
+  // CHECK: w_plan = fftw_plan_dft(rank, &n, &w_complex_in, &w_complex_out, sign, flags);
+  w_plan = fftw_plan_dft(rank, &n, &w_complex_in, &w_complex_out, sign, flags);
+
+  // CUDA: fftw_plan CUFFTAPI fftw_plan_dft_r2c_1d(int n, double* in, fftw_complex* out, unsigned flags);
+  // HIP: HIPFFT_EXPORT fftw_plan fftw_plan_dft_r2c_1d(int n, double* in, fftw_complex* out, unsigned flags);
+  // CHECK: w_plan = fftw_plan_dft_r2c_1d(n, &d_in, &w_complex_out, flags);
+  w_plan = fftw_plan_dft_r2c_1d(n, &d_in, &w_complex_out, flags);
+
+  // CUDA: fftw_plan CUFFTAPI fftw_plan_dft_r2c_2d(int n0, int n1, double* in, fftw_complex* out, unsigned flags);
+  // HIP: HIPFFT_EXPORT fftw_plan fftw_plan_dft_r2c_2d(int n0, int n1, double* in, fftw_complex * out, unsigned flags);
+  // CHECK: w_plan = fftw_plan_dft_r2c_2d(n0, n1, &d_in, &w_complex_out, flags);
+  w_plan = fftw_plan_dft_r2c_2d(n0, n1, &d_in, &w_complex_out, flags);
+
+  // CUDA: fftw_plan CUFFTAPI fftw_plan_dft_r2c_3d(int n0, int n1, int n2, double* in, fftw_complex* out, unsigned flags);
+  // HIP: HIPFFT_EXPORT fftw_plan fftw_plan_dft_r2c_3d(int n0, int n1, int n2, double* in, fftw_complex * out, unsigned flags);
+  // CHECK: w_plan = fftw_plan_dft_r2c_3d(n0, n1, n2, &d_in, &w_complex_out, flags);
+  w_plan = fftw_plan_dft_r2c_3d(n0, n1, n2, &d_in, &w_complex_out, flags);
+
+  // CUDA: fftw_plan CUFFTAPI fftw_plan_dft_r2c(int rank, const int* n, double* in, fftw_complex* out, unsigned flags);
+  // HIP: HIPFFT_EXPORT fftw_plan fftw_plan_dft_r2c(int rank, const int* n, double* in, fftw_complex * out, unsigned flags);
+  // CHECK: w_plan = fftw_plan_dft_r2c(rank, &n, &d_in, &w_complex_out, flags);
+  w_plan = fftw_plan_dft_r2c(rank, &n, &d_in, &w_complex_out, flags);
+
+  // CUDA: fftw_plan CUFFTAPI fftw_plan_dft_c2r_1d(int n, fftw_complex* in, double* out, unsigned flags);
+  // HIP: HIPFFT_EXPORT fftw_plan fftw_plan_dft_c2r_1d(int n, fftw_complex* in, double* out, unsigned flags);
+  // CHECK: w_plan = fftw_plan_dft_c2r_1d(n, &w_complex_in, &d_out, flags);
+  w_plan = fftw_plan_dft_c2r_1d(n, &w_complex_in, &d_out, flags);
+
+  // CUDA: fftw_plan CUFFTAPI fftw_plan_dft_c2r_2d(int n0, int n1, fftw_complex* in, double* out, unsigned flags);
+  // HIP: HIPFFT_EXPORT fftw_plan fftw_plan_dft_c2r_2d(int n0, int n1, fftw_complex * in, double* out, unsigned flags);
+  // CHECK: w_plan = fftw_plan_dft_c2r_2d(n0, n1, &w_complex_in, &d_out, flags);
+  w_plan = fftw_plan_dft_c2r_2d(n0, n1, &w_complex_in, &d_out, flags);
+
+  // CUDA: fftw_plan CUFFTAPI fftw_plan_dft_c2r_3d(int n0, int n1, int n2, fftw_complex* in, double* out, unsigned flags);
+  // HIP: HIPFFT_EXPORT fftw_plan fftw_plan_dft_c2r_3d(int n0, int n1, int n2, fftw_complex * in, double* out, unsigned flags);
+  // CHECK: w_plan = fftw_plan_dft_c2r_3d(n0, n1, n2, &w_complex_in, &d_out, flags);
+  w_plan = fftw_plan_dft_c2r_3d(n0, n1, n2, &w_complex_in, &d_out, flags);
+
+  // CUDA: fftw_plan CUFFTAPI fftw_plan_dft_c2r(int rank, const int* n, fftw_complex* in, double* out, unsigned flags);
+  // HIP: HIPFFT_EXPORT fftw_plan fftw_plan_dft_c2r(int rank, const int* n, fftw_complex* in, double* out, unsigned flags);
+  // CHECK: w_plan = fftw_plan_dft_c2r(rank, &n, &w_complex_in, &d_out, flags);
+  w_plan = fftw_plan_dft_c2r(rank, &n, &w_complex_in, &d_out, flags);
+
   return 0;
-} 
+}


### PR DESCRIPTION
+ Updated synthetic tests, the regenerated `hipify-perl`, and `FFT` `CUDA2HIP` docs accordingly
