### PR TITLE
[HIPIFY][7.1][HIP] Sync with `ROCm HIP 7.1` - Part 3 - `HIP` - Step 7 - `Runtime` and `Driver` Functions

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -1747,11 +1747,15 @@ my %experimental_funcs = (
     "cudaMemcpyFlags" => "7.1.0",
     "cudaMemcpyFlagPreferOverlapWithCompute" => "7.1.0",
     "cudaMemcpyFlagDefault" => "7.1.0",
+    "cudaMemcpyBatchAsync" => "7.1.0",
     "cudaMemcpyAttributes" => "7.1.0",
     "cudaMemcpy3DPeerParms" => "7.1.0",
+    "cudaMemcpy3DPeerAsync" => "7.1.0",
+    "cudaMemcpy3DPeer" => "7.1.0",
     "cudaMemcpy3DOperandType" => "7.1.0",
     "cudaMemcpy3DOperand" => "7.1.0",
     "cudaMemcpy3DBatchOp" => "7.1.0",
+    "cudaMemcpy3DBatchAsync" => "7.1.0",
     "cudaMemLocationTypeNone" => "7.1.0",
     "cudaMemLocationTypeHostNumaCurrent" => "7.1.0",
     "cudaMemLocationTypeHostNuma" => "7.1.0",
@@ -1789,6 +1793,8 @@ my %experimental_funcs = (
     "cuMemsetD2D16_v2" => "7.1.0",
     "cuMemsetD2D16Async" => "7.1.0",
     "cuMemsetD2D16" => "7.1.0",
+    "cuMemcpyBatchAsync" => "7.1.0",
+    "cuMemcpy3DBatchAsync" => "7.1.0",
     "cuLibraryEnumerateKernels" => "7.2.0",
     "cuKernelGetName" => "7.2.0",
     "cuKernelGetLibrary" => "7.2.0",
@@ -2004,6 +2010,8 @@ sub experimentalSubstitutions {
     subst("cuKernelGetName", "hipKernelGetName", "library");
     subst("cuLibraryEnumerateKernels", "hipLibraryEnumerateKernels", "library");
     subst("cudaLibraryEnumerateKernels", "hipLibraryEnumerateKernels", "library");
+    subst("cuMemcpy3DBatchAsync", "hipMemcpy3DBatchAsync", "memory");
+    subst("cuMemcpyBatchAsync", "hipMemcpyBatchAsync", "memory");
     subst("cuMemsetD2D16", "hipMemsetD2D16", "memory");
     subst("cuMemsetD2D16Async", "hipMemsetD2D16Async", "memory");
     subst("cuMemsetD2D16_v2", "hipMemsetD2D16", "memory");
@@ -2013,6 +2021,10 @@ sub experimentalSubstitutions {
     subst("cuMemsetD2D8", "hipMemsetD2D8", "memory");
     subst("cuMemsetD2D8Async", "hipMemsetD2D8Async", "memory");
     subst("cuMemsetD2D8_v2", "hipMemsetD2D8", "memory");
+    subst("cudaMemcpy3DBatchAsync", "hipMemcpy3DBatchAsync", "memory");
+    subst("cudaMemcpy3DPeer", "hipMemcpy3DPeer", "memory");
+    subst("cudaMemcpy3DPeerAsync", "hipMemcpy3DPeerAsync", "memory");
+    subst("cudaMemcpyBatchAsync", "hipMemcpyBatchAsync", "memory");
     subst("cuStreamCopyAttributes", "hipStreamCopyAttributes", "stream");
     subst("cuStreamGetAttribute", "hipStreamGetAttribute", "stream");
     subst("cuStreamGetId", "hipStreamGetId", "stream");
@@ -11902,11 +11914,7 @@ sub warnRemovedFunctions {
     "cudaMemoryTypeUnregistered",
     "cudaMemcpyToArrayAsync",
     "cudaMemcpyFromArrayAsync",
-    "cudaMemcpyBatchAsync",
     "cudaMemcpyArrayToArray",
-    "cudaMemcpy3DPeerAsync",
-    "cudaMemcpy3DPeer",
-    "cudaMemcpy3DBatchAsync",
     "cudaMemSetMemPool",
     "cudaMemRangeAttributePreferredLocationType",
     "cudaMemRangeAttributePreferredLocationId",
@@ -12654,11 +12662,9 @@ sub warnRemovedFunctions {
     "cuMipmappedArrayGetMemoryRequirements",
     "cuMemcpyPeerAsync",
     "cuMemcpyPeer",
-    "cuMemcpyBatchAsync",
     "cuMemcpyAsync",
     "cuMemcpy3DPeerAsync",
     "cuMemcpy3DPeer",
-    "cuMemcpy3DBatchAsync",
     "cuMemcpy",
     "cuMemSetMemPool",
     "cuMemPrefetchBatchAsync",

--- a/docs/reference/tables/CUDA_Driver_API_functions_supported_by_HIP.md
+++ b/docs/reference/tables/CUDA_Driver_API_functions_supported_by_HIP.md
@@ -1827,7 +1827,7 @@
 |`cuMemcpy3D`| | | | |`hipDrvMemcpy3D`|3.5.0| | | | | |
 |`cuMemcpy3DAsync`| | | | |`hipDrvMemcpy3DAsync`|3.5.0| | | | | |
 |`cuMemcpy3DAsync_v2`| | | | |`hipDrvMemcpy3DAsync`|3.5.0| | | | | |
-|`cuMemcpy3DBatchAsync`|12.8| |13.0| | | | | | | | |
+|`cuMemcpy3DBatchAsync`|12.8| |13.0| |`hipMemcpy3DBatchAsync`|7.1.0| | | |13.0|7.1.0|
 |`cuMemcpy3DPeer`| | | | | | | | | | | |
 |`cuMemcpy3DPeerAsync`| | | | | | | | | | | |
 |`cuMemcpy3D_v2`| | | | |`hipDrvMemcpy3D`|3.5.0| | | | | |
@@ -1840,7 +1840,7 @@
 |`cuMemcpyAtoHAsync`| | | | |`hipMemcpyAtoHAsync`|6.2.0| | | | | |
 |`cuMemcpyAtoHAsync_v2`| | | | |`hipMemcpyAtoHAsync`|6.2.0| | | | | |
 |`cuMemcpyAtoH_v2`| | | | |`hipMemcpyAtoH`|1.9.0| | | | | |
-|`cuMemcpyBatchAsync`|12.8| |13.0| | | | | | | | |
+|`cuMemcpyBatchAsync`|12.8| |13.0| |`hipMemcpyBatchAsync`|7.1.0| | | |13.0|7.1.0|
 |`cuMemcpyDtoA`| | | | |`hipMemcpyDtoA`|6.2.0| | | | | |
 |`cuMemcpyDtoA_v2`| | | | |`hipMemcpyDtoA`|6.2.0| | | | | |
 |`cuMemcpyDtoD`| | | | |`hipMemcpyDtoD`|1.6.0| | | | | |

--- a/docs/reference/tables/CUDA_Runtime_API_functions_supported_by_HIP.md
+++ b/docs/reference/tables/CUDA_Runtime_API_functions_supported_by_HIP.md
@@ -211,11 +211,11 @@
 |`cudaMemcpy2DToArrayAsync`| | | | |`hipMemcpy2DToArrayAsync`|4.3.0| | | | | |
 |`cudaMemcpy3D`| | | | |`hipMemcpy3D`|1.6.0| | | | | |
 |`cudaMemcpy3DAsync`| | | | |`hipMemcpy3DAsync`|2.8.0| | | | | |
-|`cudaMemcpy3DBatchAsync`|12.8| |13.0| | | | | | | | |
-|`cudaMemcpy3DPeer`| | | | | | | | | | | |
-|`cudaMemcpy3DPeerAsync`| | | | | | | | | | | |
+|`cudaMemcpy3DBatchAsync`|12.8| |13.0| |`hipMemcpy3DBatchAsync`|7.1.0| | | |13.0|7.1.0|
+|`cudaMemcpy3DPeer`| | | | |`hipMemcpy3DPeer`|7.1.0| | | | |7.1.0|
+|`cudaMemcpy3DPeerAsync`| | | | |`hipMemcpy3DPeerAsync`|7.1.0| | | | |7.1.0|
 |`cudaMemcpyAsync`| | | | |`hipMemcpyAsync`|1.6.0| | | | | |
-|`cudaMemcpyBatchAsync`|12.8| |13.0| | | | | | | | |
+|`cudaMemcpyBatchAsync`|12.8| |13.0| |`hipMemcpyBatchAsync`|7.1.0| | | |13.0|7.1.0|
 |`cudaMemcpyFromSymbol`| | | | |`hipMemcpyFromSymbol`|1.6.0| | | | | |
 |`cudaMemcpyFromSymbolAsync`| | | | |`hipMemcpyFromSymbolAsync`|1.6.0| | | | | |
 |`cudaMemcpyPeer`| | | | |`hipMemcpyPeer`|1.6.0| | | | | |

--- a/src/CUDA2HIP_Driver_API_functions.cpp
+++ b/src/CUDA2HIP_Driver_API_functions.cpp
@@ -325,9 +325,9 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_FUNCTION_MAP {
   // NOTE: Not equal to cudaMemcpyPeerAsync due to different signatures
   {"cuMemcpyPeerAsync",                                           {"hipMemcpyPeerAsync_",                                         "", CONV_MEMORY, API_DRIVER, SEC::MEMORY, HIP_UNSUPPORTED}},
   // cudaMemcpyBatchAsync
-  {"cuMemcpyBatchAsync",                                          {"hipMemcpyBatchAsync",                                         "", CONV_MEMORY, API_DRIVER, SEC::MEMORY, HIP_UNSUPPORTED}},
+  {"cuMemcpyBatchAsync",                                          {"hipMemcpyBatchAsync",                                         "", CONV_MEMORY, API_DRIVER, SEC::MEMORY, HIP_PARTIALLY_SUPPORTED | HIP_EXPERIMENTAL}},
   // cudaMemcpy3DBatchAsync
-  {"cuMemcpy3DBatchAsync",                                        {"hipMemcpy3DBatchAsync",                                       "", CONV_MEMORY, API_DRIVER, SEC::MEMORY, HIP_UNSUPPORTED}},
+  {"cuMemcpy3DBatchAsync",                                        {"hipMemcpy3DBatchAsync",                                       "", CONV_MEMORY, API_DRIVER, SEC::MEMORY, HIP_PARTIALLY_SUPPORTED | HIP_EXPERIMENTAL}},
   //
   {"cuMemBatchDecompressAsync",                                   {"hipMemBatchDecompressAsync",                                  "", CONV_MEMORY, API_DRIVER, SEC::MEMORY, HIP_UNSUPPORTED}},
   // cudaFree
@@ -1809,6 +1809,8 @@ const std::map<llvm::StringRef, hipAPIChangedVersions> HIP_DRIVER_FUNCTION_CHANG
 const std::map<llvm::StringRef, cudaAPIUnsupportedVersions> CUDA_DRIVER_FUNCTION_UNSUPPORTED_VER_MAP {
   {"cuCtxCreate",                                                 {CUDA_130}},
   {"cuCtxCreate_v2",                                              {CUDA_130}},
+  {"cuMemcpyBatchAsync",                                          {CUDA_130}},
+  {"cuMemcpy3DBatchAsync",                                        {CUDA_130}},
   {"cuMemAdvise",                                                 {CUDA_130}},
   {"cuMemPrefetchAsync",                                          {CUDA_130}},
   {"cuStreamGetCaptureInfo",                                      {CUDA_130}},

--- a/src/CUDA2HIP_Runtime_API_functions.cpp
+++ b/src/CUDA2HIP_Runtime_API_functions.cpp
@@ -347,10 +347,10 @@ const std::map<llvm::StringRef, hipCounter> CUDA_RUNTIME_FUNCTION_MAP {
   {"cudaMemcpy3DAsync",                                       {"hipMemcpy3DAsync",                                       "", CONV_MEMORY, API_RUNTIME, SEC::MEMORY}},
   // no analogue
   // NOTE: Not equal to cuMemcpy3DPeer due to different signatures
-  {"cudaMemcpy3DPeer",                                        {"hipMemcpy3DPeer",                                        "", CONV_MEMORY, API_RUNTIME, SEC::MEMORY, HIP_UNSUPPORTED}},
+  {"cudaMemcpy3DPeer",                                        {"hipMemcpy3DPeer",                                        "", CONV_MEMORY, API_RUNTIME, SEC::MEMORY, HIP_EXPERIMENTAL}},
   // no analogue
   // NOTE: Not equal to cuMemcpy3DPeerAsync due to different signatures
-  {"cudaMemcpy3DPeerAsync",                                   {"hipMemcpy3DPeerAsync",                                   "", CONV_MEMORY, API_RUNTIME, SEC::MEMORY, HIP_UNSUPPORTED}},
+  {"cudaMemcpy3DPeerAsync",                                   {"hipMemcpy3DPeerAsync",                                   "", CONV_MEMORY, API_RUNTIME, SEC::MEMORY, HIP_EXPERIMENTAL}},
   // no analogue
   // NOTE: Not equal to cuMemcpyAsync due to different signatures
   {"cudaMemcpyAsync",                                         {"hipMemcpyAsync",                                         "", CONV_MEMORY, API_RUNTIME, SEC::MEMORY}},
@@ -369,9 +369,9 @@ const std::map<llvm::StringRef, hipCounter> CUDA_RUNTIME_FUNCTION_MAP {
   // no analogue
   {"cudaMemcpyToSymbolAsync",                                 {"hipMemcpyToSymbolAsync",                                 "", CONV_MEMORY, API_RUNTIME, SEC::MEMORY}},
   // cuMemcpyBatchAsync
-  {"cudaMemcpyBatchAsync",                                    {"hipMemcpyBatchAsync",                                    "", CONV_MEMORY, API_RUNTIME, SEC::MEMORY, HIP_UNSUPPORTED}},
+  {"cudaMemcpyBatchAsync",                                    {"hipMemcpyBatchAsync",                                    "", CONV_MEMORY, API_RUNTIME, SEC::MEMORY, HIP_PARTIALLY_SUPPORTED | HIP_EXPERIMENTAL}},
   // cuMemcpy3DBatchAsync
-  {"cudaMemcpy3DBatchAsync",                                  {"hipMemcpy3DBatchAsync",                                  "", CONV_MEMORY, API_RUNTIME, SEC::MEMORY, HIP_UNSUPPORTED}},
+  {"cudaMemcpy3DBatchAsync",                                  {"hipMemcpy3DBatchAsync",                                  "", CONV_MEMORY, API_RUNTIME, SEC::MEMORY, HIP_PARTIALLY_SUPPORTED | HIP_EXPERIMENTAL}},
   // cuMemGetInfo
   {"cudaMemGetInfo",                                          {"hipMemGetInfo",                                          "", CONV_MEMORY, API_RUNTIME, SEC::MEMORY}},
   // cuMemPrefetchAsync
@@ -1528,6 +1528,10 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_RUNTIME_FUNCTION_VER_MAP {
   {"hipStreamGetId",                                          {HIP_7010, HIP_0,    HIP_0,  HIP_LATEST}},
   {"hipStreamSetAttribute",                                   {HIP_7010, HIP_0,    HIP_0,  HIP_LATEST}},
   {"hipStreamGetAttribute",                                   {HIP_7010, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipMemcpyBatchAsync",                                     {HIP_7010, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipMemcpy3DBatchAsync",                                   {HIP_7010, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipMemcpy3DPeer",                                         {HIP_7010, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipMemcpy3DPeerAsync",                                    {HIP_7010, HIP_0,    HIP_0,  HIP_LATEST}},
   {"hipStreamCopyAttributes",                                 {HIP_7020, HIP_0,    HIP_0,  HIP_7020}},
   {"hipOccupancyAvailableDynamicSMemPerBlock",                {HIP_7020, HIP_0,    HIP_0,  HIP_7020}},
   {"hipLibraryEnumerateKernels",                              {HIP_7020, HIP_0,    HIP_0,  HIP_7020}},
@@ -1558,6 +1562,8 @@ const std::map<llvm::StringRef, hipAPIChangedVersions> HIP_RUNTIME_FUNCTION_CHAN
 const std::map<llvm::StringRef, cudaAPIUnsupportedVersions> CUDA_RUNTIME_FUNCTION_UNSUPPORTED_VER_MAP {
   {"cudaStreamGetCaptureInfo",                                {CUDA_130}},
   {"cudaStreamUpdateCaptureDependencies",                     {CUDA_130}},
+  {"cudaMemcpyBatchAsync",                                    {CUDA_130}},
+  {"cudaMemcpy3DBatchAsync",                                  {CUDA_130}},
   {"cudaMemAdvise",                                           {CUDA_130}},
   {"cudaMemPrefetchAsync",                                    {CUDA_130}},
   {"cudaGraphAddDependencies",                                {CUDA_130}},

--- a/tests/unit_tests/synthetic/driver_functions_before_13000.cu
+++ b/tests/unit_tests/synthetic/driver_functions_before_13000.cu
@@ -34,6 +34,12 @@ int main() {
   int hipVersion = 0;
   size_t bytes = 0;
   size_t bytes_2 = 0;
+  size_t sizes = 0;
+  size_t counts = 0;
+  size_t attrsIdxs = 0;
+  size_t numAttrs = 0;
+  size_t numOps = 0;
+  size_t failIdx = 0;
   void *image = nullptr;
   void *pfn = nullptr;
   void *paramsprt = nullptr;
@@ -64,6 +70,8 @@ int main() {
   // CHECK-NEXT: hipModule_t module_;
   // CHECK-NEXT: hipDeviceptr_t deviceptr;
   // CHECK-NEXT: hipDeviceptr_t deviceptr_2;
+  // CHECK-NEXT: hipDeviceptr_t deviceptr_dst;
+  // CHECK-NEXT: hipDeviceptr_t deviceptr_src;
   // CHECK-NEXT: hipTexRef texref;
   // CHECK-NEXT: hipJitOption jit_option;
   // CHECK-NEXT: hipArray_t array_;
@@ -94,6 +102,8 @@ int main() {
   CUmodule module_;
   CUdeviceptr deviceptr;
   CUdeviceptr deviceptr_2;
+  CUdeviceptr deviceptr_dst;
+  CUdeviceptr deviceptr_src;
   CUtexref texref;
   CUjit_option jit_option;
   CUarray array_;
@@ -2040,6 +2050,22 @@ int main() {
   // HIP: hipError_t hipEventElapsedTime(float* ms, hipEvent_t start, hipEvent_t stop);
   // CHECK: result = hipEventElapsedTime(&ms, event_start, event_end);
   result = cuEventElapsedTime_v2(&ms, event_start, event_end);
+
+  // CHECK: hipMemcpyAttributes memcpyAttributes;
+  CUmemcpyAttributes memcpyAttributes;
+
+  // CUDA: CUresult CUDAAPI cuMemcpyBatchAsync(CUdeviceptr *dsts, CUdeviceptr *srcs, size_t *sizes, size_t count, CUmemcpyAttributes* attrs, size_t* attrsIdxs, size_t numAttrs, size_t* failIdx, CUstream hStream);
+  // HIP: hipError_t hipMemcpyBatchAsync(void** dsts, void** srcs, size_t* sizes, size_t count, hipMemcpyAttributes* attrs, size_t* attrsIdxs, size_t numAttrs, size_t* failIdx, hipStream_t stream __dparm(0));
+  // CHECK: result = hipMemcpyBatchAsync(&deviceptr_dst, &deviceptr_src, &sizes, counts, &memcpyAttributes, &attrsIdxs, numAttrs, &failIdx, stream);
+  result = cuMemcpyBatchAsync(&deviceptr_dst, &deviceptr_src, &sizes, counts, &memcpyAttributes, &attrsIdxs, numAttrs, &failIdx, stream);
+
+  // CHECK: hipMemcpy3DBatchOp Memcpy3DBatchOp;
+  CUDA_MEMCPY3D_BATCH_OP Memcpy3DBatchOp;
+
+  // CUDA: CUresult CUDAAPI cuMemcpy3DBatchAsync(size_t numOps, CUDA_MEMCPY3D_BATCH_OP *opList, size_t* failIdx, unsigned long long flags, CUstream hStream);
+  // HIP: hipError_t hipMemcpy3DBatchAsync(size_t numOps, struct hipMemcpy3DBatchOp* opList, size_t* failIdx, unsigned long long flags, hipStream_t stream __dparm(0));
+  // CHECK: result = hipMemcpy3DBatchAsync(numOps, &Memcpy3DBatchOp, &failIdx, ull_2, stream);
+  result = cuMemcpy3DBatchAsync(numOps, &Memcpy3DBatchOp, &failIdx, ull_2, stream);
 #endif
 
   return 0;

--- a/tests/unit_tests/synthetic/runtime_functions.cu
+++ b/tests/unit_tests/synthetic/runtime_functions.cu
@@ -840,6 +840,19 @@ int main() {
   // CHECK: result = hipMemcpy2DArrayToArray(Array_t, wOffset, hOffset, Array_const_t, wOffset_src, hOffset_src, width, height, MemcpyKind);
   result = cudaMemcpy2DArrayToArray(Array_t, wOffset, hOffset, Array_const_t, wOffset_src, hOffset_src, width, height, MemcpyKind);
 
+  // CHECK: hipMemcpy3DPeerParms Memcpy3DPeerParms;
+  cudaMemcpy3DPeerParms Memcpy3DPeerParms;
+
+  // CUDA: extern __host__ cudaError_t CUDARTAPI cudaMemcpy3DPeer(const struct cudaMemcpy3DPeerParms *p);
+  // HIP: hipError_t hipMemcpy3DPeer(hipMemcpy3DPeerParms* p);
+  // CHECK: result = hipMemcpy3DPeer(&Memcpy3DPeerParms);
+  result = cudaMemcpy3DPeer(&Memcpy3DPeerParms);
+
+  // CUDA: extern __host__ cudaError_t CUDARTAPI cudaMemcpy3DPeerAsync(const struct cudaMemcpy3DPeerParms *p, cudaStream_t stream __dv(0));
+  // HIP: hipError_t hipMemcpy3DPeerAsync(hipMemcpy3DPeerParms* p, hipStream_t stream __dparm(0));
+  // CHECK: result = hipMemcpy3DPeerAsync(&Memcpy3DPeerParms, stream);
+  result = cudaMemcpy3DPeerAsync(&Memcpy3DPeerParms, stream);
+
 #if CUDA_VERSION >= 8000
   // CHECK: hipDeviceP2PAttr DeviceP2PAttr;
   cudaDeviceP2PAttr DeviceP2PAttr;

--- a/tests/unit_tests/synthetic/runtime_functions_before_13000.cu
+++ b/tests/unit_tests/synthetic/runtime_functions_before_13000.cu
@@ -22,6 +22,8 @@ int main() {
   printf("12. CUDA Runtime API Functions synthetic test\n");
 
   size_t bytes = 0;
+  size_t sizes = 0;
+  size_t counts = 0;
   size_t width = 0;
   size_t height = 0;
   size_t wOffset = 0;
@@ -30,6 +32,10 @@ int main() {
   size_t hOffset_src = 0;
   size_t pitch = 0;
   size_t pitch_2 = 0;
+  size_t attrsIdxs = 0;
+  size_t numAttrs = 0;
+  size_t numOps = 0;
+  size_t failIdx = 0;
   int device = 0;
   int deviceId = 0;
   int intVal = 0;
@@ -1673,6 +1679,24 @@ int main() {
   // HIP: hipError_t hipStreamBeginCaptureToGraph(hipStream_t stream, hipGraph_t graph, const hipGraphNode_t* dependencies, const hipGraphEdgeData* dependencyData, size_t numDependencies, hipStreamCaptureMode mode);
   // CHECK: result = hipStreamBeginCaptureToGraph(stream, Graph_t, &graphNode_2, &graphEdgeData, bytes, streamCaptureMode);
   result = cudaStreamBeginCaptureToGraph(stream, Graph_t, &graphNode_2, &graphEdgeData, bytes, streamCaptureMode);
+#endif
+
+#if CUDA_VERSION >= 12080
+  // CHECK: hipMemcpyAttributes MemcpyAttributes;
+  cudaMemcpyAttributes MemcpyAttributes;
+
+  // CUDA: extern __host__ cudaError_t CUDARTAPI cudaMemcpyBatchAsync(void **dsts, void **srcs, size_t *sizes, size_t count, struct cudaMemcpyAttributes *attrs, size_t *attrsIdxs, size_t numAttrs, size_t *failIdx, cudaStream_t stream);
+  // HIP: hipError_t hipMemcpyBatchAsync(void** dsts, void** srcs, size_t* sizes, size_t count, hipMemcpyAttributes* attrs, size_t* attrsIdxs, size_t numAttrs, size_t* failIdx, hipStream_t stream __dparm(0));
+  // CHECK: result = hipMemcpyBatchAsync(&dst, &src, &sizes, counts, &MemcpyAttributes, &attrsIdxs, numAttrs, &failIdx, stream);
+  result = cudaMemcpyBatchAsync(&dst, &src, &sizes, counts, &MemcpyAttributes, &attrsIdxs, numAttrs, &failIdx, stream);
+
+  // CHECK: hipMemcpy3DBatchOp Memcpy3DBatchOp;
+  cudaMemcpy3DBatchOp Memcpy3DBatchOp;
+
+  // CUDA: extern __host__ cudaError_t CUDARTAPI cudaMemcpy3DBatchAsync(size_t numOps, struct cudaMemcpy3DBatchOp *opList, size_t *failIdx, unsigned long long flags, cudaStream_t stream);
+  // HIP: hipError_t hipMemcpy3DBatchAsync(size_t numOps, struct hipMemcpy3DBatchOp* opList, size_t* failIdx, unsigned long long flags, hipStream_t stream __dparm(0));
+  // CHECK: result = hipMemcpy3DBatchAsync(numOps, &Memcpy3DBatchOp, &failIdx, ull_2, stream);
+  result = cudaMemcpy3DBatchAsync(numOps, &Memcpy3DBatchOp, &failIdx, ull_2, stream);
 #endif
 
   return 0;


### PR DESCRIPTION
+ Updated synthetic tests, the regenerated `hipify-perl`, and `Driver` & `Runtime` `CUDA2HIP` docs accordingly
+ [IMP] In `CUDA 13.0.0`, Runtimes's `cudaMemcpyBatchAsync` and `cudaMemcpy3DBatchAsync` and Driver's `cuMemcpyBatchAsync` and `cudaMemcpy3DPeerAsync` changed their ABI, hence they are not supported by HIP anymore (what is reflected in the `CUDA2HIP` docs)
