### PR TITLE
[HIPIFY][7.1][HIP] Sync with `ROCm HIP 7.1` - Part 3 - `HIP` - Step 6 - Driver Functions

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -1748,6 +1748,15 @@ my %experimental_funcs = (
     "cuStreamSetAttribute" => "7.1.0",
     "cuStreamGetId" => "7.1.0",
     "cuStreamGetAttribute" => "7.1.0",
+    "cuMemsetD2D8_v2" => "7.1.0",
+    "cuMemsetD2D8Async" => "7.1.0",
+    "cuMemsetD2D8" => "7.1.0",
+    "cuMemsetD2D32_v2" => "7.1.0",
+    "cuMemsetD2D32Async" => "7.1.0",
+    "cuMemsetD2D32" => "7.1.0",
+    "cuMemsetD2D16_v2" => "7.1.0",
+    "cuMemsetD2D16Async" => "7.1.0",
+    "cuMemsetD2D16" => "7.1.0",
     "FFTW_WISDOM_ONLY" => "7.1.0",
     "FFTW_UNALIGNED" => "7.1.0",
     "FFTW_PRESERVE_INPUT" => "7.1.0",
@@ -1955,6 +1964,15 @@ sub subst {
 }
 
 sub experimentalSubstitutions {
+    subst("cuMemsetD2D16", "hipMemsetD2D16", "memory");
+    subst("cuMemsetD2D16Async", "hipMemsetD2D16Async", "memory");
+    subst("cuMemsetD2D16_v2", "hipMemsetD2D16", "memory");
+    subst("cuMemsetD2D32", "hipMemsetD2D32", "memory");
+    subst("cuMemsetD2D32Async", "hipMemsetD2D32Async", "memory");
+    subst("cuMemsetD2D32_v2", "hipMemsetD2D32", "memory");
+    subst("cuMemsetD2D8", "hipMemsetD2D8", "memory");
+    subst("cuMemsetD2D8Async", "hipMemsetD2D8Async", "memory");
+    subst("cuMemsetD2D8_v2", "hipMemsetD2D8", "memory");
     subst("cuStreamGetAttribute", "hipStreamGetAttribute", "stream");
     subst("cuStreamGetId", "hipStreamGetId", "stream");
     subst("cuStreamSetAttribute", "hipStreamSetAttribute", "stream");
@@ -12540,15 +12558,6 @@ sub warnRemovedFunctions {
     "cuModuleGetFunctionCount",
     "cuModuleEnumerateFunctions",
     "cuMipmappedArrayGetMemoryRequirements",
-    "cuMemsetD2D8_v2",
-    "cuMemsetD2D8Async",
-    "cuMemsetD2D8",
-    "cuMemsetD2D32_v2",
-    "cuMemsetD2D32Async",
-    "cuMemsetD2D32",
-    "cuMemsetD2D16_v2",
-    "cuMemsetD2D16Async",
-    "cuMemsetD2D16",
     "cuMemcpyPeerAsync",
     "cuMemcpyPeer",
     "cuMemcpyBatchAsync",

--- a/docs/reference/tables/CUDA_Driver_API_functions_supported_by_HIP.md
+++ b/docs/reference/tables/CUDA_Driver_API_functions_supported_by_HIP.md
@@ -1864,15 +1864,15 @@
 |`cuMemsetD16`| | | | |`hipMemsetD16`|3.0.0| | | | | |
 |`cuMemsetD16Async`| | | | |`hipMemsetD16Async`|3.0.0| | | | | |
 |`cuMemsetD16_v2`| | | | |`hipMemsetD16`|3.0.0| | | | | |
-|`cuMemsetD2D16`| | | | | | | | | | | |
-|`cuMemsetD2D16Async`| | | | | | | | | | | |
-|`cuMemsetD2D16_v2`| | | | | | | | | | | |
-|`cuMemsetD2D32`| | | | | | | | | | | |
-|`cuMemsetD2D32Async`| | | | | | | | | | | |
-|`cuMemsetD2D32_v2`| | | | | | | | | | | |
-|`cuMemsetD2D8`| | | | | | | | | | | |
-|`cuMemsetD2D8Async`| | | | | | | | | | | |
-|`cuMemsetD2D8_v2`| | | | | | | | | | | |
+|`cuMemsetD2D16`| | | | |`hipMemsetD2D16`|7.1.0| | | | |7.1.0|
+|`cuMemsetD2D16Async`| | | | |`hipMemsetD2D16Async`|7.1.0| | | | |7.1.0|
+|`cuMemsetD2D16_v2`| | | | |`hipMemsetD2D16`|7.1.0| | | | |7.1.0|
+|`cuMemsetD2D32`| | | | |`hipMemsetD2D32`|7.1.0| | | | |7.1.0|
+|`cuMemsetD2D32Async`| | | | |`hipMemsetD2D32Async`|7.1.0| | | | |7.1.0|
+|`cuMemsetD2D32_v2`| | | | |`hipMemsetD2D32`|7.1.0| | | | |7.1.0|
+|`cuMemsetD2D8`| | | | |`hipMemsetD2D8`|7.1.0| | | | |7.1.0|
+|`cuMemsetD2D8Async`| | | | |`hipMemsetD2D8Async`|7.1.0| | | | |7.1.0|
+|`cuMemsetD2D8_v2`| | | | |`hipMemsetD2D8`|7.1.0| | | | |7.1.0|
 |`cuMemsetD32`| | | | |`hipMemsetD32`|2.3.0| | | | | |
 |`cuMemsetD32Async`| | | | |`hipMemsetD32Async`|2.3.0| | | | | |
 |`cuMemsetD32_v2`| | | | |`hipMemsetD32`|2.3.0| | | | | |

--- a/src/CUDA2HIP_Driver_API_functions.cpp
+++ b/src/CUDA2HIP_Driver_API_functions.cpp
@@ -359,20 +359,20 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_FUNCTION_MAP {
   // no analogue
   {"cuMemsetD16Async",                                            {"hipMemsetD16Async",                                           "", CONV_MEMORY, API_DRIVER, SEC::MEMORY}},
   // no analogue
-  {"cuMemsetD2D16",                                               {"hipMemsetD2D16",                                              "", CONV_MEMORY, API_DRIVER, SEC::MEMORY, HIP_UNSUPPORTED}},
-  {"cuMemsetD2D16_v2",                                            {"hipMemsetD2D16",                                              "", CONV_MEMORY, API_DRIVER, SEC::MEMORY, HIP_UNSUPPORTED}},
+  {"cuMemsetD2D16",                                               {"hipMemsetD2D16",                                              "", CONV_MEMORY, API_DRIVER, SEC::MEMORY, HIP_EXPERIMENTAL}},
+  {"cuMemsetD2D16_v2",                                            {"hipMemsetD2D16",                                              "", CONV_MEMORY, API_DRIVER, SEC::MEMORY, HIP_EXPERIMENTAL}},
   // no analogue
-  {"cuMemsetD2D16Async",                                          {"hipMemsetD2D16Async",                                         "", CONV_MEMORY, API_DRIVER, SEC::MEMORY, HIP_UNSUPPORTED}},
+  {"cuMemsetD2D16Async",                                          {"hipMemsetD2D16Async",                                         "", CONV_MEMORY, API_DRIVER, SEC::MEMORY, HIP_EXPERIMENTAL}},
   // no analogue
-  {"cuMemsetD2D32",                                               {"hipMemsetD2D32",                                              "", CONV_MEMORY, API_DRIVER, SEC::MEMORY, HIP_UNSUPPORTED}},
-  {"cuMemsetD2D32_v2",                                            {"hipMemsetD2D32",                                              "", CONV_MEMORY, API_DRIVER, SEC::MEMORY, HIP_UNSUPPORTED}},
+  {"cuMemsetD2D32",                                               {"hipMemsetD2D32",                                              "", CONV_MEMORY, API_DRIVER, SEC::MEMORY, HIP_EXPERIMENTAL}},
+  {"cuMemsetD2D32_v2",                                            {"hipMemsetD2D32",                                              "", CONV_MEMORY, API_DRIVER, SEC::MEMORY, HIP_EXPERIMENTAL}},
   // no analogue
-  {"cuMemsetD2D32Async",                                          {"hipMemsetD2D32Async",                                         "", CONV_MEMORY, API_DRIVER, SEC::MEMORY, HIP_UNSUPPORTED}},
+  {"cuMemsetD2D32Async",                                          {"hipMemsetD2D32Async",                                         "", CONV_MEMORY, API_DRIVER, SEC::MEMORY, HIP_EXPERIMENTAL}},
   // no analogue
-  {"cuMemsetD2D8",                                                {"hipMemsetD2D8",                                               "", CONV_MEMORY, API_DRIVER, SEC::MEMORY, HIP_UNSUPPORTED}},
-  {"cuMemsetD2D8_v2",                                             {"hipMemsetD2D8",                                               "", CONV_MEMORY, API_DRIVER, SEC::MEMORY, HIP_UNSUPPORTED}},
+  {"cuMemsetD2D8",                                                {"hipMemsetD2D8",                                               "", CONV_MEMORY, API_DRIVER, SEC::MEMORY, HIP_EXPERIMENTAL}},
+  {"cuMemsetD2D8_v2",                                             {"hipMemsetD2D8",                                               "", CONV_MEMORY, API_DRIVER, SEC::MEMORY, HIP_EXPERIMENTAL}},
   // no analogue
-  {"cuMemsetD2D8Async",                                           {"hipMemsetD2D8Async",                                          "", CONV_MEMORY, API_DRIVER, SEC::MEMORY, HIP_UNSUPPORTED}},
+  {"cuMemsetD2D8Async",                                           {"hipMemsetD2D8Async",                                          "", CONV_MEMORY, API_DRIVER, SEC::MEMORY, HIP_EXPERIMENTAL}},
   // cudaMemset
   {"cuMemsetD32",                                                 {"hipMemsetD32",                                                "", CONV_MEMORY, API_DRIVER, SEC::MEMORY}},
   {"cuMemsetD32_v2",                                              {"hipMemsetD32",                                                "", CONV_MEMORY, API_DRIVER, SEC::MEMORY}},
@@ -1771,6 +1771,12 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_DRIVER_FUNCTION_VER_MAP {
   {"hipEventRecordWithFlags",                                     {HIP_6040, HIP_0,    HIP_0   }},
   {"hipDrvLaunchKernelEx",                                        {HIP_7000, HIP_0,    HIP_0   }},
   {"hipMemGetHandleForAddressRange",                              {HIP_7000, HIP_0,    HIP_0   }},
+  {"hipMemsetD2D8",                                               {HIP_7010, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipMemsetD2D8Async",                                          {HIP_7010, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipMemsetD2D16",                                              {HIP_7010, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipMemsetD2D16Async",                                         {HIP_7010, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipMemsetD2D32",                                              {HIP_7010, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipMemsetD2D32Async",                                         {HIP_7010, HIP_0,    HIP_0,  HIP_LATEST}},
 };
 
 const std::map<llvm::StringRef, cudaAPIChangedVersions> CUDA_DRIVER_FUNCTION_CHANGED_VER_MAP {

--- a/tests/unit_tests/synthetic/driver_functions.cu
+++ b/tests/unit_tests/synthetic/driver_functions.cu
@@ -34,6 +34,7 @@ int main() {
   int hipVersion = 0;
   size_t bytes = 0;
   size_t bytes_2 = 0;
+  size_t dstPitch = 0;
   void *image = nullptr;
   void *pfn = nullptr;
   void *paramsprt = nullptr;
@@ -583,6 +584,46 @@ int main() {
   // HIP: hipError_t hipMemsetD8Async(hipDeviceptr_t dest, unsigned char value, size_t count, hipStream_t stream __dparm(0));
   // CHECK: result = hipMemsetD8Async(deviceptr, uc, bytes, stream);
   result = cuMemsetD8Async(deviceptr, uc, bytes, stream);
+
+  // CUDA: CUresult CUDAAPI cuMemsetD2D8   (CUdeviceptr dstDevice, size_t dstPitch, unsigned char uc, size_t Width, size_t Height);
+  // CUDA: CUresult CUDAAPI cuMemsetD2D8_v2(CUdeviceptr dstDevice, size_t dstPitch, unsigned char uc, size_t Width, size_t Height);
+  // HIP: hipError_t hipMemsetD2D8(hipDeviceptr_t dst, size_t dstPitch, unsigned char value, size_t width, size_t height);
+  // CHECK: result = hipMemsetD2D8(deviceptr, dstPitch, uc, width, height);
+  // CHECK-NEXT: result = hipMemsetD2D8(deviceptr, dstPitch, uc, width, height);
+  result = cuMemsetD2D8(deviceptr, dstPitch, uc, width, height);
+  result = cuMemsetD2D8_v2(deviceptr, dstPitch, uc, width, height);
+
+  // CUDA: CUresult CUDAAPI cuMemsetD2D8Async(CUdeviceptr dstDevice, size_t dstPitch, unsigned char uc, size_t Width, size_t Height, CUstream hStream);
+  // HIP: hipError_t hipMemsetD2D8Async(hipDeviceptr_t dst, size_t dstPitch, unsigned char value, size_t width, size_t height, hipStream_t stream __dparm(0));
+  // CHECK: result = hipMemsetD2D8Async(deviceptr, dstPitch, uc, width, height, stream);
+  result = cuMemsetD2D8Async(deviceptr, dstPitch, uc, width, height, stream);
+
+  // CUDA: CUresult CUDAAPI cuMemsetD2D16   (CUdeviceptr dstDevice, size_t dstPitch, unsigned short us, size_t Width, size_t Height);
+  // CUDA: CUresult CUDAAPI cuMemsetD2D16_v2(CUdeviceptr dstDevice, size_t dstPitch, unsigned short us, size_t Width, size_t Height);
+  // HIP: hipError_t hipMemsetD2D16(hipDeviceptr_t dst, size_t dstPitch, unsigned short value, size_t width, size_t height);
+  // CHECK: result = hipMemsetD2D16(deviceptr, dstPitch, us, width, height);
+  // CHECK-NEXT: result = hipMemsetD2D16(deviceptr, dstPitch, us, width, height);
+  result = cuMemsetD2D16(deviceptr, dstPitch, us, width, height);
+  result = cuMemsetD2D16_v2(deviceptr, dstPitch, us, width, height);
+
+  // CUDA: CUresult CUDAAPI cuMemsetD2D16Async(CUdeviceptr dstDevice, size_t dstPitch, unsigned short us, size_t Width, size_t Height, CUstream hStream);
+  // HIP: hipError_t hipMemsetD2D16Async(hipDeviceptr_t dst, size_t dstPitch, unsigned short value, size_t width, size_t height, hipStream_t stream __dparm(0));
+  // CHECK: result = hipMemsetD2D16Async(deviceptr, dstPitch, us, width, height, stream);
+  result = cuMemsetD2D16Async(deviceptr, dstPitch, us, width, height, stream);
+
+  unsigned int ui = 0;
+  // CUDA: CUresult CUDAAPI cuMemsetD2D32   (CUdeviceptr dstDevice, size_t dstPitch, unsigned int ui, size_t Width, size_t Height);
+  // CUDA: CUresult CUDAAPI cuMemsetD2D32_v2(CUdeviceptr dstDevice, size_t dstPitch, unsigned int ui, size_t Width, size_t Height);
+  // HIP: hipError_t hipMemsetD2D32(hipDeviceptr_t dst, size_t dstPitch, unsigned int value, size_t width, size_t height);
+  // CHECK: result = hipMemsetD2D32(deviceptr, dstPitch, ui, width, height);
+  // CHECK-NEXT: result = hipMemsetD2D32(deviceptr, dstPitch, ui, width, height);
+  result = cuMemsetD2D32(deviceptr, dstPitch, ui, width, height);
+  result = cuMemsetD2D32_v2(deviceptr, dstPitch, ui, width, height);
+
+  // CUDA: CUresult CUDAAPI cuMemsetD2D32Async(CUdeviceptr dstDevice, size_t dstPitch, unsigned int ui, size_t Width, size_t Height, CUstream hStream);
+  // HIP: hipError_t hipMemsetD2D32Async(hipDeviceptr_t dst, size_t dstPitch, unsigned int value, size_t width, size_t height, hipStream_t stream __dparm(0));
+  // CHECK: result = hipMemsetD2D32Async(deviceptr, dstPitch, ui, width, height, stream);
+  result = cuMemsetD2D32Async(deviceptr, dstPitch, ui, width, height, stream);
 
   // CUDA: CUresult CUDAAPI cuMipmappedArrayCreate(CUmipmappedArray *pHandle, const CUDA_ARRAY3D_DESCRIPTOR *pMipmappedArrayDesc, unsigned int numMipmapLevels);
   // HIP: hipError_t hipMipmappedArrayCreate(hipMipmappedArray_t* pHandle, HIP_ARRAY3D_DESCRIPTOR* pMipmappedArrayDesc, unsigned int numMipmapLevels);


### PR DESCRIPTION
+ Updated synthetic tests, the regenerated `hipify-perl`, and `Driver` `CUDA2HIP` docs accordingly
