### PR TITLE
[HIPIFY][7.2][Tensor] Sync with `hipTensor 7.2.0`

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -1721,6 +1721,7 @@ my %experimental_funcs = (
     "fftw_cost" => "7.1.0",
     "fftw_complex" => "7.1.0",
     "fftw_cleanup" => "7.1.0",
+    "cutensorGetVersion" => "7.2.0",
     "cudaSynchronizationPolicy" => "7.1.0",
     "cudaSyncPolicyYield" => "7.1.0",
     "cudaSyncPolicySpin" => "7.1.0",
@@ -2048,6 +2049,7 @@ sub experimentalSubstitutions {
     subst("cudaStreamSetAttribute", "hipStreamSetAttribute", "stream");
     subst("cuOccupancyAvailableDynamicSMemPerBlock", "hipOccupancyAvailableDynamicSMemPerBlock", "occupancy");
     subst("cudaOccupancyAvailableDynamicSMemPerBlock", "hipOccupancyAvailableDynamicSMemPerBlock", "occupancy");
+    subst("cutensorGetVersion", "hiptensorGetVersion", "library");
     subst("fftw_cleanup", "fftw_cleanup", "library");
     subst("fftw_cost", "fftw_cost", "library");
     subst("fftw_destroy_plan", "fftw_destroy_plan", "library");
@@ -11363,7 +11365,6 @@ sub warnRemovedFunctions {
     "cutensorMgContractionDescriptor_s",
     "cutensorMgContraction",
     "cutensorMgAlgo_t",
-    "cutensorGetVersion",
     "cutensorDestroyBlockSparseTensorDescriptor",
     "cutensorCreateContractionTrinary",
     "cutensorCreateBlockSparseTensorDescriptor",
@@ -14749,7 +14750,6 @@ sub warnHipOnlyUnsupportedFunctions {
     "cutensorMgContractionDescriptor_s",
     "cutensorMgContraction",
     "cutensorMgAlgo_t",
-    "cutensorGetVersion",
     "cutensorDestroyBlockSparseTensorDescriptor",
     "cutensorCreateContractionTrinary",
     "cutensorCreateBlockSparseTensorDescriptor",

--- a/docs/reference/tables/CUTENSOR_API_supported_by_HIP.md
+++ b/docs/reference/tables/CUTENSOR_API_supported_by_HIP.md
@@ -232,7 +232,7 @@
 |`cutensorEstimateWorkspaceSize`|2.0.0.0| | | |`hiptensorEstimateWorkspaceSize`|7.0.0| | | | | |
 |`cutensorGetCudartVersion`|1.0.1.0| | | |`hiptensorGetHiprtVersion`|5.7.0| | | | | |
 |`cutensorGetErrorString`|1.0.1.0| | | |`hiptensorGetErrorString`|5.7.0| | | | | |
-|`cutensorGetVersion`|1.0.1.0| | | | | | | | | | |
+|`cutensorGetVersion`|1.0.1.0| | | |`hiptensorGetVersion`|7.2.0| | | | |7.2.0|
 |`cutensorHandleReadPlanCacheFromFile`|2.0.0.0| | | |`hiptensorHandleReadPlanCacheFromFile`|7.0.0| | | | | |
 |`cutensorHandleResizePlanCache`|2.0.0.0| | | |`hiptensorHandleResizePlanCache`|7.0.0| | | | | |
 |`cutensorHandleWritePlanCacheToFile`|2.0.0.0| | | |`hiptensorHandleWritePlanCacheToFile`|7.0.0| | | | | |

--- a/src/CUDA2HIP_TENSOR_API_functions.cpp
+++ b/src/CUDA2HIP_TENSOR_API_functions.cpp
@@ -57,7 +57,7 @@ const std::map<llvm::StringRef, hipCounter> CUDA_TENSOR_FUNCTION_MAP {
   {"cutensorCreateReduction",                        {"hiptensorCreateReduction",                            "", CONV_LIB_FUNC, API_TENSOR, 2}},
   {"cutensorReduce",                                 {"hiptensorReduce",                                     "", CONV_LIB_FUNC, API_TENSOR, 2}},
   {"cutensorGetErrorString",                         {"hiptensorGetErrorString",                             "", CONV_LIB_FUNC, API_TENSOR, 2}},
-  {"cutensorGetVersion",                             {"",                                                    "", CONV_LIB_FUNC, API_TENSOR, 2, UNSUPPORTED}},
+  {"cutensorGetVersion",                             {"hiptensorGetVersion",                                 "", CONV_LIB_FUNC, API_TENSOR, 2, HIP_EXPERIMENTAL}},
   {"cutensorGetCudartVersion",                       {"hiptensorGetHiprtVersion",                            "", CONV_LIB_FUNC, API_TENSOR, 2}},
   {"cutensorLoggerSetCallback",                      {"hiptensorLoggerSetCallback",                          "", CONV_LIB_FUNC, API_TENSOR, 2}},
   {"cutensorLoggerSetFile",                          {"hiptensorLoggerSetFile",                              "", CONV_LIB_FUNC, API_TENSOR, 2}},
@@ -204,6 +204,7 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_TENSOR_FUNCTION_VER_MAP {
   {"hiptensorElementwiseTrinaryExecute",             {HIP_7000,      HIP_0,         HIP_0         }},
   {"hiptensorCreateReduction",                       {HIP_7000,      HIP_0,         HIP_0         }},
   {"hiptensorReduce",                                {HIP_7000,      HIP_0,         HIP_0         }},
+  {"hiptensorGetVersion",                            {HIP_7020,      HIP_0,         HIP_0,        HIP_7020}},
 };
 
 const std::map<llvm::StringRef, cudaAPIChangedVersions> CUDA_TENSOR_FUNCTION_CHANGED_VER_MAP {

--- a/tests/unit_tests/synthetic/libraries/cutensor2hiptensor.cu
+++ b/tests/unit_tests/synthetic/libraries/cutensor2hiptensor.cu
@@ -178,6 +178,11 @@ int main() {
   // HIP: int hiptensorGetHiprtVersion();
   // CHECK: ver = hiptensorGetHiprtVersion();
   ver = cutensorGetCudartVersion();
+
+  // CUDA: size_t cutensorGetVersion();
+  // HIP: size_t hiptensorGetVersion();
+  // CHECK: ver = hiptensorGetVersion();
+  ver = cutensorGetVersion();
 #endif
 
 #if (CUTENSOR_MAJOR == 1 && CUTENSOR_MINOR >= 4) || CUTENSOR_MAJOR >= 2


### PR DESCRIPTION
+ Updated synthetic tests, the regenerated `hipify-perl`, and `Tensor` `CUDA2HIP` docs accordingly
