### PR TITLE
[HIPIFY][build][Windows][fix] Fixing `D9025` compiler warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -163,6 +163,7 @@ if (NOT HIPIFY_CLANG_TESTS_ONLY)
 
   if(MSVC)
     target_link_libraries(hipify-clang PRIVATE version)
+    string(REPLACE "/EHsc" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
     target_compile_options(hipify-clang PRIVATE ${STD} /Od /GR- /EHs- /EHc- /MP)
     if((LLVM_PACKAGE_VERSION VERSION_EQUAL "18.0.0" OR LLVM_PACKAGE_VERSION VERSION_GREATER "18.0.0") AND MSVC_VERSION VERSION_GREATER "1919")
       target_compile_options(hipify-clang PRIVATE /Zc:preprocessor)


### PR DESCRIPTION
**[Synopsis]**
+ CMake adds `/EHsc` (enable exceptions) to the default flags `CMAKE_CXX_FLAGS`, which conflicts with disabling exceptions using `target_compile_options(..., /EHs-)`
+ The `cl` compiler uses the last flag it sees (`/EHs-`), but warns that the previous setting (`/EHs`) was ignored

**[Solution]**
+ Replace the existing flag in the `CMake` variable rather than just appending the new one
