### PR TITLE
[HIPIFY][SWDEV-529096][fix][Linux] Updates the cuDNN and cuTENSOR version check file logic

### DIFF
--- a/tests/lit.site.cfg.in
+++ b/tests/lit.site.cfg.in
@@ -36,18 +36,18 @@ def get_lib_major_ver(file_name):
     return 0
 
 def get_cudnn_major_ver():
-    ver_file = config.cuda_dnn_root + '/include/cudnn_version.h'
+    ver_file = config.cuda_dnn_root + '/cudnn_version.h'
     ver = get_lib_major_ver(ver_file)
     if ver == 0:
-        ver_file = config.cuda_dnn_root + '/include/cudnn_version_v9.h'
+        ver_file = config.cuda_dnn_root + '/cudnn_version_v9.h'
         ver = get_lib_major_ver(ver_file)
     if ver == 0:
-        ver_file = config.cuda_dnn_root + '/include/cudnn_version_v999.h'
+        ver_file = config.cuda_dnn_root + '/cudnn_version_v999.h'
         ver = get_lib_major_ver(ver_file)
     return int(ver)
 
 def get_cutensor_major_ver():
-    ver_file = config.cuda_tensor_root + '/include/cutensor.h'
+    ver_file = config.cuda_tensor_root + '/cutensor.h'
     ver = get_lib_major_ver(ver_file)
     if ver == 0:
         ver = 1


### PR DESCRIPTION
## Motivation

`unit_tests/synthetic/libraries/cudnn2miopen_before_9000.cu` test failure observed for `cuDNN >= 9`.

## Root Cause
`cudnn2miopen_before_9000.cu` test should not run if the cuDUNN is `>= 9`. The `get_cu*_major_ver()` logic is resulting wrong path for header files`(/usr/include/include/cudnn_version_v9.h)` which results in cudnn major version is `0`. Becuase of this, the test is not excluded for `cuDNN >= 9 `versions. 

## Solution
Remove the extra `/include` from the version logic. `cmake *` command in the build steps is already including the direct header files path instead of parent path.