### PR TITLE
[HIPIFY][#2162][clang][compatibility] Conditionally include `TargetInfo.h`

### DIFF
--- a/src/HipifyAction.cpp
+++ b/src/HipifyAction.cpp
@@ -30,7 +30,9 @@ THE SOFTWARE.
 #include "clang/ASTMatchers/ASTMatchFinder.h"
 #include "clang/ASTMatchers/ASTMatchers.h"
 #include "clang/Lex/HeaderSearch.h"
+#if LLVM_VERSION_MAJOR < 17
 #include "clang/Basic/TargetInfo.h"
+#endif
 #include "LLVMCompat.h"
 #include "CUDA2HIP.h"
 #include "StringUtils.h"


### PR DESCRIPTION
+ `TargetInfo.h` is implicitly included by `CompilerInstance.h` starting from `LLVM 17`
+ For `LLVM < 17`, include `TargetInfo.h` explicitly under the corresponding preprocessor guard
