### PR TITLE
[HIPIFY][clang][build][fix] Add the missing clang's `TargetInfo` include to fix `incomplete type error`

### DIFF
--- a/src/HipifyAction.cpp
+++ b/src/HipifyAction.cpp
@@ -30,6 +30,7 @@ THE SOFTWARE.
 #include "clang/ASTMatchers/ASTMatchFinder.h"
 #include "clang/ASTMatchers/ASTMatchers.h"
 #include "clang/Lex/HeaderSearch.h"
+#include "clang/Basic/TargetInfo.h"
 #include "LLVMCompat.h"
 #include "CUDA2HIP.h"
 #include "StringUtils.h"


### PR DESCRIPTION
## Motivation

Fix build failure in HipifyAction.cpp with LLVM/Clang 14.0.6.

```shell
/leonardo_work/cin_staff/mredenti/HIPIFY/src/HipifyAction.cpp:3319:117: error: member access into incomplete type 'const clang::TargetInfo'
Statistics::cudaVersionUsedByClang = Statistics::convertCudaToolkitVersion(clang::ToCudaVersion(PP.getTargetInfo().getSDKVersion()));
^
/leonardo/prod/spack/06/install/0.22/linux-rhel8-icelake/gcc-12.2.0/llvm-14.0.6-24mj73cub5kwvjmkwmpnolugquneqkyl/include/clang/Basic/Module.h:50:7: note: forward declaration of 'clang::TargetInfo'
class TargetInfo;
^
/leonardo_work/cin_staff/mredenti/HIPIFY/src/HipifyAction.cpp:3320:104: error: member access into incomplete type 'const clang::TargetInfo'
llvm::errs() << " !!!!!!! CUDA SDK version detected: " << int(clang::ToCudaVersion(PP.getTargetInfo().getSDKVersion())) << "\n";
^
/leonardo/prod/spack/06/install/0.22/linux-rhel8-icelake/gcc-12.2.0/llvm-14.0.6-24mj73cub5kwvjmkwmpnolugquneqkyl/include/clang/Basic/Module.h:50:7: note: forward declaration of 'clang::TargetInfo'
class TargetInfo;
^
2 errors generated.
make[2]: *** [CMakeFiles/hipify-clang.dir/build.make:538: CMakeFiles/hipify-clang.dir/src/HipifyAction.cpp.o] Error 1
make[2]: *** Waiting for unfinished jobs....
make[1]: *** [CMakeFiles/Makefile2:88: CMakeFiles/hipify-clang.dir/all] Error 2
make: *** [Makefile:136: all] Error 2
```

Resolved by adding `#include "clang/Basic/TargetInfo.h"`
