### PR TITLE
[HIPIFY][7.1][HIP] Sync with `ROCm HIP 7.1` - Part 3 - `HIP` - Step 3 - Data Types

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -1717,6 +1717,15 @@ my %experimental_funcs = (
     "cudaMemLocationTypeHostNumaCurrent" => "7.1.0",
     "cudaMemLocationTypeHostNuma" => "7.1.0",
     "cudaMemLocationTypeHost" => "7.1.0",
+    "cudaLibrary_t" => "7.1.0",
+    "cudaKernel_t" => "7.1.0",
+    "cudaEnablePerThreadDefaultStream" => "7.1.0",
+    "cudaEnableLegacyStream" => "7.1.0",
+    "cudaEnableDefault" => "7.1.0",
+    "cudaDriverEntryPointVersionNotSufficent" => "7.1.0",
+    "cudaDriverEntryPointSymbolNotFound" => "7.1.0",
+    "cudaDriverEntryPointSuccess" => "7.1.0",
+    "cudaDriverEntryPointQueryResult" => "7.1.0",
     "FFTW_WISDOM_ONLY" => "7.1.0",
     "FFTW_UNALIGNED" => "7.1.0",
     "FFTW_PRESERVE_INPUT" => "7.1.0",
@@ -1742,6 +1751,10 @@ my %experimental_funcs = (
     "CUmemcpy3DOperandType_enum" => "7.1.0",
     "CUmemcpy3DOperandType" => "7.1.0",
     "CUmemcpy3DOperand" => "7.1.0",
+    "CUlibrary" => "7.1.0",
+    "CUlib_st" => "7.1.0",
+    "CUkernel" => "7.1.0",
+    "CUkern_st" => "7.1.0",
     "CU_MEM_LOCATION_TYPE_NONE" => "7.1.0",
     "CU_MEM_LOCATION_TYPE_HOST_NUMA_CURRENT" => "7.1.0",
     "CU_MEM_LOCATION_TYPE_HOST_NUMA" => "7.1.0",
@@ -1756,6 +1769,9 @@ my %experimental_funcs = (
     "CU_MEMCPY_OPERAND_TYPE_ARRAY" => "7.1.0",
     "CU_MEMCPY_FLAG_PREFER_OVERLAP_WITH_COMPUTE" => "7.1.0",
     "CU_MEMCPY_FLAG_DEFAULT" => "7.1.0",
+    "CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM" => "7.1.0",
+    "CU_GET_PROC_ADDRESS_LEGACY_STREAM" => "7.1.0",
+    "CU_GET_PROC_ADDRESS_DEFAULT" => "7.1.0",
     "CUDA_MEMCPY3D_BATCH_OP_v1" => "7.1.0",
     "CUDA_MEMCPY3D_BATCH_OP_st" => "7.1.0",
     "CUDA_MEMCPY3D_BATCH_OP" => "7.1.0",
@@ -1913,6 +1929,10 @@ sub experimentalSubstitutions {
     subst("CUDA_MEMCPY3D_BATCH_OP", "hipMemcpy3DBatchOp", "type");
     subst("CUDA_MEMCPY3D_BATCH_OP_st", "hipMemcpy3DBatchOp", "type");
     subst("CUDA_MEMCPY3D_BATCH_OP_v1", "hipMemcpy3DBatchOp", "type");
+    subst("CUkern_st", "ihipKernel_t", "type");
+    subst("CUkernel", "hipKernel_t", "type");
+    subst("CUlib_st", "ihipLibrary_t", "type");
+    subst("CUlibrary", "hipLibrary_t", "type");
     subst("CUmemcpy3DOperand", "hipMemcpy3DOperand", "type");
     subst("CUmemcpy3DOperandType", "hipMemcpy3DOperandType", "type");
     subst("CUmemcpy3DOperandType_enum", "hipMemcpy3DOperandType", "type");
@@ -1928,6 +1948,9 @@ sub experimentalSubstitutions {
     subst("CUoffset3D", "hipOffset3D", "type");
     subst("CUoffset3D_st", "hipOffset3D", "type");
     subst("CUoffset3D_v1", "hipOffset3D", "type");
+    subst("cudaDriverEntryPointQueryResult", "hipDriverEntryPointQueryResult", "type");
+    subst("cudaKernel_t", "hipKernel_t", "type");
+    subst("cudaLibrary_t", "hipLibrary_t", "type");
     subst("cudaMemcpy3DBatchOp", "hipMemcpy3DBatchOp", "type");
     subst("cudaMemcpy3DOperand", "hipMemcpy3DOperand", "type");
     subst("cudaMemcpy3DOperandType", "hipMemcpy3DOperandType", "type");
@@ -1942,6 +1965,9 @@ sub experimentalSubstitutions {
     subst("fftwf_plan", "fftwf_plan", "type");
     subst("CUBLASLT_EPILOGUE_RELU_AUX", "HIPBLASLT_EPILOGUE_RELU_AUX", "numeric_literal");
     subst("CUBLASLT_EPILOGUE_RELU_AUX_BIAS", "HIPBLASLT_EPILOGUE_RELU_AUX_BIAS", "numeric_literal");
+    subst("CU_GET_PROC_ADDRESS_DEFAULT", "hipEnableDefault", "numeric_literal");
+    subst("CU_GET_PROC_ADDRESS_LEGACY_STREAM", "hipEnableLegacyStream", "numeric_literal");
+    subst("CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM", "hipEnablePerThreadDefaultStream", "numeric_literal");
     subst("CU_MEMCPY_FLAG_DEFAULT", "hipMemcpyFlagDefault", "numeric_literal");
     subst("CU_MEMCPY_FLAG_PREFER_OVERLAP_WITH_COMPUTE", "hipMemcpyFlagPreferOverlapWithCompute", "numeric_literal");
     subst("CU_MEMCPY_OPERAND_TYPE_ARRAY", "hipMemcpyOperandTypeArray", "numeric_literal");
@@ -1956,6 +1982,12 @@ sub experimentalSubstitutions {
     subst("CU_MEM_LOCATION_TYPE_HOST_NUMA", "hipMemLocationTypeHostNuma", "numeric_literal");
     subst("CU_MEM_LOCATION_TYPE_HOST_NUMA_CURRENT", "hipMemLocationTypeHostNumaCurrent", "numeric_literal");
     subst("CU_MEM_LOCATION_TYPE_NONE", "hipMemLocationTypeNone", "numeric_literal");
+    subst("cudaDriverEntryPointSuccess", "hipDriverEntryPointSuccess", "numeric_literal");
+    subst("cudaDriverEntryPointSymbolNotFound", "hipDriverEntryPointSymbolNotFound", "numeric_literal");
+    subst("cudaDriverEntryPointVersionNotSufficent", "hipDriverEntryPointVersionNotSufficent", "numeric_literal");
+    subst("cudaEnableDefault", "hipEnableDefault", "numeric_literal");
+    subst("cudaEnableLegacyStream", "hipEnableLegacyStream", "numeric_literal");
+    subst("cudaEnablePerThreadDefaultStream", "hipEnablePerThreadDefaultStream", "numeric_literal");
     subst("cudaMemLocationTypeHost", "hipMemLocationTypeHost", "numeric_literal");
     subst("cudaMemLocationTypeHostNuma", "hipMemLocationTypeHostNuma", "numeric_literal");
     subst("cudaMemLocationTypeHostNumaCurrent", "hipMemLocationTypeHostNumaCurrent", "numeric_literal");
@@ -7796,7 +7828,6 @@ sub simpleSubstitutions {
     subst("cudaDeviceAttr", "hipDeviceAttribute_t", "type");
     subst("cudaDeviceP2PAttr", "hipDeviceP2PAttr", "type");
     subst("cudaDeviceProp", "hipDeviceProp_t", "type");
-    subst("cudaDriverEntryPointQueryResult", "hipDriverProcAddressQueryResult", "type");
     subst("cudaError", "hipError_t", "type");
     subst("cudaError_enum", "hipError_t", "type");
     subst("cudaError_t", "hipError_t", "type");
@@ -9262,9 +9293,6 @@ sub simpleSubstitutions {
     subst("cudaDevP2PAttrCudaArrayAccessSupported", "hipDevP2PAttrHipArrayAccessSupported", "numeric_literal");
     subst("cudaDevP2PAttrNativeAtomicSupported", "hipDevP2PAttrNativeAtomicSupported", "numeric_literal");
     subst("cudaDevP2PAttrPerformanceRank", "hipDevP2PAttrPerformanceRank", "numeric_literal");
-    subst("cudaDriverEntryPointSuccess", "HIP_GET_PROC_ADDRESS_SUCCESS", "numeric_literal");
-    subst("cudaDriverEntryPointSymbolNotFound", "HIP_GET_PROC_ADDRESS_SYMBOL_NOT_FOUND", "numeric_literal");
-    subst("cudaDriverEntryPointVersionNotSufficent", "HIP_GET_PROC_ADDRESS_VERSION_NOT_SUFFICIENT", "numeric_literal");
     subst("cudaErrorAlreadyAcquired", "hipErrorAlreadyAcquired", "numeric_literal");
     subst("cudaErrorAlreadyMapped", "hipErrorAlreadyMapped", "numeric_literal");
     subst("cudaErrorArrayIsMapped", "hipErrorArrayIsMapped", "numeric_literal");
@@ -11718,7 +11746,6 @@ sub warnRemovedFunctions {
     "cudaLimitMaxL2FetchGranularity",
     "cudaLimitDevRuntimeSyncDepth",
     "cudaLimitDevRuntimePendingLaunchCount",
-    "cudaLibrary_t",
     "cudaLibraryUnload",
     "cudaLibraryOption",
     "cudaLibraryLoadFromFile",
@@ -11752,7 +11779,6 @@ sub warnRemovedFunctions {
     "cudaLaunchAttributeClusterSchedulingPolicyPreference",
     "cudaLaunchAttributeClusterDimension",
     "cudaKeyValuePair",
-    "cudaKernel_t",
     "cudaKernelSetAttributeForDevice",
     "cudaKernelNodeParamsV2",
     "cudaKernelNodeAttributePreferredSharedMemoryCarveout",
@@ -11930,9 +11956,6 @@ sub warnRemovedFunctions {
     "cudaErrorCallRequiresNewerDriver",
     "cudaErrorApiFailureBase",
     "cudaErrorAddressOfConstant",
-    "cudaEnablePerThreadDefaultStream",
-    "cudaEnableLegacyStream",
-    "cudaEnableDefault",
     "cudaEmulationStrategy_t",
     "cudaEmulationStrategy",
     "cudaEglStreamConnection",
@@ -12734,14 +12757,10 @@ sub warnRemovedFunctions {
     "CUlibraryOption",
     "CUlibraryHostUniversalFunctionAndDataTable_st",
     "CUlibraryHostUniversalFunctionAndDataTable",
-    "CUlibrary",
-    "CUlib_st",
     "CUlaunchMemSyncDomain_enum",
     "CUlaunchMemSyncDomainMap_st",
     "CUlaunchMemSyncDomainMap",
     "CUlaunchMemSyncDomain",
-    "CUkernel",
-    "CUkern_st",
     "CUjit_target_enum",
     "CUjit_target",
     "CUjit_fallback_enum",
@@ -13066,9 +13085,6 @@ sub warnRemovedFunctions {
     "CU_GL_MAP_RESOURCE_FLAGS_WRITE_DISCARD",
     "CU_GL_MAP_RESOURCE_FLAGS_READ_ONLY",
     "CU_GL_MAP_RESOURCE_FLAGS_NONE",
-    "CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM",
-    "CU_GET_PROC_ADDRESS_LEGACY_STREAM",
-    "CU_GET_PROC_ADDRESS_DEFAULT",
     "CU_FUNC_ATTRIBUTE_REQUIRED_CLUSTER_WIDTH",
     "CU_FUNC_ATTRIBUTE_REQUIRED_CLUSTER_HEIGHT",
     "CU_FUNC_ATTRIBUTE_REQUIRED_CLUSTER_DEPTH",

--- a/docs/reference/tables/CUDA_Driver_API_functions_supported_by_HIP.md
+++ b/docs/reference/tables/CUDA_Driver_API_functions_supported_by_HIP.md
@@ -723,9 +723,9 @@
 |`CU_FUNC_CACHE_PREFER_L1`| | | | |`hipFuncCachePreferL1`|1.6.0| | | | | |
 |`CU_FUNC_CACHE_PREFER_NONE`| | | | |`hipFuncCachePreferNone`|1.6.0| | | | | |
 |`CU_FUNC_CACHE_PREFER_SHARED`| | | | |`hipFuncCachePreferShared`|1.6.0| | | | | |
-|`CU_GET_PROC_ADDRESS_DEFAULT`|11.3| | | | | | | | | | |
-|`CU_GET_PROC_ADDRESS_LEGACY_STREAM`|11.3| | | | | | | | | | |
-|`CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM`|11.3| | | | | | | | | | |
+|`CU_GET_PROC_ADDRESS_DEFAULT`|11.3| | | |`hipEnableDefault`|7.1.0| | | | |7.1.0|
+|`CU_GET_PROC_ADDRESS_LEGACY_STREAM`|11.3| | | |`hipEnableLegacyStream`|7.1.0| | | | |7.1.0|
+|`CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM`|11.3| | | |`hipEnablePerThreadDefaultStream`|7.1.0| | | | |7.1.0|
 |`CU_GET_PROC_ADDRESS_SUCCESS`|12.0| | | |`HIP_GET_PROC_ADDRESS_SUCCESS`|6.2.0| | | | | |
 |`CU_GET_PROC_ADDRESS_SYMBOL_NOT_FOUND`|12.0| | | |`HIP_GET_PROC_ADDRESS_SYMBOL_NOT_FOUND`|6.2.0| | | | | |
 |`CU_GET_PROC_ADDRESS_VERSION_NOT_SUFFICIENT`|12.0| | | |`HIP_GET_PROC_ADDRESS_VERSION_NOT_SUFFICIENT`|6.2.0| | | | | |
@@ -1404,8 +1404,8 @@
 |`CUjit_option_enum`| | | | |`hipJitOption`|1.6.0| | | | | |
 |`CUjit_target`| | | | | | | | | | | |
 |`CUjit_target_enum`| | | | | | | | | | | |
-|`CUkern_st`|12.0| | | | | | | | | | |
-|`CUkernel`|12.0| | | | | | | | | | |
+|`CUkern_st`|12.0| | | |`ihipKernel_t`|7.1.0| | | | |7.1.0|
+|`CUkernel`|12.0| | | |`hipKernel_t`|7.1.0| | | | |7.1.0|
 |`CUkernelNodeAttrID`|11.0| | | |`hipKernelNodeAttrID`|5.2.0| | | | | |
 |`CUkernelNodeAttrID_enum`|11.0| | |11.8|`hipKernelNodeAttrID`|5.2.0| | | | | |
 |`CUkernelNodeAttrValue`|11.0| | | |`hipKernelNodeAttrValue`|5.2.0| | | | | |
@@ -1423,8 +1423,8 @@
 |`CUlaunchMemSyncDomainMap`|12.0| | | | | | | | | | |
 |`CUlaunchMemSyncDomainMap_st`|12.0| | | | | | | | | | |
 |`CUlaunchMemSyncDomain_enum`|12.0| | | | | | | | | | |
-|`CUlib_st`|12.0| | | | | | | | | | |
-|`CUlibrary`|12.0| | | | | | | | | | |
+|`CUlib_st`|12.0| | | |`ihipLibrary_t`|7.1.0| | | | |7.1.0|
+|`CUlibrary`|12.0| | | |`hipLibrary_t`|7.1.0| | | | |7.1.0|
 |`CUlibraryHostUniversalFunctionAndDataTable`|12.0| | | | | | | | | | |
 |`CUlibraryHostUniversalFunctionAndDataTable_st`|12.0| | | | | | | | | | |
 |`CUlibraryOption`|12.0| | | | | | | | | | |

--- a/docs/reference/tables/CUDA_Runtime_API_functions_supported_by_HIP.md
+++ b/docs/reference/tables/CUDA_Runtime_API_functions_supported_by_HIP.md
@@ -695,7 +695,6 @@
 |`CUgraphExec_st`|10.0| | | |`hipGraphExec`|4.3.0| | | | | |
 |`CUgraphNode_st`|10.0| | | |`hipGraphNode`|4.3.0| | | | | |
 |`CUgraph_st`|10.0| | | |`ihipGraph`|4.3.0| | | | | |
-|`CUkern_st`|12.1| | | | | | | | | | |
 |`CUlogsCallbackEntry_st`|13.0| | | | | | | | | | |
 |`CUstream_st`| | | | |`ihipStream_t`|1.5.0| | | | | |
 |`CUuuid_st`| | | | |`hipUUID_t`|5.2.0| | | | | |
@@ -993,10 +992,10 @@
 |`cudaDeviceScheduleSpin`| | | | |`hipDeviceScheduleSpin`|1.6.0| | | | | |
 |`cudaDeviceScheduleYield`| | | | |`hipDeviceScheduleYield`|1.6.0| | | | | |
 |`cudaDeviceSyncMemops`|12.1| | | | | | | | | | |
-|`cudaDriverEntryPointQueryResult`|12.0| | | |`hipDriverProcAddressQueryResult`|6.2.0| | | | | |
-|`cudaDriverEntryPointSuccess`|12.0| | | |`HIP_GET_PROC_ADDRESS_SUCCESS`|6.2.0| | | | | |
-|`cudaDriverEntryPointSymbolNotFound`|12.0| | | |`HIP_GET_PROC_ADDRESS_SYMBOL_NOT_FOUND`|6.2.0| | | | | |
-|`cudaDriverEntryPointVersionNotSufficent`|12.0| | | |`HIP_GET_PROC_ADDRESS_VERSION_NOT_SUFFICIENT`|6.2.0| | | | | |
+|`cudaDriverEntryPointQueryResult`|12.0| | | |`hipDriverEntryPointQueryResult`|7.1.0| | | | |7.1.0|
+|`cudaDriverEntryPointSuccess`|12.0| | | |`hipDriverEntryPointSuccess`|7.1.0| | | | |7.1.0|
+|`cudaDriverEntryPointSymbolNotFound`|12.0| | | |`hipDriverEntryPointSymbolNotFound`|7.1.0| | | | |7.1.0|
+|`cudaDriverEntryPointVersionNotSufficent`|12.0| | | |`hipDriverEntryPointVersionNotSufficent`|7.1.0| | | | |7.1.0|
 |`cudaEglColorFormat`|9.1| | | | | | | | | | |
 |`cudaEglColorFormatA`|9.1| | | | | | | | | | |
 |`cudaEglColorFormatABGR`|9.1| | | | | | | | | | |
@@ -1127,9 +1126,9 @@
 |`cudaEglStreamConnection`|9.1| | | | | | | | | | |
 |`cudaEmulationStrategy`|13.0| | | | | | | | | | |
 |`cudaEmulationStrategy_t`|13.0| | | | | | | | | | |
-|`cudaEnableDefault`|11.3| | | | | | | | | | |
-|`cudaEnableLegacyStream`|11.3| | | | | | | | | | |
-|`cudaEnablePerThreadDefaultStream`|11.3| | | | | | | | | | |
+|`cudaEnableDefault`|11.3| | | |`hipEnableDefault`|7.1.0| | | | |7.1.0|
+|`cudaEnableLegacyStream`|11.3| | | |`hipEnableLegacyStream`|7.1.0| | | | |7.1.0|
+|`cudaEnablePerThreadDefaultStream`|11.3| | | |`hipEnablePerThreadDefaultStream`|7.1.0| | | | |7.1.0|
 |`cudaError`| | | | |`hipError_t`|1.5.0| | | | | |
 |`cudaErrorAddressOfConstant`| |3.1| | | | | | | | | |
 |`cudaErrorAlreadyAcquired`|10.1| | | |`hipErrorAlreadyAcquired`|1.6.0| | | | | |
@@ -1520,7 +1519,7 @@
 |`cudaKernelNodeAttributePriority`|11.7| | | |`hipKernelNodeAttributePriority`|6.2.0| | | | | |
 |`cudaKernelNodeParams`|10.0| | | |`hipKernelNodeParams`|4.3.0| | | | | |
 |`cudaKernelNodeParamsV2`|12.2| | | | | | | | | | |
-|`cudaKernel_t`|12.1| | | | | | | | | | |
+|`cudaKernel_t`|12.1| | | |`hipKernel_t`|7.1.0| | | | |7.1.0|
 |`cudaKeyValuePair`| | | |12.0| | | | | | | |
 |`cudaLaunchAttribute`|11.8| | | |`hipLaunchAttribute`|7.0.0| | | | | |
 |`cudaLaunchAttributeAccessPolicyWindow`|11.8| | | |`hipLaunchAttributeAccessPolicyWindow`|6.2.0| | | | | |
@@ -1553,7 +1552,7 @@
 |`cudaLibraryBinaryIsPreserved`|12.8| | | | | | | | | | |
 |`cudaLibraryHostUniversalFunctionAndDataTable`|12.8| | | | | | | | | | |
 |`cudaLibraryOption`|12.8| | | | | | | | | | |
-|`cudaLibrary_t`|12.8| | | | | | | | | | |
+|`cudaLibrary_t`|12.8| | | |`hipLibrary_t`|7.1.0| | | | |7.1.0|
 |`cudaLimit`| | | | |`hipLimit_t`|1.6.0| | | | | |
 |`cudaLimitDevRuntimePendingLaunchCount`| | | | | | | | | | | |
 |`cudaLimitDevRuntimeSyncDepth`| | | | | | | | | | | |

--- a/src/CUDA2HIP_Driver_API_types.cpp
+++ b/src/CUDA2HIP_Driver_API_types.cpp
@@ -375,14 +375,14 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_TYPE_NAME_MAP {
   {"CUlaunchConfig",                                                   {"HIP_LAUNCH_CONFIG",                                        "", CONV_TYPE, API_DRIVER, SEC::DATA_TYPES}},
 
   // CUlib_st
-  {"CUlib_st",                                                         {"hipLibraty",                                               "", CONV_TYPE, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
+  {"CUlib_st",                                                         {"ihipLibrary_t",                                            "", CONV_TYPE, API_DRIVER, SEC::DATA_TYPES, HIP_EXPERIMENTAL}},
   // cudaLibrary_t
-  {"CUlibrary",                                                        {"hipLibraty",                                               "", CONV_TYPE, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
+  {"CUlibrary",                                                        {"hipLibrary_t",                                             "", CONV_TYPE, API_DRIVER, SEC::DATA_TYPES, HIP_EXPERIMENTAL}},
 
   // the same CUkern_st
-  {"CUkern_st",                                                        {"hipKernel",                                                "", CONV_TYPE, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
+  {"CUkern_st",                                                        {"ihipKernel_t",                                             "", CONV_TYPE, API_DRIVER, SEC::DATA_TYPES, HIP_EXPERIMENTAL}},
   // cudaKernel_t
-  {"CUkernel",                                                         {"hipKernel",                                                "", CONV_TYPE, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
+  {"CUkernel",                                                         {"hipKernel_t",                                              "", CONV_TYPE, API_DRIVER, SEC::DATA_TYPES, HIP_EXPERIMENTAL}},
 
   // cudaGraphInstantiateParams_st
   {"CUDA_GRAPH_INSTANTIATE_PARAMS_st",                                 {"hipGraphInstantiateParams",                                "", CONV_TYPE, API_DRIVER, SEC::DATA_TYPES}},
@@ -2436,11 +2436,11 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_TYPE_NAME_MAP {
   {"CUdriverProcAddress_flags_enum",                                   {"hipDriverProcAddress",                                     "", CONV_TYPE, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
   // CUdriverProcAddress_flags enum values
   // cudaEnableDefault
-  {"CU_GET_PROC_ADDRESS_DEFAULT",                                      {"hipEnableDefault",                                         "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED}}, // 0
+  {"CU_GET_PROC_ADDRESS_DEFAULT",                                      {"hipEnableDefault",                                         "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES, HIP_EXPERIMENTAL}}, // 0
   // cudaEnableLegacyStream
-  {"CU_GET_PROC_ADDRESS_LEGACY_STREAM",                                {"hipEnableLegacyStream",                                    "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED}}, // 1 << 0
+  {"CU_GET_PROC_ADDRESS_LEGACY_STREAM",                                {"hipEnableLegacyStream",                                    "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES, HIP_EXPERIMENTAL}}, // 1 << 0
   // cudaEnablePerThreadDefaultStream
-  {"CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM",                    {"hipEnablePerThreadDefaultStream",                          "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED}}, // 1 << 1
+  {"CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM",                    {"hipEnablePerThreadDefaultStream",                          "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES, HIP_EXPERIMENTAL}}, // 1 << 1
 
   // cudaFlushGPUDirectRDMAWritesOptions
   {"CUflushGPUDirectRDMAWritesOptions",                                {"hipFlushGPUDirectRDMAWritesOptions",                       "", CONV_TYPE, API_DRIVER, SEC::DATA_TYPES}},
@@ -4868,4 +4868,8 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_DRIVER_TYPE_NAME_VER_MAP {
   {"hipMemRangeFlags",                                                 {HIP_7000, HIP_0,    HIP_0   }},
   {"hipMemRangeFlagDmaBufMappingTypePcie",                             {HIP_7000, HIP_0,    HIP_0   }},
   {"hipLaunchAttributeMax",                                            {HIP_7000, HIP_0,    HIP_0   }},
+  {"ihipLibrary_t",                                                    {HIP_7010, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipLibrary_t",                                                     {HIP_7010, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"ihipKernel_t",                                                     {HIP_7010, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipKernel_t",                                                      {HIP_7010, HIP_0,    HIP_0,  HIP_LATEST}},
 };

--- a/src/CUDA2HIP_Runtime_API_types.cpp
+++ b/src/CUDA2HIP_Runtime_API_types.cpp
@@ -251,10 +251,8 @@ const std::map<llvm::StringRef, hipCounter> CUDA_RUNTIME_TYPE_NAME_MAP {
   // CUlaunchMemSyncDomainMap
   {"cudaLaunchMemSyncDomainMap",                                       {"hipLaunchMemSyncDomainMap",                                "", CONV_TYPE, API_RUNTIME, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
 
-  // the same CUkern_st
-  {"CUkern_st",                                                        {"hipKernel",                                                "", CONV_TYPE, API_RUNTIME, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
   // CUkernel
-  {"cudaKernel_t",                                                     {"hipKernel",                                                "", CONV_TYPE, API_RUNTIME, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
+  {"cudaKernel_t",                                                     {"hipKernel_t",                                              "", CONV_TYPE, API_RUNTIME, SEC::DATA_TYPES, HIP_EXPERIMENTAL}},
 
   // CUDA_MEMCPY_NODE_PARAMS
   {"cudaMemcpyNodeParams",                                             {"hipMemcpyNodeParams",                                      "", CONV_TYPE, API_RUNTIME, SEC::DATA_TYPES}},
@@ -330,7 +328,7 @@ const std::map<llvm::StringRef, hipCounter> CUDA_RUNTIME_TYPE_NAME_MAP {
   {"cudalibraryHostUniversalFunctionAndDataTable",                     {"hipLibraryHostUniversalFunctionAndDataTable",              "", CONV_TYPE, API_RUNTIME, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
 
   // CUlibrary
-  {"cudaLibrary_t",                                                    {"hipLibraty",                                               "", CONV_TYPE, API_RUNTIME, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
+  {"cudaLibrary_t",                                                    {"hipLibrary_t",                                             "", CONV_TYPE, API_RUNTIME, SEC::DATA_TYPES, HIP_EXPERIMENTAL}},
 
   // 3. Enums
 
@@ -1927,11 +1925,11 @@ const std::map<llvm::StringRef, hipCounter> CUDA_RUNTIME_TYPE_NAME_MAP {
   {"cudaGetDriverEntryPointFlags",                                     {"hipGetDriverEntryPointFlags",                              "", CONV_TYPE, API_RUNTIME, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
   // cudaGetDriverEntryPointFlags enum values
   // CU_GET_PROC_ADDRESS_DEFAULT
-  {"cudaEnableDefault",                                                {"hipEnableDefault",                                         "", CONV_NUMERIC_LITERAL, API_RUNTIME, SEC::DATA_TYPES, HIP_UNSUPPORTED}}, // 0x0
+  {"cudaEnableDefault",                                                {"hipEnableDefault",                                         "", CONV_NUMERIC_LITERAL, API_RUNTIME, SEC::DATA_TYPES, HIP_EXPERIMENTAL}}, // 0x0
   // CU_GET_PROC_ADDRESS_LEGACY_STREAM
-  {"cudaEnableLegacyStream",                                           {"hipEnableLegacyStream",                                    "", CONV_NUMERIC_LITERAL, API_RUNTIME, SEC::DATA_TYPES, HIP_UNSUPPORTED}}, // 0x1
+  {"cudaEnableLegacyStream",                                           {"hipEnableLegacyStream",                                    "", CONV_NUMERIC_LITERAL, API_RUNTIME, SEC::DATA_TYPES, HIP_EXPERIMENTAL}}, // 0x1
   // CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM
-  {"cudaEnablePerThreadDefaultStream",                                 {"hipEnablePerThreadDefaultStream",                          "", CONV_NUMERIC_LITERAL, API_RUNTIME, SEC::DATA_TYPES, HIP_UNSUPPORTED}}, // 0x2
+  {"cudaEnablePerThreadDefaultStream",                                 {"hipEnablePerThreadDefaultStream",                          "", CONV_NUMERIC_LITERAL, API_RUNTIME, SEC::DATA_TYPES, HIP_EXPERIMENTAL}}, // 0x2
 
   // CUgraphDebugDot_flags
   {"cudaGraphDebugDotFlags",                                           {"hipGraphDebugDotFlags",                                    "", CONV_TYPE, API_RUNTIME, SEC::DATA_TYPES}},
@@ -2046,14 +2044,14 @@ const std::map<llvm::StringRef, hipCounter> CUDA_RUNTIME_TYPE_NAME_MAP {
   {"cudaGraphInstantiateConditionalHandleUnused",                      {"hipGraphInstantiateConditionalHandleUnused",               "", CONV_NUMERIC_LITERAL, API_RUNTIME, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
 
   // CUdriverProcAddressQueryResult
-  {"cudaDriverEntryPointQueryResult",                                  {"hipDriverProcAddressQueryResult",                           "", CONV_TYPE, API_RUNTIME, SEC::DATA_TYPES}},
+  {"cudaDriverEntryPointQueryResult",                                  {"hipDriverEntryPointQueryResult",                           "", CONV_TYPE, API_RUNTIME, SEC::DATA_TYPES, HIP_EXPERIMENTAL}},
   // cudaDriverEntryPointQueryResult enum values
   // CU_GET_PROC_ADDRESS_SUCCESS
-  {"cudaDriverEntryPointSuccess",                                      {"HIP_GET_PROC_ADDRESS_SUCCESS",                              "", CONV_NUMERIC_LITERAL, API_RUNTIME, SEC::DATA_TYPES}},
+  {"cudaDriverEntryPointSuccess",                                      {"hipDriverEntryPointSuccess",                               "", CONV_NUMERIC_LITERAL, API_RUNTIME, SEC::DATA_TYPES, HIP_EXPERIMENTAL}},
   // CU_GET_PROC_ADDRESS_SYMBOL_NOT_FOUND
-  {"cudaDriverEntryPointSymbolNotFound",                               {"HIP_GET_PROC_ADDRESS_SYMBOL_NOT_FOUND",                     "", CONV_NUMERIC_LITERAL, API_RUNTIME, SEC::DATA_TYPES}},
+  {"cudaDriverEntryPointSymbolNotFound",                               {"hipDriverEntryPointSymbolNotFound",                        "", CONV_NUMERIC_LITERAL, API_RUNTIME, SEC::DATA_TYPES, HIP_EXPERIMENTAL}},
   // CU_GET_PROC_ADDRESS_VERSION_NOT_SUFFICIENT
-  {"cudaDriverEntryPointVersionNotSufficent",                          {"HIP_GET_PROC_ADDRESS_VERSION_NOT_SUFFICIENT",               "", CONV_NUMERIC_LITERAL, API_RUNTIME, SEC::DATA_TYPES}},
+  {"cudaDriverEntryPointVersionNotSufficent",                          {"hipDriverEntryPointVersionNotSufficent",                   "", CONV_NUMERIC_LITERAL, API_RUNTIME, SEC::DATA_TYPES, HIP_EXPERIMENTAL}},
 
   // CUlaunchMemSyncDomain
   {"cudaLaunchMemSyncDomain",                                          {"hipLaunchMemSyncDomain",                                   "", CONV_TYPE, API_RUNTIME, SEC::DATA_TYPES, HIP_UNSUPPORTED}},
@@ -3092,7 +3090,6 @@ const std::map<llvm::StringRef, cudaAPIversions> CUDA_RUNTIME_TYPE_NAME_VER_MAP 
   {"cudaDevAttrReserved128",                                           {CUDA_121, CUDA_0,   CUDA_0  }},
   {"cudaDevAttrReserved129",                                           {CUDA_121, CUDA_0,   CUDA_0  }},
   {"cudaDevAttrReserved132",                                           {CUDA_121, CUDA_0,   CUDA_0  }},
-  {"CUkern_st",                                                        {CUDA_121, CUDA_0,   CUDA_0  }},
   {"cudaKernel_t",                                                     {CUDA_121, CUDA_0,   CUDA_0  }},
   {"cudaMemcpyNodeParams",                                             {CUDA_122, CUDA_0,   CUDA_0  }},
   {"cudaMemsetParamsV2",                                               {CUDA_122, CUDA_0,   CUDA_0  }},
@@ -3718,4 +3715,11 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_RUNTIME_TYPE_NAME_VER_MAP {
   {"hipMemcpy3DOperand",                                               {HIP_7010, HIP_0,    HIP_0,  HIP_LATEST}},
   {"hipMemcpy3DBatchOp",                                               {HIP_7010, HIP_0,    HIP_0,  HIP_LATEST}},
   {"hipMemcpy3DPeerParms",                                             {HIP_7010, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipDriverEntryPointQueryResult",                                   {HIP_7010, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipDriverEntryPointSuccess",                                       {HIP_7010, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipDriverEntryPointSymbolNotFound",                                {HIP_7010, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipDriverEntryPointVersionNotSufficent",                           {HIP_7010, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipEnableDefault",                                                 {HIP_7010, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipEnableLegacyStream",                                            {HIP_7010, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipEnablePerThreadDefaultStream",                                  {HIP_7010, HIP_0,    HIP_0,  HIP_LATEST}},
 };

--- a/tests/unit_tests/synthetic/driver_enums.cu
+++ b/tests/unit_tests/synthetic/driver_enums.cu
@@ -1134,6 +1134,15 @@ int main() {
   CUGPUDirectRDMAWritesOrdering GPU_DIRECT_RDMA_WRITES_ORDERING_NONE = CU_GPU_DIRECT_RDMA_WRITES_ORDERING_NONE;
   CUGPUDirectRDMAWritesOrdering GPU_DIRECT_RDMA_WRITES_ORDERING_OWNER = CU_GPU_DIRECT_RDMA_WRITES_ORDERING_OWNER;
   CUGPUDirectRDMAWritesOrdering GPU_DIRECT_RDMA_WRITES_ORDERING_ALL_DEVICES = CU_GPU_DIRECT_RDMA_WRITES_ORDERING_ALL_DEVICES;
+
+  // NOTE [HIP]: Why these numbers implemented as defines and not as enum values like in CUDA?
+  // TODO [HIP]: Consider changing them to enum values in future HIP releases: enum cudaGetDriverEntryPointFlags -> enum hipGetDriverEntryPointFlags
+  // CHECK: int EnableDefault = hipEnableDefault;
+  // CHECK-NEXT: int EnableLegacyStream = hipEnableLegacyStream;
+  // CHECK-NEXT: int EnablePerThreadDefaultStream = hipEnablePerThreadDefaultStream;
+  int EnableDefault = CU_GET_PROC_ADDRESS_DEFAULT;
+  int EnableLegacyStream = CU_GET_PROC_ADDRESS_LEGACY_STREAM;
+  int EnablePerThreadDefaultStream = CU_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM;
 #endif
 
 #if CUDA_VERSION >= 11040

--- a/tests/unit_tests/synthetic/driver_structs.cu
+++ b/tests/unit_tests/synthetic/driver_structs.cu
@@ -335,6 +335,11 @@ int main() {
   // CHECK-NEXT: hipGraphInstantiateParams GRAPH_INSTANTIATE_PARAMS;
   CUDA_GRAPH_INSTANTIATE_PARAMS_st GRAPH_INSTANTIATE_PARAMS_st;
   CUDA_GRAPH_INSTANTIATE_PARAMS GRAPH_INSTANTIATE_PARAMS;
+
+  // CHECK: ihipKernel_t *kern_st = nullptr;
+// CHECK-NEXT: hipKernel_t kernel;
+  CUkern_st *kern_st = nullptr;
+  CUkernel kernel;
 #endif
 
 #if CUDA_VERSION >= 12020

--- a/tests/unit_tests/synthetic/runtime_enums.cu
+++ b/tests/unit_tests/synthetic/runtime_enums.cu
@@ -871,6 +871,15 @@ int main() {
   cudaGPUDirectRDMAWritesOrdering GPU_DIRECT_RDMA_WRITES_ORDERING_NONE = cudaGPUDirectRDMAWritesOrderingNone;
   cudaGPUDirectRDMAWritesOrdering GPU_DIRECT_RDMA_WRITES_ORDERING_OWNER = cudaGPUDirectRDMAWritesOrderingOwner;
   cudaGPUDirectRDMAWritesOrdering GPU_DIRECT_RDMA_WRITES_ORDERING_ALL_DEVICES = cudaGPUDirectRDMAWritesOrderingAllDevices;
+
+  // NOTE [HIP]: Why these numbers implemented as defines and not as enum values like in CUDA?
+  // TODO [HIP]: Consider changing them to enum values in future HIP releases: enum cudaGetDriverEntryPointFlags -> enum hipGetDriverEntryPointFlags
+  // CHECK: int EnableDefault = hipEnableDefault;
+  // CHECK-NEXT: int EnableLegacyStream = hipEnableLegacyStream;
+  // CHECK-NEXT: int EnablePerThreadDefaultStream = hipEnablePerThreadDefaultStream;
+  int EnableDefault = cudaEnableDefault;
+  int EnableLegacyStream = cudaEnableLegacyStream;
+  int EnablePerThreadDefaultStream = cudaEnablePerThreadDefaultStream;
 #endif
 
 #if CUDA_VERSION >= 11040
@@ -936,10 +945,10 @@ int main() {
   cudaLaunchAttributeID LAUNCH_ATTRIBUTE_COOPERATIVE = cudaLaunchAttributeCooperative;
   cudaLaunchAttributeID LAUNCH_ATTRIBUTE_PRIORITY = cudaLaunchAttributePriority;
 
-  // CHECK: hipDriverProcAddressQueryResult driverProcAddressQueryResult;
-  // CHECK-NEXT:hipDriverProcAddressQueryResult GET_PROC_ADDRESS_SUCCESS = HIP_GET_PROC_ADDRESS_SUCCESS;
-  // CHECK-NEXT:hipDriverProcAddressQueryResult GET_PROC_ADDRESS_SYMBOL_NOT_FOUND = HIP_GET_PROC_ADDRESS_SYMBOL_NOT_FOUND;
-  // CHECK-NEXT:hipDriverProcAddressQueryResult GET_PROC_ADDRESS_VERSION_NOT_SUFFICIENT = HIP_GET_PROC_ADDRESS_VERSION_NOT_SUFFICIENT;
+  // CHECK: hipDriverEntryPointQueryResult driverProcAddressQueryResult;
+  // CHECK-NEXT:hipDriverEntryPointQueryResult GET_PROC_ADDRESS_SUCCESS = hipDriverEntryPointSuccess;
+  // CHECK-NEXT:hipDriverEntryPointQueryResult GET_PROC_ADDRESS_SYMBOL_NOT_FOUND = hipDriverEntryPointSymbolNotFound;
+  // CHECK-NEXT:hipDriverEntryPointQueryResult GET_PROC_ADDRESS_VERSION_NOT_SUFFICIENT = hipDriverEntryPointVersionNotSufficent;
   cudaDriverEntryPointQueryResult driverProcAddressQueryResult;
   cudaDriverEntryPointQueryResult GET_PROC_ADDRESS_SUCCESS = cudaDriverEntryPointSuccess;
   cudaDriverEntryPointQueryResult GET_PROC_ADDRESS_SYMBOL_NOT_FOUND = cudaDriverEntryPointSymbolNotFound;

--- a/tests/unit_tests/synthetic/runtime_functions_12000.cu
+++ b/tests/unit_tests/synthetic/runtime_functions_12000.cu
@@ -37,13 +37,14 @@ int main() {
   // CHECK: result = hipGraphInstantiateWithFlags(&GraphExec_t, Graph_t, ull);
   result = cudaGraphInstantiate(&GraphExec_t, Graph_t, ull);
 
-  // CHECK: hipDriverProcAddressQueryResult driverProcAddressQueryResult;
+  // CHECK: hipDriverEntryPointQueryResult driverProcAddressQueryResult;
   cudaDriverEntryPointQueryResult driverProcAddressQueryResult;
 
   // CUDA: extern __host__ cudaError_t CUDARTAPI cudaGetDriverEntryPoint(const char *symbol, void **funcPtr, unsigned long long flags, enum cudaDriverEntryPointQueryResult *driverStatus = NULL);
   // CUDA < 12000: extern __host__ cudaError_t CUDARTAPI cudaGetDriverEntryPoint(const char *symbol, void **funcPtr, unsigned long long flags);
   // NOTE: cudaGetDriverEntryPoint for CUDA < 12000 is not supported by HIP
   // TODO: detect cudaGetDriverEntryPoint signature and report warning/error for old (before CUDA 12.0) signature
+  // NOTE: [HIP] hipDriverEntryPointQueryResult should be used instead of hipDriverProcAddressQueryResult
   // HIP: hipError_t hipGetProcAddress(const char* symbol, void** pfn, int hipVersion, uint64_t flags, hipDriverProcAddressQueryResult* symbolStatus);
   // TODO: add an explicit static_cast<uint64_t> for ull
   // CHECK: result = hipGetProcAddress(symbol.c_str(), &pfn, 701, ull, &driverProcAddressQueryResult);

--- a/tests/unit_tests/synthetic/runtime_structs.cu
+++ b/tests/unit_tests/synthetic/runtime_structs.cu
@@ -212,6 +212,11 @@ int main() {
   cudaGraphInstantiateParams GRAPH_INSTANTIATE_PARAMS;
 #endif
 
+#if CUDA_VERSION >= 12010
+  // CHECK: hipKernel_t Kernel_t;
+  cudaKernel_t Kernel_t;
+#endif
+
 #if CUDA_VERSION >= 12020
   // CHECK: hipExternalSemaphoreSignalNodeParams ExternalSemaphoreSignalNodeParams_v2;
   cudaExternalSemaphoreSignalNodeParamsV2 ExternalSemaphoreSignalNodeParams_v2;


### PR DESCRIPTION
+ Updated synthetic tests, the regenerated `hipify-perl`, and `Driver` and `Runtime` `CUDA2HIP` docs accordingly
+ NOTE [HIP]: Why are the numbers `hipEnableDefault`, `hipEnableLegacyStream`, and `hipEnablePerThreadDefaultStream` implemented as defines and not as enum values like in CUDA?
+ TODO [HIP]: Consider changing them to enum values in future HIP releases: `enum cudaGetDriverEntryPointFlags` -> `enum hipGetDriverEntryPointFlags`
