### PR TITLE
[HIPIFY][7.1][HIP] Sync with `ROCm HIP 7.1` - Part 3 - `HIP` - Step 9  - `Runtime` and `Driver` - final

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -1762,9 +1762,13 @@ my %experimental_funcs = (
     "cudaMemLocationTypeHostNuma" => "7.1.0",
     "cudaMemLocationTypeHost" => "7.1.0",
     "cudaLibrary_t" => "7.1.0",
+    "cudaLibraryUnload" => "7.1.0",
     "cudaLibraryOption" => "7.1.0",
+    "cudaLibraryLoadFromFile" => "7.1.0",
     "cudaLibraryLoadData" => "7.1.0",
     "cudaLibraryHostUniversalFunctionAndDataTable" => "7.1.0",
+    "cudaLibraryGetKernelCount" => "7.1.0",
+    "cudaLibraryGetKernel" => "7.1.0",
     "cudaLibraryEnumerateKernels" => "7.2.0",
     "cudaLibraryBinaryIsPreserved" => "7.1.0",
     "cudaLaunchMemSyncDomainRemote" => "7.1.0",
@@ -1776,6 +1780,7 @@ my %experimental_funcs = (
     "cudaLaunchAttributeMemSyncDomainMap" => "7.1.0",
     "cudaLaunchAttributeMemSyncDomain" => "7.1.0",
     "cudaKernel_t" => "7.1.0",
+    "cudaGetDriverEntryPoint" => "7.1.0",
     "cudaEnablePerThreadDefaultStream" => "7.1.0",
     "cudaEnableLegacyStream" => "7.1.0",
     "cudaEnableDefault" => "7.1.0",
@@ -1790,6 +1795,7 @@ my %experimental_funcs = (
     "cuStreamCopyAttributes" => "7.2.0",
     "cuOccupancyAvailableDynamicSMemPerBlock" => "7.2.0",
     "cuModuleLoadFatBinary" => "7.1.0",
+    "cuModuleGetFunctionCount" => "7.1.0",
     "cuMemsetD2D8_v2" => "7.1.0",
     "cuMemsetD2D8Async" => "7.1.0",
     "cuMemsetD2D8" => "7.1.0",
@@ -1801,7 +1807,11 @@ my %experimental_funcs = (
     "cuMemsetD2D16" => "7.1.0",
     "cuMemcpyBatchAsync" => "7.1.0",
     "cuMemcpy3DBatchAsync" => "7.1.0",
+    "cuLibraryUnload" => "7.1.0",
+    "cuLibraryLoadFromFile" => "7.1.0",
     "cuLibraryLoadData" => "7.1.0",
+    "cuLibraryGetKernelCount" => "7.1.0",
+    "cuLibraryGetKernel" => "7.1.0",
     "cuLibraryEnumerateKernels" => "7.2.0",
     "cuKernelGetName" => "7.2.0",
     "cuKernelGetLibrary" => "7.2.0",
@@ -2017,13 +2027,22 @@ sub subst {
 }
 
 sub experimentalSubstitutions {
+    subst("cuModuleGetFunctionCount", "hipModuleGetFunctionCount", "module");
     subst("cuModuleLoadFatBinary", "hipModuleLoadFatBinary", "module");
     subst("cuKernelGetLibrary", "hipKernelGetLibrary", "library");
     subst("cuKernelGetName", "hipKernelGetName", "library");
     subst("cuLibraryEnumerateKernels", "hipLibraryEnumerateKernels", "library");
+    subst("cuLibraryGetKernel", "hipLibraryGetKernel", "library");
+    subst("cuLibraryGetKernelCount", "hipLibraryGetKernelCount", "library");
     subst("cuLibraryLoadData", "hipLibraryLoadData", "library");
+    subst("cuLibraryLoadFromFile", "hipLibraryLoadFromFile", "library");
+    subst("cuLibraryUnload", "hipLibraryUnload", "library");
     subst("cudaLibraryEnumerateKernels", "hipLibraryEnumerateKernels", "library");
+    subst("cudaLibraryGetKernel", "hipLibraryGetKernel", "library");
+    subst("cudaLibraryGetKernelCount", "hipLibraryGetKernelCount", "library");
     subst("cudaLibraryLoadData", "hipLibraryLoadData", "library");
+    subst("cudaLibraryLoadFromFile", "hipLibraryLoadFromFile", "library");
+    subst("cudaLibraryUnload", "hipLibraryUnload", "library");
     subst("cuMemcpy3DBatchAsync", "hipMemcpy3DBatchAsync", "memory");
     subst("cuMemcpyBatchAsync", "hipMemcpyBatchAsync", "memory");
     subst("cuMemsetD2D16", "hipMemsetD2D16", "memory");
@@ -2049,6 +2068,7 @@ sub experimentalSubstitutions {
     subst("cudaStreamSetAttribute", "hipStreamSetAttribute", "stream");
     subst("cuOccupancyAvailableDynamicSMemPerBlock", "hipOccupancyAvailableDynamicSMemPerBlock", "occupancy");
     subst("cudaOccupancyAvailableDynamicSMemPerBlock", "hipOccupancyAvailableDynamicSMemPerBlock", "occupancy");
+    subst("cudaGetDriverEntryPoint", "hipGetDriverEntryPoint", "driver_entry_point");
     subst("cutensorGetVersion", "hiptensorGetVersion", "library");
     subst("fftw_cleanup", "fftw_cleanup", "library");
     subst("fftw_cost", "fftw_cost", "library");
@@ -5007,7 +5027,6 @@ sub simpleSubstitutions {
     subst("cudaGraphicsUnmapResources", "hipGraphicsUnmapResources", "graphics");
     subst("cudaGraphicsUnregisterResource", "hipGraphicsUnregisterResource", "graphics");
     subst("cuGetProcAddress", "hipGetProcAddress", "driver_entry_point");
-    subst("cudaGetDriverEntryPoint", "hipGetProcAddress", "driver_entry_point");
     subst("cudaGetFuncBySymbol", "hipGetFuncBySymbol", "driver_interact");
     subst("cuProfilerStart", "hipProfilerStart", "profiler");
     subst("cuProfilerStop", "hipProfilerStop", "profiler");
@@ -11968,12 +11987,8 @@ sub warnRemovedFunctions {
     "cudaLimitMaxL2FetchGranularity",
     "cudaLimitDevRuntimeSyncDepth",
     "cudaLimitDevRuntimePendingLaunchCount",
-    "cudaLibraryUnload",
-    "cudaLibraryLoadFromFile",
     "cudaLibraryGetUnifiedFunction",
     "cudaLibraryGetManaged",
-    "cudaLibraryGetKernelCount",
-    "cudaLibraryGetKernel",
     "cudaLibraryGetGlobal",
     "cudaLibMgMatrixDesc_t",
     "cudaLibMgGrid_t",
@@ -12673,7 +12688,6 @@ sub warnRemovedFunctions {
     "cuMulticastAddDevice",
     "cuModuleGetSurfRef",
     "cuModuleGetLoadingMode",
-    "cuModuleGetFunctionCount",
     "cuModuleEnumerateFunctions",
     "cuMipmappedArrayGetMemoryRequirements",
     "cuMemcpyPeerAsync",
@@ -12696,13 +12710,9 @@ sub warnRemovedFunctions {
     "cuLogsDumpToMemory",
     "cuLogsDumpToFile",
     "cuLogsCurrent",
-    "cuLibraryUnload",
-    "cuLibraryLoadFromFile",
     "cuLibraryGetUnifiedFunction",
     "cuLibraryGetModule",
     "cuLibraryGetManaged",
-    "cuLibraryGetKernelCount",
-    "cuLibraryGetKernel",
     "cuLibraryGetGlobal",
     "cuLaunchGridAsync",
     "cuLaunchGrid",

--- a/docs/reference/tables/CUDA_Driver_API_functions_supported_by_HIP.md
+++ b/docs/reference/tables/CUDA_Driver_API_functions_supported_by_HIP.md
@@ -1730,7 +1730,7 @@
 |`cuLinkDestroy`| | | | |`hiprtcLinkDestroy`|5.3.0| | | | | |
 |`cuModuleEnumerateFunctions`|12.4| | | | | | | | | | |
 |`cuModuleGetFunction`| | | | |`hipModuleGetFunction`|1.6.0| | | | | |
-|`cuModuleGetFunctionCount`|12.4| | | | | | | | | | |
+|`cuModuleGetFunctionCount`|12.4| | | |`hipModuleGetFunctionCount`|7.1.0| | | | |7.1.0|
 |`cuModuleGetGlobal`| | | | |`hipModuleGetGlobal`|1.6.0| | | | | |
 |`cuModuleGetGlobal_v2`| | | | |`hipModuleGetGlobal`|1.6.0| | | | | |
 |`cuModuleGetLoadingMode`|11.7| | | | | | | | | | |
@@ -1760,14 +1760,14 @@
 |`cuKernelSetCacheConfig`|12.0| | | | | | | | | | |
 |`cuLibraryEnumerateKernels`|12.4| | | |`hipLibraryEnumerateKernels`|7.2.0| | | | |7.2.0|
 |`cuLibraryGetGlobal`|12.0| | | | | | | | | | |
-|`cuLibraryGetKernel`|12.0| | | | | | | | | | |
-|`cuLibraryGetKernelCount`|12.4| | | | | | | | | | |
+|`cuLibraryGetKernel`|12.0| | | |`hipLibraryGetKernel`|7.1.0| | | | |7.1.0|
+|`cuLibraryGetKernelCount`|12.4| | | |`hipLibraryGetKernelCount`|7.1.0| | | | |7.1.0|
 |`cuLibraryGetManaged`|12.0| | | | | | | | | | |
 |`cuLibraryGetModule`|12.0| | | | | | | | | | |
 |`cuLibraryGetUnifiedFunction`|12.0| | | | | | | | | | |
 |`cuLibraryLoadData`|12.0| | | |`hipLibraryLoadData`|7.1.0| | | | |7.1.0|
-|`cuLibraryLoadFromFile`|12.0| | | | | | | | | | |
-|`cuLibraryUnload`|12.0| | | | | | | | | | |
+|`cuLibraryLoadFromFile`|12.0| | | |`hipLibraryLoadFromFile`|7.1.0| | | | |7.1.0|
+|`cuLibraryUnload`|12.0| | | |`hipLibraryUnload`|7.1.0| | | | |7.1.0|
 
 ## **13. Memory Management**
 
@@ -2269,7 +2269,7 @@
 
 |**CUDA**|**A**|**D**|**C**|**R**|**HIP**|**A**|**D**|**C**|**R**|**U**|**E**|
 |:--|:-:|:-:|:-:|:-:|:--|:-:|:-:|:-:|:-:|:-:|:-:|
-|`cuGetProcAddress`|11.3| |12.0| |`hipGetProcAddress`|6.2.0| | | | | |
+|`cuGetProcAddress`|11.3| |12.0| |`hipGetProcAddress`|6.2.0| | | |11.3 11.4 11.5 11.6 11.7 11.8| |
 
 ## **34. Coredump Attributes Control API**
 

--- a/docs/reference/tables/CUDA_Runtime_API_functions_supported_by_HIP.md
+++ b/docs/reference/tables/CUDA_Runtime_API_functions_supported_by_HIP.md
@@ -545,7 +545,7 @@
 
 |**CUDA**|**A**|**D**|**C**|**R**|**HIP**|**A**|**D**|**C**|**R**|**U**|**E**|
 |:--|:-:|:-:|:-:|:-:|:--|:-:|:-:|:-:|:-:|:-:|:-:|
-|`cudaGetDriverEntryPoint`|11.3|13.0|12.0| |`hipGetProcAddress`|6.2.0| | | | | |
+|`cudaGetDriverEntryPoint`|11.3|13.0|12.0| |`hipGetDriverEntryPoint`|7.1.0| | | |11.3 11.4 11.5 11.6 11.7 11.8|7.1.0|
 |`cudaGetDriverEntryPointByVersion`|12.5| | | | | | | | | | |
 
 ## **32. Library Management**
@@ -555,13 +555,13 @@
 |`cudaKernelSetAttributeForDevice`|12.8| | | | | | | | | | |
 |`cudaLibraryEnumerateKernels`|12.8| | | |`hipLibraryEnumerateKernels`|7.2.0| | | | |7.2.0|
 |`cudaLibraryGetGlobal`|12.8| | | | | | | | | | |
-|`cudaLibraryGetKernel`|12.8| | | | | | | | | | |
-|`cudaLibraryGetKernelCount`|12.8| | | | | | | | | | |
+|`cudaLibraryGetKernel`|12.8| | | |`hipLibraryGetKernel`|7.1.0| | | | |7.1.0|
+|`cudaLibraryGetKernelCount`|12.8| | | |`hipLibraryGetKernelCount`|7.1.0| | | | |7.1.0|
 |`cudaLibraryGetManaged`|12.8| | | | | | | | | | |
 |`cudaLibraryGetUnifiedFunction`|12.8| | | | | | | | | | |
 |`cudaLibraryLoadData`|12.8| | | |`hipLibraryLoadData`|7.1.0| | | | |7.1.0|
-|`cudaLibraryLoadFromFile`|12.8| | | | | | | | | | |
-|`cudaLibraryUnload`|12.8| | | | | | | | | | |
+|`cudaLibraryLoadFromFile`|12.8| | | |`hipLibraryLoadFromFile`|7.1.0| | | | |7.1.0|
+|`cudaLibraryUnload`|12.8| | | |`hipLibraryUnload`|7.1.0| | | | |7.1.0|
 
 ## **33. C++ API Routines**
 

--- a/src/CUDA2HIP_Driver_API_functions.cpp
+++ b/src/CUDA2HIP_Driver_API_functions.cpp
@@ -170,7 +170,7 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_FUNCTION_MAP {
   {"cuModuleLoadFatBinary",                                       {"hipModuleLoadFatBinary",                                      "", CONV_MODULE, API_DRIVER, SEC::MODULE, HIP_EXPERIMENTAL}},
   {"cuModuleUnload",                                              {"hipModuleUnload",                                             "", CONV_MODULE, API_DRIVER, SEC::MODULE}},
   {"cuModuleGetLoadingMode",                                      {"hipModuleGetLoadingMode",                                     "", CONV_MODULE, API_DRIVER, SEC::MODULE, HIP_UNSUPPORTED}},
-  {"cuModuleGetFunctionCount",                                    {"hipModuleGetFunctionCount",                                   "", CONV_MODULE, API_DRIVER, SEC::MODULE, HIP_UNSUPPORTED}},
+  {"cuModuleGetFunctionCount",                                    {"hipModuleGetFunctionCount",                                   "", CONV_MODULE, API_DRIVER, SEC::MODULE, HIP_EXPERIMENTAL}},
   {"cuModuleEnumerateFunctions",                                  {"hipModuleEnumerateFunctions",                                 "", CONV_MODULE, API_DRIVER, SEC::MODULE, HIP_UNSUPPORTED}},
 
   // 11. Module Management [DEPRECATED]
@@ -181,11 +181,11 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_FUNCTION_MAP {
   // cudaLibraryLoadData
   {"cuLibraryLoadData",                                           {"hipLibraryLoadData",                                          "", CONV_LIBRARY, API_DRIVER, SEC::LIBRARY, HIP_EXPERIMENTAL}},
   // cudaLibraryLoadFromFile
-  {"cuLibraryLoadFromFile",                                       {"hipLibraryLoadFromFile",                                      "", CONV_LIBRARY, API_DRIVER, SEC::LIBRARY, HIP_UNSUPPORTED}},
+  {"cuLibraryLoadFromFile",                                       {"hipLibraryLoadFromFile",                                      "", CONV_LIBRARY, API_DRIVER, SEC::LIBRARY, HIP_EXPERIMENTAL}},
   // cudaLibraryUnload
-  {"cuLibraryUnload",                                             {"hipLibraryUnload",                                            "", CONV_LIBRARY, API_DRIVER, SEC::LIBRARY, HIP_UNSUPPORTED}},
+  {"cuLibraryUnload",                                             {"hipLibraryUnload",                                            "", CONV_LIBRARY, API_DRIVER, SEC::LIBRARY, HIP_EXPERIMENTAL}},
   // cudaLibraryGetKernel
-  {"cuLibraryGetKernel",                                          {"hipLibraryGetKernel",                                         "", CONV_LIBRARY, API_DRIVER, SEC::LIBRARY, HIP_UNSUPPORTED}},
+  {"cuLibraryGetKernel",                                          {"hipLibraryGetKernel",                                         "", CONV_LIBRARY, API_DRIVER, SEC::LIBRARY, HIP_EXPERIMENTAL}},
   {"cuLibraryGetModule",                                          {"hipLibraryGetModule",                                         "", CONV_LIBRARY, API_DRIVER, SEC::LIBRARY, HIP_UNSUPPORTED}},
   {"cuKernelGetFunction",                                         {"hipKernelGetFunction",                                        "", CONV_LIBRARY, API_DRIVER, SEC::LIBRARY, HIP_UNSUPPORTED}},
   // cudaLibraryGetGlobal
@@ -200,7 +200,7 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_FUNCTION_MAP {
   {"cuKernelSetCacheConfig",                                      {"hipKernelSetCacheConfig",                                     "", CONV_LIBRARY, API_DRIVER, SEC::LIBRARY, HIP_UNSUPPORTED}},
   {"cuKernelGetName",                                             {"hipKernelGetName",                                            "", CONV_LIBRARY, API_DRIVER, SEC::LIBRARY, HIP_EXPERIMENTAL}},
   // cudaLibraryGetKernelCount
-  {"cuLibraryGetKernelCount",                                     {"hipLibraryGetKernelCount",                                    "", CONV_LIBRARY, API_DRIVER, SEC::LIBRARY, HIP_UNSUPPORTED}},
+  {"cuLibraryGetKernelCount",                                     {"hipLibraryGetKernelCount",                                    "", CONV_LIBRARY, API_DRIVER, SEC::LIBRARY, HIP_EXPERIMENTAL}},
   // cudaLibraryEnumerateKernels
   {"cuLibraryEnumerateKernels",                                   {"hipLibraryEnumerateKernels",                                  "", CONV_LIBRARY, API_DRIVER, SEC::LIBRARY, HIP_EXPERIMENTAL}},
   {"cuKernelGetParamInfo",                                        {"hipKernelGetParamInfo",                                       "", CONV_LIBRARY, API_DRIVER, SEC::LIBRARY, HIP_UNSUPPORTED}},
@@ -1778,6 +1778,7 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_DRIVER_FUNCTION_VER_MAP {
   {"hipMemsetD2D32",                                              {HIP_7010, HIP_0,    HIP_0,  HIP_LATEST}},
   {"hipMemsetD2D32Async",                                         {HIP_7010, HIP_0,    HIP_0,  HIP_LATEST}},
   {"hipModuleLoadFatBinary",                                      {HIP_7010, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipModuleGetFunctionCount",                                   {HIP_7010, HIP_0,    HIP_0,  HIP_LATEST}},
   {"hipKernelGetName",                                            {HIP_7020, HIP_0,    HIP_0,  HIP_7020}},
   {"hipKernelGetLibrary",                                         {HIP_7020, HIP_0,    HIP_0,  HIP_7020}},
 };
@@ -1822,6 +1823,7 @@ const std::map<llvm::StringRef, cudaAPIUnsupportedVersions> CUDA_DRIVER_FUNCTION
   {"cuGraphNodeGetDependentNodes",                                {CUDA_130}},
   {"cuGraphRemoveDependencies",                                   {CUDA_130}},
   {"cuGraphAddNode",                                              {CUDA_130}},
+  {"cuGetProcAddress",                                            {CUDA_113, CUDA_114, CUDA_115, CUDA_116, CUDA_117, CUDA_118}},
 };
 
 const std::map<unsigned int, llvm::StringRef> CUDA_DRIVER_API_SECTION_MAP {

--- a/src/CUDA2HIP_Runtime_API_functions.cpp
+++ b/src/CUDA2HIP_Runtime_API_functions.cpp
@@ -899,7 +899,7 @@ const std::map<llvm::StringRef, hipCounter> CUDA_RUNTIME_FUNCTION_MAP {
 
   // 31. Driver Entry Point Access
   // cuGetProcAddress
-  {"cudaGetDriverEntryPoint",                                 {"hipGetProcAddress",                                      "", CONV_DRIVER_ENTRY_POINT, API_RUNTIME, SEC::DRIVER_ENTRY_POINT, CUDA_DEPRECATED}},
+  {"cudaGetDriverEntryPoint",                                 {"hipGetDriverEntryPoint",                                 "", CONV_DRIVER_ENTRY_POINT, API_RUNTIME, SEC::DRIVER_ENTRY_POINT, CUDA_DEPRECATED | HIP_EXPERIMENTAL}},
   //
   {"cudaGetDriverEntryPointByVersion",                        {"hipGetDriverEntryPointByVersion",                        "", CONV_DRIVER_ENTRY_POINT, API_RUNTIME, SEC::DRIVER_ENTRY_POINT, HIP_UNSUPPORTED}},
 
@@ -907,11 +907,11 @@ const std::map<llvm::StringRef, hipCounter> CUDA_RUNTIME_FUNCTION_MAP {
   // cuLibraryLoadData
   {"cudaLibraryLoadData",                                     {"hipLibraryLoadData",                                     "", CONV_LIBRARY, API_RUNTIME, SEC::LIBRARY, HIP_EXPERIMENTAL}},
   // cuLibraryLoadFromFile
-  {"cudaLibraryLoadFromFile",                                 {"hipLibraryLoadFromFile",                                 "", CONV_LIBRARY, API_RUNTIME, SEC::LIBRARY, HIP_UNSUPPORTED}},
+  {"cudaLibraryLoadFromFile",                                 {"hipLibraryLoadFromFile",                                 "", CONV_LIBRARY, API_RUNTIME, SEC::LIBRARY, HIP_EXPERIMENTAL}},
   // cuLibraryUnload
-  {"cudaLibraryUnload",                                       {"hipLibraryUnload",                                       "", CONV_LIBRARY, API_RUNTIME, SEC::LIBRARY, HIP_UNSUPPORTED}},
+  {"cudaLibraryUnload",                                       {"hipLibraryUnload",                                       "", CONV_LIBRARY, API_RUNTIME, SEC::LIBRARY, HIP_EXPERIMENTAL}},
   // cuLibraryGetKernel
-  {"cudaLibraryGetKernel",                                    {"hipLibraryGetKernel",                                    "", CONV_LIBRARY, API_RUNTIME, SEC::LIBRARY, HIP_UNSUPPORTED}},
+  {"cudaLibraryGetKernel",                                    {"hipLibraryGetKernel",                                    "", CONV_LIBRARY, API_RUNTIME, SEC::LIBRARY, HIP_EXPERIMENTAL}},
   // cuLibraryGetGlobal
   {"cudaLibraryGetGlobal",                                    {"hipLibraryGetGlobal",                                    "", CONV_LIBRARY, API_RUNTIME, SEC::LIBRARY, HIP_UNSUPPORTED}},
   // cuLibraryGetManaged
@@ -921,7 +921,7 @@ const std::map<llvm::StringRef, hipCounter> CUDA_RUNTIME_FUNCTION_MAP {
   // cuKernelSetAttribute
   {"cudaKernelSetAttributeForDevice",                         {"hipKernelSetAttribute",                                  "", CONV_LIBRARY, API_RUNTIME, SEC::LIBRARY, HIP_UNSUPPORTED}},
   // cuLibraryGetKernelCount
-  {"cudaLibraryGetKernelCount",                               {"hipLibraryGetKernelCount",                               "", CONV_LIBRARY, API_RUNTIME, SEC::LIBRARY, HIP_UNSUPPORTED}},
+  {"cudaLibraryGetKernelCount",                               {"hipLibraryGetKernelCount",                               "", CONV_LIBRARY, API_RUNTIME, SEC::LIBRARY, HIP_EXPERIMENTAL}},
   // cuLibraryEnumerateKernels
   {"cudaLibraryEnumerateKernels",                             {"hipLibraryEnumerateKernels",                             "", CONV_LIBRARY, API_RUNTIME, SEC::LIBRARY, HIP_EXPERIMENTAL}},
 
@@ -1533,6 +1533,11 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_RUNTIME_FUNCTION_VER_MAP {
   {"hipMemcpy3DPeer",                                         {HIP_7010, HIP_0,    HIP_0,  HIP_LATEST}},
   {"hipMemcpy3DPeerAsync",                                    {HIP_7010, HIP_0,    HIP_0,  HIP_LATEST}},
   {"hipLibraryLoadData",                                      {HIP_7010, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipLibraryLoadFromFile",                                  {HIP_7010, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipLibraryUnload",                                        {HIP_7010, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipLibraryGetKernel",                                     {HIP_7010, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipLibraryGetKernelCount",                                {HIP_7010, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipGetDriverEntryPoint",                                  {HIP_7010, HIP_0,    HIP_0,  HIP_LATEST}},
   {"hipStreamCopyAttributes",                                 {HIP_7020, HIP_0,    HIP_0,  HIP_7020}},
   {"hipOccupancyAvailableDynamicSMemPerBlock",                {HIP_7020, HIP_0,    HIP_0,  HIP_7020}},
   {"hipLibraryEnumerateKernels",                              {HIP_7020, HIP_0,    HIP_0,  HIP_7020}},
@@ -1573,6 +1578,7 @@ const std::map<llvm::StringRef, cudaAPIUnsupportedVersions> CUDA_RUNTIME_FUNCTIO
   {"cudaGraphNodeGetDependentNodes",                          {CUDA_130}},
   {"cudaGraphRemoveDependencies",                             {CUDA_130}},
   {"cudaGraphAddNode",                                        {CUDA_130}},
+  {"cudaGetDriverEntryPoint",                                 {CUDA_113, CUDA_114, CUDA_115, CUDA_116, CUDA_117, CUDA_118}},
 };
 
 const std::map<unsigned int, llvm::StringRef> CUDA_RUNTIME_API_SECTION_MAP {

--- a/tests/unit_tests/synthetic/driver_functions.cu
+++ b/tests/unit_tests/synthetic/driver_functions.cu
@@ -43,6 +43,7 @@ int main() {
   void *extraparamsprt = nullptr;
   void *jitOptionsValues = nullptr;
   void *libraryOptionValues = nullptr;
+  const char *const_ch = nullptr;
   std::string name = "str";
   std::string symbol = "symbol";
   uint32_t u_value = 0;
@@ -2028,6 +2029,21 @@ int main() {
   // HIP: hipError_t hipLibraryLoadData(hipLibrary_t* library, const void* code, hipJitOption** jitOptions, void** jitOptionsValues, unsigned int numJitOptions, hipLibraryOption** libraryOptions, void** libraryOptionValues, unsigned int numLibraryOptions);
   // CHECK: result = hipLibraryLoadData(&library, code, &jit_option, &jitOptionsValues, count, &LibraryOption, &libraryOptionValues, numLibraryOptions);
   result = cuLibraryLoadData(&library, code, &jit_option, &jitOptionsValues, count, &LibraryOption, &libraryOptionValues, numLibraryOptions);
+
+  // CUDA: CUresult CUDAAPI cuLibraryLoadFromFile(CUlibrary *library, const char *fileName, CUjit_option* jitOptions, void** jitOptionsValues, unsigned int numJitOptions, CUlibraryOption* libraryOptions, void** libraryOptionValues, unsigned int numLibraryOptions);
+  // HIP: hipError_t hipLibraryLoadFromFile(hipLibrary_t* library, const char* fileName, hipJitOption** jitOptions, void** jitOptionsValues, unsigned int numJitOptions, hipLibraryOption** libraryOptions, void** libraryOptionValues, unsigned int numLibraryOptions);
+  // CHECK: result = hipLibraryLoadFromFile(&library, const_ch, &jit_option, &jitOptionsValues, count, &LibraryOption, &libraryOptionValues, numLibraryOptions);
+  result = cuLibraryLoadFromFile(&library, const_ch, &jit_option, &jitOptionsValues, count, &LibraryOption, &libraryOptionValues, numLibraryOptions);
+
+  // CUDA: CUresult CUDAAPI cuLibraryUnload(CUlibrary library);
+  // HIP: hipError_t hipLibraryUnload(hipLibrary_t library);
+  // CHECK: result = hipLibraryUnload(library);
+  result = cuLibraryUnload(library);
+
+  // CUDA: CUresult CUDAAPI cuLibraryGetKernel(CUkernel *pKernel, CUlibrary library, const char *name);
+  // HIP: hipError_t hipLibraryGetKernel(hipKernel_t* pKernel, hipLibrary_t library, const char* name);
+  // CHECK: result = hipLibraryGetKernel(kernels, library, const_ch);
+  result = cuLibraryGetKernel(kernels, library, const_ch);
 #endif
 
 #if CUDA_VERSION >= 12020
@@ -2063,6 +2079,18 @@ int main() {
   // HIP: hipError_t hipKernelGetName(const char** name, hipKernel_t kernel);
   // CHECK: result = hipKernelGetName(&kernelName, kernel);
   result = cuKernelGetName(&kernelName, kernel);
+#endif
+
+#if CUDA_VERSION >= 12040
+  // CUDA: CUresult CUDAAPI cuModuleGetFunctionCount(unsigned int *count, CUmodule mod);
+  // HIP: hipError_t hipModuleGetFunctionCount(unsigned int* count, hipModule_t mod);
+  // CHECK: result = hipModuleGetFunctionCount(&icount, module_);
+  result = cuModuleGetFunctionCount(&icount, module_);
+  
+  // CUDA: CUresult CUDAAPI cuLibraryGetKernelCount(unsigned int *count, CUlibrary lib);
+  // HIP: hipError_t hipLibraryGetKernelCount(unsigned int *count, hipLibrary_t library);
+  // CHECK: result = hipLibraryGetKernelCount(&icount, library);
+  result = cuLibraryGetKernelCount(&icount, library);
 #endif
 
 #if CUDA_VERSION >= 12080

--- a/tests/unit_tests/synthetic/runtime_functions.cu
+++ b/tests/unit_tests/synthetic/runtime_functions.cu
@@ -1696,6 +1696,26 @@ int main() {
   // HIP: hipError_t hipLibraryLoadData(hipLibrary_t* library, const void* code, hipJitOption** jitOptions, void** jitOptionsValues, unsigned int numJitOptions, hipLibraryOption** libraryOptions, void** libraryOptionValues, unsigned int numLibraryOptions);
   // CHECK: result = hipLibraryLoadData(&library, code, &jit_option, &jitOptionsValues, count, &LibraryOption, &libraryOptionValues, numLibraryOptions);
   result = cudaLibraryLoadData(&library, code, &jit_option, &jitOptionsValues, count, &LibraryOption, &libraryOptionValues, numLibraryOptions);
+
+  // CUDA: extern __host__ cudaError_t CUDARTAPI cudaLibraryLoadFromFile(cudaLibrary_t *library, const char *fileName, enum cudaJitOption* jitOptions, void** jitOptionsValues, unsigned int numJitOptions, enum cudaLibraryOption* libraryOptions, void** libraryOptionValues, unsigned int numLibraryOptions);
+  // HIP: hipError_t hipLibraryLoadFromFile(hipLibrary_t* library, const char* fileName, hipJitOption** jitOptions, void** jitOptionsValues, unsigned int numJitOptions, hipLibraryOption** libraryOptions, void** libraryOptionValues, unsigned int numLibraryOptions);
+  // CHECK: result = hipLibraryLoadFromFile(&library, const_ch, &jit_option, &jitOptionsValues, count, &LibraryOption, &libraryOptionValues, numLibraryOptions);
+  result = cudaLibraryLoadFromFile(&library, const_ch, &jit_option, &jitOptionsValues, count, &LibraryOption, &libraryOptionValues, numLibraryOptions);
+
+  // CUDA: extern __host__ cudaError_t CUDARTAPI cudaLibraryUnload(cudaLibrary_t library);
+  // HIP: hipError_t hipLibraryUnload(hipLibrary_t library);
+  // CHECK: result = hipLibraryUnload(library);
+  result = cudaLibraryUnload(library);
+
+  // CUDA: extern __host__ cudaError_t CUDARTAPI cudaLibraryGetKernel(cudaKernel_t *pKernel, cudaLibrary_t library, const char *name);
+  // HIP: hipError_t hipLibraryGetKernel(hipKernel_t* pKernel, hipLibrary_t library, const char* name);
+  // CHECK: result = hipLibraryGetKernel(kernelArray, library, const_ch);
+  result = cudaLibraryGetKernel(kernelArray, library, const_ch);
+
+  // CUDA: extern __host__ cudaError_t CUDARTAPI cudaLibraryGetKernelCount(unsigned int *count, cudaLibrary_t lib);
+  // HIP: hipError_t hipLibraryGetKernelCount(unsigned int *count, hipLibrary_t library);
+  // CHECK: result = hipLibraryGetKernelCount(&count, library);
+  result = cudaLibraryGetKernelCount(&count, library);
 #endif
 
   return 0;

--- a/tests/unit_tests/synthetic/runtime_functions_12000.cu
+++ b/tests/unit_tests/synthetic/runtime_functions_12000.cu
@@ -43,11 +43,8 @@ int main() {
   // CUDA: extern __host__ cudaError_t CUDARTAPI cudaGetDriverEntryPoint(const char *symbol, void **funcPtr, unsigned long long flags, enum cudaDriverEntryPointQueryResult *driverStatus = NULL);
   // CUDA < 12000: extern __host__ cudaError_t CUDARTAPI cudaGetDriverEntryPoint(const char *symbol, void **funcPtr, unsigned long long flags);
   // NOTE: cudaGetDriverEntryPoint for CUDA < 12000 is not supported by HIP
-  // TODO: detect cudaGetDriverEntryPoint signature and report warning/error for old (before CUDA 12.0) signature
-  // NOTE: [HIP] hipDriverEntryPointQueryResult should be used instead of hipDriverProcAddressQueryResult
-  // HIP: hipError_t hipGetProcAddress(const char* symbol, void** pfn, int hipVersion, uint64_t flags, hipDriverProcAddressQueryResult* symbolStatus);
-  // TODO: add an explicit static_cast<uint64_t> for ull
-  // CHECK: result = hipGetProcAddress(symbol.c_str(), &pfn, 701, ull, &driverProcAddressQueryResult);
+  // HIP: hipError_t hipGetDriverEntryPoint(const char* symbol, void** funcPtr, unsigned long long flags, hipDriverEntryPointQueryResult* driverStatus);
+  // CHECK: result = hipGetDriverEntryPoint(symbol.c_str(), &pfn, 701, ull, &driverProcAddressQueryResult);
   result = cudaGetDriverEntryPoint(symbol.c_str(), &pfn, ull, &driverProcAddressQueryResult);
 #endif
 


### PR DESCRIPTION
+ Updated synthetic tests, the regenerated `hipify-perl`, and `Driver` & `Runtime` `CUDA2HIP` docs accordingly
+ Set unsupported CUDA versions for `cudaGetDriverEntryPoint` and `cuGetProcAddress`
