### PR TITLE
[HIPIFY][feature] Add header injection fallback for local headers hipification

### DIFF
--- a/src/HeaderInjection.cpp
+++ b/src/HeaderInjection.cpp
@@ -1,0 +1,303 @@
+/*
+Copyright (c) 2015 - present Advanced Micro Devices, Inc. All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+#include "HeaderInjection.h"
+#include "LocalHeader.h"
+#include "LLVMCompat.h"
+
+#include <sstream>
+#include <regex>
+#include <fstream>
+
+#include "llvm/Support/FileSystem.h"
+#include "llvm/Support/Path.h"
+#include "llvm/Support/MemoryBuffer.h"
+#include "llvm/Support/raw_ostream.h"
+
+using namespace llvm;
+using namespace std;
+
+namespace {
+
+// Matches system/library includes
+static const std::regex SystemIncludeRe(
+    R"(^\s*#\s*include\s*<([^>\n]+)>)", std::regex::ECMAScript);
+
+// Matches local (quoted) includes
+static const std::regex LocalIncludeRe(
+    R"(^\s*#\s*include\s*\"([^\"\n]+)\")", std::regex::ECMAScript);
+
+// Matches #ifndef guard
+static const std::regex IfndefGuardRe(
+    R"(^\s*#\s*ifndef\s+(\w+)\s*$)", std::regex::ECMAScript);
+
+// Matches #define for guard
+static const std::regex DefineGuardRe(
+    R"(^\s*#\s*define\s+(\w+)\s*$)", std::regex::ECMAScript);
+
+static const std::regex PragmaOnceRe(
+    R"(^\s*#\s*pragma\s+once\s*$)", std::regex::ECMAScript);
+
+bool readFileContent(const std::string &path, std::string &out) {
+  auto MBOrErr = llvm::MemoryBuffer::getFile(path);
+  if (!MBOrErr) return false;
+  out = MBOrErr->get()->getBuffer().str();
+  return true;
+}
+
+std::string extractIncludePath(const std::string &line) {
+  std::smatch m;
+  if (std::regex_search(line, m, SystemIncludeRe)) {
+    return m[1].str();
+  }
+  return "";
+}
+
+}
+
+bool collectPrecedingSystemIncludes(const std::string &mainSourceAbsPath,
+                                     const std::string &targetHeaderAbsPath,
+                                     std::vector<std::string> &outSystemIncludes) {
+  std::string content;
+  if (!readFileContent(mainSourceAbsPath, content)) {
+    errs() << sHipify << sError << "Cannot read source file: " << mainSourceAbsPath << "\n";
+    return false;
+  }
+
+  std::string targetFileName = std::string(sys::path::filename(targetHeaderAbsPath));
+
+  std::istringstream iss(content);
+  std::string line;
+  std::smatch sysMatch, localMatch;
+
+  while (std::getline(iss, line)) {
+    if (std::regex_search(line, localMatch, LocalIncludeRe)) {
+      std::string localInc = localMatch[1].str();
+      std::string localFileName = std::string(sys::path::filename(localInc));
+      if (localFileName == targetFileName) {
+        break;
+      }
+      continue;
+    }
+
+    if (std::regex_search(line, sysMatch, SystemIncludeRe)) {
+      outSystemIncludes.push_back(line);
+    }
+  }
+
+  return true;
+}
+
+void detectIncludeGuard(const std::string &headerContent,
+                        size_t &guardEndLine,
+                        std::string &guardType) {
+  guardEndLine = 0;
+  guardType = "none";
+
+  std::istringstream iss(headerContent);
+  std::string line;
+  size_t lineNum = 0;
+  std::string ifndefSymbol;
+
+  while (std::getline(iss, line)) {
+    std::smatch m;
+
+    if (std::regex_match(line, PragmaOnceRe)) {
+      guardType = "pragma_once";
+      guardEndLine = lineNum;
+      return;
+    }
+
+    if (std::regex_match(line, m, IfndefGuardRe)) {
+      ifndefSymbol = m[1].str();
+      for (int i = 0; i < 5 && std::getline(iss, line); ++i) {
+        lineNum++;
+        if (std::regex_match(line, m, DefineGuardRe)) {
+          if (m[1].str() == ifndefSymbol) {
+            guardType = "ifndef";
+            guardEndLine = lineNum;
+            return;
+          }
+        }
+        if (line.empty() || line.find("//") == 0 || line.find("/*") == 0) {
+          continue;
+        }
+        break;
+      }
+    }
+
+    lineNum++;
+  }
+}
+
+void getExistingIncludes(const std::string &headerContent,
+                         std::set<std::string> &existingIncludes) {
+  std::istringstream iss(headerContent);
+  std::string line;
+  std::smatch m;
+
+  while (std::getline(iss, line)) {
+    if (std::regex_search(line, m, SystemIncludeRe)) {
+      existingIncludes.insert(m[1].str());
+    }
+  }
+}
+
+bool createInjectedHeader(const std::string &mainSourceAbsPath,
+                          const std::string &targetHeaderAbsPath,
+                          const std::string &injectedFilePath) {
+  std::string headerContent;
+  if (!readFileContent(targetHeaderAbsPath, headerContent)) {
+    errs() << sHipify << sError << "Cannot read target header: " << targetHeaderAbsPath << "\n";
+    return false;
+  }
+
+  std::vector<std::string> systemIncludes;
+  if (!collectPrecedingSystemIncludes(mainSourceAbsPath, targetHeaderAbsPath,
+                                       systemIncludes)) {
+  }
+
+  std::set<std::string> existingIncludes;
+  getExistingIncludes(headerContent, existingIncludes);
+
+  std::vector<std::string> uniqueIncludes;
+  for (const auto &inc : systemIncludes) {
+    std::string path = extractIncludePath(inc);
+    if (!path.empty() && existingIncludes.find(path) == existingIncludes.end()) {
+      uniqueIncludes.push_back(inc);
+      existingIncludes.insert(path);
+    }
+  }
+
+  if (uniqueIncludes.empty()) {
+    std::ofstream out(injectedFilePath);
+    if (!out.is_open()) {
+      errs() << sHipify << sError << "Cannot create injected file: " << injectedFilePath << "\n";
+      return false;
+    }
+    out << headerContent;
+    out.close();
+    return true;
+  }
+
+  size_t guardEndLine;
+  std::string guardType;
+  detectIncludeGuard(headerContent, guardEndLine, guardType);
+
+  std::string mainFileName = std::string(sys::path::filename(mainSourceAbsPath));
+  std::ostringstream injection;
+  injection << "// --- HIPIFY: Injected dependencies from " << mainFileName << " ---\n";
+  for (const auto &inc : uniqueIncludes) {
+    injection << inc << "\n";
+  }
+  injection << "// --- End injected dependencies ---\n";
+  injection << "\n";
+
+  std::ofstream out(injectedFilePath);
+  if (!out.is_open()) {
+    errs() << sHipify << sError << "Cannot create injected file: " << injectedFilePath << "\n";
+    return false;
+  }
+
+  std::istringstream iss(headerContent);
+  std::string line;
+  size_t lineNum = 0;
+  bool injected = false;
+
+  while (std::getline(iss, line)) {
+    out << line << "\n";
+
+    if (!injected && lineNum == guardEndLine && guardType != "none") {
+      out << injection.str();
+      injected = true;
+    }
+
+    lineNum++;
+  }
+
+  if (!injected && guardType == "none") {
+    out.close();
+    std::ofstream outNew(injectedFilePath);
+    if (!outNew.is_open()) {
+      errs() << sHipify << sError << "Cannot create injected file: " << injectedFilePath << "\n";
+      return false;
+    }
+    outNew << injection.str();
+    outNew << headerContent;
+    outNew.close();
+  } else {
+    out.close();
+  }
+
+  return true;
+}
+
+bool hipifyHeaderWithInjection(const std::string &headerAbsPath,
+                               const std::string &outputPath,
+                               const std::string &mainSourceAbsPath,
+                               const ct::CompilationDatabase *compDB,
+                               ct::CommonOptionsParser *OptionsParserPtr,
+                               const char *hipify_exe) {
+  std::string headerStem = std::string(sys::path::stem(headerAbsPath));
+  std::string headerExt = std::string(sys::path::extension(headerAbsPath));
+  
+  if (!headerExt.empty() && headerExt[0] == '.') {
+    headerExt = headerExt.substr(1);
+  }
+  if (headerExt.empty()) {
+    headerExt = "h";
+  }
+  
+  std::string tempPrefix = "inject_" + headerStem;
+  
+  SmallString<256> injectedPath;
+  std::error_code EC = sys::fs::createTemporaryFile(tempPrefix, headerExt, injectedPath);
+  if (EC) {
+    errs() << sHipify << sError << "Cannot create temporary file: " << EC.message() << "\n";
+    return false;
+  }
+
+  if (!createInjectedHeader(mainSourceAbsPath, headerAbsPath, std::string(injectedPath.str()))) {
+    sys::fs::remove(injectedPath);
+    return false;
+  }
+
+  bool hipifyOk = hipifySingleSource(
+      std::string(injectedPath.str()),
+      outputPath,
+      compDB,
+      OptionsParserPtr,
+      hipify_exe,
+      mainSourceAbsPath,
+      false
+  );
+
+  sys::fs::remove(injectedPath);
+
+  if (!hipifyOk) {
+    errs() << sHipify << sError << "Failed to hipify (injection): " << headerAbsPath << "\n";
+    return false;
+  }
+
+  return true;
+}
+

--- a/src/HeaderInjection.cpp
+++ b/src/HeaderInjection.cpp
@@ -39,34 +39,34 @@ using namespace std;
 namespace {
 
 // Matches system/library includes
-static const std::regex SystemIncludeRe(
-    R"(^\s*#\s*include\s*<([^>\n]+)>)", std::regex::ECMAScript);
+static const regex SystemIncludeRe(
+    R"(^\s*#\s*include\s*<([^>\n]+)>)", regex::ECMAScript);
 
 // Matches local (quoted) includes
-static const std::regex LocalIncludeRe(
-    R"(^\s*#\s*include\s*\"([^\"\n]+)\")", std::regex::ECMAScript);
+static const regex LocalIncludeRe(
+    R"(^\s*#\s*include\s*\"([^\"\n]+)\")", regex::ECMAScript);
 
 // Matches #ifndef guard
-static const std::regex IfndefGuardRe(
-    R"(^\s*#\s*ifndef\s+(\w+)\s*$)", std::regex::ECMAScript);
+static const regex IfndefGuardRe(
+    R"(^\s*#\s*ifndef\s+(\w+)\s*$)", regex::ECMAScript);
 
 // Matches #define for guard
-static const std::regex DefineGuardRe(
-    R"(^\s*#\s*define\s+(\w+)\s*$)", std::regex::ECMAScript);
+static const regex DefineGuardRe(
+    R"(^\s*#\s*define\s+(\w+)\s*$)", regex::ECMAScript);
 
-static const std::regex PragmaOnceRe(
-    R"(^\s*#\s*pragma\s+once\s*$)", std::regex::ECMAScript);
+static const regex PragmaOnceRe(
+    R"(^\s*#\s*pragma\s+once\s*$)", regex::ECMAScript);
 
-bool readFileContent(const std::string &path, std::string &out) {
-  auto MBOrErr = llvm::MemoryBuffer::getFile(path);
+bool readFileContent(const string &path, string &out) {
+  auto MBOrErr = MemoryBuffer::getFile(path);
   if (!MBOrErr) return false;
   out = MBOrErr->get()->getBuffer().str();
   return true;
 }
 
-std::string extractIncludePath(const std::string &line) {
-  std::smatch m;
-  if (std::regex_search(line, m, SystemIncludeRe)) {
+string extractIncludePath(const string &line) {
+  smatch m;
+  if (regex_search(line, m, SystemIncludeRe)) {
     return m[1].str();
   }
   return "";
@@ -74,32 +74,32 @@ std::string extractIncludePath(const std::string &line) {
 
 }
 
-bool collectPrecedingSystemIncludes(const std::string &mainSourceAbsPath,
-                                     const std::string &targetHeaderAbsPath,
-                                     std::vector<std::string> &outSystemIncludes) {
-  std::string content;
+bool collectPrecedingSystemIncludes(const string &mainSourceAbsPath,
+                                     const string &targetHeaderAbsPath,
+                                     vector<string> &outSystemIncludes) {
+  string content;
   if (!readFileContent(mainSourceAbsPath, content)) {
     errs() << sHipify << sError << "Cannot read source file: " << mainSourceAbsPath << "\n";
     return false;
   }
 
-  std::string targetFileName = std::string(sys::path::filename(targetHeaderAbsPath));
+  string targetFileName = string(sys::path::filename(targetHeaderAbsPath));
 
-  std::istringstream iss(content);
-  std::string line;
-  std::smatch sysMatch, localMatch;
+  istringstream iss(content);
+  string line;
+  smatch sysMatch, localMatch;
 
-  while (std::getline(iss, line)) {
-    if (std::regex_search(line, localMatch, LocalIncludeRe)) {
-      std::string localInc = localMatch[1].str();
-      std::string localFileName = std::string(sys::path::filename(localInc));
+  while (getline(iss, line)) {
+    if (regex_search(line, localMatch, LocalIncludeRe)) {
+      string localInc = localMatch[1].str();
+      string localFileName = string(sys::path::filename(localInc));
       if (localFileName == targetFileName) {
         break;
       }
       continue;
     }
 
-    if (std::regex_search(line, sysMatch, SystemIncludeRe)) {
+    if (regex_search(line, sysMatch, SystemIncludeRe)) {
       outSystemIncludes.push_back(line);
     }
   }
@@ -107,31 +107,31 @@ bool collectPrecedingSystemIncludes(const std::string &mainSourceAbsPath,
   return true;
 }
 
-void detectIncludeGuard(const std::string &headerContent,
+void detectIncludeGuard(const string &headerContent,
                         size_t &guardEndLine,
-                        std::string &guardType) {
+                        string &guardType) {
   guardEndLine = 0;
   guardType = "none";
 
-  std::istringstream iss(headerContent);
-  std::string line;
+  istringstream iss(headerContent);
+  string line;
   size_t lineNum = 0;
-  std::string ifndefSymbol;
+  string ifndefSymbol;
 
-  while (std::getline(iss, line)) {
-    std::smatch m;
+  while (getline(iss, line)) {
+    smatch m;
 
-    if (std::regex_match(line, PragmaOnceRe)) {
+    if (regex_match(line, PragmaOnceRe)) {
       guardType = "pragma_once";
       guardEndLine = lineNum;
       return;
     }
 
-    if (std::regex_match(line, m, IfndefGuardRe)) {
+    if (regex_match(line, m, IfndefGuardRe)) {
       ifndefSymbol = m[1].str();
-      for (int i = 0; i < 5 && std::getline(iss, line); ++i) {
+      for (int i = 0; i < 5 && getline(iss, line); ++i) {
         lineNum++;
-        if (std::regex_match(line, m, DefineGuardRe)) {
+        if (regex_match(line, m, DefineGuardRe)) {
           if (m[1].str() == ifndefSymbol) {
             guardType = "ifndef";
             guardEndLine = lineNum;
@@ -149,39 +149,39 @@ void detectIncludeGuard(const std::string &headerContent,
   }
 }
 
-void getExistingIncludes(const std::string &headerContent,
-                         std::set<std::string> &existingIncludes) {
-  std::istringstream iss(headerContent);
-  std::string line;
-  std::smatch m;
+void getExistingIncludes(const string &headerContent,
+                         set<string> &existingIncludes) {
+  istringstream iss(headerContent);
+  string line;
+  smatch m;
 
-  while (std::getline(iss, line)) {
-    if (std::regex_search(line, m, SystemIncludeRe)) {
+  while (getline(iss, line)) {
+    if (regex_search(line, m, SystemIncludeRe)) {
       existingIncludes.insert(m[1].str());
     }
   }
 }
 
-bool createInjectedHeader(const std::string &mainSourceAbsPath,
-                          const std::string &targetHeaderAbsPath,
-                          const std::string &injectedFilePath) {
-  std::string headerContent;
+bool createInjectedHeader(const string &mainSourceAbsPath,
+                          const string &targetHeaderAbsPath,
+                          const string &injectedFilePath) {
+  string headerContent;
   if (!readFileContent(targetHeaderAbsPath, headerContent)) {
     errs() << sHipify << sError << "Cannot read target header: " << targetHeaderAbsPath << "\n";
     return false;
   }
 
-  std::vector<std::string> systemIncludes;
+  vector<string> systemIncludes;
   if (!collectPrecedingSystemIncludes(mainSourceAbsPath, targetHeaderAbsPath,
                                        systemIncludes)) {
   }
 
-  std::set<std::string> existingIncludes;
+  set<string> existingIncludes;
   getExistingIncludes(headerContent, existingIncludes);
 
-  std::vector<std::string> uniqueIncludes;
+  vector<string> uniqueIncludes;
   for (const auto &inc : systemIncludes) {
-    std::string path = extractIncludePath(inc);
+    string path = extractIncludePath(inc);
     if (!path.empty() && existingIncludes.find(path) == existingIncludes.end()) {
       uniqueIncludes.push_back(inc);
       existingIncludes.insert(path);
@@ -189,7 +189,7 @@ bool createInjectedHeader(const std::string &mainSourceAbsPath,
   }
 
   if (uniqueIncludes.empty()) {
-    std::ofstream out(injectedFilePath);
+    ofstream out(injectedFilePath);
     if (!out.is_open()) {
       errs() << sHipify << sError << "Cannot create injected file: " << injectedFilePath << "\n";
       return false;
@@ -200,11 +200,11 @@ bool createInjectedHeader(const std::string &mainSourceAbsPath,
   }
 
   size_t guardEndLine;
-  std::string guardType;
+  string guardType;
   detectIncludeGuard(headerContent, guardEndLine, guardType);
 
-  std::string mainFileName = std::string(sys::path::filename(mainSourceAbsPath));
-  std::ostringstream injection;
+  string mainFileName = string(sys::path::filename(mainSourceAbsPath));
+  ostringstream injection;
   injection << "// --- HIPIFY: Injected dependencies from " << mainFileName << " ---\n";
   for (const auto &inc : uniqueIncludes) {
     injection << inc << "\n";
@@ -212,18 +212,18 @@ bool createInjectedHeader(const std::string &mainSourceAbsPath,
   injection << "// --- End injected dependencies ---\n";
   injection << "\n";
 
-  std::ofstream out(injectedFilePath);
+  ofstream out(injectedFilePath);
   if (!out.is_open()) {
     errs() << sHipify << sError << "Cannot create injected file: " << injectedFilePath << "\n";
     return false;
   }
 
-  std::istringstream iss(headerContent);
-  std::string line;
+  istringstream iss(headerContent);
+  string line;
   size_t lineNum = 0;
   bool injected = false;
 
-  while (std::getline(iss, line)) {
+  while (getline(iss, line)) {
     out << line << "\n";
 
     if (!injected && lineNum == guardEndLine && guardType != "none") {
@@ -236,7 +236,7 @@ bool createInjectedHeader(const std::string &mainSourceAbsPath,
 
   if (!injected && guardType == "none") {
     out.close();
-    std::ofstream outNew(injectedFilePath);
+    ofstream outNew(injectedFilePath);
     if (!outNew.is_open()) {
       errs() << sHipify << sError << "Cannot create injected file: " << injectedFilePath << "\n";
       return false;
@@ -251,14 +251,14 @@ bool createInjectedHeader(const std::string &mainSourceAbsPath,
   return true;
 }
 
-bool hipifyHeaderWithInjection(const std::string &headerAbsPath,
-                               const std::string &outputPath,
-                               const std::string &mainSourceAbsPath,
+bool hipifyHeaderWithInjection(const string &headerAbsPath,
+                               const string &outputPath,
+                               const string &mainSourceAbsPath,
                                const ct::CompilationDatabase *compDB,
                                ct::CommonOptionsParser *OptionsParserPtr,
                                const char *hipify_exe) {
-  std::string headerStem = std::string(sys::path::stem(headerAbsPath));
-  std::string headerExt = std::string(sys::path::extension(headerAbsPath));
+  string headerStem = string(sys::path::stem(headerAbsPath));
+  string headerExt = string(sys::path::extension(headerAbsPath));
   
   if (!headerExt.empty() && headerExt[0] == '.') {
     headerExt = headerExt.substr(1);
@@ -267,22 +267,22 @@ bool hipifyHeaderWithInjection(const std::string &headerAbsPath,
     headerExt = "h";
   }
   
-  std::string tempPrefix = "inject_" + headerStem;
+  string tempPrefix = "inject_" + headerStem;
   
   SmallString<256> injectedPath;
-  std::error_code EC = sys::fs::createTemporaryFile(tempPrefix, headerExt, injectedPath);
+  error_code EC = sys::fs::createTemporaryFile(tempPrefix, headerExt, injectedPath);
   if (EC) {
     errs() << sHipify << sError << "Cannot create temporary file: " << EC.message() << "\n";
     return false;
   }
 
-  if (!createInjectedHeader(mainSourceAbsPath, headerAbsPath, std::string(injectedPath.str()))) {
+  if (!createInjectedHeader(mainSourceAbsPath, headerAbsPath, string(injectedPath.str()))) {
     sys::fs::remove(injectedPath);
     return false;
   }
 
   bool hipifyOk = hipifySingleSource(
-      std::string(injectedPath.str()),
+      string(injectedPath.str()),
       outputPath,
       compDB,
       OptionsParserPtr,

--- a/src/HeaderInjection.h
+++ b/src/HeaderInjection.h
@@ -24,28 +24,30 @@ THE SOFTWARE.
 
 #include <string>
 #include <vector>
+#include <set>
 #include "clang/Tooling/CommonOptionsParser.h"
 
 namespace ct = clang::tooling;
 
-extern bool hipifySingleSource(const std::string &srcPath,
-                               const std::string &dstPath,
+bool collectPrecedingSystemIncludes(const std::string &mainSourceAbsPath,
+                                     const std::string &targetHeaderAbsPath,
+                                     std::vector<std::string> &outSystemIncludes);
+
+void detectIncludeGuard(const std::string &headerContent,
+                        size_t &guardEndLine,
+                        std::string &guardType);
+
+void getExistingIncludes(const std::string &headerContent,
+                         std::set<std::string> &existingIncludes);
+
+bool createInjectedHeader(const std::string &mainSourceAbsPath,
+                          const std::string &targetHeaderAbsPath,
+                          const std::string &injectedFilePath);
+
+bool hipifyHeaderWithInjection(const std::string &headerAbsPath,
+                               const std::string &outputPath,
+                               const std::string &mainSourceAbsPath,
                                const ct::CompilationDatabase *compDB,
                                ct::CommonOptionsParser *OptionsParserPtr,
-                               const char *hipify_exe_path,
-                               const std::string &mainContextPath,
-                               bool preserveTemp,
-                               bool silent = false);
+                               const char *hipify_exe);
 
-bool hipifyLocalHeaders(const std::string &srcPath,
-                        const ct::CompilationDatabase *compDB,
-                        ct::CommonOptionsParser *OptionsParserPtr,
-                        const char *hipify_exe,
-                        bool recursive = false);
-
-bool resolveLocalInclude(const std::string &mainSourceAbsPath,
-                         const std::string &includeToken,
-                         std::string &outAbsPath);
-
-bool collectLocalQuotedIncludes(const std::string &mainSourceAbsPath,
-                                std::vector<std::string> &outHeaders);

--- a/src/LocalHeader.cpp
+++ b/src/LocalHeader.cpp
@@ -1,27 +1,50 @@
+/*
+Copyright (c) 2015 - present Advanced Micro Devices, Inc. All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
 #include "LocalHeader.h"
+#include "HeaderInjection.h"
+#include "StderrCapture.h"
+#include "LLVMCompat.h"
 
 #include <sstream>
 #include <regex>
 #include <set>
 #include <vector>
+#include <map>
 #include <system_error>
+#include <fstream>
 
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/Path.h"
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/raw_ostream.h"
 
-#include "clang/Tooling/Refactoring.h"
-#include "clang/Tooling/Tooling.h"
-
-#include "CUDA2HIP.h"       
-#include "LLVMCompat.h"     
-#include "HipifyAction.h"   
-
-using namespace clang;
-using namespace clang::tooling;
 using namespace llvm;
 using namespace std;
+using hipify::StderrCapture;
+
+// Matches local (quoted) includes
+static const std::regex LocalIncludeRe(
+    R"(^\s*#\s*include\s*\"([^\"\n]+)\"\s*(?://.*)?$)", std::regex::ECMAScript);
 
 static std::string normalizeSmallStringPath(SmallString<256> &p) {
   llvm::sys::path::remove_dots(p, true);
@@ -47,32 +70,27 @@ static bool pathExists(const std::string &p) {
   return llvm::sys::fs::exists(norm);
 }
 
-namespace {
-  static const std::regex LocalIncludeRe(
-      R"(^\s*#\s*include\s*\"([^\"\n]+)\"\s*(?://.*)?$)", std::regex::ECMAScript);
+bool readFile(const std::string &path, std::string &out) {
+  auto MBOrErr = llvm::MemoryBuffer::getFile(path);
+  if (!MBOrErr) return false;
+  out = MBOrErr->get()->getBuffer().str();
+  return true;
+}
 
-  bool readFile(const std::string &path, std::string &out) {
-    auto MBOrErr = llvm::MemoryBuffer::getFile(path);
-    if (!MBOrErr) return false;
-    out = MBOrErr->get()->getBuffer().str();
+bool resolveLocalIncludeInternal(const std::string &mainSourceAbsPath,
+                                const std::string &includeTok,
+                                std::string &outAbs) {
+  SmallString<256> base(mainSourceAbsPath);
+  sys::path::remove_filename(base);
+  SmallString<256> candidate(base);
+  sys::path::append(candidate, includeTok);
+  sys::path::remove_dots(candidate, true);
+  if (pathExists(std::string(candidate.str()))) {
+    outAbs = normalizeSmallStringPath(candidate);
     return true;
   }
-
-  bool resolveLocalIncludeInternal(const std::string &mainSourceAbsPath,
-                                  const std::string &includeTok,
-                                  std::string &outAbs) {
-    SmallString<256> base(mainSourceAbsPath);
-    sys::path::remove_filename(base);
-    SmallString<256> candidate(base);
-    sys::path::append(candidate, includeTok);
-    sys::path::remove_dots(candidate, true);
-    if (pathExists(std::string(candidate.str()))) {
-      outAbs = normalizeSmallStringPath(candidate);
-      return true;
-    }
-    return false;
-  }
-} 
+  return false;
+}
 
 bool resolveLocalInclude(const std::string &mainSourceAbsPath,
                          const std::string &includeToken,
@@ -125,14 +143,27 @@ bool hipifyLocalHeaders(const std::string &mainSourceAbsPath,
     return true;
   }
 
+  outs() << "\n";
+  outs() << sHipify << "Found " << initial.size() << " local header(s) to process\n";
+  outs() << sHipify << "Note: Compilation errors during direct attempts may be safely ignored\n";
+  outs() << sHipify << "      if the injection fallback succeeds.\n";
+  outs() << "\n";
+  outs().flush();
+
   std::vector<std::string> work(initial.begin(), initial.end());
   std::set<std::string> processed;
+  
+  std::vector<std::string> directSuccess;
+  std::vector<std::string> injectionSuccess;
+  std::vector<std::string> failed;
+  
+  // Store captured error output for failed files
+  std::map<std::string, std::string> capturedErrors;
 
   while (!work.empty()) {
     std::string hdr = work.back();
     work.pop_back();
     if (processed.count(hdr)) {
-      errs() << sHipify << sWarning << "Duplicate local header reference ignored: " << hdr << "\n";
       continue;
     }
     processed.insert(hdr);
@@ -140,18 +171,74 @@ bool hipifyLocalHeaders(const std::string &mainSourceAbsPath,
     std::string original;
     if (!readFile(hdr, original)) {
       errs() << sHipify << sError << "Cannot read header: " << hdr << "\n";
+      failed.push_back(hdr);
       continue;
     }
 
     std::string hipOut = hdr + ".hip";
-    bool ok = hipifySingleSource(hdr, hipOut, compDB, OptionsParserPtr,
-                                  hipify_exe, mainSourceAbsPath, false);
+    std::string hdrFileName = std::string(sys::path::filename(hdr));
+    bool ok = false;
 
-    if (!ok) {
-      errs() << sHipify << sError << "Hipify failed for header: " << hdr << "\n";
-      return false;
+    // HYBRID APPROACH:
+    // Step 1: Try direct hipification first (works for self-contained headers)
+    // Capture stderr - if both approaches fail, we'll show the errors
+    outs() << sHipify << "[" << (directSuccess.size() + injectionSuccess.size() + 1) 
+           << "/" << initial.size() << "] Hipifying source: " << hdr << "\n";
+    outs().flush();
+    
+    std::string directErrors;
+    {
+      // Capture stderr during direct attempt
+      StderrCapture capture;
+      ok = hipifySingleSource(hdr, hipOut, compDB, OptionsParserPtr,
+                               hipify_exe, mainSourceAbsPath, false, true);
+      if (!ok) {
+        directErrors = capture.getCapturedOutput();
+      }
     }
 
+    if (ok) {
+      outs() << sHipify << "  -> OK (direct)\n";
+      directSuccess.push_back(hdrFileName);
+    } else {
+      // Step 2: If direct fails, inject preceding includes
+      outs() << sHipify << "  -> Trying injection approach...\n";
+      outs().flush();
+      
+      std::string injectionErrors;
+      {
+        // Capture stderr during injection attempt
+        StderrCapture capture;
+        ok = hipifyHeaderWithInjection(hdr, hipOut, mainSourceAbsPath,
+                                        compDB, OptionsParserPtr, hipify_exe);
+        if (!ok) {
+          injectionErrors = capture.getCapturedOutput();
+        }
+      }
+      
+      if (ok) {
+        outs() << sHipify << "  -> OK (injection)\n";
+        injectionSuccess.push_back(hdrFileName);
+      } else {
+        outs() << sHipify << "  -> FAILED\n";
+        failed.push_back(hdrFileName);
+        
+        // Store errors for this file - combine both attempts' errors
+        std::string combinedErrors;
+        if (!directErrors.empty()) {
+          combinedErrors += "=== Direct approach errors ===\n" + directErrors;
+        }
+        if (!injectionErrors.empty()) {
+          if (!combinedErrors.empty()) combinedErrors += "\n";
+          combinedErrors += "=== Injection approach errors ===\n" + injectionErrors;
+        }
+        if (!combinedErrors.empty()) {
+          capturedErrors[hdrFileName] = combinedErrors;
+        }
+      }
+    }
+
+    // If recursive, find and queue nested local headers
     if (recursive) {
       std::smatch m;
       std::istringstream iss(original);
@@ -166,6 +253,55 @@ bool hipifyLocalHeaders(const std::string &mainSourceAbsPath,
         }
       }
     }
+  }
+
+  outs() << "\n";
+  outs() << sHipify << "Local Header Hipification Summary\n";
+  
+  size_t total = directSuccess.size() + injectionSuccess.size() + failed.size();
+  size_t success = directSuccess.size() + injectionSuccess.size();
+  
+  if (!directSuccess.empty()) {
+    outs() << sHipify << "  Direct:    " << directSuccess.size() << " header(s)\n";
+  }
+  if (!injectionSuccess.empty()) {
+    outs() << sHipify << "  Injection: " << injectionSuccess.size() << " header(s) (needed deps from main source)\n";
+  }
+  if (!failed.empty()) {
+    outs() << sHipify << "  Failed:  " << failed.size() << " header(s)\n";
+    for (const auto &f : failed) {
+      outs() << sHipify << "    - " << f << "\n";
+    }
+  }
+  
+  outs() << sHipify << "  Total:   " << success << "/" << total << " succeeded\n";
+  outs() << "\n";
+
+  // If there were failures, show the captured error details
+  if (!failed.empty()) {
+    errs() << sHipify << sError << "The following headers failed to hipify:\n";
+    errs() << "\n";
+    
+    for (const auto &f : failed) {
+      errs() << "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n";
+      errs() << "  Failed: " << f << "\n";
+      errs() << "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n";
+      
+      auto it = capturedErrors.find(f);
+      if (it != capturedErrors.end() && !it->second.empty()) {
+        errs() << it->second << "\n";
+      } else {
+        errs() << "  (No detailed error output captured)\n\n";
+      }
+    }
+    
+    errs() << sHipify << "Hint: Check if the headers have:\n";
+    errs() << sHipify << "  - Missing #include dependencies\n";
+    errs() << sHipify << "  - Syntax errors\n";
+    errs() << sHipify << "  - Types/operators not available in HIP\n";
+    errs() << "\n";
+    
+    return false;
   }
 
   return true;

--- a/src/LocalHeader.cpp
+++ b/src/LocalHeader.cpp
@@ -43,77 +43,77 @@ using namespace std;
 using hipify::StderrCapture;
 
 // Matches local (quoted) includes
-static const std::regex LocalIncludeRe(
-    R"(^\s*#\s*include\s*\"([^\"\n]+)\"\s*(?://.*)?$)", std::regex::ECMAScript);
+static const regex LocalIncludeRe(
+    R"(^\s*#\s*include\s*\"([^\"\n]+)\"\s*(?://.*)?$)", regex::ECMAScript);
 
-static std::string normalizeSmallStringPath(SmallString<256> &p) {
-  llvm::sys::path::remove_dots(p, true);
+static string normalizeSmallStringPath(SmallString<256> &p) {
+  sys::path::remove_dots(p, true);
 
   SmallString<256> realBuf;
-  std::error_code ec = llvm::sys::fs::real_path(p, realBuf);
+  error_code ec = sys::fs::real_path(p, realBuf);
   if (!ec) {
-    return std::string(realBuf.str());
+    return string(realBuf.str());
   }
 
-  return std::string(p.str());
+  return string(p.str());
 }
 
-static bool pathExists(const std::string &p) {
+static bool pathExists(const string &p) {
   SmallString<256> in(p.begin(), p.end());
 
   SmallString<256> realBuf;
-  std::error_code ec = llvm::sys::fs::real_path(in, realBuf);
+  error_code ec = sys::fs::real_path(in, realBuf);
   if (!ec) return true;
 
   SmallString<256> norm = in;
-  llvm::sys::path::remove_dots(norm, true);
-  return llvm::sys::fs::exists(norm);
+  sys::path::remove_dots(norm, true);
+  return sys::fs::exists(norm);
 }
 
-bool readFile(const std::string &path, std::string &out) {
-  auto MBOrErr = llvm::MemoryBuffer::getFile(path);
+bool readFile(const string &path, string &out) {
+  auto MBOrErr = MemoryBuffer::getFile(path);
   if (!MBOrErr) return false;
   out = MBOrErr->get()->getBuffer().str();
   return true;
 }
 
-bool resolveLocalIncludeInternal(const std::string &mainSourceAbsPath,
-                                const std::string &includeTok,
-                                std::string &outAbs) {
+bool resolveLocalIncludeInternal(const string &mainSourceAbsPath,
+                                const string &includeTok,
+                                string &outAbs) {
   SmallString<256> base(mainSourceAbsPath);
   sys::path::remove_filename(base);
   SmallString<256> candidate(base);
   sys::path::append(candidate, includeTok);
   sys::path::remove_dots(candidate, true);
-  if (pathExists(std::string(candidate.str()))) {
+  if (pathExists(string(candidate.str()))) {
     outAbs = normalizeSmallStringPath(candidate);
     return true;
   }
   return false;
 }
 
-bool resolveLocalInclude(const std::string &mainSourceAbsPath,
-                         const std::string &includeToken,
-                         std::string &outAbsPath) {
+bool resolveLocalInclude(const string &mainSourceAbsPath,
+                         const string &includeToken,
+                         string &outAbsPath) {
   return resolveLocalIncludeInternal(mainSourceAbsPath, includeToken, outAbsPath);
 }
 
-bool collectLocalQuotedIncludes(const std::string &mainSourceAbsPath,
-                                std::vector<std::string> &outHeaders) {
-  std::string content;
+bool collectLocalQuotedIncludes(const string &mainSourceAbsPath,
+                                vector<string> &outHeaders) {
+  string content;
   if (!readFile(mainSourceAbsPath, content)) {
     errs() << "\n" << sHipify << sError << "Cannot read source file: " << mainSourceAbsPath << "\n";
     return false;
   }
 
-  std::set<std::string> uniq;
-  std::smatch m;
-  std::istringstream iss(content);
-  std::string line;
-  while (std::getline(iss, line)) {
-    if (std::regex_match(line, m, LocalIncludeRe)) {
-      std::string rel = m[1].str();
-      std::string abs;
+  set<string> uniq;
+  smatch m;
+  istringstream iss(content);
+  string line;
+  while (getline(iss, line)) {
+    if (regex_match(line, m, LocalIncludeRe)) {
+      string rel = m[1].str();
+      string abs;
       if (resolveLocalIncludeInternal(mainSourceAbsPath, rel, abs)){
         uniq.insert(abs);
       } else {
@@ -127,13 +127,13 @@ bool collectLocalQuotedIncludes(const std::string &mainSourceAbsPath,
   return true;
 }
 
-bool hipifyLocalHeaders(const std::string &mainSourceAbsPath,
+bool hipifyLocalHeaders(const string &mainSourceAbsPath,
                              const ct::CompilationDatabase *compDB,
                              ct::CommonOptionsParser *OptionsParserPtr,
                              const char *hipify_exe,
                              bool recursive) {
 
-  std::vector<std::string> initial;
+  vector<string> initial;
   if (!collectLocalQuotedIncludes(mainSourceAbsPath, initial)) {
     return false;
   }
@@ -150,33 +150,33 @@ bool hipifyLocalHeaders(const std::string &mainSourceAbsPath,
   outs() << "\n";
   outs().flush();
 
-  std::vector<std::string> work(initial.begin(), initial.end());
-  std::set<std::string> processed;
+  vector<string> work(initial.begin(), initial.end());
+  set<string> processed;
   
-  std::vector<std::string> directSuccess;
-  std::vector<std::string> injectionSuccess;
-  std::vector<std::string> failed;
+  vector<string> directSuccess;
+  vector<string> injectionSuccess;
+  vector<string> failed;
   
   // Store captured error output for failed files
-  std::map<std::string, std::string> capturedErrors;
+  map<string, string> capturedErrors;
 
   while (!work.empty()) {
-    std::string hdr = work.back();
+    string hdr = work.back();
     work.pop_back();
     if (processed.count(hdr)) {
       continue;
     }
     processed.insert(hdr);
 
-    std::string original;
+    string original;
     if (!readFile(hdr, original)) {
       errs() << sHipify << sError << "Cannot read header: " << hdr << "\n";
       failed.push_back(hdr);
       continue;
     }
 
-    std::string hipOut = hdr + ".hip";
-    std::string hdrFileName = std::string(sys::path::filename(hdr));
+    string hipOut = hdr + ".hip";
+    string hdrFileName = string(sys::path::filename(hdr));
     bool ok = false;
 
     // HYBRID APPROACH:
@@ -186,7 +186,7 @@ bool hipifyLocalHeaders(const std::string &mainSourceAbsPath,
            << "/" << initial.size() << "] Hipifying source: " << hdr << "\n";
     outs().flush();
     
-    std::string directErrors;
+    string directErrors;
     {
       // Capture stderr during direct attempt
       StderrCapture capture;
@@ -205,7 +205,7 @@ bool hipifyLocalHeaders(const std::string &mainSourceAbsPath,
       outs() << sHipify << "  -> Trying injection approach...\n";
       outs().flush();
       
-      std::string injectionErrors;
+      string injectionErrors;
       {
         // Capture stderr during injection attempt
         StderrCapture capture;
@@ -224,7 +224,7 @@ bool hipifyLocalHeaders(const std::string &mainSourceAbsPath,
         failed.push_back(hdrFileName);
         
         // Store errors for this file - combine both attempts' errors
-        std::string combinedErrors;
+        string combinedErrors;
         if (!directErrors.empty()) {
           combinedErrors += "=== Direct approach errors ===\n" + directErrors;
         }
@@ -240,13 +240,13 @@ bool hipifyLocalHeaders(const std::string &mainSourceAbsPath,
 
     // If recursive, find and queue nested local headers
     if (recursive) {
-      std::smatch m;
-      std::istringstream iss(original);
-      std::string line;
-      while (std::getline(iss, line)) {
-        if (std::regex_match(line, m, LocalIncludeRe)) {
-          std::string rel = m[1].str();
-          std::string abs;
+      smatch m;
+      istringstream iss(original);
+      string line;
+      while (getline(iss, line)) {
+        if (regex_match(line, m, LocalIncludeRe)) {
+          string rel = m[1].str();
+          string abs;
           if (resolveLocalIncludeInternal(hdr, rel, abs) &&
               !processed.count(abs))
             work.push_back(abs);

--- a/src/StderrCapture.h
+++ b/src/StderrCapture.h
@@ -28,6 +28,9 @@ THE SOFTWARE.
 #include <cstdio>
 
 #ifdef _WIN32
+  #ifndef NOMINMAX
+    #define NOMINMAX
+  #endif
   #include <io.h>
   #include <fcntl.h>
   #include <sys/stat.h>

--- a/src/StderrCapture.h
+++ b/src/StderrCapture.h
@@ -26,6 +26,7 @@ THE SOFTWARE.
 #include <sstream>
 #include <fstream>
 #include <cstdio>
+#include <mutex>
 
 #ifdef _WIN32
   #ifndef NOMINMAX
@@ -53,7 +54,7 @@ namespace hipify {
 // Capture stderr output to a temp file.
 class StderrCapture {
 public:
-  StderrCapture() : saved_stderr_(-1), temp_fd_(-1), active_(false) {
+  StderrCapture() : lock_(getMutex()), saved_stderr_(-1), temp_fd_(-1), active_(false) {
 #ifdef _WIN32
     char tempDir[MAX_PATH];
     DWORD tempDirLen = GetTempPathA(MAX_PATH, tempDir);
@@ -133,6 +134,11 @@ public:
   bool isActive() const { return active_; }
   
 private:
+  static std::mutex& getMutex() {
+    static std::mutex mtx;
+    return mtx;
+  }
+
   void removeTempFile() {
     if (!tempFilePath_.empty()) {
 #ifdef _WIN32
@@ -152,6 +158,7 @@ private:
     removeTempFile();
   }
 
+  std::unique_lock<std::mutex> lock_;
   int saved_stderr_;
   int temp_fd_;
   bool active_;

--- a/src/StderrCapture.h
+++ b/src/StderrCapture.h
@@ -1,0 +1,163 @@
+/*
+Copyright (c) 2015 - present Advanced Micro Devices, Inc. All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+#pragma once
+
+#include <string>
+#include <sstream>
+#include <fstream>
+#include <cstdio>
+
+#ifdef _WIN32
+  #include <io.h>
+  #include <fcntl.h>
+  #include <sys/stat.h>
+  #include <windows.h>
+  #define STDERR_FD _fileno(stderr)
+  #define DUP(fd) _dup(fd)
+  #define DUP2(fd1, fd2) _dup2(fd1, fd2)
+  #define CLOSE(fd) _close(fd)
+#else
+  #include <unistd.h>
+  #include <fcntl.h>
+  #define STDERR_FD STDERR_FILENO
+  #define DUP(fd) dup(fd)
+  #define DUP2(fd1, fd2) dup2(fd1, fd2)
+  #define CLOSE(fd) close(fd)
+#endif
+
+namespace hipify {
+
+// Capture stderr output to a temp file.
+class StderrCapture {
+public:
+  StderrCapture() : saved_stderr_(-1), temp_fd_(-1), active_(false) {
+#ifdef _WIN32
+    char tempDir[MAX_PATH];
+    DWORD tempDirLen = GetTempPathA(MAX_PATH, tempDir);
+    if (tempDirLen == 0 || tempDirLen > MAX_PATH) return;
+    
+    char tempFile[MAX_PATH];
+    if (GetTempFileNameA(tempDir, "hip", 0, tempFile) == 0) return;
+    
+    tempFilePath_ = tempFile;
+    
+    temp_fd_ = _open(tempFile, _O_RDWR | _O_CREAT | _O_TRUNC, _S_IREAD | _S_IWRITE);
+    if (temp_fd_ == -1) {
+      DeleteFileA(tempFile);
+      tempFilePath_.clear();
+      return;
+    }
+#else
+    char tmpPath[] = "/tmp/hipify_stderr_XXXXXX";
+    temp_fd_ = mkstemp(tmpPath);
+    if (temp_fd_ == -1) return;
+    
+    tempFilePath_ = tmpPath;
+#endif
+
+    saved_stderr_ = DUP(STDERR_FD);
+    if (saved_stderr_ == -1) {
+      CLOSE(temp_fd_);
+      removeTempFile();
+      temp_fd_ = -1;
+      return;
+    }
+    
+    if (DUP2(temp_fd_, STDERR_FD) != -1) {
+      active_ = true;
+    }
+  }
+  
+  // Restores stderr and deletes temp file.
+  ~StderrCapture() {
+    restore();
+    cleanup();
+  }
+  
+  StderrCapture(const StderrCapture&) = delete;
+  StderrCapture& operator=(const StderrCapture&) = delete;
+  
+  // Restores stderr to original state.
+  void restore() {
+    if (active_ && saved_stderr_ != -1) {
+      fflush(stderr);
+      DUP2(saved_stderr_, STDERR_FD);
+      active_ = false;
+    }
+    if (saved_stderr_ != -1) {
+      CLOSE(saved_stderr_);
+      saved_stderr_ = -1;
+    }
+  }
+  
+  // Returns captured stderr content and restores stderr.
+  std::string getCapturedOutput() {
+    std::string content;
+    restore();
+    
+    if (temp_fd_ != -1 && !tempFilePath_.empty()) {
+      std::ifstream file(tempFilePath_);
+      if (file.is_open()) {
+        std::stringstream buffer;
+        buffer << file.rdbuf();
+        content = buffer.str();
+        file.close();
+      }
+    }
+    return content;
+  }
+  
+  bool isActive() const { return active_; }
+  
+private:
+  void removeTempFile() {
+    if (!tempFilePath_.empty()) {
+#ifdef _WIN32
+      DeleteFileA(tempFilePath_.c_str());
+#else
+      unlink(tempFilePath_.c_str());
+#endif
+      tempFilePath_.clear();
+    }
+  }
+
+  void cleanup() {
+    if (temp_fd_ != -1) {
+      CLOSE(temp_fd_);
+      temp_fd_ = -1;
+    }
+    removeTempFile();
+  }
+
+  int saved_stderr_;
+  int temp_fd_;
+  bool active_;
+  std::string tempFilePath_;
+};
+
+} // namespace hipify
+
+#undef STDERR_FD
+#undef DUP
+#undef DUP2
+#undef CLOSE

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -206,6 +206,7 @@ bool appendArgumentsAdjusters(ct::RefactoringTool &Tool, const std::string &sSou
       Tool.appendArgumentsAdjuster(ct::getInsertArgumentAdjuster("-D", ct::ArgumentInsertPosition::BEGIN));
     }
   }
+ 
   // Standard c++ to use in hipification by default
   llcompat::setStdCPP(Tool);
   std::string sInclude = "-I" + sys::path::parent_path(sSourceAbsPath).str();
@@ -239,7 +240,13 @@ bool hipifySingleSource(const std::string &srcPath,
                                ct::CommonOptionsParser *OptionsParserPtr,
                                const char *hipify_exe_path,
                                const std::string &mainContextPath,
-                               bool preserveTemp) {
+                               bool preserveTemp,
+                               bool silent) {
+  // Print info message for each file being hipified (unless silent)
+  if (!silent) {
+    llvm::outs() << sHipify << "Hipifying source: " << srcPath << "\n";
+  }
+
   std::error_code EC;
   SmallString<128> tmpFile;
   StringRef srcFileName = sys::path::filename(srcPath);

--- a/tests/unit_tests/headers/local_headers/injection_has_cmath.h
+++ b/tests/unit_tests/headers/local_headers/injection_has_cmath.h
@@ -1,0 +1,16 @@
+// RUN: %run_test hipify "%s" "%t" %hipify_args --local-headers %clang_args
+
+#ifndef INJECTION_HAS_CMATH_H
+#define INJECTION_HAS_CMATH_H
+
+// CHECK: #include <hip/hip_runtime.h>
+// CHECK-NOT: #include <cuda_runtime.h>
+// CHECK: #include <cmath>
+#include <cuda_runtime.h>
+#include <cmath>
+
+inline float compute_value(float x) {
+    return sqrtf(x) + 1.0f;
+}
+
+#endif

--- a/tests/unit_tests/headers/local_headers/injection_helper.h
+++ b/tests/unit_tests/headers/local_headers/injection_helper.h
@@ -1,0 +1,22 @@
+// RUN: %run_test hipify "%s" "%t" %hipify_args --local-headers %clang_args
+
+#ifndef INJECTION_HELPER_H
+#define INJECTION_HELPER_H
+
+// CHECK: #include <hip/hip_runtime.h>
+// CHECK-NOT: #include <cuda_runtime.h>
+#include <cuda_runtime.h>
+
+inline __device__ float3 add_vectors(float3 a, float3 b) {
+    return make_float3(0.0f, 0.0f, 0.0f);
+}
+
+inline __device__ void accumulate(float3* sum, float3 val) {
+    return;
+}
+
+inline __device__ float3 scale_and_diff(float3 a, float3 b, float s) {
+    return make_float3(0.0f, 0.0f, 0.0f);
+}
+
+#endif

--- a/tests/unit_tests/headers/local_headers/injection_inner.h
+++ b/tests/unit_tests/headers/local_headers/injection_inner.h
@@ -1,0 +1,14 @@
+// RUN: %run_test hipify "%s" "%t" %hipify_args --local-headers-recursive %clang_args
+
+#ifndef INJECTION_INNER_H
+#define INJECTION_INNER_H
+
+// CHECK: #include <hip/hip_runtime.h>
+// CHECK-NOT: #include <cuda_runtime.h>
+#include <cuda_runtime.h>
+
+inline __device__ void inner_add(float3* data, int idx) {
+    return;
+}
+
+#endif

--- a/tests/unit_tests/headers/local_headers/injection_multi.cu
+++ b/tests/unit_tests/headers/local_headers/injection_multi.cu
@@ -1,0 +1,22 @@
+// RUN: %run_test hipify "%s" "%t" %hipify_args --local-headers %clang_args
+
+// CHECK: #include <hip/hip_runtime.h>
+// CHECK-NOT: #include <cuda_runtime.h>
+// CHECK: #include <cmath>
+// CHECK: #include "vector_math.h"
+// CHECK: #include "injection_helper.h"
+// CHECK: #include "injection_uses_cmath.h"
+#include <cuda_runtime.h>
+#include <cmath>
+#include "vector_math.h"
+#include "injection_helper.h"
+#include "injection_uses_cmath.h"
+
+__global__ void multiKernel(float3* data, float* vals) {
+    int idx = threadIdx.x;
+    dummy_vector_op();
+    add_vectors(data[idx], data[idx + 1]);
+    vals[idx] = compute_sqrt(vals[idx]);
+}
+
+int main() { return 0; }

--- a/tests/unit_tests/headers/local_headers/injection_no_duplicate.cu
+++ b/tests/unit_tests/headers/local_headers/injection_no_duplicate.cu
@@ -1,0 +1,14 @@
+// RUN: %run_test hipify "%s" "%t" %hipify_args --local-headers %clang_args
+
+// CHECK: #include <hip/hip_runtime.h>
+// CHECK-NOT: #include <cuda_runtime.h>
+// CHECK: #include <cmath>
+// CHECK: #include "injection_has_cmath.h"
+#include <cuda_runtime.h>
+#include <cmath>
+#include "injection_has_cmath.h"
+
+int main() {
+    float x = compute_value(4.0f);
+    return (int)x;
+}

--- a/tests/unit_tests/headers/local_headers/injection_outer.h
+++ b/tests/unit_tests/headers/local_headers/injection_outer.h
@@ -1,0 +1,16 @@
+// RUN: %run_test hipify "%s" "%t" %hipify_args --local-headers-recursive %clang_args
+
+#ifndef INJECTION_OUTER_H
+#define INJECTION_OUTER_H
+
+// CHECK: #include <hip/hip_runtime.h>
+// CHECK-NOT: #include <cuda_runtime.h>
+// CHECK: #include "injection_inner.h"
+#include <cuda_runtime.h>
+#include "injection_inner.h"
+
+inline __device__ void outer_process(float3* data, int idx) {
+    inner_add(data, idx);
+}
+
+#endif

--- a/tests/unit_tests/headers/local_headers/injection_pragma_header.h
+++ b/tests/unit_tests/headers/local_headers/injection_pragma_header.h
@@ -1,0 +1,11 @@
+// RUN: %run_test hipify "%s" "%t" %hipify_args --local-headers %clang_args
+
+#pragma once
+
+// CHECK: #include <hip/hip_runtime.h>
+// CHECK-NOT: #include <cuda_runtime.h>
+#include <cuda_runtime.h>
+
+inline __device__ void pragma_add(float3* data, int idx) {
+    return;
+}

--- a/tests/unit_tests/headers/local_headers/injection_pragma_once.cu
+++ b/tests/unit_tests/headers/local_headers/injection_pragma_once.cu
@@ -1,0 +1,17 @@
+// RUN: %run_test hipify "%s" "%t" %hipify_args --local-headers %clang_args
+
+// CHECK: #include <hip/hip_runtime.h>
+// CHECK-NOT: #include <cuda_runtime.h>
+// CHECK: #include "vector_math.h"
+// CHECK: #include "injection_pragma_header.h"
+#include <cuda_runtime.h>
+#include "vector_math.h"
+#include "injection_pragma_header.h"
+
+__global__ void pragmaKernel(float3* data) {
+    int idx = threadIdx.x;
+    dummy_vector_op();
+    pragma_add(data, idx);
+}
+
+int main() { return 0; }

--- a/tests/unit_tests/headers/local_headers/injection_recursive.cu
+++ b/tests/unit_tests/headers/local_headers/injection_recursive.cu
@@ -1,0 +1,17 @@
+// RUN: %run_test hipify "%s" "%t" %hipify_args --local-headers-recursive %clang_args
+
+// CHECK: #include <hip/hip_runtime.h>
+// CHECK-NOT: #include <cuda_runtime.h>
+// CHECK: #include "vector_math.h"
+// CHECK: #include "injection_outer.h"
+#include <cuda_runtime.h>
+#include "vector_math.h"
+#include "injection_outer.h"
+
+__global__ void recursiveKernel(float3* data) {
+    int idx = threadIdx.x;
+    dummy_vector_op();
+    outer_process(data, idx);
+}
+
+int main() { return 0; }

--- a/tests/unit_tests/headers/local_headers/injection_test.cu
+++ b/tests/unit_tests/headers/local_headers/injection_test.cu
@@ -1,0 +1,17 @@
+// RUN: %run_test hipify "%s" "%t" %hipify_args --local-headers %clang_args
+
+// CHECK: #include <hip/hip_runtime.h>
+// CHECK-NOT: #include <cuda_runtime.h>
+// CHECK: #include "vector_math.h"
+// CHECK: #include "injection_helper.h"
+#include <cuda_runtime.h>
+#include "vector_math.h"
+#include "injection_helper.h"
+
+__global__ void testKernel(float3* data) {
+    int idx = threadIdx.x;
+    dummy_vector_op();
+    add_vectors(data[idx], data[idx + 1]);
+}
+
+int main() { return 0; }

--- a/tests/unit_tests/headers/local_headers/injection_uses_cmath.h
+++ b/tests/unit_tests/headers/local_headers/injection_uses_cmath.h
@@ -1,0 +1,18 @@
+// RUN: %run_test hipify "%s" "%t" %hipify_args --local-headers %clang_args
+
+#ifndef INJECTION_USES_CMATH_H
+#define INJECTION_USES_CMATH_H
+
+// CHECK: #include <hip/hip_runtime.h>
+// CHECK-NOT: #include <cuda_runtime.h>
+#include <cuda_runtime.h>
+
+inline __device__ float compute_sqrt(float x) {
+    return sqrtf(x);
+}
+
+inline __device__ float compute_magnitude(float x, float y) {
+    return sqrtf(x * x + y * y);
+}
+
+#endif

--- a/tests/unit_tests/headers/local_headers/vector_math.h
+++ b/tests/unit_tests/headers/local_headers/vector_math.h
@@ -1,0 +1,12 @@
+// RUN: %run_test hipify "%s" "%t" %hipify_args --local-headers %clang_args
+
+#ifndef VECTOR_MATH_H
+#define VECTOR_MATH_H
+
+// CHECK: #include <hip/hip_runtime.h>
+// CHECK-NOT: #include <cuda_runtime.h>
+#include <cuda_runtime.h>
+
+inline __host__ __device__ void dummy_vector_op() { return; }
+
+#endif


### PR DESCRIPTION
## Motivation

https://github.com/NVIDIA/cuda-samples/blob/master/Samples/5_Domain_Specific/dxtc/dxtc.cu

The `dxtc.cu` cuda-samples includes multiple local headers (`CudaMath.h, dds.h, permutations.h`) that depend on `helper_math.h` for float3 operator definitions. Without header injection, these headers fail with standalone hipify-clang because they lack the required operator overloads.

## Purpose

Enhances the existing `--local-headers` and `--local-headers-recursive` options with header injection fallback mechanism. When direct hipification of a local header fails due to missing type definitions or operator overloads, the header injection method automatically injects preceding system includes from the main source file.

## Problem Statement

The initial local header hipification works well for self-contained headers that include all their dependencies. However, many cuda-samples have headers that depend on types and operators defined in preceding includes from the main source file. For example, CudaMath.h in cuda-samples/Samples/5_Domain_Specific/dxtc/ uses float3 operators (+=, *, -) that are defined in helper_math.h, which is included in the dxtc.cu. Few more below
[bodysystemcpu_impl.h](https://github.com/NVIDIA/cuda-samples/blob/master/Samples/5_Domain_Specific/nbody/bodysystemcpu_impl.h)
[MonteCarlo_reduction.cuh](https://github.com/NVIDIA/cuda-samples/blob/master/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_reduction.cuh)
[fastWalshTransform_kernel.cuh](https://github.com/NVIDIA/cuda-samples/blob/master/Samples/5_Domain_Specific/fastWalshTransform/fastWalshTransform_kernel.cuh)
[bicubicTexture_kernel.cuh](https://github.com/NVIDIA/cuda-samples/blob/master/Samples/5_Domain_Specific/bicubicTexture/bicubicTexture_kernel.cuh)

## Solution
Implements a hybrid approach:
**Existing**: First attempts direct hipification, Works for self-contained headers.
**Enhanced version**: Header Injection, when direct method fails, it collects preceding system header files (#include <...>) from the main source and includes them.

## Usage
No change to CLI flags
Non-recursive: `hipify-clang --local-headers main.cu -I include/`
Recursive: `hipify-clang --local-headers-recursive main.cu -I include/`
