### PR TITLE
[HIPIFY][7.1][HIP] Sync with `ROCm HIP 7.1` - Part 3 - `HIP` - Step 2 - Data Types

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -1695,9 +1695,24 @@ my %experimental_funcs = (
     "fftw_plan_dft" => "7.1.0",
     "fftw_plan" => "7.1.0",
     "fftw_complex" => "7.1.0",
+    "cudaOffset3D" => "7.1.0",
+    "cudaMemcpySrcAccessOrderStream" => "7.1.0",
+    "cudaMemcpySrcAccessOrderMax" => "7.1.0",
+    "cudaMemcpySrcAccessOrderInvalid" => "7.1.0",
+    "cudaMemcpySrcAccessOrderDuringApiCall" => "7.1.0",
+    "cudaMemcpySrcAccessOrderAny" => "7.1.0",
+    "cudaMemcpySrcAccessOrder" => "7.1.0",
+    "cudaMemcpyOperandTypePointer" => "7.1.0",
+    "cudaMemcpyOperandTypeMax" => "7.1.0",
+    "cudaMemcpyOperandTypeArray" => "7.1.0",
     "cudaMemcpyFlags" => "7.1.0",
     "cudaMemcpyFlagPreferOverlapWithCompute" => "7.1.0",
     "cudaMemcpyFlagDefault" => "7.1.0",
+    "cudaMemcpyAttributes" => "7.1.0",
+    "cudaMemcpy3DPeerParms" => "7.1.0",
+    "cudaMemcpy3DOperandType" => "7.1.0",
+    "cudaMemcpy3DOperand" => "7.1.0",
+    "cudaMemcpy3DBatchOp" => "7.1.0",
     "cudaMemLocationTypeNone" => "7.1.0",
     "cudaMemLocationTypeHostNumaCurrent" => "7.1.0",
     "cudaMemLocationTypeHostNuma" => "7.1.0",
@@ -1712,14 +1727,38 @@ my %experimental_funcs = (
     "FFTW_ESTIMATE" => "7.1.0",
     "FFTW_DESTROY_INPUT" => "7.1.0",
     "FFTW_BACKWARD" => "7.1.0",
+    "CUoffset3D_v1" => "7.1.0",
+    "CUoffset3D_st" => "7.1.0",
+    "CUoffset3D" => "7.1.0",
+    "CUmemcpySrcAccessOrder_enum" => "7.1.0",
+    "CUmemcpySrcAccessOrder" => "7.1.0",
     "CUmemcpyFlags_enum" => "7.1.0",
     "CUmemcpyFlags" => "7.1.0",
+    "CUmemcpyAttributes_v1" => "7.1.0",
+    "CUmemcpyAttributes_st" => "7.1.0",
+    "CUmemcpyAttributes" => "7.1.0",
+    "CUmemcpy3DOperand_v1" => "7.1.0",
+    "CUmemcpy3DOperand_st" => "7.1.0",
+    "CUmemcpy3DOperandType_enum" => "7.1.0",
+    "CUmemcpy3DOperandType" => "7.1.0",
+    "CUmemcpy3DOperand" => "7.1.0",
     "CU_MEM_LOCATION_TYPE_NONE" => "7.1.0",
     "CU_MEM_LOCATION_TYPE_HOST_NUMA_CURRENT" => "7.1.0",
     "CU_MEM_LOCATION_TYPE_HOST_NUMA" => "7.1.0",
     "CU_MEM_LOCATION_TYPE_HOST" => "7.1.0",
+    "CU_MEMCPY_SRC_ACCESS_ORDER_STREAM" => "7.1.0",
+    "CU_MEMCPY_SRC_ACCESS_ORDER_MAX" => "7.1.0",
+    "CU_MEMCPY_SRC_ACCESS_ORDER_INVALID" => "7.1.0",
+    "CU_MEMCPY_SRC_ACCESS_ORDER_DURING_API_CALL" => "7.1.0",
+    "CU_MEMCPY_SRC_ACCESS_ORDER_ANY" => "7.1.0",
+    "CU_MEMCPY_OPERAND_TYPE_POINTER" => "7.1.0",
+    "CU_MEMCPY_OPERAND_TYPE_MAX" => "7.1.0",
+    "CU_MEMCPY_OPERAND_TYPE_ARRAY" => "7.1.0",
     "CU_MEMCPY_FLAG_PREFER_OVERLAP_WITH_COMPUTE" => "7.1.0",
     "CU_MEMCPY_FLAG_DEFAULT" => "7.1.0",
+    "CUDA_MEMCPY3D_BATCH_OP_v1" => "7.1.0",
+    "CUDA_MEMCPY3D_BATCH_OP_st" => "7.1.0",
+    "CUDA_MEMCPY3D_BATCH_OP" => "7.1.0",
     "CUBLASLT_EPILOGUE_RELU_AUX_BIAS" => "7.1.0",
     "CUBLASLT_EPILOGUE_RELU_AUX" => "7.1.0"
 );
@@ -1871,9 +1910,32 @@ sub experimentalSubstitutions {
     subst("fftw_plan_dft_r2c_1d", "fftw_plan_dft_r2c_1d", "library");
     subst("fftw_plan_dft_r2c_2d", "fftw_plan_dft_r2c_2d", "library");
     subst("fftw_plan_dft_r2c_3d", "fftw_plan_dft_r2c_3d", "library");
+    subst("CUDA_MEMCPY3D_BATCH_OP", "hipMemcpy3DBatchOp", "type");
+    subst("CUDA_MEMCPY3D_BATCH_OP_st", "hipMemcpy3DBatchOp", "type");
+    subst("CUDA_MEMCPY3D_BATCH_OP_v1", "hipMemcpy3DBatchOp", "type");
+    subst("CUmemcpy3DOperand", "hipMemcpy3DOperand", "type");
+    subst("CUmemcpy3DOperandType", "hipMemcpy3DOperandType", "type");
+    subst("CUmemcpy3DOperandType_enum", "hipMemcpy3DOperandType", "type");
+    subst("CUmemcpy3DOperand_st", "hipMemcpy3DOperand", "type");
+    subst("CUmemcpy3DOperand_v1", "hipMemcpy3DOperand", "type");
+    subst("CUmemcpyAttributes", "hipMemcpyAttributes", "type");
+    subst("CUmemcpyAttributes_st", "hipMemcpyAttributes", "type");
+    subst("CUmemcpyAttributes_v1", "hipMemcpyAttributes", "type");
     subst("CUmemcpyFlags", "hipMemcpyFlags", "type");
     subst("CUmemcpyFlags_enum", "hipMemcpyFlags", "type");
+    subst("CUmemcpySrcAccessOrder", "hipMemcpySrcAccessOrder", "type");
+    subst("CUmemcpySrcAccessOrder_enum", "hipMemcpySrcAccessOrder", "type");
+    subst("CUoffset3D", "hipOffset3D", "type");
+    subst("CUoffset3D_st", "hipOffset3D", "type");
+    subst("CUoffset3D_v1", "hipOffset3D", "type");
+    subst("cudaMemcpy3DBatchOp", "hipMemcpy3DBatchOp", "type");
+    subst("cudaMemcpy3DOperand", "hipMemcpy3DOperand", "type");
+    subst("cudaMemcpy3DOperandType", "hipMemcpy3DOperandType", "type");
+    subst("cudaMemcpy3DPeerParms", "hipMemcpy3DPeerParms", "type");
+    subst("cudaMemcpyAttributes", "hipMemcpyAttributes", "type");
     subst("cudaMemcpyFlags", "hipMemcpyFlags", "type");
+    subst("cudaMemcpySrcAccessOrder", "hipMemcpySrcAccessOrder", "type");
+    subst("cudaOffset3D", "hipOffset3D", "type");
     subst("fftw_complex", "fftw_complex", "type");
     subst("fftw_plan", "fftw_plan", "type");
     subst("fftwf_complex", "fftwf_complex", "type");
@@ -1882,6 +1944,14 @@ sub experimentalSubstitutions {
     subst("CUBLASLT_EPILOGUE_RELU_AUX_BIAS", "HIPBLASLT_EPILOGUE_RELU_AUX_BIAS", "numeric_literal");
     subst("CU_MEMCPY_FLAG_DEFAULT", "hipMemcpyFlagDefault", "numeric_literal");
     subst("CU_MEMCPY_FLAG_PREFER_OVERLAP_WITH_COMPUTE", "hipMemcpyFlagPreferOverlapWithCompute", "numeric_literal");
+    subst("CU_MEMCPY_OPERAND_TYPE_ARRAY", "hipMemcpyOperandTypeArray", "numeric_literal");
+    subst("CU_MEMCPY_OPERAND_TYPE_MAX", "hipMemcpyOperandTypeMax", "numeric_literal");
+    subst("CU_MEMCPY_OPERAND_TYPE_POINTER", "hipMemcpyOperandTypePointer", "numeric_literal");
+    subst("CU_MEMCPY_SRC_ACCESS_ORDER_ANY", "hipMemcpySrcAccessOrderAny", "numeric_literal");
+    subst("CU_MEMCPY_SRC_ACCESS_ORDER_DURING_API_CALL", "hipMemcpySrcAccessOrderDuringApiCall", "numeric_literal");
+    subst("CU_MEMCPY_SRC_ACCESS_ORDER_INVALID", "hipMemcpySrcAccessOrderInvalid", "numeric_literal");
+    subst("CU_MEMCPY_SRC_ACCESS_ORDER_MAX", "hipMemcpySrcAccessOrderMax", "numeric_literal");
+    subst("CU_MEMCPY_SRC_ACCESS_ORDER_STREAM", "hipMemcpySrcAccessOrderStream", "numeric_literal");
     subst("CU_MEM_LOCATION_TYPE_HOST", "hipMemLocationTypeHost", "numeric_literal");
     subst("CU_MEM_LOCATION_TYPE_HOST_NUMA", "hipMemLocationTypeHostNuma", "numeric_literal");
     subst("CU_MEM_LOCATION_TYPE_HOST_NUMA_CURRENT", "hipMemLocationTypeHostNumaCurrent", "numeric_literal");
@@ -1892,6 +1962,14 @@ sub experimentalSubstitutions {
     subst("cudaMemLocationTypeNone", "hipMemLocationTypeNone", "numeric_literal");
     subst("cudaMemcpyFlagDefault", "hipMemcpyFlagDefault", "numeric_literal");
     subst("cudaMemcpyFlagPreferOverlapWithCompute", "hipMemcpyFlagPreferOverlapWithCompute", "numeric_literal");
+    subst("cudaMemcpyOperandTypeArray", "hipMemcpyOperandTypeArray", "numeric_literal");
+    subst("cudaMemcpyOperandTypeMax", "hipMemcpyOperandTypeMax", "numeric_literal");
+    subst("cudaMemcpyOperandTypePointer", "hipMemcpyOperandTypePointer", "numeric_literal");
+    subst("cudaMemcpySrcAccessOrderAny", "hipMemcpySrcAccessOrderAny", "numeric_literal");
+    subst("cudaMemcpySrcAccessOrderDuringApiCall", "hipMemcpySrcAccessOrderDuringApiCall", "numeric_literal");
+    subst("cudaMemcpySrcAccessOrderInvalid", "hipMemcpySrcAccessOrderInvalid", "numeric_literal");
+    subst("cudaMemcpySrcAccessOrderMax", "hipMemcpySrcAccessOrderMax", "numeric_literal");
+    subst("cudaMemcpySrcAccessOrderStream", "hipMemcpySrcAccessOrderStream", "numeric_literal");
     subst("FFTW_BACKWARD", "FFTW_BACKWARD", "define");
     subst("FFTW_DESTROY_INPUT", "FFTW_DESTROY_INPUT", "define");
     subst("FFTW_ESTIMATE", "FFTW_ESTIMATE", "define");
@@ -11594,7 +11672,6 @@ sub warnRemovedFunctions {
     "cudaPreferBinary",
     "cudaOutputMode_t",
     "cudaOutputMode",
-    "cudaOffset3D",
     "cudaOccupancyMaxPotentialClusterSize",
     "cudaOccupancyMaxActiveClusters",
     "cudaOccupancyAvailableDynamicSMemPerBlock",
@@ -11603,25 +11680,11 @@ sub warnRemovedFunctions {
     "cudaMemsetParamsV2",
     "cudaMemoryTypeUnregistered",
     "cudaMemcpyToArrayAsync",
-    "cudaMemcpySrcAccessOrderStream",
-    "cudaMemcpySrcAccessOrderMax",
-    "cudaMemcpySrcAccessOrderInvalid",
-    "cudaMemcpySrcAccessOrderDuringApiCall",
-    "cudaMemcpySrcAccessOrderAny",
-    "cudaMemcpySrcAccessOrder",
-    "cudaMemcpyOperandTypePointer",
-    "cudaMemcpyOperandTypeMax",
-    "cudaMemcpyOperandTypeArray",
     "cudaMemcpyFromArrayAsync",
     "cudaMemcpyBatchAsync",
-    "cudaMemcpyAttributes",
     "cudaMemcpyArrayToArray",
-    "cudaMemcpy3DPeerParms",
     "cudaMemcpy3DPeerAsync",
     "cudaMemcpy3DPeer",
-    "cudaMemcpy3DOperandType",
-    "cudaMemcpy3DOperand",
-    "cudaMemcpy3DBatchOp",
     "cudaMemcpy3DBatchAsync",
     "cudaMemSetMemPool",
     "cudaMemRangeAttributePreferredLocationType",
@@ -12643,9 +12706,6 @@ sub warnRemovedFunctions {
     "CUshared_carveout",
     "CUprocessState_enum",
     "CUprocessState",
-    "CUoffset3D_v1",
-    "CUoffset3D_st",
-    "CUoffset3D",
     "CUoccupancy_flags_enum",
     "CUoccupancy_flags",
     "CUmulticastObjectProp_v1",
@@ -12655,16 +12715,6 @@ sub warnRemovedFunctions {
     "CUmulticastGranularity_flags",
     "CUmoduleLoadingMode_enum",
     "CUmoduleLoadingMode",
-    "CUmemcpySrcAccessOrder_enum",
-    "CUmemcpySrcAccessOrder",
-    "CUmemcpyAttributes_v1",
-    "CUmemcpyAttributes_st",
-    "CUmemcpyAttributes",
-    "CUmemcpy3DOperand_v1",
-    "CUmemcpy3DOperand_st",
-    "CUmemcpy3DOperandType_enum",
-    "CUmemcpy3DOperandType",
-    "CUmemcpy3DOperand",
     "CUmemFabricHandle_v1",
     "CUmemFabricHandle_st",
     "CUmemFabricHandle",
@@ -12948,14 +12998,6 @@ sub warnRemovedFunctions {
     "CU_MEM_CREATE_USAGE_HW_DECOMPRESS",
     "CU_MEM_ALLOCATION_TYPE_MANAGED",
     "CU_MEM_ACCESS_FLAGS_PROT_MAX",
-    "CU_MEMCPY_SRC_ACCESS_ORDER_STREAM",
-    "CU_MEMCPY_SRC_ACCESS_ORDER_MAX",
-    "CU_MEMCPY_SRC_ACCESS_ORDER_INVALID",
-    "CU_MEMCPY_SRC_ACCESS_ORDER_DURING_API_CALL",
-    "CU_MEMCPY_SRC_ACCESS_ORDER_ANY",
-    "CU_MEMCPY_OPERAND_TYPE_POINTER",
-    "CU_MEMCPY_OPERAND_TYPE_MAX",
-    "CU_MEMCPY_OPERAND_TYPE_ARRAY",
     "CU_LOG_LEVEL_WARNING",
     "CU_LOG_LEVEL_ERROR",
     "CU_LIMIT_SHMEM_SIZE",
@@ -13464,9 +13506,6 @@ sub warnRemovedFunctions {
     "CUDA_MEMCPY3D_PEER_v1",
     "CUDA_MEMCPY3D_PEER_st",
     "CUDA_MEMCPY3D_PEER",
-    "CUDA_MEMCPY3D_BATCH_OP_v1",
-    "CUDA_MEMCPY3D_BATCH_OP_st",
-    "CUDA_MEMCPY3D_BATCH_OP",
     "CUDA_KERNEL_NODE_PARAMS_v3_st",
     "CUDA_KERNEL_NODE_PARAMS_v3",
     "CUDA_KERNEL_NODE_PARAMS_v2_st",

--- a/docs/reference/tables/CUDA_Driver_API_functions_supported_by_HIP.md
+++ b/docs/reference/tables/CUDA_Driver_API_functions_supported_by_HIP.md
@@ -221,9 +221,9 @@
 |`CUDA_MEMCPY2D_v1_st`| | | | |`hip_Memcpy2D`|1.7.0| | | | | |
 |`CUDA_MEMCPY2D_v2`|11.3| | | |`hip_Memcpy2D`|1.7.0| | | | | |
 |`CUDA_MEMCPY3D`| | | | |`HIP_MEMCPY3D`|3.2.0| | | | | |
-|`CUDA_MEMCPY3D_BATCH_OP`|12.8| | | | | | | | | | |
-|`CUDA_MEMCPY3D_BATCH_OP_st`|12.8| | | | | | | | | | |
-|`CUDA_MEMCPY3D_BATCH_OP_v1`|12.8| | | | | | | | | | |
+|`CUDA_MEMCPY3D_BATCH_OP`|12.8| | | |`hipMemcpy3DBatchOp`|7.1.0| | | | |7.1.0|
+|`CUDA_MEMCPY3D_BATCH_OP_st`|12.8| | | |`hipMemcpy3DBatchOp`|7.1.0| | | | |7.1.0|
+|`CUDA_MEMCPY3D_BATCH_OP_v1`|12.8| | | |`hipMemcpy3DBatchOp`|7.1.0| | | | |7.1.0|
 |`CUDA_MEMCPY3D_PEER`| | | | | | | | | | | |
 |`CUDA_MEMCPY3D_PEER_st`| | | | | | | | | | | |
 |`CUDA_MEMCPY3D_PEER_v1`|11.3| | | | | | | | | | |
@@ -905,14 +905,14 @@
 |`CU_LOG_LEVEL_WARNING`|12.9| | | | | | | | | | |
 |`CU_MEMCPY_FLAG_DEFAULT`|12.8| | | |`hipMemcpyFlagDefault`|7.1.0| | | | |7.1.0|
 |`CU_MEMCPY_FLAG_PREFER_OVERLAP_WITH_COMPUTE`|12.8| | | |`hipMemcpyFlagPreferOverlapWithCompute`|7.1.0| | | | |7.1.0|
-|`CU_MEMCPY_OPERAND_TYPE_ARRAY`|12.8| | | | | | | | | | |
-|`CU_MEMCPY_OPERAND_TYPE_MAX`|12.8| | | | | | | | | | |
-|`CU_MEMCPY_OPERAND_TYPE_POINTER`|12.8| | | | | | | | | | |
-|`CU_MEMCPY_SRC_ACCESS_ORDER_ANY`|12.8| | | | | | | | | | |
-|`CU_MEMCPY_SRC_ACCESS_ORDER_DURING_API_CALL`|12.8| | | | | | | | | | |
-|`CU_MEMCPY_SRC_ACCESS_ORDER_INVALID`|12.8| | | | | | | | | | |
-|`CU_MEMCPY_SRC_ACCESS_ORDER_MAX`|12.8| | | | | | | | | | |
-|`CU_MEMCPY_SRC_ACCESS_ORDER_STREAM`|12.8| | | | | | | | | | |
+|`CU_MEMCPY_OPERAND_TYPE_ARRAY`|12.8| | | |`hipMemcpyOperandTypeArray`|7.1.0| | | | |7.1.0|
+|`CU_MEMCPY_OPERAND_TYPE_MAX`|12.8| | | |`hipMemcpyOperandTypeMax`|7.1.0| | | | |7.1.0|
+|`CU_MEMCPY_OPERAND_TYPE_POINTER`|12.8| | | |`hipMemcpyOperandTypePointer`|7.1.0| | | | |7.1.0|
+|`CU_MEMCPY_SRC_ACCESS_ORDER_ANY`|12.8| | | |`hipMemcpySrcAccessOrderAny`|7.1.0| | | | |7.1.0|
+|`CU_MEMCPY_SRC_ACCESS_ORDER_DURING_API_CALL`|12.8| | | |`hipMemcpySrcAccessOrderDuringApiCall`|7.1.0| | | | |7.1.0|
+|`CU_MEMCPY_SRC_ACCESS_ORDER_INVALID`|12.8| | | |`hipMemcpySrcAccessOrderInvalid`|7.1.0| | | | |7.1.0|
+|`CU_MEMCPY_SRC_ACCESS_ORDER_MAX`|12.8| | | |`hipMemcpySrcAccessOrderMax`|7.1.0| | | | |7.1.0|
+|`CU_MEMCPY_SRC_ACCESS_ORDER_STREAM`|12.8| | | |`hipMemcpySrcAccessOrderStream`|7.1.0| | | | |7.1.0|
 |`CU_MEMHOSTALLOC_DEVICEMAP`| | | | |`hipHostMallocMapped`|1.6.0| | | | | |
 |`CU_MEMHOSTALLOC_PORTABLE`| | | | |`hipHostMallocPortable`|1.6.0| | | | | |
 |`CU_MEMHOSTALLOC_WRITECOMBINED`| | | | |`hipHostMallocWriteCombined`|1.6.0| | | | | |
@@ -1490,18 +1490,18 @@
 |`CUmem_advise_enum`|8.0| | | |`hipMemoryAdvise`|3.7.0| | | | | |
 |`CUmem_range_attribute`|8.0| | | |`hipMemRangeAttribute`|3.7.0| | | | | |
 |`CUmem_range_attribute_enum`|8.0| | | |`hipMemRangeAttribute`|3.7.0| | | | | |
-|`CUmemcpy3DOperand`|12.8| | | | | | | | | | |
-|`CUmemcpy3DOperandType`|12.8| | | | | | | | | | |
-|`CUmemcpy3DOperandType_enum`|12.8| | | | | | | | | | |
-|`CUmemcpy3DOperand_st`|12.8| | | | | | | | | | |
-|`CUmemcpy3DOperand_v1`|12.8| | | | | | | | | | |
-|`CUmemcpyAttributes`|12.8| | | | | | | | | | |
-|`CUmemcpyAttributes_st`|12.8| | | | | | | | | | |
-|`CUmemcpyAttributes_v1`|12.8| | | | | | | | | | |
+|`CUmemcpy3DOperand`|12.8| | | |`hipMemcpy3DOperand`|7.1.0| | | | |7.1.0|
+|`CUmemcpy3DOperandType`|12.8| | | |`hipMemcpy3DOperandType`|7.1.0| | | | |7.1.0|
+|`CUmemcpy3DOperandType_enum`|12.8| | | |`hipMemcpy3DOperandType`|7.1.0| | | | |7.1.0|
+|`CUmemcpy3DOperand_st`|12.8| | | |`hipMemcpy3DOperand`|7.1.0| | | | |7.1.0|
+|`CUmemcpy3DOperand_v1`|12.8| | | |`hipMemcpy3DOperand`|7.1.0| | | | |7.1.0|
+|`CUmemcpyAttributes`|12.8| | | |`hipMemcpyAttributes`|7.1.0| | | | |7.1.0|
+|`CUmemcpyAttributes_st`|12.8| | | |`hipMemcpyAttributes`|7.1.0| | | | |7.1.0|
+|`CUmemcpyAttributes_v1`|12.8| | | |`hipMemcpyAttributes`|7.1.0| | | | |7.1.0|
 |`CUmemcpyFlags`|12.8| | | |`hipMemcpyFlags`|7.1.0| | | | |7.1.0|
 |`CUmemcpyFlags_enum`|12.8| | | |`hipMemcpyFlags`|7.1.0| | | | |7.1.0|
-|`CUmemcpySrcAccessOrder`|12.8| | | | | | | | | | |
-|`CUmemcpySrcAccessOrder_enum`|12.8| | | | | | | | | | |
+|`CUmemcpySrcAccessOrder`|12.8| | | |`hipMemcpySrcAccessOrder`|7.1.0| | | | |7.1.0|
+|`CUmemcpySrcAccessOrder_enum`|12.8| | | |`hipMemcpySrcAccessOrder`|7.1.0| | | | |7.1.0|
 |`CUmemoryPool`|11.2| | | |`hipMemPool_t`|5.2.0| | | | | |
 |`CUmemorytype`| | | | |`hipMemoryType`|1.6.0| | | | | |
 |`CUmemorytype_enum`| | | | |`hipMemoryType`|1.6.0| | | | | |
@@ -1519,9 +1519,9 @@
 |`CUoccupancyB2DSize`| | | | |`void*`| | | | | | |
 |`CUoccupancy_flags`| | | | | | | | | | | |
 |`CUoccupancy_flags_enum`| | | | | | | | | | | |
-|`CUoffset3D`|12.8| | | | | | | | | | |
-|`CUoffset3D_st`|12.8| | | | | | | | | | |
-|`CUoffset3D_v1`|12.8| | | | | | | | | | |
+|`CUoffset3D`|12.8| | | |`hipOffset3D`|7.1.0| | | | |7.1.0|
+|`CUoffset3D_st`|12.8| | | |`hipOffset3D`|7.1.0| | | | |7.1.0|
+|`CUoffset3D_v1`|12.8| | | |`hipOffset3D`|7.1.0| | | | |7.1.0|
 |`CUpointer_attribute`| | | | |`hipPointer_attribute`|5.0.0| | | | | |
 |`CUpointer_attribute_enum`| | | | |`hipPointer_attribute`|5.0.0| | | | | |
 |`CUprocessState`|12.8| | | | | | | | | | |

--- a/docs/reference/tables/CUDA_Runtime_API_functions_supported_by_HIP.md
+++ b/docs/reference/tables/CUDA_Runtime_API_functions_supported_by_HIP.md
@@ -1627,12 +1627,12 @@
 |`cudaMemRangeAttributePreferredLocationId`|12.2| | | | | | | | | | |
 |`cudaMemRangeAttributePreferredLocationType`|12.2| | | | | | | | | | |
 |`cudaMemRangeAttributeReadMostly`|8.0| | | |`hipMemRangeAttributeReadMostly`|3.7.0| | | | | |
-|`cudaMemcpy3DBatchOp`|12.8| | | | | | | | | | |
-|`cudaMemcpy3DOperand`|12.8| | | | | | | | | | |
-|`cudaMemcpy3DOperandType`|12.8| | | | | | | | | | |
+|`cudaMemcpy3DBatchOp`|12.8| | | |`hipMemcpy3DBatchOp`|7.1.0| | | | |7.1.0|
+|`cudaMemcpy3DOperand`|12.8| | | |`hipMemcpy3DOperand`|7.1.0| | | | |7.1.0|
+|`cudaMemcpy3DOperandType`|12.8| | | |`hipMemcpy3DOperandType`|7.1.0| | | | |7.1.0|
 |`cudaMemcpy3DParms`| | | | |`hipMemcpy3DParms`|1.7.0| | | | | |
-|`cudaMemcpy3DPeerParms`| | | | | | | | | | | |
-|`cudaMemcpyAttributes`|12.8| | | | | | | | | | |
+|`cudaMemcpy3DPeerParms`| | | | |`hipMemcpy3DPeerParms`|7.1.0| | | | |7.1.0|
+|`cudaMemcpyAttributes`|12.8| | | |`hipMemcpyAttributes`|7.1.0| | | | |7.1.0|
 |`cudaMemcpyDefault`| | | | |`hipMemcpyDefault`|1.5.0| | | | | |
 |`cudaMemcpyDeviceToDevice`| | | | |`hipMemcpyDeviceToDevice`|1.5.0| | | | | |
 |`cudaMemcpyDeviceToHost`| | | | |`hipMemcpyDeviceToHost`|1.5.0| | | | | |
@@ -1643,15 +1643,15 @@
 |`cudaMemcpyHostToHost`| | | | |`hipMemcpyHostToHost`|1.5.0| | | | | |
 |`cudaMemcpyKind`| | | | |`hipMemcpyKind`|1.5.0| | | | | |
 |`cudaMemcpyNodeParams`|12.2| | | |`hipMemcpyNodeParams`|6.1.0| | | | | |
-|`cudaMemcpyOperandTypeArray`|12.8| | | | | | | | | | |
-|`cudaMemcpyOperandTypeMax`|12.8| | | | | | | | | | |
-|`cudaMemcpyOperandTypePointer`|12.8| | | | | | | | | | |
-|`cudaMemcpySrcAccessOrder`|12.8| | | | | | | | | | |
-|`cudaMemcpySrcAccessOrderAny`|12.8| | | | | | | | | | |
-|`cudaMemcpySrcAccessOrderDuringApiCall`|12.8| | | | | | | | | | |
-|`cudaMemcpySrcAccessOrderInvalid`|12.8| | | | | | | | | | |
-|`cudaMemcpySrcAccessOrderMax`|12.8| | | | | | | | | | |
-|`cudaMemcpySrcAccessOrderStream`|12.8| | | | | | | | | | |
+|`cudaMemcpyOperandTypeArray`|12.8| | | |`hipMemcpyOperandTypeArray`|7.1.0| | | | |7.1.0|
+|`cudaMemcpyOperandTypeMax`|12.8| | | |`hipMemcpyOperandTypeMax`|7.1.0| | | | |7.1.0|
+|`cudaMemcpyOperandTypePointer`|12.8| | | |`hipMemcpyOperandTypePointer`|7.1.0| | | | |7.1.0|
+|`cudaMemcpySrcAccessOrder`|12.8| | | |`hipMemcpySrcAccessOrder`|7.1.0| | | | |7.1.0|
+|`cudaMemcpySrcAccessOrderAny`|12.8| | | |`hipMemcpySrcAccessOrderAny`|7.1.0| | | | |7.1.0|
+|`cudaMemcpySrcAccessOrderDuringApiCall`|12.8| | | |`hipMemcpySrcAccessOrderDuringApiCall`|7.1.0| | | | |7.1.0|
+|`cudaMemcpySrcAccessOrderInvalid`|12.8| | | |`hipMemcpySrcAccessOrderInvalid`|7.1.0| | | | |7.1.0|
+|`cudaMemcpySrcAccessOrderMax`|12.8| | | |`hipMemcpySrcAccessOrderMax`|7.1.0| | | | |7.1.0|
+|`cudaMemcpySrcAccessOrderStream`|12.8| | | |`hipMemcpySrcAccessOrderStream`|7.1.0| | | | |7.1.0|
 |`cudaMemoryAdvise`|8.0| | | |`hipMemoryAdvise`|3.7.0| | | | | |
 |`cudaMemoryType`| | | | |`hipMemoryType`|1.6.0| | | | | |
 |`cudaMemoryTypeDevice`| | | | |`hipMemoryTypeDevice`|1.6.0| | | | | |
@@ -1667,7 +1667,7 @@
 |`cudaNvSciSyncAttrWait`|10.2| | | | | | | | | | |
 |`cudaOccupancyDefault`| | | | |`hipOccupancyDefault`|3.2.0| | | | | |
 |`cudaOccupancyDisableCachingOverride`| | | | |`hipOccupancyDisableCachingOverride`|5.5.0| | | | | |
-|`cudaOffset3D`|12.8| | | | | | | | | | |
+|`cudaOffset3D`|12.8| | | |`hipOffset3D`|7.1.0| | | | |7.1.0|
 |`cudaOutputMode`| | | |12.0| | | | | | | |
 |`cudaOutputMode_t`| | | |12.0| | | | | | | |
 |`cudaPitchedPtr`| | | | |`hipPitchedPtr`|1.7.0| | | | | |

--- a/src/CUDA2HIP_Driver_API_types.cpp
+++ b/src/CUDA2HIP_Driver_API_types.cpp
@@ -494,9 +494,11 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_TYPE_NAME_MAP {
   {"CUcheckpointGpuPair",                                              {"hipCheckpointGpuPair",                                     "", CONV_TYPE, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
 
   // cudaMemcpyAttributes
-  {"CUmemcpyAttributes_st",                                            {"hipMemcpyAttributes",                                      "", CONV_TYPE, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
+  {"CUmemcpyAttributes_st",                                            {"hipMemcpyAttributes",                                      "", CONV_TYPE, API_DRIVER, SEC::DATA_TYPES, HIP_EXPERIMENTAL}},
   // cudaMemcpyAttributes
-  {"CUmemcpyAttributes",                                               {"hipMemcpyAttributes",                                      "", CONV_TYPE, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
+  {"CUmemcpyAttributes",                                               {"hipMemcpyAttributes",                                      "", CONV_TYPE, API_DRIVER, SEC::DATA_TYPES, HIP_EXPERIMENTAL}},
+  // cudaMemcpyAttributes
+  {"CUmemcpyAttributes_v1",                                            {"hipMemcpyAttributes",                                      "", CONV_TYPE, API_DRIVER, SEC::DATA_TYPES, HIP_EXPERIMENTAL}},
 
   //
   {"CUcheckpointUnlockArgs_st",                                        {"hipCheckpointUnlockArgs",                                  "", CONV_TYPE, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
@@ -504,9 +506,11 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_TYPE_NAME_MAP {
   {"CUcheckpointUnlockArgs",                                           {"hipCheckpointUnlockArgs",                                  "", CONV_TYPE, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
 
   // cudaOffset3D
-  {"CUoffset3D_st",                                                    {"hipOffset3D",                                              "", CONV_TYPE, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
+  {"CUoffset3D_st",                                                    {"hipOffset3D",                                              "", CONV_TYPE, API_DRIVER, SEC::DATA_TYPES, HIP_EXPERIMENTAL}},
   // cudaOffset3D
-  {"CUoffset3D",                                                       {"hipOffset3D",                                              "", CONV_TYPE, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
+  {"CUoffset3D",                                                       {"hipOffset3D",                                              "", CONV_TYPE, API_DRIVER, SEC::DATA_TYPES, HIP_EXPERIMENTAL}},
+  // cudaOffset3D
+  {"CUoffset3D_v1",                                                    {"hipOffset3D",                                              "", CONV_TYPE, API_DRIVER, SEC::DATA_TYPES, HIP_EXPERIMENTAL}},
 
   //
   {"CUextent3D_st",                                                    {"hipExtent3D",                                              "", CONV_TYPE, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
@@ -514,14 +518,18 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_TYPE_NAME_MAP {
   {"CUextent3D",                                                       {"hipExtent3D",                                              "", CONV_TYPE, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
 
   // cudaMemcpy3DOperand
-  {"CUmemcpy3DOperand_st",                                             {"hipMemcpy3DOperand",                                       "", CONV_TYPE, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
+  {"CUmemcpy3DOperand_st",                                             {"hipMemcpy3DOperand",                                       "", CONV_TYPE, API_DRIVER, SEC::DATA_TYPES, HIP_EXPERIMENTAL}},
   // cudaMemcpy3DOperand
-  {"CUmemcpy3DOperand",                                                {"hipMemcpy3DOperand",                                       "", CONV_TYPE, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
+  {"CUmemcpy3DOperand",                                                {"hipMemcpy3DOperand",                                       "", CONV_TYPE, API_DRIVER, SEC::DATA_TYPES, HIP_EXPERIMENTAL}},
+  // cudaMemcpy3DOperand
+  {"CUmemcpy3DOperand_v1",                                             {"hipMemcpy3DOperand",                                       "", CONV_TYPE, API_DRIVER, SEC::DATA_TYPES, HIP_EXPERIMENTAL}},
 
   // cudaMemcpy3DBatchOp
-  {"CUDA_MEMCPY3D_BATCH_OP_st",                                        {"HIP_MEMCPY3D_BATCH_OP",                                    "", CONV_TYPE, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
+  {"CUDA_MEMCPY3D_BATCH_OP_st",                                        {"hipMemcpy3DBatchOp",                                       "", CONV_TYPE, API_DRIVER, SEC::DATA_TYPES, HIP_EXPERIMENTAL}},
   // cudaMemcpy3DBatchOp
-  {"CUDA_MEMCPY3D_BATCH_OP",                                           {"HIP_MEMCPY3D_BATCH_OP",                                    "", CONV_TYPE, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
+  {"CUDA_MEMCPY3D_BATCH_OP",                                           {"hipMemcpy3DBatchOp",                                       "", CONV_TYPE, API_DRIVER, SEC::DATA_TYPES, HIP_EXPERIMENTAL}},
+  // cudaMemcpy3DBatchOp
+  {"CUDA_MEMCPY3D_BATCH_OP_v1",                                        {"hipMemcpy3DBatchOp",                                       "", CONV_TYPE, API_DRIVER, SEC::DATA_TYPES, HIP_EXPERIMENTAL}},
 
   //
   {"CUmemDecompressParams_st",                                         {"hipMemDecompressParams",                                   "", CONV_TYPE, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
@@ -2970,20 +2978,20 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_TYPE_NAME_MAP {
   {"CU_PROCESS_STATE_FAILED",                                          {"HIP_PROCESS_STATE_FAILED",                                 "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
 
   // cudaMemcpySrcAccessOrder
-  {"CUmemcpySrcAccessOrder",                                           {"hipMemcpySrcAccessOrder",                                  "", CONV_TYPE, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
+  {"CUmemcpySrcAccessOrder",                                           {"hipMemcpySrcAccessOrder",                                  "", CONV_TYPE, API_DRIVER, SEC::DATA_TYPES, HIP_EXPERIMENTAL}},
   //
-  {"CUmemcpySrcAccessOrder_enum",                                      {"hipMemcpySrcAccessOrder",                                  "", CONV_TYPE, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
+  {"CUmemcpySrcAccessOrder_enum",                                      {"hipMemcpySrcAccessOrder",                                  "", CONV_TYPE, API_DRIVER, SEC::DATA_TYPES, HIP_EXPERIMENTAL}},
   // CUmemcpySrcAccessOrder enum values
   // cudaMemcpySrcAccessOrderInvalid
-  {"CU_MEMCPY_SRC_ACCESS_ORDER_INVALID",                               {"HIP_MEMCPY_SRC_ACCESS_ORDER_INVALID",                      "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
+  {"CU_MEMCPY_SRC_ACCESS_ORDER_INVALID",                               {"hipMemcpySrcAccessOrderInvalid",                           "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES, HIP_EXPERIMENTAL}},
   // cudaMemcpySrcAccessOrderStream
-  {"CU_MEMCPY_SRC_ACCESS_ORDER_STREAM",                                {"HIP_MEMCPY_SRC_ACCESS_ORDER_STREAM",                       "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
+  {"CU_MEMCPY_SRC_ACCESS_ORDER_STREAM",                                {"hipMemcpySrcAccessOrderStream",                            "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES, HIP_EXPERIMENTAL}},
   // cudaMemcpySrcAccessOrderDuringApiCall
-  {"CU_MEMCPY_SRC_ACCESS_ORDER_DURING_API_CALL",                       {"HIP_MEMCPY_SRC_ACCESS_ORDER_DURING_API_CALL",              "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
+  {"CU_MEMCPY_SRC_ACCESS_ORDER_DURING_API_CALL",                       {"hipMemcpySrcAccessOrderDuringApiCall",                     "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES, HIP_EXPERIMENTAL}},
   // cudaMemcpySrcAccessOrderAny
-  {"CU_MEMCPY_SRC_ACCESS_ORDER_ANY",                                   {"HIP_MEMCPY_SRC_ACCESS_ORDER_ANY",                          "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
+  {"CU_MEMCPY_SRC_ACCESS_ORDER_ANY",                                   {"hipMemcpySrcAccessOrderAny",                               "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES, HIP_EXPERIMENTAL}},
   // cudaMemcpySrcAccessOrderMax
-  {"CU_MEMCPY_SRC_ACCESS_ORDER_MAX",                                   {"HIP_MEMCPY_SRC_ACCESS_ORDER_MAX",                          "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
+  {"CU_MEMCPY_SRC_ACCESS_ORDER_MAX",                                   {"hipMemcpySrcAccessOrderMax",                               "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES, HIP_EXPERIMENTAL}},
 
   // cudaMemcpyFlags
   {"CUmemcpyFlags",                                                    {"hipMemcpyFlags",                                           "", CONV_TYPE, API_DRIVER, SEC::DATA_TYPES, HIP_EXPERIMENTAL}},
@@ -2995,17 +3003,17 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_TYPE_NAME_MAP {
   // cudaMemcpyFlagPreferOverlapWithCompute
   {"CU_MEMCPY_FLAG_PREFER_OVERLAP_WITH_COMPUTE",                       {"hipMemcpyFlagPreferOverlapWithCompute",                    "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES, HIP_EXPERIMENTAL}},
 
+  // cudaMemcpy3DOperandType
+  {"CUmemcpy3DOperandType",                                            {"hipMemcpy3DOperandType",                                   "", CONV_TYPE, API_DRIVER, SEC::DATA_TYPES, HIP_EXPERIMENTAL}},
   //
-  {"CUmemcpy3DOperandType",                                            {"hipMemcpy3DOperandType",                                   "", CONV_TYPE, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
-  //
-  {"CUmemcpy3DOperandType_enum",                                       {"hipMemcpy3DOperandType",                                   "", CONV_TYPE, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
+  {"CUmemcpy3DOperandType_enum",                                       {"hipMemcpy3DOperandType",                                   "", CONV_TYPE, API_DRIVER, SEC::DATA_TYPES, HIP_EXPERIMENTAL}},
   // CUmemcpy3DOperandType enum values
-  //
-  {"CU_MEMCPY_OPERAND_TYPE_POINTER",                                   {"HIP_MEMCPY_OPERAND_TYPE_POINTER",                          "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
-  //
-  {"CU_MEMCPY_OPERAND_TYPE_ARRAY",                                     {"HIP_MEMCPY_OPERAND_TYPE_ARRAY",                            "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
-  //
-  {"CU_MEMCPY_OPERAND_TYPE_MAX",                                       {"HIP_MEMCPY_OPERAND_TYPE_MAX",                              "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
+  // cudaMemcpyOperandTypePointer
+  {"CU_MEMCPY_OPERAND_TYPE_POINTER",                                   {"hipMemcpyOperandTypePointer",                              "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES, HIP_EXPERIMENTAL}},
+  // cudaMemcpyOperandTypeArray
+  {"CU_MEMCPY_OPERAND_TYPE_ARRAY",                                     {"hipMemcpyOperandTypeArray",                                "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES, HIP_EXPERIMENTAL}},
+  // cudaMemcpyOperandTypeMax
+  {"CU_MEMCPY_OPERAND_TYPE_MAX",                                       {"hipMemcpyOperandTypeMax",                                  "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES, HIP_EXPERIMENTAL}},
 
   // cudaGraphChildGraphNodeOwnership
   {"CUgraphChildGraphNodeOwnership",                                   {"hipGraphChildGraphNodeOwnership",                          "", CONV_TYPE, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
@@ -3142,19 +3150,7 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_TYPE_NAME_MAP {
   {"CUasyncCallback",                                                  {"hipAsyncCallback",                                         "", CONV_TYPE, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
 
   //
-  {"CUmemcpyAttributes_v1",                                            {"hipMemcpyAttributes",                                      "", CONV_TYPE, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
-
-  //
-  {"CUoffset3D_v1",                                                    {"hipOffset3D",                                              "", CONV_TYPE, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
-
-  //
   {"CUextent3D_v1",                                                    {"hipExtent3D",                                              "", CONV_TYPE, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
-
-  //
-  {"CUmemcpy3DOperand_v1",                                             {"hipMemcpy3DOperand",                                       "", CONV_TYPE, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
-
-  //
-  {"CUDA_MEMCPY3D_BATCH_OP_v1",                                        {"HIP_MEMCPY3D_BATCH_OP",                                    "", CONV_TYPE, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
 
   //
   {"CUlogsCallback",                                                   {"hipLogsCallback",                                          "", CONV_TYPE, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED}},

--- a/src/CUDA2HIP_Runtime_API_types.cpp
+++ b/src/CUDA2HIP_Runtime_API_types.cpp
@@ -96,7 +96,7 @@ const std::map<llvm::StringRef, hipCounter> CUDA_RUNTIME_TYPE_NAME_MAP {
   {"cudaMemcpy3DParms",                                                {"hipMemcpy3DParms",                                         "", CONV_TYPE, API_RUNTIME, SEC::DATA_TYPES}},
 
   // no analogue
-  {"cudaMemcpy3DPeerParms",                                            {"hipMemcpy3DPeerParms",                                     "", CONV_TYPE, API_RUNTIME, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
+  {"cudaMemcpy3DPeerParms",                                            {"hipMemcpy3DPeerParms",                                     "", CONV_TYPE, API_RUNTIME, SEC::DATA_TYPES, HIP_EXPERIMENTAL}},
 
   //
   {"cudaMemsetParams",                                                 {"hipMemsetParams",                                          "", CONV_TYPE, API_RUNTIME, SEC::DATA_TYPES}},
@@ -271,7 +271,7 @@ const std::map<llvm::StringRef, hipCounter> CUDA_RUNTIME_TYPE_NAME_MAP {
   {"cudaGraphKernelNodeUpdate",                                        {"hipGraphKernelNodeUpdate",                                 "", CONV_TYPE, API_RUNTIME, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
 
   // CUmemcpyAttributes
-  {"cudaMemcpyAttributes",                                             {"hipMemcpyAttributes",                                      "", CONV_TYPE, API_RUNTIME, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
+  {"cudaMemcpyAttributes",                                             {"hipMemcpyAttributes",                                      "", CONV_TYPE, API_RUNTIME, SEC::DATA_TYPES, HIP_EXPERIMENTAL}},
 
   // 2. Unions
 
@@ -318,13 +318,13 @@ const std::map<llvm::StringRef, hipCounter> CUDA_RUNTIME_TYPE_NAME_MAP {
   {"cudaAsyncNotificationInfo_t",                                      {"hipAsyncNotificationInfo",                                 "", CONV_TYPE, API_RUNTIME, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
 
   // CUoffset3D
-  {"cudaOffset3D",                                                     {"hipOffset3D",                                              "", CONV_TYPE, API_RUNTIME, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
+  {"cudaOffset3D",                                                     {"hipOffset3D",                                              "", CONV_TYPE, API_RUNTIME, SEC::DATA_TYPES, HIP_EXPERIMENTAL}},
 
   // CUmemcpy3DOperand
-  {"cudaMemcpy3DOperand",                                              {"hipMemcpy3DOperand",                                       "", CONV_TYPE, API_RUNTIME, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
+  {"cudaMemcpy3DOperand",                                              {"hipMemcpy3DOperand",                                       "", CONV_TYPE, API_RUNTIME, SEC::DATA_TYPES, HIP_EXPERIMENTAL}},
 
   // CUDA_MEMCPY3D_BATCH_OP
-  {"cudaMemcpy3DBatchOp",                                              {"HIP_MEMCPY3D_BATCH_OP",                                    "", CONV_TYPE, API_RUNTIME, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
+  {"cudaMemcpy3DBatchOp",                                              {"hipMemcpy3DBatchOp",                                       "", CONV_TYPE, API_RUNTIME, SEC::DATA_TYPES, HIP_EXPERIMENTAL}},
 
   // CUlibraryHostUniversalFunctionAndDataTable
   {"cudalibraryHostUniversalFunctionAndDataTable",                     {"hipLibraryHostUniversalFunctionAndDataTable",              "", CONV_TYPE, API_RUNTIME, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
@@ -2114,28 +2114,28 @@ const std::map<llvm::StringRef, hipCounter> CUDA_RUNTIME_TYPE_NAME_MAP {
   {"cudaMemcpyFlagPreferOverlapWithCompute",                           {"hipMemcpyFlagPreferOverlapWithCompute",                    "", CONV_NUMERIC_LITERAL, API_RUNTIME, SEC::DATA_TYPES, HIP_EXPERIMENTAL}},
 
   // CUmemcpySrcAccessOrder
-  {"cudaMemcpySrcAccessOrder",                                         {"hipMemcpySrcAccessOrder",                                  "", CONV_TYPE, API_RUNTIME, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
+  {"cudaMemcpySrcAccessOrder",                                         {"hipMemcpySrcAccessOrder",                                  "", CONV_TYPE, API_RUNTIME, SEC::DATA_TYPES, HIP_EXPERIMENTAL}},
   // cudaMemcpySrcAccessOrder enum values
   // CU_MEMCPY_SRC_ACCESS_ORDER_INVALID
-  {"cudaMemcpySrcAccessOrderInvalid",                                  {"HIP_MEMCPY_SRC_ACCESS_ORDER_INVALID",                      "", CONV_NUMERIC_LITERAL, API_RUNTIME, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
+  {"cudaMemcpySrcAccessOrderInvalid",                                  {"hipMemcpySrcAccessOrderInvalid",                           "", CONV_NUMERIC_LITERAL, API_RUNTIME, SEC::DATA_TYPES, HIP_EXPERIMENTAL}},
   // CU_MEMCPY_SRC_ACCESS_ORDER_STREAM
-  {"cudaMemcpySrcAccessOrderStream",                                   {"HIP_MEMCPY_SRC_ACCESS_ORDER_STREAM",                       "", CONV_NUMERIC_LITERAL, API_RUNTIME, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
+  {"cudaMemcpySrcAccessOrderStream",                                   {"hipMemcpySrcAccessOrderStream",                            "", CONV_NUMERIC_LITERAL, API_RUNTIME, SEC::DATA_TYPES, HIP_EXPERIMENTAL}},
   // CU_MEMCPY_SRC_ACCESS_ORDER_DURING_API_CALL
-  {"cudaMemcpySrcAccessOrderDuringApiCall",                            {"HIP_MEMCPY_SRC_ACCESS_ORDER_DURING_API_CALL",              "", CONV_NUMERIC_LITERAL, API_RUNTIME, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
+  {"cudaMemcpySrcAccessOrderDuringApiCall",                            {"hipMemcpySrcAccessOrderDuringApiCall",                     "", CONV_NUMERIC_LITERAL, API_RUNTIME, SEC::DATA_TYPES, HIP_EXPERIMENTAL}},
   // CU_MEMCPY_SRC_ACCESS_ORDER_ANY
-  {"cudaMemcpySrcAccessOrderAny",                                      {"HIP_MEMCPY_SRC_ACCESS_ORDER_ANY",                          "", CONV_NUMERIC_LITERAL, API_RUNTIME, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
+  {"cudaMemcpySrcAccessOrderAny",                                      {"hipMemcpySrcAccessOrderAny",                               "", CONV_NUMERIC_LITERAL, API_RUNTIME, SEC::DATA_TYPES, HIP_EXPERIMENTAL}},
   // CU_MEMCPY_SRC_ACCESS_ORDER_MAX
-  {"cudaMemcpySrcAccessOrderMax",                                      {"HIP_MEMCPY_SRC_ACCESS_ORDER_MAX",                          "", CONV_NUMERIC_LITERAL, API_RUNTIME, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
+  {"cudaMemcpySrcAccessOrderMax",                                      {"hipMemcpySrcAccessOrderMax",                               "", CONV_NUMERIC_LITERAL, API_RUNTIME, SEC::DATA_TYPES, HIP_EXPERIMENTAL}},
 
-  //
-  {"cudaMemcpy3DOperandType",                                          {"hipMemcpy3DOperandType",                                   "", CONV_TYPE, API_RUNTIME, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
-  // cudaMemcpySrcAccessOrder enum values
-  //
-  {"cudaMemcpyOperandTypePointer",                                     {"hipMemcpyOperandTypePointer",                              "", CONV_NUMERIC_LITERAL, API_RUNTIME, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
-  //
-  {"cudaMemcpyOperandTypeArray",                                       {"hipMemcpyOperandTypeArray",                                "", CONV_NUMERIC_LITERAL, API_RUNTIME, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
-  //
-  {"cudaMemcpyOperandTypeMax",                                         {"hipMemcpyOperandTypeMax",                                  "", CONV_NUMERIC_LITERAL, API_RUNTIME, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
+  // CUmemcpy3DOperandType
+  {"cudaMemcpy3DOperandType",                                          {"hipMemcpy3DOperandType",                                   "", CONV_TYPE, API_RUNTIME, SEC::DATA_TYPES, HIP_EXPERIMENTAL}},
+  // cudaMemcpy3DOperandType enum values
+  // CU_MEMCPY_OPERAND_TYPE_POINTER
+  {"cudaMemcpyOperandTypePointer",                                     {"hipMemcpyOperandTypePointer",                              "", CONV_NUMERIC_LITERAL, API_RUNTIME, SEC::DATA_TYPES, HIP_EXPERIMENTAL}},
+  // CU_MEMCPY_OPERAND_TYPE_ARRAY
+  {"cudaMemcpyOperandTypeArray",                                       {"hipMemcpyOperandTypeArray",                                "", CONV_NUMERIC_LITERAL, API_RUNTIME, SEC::DATA_TYPES, HIP_EXPERIMENTAL}},
+  // CU_MEMCPY_OPERAND_TYPE_MAX
+  {"cudaMemcpyOperandTypeMax",                                         {"hipMemcpyOperandTypeMax",                                  "", CONV_NUMERIC_LITERAL, API_RUNTIME, SEC::DATA_TYPES, HIP_EXPERIMENTAL}},
 
   //
   {"CUDAlogLevel",                                                     {"hipLogLevel",                                              "", CONV_TYPE, API_RUNTIME, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
@@ -3703,4 +3703,19 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_RUNTIME_TYPE_NAME_VER_MAP {
   {"hipMemcpyFlags",                                                   {HIP_7010, HIP_0,    HIP_0,  HIP_LATEST}},
   {"hipMemcpyFlagDefault",                                             {HIP_7010, HIP_0,    HIP_0,  HIP_LATEST}},
   {"hipMemcpyFlagPreferOverlapWithCompute",                            {HIP_7010, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipMemcpySrcAccessOrder",                                          {HIP_7010, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipMemcpySrcAccessOrderInvalid",                                   {HIP_7010, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipMemcpySrcAccessOrderStream",                                    {HIP_7010, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipMemcpySrcAccessOrderDuringApiCall",                             {HIP_7010, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipMemcpySrcAccessOrderAny",                                       {HIP_7010, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipMemcpySrcAccessOrderMax",                                       {HIP_7010, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipMemcpyAttributes",                                              {HIP_7010, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipMemcpy3DOperandType",                                           {HIP_7010, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipMemcpyOperandTypePointer",                                      {HIP_7010, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipMemcpyOperandTypeArray",                                        {HIP_7010, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipMemcpyOperandTypeMax",                                          {HIP_7010, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipOffset3D",                                                      {HIP_7010, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipMemcpy3DOperand",                                               {HIP_7010, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipMemcpy3DBatchOp",                                               {HIP_7010, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipMemcpy3DPeerParms",                                             {HIP_7010, HIP_0,    HIP_0,  HIP_LATEST}},
 };

--- a/tests/unit_tests/synthetic/driver_enums.cu
+++ b/tests/unit_tests/synthetic/driver_enums.cu
@@ -1302,6 +1302,30 @@ int main() {
   CUmemcpyFlags_enum memcpyFlags_enum;
   CUmemcpyFlags MemcpyFlagDefault = CU_MEMCPY_FLAG_DEFAULT;
   CUmemcpyFlags MemcpyFlagPreferOverlapWithCompute = CU_MEMCPY_FLAG_PREFER_OVERLAP_WITH_COMPUTE;
+
+  // CHECK: hipMemcpySrcAccessOrder MemcpySrcAccessOrder;
+  // CHECK-NEXT: hipMemcpySrcAccessOrder MemcpySrcAccessOrderInvalid = hipMemcpySrcAccessOrderInvalid;
+  // CHECK-NEXT: hipMemcpySrcAccessOrder MemcpySrcAccessOrderStream = hipMemcpySrcAccessOrderStream;
+  // CHECK-NEXT: hipMemcpySrcAccessOrder MemcpySrcAccessOrderDuringApiCall = hipMemcpySrcAccessOrderDuringApiCall;
+  // CHECK-NEXT: hipMemcpySrcAccessOrder MemcpySrcAccessOrderAny = hipMemcpySrcAccessOrderAny;
+  // CHECK-NEXT: hipMemcpySrcAccessOrder MemcpySrcAccessOrderMax = hipMemcpySrcAccessOrderMax;
+  CUmemcpySrcAccessOrder MemcpySrcAccessOrder;
+  CUmemcpySrcAccessOrder MemcpySrcAccessOrderInvalid = CU_MEMCPY_SRC_ACCESS_ORDER_INVALID;
+  CUmemcpySrcAccessOrder MemcpySrcAccessOrderStream = CU_MEMCPY_SRC_ACCESS_ORDER_STREAM;
+  CUmemcpySrcAccessOrder MemcpySrcAccessOrderDuringApiCall = CU_MEMCPY_SRC_ACCESS_ORDER_DURING_API_CALL;
+  CUmemcpySrcAccessOrder MemcpySrcAccessOrderAny = CU_MEMCPY_SRC_ACCESS_ORDER_ANY;
+  CUmemcpySrcAccessOrder MemcpySrcAccessOrderMax = CU_MEMCPY_SRC_ACCESS_ORDER_MAX;
+
+  // CHECK: hipMemcpy3DOperandType memcpy3DOperandType;
+  // CHECK-NEXT: hipMemcpy3DOperandType memcpy3DOperandType_enum;
+  // CHECK-NEXT: hipMemcpy3DOperandType MemcpyOperandTypePointer = hipMemcpyOperandTypePointer;
+  // CHECK-NEXT: hipMemcpy3DOperandType MemcpyOperandTypeArray = hipMemcpyOperandTypeArray;
+  // CHECK-NEXT: hipMemcpy3DOperandType MemcpyOperandTypeMax = hipMemcpyOperandTypeMax;
+  CUmemcpy3DOperandType memcpy3DOperandType;
+  CUmemcpy3DOperandType_enum memcpy3DOperandType_enum;
+  CUmemcpy3DOperandType MemcpyOperandTypePointer = CU_MEMCPY_OPERAND_TYPE_POINTER;
+  CUmemcpy3DOperandType MemcpyOperandTypeArray = CU_MEMCPY_OPERAND_TYPE_ARRAY;
+  CUmemcpy3DOperandType MemcpyOperandTypeMax = CU_MEMCPY_OPERAND_TYPE_MAX;
 #endif
 
 #if CUDA_VERSION >= 13000

--- a/tests/unit_tests/synthetic/driver_structs.cu
+++ b/tests/unit_tests/synthetic/driver_structs.cu
@@ -400,5 +400,35 @@ int main() {
   CUgraphEdgeData graphEdgeData;
 #endif
 
+#if CUDA_VERSION >= 12080
+  // CHECK: hipMemcpyAttributes memcpyAttributes_st;
+  // CHECK-NEXT: hipMemcpyAttributes memcpyAttributes;
+  // CHECK-NEXT: hipMemcpyAttributes memcpyAttributes_v1;
+  CUmemcpyAttributes_st memcpyAttributes_st;
+  CUmemcpyAttributes memcpyAttributes;
+  CUmemcpyAttributes_v1 memcpyAttributes_v1;
+
+  // CHECK: hipOffset3D offset3D;
+  // CHECK-NEXT: hipOffset3D offset3D_st;
+  // CHECK-NEXT: hipOffset3D offset3D_v1;
+  CUoffset3D offset3D;
+  CUoffset3D_st offset3D_st;
+  CUoffset3D_v1 offset3D_v1;
+
+  // CHECK: hipMemcpy3DOperand memcpy3DOperand;
+  // CHECK-NEXT: hipMemcpy3DOperand memcpy3DOperand_st;
+  // CHECK-NEXT: hipMemcpy3DOperand memcpy3DOperand_v1;
+  CUmemcpy3DOperand memcpy3DOperand;
+  CUmemcpy3DOperand_st memcpy3DOperand_st;
+  CUmemcpy3DOperand_v1  memcpy3DOperand_v1;
+
+  // CHECK: hipMemcpy3DBatchOp Memcpy3DBatchOp;
+  // CHECK-NEXT: hipMemcpy3DBatchOp Memcpy3DBatchOp_st;
+  // CHECK-NEXT: hipMemcpy3DBatchOp Memcpy3DBatchOp_v1;
+  CUDA_MEMCPY3D_BATCH_OP Memcpy3DBatchOp;
+  CUDA_MEMCPY3D_BATCH_OP_st Memcpy3DBatchOp_st;
+  CUDA_MEMCPY3D_BATCH_OP_v1  Memcpy3DBatchOp_v1;
+#endif
+
   return 0;
 }

--- a/tests/unit_tests/synthetic/runtime_enums.cu
+++ b/tests/unit_tests/synthetic/runtime_enums.cu
@@ -1010,6 +1010,28 @@ int main() {
   cudaMemcpyFlags MemcpyFlags;
   cudaMemcpyFlags MemcpyFlagDefault = cudaMemcpyFlagDefault;
   cudaMemcpyFlags MemcpyFlagPreferOverlapWithCompute = cudaMemcpyFlagPreferOverlapWithCompute;
+
+  // CHECK: hipMemcpySrcAccessOrder MemcpySrcAccessOrder;
+  // CHECK-NEXT: hipMemcpySrcAccessOrder MemcpySrcAccessOrderInvalid = hipMemcpySrcAccessOrderInvalid;
+  // CHECK-NEXT: hipMemcpySrcAccessOrder MemcpySrcAccessOrderStream = hipMemcpySrcAccessOrderStream;
+  // CHECK-NEXT: hipMemcpySrcAccessOrder MemcpySrcAccessOrderDuringApiCall = hipMemcpySrcAccessOrderDuringApiCall;
+  // CHECK-NEXT: hipMemcpySrcAccessOrder MemcpySrcAccessOrderAny = hipMemcpySrcAccessOrderAny;
+  // CHECK-NEXT: hipMemcpySrcAccessOrder MemcpySrcAccessOrderMax = hipMemcpySrcAccessOrderMax;
+  cudaMemcpySrcAccessOrder MemcpySrcAccessOrder;
+  cudaMemcpySrcAccessOrder MemcpySrcAccessOrderInvalid = cudaMemcpySrcAccessOrderInvalid;
+  cudaMemcpySrcAccessOrder MemcpySrcAccessOrderStream = cudaMemcpySrcAccessOrderStream;
+  cudaMemcpySrcAccessOrder MemcpySrcAccessOrderDuringApiCall = cudaMemcpySrcAccessOrderDuringApiCall;
+  cudaMemcpySrcAccessOrder MemcpySrcAccessOrderAny = cudaMemcpySrcAccessOrderAny;
+  cudaMemcpySrcAccessOrder MemcpySrcAccessOrderMax = cudaMemcpySrcAccessOrderMax;
+
+  // CHECK: hipMemcpy3DOperandType Memcpy3DOperandType;
+  // CHECK-NEXT: hipMemcpy3DOperandType MemcpyOperandTypePointer = hipMemcpyOperandTypePointer;
+  // CHECK-NEXT: hipMemcpy3DOperandType MemcpyOperandTypeArray = hipMemcpyOperandTypeArray;
+  // CHECK-NEXT: hipMemcpy3DOperandType MemcpyOperandTypeMax = hipMemcpyOperandTypeMax;
+  cudaMemcpy3DOperandType Memcpy3DOperandType;
+  cudaMemcpy3DOperandType MemcpyOperandTypePointer = cudaMemcpyOperandTypePointer;
+  cudaMemcpy3DOperandType MemcpyOperandTypeArray = cudaMemcpyOperandTypeArray;
+  cudaMemcpy3DOperandType MemcpyOperandTypeMax = cudaMemcpyOperandTypeMax;
 #endif
 
 #if CUDA_VERSION >= 13000

--- a/tests/unit_tests/synthetic/runtime_structs.cu
+++ b/tests/unit_tests/synthetic/runtime_structs.cu
@@ -85,6 +85,9 @@ int main() {
   // CHECK: hipUUID_t uuid_st;
   CUuuid_st uuid_st;
 
+  // CHECK: hipMemcpy3DPeerParms Memcpy3DPeerParms;
+  cudaMemcpy3DPeerParms Memcpy3DPeerParms;
+
 #if CUDA_VERSION >= 9000 && CUDA_VERSION < 13000
   // CHECK: hipLaunchParams LaunchParams;
   cudaLaunchParams LaunchParams;
@@ -237,6 +240,20 @@ int main() {
   // CHECK-NEXT: hipGraphEdgeData graphEdgeData;
   cudaGraphEdgeData_st graphEdgeData_st;
   cudaGraphEdgeData graphEdgeData;
+#endif
+
+#if CUDA_VERSION >= 12080
+  // CHECK: hipMemcpyAttributes MemcpyAttributes;
+  cudaMemcpyAttributes MemcpyAttributes;
+
+  // CHECK: hipOffset3D Offset3D;
+  cudaOffset3D Offset3D;
+
+  // CHECK: hipMemcpy3DOperand Memcpy3DOperand;
+  cudaMemcpy3DOperand Memcpy3DOperand;
+
+  // CHECK: hipMemcpy3DBatchOp Memcpy3DBatchOp;
+  cudaMemcpy3DBatchOp Memcpy3DBatchOp;
 #endif
 
   return 0;


### PR DESCRIPTION
+ Updated synthetic tests, the regenerated `hipify-perl`, and `Driver` and `Runtime` `CUDA2HIP` docs accordingly
