### PR TITLE
[HIPIFY][fix] `Stack Overflow` possible Issues - Part 2 - `SPARSE`, `SOLVER`

### DIFF
--- a/src/CUDA2HIP_SOLVER_API_functions.cpp
+++ b/src/CUDA2HIP_SOLVER_API_functions.cpp
@@ -23,1537 +23,1552 @@ THE SOFTWARE.
 #include "CUDA2HIP.h"
 
 // Map of all functions
-const std::map<llvm::StringRef, hipCounter> CUDA_SOLVER_FUNCTION_MAP {
-  {"cusolverDnCreate",                                   {"hipsolverDnCreate",                                     "rocblas_create_handle",                                          CONV_LIB_FUNC, API_SOLVER, 2}},
-  {"cusolverDnDestroy",                                  {"hipsolverDnDestroy",                                    "rocblas_destroy_handle",                                         CONV_LIB_FUNC, API_SOLVER, 2}},
+const std::map<llvm::StringRef, hipCounter> CUDA_SOLVER_FUNCTION_MAP = [] {
+  std::map<llvm::StringRef, hipCounter> m;
+
+  m["cusolverDnCreate"]                                               = {"hipsolverDnCreate",                                     "rocblas_create_handle",                                          CONV_LIB_FUNC, API_SOLVER, 2};
+  m["cusolverDnDestroy"]                                              = {"hipsolverDnDestroy",                                    "rocblas_destroy_handle",                                         CONV_LIB_FUNC, API_SOLVER, 2};
   // NOTE: cusolverDn(S|D|C|Z)getrf -> rocsolver_(s|d|c|z)getrf + harness of other API calls
-  {"cusolverDnSgetrf",                                   {"hipsolverDnSgetrf",                                     "rocsolver_sgetrf",                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnDgetrf",                                   {"hipsolverDnDgetrf",                                     "rocsolver_dgetrf",                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnCgetrf",                                   {"hipsolverDnCgetrf",                                     "rocsolver_cgetrf",                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnZgetrf",                                   {"hipsolverDnZgetrf",                                     "rocsolver_zgetrf",                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
+  m["cusolverDnSgetrf"]                                               = {"hipsolverDnSgetrf",                                     "rocsolver_sgetrf",                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnDgetrf"]                                               = {"hipsolverDnDgetrf",                                     "rocsolver_dgetrf",                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnCgetrf"]                                               = {"hipsolverDnCgetrf",                                     "rocsolver_cgetrf",                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnZgetrf"]                                               = {"hipsolverDnZgetrf",                                     "rocsolver_zgetrf",                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
   // NOTE: cusolverDn(S|D|C|Z)getrf_bufferSize -> rocsolver_(s|d|c|z)getrf + harness of other API calls
-  {"cusolverDnSgetrf_bufferSize",                        {"hipsolverDnSgetrf_bufferSize",                          "rocsolver_sgetrf",                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnDgetrf_bufferSize",                        {"hipsolverDnDgetrf_bufferSize",                          "rocsolver_dgetrf",                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnCgetrf_bufferSize",                        {"hipsolverDnCgetrf_bufferSize",                          "rocsolver_cgetrf",                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnZgetrf_bufferSize",                        {"hipsolverDnZgetrf_bufferSize",                          "rocsolver_zgetrf",                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
+  m["cusolverDnSgetrf_bufferSize"]                                    = {"hipsolverDnSgetrf_bufferSize",                          "rocsolver_sgetrf",                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnDgetrf_bufferSize"]                                    = {"hipsolverDnDgetrf_bufferSize",                          "rocsolver_dgetrf",                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnCgetrf_bufferSize"]                                    = {"hipsolverDnCgetrf_bufferSize",                          "rocsolver_cgetrf",                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnZgetrf_bufferSize"]                                    = {"hipsolverDnZgetrf_bufferSize",                          "rocsolver_zgetrf",                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
   // NOTE: cusolverDn(S|D|C|Z)getrs -> rocsolver_(s|d|c|z)getrs + harness of other API calls
-  {"cusolverDnSgetrs",                                   {"hipsolverDnSgetrs",                                     "rocsolver_sgetrs",                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnDgetrs",                                   {"hipsolverDnDgetrs",                                     "rocsolver_dgetrs",                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnCgetrs",                                   {"hipsolverDnCgetrs",                                     "rocsolver_cgetrs",                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnZgetrs",                                   {"hipsolverDnZgetrs",                                     "rocsolver_zgetrs",                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnXgetrf",                                   {"hipsolverDnXgetrf",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnXgetrf_bufferSize",                        {"hipsolverDnXgetrf_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnXgetrs",                                   {"hipsolverDnXgetrs",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnCreateParams",                             {"hipsolverDnCreateParams",                               "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnDestroyParams",                            {"hipsolverDnDestroyParams",                              "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnSetAdvOptions",                            {"hipsolverDnSetAdvOptions",                              "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnSetStream",                                {"hipsolverSetStream",                                    "rocblas_set_stream",                                             CONV_LIB_FUNC, API_SOLVER, 2}},
-  {"cusolverDnGetStream",                                {"hipsolverGetStream",                                    "rocblas_get_stream",                                             CONV_LIB_FUNC, API_SOLVER, 2}},
-  {"cusolverDnSetDeterministicMode",                     {"hipsolverDnSetDeterministicMode",                       "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnGetDeterministicMode",                     {"hipsolverDnGetDeterministicMode",                       "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnIRSParamsCreate",                          {"hipsolverDnIRSParamsCreate",                            "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
-  {"cusolverDnIRSParamsDestroy",                         {"hipsolverDnIRSParamsDestroy",                           "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
-  {"cusolverDnIRSParamsSetRefinementSolver",             {"hipsolverDnIRSParamsSetRefinementSolver",               "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
-  {"cusolverDnIRSParamsSetSolverMainPrecision",          {"hipsolverDnIRSParamsSetSolverMainPrecision",            "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
-  {"cusolverDnIRSParamsSetSolverLowestPrecision",        {"hipsolverDnIRSParamsSetSolverLowestPrecision",          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
-  {"cusolverDnIRSParamsSetSolverPrecisions",             {"hipsolverDnIRSParamsSetSolverPrecisions",               "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
-  {"cusolverDnIRSParamsSetTol",                          {"hipsolverDnIRSParamsSetTol",                            "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
-  {"cusolverDnIRSParamsSetTolInner",                     {"hipsolverDnIRSParamsSetTolInner",                       "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
-  {"cusolverDnIRSParamsSetMaxIters",                     {"hipsolverDnIRSParamsSetMaxIters",                       "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
-  {"cusolverDnIRSParamsSetMaxItersInner",                {"hipsolverDnIRSParamsSetMaxItersInner",                  "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
-  {"cusolverDnIRSParamsGetMaxIters",                     {"hipsolverDnIRSParamsGetMaxIters",                       "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
-  {"cusolverDnIRSParamsEnableFallback",                  {"hipsolverDnIRSParamsEnableFallback",                    "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
-  {"cusolverDnIRSParamsDisableFallback",                 {"hipsolverDnIRSParamsDisableFallback",                   "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
-  {"cusolverDnIRSInfosCreate",                           {"hipsolverDnIRSInfosCreate",                             "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
-  {"cusolverDnIRSInfosDestroy",                          {"hipsolverDnIRSInfosDestroy",                            "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
-  {"cusolverDnIRSInfosGetNiters",                        {"hipsolverDnIRSInfosGetNiters",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
-  {"cusolverDnIRSInfosGetOuterNiters",                   {"hipsolverDnIRSInfosGetOuterNiters",                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
-  {"cusolverDnIRSInfosRequestResidual",                  {"hipsolverDnIRSInfosRequestResidual",                    "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
-  {"cusolverDnIRSInfosGetResidualHistory",               {"hipsolverDnIRSInfosGetResidualHistory",                 "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
-  {"cusolverDnIRSInfosGetMaxIters",                      {"hipsolverDnIRSInfosGetMaxIters",                        "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
+  m["cusolverDnSgetrs"]                                               = {"hipsolverDnSgetrs",                                     "rocsolver_sgetrs",                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnDgetrs"]                                               = {"hipsolverDnDgetrs",                                     "rocsolver_dgetrs",                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnCgetrs"]                                               = {"hipsolverDnCgetrs",                                     "rocsolver_cgetrs",                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnZgetrs"]                                               = {"hipsolverDnZgetrs",                                     "rocsolver_zgetrs",                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnXgetrf"]                                               = {"hipsolverDnXgetrf",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnXgetrf_bufferSize"]                                    = {"hipsolverDnXgetrf_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnXgetrs"]                                               = {"hipsolverDnXgetrs",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnCreateParams"]                                         = {"hipsolverDnCreateParams",                               "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnDestroyParams"]                                        = {"hipsolverDnDestroyParams",                              "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnSetAdvOptions"]                                        = {"hipsolverDnSetAdvOptions",                              "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnSetStream"]                                            = {"hipsolverSetStream",                                    "rocblas_set_stream",                                             CONV_LIB_FUNC, API_SOLVER, 2};
+  m["cusolverDnGetStream"]                                            = {"hipsolverGetStream",                                    "rocblas_get_stream",                                             CONV_LIB_FUNC, API_SOLVER, 2};
+  m["cusolverDnSetDeterministicMode"]                                 = {"hipsolverDnSetDeterministicMode",                       "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnGetDeterministicMode"]                                 = {"hipsolverDnGetDeterministicMode",                       "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnIRSParamsCreate"]                                      = {"hipsolverDnIRSParamsCreate",                            "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
+  m["cusolverDnIRSParamsDestroy"]                                     = {"hipsolverDnIRSParamsDestroy",                           "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
+  m["cusolverDnIRSParamsSetRefinementSolver"]                         = {"hipsolverDnIRSParamsSetRefinementSolver",               "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
+  m["cusolverDnIRSParamsSetSolverMainPrecision"]                      = {"hipsolverDnIRSParamsSetSolverMainPrecision",            "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
+  m["cusolverDnIRSParamsSetSolverLowestPrecision"]                    = {"hipsolverDnIRSParamsSetSolverLowestPrecision",          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
+  m["cusolverDnIRSParamsSetSolverPrecisions"]                         = {"hipsolverDnIRSParamsSetSolverPrecisions",               "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
+  m["cusolverDnIRSParamsSetTol"]                                      = {"hipsolverDnIRSParamsSetTol",                            "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
+  m["cusolverDnIRSParamsSetTolInner"]                                 = {"hipsolverDnIRSParamsSetTolInner",                       "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
+  m["cusolverDnIRSParamsSetMaxIters"]                                 = {"hipsolverDnIRSParamsSetMaxIters",                       "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
+  m["cusolverDnIRSParamsSetMaxItersInner"]                            = {"hipsolverDnIRSParamsSetMaxItersInner",                  "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
+  m["cusolverDnIRSParamsGetMaxIters"]                                 = {"hipsolverDnIRSParamsGetMaxIters",                       "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
+  m["cusolverDnIRSParamsEnableFallback"]                              = {"hipsolverDnIRSParamsEnableFallback",                    "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
+  m["cusolverDnIRSParamsDisableFallback"]                             = {"hipsolverDnIRSParamsDisableFallback",                   "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
+  m["cusolverDnIRSInfosCreate"]                                       = {"hipsolverDnIRSInfosCreate",                             "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
+  m["cusolverDnIRSInfosDestroy"]                                      = {"hipsolverDnIRSInfosDestroy",                            "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
+  m["cusolverDnIRSInfosGetNiters"]                                    = {"hipsolverDnIRSInfosGetNiters",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
+  m["cusolverDnIRSInfosGetOuterNiters"]                               = {"hipsolverDnIRSInfosGetOuterNiters",                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
+  m["cusolverDnIRSInfosRequestResidual"]                              = {"hipsolverDnIRSInfosRequestResidual",                    "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
+  m["cusolverDnIRSInfosGetResidualHistory"]                           = {"hipsolverDnIRSInfosGetResidualHistory",                 "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
+  m["cusolverDnIRSInfosGetMaxIters"]                                  = {"hipsolverDnIRSInfosGetMaxIters",                        "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
   // NOTE: rocsolver_zgesv has a harness of rocblas_set_workspace, hipsolverZZgesv_bufferSize, and rocsolver_zgesv_outofplace
-  {"cusolverDnZZgesv",                                   {"hipsolverDnZZgesv",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnZCgesv",                                   {"hipsolverDnZCgesv",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
-  {"cusolverDnZKgesv",                                   {"hipsolverDnZKgesv",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
-  {"cusolverDnZEgesv",                                   {"hipsolverDnZEgesv",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
-  {"cusolverDnZYgesv",                                   {"hipsolverDnZYgesv",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
+  m["cusolverDnZZgesv"]                                               = {"hipsolverDnZZgesv",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnZCgesv"]                                               = {"hipsolverDnZCgesv",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
+  m["cusolverDnZKgesv"]                                               = {"hipsolverDnZKgesv",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
+  m["cusolverDnZEgesv"]                                               = {"hipsolverDnZEgesv",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
+  m["cusolverDnZYgesv"]                                               = {"hipsolverDnZYgesv",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
   // NOTE: rocsolver_cgesv has a harness of rocblas_set_workspace, hipsolverCCgesv_bufferSize, and rocsolver_cgesv_outofplace
-  {"cusolverDnCCgesv",                                   {"hipsolverDnCCgesv",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnCEgesv",                                   {"hipsolverDnCEgesv",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
-  {"cusolverDnCKgesv",                                   {"hipsolverDnCKgesv",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
-  {"cusolverDnCYgesv",                                   {"hipsolverDnCYgesv",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
+  m["cusolverDnCCgesv"]                                               = {"hipsolverDnCCgesv",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnCEgesv"]                                               = {"hipsolverDnCEgesv",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
+  m["cusolverDnCKgesv"]                                               = {"hipsolverDnCKgesv",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
+  m["cusolverDnCYgesv"]                                               = {"hipsolverDnCYgesv",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
   // NOTE: rocsolver_dgesv has a harness of rocblas_set_workspace, hipsolverDDgesv_bufferSize, and rocsolver_dgesv_outofplace
-  {"cusolverDnDDgesv",                                   {"hipsolverDnDDgesv",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnDSgesv",                                   {"hipsolverDnDSgesv",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
-  {"cusolverDnDHgesv",                                   {"hipsolverDnDHgesv",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
-  {"cusolverDnDBgesv",                                   {"hipsolverDnDBgesv",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
-  {"cusolverDnDXgesv",                                   {"hipsolverDnDXgesv",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
+  m["cusolverDnDDgesv"]                                               = {"hipsolverDnDDgesv",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnDSgesv"]                                               = {"hipsolverDnDSgesv",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
+  m["cusolverDnDHgesv"]                                               = {"hipsolverDnDHgesv",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
+  m["cusolverDnDBgesv"]                                               = {"hipsolverDnDBgesv",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
+  m["cusolverDnDXgesv"]                                               = {"hipsolverDnDXgesv",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
   // NOTE: rocsolver_sgesv has a harness of rocblas_set_workspace, hipsolverSSgesv_bufferSize, and rocsolver_sgesv_outofplace
-  {"cusolverDnSSgesv",                                   {"hipsolverDnSSgesv",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnSHgesv",                                   {"hipsolverDnSHgesv",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
-  {"cusolverDnSBgesv",                                   {"hipsolverDnSBgesv",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
-  {"cusolverDnSXgesv",                                   {"hipsolverDnSXgesv",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
+  m["cusolverDnSSgesv"]                                               = {"hipsolverDnSSgesv",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnSHgesv"]                                               = {"hipsolverDnSHgesv",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
+  m["cusolverDnSBgesv"]                                               = {"hipsolverDnSBgesv",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
+  m["cusolverDnSXgesv"]                                               = {"hipsolverDnSXgesv",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
   // NOTE: rocsolver_zgesv has a harness of rocblas_start_device_memory_size_query, rocsolver_zgesv_outofplace, and rocblas_stop_device_memory_size_query
-  {"cusolverDnZZgesv_bufferSize",                        {"hipsolverDnZZgesv_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnZCgesv_bufferSize",                        {"hipsolverDnZCgesv_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
-  {"cusolverDnZKgesv_bufferSize",                        {"hipsolverDnZKgesv_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
-  {"cusolverDnZEgesv_bufferSize",                        {"hipsolverDnZEgesv_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
-  {"cusolverDnZYgesv_bufferSize",                        {"hipsolverDnZYgesv_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
+  m["cusolverDnZZgesv_bufferSize"]                                    = {"hipsolverDnZZgesv_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnZCgesv_bufferSize"]                                    = {"hipsolverDnZCgesv_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
+  m["cusolverDnZKgesv_bufferSize"]                                    = {"hipsolverDnZKgesv_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
+  m["cusolverDnZEgesv_bufferSize"]                                    = {"hipsolverDnZEgesv_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
+  m["cusolverDnZYgesv_bufferSize"]                                    = {"hipsolverDnZYgesv_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
   // NOTE: rocsolver_cgesv has a harness of rocblas_start_device_memory_size_query, rocsolver_cgesv_outofplace, and rocblas_stop_device_memory_size_query
-  {"cusolverDnCCgesv_bufferSize",                        {"hipsolverDnCCgesv_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnCKgesv_bufferSize",                        {"hipsolverDnCKgesv_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
-  {"cusolverDnCEgesv_bufferSize",                        {"hipsolverDnCEgesv_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
-  {"cusolverDnCYgesv_bufferSize",                        {"hipsolverDnCYgesv_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
+  m["cusolverDnCCgesv_bufferSize"]                                    = {"hipsolverDnCCgesv_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnCKgesv_bufferSize"]                                    = {"hipsolverDnCKgesv_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
+  m["cusolverDnCEgesv_bufferSize"]                                    = {"hipsolverDnCEgesv_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
+  m["cusolverDnCYgesv_bufferSize"]                                    = {"hipsolverDnCYgesv_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
   // NOTE: rocsolver_dgesv has a harness of rocblas_start_device_memory_size_query, rocsolver_dgesv_outofplace, and rocblas_stop_device_memory_size_query
-  {"cusolverDnDDgesv_bufferSize",                        {"hipsolverDnDDgesv_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnDSgesv_bufferSize",                        {"hipsolverDnDSgesv_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
-  {"cusolverDnDHgesv_bufferSize",                        {"hipsolverDnDHgesv_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
-  {"cusolverDnDBgesv_bufferSize",                        {"hipsolverDnDBgesv_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
-  {"cusolverDnDXgesv_bufferSize",                        {"hipsolverDnDXgesv_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
+  m["cusolverDnDDgesv_bufferSize"]                                    = {"hipsolverDnDDgesv_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnDSgesv_bufferSize"]                                    = {"hipsolverDnDSgesv_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
+  m["cusolverDnDHgesv_bufferSize"]                                    = {"hipsolverDnDHgesv_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
+  m["cusolverDnDBgesv_bufferSize"]                                    = {"hipsolverDnDBgesv_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
+  m["cusolverDnDXgesv_bufferSize"]                                    = {"hipsolverDnDXgesv_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
   // NOTE: rocsolver_sgesv has a harness of rocblas_start_device_memory_size_query, rocsolver_sgesv_outofplace, and rocblas_stop_device_memory_size_query
-  {"cusolverDnSSgesv_bufferSize",                        {"hipsolverDnSSgesv_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnSHgesv_bufferSize",                        {"hipsolverDnSHgesv_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
-  {"cusolverDnSBgesv_bufferSize",                        {"hipsolverDnSBgesv_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
-  {"cusolverDnSXgesv_bufferSize",                        {"hipsolverDnSXgesv_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
+  m["cusolverDnSSgesv_bufferSize"]                                    = {"hipsolverDnSSgesv_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnSHgesv_bufferSize"]                                    = {"hipsolverDnSHgesv_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
+  m["cusolverDnSBgesv_bufferSize"]                                    = {"hipsolverDnSBgesv_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
+  m["cusolverDnSXgesv_bufferSize"]                                    = {"hipsolverDnSXgesv_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
   // NOTE: rocsolver_zgels has a harness of rocblas_set_workspace, hipsolverZZgels_bufferSize, hipsolverManageWorkspace, and rocsolver_zgels_outofplace
-  {"cusolverDnZZgels",                                   {"hipsolverDnZZgels",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnZCgels",                                   {"hipsolverDnZCgels",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
-  {"cusolverDnZKgels",                                   {"hipsolverDnZKgels",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
-  {"cusolverDnZEgels",                                   {"hipsolverDnZEgels",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
-  {"cusolverDnZYgels",                                   {"hipsolverDnZYgels",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
+  m["cusolverDnZZgels"]                                               = {"hipsolverDnZZgels",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnZCgels"]                                               = {"hipsolverDnZCgels",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
+  m["cusolverDnZKgels"]                                               = {"hipsolverDnZKgels",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
+  m["cusolverDnZEgels"]                                               = {"hipsolverDnZEgels",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
+  m["cusolverDnZYgels"]                                               = {"hipsolverDnZYgels",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
   // NOTE: rocsolver_cgels has a harness of rocblas_set_workspace, hipsolverCCgels_bufferSize, hipsolverManageWorkspace, and rocsolver_cgels_outofplace
-  {"cusolverDnCCgels",                                   {"hipsolverDnCCgels",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnCKgels",                                   {"hipsolverDnCKgels",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
-  {"cusolverDnCEgels",                                   {"hipsolverDnCEgels",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
-  {"cusolverDnCYgels",                                   {"hipsolverDnCYgels",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
+  m["cusolverDnCCgels"]                                               = {"hipsolverDnCCgels",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnCKgels"]                                               = {"hipsolverDnCKgels",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
+  m["cusolverDnCEgels"]                                               = {"hipsolverDnCEgels",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
+  m["cusolverDnCYgels"]                                               = {"hipsolverDnCYgels",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
   // NOTE: rocsolver_dgels has a harness of rocblas_set_workspace, hipsolverDDgels_bufferSize, hipsolverManageWorkspace, and rocsolver_dgels_outofplace
-  {"cusolverDnDDgels",                                   {"hipsolverDnDDgels",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnDSgels",                                   {"hipsolverDnDSgels",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
-  {"cusolverDnDHgels",                                   {"hipsolverDnDHgels",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
-  {"cusolverDnDBgels",                                   {"hipsolverDnDBgels",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
-  {"cusolverDnDXgels",                                   {"hipsolverDnDXgels",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
+  m["cusolverDnDDgels"]                                               = {"hipsolverDnDDgels",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnDSgels"]                                               = {"hipsolverDnDSgels",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
+  m["cusolverDnDHgels"]                                               = {"hipsolverDnDHgels",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
+  m["cusolverDnDBgels"]                                               = {"hipsolverDnDBgels",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
+  m["cusolverDnDXgels"]                                               = {"hipsolverDnDXgels",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
   // NOTE: rocsolver_sgels has a harness of rocblas_set_workspace, hipsolverSSgels_bufferSize, hipsolverManageWorkspace, and rocsolver_sgels_outofplace
-  {"cusolverDnSSgels",                                   {"hipsolverDnSSgels",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnSHgels",                                   {"hipsolverDnSHgels",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
-  {"cusolverDnSBgels",                                   {"hipsolverDnSBgels",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
-  {"cusolverDnSXgels",                                   {"hipsolverDnSXgels",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
+  m["cusolverDnSSgels"]                                               = {"hipsolverDnSSgels",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnSHgels"]                                               = {"hipsolverDnSHgels",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
+  m["cusolverDnSBgels"]                                               = {"hipsolverDnSBgels",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
+  m["cusolverDnSXgels"]                                               = {"hipsolverDnSXgels",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
   // NOTE: rocsolver_zgels has a harness of rocblas_start_device_memory_size_query, rocsolver_zgels_outofplace, and rocblas_stop_device_memory_size_query
-  {"cusolverDnZZgels_bufferSize",                        {"hipsolverDnZZgels_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnZCgels_bufferSize",                        {"hipsolverDnZCgels_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
-  {"cusolverDnZKgels_bufferSize",                        {"hipsolverDnZKgels_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
-  {"cusolverDnZEgels_bufferSize",                        {"hipsolverDnZEgels_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
-  {"cusolverDnZYgels_bufferSize",                        {"hipsolverDnZYgels_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
+  m["cusolverDnZZgels_bufferSize"]                                    = {"hipsolverDnZZgels_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnZCgels_bufferSize"]                                    = {"hipsolverDnZCgels_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
+  m["cusolverDnZKgels_bufferSize"]                                    = {"hipsolverDnZKgels_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
+  m["cusolverDnZEgels_bufferSize"]                                    = {"hipsolverDnZEgels_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
+  m["cusolverDnZYgels_bufferSize"]                                    = {"hipsolverDnZYgels_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
   // NOTE: rocsolver_cgels has a harness of rocblas_start_device_memory_size_query, rocsolver_cgels_outofplace, and rocblas_stop_device_memory_size_query
-  {"cusolverDnCCgels_bufferSize",                        {"hipsolverDnCCgels_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnCKgels_bufferSize",                        {"hipsolverDnCKgels_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
-  {"cusolverDnCEgels_bufferSize",                        {"hipsolverDnCEgels_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
-  {"cusolverDnCYgels_bufferSize",                        {"hipsolverDnCYgels_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
+  m["cusolverDnCCgels_bufferSize"]                                    = {"hipsolverDnCCgels_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnCKgels_bufferSize"]                                    = {"hipsolverDnCKgels_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
+  m["cusolverDnCEgels_bufferSize"]                                    = {"hipsolverDnCEgels_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
+  m["cusolverDnCYgels_bufferSize"]                                    = {"hipsolverDnCYgels_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
   // NOTE: rocsolver_dgels has a harness of rocblas_start_device_memory_size_query, rocsolver_dgels_outofplace, and rocblas_stop_device_memory_size_query
-  {"cusolverDnDDgels_bufferSize",                        {"hipsolverDnDDgels_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnDSgels_bufferSize",                        {"hipsolverDnDSgels_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
-  {"cusolverDnDHgels_bufferSize",                        {"hipsolverDnDHgels_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
-  {"cusolverDnDBgels_bufferSize",                        {"hipsolverDnDBgels_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
-  {"cusolverDnDXgels_bufferSize",                        {"hipsolverDnDXgels_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
+  m["cusolverDnDDgels_bufferSize"]                                    = {"hipsolverDnDDgels_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnDSgels_bufferSize"]                                    = {"hipsolverDnDSgels_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
+  m["cusolverDnDHgels_bufferSize"]                                    = {"hipsolverDnDHgels_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
+  m["cusolverDnDBgels_bufferSize"]                                    = {"hipsolverDnDBgels_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
+  m["cusolverDnDXgels_bufferSize"]                                    = {"hipsolverDnDXgels_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
   // NOTE: rocsolver_sgels has a harness of rocblas_start_device_memory_size_query, rocsolver_sgels_outofplace, and rocblas_stop_device_memory_size_query
-  {"cusolverDnSSgels_bufferSize",                        {"hipsolverDnSSgels_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnSHgels_bufferSize",                        {"hipsolverDnSHgels_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
-  {"cusolverDnSBgels_bufferSize",                        {"hipsolverDnSBgels_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
-  {"cusolverDnSXgels_bufferSize",                        {"hipsolverDnSXgels_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
-  {"cusolverDnIRSXgesv",                                 {"hipsolverDnIRSXgesv",                                   "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
-  {"cusolverDnIRSXgesv_bufferSize",                      {"hipsolverDnIRSXgesv_bufferSize",                        "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
-  {"cusolverDnIRSXgels",                                 {"hipsolverDnIRSXgels",                                   "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
-  {"cusolverDnIRSXgels_bufferSize",                      {"hipsolverDnIRSXgels_bufferSize",                        "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
+  m["cusolverDnSSgels_bufferSize"]                                    = {"hipsolverDnSSgels_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnSHgels_bufferSize"]                                    = {"hipsolverDnSHgels_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
+  m["cusolverDnSBgels_bufferSize"]                                    = {"hipsolverDnSBgels_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
+  m["cusolverDnSXgels_bufferSize"]                                    = {"hipsolverDnSXgels_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
+  m["cusolverDnIRSXgesv"]                                             = {"hipsolverDnIRSXgesv",                                   "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
+  m["cusolverDnIRSXgesv_bufferSize"]                                  = {"hipsolverDnIRSXgesv_bufferSize",                        "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
+  m["cusolverDnIRSXgels"]                                             = {"hipsolverDnIRSXgels",                                   "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
+  m["cusolverDnIRSXgels_bufferSize"]                                  = {"hipsolverDnIRSXgels_bufferSize",                        "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
   // NOTE: rocsolver_(s|d|c|z)potrf has a harness of rocblas_start_device_memory_size_query and rocblas_stop_device_memory_size_query
-  {"cusolverDnSpotrf_bufferSize",                        {"hipsolverDnSpotrf_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnDpotrf_bufferSize",                        {"hipsolverDnDpotrf_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnCpotrf_bufferSize",                        {"hipsolverDnCpotrf_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnZpotrf_bufferSize",                        {"hipsolverDnZpotrf_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
+  m["cusolverDnSpotrf_bufferSize"]                                    = {"hipsolverDnSpotrf_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnDpotrf_bufferSize"]                                    = {"hipsolverDnDpotrf_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnCpotrf_bufferSize"]                                    = {"hipsolverDnCpotrf_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnZpotrf_bufferSize"]                                    = {"hipsolverDnZpotrf_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
   // TODO: rocsolver_(s|d|c|z)potrf needs second call to calculate workspaces
-  {"cusolverDnSpotrf",                                   {"hipsolverDnSpotrf",                                     "rocsolver_spotrf",                                               CONV_LIB_FUNC, API_SOLVER, 2}},
-  {"cusolverDnDpotrf",                                   {"hipsolverDnDpotrf",                                     "rocsolver_dpotrf",                                               CONV_LIB_FUNC, API_SOLVER, 2}},
-  {"cusolverDnCpotrf",                                   {"hipsolverDnCpotrf",                                     "rocsolver_cpotrf",                                               CONV_LIB_FUNC, API_SOLVER, 2}},
-  {"cusolverDnZpotrf",                                   {"hipsolverDnZpotrf",                                     "rocsolver_zpotrf",                                               CONV_LIB_FUNC, API_SOLVER, 2}},
+  m["cusolverDnSpotrf"]                                               = {"hipsolverDnSpotrf",                                     "rocsolver_spotrf",                                               CONV_LIB_FUNC, API_SOLVER, 2};
+  m["cusolverDnDpotrf"]                                               = {"hipsolverDnDpotrf",                                     "rocsolver_dpotrf",                                               CONV_LIB_FUNC, API_SOLVER, 2};
+  m["cusolverDnCpotrf"]                                               = {"hipsolverDnCpotrf",                                     "rocsolver_cpotrf",                                               CONV_LIB_FUNC, API_SOLVER, 2};
+  m["cusolverDnZpotrf"]                                               = {"hipsolverDnZpotrf",                                     "rocsolver_zpotrf",                                               CONV_LIB_FUNC, API_SOLVER, 2};
   // NOTE: rocsolver_(s|d|c|z)potrs has a harness of rocblas_set_workspace, hipsolver(S|D|C|Z)potrs_bufferSize, hipsolverManageWorkspace, and hipsolverZeroInfo
-  {"cusolverDnSpotrs",                                   {"hipsolverDnSpotrs",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnDpotrs",                                   {"hipsolverDnDpotrs",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnCpotrs",                                   {"hipsolverDnCpotrs",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnZpotrs",                                   {"hipsolverDnZpotrs",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
+  m["cusolverDnSpotrs"]                                               = {"hipsolverDnSpotrs",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnDpotrs"]                                               = {"hipsolverDnDpotrs",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnCpotrs"]                                               = {"hipsolverDnCpotrs",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnZpotrs"]                                               = {"hipsolverDnZpotrs",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
   // NOTE: rocsolver_(s|d|c|z)potrf_batched has a harness of rocblas_set_workspace, hipsolver(S|D|C|Z)potrfBatched_bufferSize, and hipsolverManageWorkspace
-  {"cusolverDnSpotrfBatched",                            {"hipsolverDnSpotrfBatched",                              "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnDpotrfBatched",                            {"hipsolverDnDpotrfBatched",                              "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnCpotrfBatched",                            {"hipsolverDnCpotrfBatched",                              "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnZpotrfBatched",                            {"hipsolverDnZpotrfBatched",                              "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
+  m["cusolverDnSpotrfBatched"]                                        = {"hipsolverDnSpotrfBatched",                              "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnDpotrfBatched"]                                        = {"hipsolverDnDpotrfBatched",                              "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnCpotrfBatched"]                                        = {"hipsolverDnCpotrfBatched",                              "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnZpotrfBatched"]                                        = {"hipsolverDnZpotrfBatched",                              "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
   // NOTE: rocsolver_(s|d|c|z)potrs_batched has a harness of rocblas_set_workspace, hipsolver(S|D|C|Z)potrsBatched_bufferSize, and hipsolverManageWorkspace
-  {"cusolverDnSpotrsBatched",                            {"hipsolverDnSpotrsBatched",                              "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnDpotrsBatched",                            {"hipsolverDnDpotrsBatched",                              "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnCpotrsBatched",                            {"hipsolverDnCpotrsBatched",                              "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnZpotrsBatched",                            {"hipsolverDnZpotrsBatched",                              "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
+  m["cusolverDnSpotrsBatched"]                                        = {"hipsolverDnSpotrsBatched",                              "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnDpotrsBatched"]                                        = {"hipsolverDnDpotrsBatched",                              "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnCpotrsBatched"]                                        = {"hipsolverDnCpotrsBatched",                              "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnZpotrsBatched"]                                        = {"hipsolverDnZpotrsBatched",                              "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
   // NOTE: rocsolver_(s|d|c|z)potri has a harness of rocblas_start_device_memory_size_query and rocblas_stop_device_memory_size_query
-  {"cusolverDnSpotri_bufferSize",                        {"hipsolverDnSpotri_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnDpotri_bufferSize",                        {"hipsolverDnDpotri_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnCpotri_bufferSize",                        {"hipsolverDnCpotri_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnZpotri_bufferSize",                        {"hipsolverDnZpotri_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
+  m["cusolverDnSpotri_bufferSize"]                                    = {"hipsolverDnSpotri_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnDpotri_bufferSize"]                                    = {"hipsolverDnDpotri_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnCpotri_bufferSize"]                                    = {"hipsolverDnCpotri_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnZpotri_bufferSize"]                                    = {"hipsolverDnZpotri_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
   // NOTE: rocsolver_(s|d|c|z)potri has a harness of rocblas_set_workspace, hipsolver(S|D|C|Z)potri_bufferSize and hipsolverManageWorkspace
-  {"cusolverDnSpotri",                                   {"hipsolverDnSpotri",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnDpotri",                                   {"hipsolverDnDpotri",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnCpotri",                                   {"hipsolverDnCpotri",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnZpotri",                                   {"hipsolverDnZpotri",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnXtrtri_bufferSize",                        {"hipsolverDnXtrtri_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
-  {"cusolverDnXtrtri",                                   {"hipsolverDnXtrtri",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
-  {"cusolverDnSlauum_bufferSize",                        {"hipsolverDnSlauum_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
-  {"cusolverDnDlauum_bufferSize",                        {"hipsolverDnDlauum_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
-  {"cusolverDnClauum_bufferSize",                        {"hipsolverDnClauum_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
-  {"cusolverDnZlauum_bufferSize",                        {"hipsolverDnZlauum_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
-  {"cusolverDnSlauum",                                   {"hipsolverDnSlauum",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
-  {"cusolverDnDlauum",                                   {"hipsolverDnDlauum",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
-  {"cusolverDnClauum",                                   {"hipsolverDnClauum",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
-  {"cusolverDnZlauum",                                   {"hipsolverDnZlauum",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
-  {"cusolverDnSlaswp",                                   {"hipsolverDnSlaswp",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
-  {"cusolverDnDlaswp",                                   {"hipsolverDnDlaswp",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
-  {"cusolverDnClaswp",                                   {"hipsolverDnClaswp",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
-  {"cusolverDnZlaswp",                                   {"hipsolverDnZlaswp",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
+  m["cusolverDnSpotri"]                                               = {"hipsolverDnSpotri",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnDpotri"]                                               = {"hipsolverDnDpotri",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnCpotri"]                                               = {"hipsolverDnCpotri",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnZpotri"]                                               = {"hipsolverDnZpotri",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnXtrtri_bufferSize"]                                    = {"hipsolverDnXtrtri_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
+  m["cusolverDnXtrtri"]                                               = {"hipsolverDnXtrtri",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
+  m["cusolverDnSlauum_bufferSize"]                                    = {"hipsolverDnSlauum_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
+  m["cusolverDnDlauum_bufferSize"]                                    = {"hipsolverDnDlauum_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
+  m["cusolverDnClauum_bufferSize"]                                    = {"hipsolverDnClauum_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
+  m["cusolverDnZlauum_bufferSize"]                                    = {"hipsolverDnZlauum_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
+  m["cusolverDnSlauum"]                                               = {"hipsolverDnSlauum",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
+  m["cusolverDnDlauum"]                                               = {"hipsolverDnDlauum",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
+  m["cusolverDnClauum"]                                               = {"hipsolverDnClauum",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
+  m["cusolverDnZlauum"]                                               = {"hipsolverDnZlauum",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
+  m["cusolverDnSlaswp"]                                               = {"hipsolverDnSlaswp",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
+  m["cusolverDnDlaswp"]                                               = {"hipsolverDnDlaswp",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
+  m["cusolverDnClaswp"]                                               = {"hipsolverDnClaswp",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
+  m["cusolverDnZlaswp"]                                               = {"hipsolverDnZlaswp",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
   // NOTE: rocsolver_(s|d|c|z)geqrf have a harness of other HIP and ROC API calls
-  {"cusolverDnSgeqrf_bufferSize",                        {"hipsolverDnSgeqrf_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnDgeqrf_bufferSize",                        {"hipsolverDnDgeqrf_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnCgeqrf_bufferSize",                        {"hipsolverDnCgeqrf_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnZgeqrf_bufferSize",                        {"hipsolverDnZgeqrf_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
+  m["cusolverDnSgeqrf_bufferSize"]                                    = {"hipsolverDnSgeqrf_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnDgeqrf_bufferSize"]                                    = {"hipsolverDnDgeqrf_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnCgeqrf_bufferSize"]                                    = {"hipsolverDnCgeqrf_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnZgeqrf_bufferSize"]                                    = {"hipsolverDnZgeqrf_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
   // NOTE: rocsolver_(s|d|c|z)geqrf have a harness of other HIP and ROC API calls
-  {"cusolverDnSgeqrf",                                   {"hipsolverDnSgeqrf",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnDgeqrf",                                   {"hipsolverDnDgeqrf",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnCgeqrf",                                   {"hipsolverDnCgeqrf",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnZgeqrf",                                   {"hipsolverDnZgeqrf",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
+  m["cusolverDnSgeqrf"]                                               = {"hipsolverDnSgeqrf",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnDgeqrf"]                                               = {"hipsolverDnDgeqrf",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnCgeqrf"]                                               = {"hipsolverDnCgeqrf",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnZgeqrf"]                                               = {"hipsolverDnZgeqrf",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
   // NOTE: rocsolver_(s|d)orgqr and rocsolver_(c|z)ungqr have a harness of other HIP and ROC API calls
-  {"cusolverDnSorgqr_bufferSize",                        {"hipsolverDnSorgqr_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnDorgqr_bufferSize",                        {"hipsolverDnDorgqr_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnCungqr_bufferSize",                        {"hipsolverDnCungqr_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnZungqr_bufferSize",                        {"hipsolverDnZungqr_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
+  m["cusolverDnSorgqr_bufferSize"]                                    = {"hipsolverDnSorgqr_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnDorgqr_bufferSize"]                                    = {"hipsolverDnDorgqr_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnCungqr_bufferSize"]                                    = {"hipsolverDnCungqr_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnZungqr_bufferSize"]                                    = {"hipsolverDnZungqr_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
   // NOTE: rocsolver_(s|d)orgqr and rocsolver_(c|z)ungqr have a harness of other HIP and ROC API calls
-  {"cusolverDnSorgqr",                                   {"hipsolverDnSorgqr",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnDorgqr",                                   {"hipsolverDnDorgqr",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnCungqr",                                   {"hipsolverDnCungqr",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnZungqr",                                   {"hipsolverDnZungqr",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
+  m["cusolverDnSorgqr"]                                               = {"hipsolverDnSorgqr",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnDorgqr"]                                               = {"hipsolverDnDorgqr",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnCungqr"]                                               = {"hipsolverDnCungqr",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnZungqr"]                                               = {"hipsolverDnZungqr",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
   // NOTE: rocsolver_(s|d)ormqr and rocsolver_(c|z)unmqr have a harness of other HIP and ROC API calls
-  {"cusolverDnSormqr_bufferSize",                        {"hipsolverDnSormqr_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnDormqr_bufferSize",                        {"hipsolverDnDormqr_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnCunmqr_bufferSize",                        {"hipsolverDnCunmqr_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnZunmqr_bufferSize",                        {"hipsolverDnZunmqr_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
+  m["cusolverDnSormqr_bufferSize"]                                    = {"hipsolverDnSormqr_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnDormqr_bufferSize"]                                    = {"hipsolverDnDormqr_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnCunmqr_bufferSize"]                                    = {"hipsolverDnCunmqr_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnZunmqr_bufferSize"]                                    = {"hipsolverDnZunmqr_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
   // NOTE: rocsolver_(s|d)ormqr and rocsolver_(c|z)unmqr have a harness of other HIP and ROC API calls
-  {"cusolverDnSormqr",                                   {"hipsolverDnSormqr",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnDormqr",                                   {"hipsolverDnDormqr",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnCunmqr",                                   {"hipsolverDnCunmqr",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnZunmqr",                                   {"hipsolverDnZunmqr",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
+  m["cusolverDnSormqr"]                                               = {"hipsolverDnSormqr",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnDormqr"]                                               = {"hipsolverDnDormqr",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnCunmqr"]                                               = {"hipsolverDnCunmqr",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnZunmqr"]                                               = {"hipsolverDnZunmqr",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
   // NOTE: rocsolver_(s|d|c|z)sytrf have a harness of other HIP and ROC API calls
-  {"cusolverDnSsytrf_bufferSize",                        {"hipsolverDnSsytrf_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnDsytrf_bufferSize",                        {"hipsolverDnDsytrf_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnCsytrf_bufferSize",                        {"hipsolverDnCsytrf_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnZsytrf_bufferSize",                        {"hipsolverDnZsytrf_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
+  m["cusolverDnSsytrf_bufferSize"]                                    = {"hipsolverDnSsytrf_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnDsytrf_bufferSize"]                                    = {"hipsolverDnDsytrf_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnCsytrf_bufferSize"]                                    = {"hipsolverDnCsytrf_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnZsytrf_bufferSize"]                                    = {"hipsolverDnZsytrf_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
   // NOTE: rocsolver_(s|d|c|z)sytrf have a harness of other HIP and ROC API calls
-  {"cusolverDnSsytrf",                                   {"hipsolverDnSsytrf",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnDsytrf",                                   {"hipsolverDnDsytrf",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnCsytrf",                                   {"hipsolverDnCsytrf",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnZsytrf",                                   {"hipsolverDnZsytrf",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnXsytrs_bufferSize",                        {"hipsolverDnXsytrs_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
-  {"cusolverDnXsytrs",                                   {"hipsolverDnXsytrs",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
-  {"cusolverDnSsytri_bufferSize",                        {"hipsolverDnSsytri_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
-  {"cusolverDnDsytri_bufferSize",                        {"hipsolverDnDsytri_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
-  {"cusolverDnCsytri_bufferSize",                        {"hipsolverDnCsytri_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
-  {"cusolverDnZsytri_bufferSize",                        {"hipsolverDnZsytri_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
-  {"cusolverDnSsytri",                                   {"hipsolverDnSsytri",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
-  {"cusolverDnDsytri",                                   {"hipsolverDnDsytri",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
-  {"cusolverDnCsytri",                                   {"hipsolverDnCsytri",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
-  {"cusolverDnZsytri",                                   {"hipsolverDnZsytri",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
+  m["cusolverDnSsytrf"]                                               = {"hipsolverDnSsytrf",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnDsytrf"]                                               = {"hipsolverDnDsytrf",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnCsytrf"]                                               = {"hipsolverDnCsytrf",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnZsytrf"]                                               = {"hipsolverDnZsytrf",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnXsytrs_bufferSize"]                                    = {"hipsolverDnXsytrs_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
+  m["cusolverDnXsytrs"]                                               = {"hipsolverDnXsytrs",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
+  m["cusolverDnSsytri_bufferSize"]                                    = {"hipsolverDnSsytri_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
+  m["cusolverDnDsytri_bufferSize"]                                    = {"hipsolverDnDsytri_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
+  m["cusolverDnCsytri_bufferSize"]                                    = {"hipsolverDnCsytri_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
+  m["cusolverDnZsytri_bufferSize"]                                    = {"hipsolverDnZsytri_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
+  m["cusolverDnSsytri"]                                               = {"hipsolverDnSsytri",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
+  m["cusolverDnDsytri"]                                               = {"hipsolverDnDsytri",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
+  m["cusolverDnCsytri"]                                               = {"hipsolverDnCsytri",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
+  m["cusolverDnZsytri"]                                               = {"hipsolverDnZsytri",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
   // NOTE: rocsolver_(s|d|c|z)gebrd have a harness of other HIP and ROC API calls
-  {"cusolverDnSgebrd_bufferSize",                        {"hipsolverDnSgebrd_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnDgebrd_bufferSize",                        {"hipsolverDnDgebrd_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnCgebrd_bufferSize",                        {"hipsolverDnCgebrd_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnZgebrd_bufferSize",                        {"hipsolverDnZgebrd_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
+  m["cusolverDnSgebrd_bufferSize"]                                    = {"hipsolverDnSgebrd_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnDgebrd_bufferSize"]                                    = {"hipsolverDnDgebrd_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnCgebrd_bufferSize"]                                    = {"hipsolverDnCgebrd_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnZgebrd_bufferSize"]                                    = {"hipsolverDnZgebrd_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
   // NOTE: rocsolver_(s|d|c|z)gebrd have a harness of other HIP and ROC API calls
-  {"cusolverDnSgebrd",                                   {"hipsolverDnSgebrd",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnDgebrd",                                   {"hipsolverDnDgebrd",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnCgebrd",                                   {"hipsolverDnCgebrd",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnZgebrd",                                   {"hipsolverDnZgebrd",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
+  m["cusolverDnSgebrd"]                                               = {"hipsolverDnSgebrd",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnDgebrd"]                                               = {"hipsolverDnDgebrd",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnCgebrd"]                                               = {"hipsolverDnCgebrd",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnZgebrd"]                                               = {"hipsolverDnZgebrd",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
   // NOTE: rocsolver_(s|d)orgbr and rocsolver_(c|z)ungbr have a harness of other HIP and ROC API calls
-  {"cusolverDnSorgbr_bufferSize",                        {"hipsolverDnSorgbr_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnDorgbr_bufferSize",                        {"hipsolverDnDorgbr_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnCungbr_bufferSize",                        {"hipsolverDnCungbr_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnZungbr_bufferSize",                        {"hipsolverDnZungbr_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
+  m["cusolverDnSorgbr_bufferSize"]                                    = {"hipsolverDnSorgbr_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnDorgbr_bufferSize"]                                    = {"hipsolverDnDorgbr_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnCungbr_bufferSize"]                                    = {"hipsolverDnCungbr_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnZungbr_bufferSize"]                                    = {"hipsolverDnZungbr_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
   // NOTE: rocsolver_(s|d)orgbr and rocsolver_(c|z)ungbr have a harness of other HIP and ROC API calls
-  {"cusolverDnSorgbr",                                   {"hipsolverDnSorgbr",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnDorgbr",                                   {"hipsolverDnDorgbr",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnCungbr",                                   {"hipsolverDnCungbr",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnZungbr",                                   {"hipsolverDnZungbr",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
+  m["cusolverDnSorgbr"]                                               = {"hipsolverDnSorgbr",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnDorgbr"]                                               = {"hipsolverDnDorgbr",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnCungbr"]                                               = {"hipsolverDnCungbr",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnZungbr"]                                               = {"hipsolverDnZungbr",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
   // NOTE: rocsolver_(s|d)sytrd and rocsolver_(c|z)hetrd have a harness of other HIP and ROC API calls
-  {"cusolverDnSsytrd_bufferSize",                        {"hipsolverDnSsytrd_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnDsytrd_bufferSize",                        {"hipsolverDnDsytrd_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnChetrd_bufferSize",                        {"hipsolverDnChetrd_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnZhetrd_bufferSize",                        {"hipsolverDnZhetrd_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
+  m["cusolverDnSsytrd_bufferSize"]                                    = {"hipsolverDnSsytrd_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnDsytrd_bufferSize"]                                    = {"hipsolverDnDsytrd_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnChetrd_bufferSize"]                                    = {"hipsolverDnChetrd_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnZhetrd_bufferSize"]                                    = {"hipsolverDnZhetrd_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
   // NOTE: rocsolver_(s|d)sytrd and rocsolver_(c|z)hetrd have a harness of other HIP and ROC API calls
-  {"cusolverDnSsytrd",                                   {"hipsolverDnSsytrd",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnDsytrd",                                   {"hipsolverDnDsytrd",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnChetrd",                                   {"hipsolverDnChetrd",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnZhetrd",                                   {"hipsolverDnZhetrd",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
+  m["cusolverDnSsytrd"]                                               = {"hipsolverDnSsytrd",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnDsytrd"]                                               = {"hipsolverDnDsytrd",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnChetrd"]                                               = {"hipsolverDnChetrd",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnZhetrd"]                                               = {"hipsolverDnZhetrd",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
   // NOTE: rocsolver_(s|d)orgtr and rocsolver_(c|z)ungtr have a harness of other HIP and ROC API calls
-  {"cusolverDnSorgtr_bufferSize",                        {"hipsolverDnSorgtr_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnDorgtr_bufferSize",                        {"hipsolverDnDorgtr_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnCungtr_bufferSize",                        {"hipsolverDnCungtr_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnZungtr_bufferSize",                        {"hipsolverDnZungtr_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
+  m["cusolverDnSorgtr_bufferSize"]                                    = {"hipsolverDnSorgtr_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnDorgtr_bufferSize"]                                    = {"hipsolverDnDorgtr_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnCungtr_bufferSize"]                                    = {"hipsolverDnCungtr_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnZungtr_bufferSize"]                                    = {"hipsolverDnZungtr_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
   // NOTE: rocsolver_(s|d)orgtr and rocsolver_(c|z)ungtr have a harness of other HIP and ROC API calls
-  {"cusolverDnSorgtr",                                   {"hipsolverDnSorgtr",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnDorgtr",                                   {"hipsolverDnDorgtr",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnCungtr",                                   {"hipsolverDnCungtr",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnZungtr",                                   {"hipsolverDnZungtr",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
+  m["cusolverDnSorgtr"]                                               = {"hipsolverDnSorgtr",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnDorgtr"]                                               = {"hipsolverDnDorgtr",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnCungtr"]                                               = {"hipsolverDnCungtr",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnZungtr"]                                               = {"hipsolverDnZungtr",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
   // NOTE: rocsolver_(s|d)ormtr and rocsolver_(c|z)unmtr have a harness of other HIP and ROC API calls
-  {"cusolverDnSormtr_bufferSize",                        {"hipsolverDnSormtr_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnDormtr_bufferSize",                        {"hipsolverDnDormtr_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnCunmtr_bufferSize",                        {"hipsolverDnCunmtr_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnZunmtr_bufferSize",                        {"hipsolverDnZunmtr_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
+  m["cusolverDnSormtr_bufferSize"]                                    = {"hipsolverDnSormtr_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnDormtr_bufferSize"]                                    = {"hipsolverDnDormtr_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnCunmtr_bufferSize"]                                    = {"hipsolverDnCunmtr_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnZunmtr_bufferSize"]                                    = {"hipsolverDnZunmtr_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
   // NOTE: rocsolver_(s|d)ormtr and rocsolver_(c|z)unmtr have a harness of other HIP and ROC API calls
-  {"cusolverDnSormtr",                                   {"hipsolverDnSormtr",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnDormtr",                                   {"hipsolverDnDormtr",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnCunmtr",                                   {"hipsolverDnCunmtr",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnZunmtr",                                   {"hipsolverDnZunmtr",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
+  m["cusolverDnSormtr"]                                               = {"hipsolverDnSormtr",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnDormtr"]                                               = {"hipsolverDnDormtr",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnCunmtr"]                                               = {"hipsolverDnCunmtr",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnZunmtr"]                                               = {"hipsolverDnZunmtr",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
   // NOTE: rocsolver_(s|d|c|z)gesvd have a harness of other HIP and ROC API calls
-  {"cusolverDnSgesvd_bufferSize",                        {"hipsolverDnSgesvd_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnDgesvd_bufferSize",                        {"hipsolverDnDgesvd_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnCgesvd_bufferSize",                        {"hipsolverDnCgesvd_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnZgesvd_bufferSize",                        {"hipsolverDnZgesvd_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
+  m["cusolverDnSgesvd_bufferSize"]                                    = {"hipsolverDnSgesvd_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnDgesvd_bufferSize"]                                    = {"hipsolverDnDgesvd_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnCgesvd_bufferSize"]                                    = {"hipsolverDnCgesvd_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnZgesvd_bufferSize"]                                    = {"hipsolverDnZgesvd_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
   // NOTE: rocsolver_(s|d|c|z)gesvd have a harness of other HIP and ROC API calls
-  {"cusolverDnSgesvd",                                   {"hipsolverDnSgesvd",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnDgesvd",                                   {"hipsolverDnDgesvd",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnCgesvd",                                   {"hipsolverDnCgesvd",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnZgesvd",                                   {"hipsolverDnZgesvd",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
+  m["cusolverDnSgesvd"]                                               = {"hipsolverDnSgesvd",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnDgesvd"]                                               = {"hipsolverDnDgesvd",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnCgesvd"]                                               = {"hipsolverDnCgesvd",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnZgesvd"]                                               = {"hipsolverDnZgesvd",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
   // NOTE: rocsolver_(s|d)syevd and rocsolver_(c|z)heevd have a harness of other HIP and ROC API calls
-  {"cusolverDnSsyevd_bufferSize",                        {"hipsolverDnSsyevd_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnDsyevd_bufferSize",                        {"hipsolverDnDsyevd_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnCheevd_bufferSize",                        {"hipsolverDnCheevd_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnZheevd_bufferSize",                        {"hipsolverDnZheevd_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
+  m["cusolverDnSsyevd_bufferSize"]                                    = {"hipsolverDnSsyevd_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnDsyevd_bufferSize"]                                    = {"hipsolverDnDsyevd_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnCheevd_bufferSize"]                                    = {"hipsolverDnCheevd_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnZheevd_bufferSize"]                                    = {"hipsolverDnZheevd_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
   // NOTE: rocsolver_(s|d)syevd and rocsolver_(c|z)heevd have a harness of other HIP and ROC API calls
-  {"cusolverDnSsyevd",                                   {"hipsolverDnSsyevd",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnDsyevd",                                   {"hipsolverDnDsyevd",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnCheevd",                                   {"hipsolverDnCheevd",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnZheevd",                                   {"hipsolverDnZheevd",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
+  m["cusolverDnSsyevd"]                                               = {"hipsolverDnSsyevd",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnDsyevd"]                                               = {"hipsolverDnDsyevd",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnCheevd"]                                               = {"hipsolverDnCheevd",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnZheevd"]                                               = {"hipsolverDnZheevd",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
   // NOTE: rocsolver_(s|d)syevdx_inplace and rocsolver_(c|z)heevdx_inplace have a harness of other ROC API calls
-  {"cusolverDnSsyevdx_bufferSize",                       {"hipsolverDnSsyevdx_bufferSize",                         "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnDsyevdx_bufferSize",                       {"hipsolverDnDsyevdx_bufferSize",                         "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnCheevdx_bufferSize",                       {"hipsolverDnCheevdx_bufferSize",                         "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnZheevdx_bufferSize",                       {"hipsolverDnZheevdx_bufferSize",                         "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
+  m["cusolverDnSsyevdx_bufferSize"]                                   = {"hipsolverDnSsyevdx_bufferSize",                         "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnDsyevdx_bufferSize"]                                   = {"hipsolverDnDsyevdx_bufferSize",                         "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnCheevdx_bufferSize"]                                   = {"hipsolverDnCheevdx_bufferSize",                         "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnZheevdx_bufferSize"]                                   = {"hipsolverDnZheevdx_bufferSize",                         "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
   // NOTE: rocsolver_(s|d)syevdx_inplace and rocsolver_(c|z)heevdx_inplace have a harness of other ROC and HIP API calls
-  {"cusolverDnSsyevdx",                                  {"hipsolverDnSsyevdx",                                    "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnDsyevdx",                                  {"hipsolverDnDsyevdx",                                    "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnCheevdx",                                  {"hipsolverDnCheevdx",                                    "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnZheevdx",                                  {"hipsolverDnZheevdx",                                    "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
+  m["cusolverDnSsyevdx"]                                              = {"hipsolverDnSsyevdx",                                    "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnDsyevdx"]                                              = {"hipsolverDnDsyevdx",                                    "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnCheevdx"]                                              = {"hipsolverDnCheevdx",                                    "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnZheevdx"]                                              = {"hipsolverDnZheevdx",                                    "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
   // NOTE: rocsolver_(s|d)sygvdx_inplace and rocsolver_(c|z)hegvdx_inplace have a harness of other ROC and HIP API calls
-  {"cusolverDnSsygvdx_bufferSize",                       {"hipsolverDnSsygvdx_bufferSize",                         "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnDsygvdx_bufferSize",                       {"hipsolverDnDsygvdx_bufferSize",                         "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnChegvdx_bufferSize",                       {"hipsolverDnChegvdx_bufferSize",                         "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnZhegvdx_bufferSize",                       {"hipsolverDnZhegvdx_bufferSize",                         "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
+  m["cusolverDnSsygvdx_bufferSize"]                                   = {"hipsolverDnSsygvdx_bufferSize",                         "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnDsygvdx_bufferSize"]                                   = {"hipsolverDnDsygvdx_bufferSize",                         "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnChegvdx_bufferSize"]                                   = {"hipsolverDnChegvdx_bufferSize",                         "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnZhegvdx_bufferSize"]                                   = {"hipsolverDnZhegvdx_bufferSize",                         "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
   // NOTE: rocsolver_(s|d)sygvdx_inplace and rocsolver_(c|z)hegvdx_inplace have a harness of other ROC and HIP API calls
-  {"cusolverDnSsygvdx",                                  {"hipsolverDnSsygvdx",                                    "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnDsygvdx",                                  {"hipsolverDnDsygvdx",                                    "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnChegvdx",                                  {"hipsolverDnChegvdx",                                    "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnZhegvdx",                                  {"hipsolverDnZhegvdx",                                    "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
+  m["cusolverDnSsygvdx"]                                              = {"hipsolverDnSsygvdx",                                    "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnDsygvdx"]                                              = {"hipsolverDnDsygvdx",                                    "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnChegvdx"]                                              = {"hipsolverDnChegvdx",                                    "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnZhegvdx"]                                              = {"hipsolverDnZhegvdx",                                    "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
   // NOTE: rocsolver_(s|d)sygvd and rocsolver_(c|z)hegvd have a harness of other ROC and HIP API calls
-  {"cusolverDnSsygvd_bufferSize",                        {"hipsolverDnSsygvd_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnDsygvd_bufferSize",                        {"hipsolverDnDsygvd_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnChegvd_bufferSize",                        {"hipsolverDnChegvd_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnZhegvd_bufferSize",                        {"hipsolverDnZhegvd_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
+  m["cusolverDnSsygvd_bufferSize"]                                    = {"hipsolverDnSsygvd_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnDsygvd_bufferSize"]                                    = {"hipsolverDnDsygvd_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnChegvd_bufferSize"]                                    = {"hipsolverDnChegvd_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnZhegvd_bufferSize"]                                    = {"hipsolverDnZhegvd_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
   // NOTE: rocsolver_(s|d)sygvd and rocsolver_(c|z)hegvd have a harness of other ROC and HIP API calls
-  {"cusolverDnSsygvd",                                   {"hipsolverDnSsygvd",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnDsygvd",                                   {"hipsolverDnDsygvd",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnChegvd",                                   {"hipsolverDnChegvd",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnZhegvd",                                   {"hipsolverDnZhegvd",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
+  m["cusolverDnSsygvd"]                                               = {"hipsolverDnSsygvd",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnDsygvd"]                                               = {"hipsolverDnDsygvd",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnChegvd"]                                               = {"hipsolverDnChegvd",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnZhegvd"]                                               = {"hipsolverDnZhegvd",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
   // no ROC analogues
-  {"cusolverDnCreateSyevjInfo",                          {"hipsolverDnCreateSyevjInfo",                            "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnDestroySyevjInfo",                         {"hipsolverDnDestroySyevjInfo",                           "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnXsyevjSetTolerance",                       {"hipsolverDnXsyevjSetTolerance",                         "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnXsyevjSetMaxSweeps",                       {"hipsolverDnXsyevjSetMaxSweeps",                         "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnXsyevjSetSortEig",                         {"hipsolverDnXsyevjSetSortEig",                           "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnXsyevjGetResidual",                        {"hipsolverDnXsyevjGetResidual",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnXsyevjGetSweeps",                          {"hipsolverDnXsyevjGetSweeps",                            "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
+  m["cusolverDnCreateSyevjInfo"]                                      = {"hipsolverDnCreateSyevjInfo",                            "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnDestroySyevjInfo"]                                     = {"hipsolverDnDestroySyevjInfo",                           "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnXsyevjSetTolerance"]                                   = {"hipsolverDnXsyevjSetTolerance",                         "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnXsyevjSetMaxSweeps"]                                   = {"hipsolverDnXsyevjSetMaxSweeps",                         "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnXsyevjSetSortEig"]                                     = {"hipsolverDnXsyevjSetSortEig",                           "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnXsyevjGetResidual"]                                    = {"hipsolverDnXsyevjGetResidual",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnXsyevjGetSweeps"]                                      = {"hipsolverDnXsyevjGetSweeps",                            "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
   // NOTE: rocsolver_(s|d)syevj_strided_batched and rocsolver_(c|z)heevj_strided_batched have a harness of other ROC and HIP API calls
-  {"cusolverDnSsyevjBatched_bufferSize",                 {"hipsolverDnSsyevjBatched_bufferSize",                   "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnDsyevjBatched_bufferSize",                 {"hipsolverDnDsyevjBatched_bufferSize",                   "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnCheevjBatched_bufferSize",                 {"hipsolverDnCheevjBatched_bufferSize",                   "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnZheevjBatched_bufferSize",                 {"hipsolverDnZheevjBatched_bufferSize",                   "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
+  m["cusolverDnSsyevjBatched_bufferSize"]                             = {"hipsolverDnSsyevjBatched_bufferSize",                   "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnDsyevjBatched_bufferSize"]                             = {"hipsolverDnDsyevjBatched_bufferSize",                   "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnCheevjBatched_bufferSize"]                             = {"hipsolverDnCheevjBatched_bufferSize",                   "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnZheevjBatched_bufferSize"]                             = {"hipsolverDnZheevjBatched_bufferSize",                   "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
   // NOTE: rocsolver_(s|d)syevj_strided_batched and rocsolver_(c|z)heevj_strided_batched have a harness of other ROC and HIP API calls
-  {"cusolverDnSsyevjBatched",                            {"hipsolverDnSsyevjBatched",                              "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnDsyevjBatched",                            {"hipsolverDnDsyevjBatched",                              "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnCheevjBatched",                            {"hipsolverDnCheevjBatched",                              "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnZheevjBatched",                            {"hipsolverDnZheevjBatched",                              "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
+  m["cusolverDnSsyevjBatched"]                                        = {"hipsolverDnSsyevjBatched",                              "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnDsyevjBatched"]                                        = {"hipsolverDnDsyevjBatched",                              "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnCheevjBatched"]                                        = {"hipsolverDnCheevjBatched",                              "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnZheevjBatched"]                                        = {"hipsolverDnZheevjBatched",                              "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
   // NOTE: rocsolver_(s|d)syevj and rocsolver_(c|z)heevj have a harness of other ROC and HIP API calls
-  {"cusolverDnSsyevj_bufferSize",                        {"hipsolverDnSsyevj_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnDsyevj_bufferSize",                        {"hipsolverDnDsyevj_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnCheevj_bufferSize",                        {"hipsolverDnCheevj_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnZheevj_bufferSize",                        {"hipsolverDnZheevj_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
+  m["cusolverDnSsyevj_bufferSize"]                                    = {"hipsolverDnSsyevj_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnDsyevj_bufferSize"]                                    = {"hipsolverDnDsyevj_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnCheevj_bufferSize"]                                    = {"hipsolverDnCheevj_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnZheevj_bufferSize"]                                    = {"hipsolverDnZheevj_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
   // NOTE: rocsolver_(s|d)syevj and rocsolver_(c|z)heevj have a harness of other ROC and HIP API calls
-  {"cusolverDnSsyevj",                                   {"hipsolverDnSsyevj",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnDsyevj",                                   {"hipsolverDnDsyevj",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnCheevj",                                   {"hipsolverDnCheevj",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnZheevj",                                   {"hipsolverDnZheevj",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
+  m["cusolverDnSsyevj"]                                               = {"hipsolverDnSsyevj",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnDsyevj"]                                               = {"hipsolverDnDsyevj",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnCheevj"]                                               = {"hipsolverDnCheevj",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnZheevj"]                                               = {"hipsolverDnZheevj",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
   // NOTE: rocsolver_(s|d)sygvj and rocsolver_(c|z)hegvj have a harness of other ROC and HIP API calls
-  {"cusolverDnSsygvj_bufferSize",                        {"hipsolverDnSsygvj_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnDsygvj_bufferSize",                        {"hipsolverDnDsygvj_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnChegvj_bufferSize",                        {"hipsolverDnChegvj_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnZhegvj_bufferSize",                        {"hipsolverDnZhegvj_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
+  m["cusolverDnSsygvj_bufferSize"]                                    = {"hipsolverDnSsygvj_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnDsygvj_bufferSize"]                                    = {"hipsolverDnDsygvj_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnChegvj_bufferSize"]                                    = {"hipsolverDnChegvj_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnZhegvj_bufferSize"]                                    = {"hipsolverDnZhegvj_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
   // NOTE: rocsolver_(s|d)sygvj and rocsolver_(c|z)hegvj have a harness of other ROC and HIP API calls
-  {"cusolverDnSsygvj",                                   {"hipsolverDnSsygvj",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnDsygvj",                                   {"hipsolverDnDsygvj",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnChegvj",                                   {"hipsolverDnChegvj",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnZhegvj",                                   {"hipsolverDnZhegvj",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
+  m["cusolverDnSsygvj"]                                               = {"hipsolverDnSsygvj",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnDsygvj"]                                               = {"hipsolverDnDsygvj",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnChegvj"]                                               = {"hipsolverDnChegvj",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnZhegvj"]                                               = {"hipsolverDnZhegvj",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
   // no ROC analogues
-  {"cusolverDnCreateGesvdjInfo",                         {"hipsolverDnCreateGesvdjInfo",                           "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnDestroyGesvdjInfo",                        {"hipsolverDnDestroyGesvdjInfo",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnXgesvdjSetTolerance",                      {"hipsolverDnXgesvdjSetTolerance",                        "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnXgesvdjSetMaxSweeps",                      {"hipsolverDnXgesvdjSetMaxSweeps",                        "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnXgesvdjSetSortEig",                        {"hipsolverDnXgesvdjSetSortEig",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnXgesvdjGetResidual",                       {"hipsolverDnXgesvdjGetResidual",                         "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnXgesvdjGetSweeps",                         {"hipsolverDnXgesvdjGetSweeps",                           "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
+  m["cusolverDnCreateGesvdjInfo"]                                     = {"hipsolverDnCreateGesvdjInfo",                           "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnDestroyGesvdjInfo"]                                    = {"hipsolverDnDestroyGesvdjInfo",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnXgesvdjSetTolerance"]                                  = {"hipsolverDnXgesvdjSetTolerance",                        "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnXgesvdjSetMaxSweeps"]                                  = {"hipsolverDnXgesvdjSetMaxSweeps",                        "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnXgesvdjSetSortEig"]                                    = {"hipsolverDnXgesvdjSetSortEig",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnXgesvdjGetResidual"]                                   = {"hipsolverDnXgesvdjGetResidual",                         "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnXgesvdjGetSweeps"]                                     = {"hipsolverDnXgesvdjGetSweeps",                           "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
   // NOTE: rocsolver_(s|d|c|z)gesvdj_notransv_strided_batched have a harness of other ROC and HIP API calls
-  {"cusolverDnSgesvdjBatched_bufferSize",                {"hipsolverDnSgesvdjBatched_bufferSize",                  "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnDgesvdjBatched_bufferSize",                {"hipsolverDnDgesvdjBatched_bufferSize",                  "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnCgesvdjBatched_bufferSize",                {"hipsolverDnCgesvdjBatched_bufferSize",                  "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnZgesvdjBatched_bufferSize",                {"hipsolverDnZgesvdjBatched_bufferSize",                  "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
+  m["cusolverDnSgesvdjBatched_bufferSize"]                            = {"hipsolverDnSgesvdjBatched_bufferSize",                  "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnDgesvdjBatched_bufferSize"]                            = {"hipsolverDnDgesvdjBatched_bufferSize",                  "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnCgesvdjBatched_bufferSize"]                            = {"hipsolverDnCgesvdjBatched_bufferSize",                  "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnZgesvdjBatched_bufferSize"]                            = {"hipsolverDnZgesvdjBatched_bufferSize",                  "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
   // NOTE: rocsolver_(s|d|c|z)gesvdj_notransv_strided_batched have a harness of other ROC and HIP API calls
-  {"cusolverDnSgesvdjBatched",                           {"hipsolverDnSgesvdjBatched",                             "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnDgesvdjBatched",                           {"hipsolverDnDgesvdjBatched",                             "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnCgesvdjBatched",                           {"hipsolverDnCgesvdjBatched",                             "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnZgesvdjBatched",                           {"hipsolverDnZgesvdjBatched",                             "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
+  m["cusolverDnSgesvdjBatched"]                                       = {"hipsolverDnSgesvdjBatched",                             "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnDgesvdjBatched"]                                       = {"hipsolverDnDgesvdjBatched",                             "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnCgesvdjBatched"]                                       = {"hipsolverDnCgesvdjBatched",                             "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnZgesvdjBatched"]                                       = {"hipsolverDnZgesvdjBatched",                             "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
   // NOTE: rocsolver_(s|d|c|z)gesvdj_notransv have a harness of other ROC and HIP API calls
-  {"cusolverDnSgesvdj_bufferSize",                       {"hipsolverDnSgesvdj_bufferSize",                         "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnDgesvdj_bufferSize",                       {"hipsolverDnDgesvdj_bufferSize",                         "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnCgesvdj_bufferSize",                       {"hipsolverDnCgesvdj_bufferSize",                         "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnZgesvdj_bufferSize",                       {"hipsolverDnZgesvdj_bufferSize",                         "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
+  m["cusolverDnSgesvdj_bufferSize"]                                   = {"hipsolverDnSgesvdj_bufferSize",                         "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnDgesvdj_bufferSize"]                                   = {"hipsolverDnDgesvdj_bufferSize",                         "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnCgesvdj_bufferSize"]                                   = {"hipsolverDnCgesvdj_bufferSize",                         "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnZgesvdj_bufferSize"]                                   = {"hipsolverDnZgesvdj_bufferSize",                         "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
   // NOTE: rocsolver_(s|d|c|z)gesvdj_notransv have a harness of other ROC and HIP API calls
-  {"cusolverDnSgesvdj",                                  {"hipsolverDnSgesvdj",                                    "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnDgesvdj",                                  {"hipsolverDnDgesvdj",                                    "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnCgesvdj",                                  {"hipsolverDnCgesvdj",                                    "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnZgesvdj",                                  {"hipsolverDnZgesvdj",                                    "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
+  m["cusolverDnSgesvdj"]                                              = {"hipsolverDnSgesvdj",                                    "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnDgesvdj"]                                              = {"hipsolverDnDgesvdj",                                    "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnCgesvdj"]                                              = {"hipsolverDnCgesvdj",                                    "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnZgesvdj"]                                              = {"hipsolverDnZgesvdj",                                    "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
   // NOTE: rocsolver_(s|d|c|z)gesvdx_strided_batched have a harness of other ROC and HIP API calls
-  {"cusolverDnSgesvdaStridedBatched_bufferSize",         {"hipsolverDnSgesvdaStridedBatched_bufferSize",           "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnDgesvdaStridedBatched_bufferSize",         {"hipsolverDnDgesvdaStridedBatched_bufferSize",           "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnCgesvdaStridedBatched_bufferSize",         {"hipsolverDnCgesvdaStridedBatched_bufferSize",           "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnZgesvdaStridedBatched_bufferSize",         {"hipsolverDnZgesvdaStridedBatched_bufferSize",           "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
+  m["cusolverDnSgesvdaStridedBatched_bufferSize"]                     = {"hipsolverDnSgesvdaStridedBatched_bufferSize",           "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnDgesvdaStridedBatched_bufferSize"]                     = {"hipsolverDnDgesvdaStridedBatched_bufferSize",           "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnCgesvdaStridedBatched_bufferSize"]                     = {"hipsolverDnCgesvdaStridedBatched_bufferSize",           "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnZgesvdaStridedBatched_bufferSize"]                     = {"hipsolverDnZgesvdaStridedBatched_bufferSize",           "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
   // NOTE: rocsolver_(s|d|c|z)gesvdx_strided_batched have a harness of other ROC and HIP API calls
-  {"cusolverDnSgesvdaStridedBatched",                    {"hipsolverDnSgesvdaStridedBatched",                      "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnDgesvdaStridedBatched",                    {"hipsolverDnDgesvdaStridedBatched",                      "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnCgesvdaStridedBatched",                    {"hipsolverDnCgesvdaStridedBatched",                      "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnZgesvdaStridedBatched",                    {"hipsolverDnZgesvdaStridedBatched",                      "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnPotrf_bufferSize",                         {"hipsolverDnPotrf_bufferSize",                           "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | CUDA_REMOVED | UNSUPPORTED}},
-  {"cusolverDnPotrf",                                    {"hipsolverDnPotrf",                                      "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | CUDA_REMOVED | UNSUPPORTED}},
-  {"cusolverDnPotrs",                                    {"hipsolverDnPotrs",                                      "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | CUDA_REMOVED | UNSUPPORTED}},
-  {"cusolverDnGeqrf_bufferSize",                         {"hipsolverDnGeqrf_bufferSize",                           "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | CUDA_REMOVED | UNSUPPORTED}},
-  {"cusolverDnGeqrf",                                    {"hipsolverDnGeqrf",                                      "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | CUDA_REMOVED | UNSUPPORTED}},
-  {"cusolverDnGetrf_bufferSize",                         {"hipsolverDnGetrf_bufferSize",                           "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | CUDA_REMOVED | UNSUPPORTED}},
-  {"cusolverDnGetrf",                                    {"hipsolverDnGetrf",                                      "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | CUDA_REMOVED | UNSUPPORTED}},
-  {"cusolverDnGetrs",                                    {"hipsolverDnGetrs",                                      "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | CUDA_REMOVED | UNSUPPORTED}},
-  {"cusolverDnSyevd_bufferSize",                         {"hipsolverDnSyevd_bufferSize",                           "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | CUDA_REMOVED | UNSUPPORTED}},
-  {"cusolverDnSyevd",                                    {"hipsolverDnSyevd",                                      "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | CUDA_REMOVED | UNSUPPORTED}},
-  {"cusolverDnSyevdx_bufferSize",                        {"hipsolverDnSyevdx_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | CUDA_REMOVED | UNSUPPORTED}},
-  {"cusolverDnSyevdx",                                   {"hipsolverDnSyevdx",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | CUDA_REMOVED | UNSUPPORTED}},
-  {"cusolverDnGesvd_bufferSize",                         {"hipsolverDnGesvd_bufferSize",                           "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | CUDA_REMOVED | UNSUPPORTED}},
-  {"cusolverDnGesvd",                                    {"hipsolverDnGesvd",                                      "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | CUDA_REMOVED | UNSUPPORTED}},
-  {"cusolverDnXpotrf_bufferSize",                        {"hipsolverDnXpotrf_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnXpotrf",                                   {"hipsolverDnXpotrf",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnXpotrs",                                   {"hipsolverDnXpotrs",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnXgeqrf_bufferSize",                        {"hipsolverDnXgeqrf_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnXgeqrf",                                   {"hipsolverDnXgeqrf",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED}},
-  {"cusolverDnXsyevBatched",                             {"hipsolverDnXsyevBatched",                               "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
-  {"cusolverDnXsyevBatched_bufferSize",                  {"hipsolverDnXsyevBatched_bufferSize",                    "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
-  {"cusolverDnXsyevd_bufferSize",                        {"hipsolverDnXsyevd_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
-  {"cusolverDnXsyevd",                                   {"hipsolverDnXsyevd",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
-  {"cusolverDnXsyevdx_bufferSize",                       {"hipsolverDnXsyevdx_bufferSize",                         "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
-  {"cusolverDnXsyevdx",                                  {"hipsolverDnXsyevdx",                                    "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
-  {"cusolverDnXgesvd_bufferSize",                        {"hipsolverDnXgesvd_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
-  {"cusolverDnXgeev",                                    {"hipsolverDnXgeev",                                      "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
-  {"cusolverDnXgeev_bufferSize",                         {"hipsolverDnXgeev_bufferSize",                           "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
-  {"cusolverDnXgesvd",                                   {"hipsolverDnXgesvd",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
-  {"cusolverDnXgesvdp_bufferSize",                       {"hipsolverDnXgesvdp_bufferSize",                         "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
-  {"cusolverDnXgesvdp",                                  {"hipsolverDnXgesvdp",                                    "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
-  {"cusolverDnXgesvdr_bufferSize",                       {"hipsolverDnXgesvdr_bufferSize",                         "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
-  {"cusolverDnXgesvdr",                                  {"hipsolverDnXgesvdr",                                    "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
-  {"cusolverDnXlarft_bufferSize",                        {"hipsolverDnXlarft_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
-  {"cusolverDnXlarft",                                   {"hipsolverDnXlarft",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
-  {"cusolverDnLoggerSetCallback",                        {"hipsolverDnLoggerSetCallback",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
-  {"cusolverDnLoggerSetFile",                            {"hipsolverDnLoggerSetFile",                              "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
-  {"cusolverDnLoggerOpenFile",                           {"hipsolverDnLoggerOpenFile",                             "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
-  {"cusolverDnLoggerSetLevel",                           {"hipsolverDnLoggerSetLevel",                             "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
-  {"cusolverDnLoggerSetMask",                            {"hipsolverDnLoggerSetMask",                              "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
-  {"cusolverDnLoggerForceDisable",                       {"hipsolverDnLoggerForceDisable",                         "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
-  {"cusolverMgCreate",                                   {"hipsolverMgCreate",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED}},
-  {"cusolverMgDestroy",                                  {"hipsolverMgDestroy",                                    "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED}},
-  {"cusolverMgDeviceSelect",                             {"hipsolverMgDeviceSelect",                               "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED}},
-  {"cusolverMgCreateDeviceGrid",                         {"hipsolverMgCreateDeviceGrid",                           "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED}},
-  {"cusolverMgDestroyGrid",                              {"hipsolverMgDestroyGrid",                                "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED}},
-  {"cusolverMgCreateMatrixDesc",                         {"hipsolverMgCreateMatrixDesc",                           "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED}},
-  {"cusolverMgDestroyMatrixDesc",                        {"hipsolverMgDestroyMatrixDesc",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED}},
-  {"cusolverMgSyevd_bufferSize",                         {"hipsolverMgSyevd_bufferSize",                           "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED}},
-  {"cusolverMgSyevd",                                    {"hipsolverMgSyevd",                                      "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED}},
-  {"cusolverMgGetrf_bufferSize",                         {"hipsolverMgGetrf_bufferSize",                           "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED}},
-  {"cusolverMgGetrf",                                    {"hipsolverMgGetrf",                                      "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED}},
-  {"cusolverMgGetrs_bufferSize",                         {"hipsolverMgGetrs_bufferSize",                           "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED}},
-  {"cusolverMgGetrs",                                    {"hipsolverMgGetrs",                                      "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED}},
-  {"cusolverMgPotrf_bufferSize",                         {"hipsolverMgPotrf_bufferSize",                           "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED}},
-  {"cusolverMgPotrf",                                    {"hipsolverMgPotrf",                                      "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED}},
-  {"cusolverMgPotrs_bufferSize",                         {"hipsolverMgPotrs_bufferSize",                           "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED}},
-  {"cusolverMgPotrs",                                    {"hipsolverMgPotrs",                                      "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED}},
-  {"cusolverMgPotri_bufferSize",                         {"hipsolverMgPotri_bufferSize",                           "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED}},
-  {"cusolverMgPotri",                                    {"hipsolverMgPotri",                                      "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED}},
+  m["cusolverDnSgesvdaStridedBatched"]                                = {"hipsolverDnSgesvdaStridedBatched",                      "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnDgesvdaStridedBatched"]                                = {"hipsolverDnDgesvdaStridedBatched",                      "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnCgesvdaStridedBatched"]                                = {"hipsolverDnCgesvdaStridedBatched",                      "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnZgesvdaStridedBatched"]                                = {"hipsolverDnZgesvdaStridedBatched",                      "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnPotrf_bufferSize"]                                     = {"hipsolverDnPotrf_bufferSize",                           "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | CUDA_REMOVED | UNSUPPORTED};
+  m["cusolverDnPotrf"]                                                = {"hipsolverDnPotrf",                                      "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | CUDA_REMOVED | UNSUPPORTED};
+  m["cusolverDnPotrs"]                                                = {"hipsolverDnPotrs",                                      "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | CUDA_REMOVED | UNSUPPORTED};
+  m["cusolverDnGeqrf_bufferSize"]                                     = {"hipsolverDnGeqrf_bufferSize",                           "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | CUDA_REMOVED | UNSUPPORTED};
+  m["cusolverDnGeqrf"]                                                = {"hipsolverDnGeqrf",                                      "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | CUDA_REMOVED | UNSUPPORTED};
+  m["cusolverDnGetrf_bufferSize"]                                     = {"hipsolverDnGetrf_bufferSize",                           "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | CUDA_REMOVED | UNSUPPORTED};
+  m["cusolverDnGetrf"]                                                = {"hipsolverDnGetrf",                                      "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | CUDA_REMOVED | UNSUPPORTED};
+  m["cusolverDnGetrs"]                                                = {"hipsolverDnGetrs",                                      "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | CUDA_REMOVED | UNSUPPORTED};
+  m["cusolverDnSyevd_bufferSize"]                                     = {"hipsolverDnSyevd_bufferSize",                           "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | CUDA_REMOVED | UNSUPPORTED};
+  m["cusolverDnSyevd"]                                                = {"hipsolverDnSyevd",                                      "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | CUDA_REMOVED | UNSUPPORTED};
+  m["cusolverDnSyevdx_bufferSize"]                                    = {"hipsolverDnSyevdx_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | CUDA_REMOVED | UNSUPPORTED};
+  m["cusolverDnSyevdx"]                                               = {"hipsolverDnSyevdx",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | CUDA_REMOVED | UNSUPPORTED};
+  m["cusolverDnGesvd_bufferSize"]                                     = {"hipsolverDnGesvd_bufferSize",                           "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | CUDA_REMOVED | UNSUPPORTED};
+  m["cusolverDnGesvd"]                                                = {"hipsolverDnGesvd",                                      "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | CUDA_REMOVED | UNSUPPORTED};
+  m["cusolverDnXpotrf_bufferSize"]                                    = {"hipsolverDnXpotrf_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnXpotrf"]                                               = {"hipsolverDnXpotrf",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnXpotrs"]                                               = {"hipsolverDnXpotrs",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnXgeqrf_bufferSize"]                                    = {"hipsolverDnXgeqrf_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnXgeqrf"]                                               = {"hipsolverDnXgeqrf",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, ROC_UNSUPPORTED};
+  m["cusolverDnXsyevBatched"]                                         = {"hipsolverDnXsyevBatched",                               "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
+  m["cusolverDnXsyevBatched_bufferSize"]                              = {"hipsolverDnXsyevBatched_bufferSize",                    "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
+  m["cusolverDnXsyevd_bufferSize"]                                    = {"hipsolverDnXsyevd_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
+  m["cusolverDnXsyevd"]                                               = {"hipsolverDnXsyevd",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
+  m["cusolverDnXsyevdx_bufferSize"]                                   = {"hipsolverDnXsyevdx_bufferSize",                         "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
+  m["cusolverDnXsyevdx"]                                              = {"hipsolverDnXsyevdx",                                    "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
+  m["cusolverDnXgesvd_bufferSize"]                                    = {"hipsolverDnXgesvd_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
+  m["cusolverDnXgeev"]                                                = {"hipsolverDnXgeev",                                      "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
+  m["cusolverDnXgeev_bufferSize"]                                     = {"hipsolverDnXgeev_bufferSize",                           "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
+  m["cusolverDnXgesvd"]                                               = {"hipsolverDnXgesvd",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
+  m["cusolverDnXgesvdp_bufferSize"]                                   = {"hipsolverDnXgesvdp_bufferSize",                         "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
+  m["cusolverDnXgesvdp"]                                              = {"hipsolverDnXgesvdp",                                    "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
+  m["cusolverDnXgesvdr_bufferSize"]                                   = {"hipsolverDnXgesvdr_bufferSize",                         "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
+  m["cusolverDnXgesvdr"]                                              = {"hipsolverDnXgesvdr",                                    "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
+  m["cusolverDnXlarft_bufferSize"]                                    = {"hipsolverDnXlarft_bufferSize",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
+  m["cusolverDnXlarft"]                                               = {"hipsolverDnXlarft",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
+  m["cusolverDnLoggerSetCallback"]                                    = {"hipsolverDnLoggerSetCallback",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
+  m["cusolverDnLoggerSetFile"]                                        = {"hipsolverDnLoggerSetFile",                              "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
+  m["cusolverDnLoggerOpenFile"]                                       = {"hipsolverDnLoggerOpenFile",                             "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
+  m["cusolverDnLoggerSetLevel"]                                       = {"hipsolverDnLoggerSetLevel",                             "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
+  m["cusolverDnLoggerSetMask"]                                        = {"hipsolverDnLoggerSetMask",                              "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
+  m["cusolverDnLoggerForceDisable"]                                   = {"hipsolverDnLoggerForceDisable",                         "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
+  m["cusolverMgCreate"]                                               = {"hipsolverMgCreate",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED};
+  m["cusolverMgDestroy"]                                              = {"hipsolverMgDestroy",                                    "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED};
+  m["cusolverMgDeviceSelect"]                                         = {"hipsolverMgDeviceSelect",                               "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED};
+  m["cusolverMgCreateDeviceGrid"]                                     = {"hipsolverMgCreateDeviceGrid",                           "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED};
+  m["cusolverMgDestroyGrid"]                                          = {"hipsolverMgDestroyGrid",                                "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED};
+  m["cusolverMgCreateMatrixDesc"]                                     = {"hipsolverMgCreateMatrixDesc",                           "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED};
+  m["cusolverMgDestroyMatrixDesc"]                                    = {"hipsolverMgDestroyMatrixDesc",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED};
+  m["cusolverMgSyevd_bufferSize"]                                     = {"hipsolverMgSyevd_bufferSize",                           "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED};
+  m["cusolverMgSyevd"]                                                = {"hipsolverMgSyevd",                                      "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED};
+  m["cusolverMgGetrf_bufferSize"]                                     = {"hipsolverMgGetrf_bufferSize",                           "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED};
+  m["cusolverMgGetrf"]                                                = {"hipsolverMgGetrf",                                      "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED};
+  m["cusolverMgGetrs_bufferSize"]                                     = {"hipsolverMgGetrs_bufferSize",                           "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED};
+  m["cusolverMgGetrs"]                                                = {"hipsolverMgGetrs",                                      "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED};
+  m["cusolverMgPotrf_bufferSize"]                                     = {"hipsolverMgPotrf_bufferSize",                           "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED};
+  m["cusolverMgPotrf"]                                                = {"hipsolverMgPotrf",                                      "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED};
+  m["cusolverMgPotrs_bufferSize"]                                     = {"hipsolverMgPotrs_bufferSize",                           "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED};
+  m["cusolverMgPotrs"]                                                = {"hipsolverMgPotrs",                                      "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED};
+  m["cusolverMgPotri_bufferSize"]                                     = {"hipsolverMgPotri_bufferSize",                           "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED};
+  m["cusolverMgPotri"]                                                = {"hipsolverMgPotri",                                      "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED};
   // NOTE: rocsolver_create_rfinfo have a harness of other ROC and HIP API calls
-  {"cusolverRfCreate",                                   {"hipsolverRfCreate",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | ROC_UNSUPPORTED}},
+  m["cusolverRfCreate"]                                               = {"hipsolverRfCreate",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | ROC_UNSUPPORTED};
   // NOTE: rocsolver_destroy_rfinfo have a harness of other ROC and HIP API calls
-  {"cusolverRfDestroy",                                  {"hipsolverRfDestroy",                                    "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | ROC_UNSUPPORTED}},
+  m["cusolverRfDestroy"]                                              = {"hipsolverRfDestroy",                                    "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | ROC_UNSUPPORTED};
   // no ROC analogues
-  {"cusolverRfGetMatrixFormat",                          {"hipsolverRfGetMatrixFormat",                            "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | ROC_UNSUPPORTED}},
-  {"cusolverRfSetMatrixFormat",                          {"hipsolverRfSetMatrixFormat",                            "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | ROC_UNSUPPORTED}},
-  {"cusolverRfSetNumericProperties",                     {"hipsolverRfSetNumericProperties",                       "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | ROC_UNSUPPORTED}},
-  {"cusolverRfGetNumericProperties",                     {"hipsolverRfGetNumericProperties",                       "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | ROC_UNSUPPORTED}},
-  {"cusolverRfGetNumericBoostReport",                    {"hipsolverRfGetNumericBoostReport",                      "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | ROC_UNSUPPORTED}},
-  {"cusolverRfSetAlgs",                                  {"hipsolverRfSetAlgs",                                    "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | ROC_UNSUPPORTED}},
-  {"cusolverRfGetAlgs",                                  {"hipsolverRfGetAlgs",                                    "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED}},
-  {"cusolverRfGetResetValuesFastMode",                   {"hipsolverRfGetResetValuesFastMode",                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | ROC_UNSUPPORTED}},
-  {"cusolverRfSetResetValuesFastMode",                   {"hipsolverRfSetResetValuesFastMode",                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | ROC_UNSUPPORTED}},
+  m["cusolverRfGetMatrixFormat"]                                      = {"hipsolverRfGetMatrixFormat",                            "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | ROC_UNSUPPORTED};
+  m["cusolverRfSetMatrixFormat"]                                      = {"hipsolverRfSetMatrixFormat",                            "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | ROC_UNSUPPORTED};
+  m["cusolverRfSetNumericProperties"]                                 = {"hipsolverRfSetNumericProperties",                       "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | ROC_UNSUPPORTED};
+  m["cusolverRfGetNumericProperties"]                                 = {"hipsolverRfGetNumericProperties",                       "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | ROC_UNSUPPORTED};
+  m["cusolverRfGetNumericBoostReport"]                                = {"hipsolverRfGetNumericBoostReport",                      "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | ROC_UNSUPPORTED};
+  m["cusolverRfSetAlgs"]                                              = {"hipsolverRfSetAlgs",                                    "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | ROC_UNSUPPORTED};
+  m["cusolverRfGetAlgs"]                                              = {"hipsolverRfGetAlgs",                                    "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED};
+  m["cusolverRfGetResetValuesFastMode"]                               = {"hipsolverRfGetResetValuesFastMode",                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | ROC_UNSUPPORTED};
+  m["cusolverRfSetResetValuesFastMode"]                               = {"hipsolverRfSetResetValuesFastMode",                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | ROC_UNSUPPORTED};
   // NOTE: rocsolver_dcsrrf_sumlu have a harness of other ROC and HIP API calls
-  {"cusolverRfSetupHost",                                {"hipsolverRfSetupHost",                                  "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | ROC_UNSUPPORTED}},
+  m["cusolverRfSetupHost"]                                            = {"hipsolverRfSetupHost",                                  "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | ROC_UNSUPPORTED};
   // NOTE: rocsolver_dcsrrf_sumlu have a harness of other ROC and HIP API calls
-  {"cusolverRfSetupDevice",                              {"hipsolverRfSetupDevice",                                "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | ROC_UNSUPPORTED}},
+  m["cusolverRfSetupDevice"]                                          = {"hipsolverRfSetupDevice",                                "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | ROC_UNSUPPORTED};
   // no ROC analogues
-  {"cusolverRfResetValues",                              {"hipsolverRfResetValues",                                "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | ROC_UNSUPPORTED}},
+  m["cusolverRfResetValues"]                                          = {"hipsolverRfResetValues",                                "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | ROC_UNSUPPORTED};
   // NOTE: can't call rocsolver_dcsrrf_analysis w/o using hipSOLVER's hipsolverRfHandle
-  {"cusolverRfAnalyze",                                  {"hipsolverRfAnalyze",                                    "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | ROC_UNSUPPORTED}},
+  m["cusolverRfAnalyze"]                                              = {"hipsolverRfAnalyze",                                    "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | ROC_UNSUPPORTED};
   // NOTE: can't call rocsolver_dcsrrf_refactlu w/o using hipSOLVER's hipsolverRfHandle
-  {"cusolverRfRefactor",                                 {"hipsolverRfRefactor",                                   "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | ROC_UNSUPPORTED}},
+  m["cusolverRfRefactor"]                                             = {"hipsolverRfRefactor",                                   "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | ROC_UNSUPPORTED};
   // no ROC analogues
-  {"cusolverRfAccessBundledFactorsDevice",               {"hipsolverRfAccessBundledFactorsDevice",                 "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | ROC_UNSUPPORTED}},
+  m["cusolverRfAccessBundledFactorsDevice"]                           = {"hipsolverRfAccessBundledFactorsDevice",                 "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | ROC_UNSUPPORTED};
   // no ROC analogues
-  {"cusolverRfExtractBundledFactorsHost",                {"hipsolverRfExtractBundledFactorsHost",                  "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | ROC_UNSUPPORTED}},
+  m["cusolverRfExtractBundledFactorsHost"]                            = {"hipsolverRfExtractBundledFactorsHost",                  "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | ROC_UNSUPPORTED};
   // no ROC analogues
-  {"cusolverRfExtractSplitFactorsHost",                  {"hipsolverRfExtractSplitFactorsHost",                    "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | ROC_UNSUPPORTED}},
+  m["cusolverRfExtractSplitFactorsHost"]                              = {"hipsolverRfExtractSplitFactorsHost",                    "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | ROC_UNSUPPORTED};
   // NOTE: can't call rocsolver_dcsrrf_solve w/o using hipSOLVER's hipsolverRfHandle
-  {"cusolverRfSolve",                                    {"hipsolverRfSolve",                                      "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | ROC_UNSUPPORTED}},
+  m["cusolverRfSolve"]                                                = {"hipsolverRfSolve",                                      "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | ROC_UNSUPPORTED};
   // no ROC analogues
-  {"cusolverRfBatchSetupHost",                           {"hipsolverRfBatchSetupHost",                             "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | ROC_UNSUPPORTED}},
+  m["cusolverRfBatchSetupHost"]                                       = {"hipsolverRfBatchSetupHost",                             "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | ROC_UNSUPPORTED};
   // no ROC analogues
-  {"cusolverRfBatchResetValues",                         {"hipsolverRfBatchResetValues",                           "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | ROC_UNSUPPORTED}},
+  m["cusolverRfBatchResetValues"]                                     = {"hipsolverRfBatchResetValues",                           "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | ROC_UNSUPPORTED};
   // no ROC analogues
-  {"cusolverRfBatchAnalyze",                             {"hipsolverRfBatchAnalyze",                               "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | ROC_UNSUPPORTED}},
+  m["cusolverRfBatchAnalyze"]                                         = {"hipsolverRfBatchAnalyze",                               "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | ROC_UNSUPPORTED};
   // no ROC analogues
-  {"cusolverRfBatchRefactor",                            {"hipsolverRfBatchRefactor",                              "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | ROC_UNSUPPORTED}},
+  m["cusolverRfBatchRefactor"]                                        = {"hipsolverRfBatchRefactor",                              "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | ROC_UNSUPPORTED};
   // no ROC analogues
-  {"cusolverRfBatchSolve",                               {"hipsolverRfBatchSolve",                                 "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | ROC_UNSUPPORTED}},
+  m["cusolverRfBatchSolve"]                                           = {"hipsolverRfBatchSolve",                                 "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | ROC_UNSUPPORTED};
   // no ROC analogues
-  {"cusolverRfBatchZeroPivot",                           {"hipsolverRfBatchZeroPivot",                             "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | ROC_UNSUPPORTED}},
+  m["cusolverRfBatchZeroPivot"]                                       = {"hipsolverRfBatchZeroPivot",                             "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | ROC_UNSUPPORTED};
+  m["cusolverSpCreate"]                                               = {"hipsolverSpCreate",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | ROC_UNSUPPORTED};
+  m["cusolverSpDestroy"]                                              = {"hipsolverSpDestroy",                                    "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | ROC_UNSUPPORTED};
+  m["cusolverSpSetStream"]                                            = {"hipsolverSpSetStream",                                  "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | ROC_UNSUPPORTED};
+  m["cusolverSpGetStream"]                                            = {"hipsolverSpGetStream",                                  "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED};
+  m["cusolverSpXcsrissymHost"]                                        = {"hipsolverSpXcsrissymHost",                              "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED};
+  m["cusolverSpScsrlsvluHost"]                                        = {"hipsolverSpScsrlsvluHost",                              "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED};
+  m["cusolverSpDcsrlsvluHost"]                                        = {"hipsolverSpDcsrlsvluHost",                              "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED};
+  m["cusolverSpCcsrlsvluHost"]                                        = {"hipsolverSpCcsrlsvluHost",                              "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED};
+  m["cusolverSpZcsrlsvluHost"]                                        = {"hipsolverSpZcsrlsvluHost",                              "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED};
+  m["cusolverSpScsrlsvqr"]                                            = {"hipsolverSpScsrlsvqr",                                  "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | ROC_UNSUPPORTED};
+  m["cusolverSpDcsrlsvqr"]                                            = {"hipsolverSpDcsrlsvqr",                                  "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | ROC_UNSUPPORTED};
+  m["cusolverSpCcsrlsvqr"]                                            = {"hipsolverSpCcsrlsvqr",                                  "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | ROC_UNSUPPORTED};
+  m["cusolverSpZcsrlsvqr"]                                            = {"hipsolverSpZcsrlsvqr",                                  "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | ROC_UNSUPPORTED};
+  m["cusolverSpScsrlsvqrHost"]                                        = {"hipsolverSpScsrlsvqrHost",                              "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED};
+  m["cusolverSpDcsrlsvqrHost"]                                        = {"hipsolverSpDcsrlsvqrHost",                              "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED};
+  m["cusolverSpCcsrlsvqrHost"]                                        = {"hipsolverSpCcsrlsvqrHost",                              "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED};
+  m["cusolverSpZcsrlsvqrHost"]                                        = {"hipsolverSpZcsrlsvqrHost",                              "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED};
+  m["cusolverSpScsrlsvcholHost"]                                      = {"hipsolverSpScsrlsvcholHost",                            "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | ROC_UNSUPPORTED};
+  m["cusolverSpDcsrlsvcholHost"]                                      = {"hipsolverSpDcsrlsvcholHost",                            "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | ROC_UNSUPPORTED};
+  m["cusolverSpCcsrlsvcholHost"]                                      = {"hipsolverSpCcsrlsvcholHost",                            "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED};
+  m["cusolverSpZcsrlsvcholHost"]                                      = {"hipsolverSpZcsrlsvcholHost",                            "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED};
+  m["cusolverSpScsrlsvchol"]                                          = {"hipsolverSpScsrlsvchol",                                "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | ROC_UNSUPPORTED};
+  m["cusolverSpDcsrlsvchol"]                                          = {"hipsolverSpDcsrlsvchol",                                "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | ROC_UNSUPPORTED};
+  m["cusolverSpCcsrlsvchol"]                                          = {"hipsolverSpCcsrlsvchol",                                "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED};
+  m["cusolverSpZcsrlsvchol"]                                          = {"hipsolverSpZcsrlsvchol",                                "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED};
+  m["cusolverSpScsrlsqvqrHost"]                                       = {"hipsolverSpScsrlsqvqrHost",                             "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED};
+  m["cusolverSpDcsrlsqvqrHost"]                                       = {"hipsolverSpDcsrlsqvqrHost",                             "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED};
+  m["cusolverSpCcsrlsqvqrHost"]                                       = {"hipsolverSpCcsrlsqvqrHost",                             "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED};
+  m["cusolverSpZcsrlsqvqrHost"]                                       = {"hipsolverSpZcsrlsqvqrHost",                             "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED};
+  m["cusolverSpScsreigvsiHost"]                                       = {"hipsolverSpScsreigvsiHost",                             "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED};
+  m["cusolverSpDcsreigvsiHost"]                                       = {"hipsolverSpDcsreigvsiHost",                             "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED};
+  m["cusolverSpCcsreigvsiHost"]                                       = {"hipsolverSpCcsreigvsiHost",                             "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED};
+  m["cusolverSpZcsreigvsiHost"]                                       = {"hipsolverSpZcsreigvsiHost",                             "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED};
+  m["cusolverSpScsreigvsi"]                                           = {"hipsolverSpScsreigvsi",                                 "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED};
+  m["cusolverSpDcsreigvsi"]                                           = {"hipsolverSpDcsreigvsi",                                 "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED};
+  m["cusolverSpCcsreigvsi"]                                           = {"hipsolverSpCcsreigvsi",                                 "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED};
+  m["cusolverSpZcsreigvsi"]                                           = {"hipsolverSpZcsreigvsi",                                 "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED};
+  m["cusolverSpScsreigsHost"]                                         = {"hipsolverSpScsreigsHost",                               "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED};
+  m["cusolverSpDcsreigsHost"]                                         = {"hipsolverSpDcsreigsHost",                               "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED};
+  m["cusolverSpCcsreigsHost"]                                         = {"hipsolverSpCcsreigsHost",                               "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED};
+  m["cusolverSpZcsreigsHost"]                                         = {"hipsolverSpZcsreigsHost",                               "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED};
+  m["cusolverSpXcsrsymrcmHost"]                                       = {"hipsolverSpXcsrsymrcmHost",                             "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED};
+  m["cusolverSpXcsrsymmdqHost"]                                       = {"hipsolverSpXcsrsymmdqHost",                             "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED};
+  m["cusolverSpXcsrsymamdHost"]                                       = {"hipsolverSpXcsrsymamdHost",                             "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED};
+  m["cusolverSpXcsrmetisndHost"]                                      = {"hipsolverSpXcsrmetisndHost",                            "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED};
+  m["cusolverSpScsrzfdHost"]                                          = {"hipsolverSpScsrzfdHost",                                "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED};
+  m["cusolverSpDcsrzfdHost"]                                          = {"hipsolverSpDcsrzfdHost",                                "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED};
+  m["cusolverSpCcsrzfdHost"]                                          = {"hipsolverSpCcsrzfdHost",                                "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED};
+  m["cusolverSpZcsrzfdHost"]                                          = {"hipsolverSpZcsrzfdHost",                                "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED};
+  m["cusolverSpXcsrperm_bufferSizeHost"]                              = {"hipsolverSpXcsrperm_bufferSizeHost",                    "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED};
+  m["cusolverSpXcsrpermHost"]                                         = {"hipsolverSpXcsrpermHost",                               "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED};
+  m["cusolverSpCreateCsrqrInfo"]                                      = {"hipsolverSpCreateCsrqrInfo",                            "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED};
+  m["cusolverSpDestroyCsrqrInfo"]                                     = {"hipsolverSpDestroyCsrqrInfo",                           "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED};
+  m["cusolverSpXcsrqrAnalysisBatched"]                                = {"hipsolverSpXcsrqrAnalysisBatched",                      "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED};
+  m["cusolverSpScsrqrBufferInfoBatched"]                              = {"hipsolverSpScsrqrBufferInfoBatched",                    "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED};
+  m["cusolverSpDcsrqrBufferInfoBatched"]                              = {"hipsolverSpDcsrqrBufferInfoBatched",                    "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED};
+  m["cusolverSpCcsrqrBufferInfoBatched"]                              = {"hipsolverSpCcsrqrBufferInfoBatched",                    "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED};
+  m["cusolverSpZcsrqrBufferInfoBatched"]                              = {"hipsolverSpZcsrqrBufferInfoBatched",                    "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED};
+  m["cusolverSpScsrqrsvBatched"]                                      = {"hipsolverSpScsrqrsvBatched",                            "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED};
+  m["cusolverSpDcsrqrsvBatched"]                                      = {"hipsolverSpDcsrqrsvBatched",                            "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED};
+  m["cusolverSpCcsrqrsvBatched"]                                      = {"hipsolverSpCcsrqrsvBatched",                            "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED};
+  m["cusolverSpZcsrqrsvBatched"]                                      = {"hipsolverSpZcsrqrsvBatched",                            "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED};
+  m["cusolverSpCreateCsrluInfoHost"]                                  = {"hipsolverSpCreateCsrluInfoHost",                        "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
+  m["cusolverSpDestroyCsrluInfoHost"]                                 = {"hipsolverSpDestroyCsrluInfoHost",                       "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
+  m["cusolverSpXcsrluAnalysisHost"]                                   = {"hipsolverSpXcsrluAnalysisHost",                         "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED};
+  m["cusolverSpScsrluBufferInfoHost"]                                 = {"hipsolverSpScsrluBufferInfoHost",                       "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED};
+  m["cusolverSpDcsrluBufferInfoHost"]                                 = {"hipsolverSpDcsrluBufferInfoHost",                       "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED};
+  m["cusolverSpCcsrluBufferInfoHost"]                                 = {"hipsolverSpCcsrluBufferInfoHost",                       "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED};
+  m["cusolverSpZcsrluBufferInfoHost"]                                 = {"hipsolverSpZcsrluBufferInfoHost",                       "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED};
+  m["cusolverSpScsrluFactorHost"]                                     = {"hipsolverSpScsrluFactorHost",                           "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED};
+  m["cusolverSpDcsrluFactorHost"]                                     = {"hipsolverSpDcsrluFactorHost",                           "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED};
+  m["cusolverSpCcsrluFactorHost"]                                     = {"hipsolverSpCcsrluFactorHost",                           "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED};
+  m["cusolverSpZcsrluFactorHost"]                                     = {"hipsolverSpZcsrluFactorHost",                           "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED};
+  m["cusolverSpScsrluZeroPivotHost"]                                  = {"hipsolverSpScsrluZeroPivotHost",                        "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED};
+  m["cusolverSpDcsrluZeroPivotHost"]                                  = {"hipsolverSpDcsrluZeroPivotHost",                        "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED};
+  m["cusolverSpCcsrluZeroPivotHost"]                                  = {"hipsolverSpCcsrluZeroPivotHost",                        "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED};
+  m["cusolverSpZcsrluZeroPivotHost"]                                  = {"hipsolverSpZcsrluZeroPivotHost",                        "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED};
+  m["cusolverSpScsrluSolveHost"]                                      = {"hipsolverSpScsrluSolveHost",                            "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED};
+  m["cusolverSpDcsrluSolveHost"]                                      = {"hipsolverSpDcsrluSolveHost",                            "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED};
+  m["cusolverSpCcsrluSolveHost"]                                      = {"hipsolverSpCcsrluSolveHost",                            "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED};
+  m["cusolverSpZcsrluSolveHost"]                                      = {"hipsolverSpZcsrluSolveHost",                            "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED};
+  m["cusolverSpXcsrluNnzHost"]                                        = {"hipsolverSpXcsrluNnzHost",                              "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED};
+  m["cusolverSpScsrluExtractHost"]                                    = {"hipsolverSpScsrluExtractHost",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED};
+  m["cusolverSpDcsrluExtractHost"]                                    = {"hipsolverSpDcsrluExtractHost",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED};
+  m["cusolverSpCcsrluExtractHost"]                                    = {"hipsolverSpCcsrluExtractHost",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED};
+  m["cusolverSpZcsrluExtractHost"]                                    = {"hipsolverSpZcsrluExtractHost",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED};
+  m["cusolverSpCreateCsrqrInfoHost"]                                  = {"hipsolverSpCreateCsrqrInfoHost",                        "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
+  m["cusolverSpDestroyCsrqrInfoHost"]                                 = {"hipsolverSpDestroyCsrqrInfoHost",                       "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
+  m["cusolverSpXcsrqrAnalysisHost"]                                   = {"hipsolverSpXcsrqrAnalysisHost",                         "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
+  m["cusolverSpScsrqrBufferInfoHost"]                                 = {"hipsolverSpScsrqrBufferInfoHost",                       "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
+  m["cusolverSpDcsrqrBufferInfoHost"]                                 = {"hipsolverSpDcsrqrBufferInfoHost",                       "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
+  m["cusolverSpCcsrqrBufferInfoHost"]                                 = {"hipsolverSpCcsrqrBufferInfoHost",                       "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
+  m["cusolverSpZcsrqrBufferInfoHost"]                                 = {"hipsolverSpZcsrqrBufferInfoHost",                       "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
+  m["cusolverSpScsrqrSetupHost"]                                      = {"hipsolverSpScsrqrSetupHost",                            "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
+  m["cusolverSpDcsrqrSetupHost"]                                      = {"hipsolverSpDcsrqrSetupHost",                            "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
+  m["cusolverSpCcsrqrSetupHost"]                                      = {"hipsolverSpCcsrqrSetupHost",                            "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
+  m["cusolverSpZcsrqrSetupHost"]                                      = {"hipsolverSpZcsrqrSetupHost",                            "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
+  m["cusolverSpScsrqrFactorHost"]                                     = {"hipsolverSpScsrqrFactorHost",                           "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
+  m["cusolverSpDcsrqrFactorHost"]                                     = {"hipsolverSpDcsrqrFactorHost",                           "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
+  m["cusolverSpCcsrqrFactorHost"]                                     = {"hipsolverSpCcsrqrFactorHost",                           "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
+  m["cusolverSpZcsrqrFactorHost"]                                     = {"hipsolverSpZcsrqrFactorHost",                           "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
+  m["cusolverSpScsrqrZeroPivotHost"]                                  = {"hipsolverSpScsrqrZeroPivotHost",                        "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
+  m["cusolverSpDcsrqrZeroPivotHost"]                                  = {"hipsolverSpDcsrqrZeroPivotHost",                        "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
+  m["cusolverSpCcsrqrZeroPivotHost"]                                  = {"hipsolverSpCcsrqrZeroPivotHost",                        "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
+  m["cusolverSpZcsrqrZeroPivotHost"]                                  = {"hipsolverSpZcsrqrZeroPivotHost",                        "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
+  m["cusolverSpScsrqrSolveHost"]                                      = {"hipsolverSpScsrqrSolveHost",                            "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
+  m["cusolverSpDcsrqrSolveHost"]                                      = {"hipsolverSpDcsrqrSolveHost",                            "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
+  m["cusolverSpCcsrqrSolveHost"]                                      = {"hipsolverSpCcsrqrSolveHost",                            "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
+  m["cusolverSpZcsrqrSolveHost"]                                      = {"hipsolverSpZcsrqrSolveHost",                            "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
+  m["cusolverSpXcsrqrAnalysis"]                                       = {"hipsolverSpXcsrqrAnalysis",                             "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
+  m["cusolverSpScsrqrBufferInfo"]                                     = {"hipsolverSpScsrqrBufferInfo",                           "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
+  m["cusolverSpDcsrqrBufferInfo"]                                     = {"hipsolverSpDcsrqrBufferInfo",                           "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
+  m["cusolverSpCcsrqrBufferInfo"]                                     = {"hipsolverSpCcsrqrBufferInfo",                           "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
+  m["cusolverSpZcsrqrBufferInfo"]                                     = {"hipsolverSpZcsrqrBufferInfo",                           "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
+  m["cusolverSpScsrqrSetup"]                                          = {"hipsolverSpScsrqrSetup",                                "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
+  m["cusolverSpDcsrqrSetup"]                                          = {"hipsolverSpDcsrqrSetup",                                "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
+  m["cusolverSpCcsrqrSetup"]                                          = {"hipsolverSpCcsrqrSetup",                                "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
+  m["cusolverSpZcsrqrSetup"]                                          = {"hipsolverSpZcsrqrSetup",                                "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
+  m["cusolverSpScsrqrFactor"]                                         = {"hipsolverSpScsrqrFactor",                               "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
+  m["cusolverSpDcsrqrFactor"]                                         = {"hipsolverSpDcsrqrFactor",                               "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
+  m["cusolverSpCcsrqrFactor"]                                         = {"hipsolverSpCcsrqrFactor",                               "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
+  m["cusolverSpZcsrqrFactor"]                                         = {"hipsolverSpZcsrqrFactor",                               "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
+  m["cusolverSpScsrqrZeroPivot"]                                      = {"hipsolverSpScsrqrZeroPivot",                            "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
+  m["cusolverSpDcsrqrZeroPivot"]                                      = {"hipsolverSpDcsrqrZeroPivot",                            "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
+  m["cusolverSpCcsrqrZeroPivot"]                                      = {"hipsolverSpCcsrqrZeroPivot",                            "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
+  m["cusolverSpZcsrqrZeroPivot"]                                      = {"hipsolverSpZcsrqrZeroPivot",                            "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
+  m["cusolverSpScsrqrSolve"]                                          = {"hipsolverSpScsrqrSolve",                                "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
+  m["cusolverSpDcsrqrSolve"]                                          = {"hipsolverSpDcsrqrSolve",                                "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
+  m["cusolverSpCcsrqrSolve"]                                          = {"hipsolverSpCcsrqrSolve",                                "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
+  m["cusolverSpZcsrqrSolve"]                                          = {"hipsolverSpZcsrqrSolve",                                "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
+  m["cusolverSpCreateCsrcholInfoHost"]                                = {"hipsolverSpCreateCsrcholInfoHost",                      "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
+  m["cusolverSpDestroyCsrcholInfoHost"]                               = {"hipsolverSpDestroyCsrcholInfoHost",                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
+  m["cusolverSpXcsrcholAnalysisHost"]                                 = {"hipsolverSpXcsrcholAnalysisHost",                       "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED};
+  m["cusolverSpScsrcholBufferInfoHost"]                               = {"hipsolverSpScsrcholBufferInfoHost",                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED};
+  m["cusolverSpDcsrcholBufferInfoHost"]                               = {"hipsolverSpDcsrcholBufferInfoHost",                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED};
+  m["cusolverSpCcsrcholBufferInfoHost"]                               = {"hipsolverSpCcsrcholBufferInfoHost",                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED};
+  m["cusolverSpZcsrcholBufferInfoHost"]                               = {"hipsolverSpZcsrcholBufferInfoHost",                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED};
+  m["cusolverSpScsrcholFactorHost"]                                   = {"hipsolverSpScsrcholFactorHost",                         "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED};
+  m["cusolverSpDcsrcholFactorHost"]                                   = {"hipsolverSpDcsrcholFactorHost",                         "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED};
+  m["cusolverSpCcsrcholFactorHost"]                                   = {"hipsolverSpCcsrcholFactorHost",                         "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED};
+  m["cusolverSpZcsrcholFactorHost"]                                   = {"hipsolverSpZcsrcholFactorHost",                         "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED};
+  m["cusolverSpScsrcholZeroPivotHost"]                                = {"hipsolverSpScsrcholZeroPivotHost",                      "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED};
+  m["cusolverSpDcsrcholZeroPivotHost"]                                = {"hipsolverSpDcsrcholZeroPivotHost",                      "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED};
+  m["cusolverSpCcsrcholZeroPivotHost"]                                = {"hipsolverSpCcsrcholZeroPivotHost",                      "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED};
+  m["cusolverSpZcsrcholZeroPivotHost"]                                = {"hipsolverSpZcsrcholZeroPivotHost",                      "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED};
+  m["cusolverSpScsrcholSolveHost"]                                    = {"hipsolverSpScsrcholSolveHost",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED};
+  m["cusolverSpDcsrcholSolveHost"]                                    = {"hipsolverSpDcsrcholSolveHost",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED};
+  m["cusolverSpCcsrcholSolveHost"]                                    = {"hipsolverSpCcsrcholSolveHost",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED};
+  m["cusolverSpZcsrcholSolveHost"]                                    = {"hipsolverSpZcsrcholSolveHost",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED};
+  m["cusolverSpCreateCsrcholInfo"]                                    = {"hipsolverSpCreateCsrcholInfo",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED};
+  m["cusolverSpDestroyCsrcholInfo"]                                   = {"hipsolverSpDestroyCsrcholInfo",                         "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED};
+  m["cusolverSpXcsrcholAnalysis"]                                     = {"hipsolverSpXcsrcholAnalysis",                           "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED};
+  m["cusolverSpScsrcholBufferInfo"]                                   = {"hipsolverSpScsrcholBufferInfo",                         "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED};
+  m["cusolverSpDcsrcholBufferInfo"]                                   = {"hipsolverSpDcsrcholBufferInfo",                         "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED};
+  m["cusolverSpCcsrcholBufferInfo"]                                   = {"hipsolverSpCcsrcholBufferInfo",                         "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED};
+  m["cusolverSpZcsrcholBufferInfo"]                                   = {"hipsolverSpZcsrcholBufferInfo",                         "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED};
+  m["cusolverSpScsrcholFactor"]                                       = {"hipsolverSpScsrcholFactor",                             "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED};
+  m["cusolverSpDcsrcholFactor"]                                       = {"hipsolverSpDcsrcholFactor",                             "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED};
+  m["cusolverSpCcsrcholFactor"]                                       = {"hipsolverSpCcsrcholFactor",                             "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED};
+  m["cusolverSpZcsrcholFactor"]                                       = {"hipsolverSpZcsrcholFactor",                             "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED};
+  m["cusolverSpScsrcholZeroPivot"]                                    = {"hipsolverSpScsrcholZeroPivot",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED};
+  m["cusolverSpDcsrcholZeroPivot"]                                    = {"hipsolverSpDcsrcholZeroPivot",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED};
+  m["cusolverSpCcsrcholZeroPivot"]                                    = {"hipsolverSpCcsrcholZeroPivot",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED};
+  m["cusolverSpZcsrcholZeroPivot"]                                    = {"hipsolverSpZcsrcholZeroPivot",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED};
+  m["cusolverSpScsrcholSolve"]                                        = {"hipsolverSpScsrcholSolve",                              "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED};
+  m["cusolverSpDcsrcholSolve"]                                        = {"hipsolverSpDcsrcholSolve",                              "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED};
+  m["cusolverSpCcsrcholSolve"]                                        = {"hipsolverSpCcsrcholSolve",                              "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED};
+  m["cusolverSpZcsrcholSolve"]                                        = {"hipsolverSpZcsrcholSolve",                              "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED};
+  m["cusolverSpScsrcholDiag"]                                         = {"hipsolverSpScsrcholDiag",                               "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED};
+  m["cusolverSpDcsrcholDiag"]                                         = {"hipsolverSpDcsrcholDiag",                               "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED};
+  m["cusolverSpCcsrcholDiag"]                                         = {"hipsolverSpCcsrcholDiag",                               "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED};
+  m["cusolverSpZcsrcholDiag"]                                         = {"hipsolverSpZcsrcholDiag",                               "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED};
+  m["cusolverDnSetMathMode"]                                          = {"hipsolverDnSetMathMode",                                "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
+  m["cusolverDnGetMathMode"]                                          = {"hipsolverDnGetMathMode",                                "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
+  m["cusolverDnSetEmulationStrategy"]                                 = {"hipsolverDnSetEmulationStrategy",                       "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
+  m["cusolverDnGetEmulationStrategy"]                                 = {"hipsolverDnGetEmulationStrategy",                       "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED};
 
-  {"cusolverSpCreate",                                   {"hipsolverSpCreate",                                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | ROC_UNSUPPORTED}},
-  {"cusolverSpDestroy",                                  {"hipsolverSpDestroy",                                    "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | ROC_UNSUPPORTED}},
-  {"cusolverSpSetStream",                                {"hipsolverSpSetStream",                                  "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | ROC_UNSUPPORTED}},
-  {"cusolverSpGetStream",                                {"hipsolverSpGetStream",                                  "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED}},
-  {"cusolverSpXcsrissymHost",                            {"hipsolverSpXcsrissymHost",                              "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED}},
-  {"cusolverSpScsrlsvluHost",                            {"hipsolverSpScsrlsvluHost",                              "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED}},
-  {"cusolverSpDcsrlsvluHost",                            {"hipsolverSpDcsrlsvluHost",                              "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED}},
-  {"cusolverSpCcsrlsvluHost",                            {"hipsolverSpCcsrlsvluHost",                              "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED}},
-  {"cusolverSpZcsrlsvluHost",                            {"hipsolverSpZcsrlsvluHost",                              "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED}},
-  {"cusolverSpScsrlsvqr",                                {"hipsolverSpScsrlsvqr",                                  "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | ROC_UNSUPPORTED}},
-  {"cusolverSpDcsrlsvqr",                                {"hipsolverSpDcsrlsvqr",                                  "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | ROC_UNSUPPORTED}},
-  {"cusolverSpCcsrlsvqr",                                {"hipsolverSpCcsrlsvqr",                                  "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | ROC_UNSUPPORTED}},
-  {"cusolverSpZcsrlsvqr",                                {"hipsolverSpZcsrlsvqr",                                  "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | ROC_UNSUPPORTED}},
-  {"cusolverSpScsrlsvqrHost",                            {"hipsolverSpScsrlsvqrHost",                              "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED}},
-  {"cusolverSpDcsrlsvqrHost",                            {"hipsolverSpDcsrlsvqrHost",                              "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED}},
-  {"cusolverSpCcsrlsvqrHost",                            {"hipsolverSpCcsrlsvqrHost",                              "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED}},
-  {"cusolverSpZcsrlsvqrHost",                            {"hipsolverSpZcsrlsvqrHost",                              "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED}},
-  {"cusolverSpScsrlsvcholHost",                          {"hipsolverSpScsrlsvcholHost",                            "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | ROC_UNSUPPORTED}},
-  {"cusolverSpDcsrlsvcholHost",                          {"hipsolverSpDcsrlsvcholHost",                            "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | ROC_UNSUPPORTED}},
-  {"cusolverSpCcsrlsvcholHost",                          {"hipsolverSpCcsrlsvcholHost",                            "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED}},
-  {"cusolverSpZcsrlsvcholHost",                          {"hipsolverSpZcsrlsvcholHost",                            "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED}},
-  {"cusolverSpScsrlsvchol",                              {"hipsolverSpScsrlsvchol",                                "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | ROC_UNSUPPORTED}},
-  {"cusolverSpDcsrlsvchol",                              {"hipsolverSpDcsrlsvchol",                                "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | ROC_UNSUPPORTED}},
-  {"cusolverSpCcsrlsvchol",                              {"hipsolverSpCcsrlsvchol",                                "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED}},
-  {"cusolverSpZcsrlsvchol",                              {"hipsolverSpZcsrlsvchol",                                "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED}},
-  {"cusolverSpScsrlsqvqrHost",                           {"hipsolverSpScsrlsqvqrHost",                             "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED}},
-  {"cusolverSpDcsrlsqvqrHost",                           {"hipsolverSpDcsrlsqvqrHost",                             "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED}},
-  {"cusolverSpCcsrlsqvqrHost",                           {"hipsolverSpCcsrlsqvqrHost",                             "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED}},
-  {"cusolverSpZcsrlsqvqrHost",                           {"hipsolverSpZcsrlsqvqrHost",                             "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED}},
-  {"cusolverSpScsreigvsiHost",                           {"hipsolverSpScsreigvsiHost",                             "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED}},
-  {"cusolverSpDcsreigvsiHost",                           {"hipsolverSpDcsreigvsiHost",                             "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED}},
-  {"cusolverSpCcsreigvsiHost",                           {"hipsolverSpCcsreigvsiHost",                             "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED}},
-  {"cusolverSpZcsreigvsiHost",                           {"hipsolverSpZcsreigvsiHost",                             "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED}},
-  {"cusolverSpScsreigvsi",                               {"hipsolverSpScsreigvsi",                                 "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED}},
-  {"cusolverSpDcsreigvsi",                               {"hipsolverSpDcsreigvsi",                                 "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED}},
-  {"cusolverSpCcsreigvsi",                               {"hipsolverSpCcsreigvsi",                                 "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED}},
-  {"cusolverSpZcsreigvsi",                               {"hipsolverSpZcsreigvsi",                                 "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED}},
-  {"cusolverSpScsreigsHost",                             {"hipsolverSpScsreigsHost",                               "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED}},
-  {"cusolverSpDcsreigsHost",                             {"hipsolverSpDcsreigsHost",                               "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED}},
-  {"cusolverSpCcsreigsHost",                             {"hipsolverSpCcsreigsHost",                               "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED}},
-  {"cusolverSpZcsreigsHost",                             {"hipsolverSpZcsreigsHost",                               "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED}},
-  {"cusolverSpXcsrsymrcmHost",                           {"hipsolverSpXcsrsymrcmHost",                             "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED}},
-  {"cusolverSpXcsrsymmdqHost",                           {"hipsolverSpXcsrsymmdqHost",                             "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED}},
-  {"cusolverSpXcsrsymamdHost",                           {"hipsolverSpXcsrsymamdHost",                             "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED}},
-  {"cusolverSpXcsrmetisndHost",                          {"hipsolverSpXcsrmetisndHost",                            "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED}},
-  {"cusolverSpScsrzfdHost",                              {"hipsolverSpScsrzfdHost",                                "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED}},
-  {"cusolverSpDcsrzfdHost",                              {"hipsolverSpDcsrzfdHost",                                "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED}},
-  {"cusolverSpCcsrzfdHost",                              {"hipsolverSpCcsrzfdHost",                                "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED}},
-  {"cusolverSpZcsrzfdHost",                              {"hipsolverSpZcsrzfdHost",                                "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED}},
-  {"cusolverSpXcsrperm_bufferSizeHost",                  {"hipsolverSpXcsrperm_bufferSizeHost",                    "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED}},
-  {"cusolverSpXcsrpermHost",                             {"hipsolverSpXcsrpermHost",                               "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED}},
-  {"cusolverSpCreateCsrqrInfo",                          {"hipsolverSpCreateCsrqrInfo",                            "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED}},
-  {"cusolverSpDestroyCsrqrInfo",                         {"hipsolverSpDestroyCsrqrInfo",                           "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED}},
-  {"cusolverSpXcsrqrAnalysisBatched",                    {"hipsolverSpXcsrqrAnalysisBatched",                      "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED}},
-  {"cusolverSpScsrqrBufferInfoBatched",                  {"hipsolverSpScsrqrBufferInfoBatched",                    "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED}},
-  {"cusolverSpDcsrqrBufferInfoBatched",                  {"hipsolverSpDcsrqrBufferInfoBatched",                    "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED}},
-  {"cusolverSpCcsrqrBufferInfoBatched",                  {"hipsolverSpCcsrqrBufferInfoBatched",                    "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED}},
-  {"cusolverSpZcsrqrBufferInfoBatched",                  {"hipsolverSpZcsrqrBufferInfoBatched",                    "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED}},
-  {"cusolverSpScsrqrsvBatched",                          {"hipsolverSpScsrqrsvBatched",                            "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED}},
-  {"cusolverSpDcsrqrsvBatched",                          {"hipsolverSpDcsrqrsvBatched",                            "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED}},
-  {"cusolverSpCcsrqrsvBatched",                          {"hipsolverSpCcsrqrsvBatched",                            "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED}},
-  {"cusolverSpZcsrqrsvBatched",                          {"hipsolverSpZcsrqrsvBatched",                            "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED}},
-  {"cusolverSpCreateCsrluInfoHost",                      {"hipsolverSpCreateCsrluInfoHost",                        "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
-  {"cusolverSpDestroyCsrluInfoHost",                     {"hipsolverSpDestroyCsrluInfoHost",                       "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
-  {"cusolverSpXcsrluAnalysisHost",                       {"hipsolverSpXcsrluAnalysisHost",                         "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED}},
-  {"cusolverSpScsrluBufferInfoHost",                     {"hipsolverSpScsrluBufferInfoHost",                       "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED}},
-  {"cusolverSpDcsrluBufferInfoHost",                     {"hipsolverSpDcsrluBufferInfoHost",                       "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED}},
-  {"cusolverSpCcsrluBufferInfoHost",                     {"hipsolverSpCcsrluBufferInfoHost",                       "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED}},
-  {"cusolverSpZcsrluBufferInfoHost",                     {"hipsolverSpZcsrluBufferInfoHost",                       "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED}},
-  {"cusolverSpScsrluFactorHost",                         {"hipsolverSpScsrluFactorHost",                           "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED}},
-  {"cusolverSpDcsrluFactorHost",                         {"hipsolverSpDcsrluFactorHost",                           "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED}},
-  {"cusolverSpCcsrluFactorHost",                         {"hipsolverSpCcsrluFactorHost",                           "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED}},
-  {"cusolverSpZcsrluFactorHost",                         {"hipsolverSpZcsrluFactorHost",                           "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED}},
-  {"cusolverSpScsrluZeroPivotHost",                      {"hipsolverSpScsrluZeroPivotHost",                        "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED}},
-  {"cusolverSpDcsrluZeroPivotHost",                      {"hipsolverSpDcsrluZeroPivotHost",                        "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED}},
-  {"cusolverSpCcsrluZeroPivotHost",                      {"hipsolverSpCcsrluZeroPivotHost",                        "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED}},
-  {"cusolverSpZcsrluZeroPivotHost",                      {"hipsolverSpZcsrluZeroPivotHost",                        "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED}},
-  {"cusolverSpScsrluSolveHost",                          {"hipsolverSpScsrluSolveHost",                            "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED}},
-  {"cusolverSpDcsrluSolveHost",                          {"hipsolverSpDcsrluSolveHost",                            "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED}},
-  {"cusolverSpCcsrluSolveHost",                          {"hipsolverSpCcsrluSolveHost",                            "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED}},
-  {"cusolverSpZcsrluSolveHost",                          {"hipsolverSpZcsrluSolveHost",                            "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED}},
-  {"cusolverSpXcsrluNnzHost",                            {"hipsolverSpXcsrluNnzHost",                              "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED}},
-  {"cusolverSpScsrluExtractHost",                        {"hipsolverSpScsrluExtractHost",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED}},
-  {"cusolverSpDcsrluExtractHost",                        {"hipsolverSpDcsrluExtractHost",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED}},
-  {"cusolverSpCcsrluExtractHost",                        {"hipsolverSpCcsrluExtractHost",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED}},
-  {"cusolverSpZcsrluExtractHost",                        {"hipsolverSpZcsrluExtractHost",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED}},
-  {"cusolverSpCreateCsrqrInfoHost",                      {"hipsolverSpCreateCsrqrInfoHost",                        "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
-  {"cusolverSpDestroyCsrqrInfoHost",                     {"hipsolverSpDestroyCsrqrInfoHost",                       "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
-  {"cusolverSpXcsrqrAnalysisHost",                       {"hipsolverSpXcsrqrAnalysisHost",                         "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
-  {"cusolverSpScsrqrBufferInfoHost",                     {"hipsolverSpScsrqrBufferInfoHost",                       "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
-  {"cusolverSpDcsrqrBufferInfoHost",                     {"hipsolverSpDcsrqrBufferInfoHost",                       "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
-  {"cusolverSpCcsrqrBufferInfoHost",                     {"hipsolverSpCcsrqrBufferInfoHost",                       "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
-  {"cusolverSpZcsrqrBufferInfoHost",                     {"hipsolverSpZcsrqrBufferInfoHost",                       "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
-  {"cusolverSpScsrqrSetupHost",                          {"hipsolverSpScsrqrSetupHost",                            "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
-  {"cusolverSpDcsrqrSetupHost",                          {"hipsolverSpDcsrqrSetupHost",                            "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
-  {"cusolverSpCcsrqrSetupHost",                          {"hipsolverSpCcsrqrSetupHost",                            "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
-  {"cusolverSpZcsrqrSetupHost",                          {"hipsolverSpZcsrqrSetupHost",                            "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
-  {"cusolverSpScsrqrFactorHost",                         {"hipsolverSpScsrqrFactorHost",                           "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
-  {"cusolverSpDcsrqrFactorHost",                         {"hipsolverSpDcsrqrFactorHost",                           "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
-  {"cusolverSpCcsrqrFactorHost",                         {"hipsolverSpCcsrqrFactorHost",                           "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
-  {"cusolverSpZcsrqrFactorHost",                         {"hipsolverSpZcsrqrFactorHost",                           "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
-  {"cusolverSpScsrqrZeroPivotHost",                      {"hipsolverSpScsrqrZeroPivotHost",                        "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
-  {"cusolverSpDcsrqrZeroPivotHost",                      {"hipsolverSpDcsrqrZeroPivotHost",                        "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
-  {"cusolverSpCcsrqrZeroPivotHost",                      {"hipsolverSpCcsrqrZeroPivotHost",                        "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
-  {"cusolverSpZcsrqrZeroPivotHost",                      {"hipsolverSpZcsrqrZeroPivotHost",                        "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
-  {"cusolverSpScsrqrSolveHost",                          {"hipsolverSpScsrqrSolveHost",                            "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
-  {"cusolverSpDcsrqrSolveHost",                          {"hipsolverSpDcsrqrSolveHost",                            "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
-  {"cusolverSpCcsrqrSolveHost",                          {"hipsolverSpCcsrqrSolveHost",                            "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
-  {"cusolverSpZcsrqrSolveHost",                          {"hipsolverSpZcsrqrSolveHost",                            "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
-  {"cusolverSpXcsrqrAnalysis",                           {"hipsolverSpXcsrqrAnalysis",                             "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
-  {"cusolverSpScsrqrBufferInfo",                         {"hipsolverSpScsrqrBufferInfo",                           "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
-  {"cusolverSpDcsrqrBufferInfo",                         {"hipsolverSpDcsrqrBufferInfo",                           "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
-  {"cusolverSpCcsrqrBufferInfo",                         {"hipsolverSpCcsrqrBufferInfo",                           "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
-  {"cusolverSpZcsrqrBufferInfo",                         {"hipsolverSpZcsrqrBufferInfo",                           "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
-  {"cusolverSpScsrqrSetup",                              {"hipsolverSpScsrqrSetup",                                "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
-  {"cusolverSpDcsrqrSetup",                              {"hipsolverSpDcsrqrSetup",                                "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
-  {"cusolverSpCcsrqrSetup",                              {"hipsolverSpCcsrqrSetup",                                "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
-  {"cusolverSpZcsrqrSetup",                              {"hipsolverSpZcsrqrSetup",                                "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
-  {"cusolverSpScsrqrFactor",                             {"hipsolverSpScsrqrFactor",                               "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
-  {"cusolverSpDcsrqrFactor",                             {"hipsolverSpDcsrqrFactor",                               "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
-  {"cusolverSpCcsrqrFactor",                             {"hipsolverSpCcsrqrFactor",                               "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
-  {"cusolverSpZcsrqrFactor",                             {"hipsolverSpZcsrqrFactor",                               "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
-  {"cusolverSpScsrqrZeroPivot",                          {"hipsolverSpScsrqrZeroPivot",                            "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
-  {"cusolverSpDcsrqrZeroPivot",                          {"hipsolverSpDcsrqrZeroPivot",                            "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
-  {"cusolverSpCcsrqrZeroPivot",                          {"hipsolverSpCcsrqrZeroPivot",                            "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
-  {"cusolverSpZcsrqrZeroPivot",                          {"hipsolverSpZcsrqrZeroPivot",                            "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
-  {"cusolverSpScsrqrSolve",                              {"hipsolverSpScsrqrSolve",                                "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
-  {"cusolverSpDcsrqrSolve",                              {"hipsolverSpDcsrqrSolve",                                "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
-  {"cusolverSpCcsrqrSolve",                              {"hipsolverSpCcsrqrSolve",                                "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
-  {"cusolverSpZcsrqrSolve",                              {"hipsolverSpZcsrqrSolve",                                "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
-  {"cusolverSpCreateCsrcholInfoHost",                    {"hipsolverSpCreateCsrcholInfoHost",                      "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
-  {"cusolverSpDestroyCsrcholInfoHost",                   {"hipsolverSpDestroyCsrcholInfoHost",                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
-  {"cusolverSpXcsrcholAnalysisHost",                     {"hipsolverSpXcsrcholAnalysisHost",                       "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED}},
-  {"cusolverSpScsrcholBufferInfoHost",                   {"hipsolverSpScsrcholBufferInfoHost",                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED}},
-  {"cusolverSpDcsrcholBufferInfoHost",                   {"hipsolverSpDcsrcholBufferInfoHost",                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED}},
-  {"cusolverSpCcsrcholBufferInfoHost",                   {"hipsolverSpCcsrcholBufferInfoHost",                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED}},
-  {"cusolverSpZcsrcholBufferInfoHost",                   {"hipsolverSpZcsrcholBufferInfoHost",                     "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED}},
-  {"cusolverSpScsrcholFactorHost",                       {"hipsolverSpScsrcholFactorHost",                         "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED}},
-  {"cusolverSpDcsrcholFactorHost",                       {"hipsolverSpDcsrcholFactorHost",                         "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED}},
-  {"cusolverSpCcsrcholFactorHost",                       {"hipsolverSpCcsrcholFactorHost",                         "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED}},
-  {"cusolverSpZcsrcholFactorHost",                       {"hipsolverSpZcsrcholFactorHost",                         "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED}},
-  {"cusolverSpScsrcholZeroPivotHost",                    {"hipsolverSpScsrcholZeroPivotHost",                      "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED}},
-  {"cusolverSpDcsrcholZeroPivotHost",                    {"hipsolverSpDcsrcholZeroPivotHost",                      "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED}},
-  {"cusolverSpCcsrcholZeroPivotHost",                    {"hipsolverSpCcsrcholZeroPivotHost",                      "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED}},
-  {"cusolverSpZcsrcholZeroPivotHost",                    {"hipsolverSpZcsrcholZeroPivotHost",                      "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED}},
-  {"cusolverSpScsrcholSolveHost",                        {"hipsolverSpScsrcholSolveHost",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED}},
-  {"cusolverSpDcsrcholSolveHost",                        {"hipsolverSpDcsrcholSolveHost",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED}},
-  {"cusolverSpCcsrcholSolveHost",                        {"hipsolverSpCcsrcholSolveHost",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED}},
-  {"cusolverSpZcsrcholSolveHost",                        {"hipsolverSpZcsrcholSolveHost",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED}},
-  {"cusolverSpCreateCsrcholInfo",                        {"hipsolverSpCreateCsrcholInfo",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED}},
-  {"cusolverSpDestroyCsrcholInfo",                       {"hipsolverSpDestroyCsrcholInfo",                         "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED}},
-  {"cusolverSpXcsrcholAnalysis",                         {"hipsolverSpXcsrcholAnalysis",                           "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED}},
-  {"cusolverSpScsrcholBufferInfo",                       {"hipsolverSpScsrcholBufferInfo",                         "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED}},
-  {"cusolverSpDcsrcholBufferInfo",                       {"hipsolverSpDcsrcholBufferInfo",                         "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED}},
-  {"cusolverSpCcsrcholBufferInfo",                       {"hipsolverSpCcsrcholBufferInfo",                         "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED}},
-  {"cusolverSpZcsrcholBufferInfo",                       {"hipsolverSpZcsrcholBufferInfo",                         "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED}},
-  {"cusolverSpScsrcholFactor",                           {"hipsolverSpScsrcholFactor",                             "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED}},
-  {"cusolverSpDcsrcholFactor",                           {"hipsolverSpDcsrcholFactor",                             "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED}},
-  {"cusolverSpCcsrcholFactor",                           {"hipsolverSpCcsrcholFactor",                             "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED}},
-  {"cusolverSpZcsrcholFactor",                           {"hipsolverSpZcsrcholFactor",                             "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED}},
-  {"cusolverSpScsrcholZeroPivot",                        {"hipsolverSpScsrcholZeroPivot",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED}},
-  {"cusolverSpDcsrcholZeroPivot",                        {"hipsolverSpDcsrcholZeroPivot",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED}},
-  {"cusolverSpCcsrcholZeroPivot",                        {"hipsolverSpCcsrcholZeroPivot",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED}},
-  {"cusolverSpZcsrcholZeroPivot",                        {"hipsolverSpZcsrcholZeroPivot",                          "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED}},
-  {"cusolverSpScsrcholSolve",                            {"hipsolverSpScsrcholSolve",                              "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED}},
-  {"cusolverSpDcsrcholSolve",                            {"hipsolverSpDcsrcholSolve",                              "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED}},
-  {"cusolverSpCcsrcholSolve",                            {"hipsolverSpCcsrcholSolve",                              "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED}},
-  {"cusolverSpZcsrcholSolve",                            {"hipsolverSpZcsrcholSolve",                              "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED}},
-  {"cusolverSpScsrcholDiag",                             {"hipsolverSpScsrcholDiag",                               "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED}},
-  {"cusolverSpDcsrcholDiag",                             {"hipsolverSpDcsrcholDiag",                               "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED}},
-  {"cusolverSpCcsrcholDiag",                             {"hipsolverSpCcsrcholDiag",                               "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED}},
-  {"cusolverSpZcsrcholDiag",                             {"hipsolverSpZcsrcholDiag",                               "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, CUDA_DEPRECATED | UNSUPPORTED}},
-  {"cusolverDnSetMathMode",                              {"hipsolverDnSetMathMode",                                "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
-  {"cusolverDnGetMathMode",                              {"hipsolverDnGetMathMode",                                "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
-  {"cusolverDnSetEmulationStrategy",                     {"hipsolverDnSetEmulationStrategy",                       "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
-  {"cusolverDnGetEmulationStrategy",                     {"hipsolverDnGetEmulationStrategy",                       "",                                                               CONV_LIB_FUNC, API_SOLVER, 2, UNSUPPORTED}},
-};
+  return m;
+}();
 
-const std::map<llvm::StringRef, cudaAPIversions> CUDA_SOLVER_FUNCTION_VER_MAP {
-  {"cusolverDnCreateParams",                             {CUDA_110, CUDA_0,   CUDA_0  }},
-  {"cusolverDnDestroyParams",                            {CUDA_110, CUDA_0,   CUDA_0  }},
-  {"cusolverDnSetAdvOptions",                            {CUDA_110, CUDA_0,   CUDA_0  }},
-  {"cusolverDnXgetrf",                                   {CUDA_111, CUDA_0,   CUDA_0  }},
-  {"cusolverDnXgetrf_bufferSize",                        {CUDA_111, CUDA_0,   CUDA_0  }},
-  {"cusolverDnXgetrs",                                   {CUDA_111, CUDA_0,   CUDA_0  }},
-  {"cusolverDnSetDeterministicMode",                     {CUDA_122, CUDA_0,   CUDA_0  }},
-  {"cusolverDnGetDeterministicMode",                     {CUDA_122, CUDA_0,   CUDA_0  }},
-  {"cusolverDnIRSParamsCreate",                          {CUDA_102, CUDA_0,   CUDA_0  }},
-  {"cusolverDnIRSParamsDestroy",                         {CUDA_102, CUDA_0,   CUDA_0  }},
-  {"cusolverDnIRSParamsSetRefinementSolver",             {CUDA_102, CUDA_0,   CUDA_0  }},
-  {"cusolverDnIRSParamsSetSolverMainPrecision",          {CUDA_102, CUDA_0,   CUDA_0  }},
-  {"cusolverDnIRSParamsSetSolverLowestPrecision",        {CUDA_102, CUDA_0,   CUDA_0  }},
-  {"cusolverDnIRSParamsSetSolverPrecisions",             {CUDA_102, CUDA_0,   CUDA_0  }},
-  {"cusolverDnIRSParamsSetTol",                          {CUDA_102, CUDA_0,   CUDA_0  }},
-  {"cusolverDnIRSParamsSetTolInner",                     {CUDA_102, CUDA_0,   CUDA_0  }},
-  {"cusolverDnIRSParamsSetMaxIters",                     {CUDA_102, CUDA_0,   CUDA_0  }},
-  {"cusolverDnIRSParamsSetMaxItersInner",                {CUDA_102, CUDA_0,   CUDA_0  }},
-  {"cusolverDnIRSParamsGetMaxIters",                     {CUDA_102, CUDA_0,   CUDA_0  }},
-  {"cusolverDnIRSParamsEnableFallback",                  {CUDA_110, CUDA_0,   CUDA_0  }},
-  {"cusolverDnIRSParamsDisableFallback",                 {CUDA_110, CUDA_0,   CUDA_0  }},
-  {"cusolverDnIRSInfosCreate",                           {CUDA_102, CUDA_0,   CUDA_0  }},
-  {"cusolverDnIRSInfosDestroy",                          {CUDA_102, CUDA_0,   CUDA_0  }},
-  {"cusolverDnIRSInfosGetNiters",                        {CUDA_102, CUDA_0,   CUDA_0  }},
-  {"cusolverDnIRSInfosGetOuterNiters",                   {CUDA_102, CUDA_0,   CUDA_0  }},
-  {"cusolverDnIRSInfosRequestResidual",                  {CUDA_102, CUDA_0,   CUDA_0  }},
-  {"cusolverDnIRSInfosGetResidualHistory",               {CUDA_102, CUDA_0,   CUDA_0  }},
-  {"cusolverDnIRSInfosGetMaxIters",                      {CUDA_102, CUDA_0,   CUDA_0  }},
-  {"cusolverDnZZgesv",                                   {CUDA_102, CUDA_0,   CUDA_0  }},
-  {"cusolverDnZCgesv",                                   {CUDA_102, CUDA_0,   CUDA_0  }},
-  {"cusolverDnZKgesv",                                   {CUDA_102, CUDA_0,   CUDA_0  }},
-  {"cusolverDnZEgesv",                                   {CUDA_110, CUDA_0,   CUDA_0  }},
-  {"cusolverDnZYgesv",                                   {CUDA_110, CUDA_0,   CUDA_0  }},
-  {"cusolverDnCCgesv",                                   {CUDA_102, CUDA_0,   CUDA_0  }},
-  {"cusolverDnCEgesv",                                   {CUDA_110, CUDA_0,   CUDA_0  }},
-  {"cusolverDnCKgesv",                                   {CUDA_102, CUDA_0,   CUDA_0  }},
-  {"cusolverDnCYgesv",                                   {CUDA_110, CUDA_0,   CUDA_0  }},
-  {"cusolverDnDDgesv",                                   {CUDA_102, CUDA_0,   CUDA_0  }},
-  {"cusolverDnDSgesv",                                   {CUDA_102, CUDA_0,   CUDA_0  }},
-  {"cusolverDnDHgesv",                                   {CUDA_102, CUDA_0,   CUDA_0  }},
-  {"cusolverDnDBgesv",                                   {CUDA_110, CUDA_0,   CUDA_0  }},
-  {"cusolverDnDXgesv",                                   {CUDA_110, CUDA_0,   CUDA_0  }},
-  {"cusolverDnSSgesv",                                   {CUDA_102, CUDA_0,   CUDA_0  }},
-  {"cusolverDnSHgesv",                                   {CUDA_102, CUDA_0,   CUDA_0  }},
-  {"cusolverDnSBgesv",                                   {CUDA_110, CUDA_0,   CUDA_0  }},
-  {"cusolverDnSXgesv",                                   {CUDA_110, CUDA_0,   CUDA_0  }},
-  {"cusolverDnZZgesv_bufferSize",                        {CUDA_102, CUDA_0,   CUDA_0  }},
-  {"cusolverDnZCgesv_bufferSize",                        {CUDA_102, CUDA_0,   CUDA_0  }},
-  {"cusolverDnZKgesv_bufferSize",                        {CUDA_102, CUDA_0,   CUDA_0  }},
-  {"cusolverDnZEgesv_bufferSize",                        {CUDA_110, CUDA_0,   CUDA_0  }},
-  {"cusolverDnZYgesv_bufferSize",                        {CUDA_110, CUDA_0,   CUDA_0  }},
-  {"cusolverDnCCgesv_bufferSize",                        {CUDA_102, CUDA_0,   CUDA_0  }},
-  {"cusolverDnCKgesv_bufferSize",                        {CUDA_102, CUDA_0,   CUDA_0  }},
-  {"cusolverDnCEgesv_bufferSize",                        {CUDA_110, CUDA_0,   CUDA_0  }},
-  {"cusolverDnCYgesv_bufferSize",                        {CUDA_110, CUDA_0,   CUDA_0  }},
-  {"cusolverDnDDgesv_bufferSize",                        {CUDA_102, CUDA_0,   CUDA_0  }},
-  {"cusolverDnDSgesv_bufferSize",                        {CUDA_102, CUDA_0,   CUDA_0  }},
-  {"cusolverDnDHgesv_bufferSize",                        {CUDA_102, CUDA_0,   CUDA_0  }},
-  {"cusolverDnDBgesv_bufferSize",                        {CUDA_110, CUDA_0,   CUDA_0  }},
-  {"cusolverDnDXgesv_bufferSize",                        {CUDA_110, CUDA_0,   CUDA_0  }},
-  {"cusolverDnSSgesv_bufferSize",                        {CUDA_102, CUDA_0,   CUDA_0  }},
-  {"cusolverDnSHgesv_bufferSize",                        {CUDA_102, CUDA_0,   CUDA_0  }},
-  {"cusolverDnSBgesv_bufferSize",                        {CUDA_110, CUDA_0,   CUDA_0  }},
-  {"cusolverDnSXgesv_bufferSize",                        {CUDA_110, CUDA_0,   CUDA_0  }},
-  {"cusolverDnZZgels",                                   {CUDA_110, CUDA_0,   CUDA_0  }},
-  {"cusolverDnZCgels",                                   {CUDA_110, CUDA_0,   CUDA_0  }},
-  {"cusolverDnZKgels",                                   {CUDA_110, CUDA_0,   CUDA_0  }},
-  {"cusolverDnZEgels",                                   {CUDA_110, CUDA_0,   CUDA_0  }},
-  {"cusolverDnZYgels",                                   {CUDA_110, CUDA_0,   CUDA_0  }},
-  {"cusolverDnCCgels",                                   {CUDA_110, CUDA_0,   CUDA_0  }},
-  {"cusolverDnCKgels",                                   {CUDA_110, CUDA_0,   CUDA_0  }},
-  {"cusolverDnCEgels",                                   {CUDA_110, CUDA_0,   CUDA_0  }},
-  {"cusolverDnCYgels",                                   {CUDA_110, CUDA_0,   CUDA_0  }},
-  {"cusolverDnDDgels",                                   {CUDA_110, CUDA_0,   CUDA_0  }},
-  {"cusolverDnDSgels",                                   {CUDA_110, CUDA_0,   CUDA_0  }},
-  {"cusolverDnDHgels",                                   {CUDA_110, CUDA_0,   CUDA_0  }},
-  {"cusolverDnDBgels",                                   {CUDA_110, CUDA_0,   CUDA_0  }},
-  {"cusolverDnDXgels",                                   {CUDA_110, CUDA_0,   CUDA_0  }},
-  {"cusolverDnSSgels",                                   {CUDA_110, CUDA_0,   CUDA_0  }},
-  {"cusolverDnSHgels",                                   {CUDA_110, CUDA_0,   CUDA_0  }},
-  {"cusolverDnSBgels",                                   {CUDA_110, CUDA_0,   CUDA_0  }},
-  {"cusolverDnSXgels",                                   {CUDA_110, CUDA_0,   CUDA_0  }},
-  {"cusolverDnZZgels_bufferSize",                        {CUDA_110, CUDA_0,   CUDA_0  }},
-  {"cusolverDnZCgels_bufferSize",                        {CUDA_110, CUDA_0,   CUDA_0  }},
-  {"cusolverDnZKgels_bufferSize",                        {CUDA_110, CUDA_0,   CUDA_0  }},
-  {"cusolverDnZEgels_bufferSize",                        {CUDA_110, CUDA_0,   CUDA_0  }},
-  {"cusolverDnZYgels_bufferSize",                        {CUDA_110, CUDA_0,   CUDA_0  }},
-  {"cusolverDnCCgels_bufferSize",                        {CUDA_110, CUDA_0,   CUDA_0  }},
-  {"cusolverDnCKgels_bufferSize",                        {CUDA_110, CUDA_0,   CUDA_0  }},
-  {"cusolverDnCEgels_bufferSize",                        {CUDA_110, CUDA_0,   CUDA_0  }},
-  {"cusolverDnCYgels_bufferSize",                        {CUDA_110, CUDA_0,   CUDA_0  }},
-  {"cusolverDnDDgels_bufferSize",                        {CUDA_110, CUDA_0,   CUDA_0  }},
-  {"cusolverDnDSgels_bufferSize",                        {CUDA_110, CUDA_0,   CUDA_0  }},
-  {"cusolverDnDHgels_bufferSize",                        {CUDA_110, CUDA_0,   CUDA_0  }},
-  {"cusolverDnDBgels_bufferSize",                        {CUDA_110, CUDA_0,   CUDA_0  }},
-  {"cusolverDnDXgels_bufferSize",                        {CUDA_110, CUDA_0,   CUDA_0  }},
-  {"cusolverDnSSgels_bufferSize",                        {CUDA_110, CUDA_0,   CUDA_0  }},
-  {"cusolverDnSHgels_bufferSize",                        {CUDA_110, CUDA_0,   CUDA_0  }},
-  {"cusolverDnSBgels_bufferSize",                        {CUDA_110, CUDA_0,   CUDA_0  }},
-  {"cusolverDnSXgels_bufferSize",                        {CUDA_110, CUDA_0,   CUDA_0  }},
-  {"cusolverDnIRSXgesv",                                 {CUDA_102, CUDA_0,   CUDA_0  }},
-  {"cusolverDnIRSXgesv_bufferSize",                      {CUDA_102, CUDA_0,   CUDA_0  }},
-  {"cusolverDnIRSXgels",                                 {CUDA_110, CUDA_0,   CUDA_0  }},
-  {"cusolverDnIRSXgels_bufferSize",                      {CUDA_110, CUDA_0,   CUDA_0  }},
-  {"cusolverDnSpotrfBatched",                            {CUDA_91,  CUDA_0,   CUDA_0  }},
-  {"cusolverDnDpotrfBatched",                            {CUDA_91,  CUDA_0,   CUDA_0  }},
-  {"cusolverDnCpotrfBatched",                            {CUDA_91,  CUDA_0,   CUDA_0  }},
-  {"cusolverDnZpotrfBatched",                            {CUDA_91,  CUDA_0,   CUDA_0  }},
-  {"cusolverDnSpotrsBatched",                            {CUDA_91,  CUDA_0,   CUDA_0  }},
-  {"cusolverDnDpotrsBatched",                            {CUDA_91,  CUDA_0,   CUDA_0  }},
-  {"cusolverDnCpotrsBatched",                            {CUDA_91,  CUDA_0,   CUDA_0  }},
-  {"cusolverDnZpotrsBatched",                            {CUDA_91,  CUDA_0,   CUDA_0  }},
-  {"cusolverDnSpotri_bufferSize",                        {CUDA_101, CUDA_0,   CUDA_0  }},
-  {"cusolverDnDpotri_bufferSize",                        {CUDA_101, CUDA_0,   CUDA_0  }},
-  {"cusolverDnCpotri_bufferSize",                        {CUDA_101, CUDA_0,   CUDA_0  }},
-  {"cusolverDnZpotri_bufferSize",                        {CUDA_101, CUDA_0,   CUDA_0  }},
-  {"cusolverDnSpotri",                                   {CUDA_101, CUDA_0,   CUDA_0  }},
-  {"cusolverDnDpotri",                                   {CUDA_101, CUDA_0,   CUDA_0  }},
-  {"cusolverDnCpotri",                                   {CUDA_101, CUDA_0,   CUDA_0  }},
-  {"cusolverDnZpotri",                                   {CUDA_101, CUDA_0,   CUDA_0  }},
-  {"cusolverDnXtrtri_bufferSize",                        {CUDA_114, CUDA_0,   CUDA_0  }},
-  {"cusolverDnXtrtri",                                   {CUDA_114, CUDA_0,   CUDA_0  }},
-  {"cusolverDnSlauum_bufferSize",                        {CUDA_101, CUDA_0,   CUDA_0  }},
-  {"cusolverDnDlauum_bufferSize",                        {CUDA_101, CUDA_0,   CUDA_0  }},
-  {"cusolverDnClauum_bufferSize",                        {CUDA_101, CUDA_0,   CUDA_0  }},
-  {"cusolverDnZlauum_bufferSize",                        {CUDA_101, CUDA_0,   CUDA_0  }},
-  {"cusolverDnSlauum",                                   {CUDA_101, CUDA_0,   CUDA_0  }},
-  {"cusolverDnDlauum",                                   {CUDA_101, CUDA_0,   CUDA_0  }},
-  {"cusolverDnClauum",                                   {CUDA_101, CUDA_0,   CUDA_0  }},
-  {"cusolverDnZlauum",                                   {CUDA_101, CUDA_0,   CUDA_0  }},
-  {"cusolverDnSorgqr_bufferSize",                        {CUDA_80,  CUDA_0,   CUDA_0  }},
-  {"cusolverDnDorgqr_bufferSize",                        {CUDA_80,  CUDA_0,   CUDA_0  }},
-  {"cusolverDnCungqr_bufferSize",                        {CUDA_80,  CUDA_0,   CUDA_0  }},
-  {"cusolverDnZungqr_bufferSize",                        {CUDA_80,  CUDA_0,   CUDA_0  }},
-  {"cusolverDnSorgqr",                                   {CUDA_80,  CUDA_0,   CUDA_0  }},
-  {"cusolverDnDorgqr",                                   {CUDA_80,  CUDA_0,   CUDA_0  }},
-  {"cusolverDnCungqr",                                   {CUDA_80,  CUDA_0,   CUDA_0  }},
-  {"cusolverDnZungqr",                                   {CUDA_80,  CUDA_0,   CUDA_0  }},
-  {"cusolverDnSormqr_bufferSize",                        {CUDA_80,  CUDA_0,   CUDA_0  }},
-  {"cusolverDnDormqr_bufferSize",                        {CUDA_80,  CUDA_0,   CUDA_0  }},
-  {"cusolverDnCunmqr_bufferSize",                        {CUDA_80,  CUDA_0,   CUDA_0  }},
-  {"cusolverDnZunmqr_bufferSize",                        {CUDA_80,  CUDA_0,   CUDA_0  }},
-  {"cusolverDnXsytrs_bufferSize",                        {CUDA_113, CUDA_0,   CUDA_0  }},
-  {"cusolverDnXsytrs",                                   {CUDA_113, CUDA_0,   CUDA_0  }},
-  {"cusolverDnSsytri_bufferSize",                        {CUDA_101, CUDA_0,   CUDA_0  }},
-  {"cusolverDnDsytri_bufferSize",                        {CUDA_101, CUDA_0,   CUDA_0  }},
-  {"cusolverDnCsytri_bufferSize",                        {CUDA_101, CUDA_0,   CUDA_0  }},
-  {"cusolverDnZsytri_bufferSize",                        {CUDA_101, CUDA_0,   CUDA_0  }},
-  {"cusolverDnSsytri",                                   {CUDA_101, CUDA_0,   CUDA_0  }},
-  {"cusolverDnDsytri",                                   {CUDA_101, CUDA_0,   CUDA_0  }},
-  {"cusolverDnCsytri",                                   {CUDA_101, CUDA_0,   CUDA_0  }},
-  {"cusolverDnZsytri",                                   {CUDA_101, CUDA_0,   CUDA_0  }},
-  {"cusolverDnSorgbr_bufferSize",                        {CUDA_80,  CUDA_0,   CUDA_0  }},
-  {"cusolverDnDorgbr_bufferSize",                        {CUDA_80,  CUDA_0,   CUDA_0  }},
-  {"cusolverDnCungbr_bufferSize",                        {CUDA_80,  CUDA_0,   CUDA_0  }},
-  {"cusolverDnZungbr_bufferSize",                        {CUDA_80,  CUDA_0,   CUDA_0  }},
-  {"cusolverDnSorgbr",                                   {CUDA_80,  CUDA_0,   CUDA_0  }},
-  {"cusolverDnDorgbr",                                   {CUDA_80,  CUDA_0,   CUDA_0  }},
-  {"cusolverDnCungbr",                                   {CUDA_80,  CUDA_0,   CUDA_0  }},
-  {"cusolverDnZungbr",                                   {CUDA_80,  CUDA_0,   CUDA_0  }},
-  {"cusolverDnSsytrd_bufferSize",                        {CUDA_80,  CUDA_0,   CUDA_0  }},
-  {"cusolverDnDsytrd_bufferSize",                        {CUDA_80,  CUDA_0,   CUDA_0  }},
-  {"cusolverDnChetrd_bufferSize",                        {CUDA_80,  CUDA_0,   CUDA_0  }},
-  {"cusolverDnZhetrd_bufferSize",                        {CUDA_80,  CUDA_0,   CUDA_0  }},
-  {"cusolverDnChetrd",                                   {CUDA_80,  CUDA_0,   CUDA_0  }},
-  {"cusolverDnZhetrd",                                   {CUDA_80,  CUDA_0,   CUDA_0  }},
-  {"cusolverDnSorgtr_bufferSize",                        {CUDA_80,  CUDA_0,   CUDA_0  }},
-  {"cusolverDnDorgtr_bufferSize",                        {CUDA_80,  CUDA_0,   CUDA_0  }},
-  {"cusolverDnCungtr_bufferSize",                        {CUDA_80,  CUDA_0,   CUDA_0  }},
-  {"cusolverDnZungtr_bufferSize",                        {CUDA_80,  CUDA_0,   CUDA_0  }},
-  {"cusolverDnSorgtr",                                   {CUDA_80,  CUDA_0,   CUDA_0  }},
-  {"cusolverDnDorgtr",                                   {CUDA_80,  CUDA_0,   CUDA_0  }},
-  {"cusolverDnCungtr",                                   {CUDA_80,  CUDA_0,   CUDA_0  }},
-  {"cusolverDnZungtr",                                   {CUDA_80,  CUDA_0,   CUDA_0  }},
-  {"cusolverDnSormtr_bufferSize",                        {CUDA_80,  CUDA_0,   CUDA_0  }},
-  {"cusolverDnDormtr_bufferSize",                        {CUDA_80,  CUDA_0,   CUDA_0  }},
-  {"cusolverDnCunmtr_bufferSize",                        {CUDA_80,  CUDA_0,   CUDA_0  }},
-  {"cusolverDnZunmtr_bufferSize",                        {CUDA_80,  CUDA_0,   CUDA_0  }},
-  {"cusolverDnSormtr",                                   {CUDA_80,  CUDA_0,   CUDA_0  }},
-  {"cusolverDnDormtr",                                   {CUDA_80,  CUDA_0,   CUDA_0  }},
-  {"cusolverDnCunmtr",                                   {CUDA_80,  CUDA_0,   CUDA_0  }},
-  {"cusolverDnZunmtr",                                   {CUDA_80,  CUDA_0,   CUDA_0  }},
-  {"cusolverDnSsyevd_bufferSize",                        {CUDA_80,  CUDA_0,   CUDA_0  }},
-  {"cusolverDnDsyevd_bufferSize",                        {CUDA_80,  CUDA_0,   CUDA_0  }},
-  {"cusolverDnCheevd_bufferSize",                        {CUDA_80,  CUDA_0,   CUDA_0  }},
-  {"cusolverDnZheevd_bufferSize",                        {CUDA_80,  CUDA_0,   CUDA_0  }},
-  {"cusolverDnSsyevd",                                   {CUDA_80,  CUDA_0,   CUDA_0  }},
-  {"cusolverDnDsyevd",                                   {CUDA_80,  CUDA_0,   CUDA_0  }},
-  {"cusolverDnCheevd",                                   {CUDA_80,  CUDA_0,   CUDA_0  }},
-  {"cusolverDnZheevd",                                   {CUDA_80,  CUDA_0,   CUDA_0  }},
-  {"cusolverDnSsyevdx_bufferSize",                       {CUDA_101, CUDA_0,   CUDA_0  }},
-  {"cusolverDnDsyevdx_bufferSize",                       {CUDA_101, CUDA_0,   CUDA_0  }},
-  {"cusolverDnCheevdx_bufferSize",                       {CUDA_101, CUDA_0,   CUDA_0  }},
-  {"cusolverDnZheevdx_bufferSize",                       {CUDA_101, CUDA_0,   CUDA_0  }},
-  {"cusolverDnSsyevdx",                                  {CUDA_101, CUDA_0,   CUDA_0  }},
-  {"cusolverDnDsyevdx",                                  {CUDA_101, CUDA_0,   CUDA_0  }},
-  {"cusolverDnCheevdx",                                  {CUDA_101, CUDA_0,   CUDA_0  }},
-  {"cusolverDnZheevdx",                                  {CUDA_101, CUDA_0,   CUDA_0  }},
-  {"cusolverDnSsygvdx_bufferSize",                       {CUDA_101, CUDA_0,   CUDA_0  }},
-  {"cusolverDnDsygvdx_bufferSize",                       {CUDA_101, CUDA_0,   CUDA_0  }},
-  {"cusolverDnChegvdx_bufferSize",                       {CUDA_101, CUDA_0,   CUDA_0  }},
-  {"cusolverDnZhegvdx_bufferSize",                       {CUDA_101, CUDA_0,   CUDA_0  }},
-  {"cusolverDnSsygvdx",                                  {CUDA_101, CUDA_0,   CUDA_0  }},
-  {"cusolverDnDsygvdx",                                  {CUDA_101, CUDA_0,   CUDA_0  }},
-  {"cusolverDnChegvdx",                                  {CUDA_101, CUDA_0,   CUDA_0  }},
-  {"cusolverDnZhegvdx",                                  {CUDA_101, CUDA_0,   CUDA_0  }},
-  {"cusolverDnSsygvd_bufferSize",                        {CUDA_80,  CUDA_0,   CUDA_0  }},
-  {"cusolverDnDsygvd_bufferSize",                        {CUDA_80,  CUDA_0,   CUDA_0  }},
-  {"cusolverDnChegvd_bufferSize",                        {CUDA_80,  CUDA_0,   CUDA_0  }},
-  {"cusolverDnZhegvd_bufferSize",                        {CUDA_80,  CUDA_0,   CUDA_0  }},
-  {"cusolverDnSsygvd",                                   {CUDA_80,  CUDA_0,   CUDA_0  }},
-  {"cusolverDnDsygvd",                                   {CUDA_80,  CUDA_0,   CUDA_0  }},
-  {"cusolverDnChegvd",                                   {CUDA_80,  CUDA_0,   CUDA_0  }},
-  {"cusolverDnZhegvd",                                   {CUDA_80,  CUDA_0,   CUDA_0  }},
-  {"cusolverDnCreateSyevjInfo",                          {CUDA_90,  CUDA_0,   CUDA_0  }},
-  {"cusolverDnDestroySyevjInfo",                         {CUDA_90,  CUDA_0,   CUDA_0  }},
-  {"cusolverDnXsyevjSetTolerance",                       {CUDA_90,  CUDA_0,   CUDA_0  }},
-  {"cusolverDnXsyevjSetMaxSweeps",                       {CUDA_90,  CUDA_0,   CUDA_0  }},
-  {"cusolverDnXsyevjSetSortEig",                         {CUDA_90,  CUDA_0,   CUDA_0  }},
-  {"cusolverDnXsyevjGetResidual",                        {CUDA_90,  CUDA_0,   CUDA_0  }},
-  {"cusolverDnXsyevjGetSweeps",                          {CUDA_90,  CUDA_0,   CUDA_0  }},
-  {"cusolverDnSsyevjBatched_bufferSize",                 {CUDA_90,  CUDA_0,   CUDA_0  }},
-  {"cusolverDnDsyevjBatched_bufferSize",                 {CUDA_90,  CUDA_0,   CUDA_0  }},
-  {"cusolverDnCheevjBatched_bufferSize",                 {CUDA_90,  CUDA_0,   CUDA_0  }},
-  {"cusolverDnZheevjBatched_bufferSize",                 {CUDA_90,  CUDA_0,   CUDA_0  }},
-  {"cusolverDnSsyevjBatched",                            {CUDA_90,  CUDA_0,   CUDA_0  }},
-  {"cusolverDnDsyevjBatched",                            {CUDA_90,  CUDA_0,   CUDA_0  }},
-  {"cusolverDnCheevjBatched",                            {CUDA_90,  CUDA_0,   CUDA_0  }},
-  {"cusolverDnZheevjBatched",                            {CUDA_90,  CUDA_0,   CUDA_0  }},
-  {"cusolverDnSsyevj_bufferSize",                        {CUDA_90,  CUDA_0,   CUDA_0  }},
-  {"cusolverDnDsyevj_bufferSize",                        {CUDA_90,  CUDA_0,   CUDA_0  }},
-  {"cusolverDnCheevj_bufferSize",                        {CUDA_90,  CUDA_0,   CUDA_0  }},
-  {"cusolverDnZheevj_bufferSize",                        {CUDA_90,  CUDA_0,   CUDA_0  }},
-  {"cusolverDnSsyevj",                                   {CUDA_90,  CUDA_0,   CUDA_0  }},
-  {"cusolverDnDsyevj",                                   {CUDA_90,  CUDA_0,   CUDA_0  }},
-  {"cusolverDnCheevj",                                   {CUDA_90,  CUDA_0,   CUDA_0  }},
-  {"cusolverDnZheevj",                                   {CUDA_90,  CUDA_0,   CUDA_0  }},
-  {"cusolverDnSsygvj_bufferSize",                        {CUDA_90,  CUDA_0,   CUDA_0  }},
-  {"cusolverDnDsygvj_bufferSize",                        {CUDA_90,  CUDA_0,   CUDA_0  }},
-  {"cusolverDnChegvj_bufferSize",                        {CUDA_90,  CUDA_0,   CUDA_0  }},
-  {"cusolverDnZhegvj_bufferSize",                        {CUDA_90,  CUDA_0,   CUDA_0  }},
-  {"cusolverDnSsygvj",                                   {CUDA_90,  CUDA_0,   CUDA_0  }},
-  {"cusolverDnDsygvj",                                   {CUDA_90,  CUDA_0,   CUDA_0  }},
-  {"cusolverDnChegvj",                                   {CUDA_90,  CUDA_0,   CUDA_0  }},
-  {"cusolverDnZhegvj",                                   {CUDA_90,  CUDA_0,   CUDA_0  }},
-  {"cusolverDnCreateGesvdjInfo",                         {CUDA_90,  CUDA_0,   CUDA_0  }},
-  {"cusolverDnDestroyGesvdjInfo",                        {CUDA_90,  CUDA_0,   CUDA_0  }},
-  {"cusolverDnXgesvdjSetTolerance",                      {CUDA_90,  CUDA_0,   CUDA_0  }},
-  {"cusolverDnXgesvdjSetMaxSweeps",                      {CUDA_90,  CUDA_0,   CUDA_0  }},
-  {"cusolverDnXgesvdjSetSortEig",                        {CUDA_90,  CUDA_0,   CUDA_0  }},
-  {"cusolverDnXgesvdjGetResidual",                       {CUDA_90,  CUDA_0,   CUDA_0  }},
-  {"cusolverDnXgesvdjGetSweeps",                         {CUDA_90,  CUDA_0,   CUDA_0  }},
-  {"cusolverDnSgesvdjBatched_bufferSize",                {CUDA_90,  CUDA_0,   CUDA_0  }},
-  {"cusolverDnDgesvdjBatched_bufferSize",                {CUDA_90,  CUDA_0,   CUDA_0  }},
-  {"cusolverDnCgesvdjBatched_bufferSize",                {CUDA_90,  CUDA_0,   CUDA_0  }},
-  {"cusolverDnZgesvdjBatched_bufferSize",                {CUDA_90,  CUDA_0,   CUDA_0  }},
-  {"cusolverDnSgesvdjBatched",                           {CUDA_90,  CUDA_0,   CUDA_0  }},
-  {"cusolverDnDgesvdjBatched",                           {CUDA_90,  CUDA_0,   CUDA_0  }},
-  {"cusolverDnCgesvdjBatched",                           {CUDA_90,  CUDA_0,   CUDA_0  }},
-  {"cusolverDnZgesvdjBatched",                           {CUDA_90,  CUDA_0,   CUDA_0  }},
-  {"cusolverDnSgesvdj_bufferSize",                       {CUDA_90,  CUDA_0,   CUDA_0  }},
-  {"cusolverDnDgesvdj_bufferSize",                       {CUDA_90,  CUDA_0,   CUDA_0  }},
-  {"cusolverDnCgesvdj_bufferSize",                       {CUDA_90,  CUDA_0,   CUDA_0  }},
-  {"cusolverDnZgesvdj_bufferSize",                       {CUDA_90,  CUDA_0,   CUDA_0  }},
-  {"cusolverDnSgesvdj",                                  {CUDA_90,  CUDA_0,   CUDA_0  }},
-  {"cusolverDnDgesvdj",                                  {CUDA_90,  CUDA_0,   CUDA_0  }},
-  {"cusolverDnCgesvdj",                                  {CUDA_90,  CUDA_0,   CUDA_0  }},
-  {"cusolverDnZgesvdj",                                  {CUDA_90,  CUDA_0,   CUDA_0  }},
-  {"cusolverDnSgesvdaStridedBatched_bufferSize",         {CUDA_101, CUDA_0,   CUDA_0  }},
-  {"cusolverDnDgesvdaStridedBatched_bufferSize",         {CUDA_101, CUDA_0,   CUDA_0  }},
-  {"cusolverDnCgesvdaStridedBatched_bufferSize",         {CUDA_101, CUDA_0,   CUDA_0  }},
-  {"cusolverDnZgesvdaStridedBatched_bufferSize",         {CUDA_101, CUDA_0,   CUDA_0  }},
-  {"cusolverDnSgesvdaStridedBatched",                    {CUDA_101, CUDA_0,   CUDA_0  }},
-  {"cusolverDnDgesvdaStridedBatched",                    {CUDA_101, CUDA_0,   CUDA_0  }},
-  {"cusolverDnCgesvdaStridedBatched",                    {CUDA_101, CUDA_0,   CUDA_0  }},
-  {"cusolverDnZgesvdaStridedBatched",                    {CUDA_101, CUDA_0,   CUDA_0  }},
-  {"cusolverDnPotrf_bufferSize",                         {CUDA_110, CUDA_111, CUDA_130}},
-  {"cusolverDnPotrf",                                    {CUDA_110, CUDA_111, CUDA_130}},
-  {"cusolverDnPotrs",                                    {CUDA_110, CUDA_111, CUDA_130}},
-  {"cusolverDnGeqrf_bufferSize",                         {CUDA_110, CUDA_111, CUDA_130}},
-  {"cusolverDnGeqrf",                                    {CUDA_110, CUDA_111, CUDA_130}},
-  {"cusolverDnGetrf_bufferSize",                         {CUDA_110, CUDA_111, CUDA_130}},
-  {"cusolverDnGetrf",                                    {CUDA_110, CUDA_111, CUDA_130}},
-  {"cusolverDnGetrs",                                    {CUDA_110, CUDA_111, CUDA_130}},
-  {"cusolverDnSyevd_bufferSize",                         {CUDA_110, CUDA_111, CUDA_130}},
-  {"cusolverDnSyevd",                                    {CUDA_110, CUDA_111, CUDA_130}},
-  {"cusolverDnSyevdx_bufferSize",                        {CUDA_110, CUDA_111, CUDA_130}},
-  {"cusolverDnSyevdx",                                   {CUDA_110, CUDA_111, CUDA_130}},
-  {"cusolverDnGesvd_bufferSize",                         {CUDA_110, CUDA_111, CUDA_130}},
-  {"cusolverDnGesvd",                                    {CUDA_110, CUDA_111, CUDA_130}},
-  {"cusolverDnXpotrf_bufferSize",                        {CUDA_111, CUDA_0,   CUDA_0  }},
-  {"cusolverDnXpotrf",                                   {CUDA_111, CUDA_0,   CUDA_0  }},
-  {"cusolverDnXpotrs",                                   {CUDA_111, CUDA_0,   CUDA_0  }},
-  {"cusolverDnXgeqrf_bufferSize",                        {CUDA_111, CUDA_0,   CUDA_0  }},
-  {"cusolverDnXgeqrf",                                   {CUDA_111, CUDA_0,   CUDA_0  }},
-  {"cusolverDnXsyevd_bufferSize",                        {CUDA_111, CUDA_0,   CUDA_0  }},
-  {"cusolverDnXsyevd",                                   {CUDA_111, CUDA_0,   CUDA_0  }},
-  {"cusolverDnXsyevdx_bufferSize",                       {CUDA_111, CUDA_0,   CUDA_0  }},
-  {"cusolverDnXsyevdx",                                  {CUDA_111, CUDA_0,   CUDA_0  }},
-  {"cusolverDnXgesvd_bufferSize",                        {CUDA_111, CUDA_0,   CUDA_0  }},
-  {"cusolverDnXgesvd",                                   {CUDA_111, CUDA_0,   CUDA_0  }},
-  {"cusolverDnXgesvdp_bufferSize",                       {CUDA_111, CUDA_0,   CUDA_0  }},
-  {"cusolverDnXgesvdp",                                  {CUDA_111, CUDA_0,   CUDA_0  }},
-  {"cusolverDnXgesvdr_bufferSize",                       {CUDA_112, CUDA_0,   CUDA_0  }},
-  {"cusolverDnXgesvdr",                                  {CUDA_112, CUDA_0,   CUDA_0  }},
-  {"cusolverDnLoggerSetCallback",                        {CUDA_117, CUDA_0,   CUDA_0  }},
-  {"cusolverDnLoggerSetFile",                            {CUDA_117, CUDA_0,   CUDA_0  }},
-  {"cusolverDnLoggerOpenFile",                           {CUDA_117, CUDA_0,   CUDA_0  }},
-  {"cusolverDnLoggerSetLevel",                           {CUDA_117, CUDA_0,   CUDA_0  }},
-  {"cusolverDnLoggerSetMask",                            {CUDA_117, CUDA_0,   CUDA_0  }},
-  {"cusolverDnLoggerForceDisable",                       {CUDA_117, CUDA_0,   CUDA_0  }},
-  {"cusolverMgCreate",                                   {CUDA_101, CUDA_130, CUDA_0  }},
-  {"cusolverMgDestroy",                                  {CUDA_101, CUDA_130, CUDA_0  }},
-  {"cusolverMgDeviceSelect",                             {CUDA_101, CUDA_130, CUDA_0  }},
-  {"cusolverMgCreateDeviceGrid",                         {CUDA_101, CUDA_130, CUDA_0  }},
-  {"cusolverMgDestroyGrid",                              {CUDA_101, CUDA_130, CUDA_0  }},
-  {"cusolverMgCreateMatrixDesc",                         {CUDA_101, CUDA_130, CUDA_0  }},  // A: CUSOLVER_VERSION 10200
-  {"cusolverMgDestroyMatrixDesc",                        {CUDA_101, CUDA_130, CUDA_0  }},  // A: CUSOLVER_VERSION 10200
-  {"cusolverMgSyevd_bufferSize",                         {CUDA_101, CUDA_130, CUDA_0  }},  // A: CUSOLVER_VERSION 10200
-  {"cusolverMgSyevd",                                    {CUDA_101, CUDA_130, CUDA_0  }},  // A: CUSOLVER_VERSION 10200
-  {"cusolverMgGetrf_bufferSize",                         {CUDA_102, CUDA_130, CUDA_0  }},
-  {"cusolverMgGetrf",                                    {CUDA_102, CUDA_130, CUDA_0  }},
-  {"cusolverMgGetrs_bufferSize",                         {CUDA_102, CUDA_130, CUDA_0  }},
-  {"cusolverMgGetrs",                                    {CUDA_102, CUDA_130, CUDA_0  }},
-  {"cusolverMgPotrf_bufferSize",                         {CUDA_110, CUDA_130, CUDA_0  }},  // A: CUSOLVER_VERSION 10500
-  {"cusolverMgPotrf",                                    {CUDA_110, CUDA_130, CUDA_0  }},  // A: CUSOLVER_VERSION 10500
-  {"cusolverMgPotrs_bufferSize",                         {CUDA_110, CUDA_130, CUDA_0  }},  // A: CUSOLVER_VERSION 10500
-  {"cusolverMgPotrs",                                    {CUDA_110, CUDA_130, CUDA_0  }},  // A: CUSOLVER_VERSION 10500
-  {"cusolverMgPotri_bufferSize",                         {CUDA_110, CUDA_130, CUDA_0  }},  // A: CUSOLVER_VERSION 10500
-  {"cusolverMgPotri",                                    {CUDA_110, CUDA_130, CUDA_0  }},  // A: CUSOLVER_VERSION 10500
-  {"cusolverSpXcsrsymmdqHost",                           {CUDA_75,  CUDA_130, CUDA_0  }},
-  {"cusolverSpXcsrsymamdHost",                           {CUDA_75,  CUDA_130, CUDA_0  }},
-  {"cusolverSpXcsrmetisndHost",                          {CUDA_92,  CUDA_130, CUDA_0  }},
-  {"cusolverSpScsrzfdHost",                              {CUDA_92,  CUDA_130, CUDA_0  }},
-  {"cusolverSpDcsrzfdHost",                              {CUDA_92,  CUDA_130, CUDA_0  }},
-  {"cusolverSpCcsrzfdHost",                              {CUDA_92,  CUDA_130, CUDA_0  }},
-  {"cusolverSpZcsrzfdHost",                              {CUDA_92,  CUDA_130, CUDA_0  }},
-  {"cusolverSpCreateCsrluInfoHost",                      {CUDA_75,  CUDA_0,   CUDA_0  }},
-  {"cusolverSpDestroyCsrluInfoHost",                     {CUDA_75,  CUDA_0,   CUDA_0  }},
-  {"cusolverSpXcsrluAnalysisHost",                       {CUDA_75,  CUDA_128, CUDA_0  }},
-  {"cusolverSpScsrluBufferInfoHost",                     {CUDA_75,  CUDA_128, CUDA_0  }},
-  {"cusolverSpDcsrluBufferInfoHost",                     {CUDA_75,  CUDA_128, CUDA_0  }},
-  {"cusolverSpCcsrluBufferInfoHost",                     {CUDA_75,  CUDA_128, CUDA_0  }},
-  {"cusolverSpZcsrluBufferInfoHost",                     {CUDA_75,  CUDA_128, CUDA_0  }},
-  {"cusolverSpScsrluFactorHost",                         {CUDA_75,  CUDA_128, CUDA_0  }},
-  {"cusolverSpDcsrluFactorHost",                         {CUDA_75,  CUDA_128, CUDA_0  }},
-  {"cusolverSpCcsrluFactorHost",                         {CUDA_75,  CUDA_128, CUDA_0  }},
-  {"cusolverSpZcsrluFactorHost",                         {CUDA_75,  CUDA_128, CUDA_0  }},
-  {"cusolverSpScsrluZeroPivotHost",                      {CUDA_75,  CUDA_128, CUDA_0  }},
-  {"cusolverSpDcsrluZeroPivotHost",                      {CUDA_75,  CUDA_128, CUDA_0  }},
-  {"cusolverSpCcsrluZeroPivotHost",                      {CUDA_75,  CUDA_128, CUDA_0  }},
-  {"cusolverSpZcsrluZeroPivotHost",                      {CUDA_75,  CUDA_128, CUDA_0  }},
-  {"cusolverSpScsrluSolveHost",                          {CUDA_75,  CUDA_128, CUDA_0  }},
-  {"cusolverSpDcsrluSolveHost",                          {CUDA_75,  CUDA_128, CUDA_0  }},
-  {"cusolverSpCcsrluSolveHost",                          {CUDA_75,  CUDA_128, CUDA_0  }},
-  {"cusolverSpZcsrluSolveHost",                          {CUDA_75,  CUDA_128, CUDA_0  }},
-  {"cusolverSpXcsrluNnzHost",                            {CUDA_75,  CUDA_128, CUDA_0  }},
-  {"cusolverSpScsrluExtractHost",                        {CUDA_75,  CUDA_128, CUDA_0  }},
-  {"cusolverSpDcsrluExtractHost",                        {CUDA_75,  CUDA_128, CUDA_0  }},
-  {"cusolverSpCcsrluExtractHost",                        {CUDA_75,  CUDA_128, CUDA_0  }},
-  {"cusolverSpZcsrluExtractHost",                        {CUDA_75,  CUDA_128, CUDA_0  }},
-  {"cusolverSpCreateCsrqrInfoHost",                      {CUDA_75,  CUDA_0,   CUDA_0  }},
-  {"cusolverSpDestroyCsrqrInfoHost",                     {CUDA_75,  CUDA_0,   CUDA_0  }},
-  {"cusolverSpXcsrqrAnalysisHost",                       {CUDA_75,  CUDA_0,   CUDA_0  }},
-  {"cusolverSpScsrqrBufferInfoHost",                     {CUDA_75,  CUDA_0,   CUDA_0  }},
-  {"cusolverSpDcsrqrBufferInfoHost",                     {CUDA_75,  CUDA_0,   CUDA_0  }},
-  {"cusolverSpCcsrqrBufferInfoHost",                     {CUDA_75,  CUDA_0,   CUDA_0  }},
-  {"cusolverSpZcsrqrBufferInfoHost",                     {CUDA_75,  CUDA_0,   CUDA_0  }},
-  {"cusolverSpScsrqrSetupHost",                          {CUDA_75,  CUDA_0,   CUDA_0  }},
-  {"cusolverSpDcsrqrSetupHost",                          {CUDA_75,  CUDA_0,   CUDA_0  }},
-  {"cusolverSpCcsrqrSetupHost",                          {CUDA_75,  CUDA_0,   CUDA_0  }},
-  {"cusolverSpZcsrqrSetupHost",                          {CUDA_75,  CUDA_0,   CUDA_0  }},
-  {"cusolverSpScsrqrFactorHost",                         {CUDA_75,  CUDA_0,   CUDA_0  }},
-  {"cusolverSpDcsrqrFactorHost",                         {CUDA_75,  CUDA_0,   CUDA_0  }},
-  {"cusolverSpCcsrqrFactorHost",                         {CUDA_75,  CUDA_0,   CUDA_0  }},
-  {"cusolverSpZcsrqrFactorHost",                         {CUDA_75,  CUDA_0,   CUDA_0  }},
-  {"cusolverSpScsrqrZeroPivotHost",                      {CUDA_75,  CUDA_0,   CUDA_0  }},
-  {"cusolverSpDcsrqrZeroPivotHost",                      {CUDA_75,  CUDA_0,   CUDA_0  }},
-  {"cusolverSpCcsrqrZeroPivotHost",                      {CUDA_75,  CUDA_0,   CUDA_0  }},
-  {"cusolverSpZcsrqrZeroPivotHost",                      {CUDA_75,  CUDA_0,   CUDA_0  }},
-  {"cusolverSpScsrqrSolveHost",                          {CUDA_75,  CUDA_0,   CUDA_0  }},
-  {"cusolverSpDcsrqrSolveHost",                          {CUDA_75,  CUDA_0,   CUDA_0  }},
-  {"cusolverSpCcsrqrSolveHost",                          {CUDA_75,  CUDA_0,   CUDA_0  }},
-  {"cusolverSpZcsrqrSolveHost",                          {CUDA_75,  CUDA_0,   CUDA_0  }},
-  {"cusolverSpXcsrqrAnalysis",                           {CUDA_75,  CUDA_0,   CUDA_0  }},
-  {"cusolverSpScsrqrBufferInfo",                         {CUDA_75,  CUDA_0,   CUDA_0  }},
-  {"cusolverSpDcsrqrBufferInfo",                         {CUDA_75,  CUDA_0,   CUDA_0  }},
-  {"cusolverSpCcsrqrBufferInfo",                         {CUDA_75,  CUDA_0,   CUDA_0  }},
-  {"cusolverSpZcsrqrBufferInfo",                         {CUDA_75,  CUDA_0,   CUDA_0  }},
-  {"cusolverSpScsrqrSetup",                              {CUDA_75,  CUDA_0,   CUDA_0  }},
-  {"cusolverSpDcsrqrSetup",                              {CUDA_75,  CUDA_0,   CUDA_0  }},
-  {"cusolverSpCcsrqrSetup",                              {CUDA_75,  CUDA_0,   CUDA_0  }},
-  {"cusolverSpZcsrqrSetup",                              {CUDA_75,  CUDA_0,   CUDA_0  }},
-  {"cusolverSpScsrqrFactor",                             {CUDA_75,  CUDA_0,   CUDA_0  }},
-  {"cusolverSpDcsrqrFactor",                             {CUDA_75,  CUDA_0,   CUDA_0  }},
-  {"cusolverSpCcsrqrFactor",                             {CUDA_75,  CUDA_0,   CUDA_0  }},
-  {"cusolverSpZcsrqrFactor",                             {CUDA_75,  CUDA_0,   CUDA_0  }},
-  {"cusolverSpScsrqrZeroPivot",                          {CUDA_75,  CUDA_0,   CUDA_0  }},
-  {"cusolverSpDcsrqrZeroPivot",                          {CUDA_75,  CUDA_0,   CUDA_0  }},
-  {"cusolverSpCcsrqrZeroPivot",                          {CUDA_75,  CUDA_0,   CUDA_0  }},
-  {"cusolverSpZcsrqrZeroPivot",                          {CUDA_75,  CUDA_0,   CUDA_0  }},
-  {"cusolverSpScsrqrSolve",                              {CUDA_75,  CUDA_0,   CUDA_0  }},
-  {"cusolverSpDcsrqrSolve",                              {CUDA_75,  CUDA_0,   CUDA_0  }},
-  {"cusolverSpCcsrqrSolve",                              {CUDA_75,  CUDA_0,   CUDA_0  }},
-  {"cusolverSpZcsrqrSolve",                              {CUDA_75,  CUDA_0,   CUDA_0  }},
-  {"cusolverSpCreateCsrcholInfoHost",                    {CUDA_75,  CUDA_0,   CUDA_0  }},
-  {"cusolverSpDestroyCsrcholInfoHost",                   {CUDA_75,  CUDA_0,   CUDA_0  }},
-  {"cusolverSpXcsrcholAnalysisHost",                     {CUDA_75,  CUDA_128, CUDA_0  }},
-  {"cusolverSpScsrcholBufferInfoHost",                   {CUDA_75,  CUDA_128, CUDA_0  }},
-  {"cusolverSpDcsrcholBufferInfoHost",                   {CUDA_75,  CUDA_128, CUDA_0  }},
-  {"cusolverSpCcsrcholBufferInfoHost",                   {CUDA_75,  CUDA_128, CUDA_0  }},
-  {"cusolverSpZcsrcholBufferInfoHost",                   {CUDA_75,  CUDA_128, CUDA_0  }},
-  {"cusolverSpScsrcholFactorHost",                       {CUDA_75,  CUDA_128, CUDA_0  }},
-  {"cusolverSpDcsrcholFactorHost",                       {CUDA_75,  CUDA_128, CUDA_0  }},
-  {"cusolverSpCcsrcholFactorHost",                       {CUDA_75,  CUDA_128, CUDA_0  }},
-  {"cusolverSpZcsrcholFactorHost",                       {CUDA_75,  CUDA_128, CUDA_0  }},
-  {"cusolverSpScsrcholZeroPivotHost",                    {CUDA_75,  CUDA_128, CUDA_0  }},
-  {"cusolverSpDcsrcholZeroPivotHost",                    {CUDA_75,  CUDA_128, CUDA_0  }},
-  {"cusolverSpCcsrcholZeroPivotHost",                    {CUDA_75,  CUDA_128, CUDA_0  }},
-  {"cusolverSpZcsrcholZeroPivotHost",                    {CUDA_75,  CUDA_128, CUDA_0  }},
-  {"cusolverSpScsrcholSolveHost",                        {CUDA_75,  CUDA_128, CUDA_0  }},
-  {"cusolverSpDcsrcholSolveHost",                        {CUDA_75,  CUDA_128, CUDA_0  }},
-  {"cusolverSpCcsrcholSolveHost",                        {CUDA_75,  CUDA_128, CUDA_0  }},
-  {"cusolverSpZcsrcholSolveHost",                        {CUDA_75,  CUDA_128, CUDA_0  }},
-  {"cusolverSpCreateCsrcholInfo",                        {CUDA_75,  CUDA_128, CUDA_0  }},
-  {"cusolverSpDestroyCsrcholInfo",                       {CUDA_75,  CUDA_128, CUDA_0  }},
-  {"cusolverSpXcsrcholAnalysis",                         {CUDA_75,  CUDA_128, CUDA_0  }},
-  {"cusolverSpScsrcholBufferInfo",                       {CUDA_75,  CUDA_128, CUDA_0  }},
-  {"cusolverSpDcsrcholBufferInfo",                       {CUDA_75,  CUDA_128, CUDA_0  }},
-  {"cusolverSpCcsrcholBufferInfo",                       {CUDA_75,  CUDA_128, CUDA_0  }},
-  {"cusolverSpZcsrcholBufferInfo",                       {CUDA_75,  CUDA_128, CUDA_0  }},
-  {"cusolverSpScsrcholFactor",                           {CUDA_75,  CUDA_128, CUDA_0  }},
-  {"cusolverSpDcsrcholFactor",                           {CUDA_75,  CUDA_128, CUDA_0  }},
-  {"cusolverSpCcsrcholFactor",                           {CUDA_75,  CUDA_128, CUDA_0  }},
-  {"cusolverSpZcsrcholFactor",                           {CUDA_75,  CUDA_128, CUDA_0  }},
-  {"cusolverSpScsrcholZeroPivot",                        {CUDA_75,  CUDA_128, CUDA_0  }},
-  {"cusolverSpDcsrcholZeroPivot",                        {CUDA_75,  CUDA_128, CUDA_0  }},
-  {"cusolverSpCcsrcholZeroPivot",                        {CUDA_75,  CUDA_128, CUDA_0  }},
-  {"cusolverSpZcsrcholZeroPivot",                        {CUDA_75,  CUDA_128, CUDA_0  }},
-  {"cusolverSpScsrcholSolve",                            {CUDA_75,  CUDA_128, CUDA_0  }},
-  {"cusolverSpDcsrcholSolve",                            {CUDA_75,  CUDA_128, CUDA_0  }},
-  {"cusolverSpCcsrcholSolve",                            {CUDA_75,  CUDA_128, CUDA_0  }},
-  {"cusolverSpZcsrcholSolve",                            {CUDA_75,  CUDA_128, CUDA_0  }},
-  {"cusolverSpScsrcholDiag",                             {CUDA_101, CUDA_128, CUDA_0  }}, // CUSOLVER_VERSION 10200
-  {"cusolverSpDcsrcholDiag",                             {CUDA_101, CUDA_128, CUDA_0  }}, // CUSOLVER_VERSION 10200
-  {"cusolverSpCcsrcholDiag",                             {CUDA_101, CUDA_128, CUDA_0  }}, // CUSOLVER_VERSION 10200
-  {"cusolverSpZcsrcholDiag",                             {CUDA_101, CUDA_128, CUDA_0  }}, // CUSOLVER_VERSION 10200
-  {"cusolverDnXlarft",                                   {CUDA_124, CUDA_0,   CUDA_0  }},
-  {"cusolverDnXlarft_bufferSize",                        {CUDA_124, CUDA_0,   CUDA_0  }},
-  {"cusolverDnXgeev",                                    {CUDA_126, CUDA_0,   CUDA_0  }}, // CUSOLVER_VERSION 11701
-  {"cusolverDnXgeev_bufferSize",                         {CUDA_126, CUDA_0,   CUDA_0  }}, // CUSOLVER_VERSION 11701
-  {"cusolverDnXsyevBatched",                             {CUDA_126, CUDA_0,   CUDA_0  }}, // CUSOLVER_VERSION 11701
-  {"cusolverDnXsyevBatched_bufferSize",                  {CUDA_126, CUDA_0,   CUDA_0  }}, // CUSOLVER_VERSION 11701
-  {"cusolverRfSetupHost",                                {CUDA_0,   CUDA_128, CUDA_0  }}, // CUSOLVER_VERSION 11702
-  {"cusolverRfSetupDevice",                              {CUDA_0,   CUDA_128, CUDA_0  }}, // CUSOLVER_VERSION 11702
-  {"cusolverRfResetValues",                              {CUDA_0,   CUDA_128, CUDA_0  }}, // CUSOLVER_VERSION 11702
-  {"cusolverRfAnalyze",                                  {CUDA_0,   CUDA_128, CUDA_0  }}, // CUSOLVER_VERSION 11702
-  {"cusolverRfRefactor",                                 {CUDA_0,   CUDA_128, CUDA_0  }}, // CUSOLVER_VERSION 11702
-  {"cusolverRfAccessBundledFactorsDevice",               {CUDA_0,   CUDA_128, CUDA_0  }}, // CUSOLVER_VERSION 11702
-  {"cusolverRfExtractBundledFactorsHost",                {CUDA_0,   CUDA_128, CUDA_0  }}, // CUSOLVER_VERSION 11702
-  {"cusolverRfExtractSplitFactorsHost",                  {CUDA_0,   CUDA_128, CUDA_0  }}, // CUSOLVER_VERSION 11702
-  {"cusolverRfSolve",                                    {CUDA_0,   CUDA_128, CUDA_0  }}, // CUSOLVER_VERSION 11702
-  {"cusolverSpScsrlsvluHost",                            {CUDA_0,   CUDA_128, CUDA_0  }}, // CUSOLVER_VERSION 11702
-  {"cusolverSpDcsrlsvluHost",                            {CUDA_0,   CUDA_128, CUDA_0  }}, // CUSOLVER_VERSION 11702
-  {"cusolverSpCcsrlsvluHost",                            {CUDA_0,   CUDA_128, CUDA_0  }}, // CUSOLVER_VERSION 11702
-  {"cusolverSpZcsrlsvluHost",                            {CUDA_0,   CUDA_128, CUDA_0  }}, // CUSOLVER_VERSION 11702
-  {"cusolverSpScsrlsvcholHost",                          {CUDA_0,   CUDA_128, CUDA_0  }}, // CUSOLVER_VERSION 11702
-  {"cusolverSpDcsrlsvcholHost",                          {CUDA_0,   CUDA_128, CUDA_0  }}, // CUSOLVER_VERSION 11702
-  {"cusolverSpCcsrlsvcholHost",                          {CUDA_0,   CUDA_128, CUDA_0  }}, // CUSOLVER_VERSION 11702
-  {"cusolverSpZcsrlsvcholHost",                          {CUDA_0,   CUDA_128, CUDA_0  }}, // CUSOLVER_VERSION 11702
-  {"cusolverSpScsrlsvchol",                              {CUDA_0,   CUDA_128, CUDA_0  }}, // CUSOLVER_VERSION 11702
-  {"cusolverSpDcsrlsvchol",                              {CUDA_0,   CUDA_128, CUDA_0  }}, // CUSOLVER_VERSION 11702
-  {"cusolverSpCcsrlsvchol",                              {CUDA_0,   CUDA_128, CUDA_0  }}, // CUSOLVER_VERSION 11702
-  {"cusolverSpZcsrlsvchol",                              {CUDA_0,   CUDA_128, CUDA_0  }}, // CUSOLVER_VERSION 11702
-  {"cusolverDnSetMathMode",                              {CUDA_130, CUDA_0,   CUDA_0  }},
-  {"cusolverDnGetMathMode",                              {CUDA_130, CUDA_0,   CUDA_0  }},
-  {"cusolverDnSetEmulationStrategy",                     {CUDA_130, CUDA_0,   CUDA_0  }},
-  {"cusolverDnGetEmulationStrategy",                     {CUDA_130, CUDA_0,   CUDA_0  }},
-  {"cusolverRfCreate",                                   {CUDA_0,   CUDA_130, CUDA_0  }},
-  {"cusolverRfDestroy",                                  {CUDA_0,   CUDA_130, CUDA_0  }},
-  {"cusolverRfGetMatrixFormat",                          {CUDA_0,   CUDA_130, CUDA_0  }},
-  {"cusolverRfSetMatrixFormat",                          {CUDA_0,   CUDA_130, CUDA_0  }},
-  {"cusolverRfSetNumericProperties",                     {CUDA_0,   CUDA_130, CUDA_0  }},
-  {"cusolverRfGetNumericProperties",                     {CUDA_0,   CUDA_130, CUDA_0  }},
-  {"cusolverRfGetNumericBoostReport",                    {CUDA_0,   CUDA_130, CUDA_0  }},
-  {"cusolverRfSetAlgs",                                  {CUDA_0,   CUDA_130, CUDA_0  }},
-  {"cusolverRfGetAlgs",                                  {CUDA_0,   CUDA_130, CUDA_0  }},
-  {"cusolverRfGetResetValuesFastMode",                   {CUDA_0,   CUDA_130, CUDA_0  }},
-  {"cusolverRfSetResetValuesFastMode",                   {CUDA_0,   CUDA_130, CUDA_0  }},
-  {"cusolverRfBatchSetupHost",                           {CUDA_0,   CUDA_130, CUDA_0  }},
-  {"cusolverRfBatchResetValues",                         {CUDA_0,   CUDA_130, CUDA_0  }},
-  {"cusolverRfBatchAnalyze",                             {CUDA_0,   CUDA_130, CUDA_0  }},
-  {"cusolverRfBatchRefactor",                            {CUDA_0,   CUDA_130, CUDA_0  }},
-  {"cusolverRfBatchSolve",                               {CUDA_0,   CUDA_130, CUDA_0  }},
-  {"cusolverRfBatchZeroPivot",                           {CUDA_0,   CUDA_130, CUDA_0  }},
-  {"cusolverSpCreate",                                   {CUDA_0,   CUDA_130, CUDA_0  }},
-  {"cusolverSpDestroy",                                  {CUDA_0,   CUDA_130, CUDA_0  }},
-  {"cusolverSpSetStream",                                {CUDA_0,   CUDA_130, CUDA_0  }},
-  {"cusolverSpGetStream",                                {CUDA_0,   CUDA_130, CUDA_0  }},
-  {"cusolverSpXcsrissymHost",                            {CUDA_0,   CUDA_130, CUDA_0  }},
-  {"cusolverSpScsrlsvqr",                                {CUDA_0,   CUDA_130, CUDA_0  }},
-  {"cusolverSpDcsrlsvqr",                                {CUDA_0,   CUDA_130, CUDA_0  }},
-  {"cusolverSpCcsrlsvqr",                                {CUDA_0,   CUDA_130, CUDA_0  }},
-  {"cusolverSpZcsrlsvqr",                                {CUDA_0,   CUDA_130, CUDA_0  }},
-  {"cusolverSpScsrlsvqrHost",                            {CUDA_0,   CUDA_130, CUDA_0  }},
-  {"cusolverSpDcsrlsvqrHost",                            {CUDA_0,   CUDA_130, CUDA_0  }},
-  {"cusolverSpCcsrlsvqrHost",                            {CUDA_0,   CUDA_130, CUDA_0  }},
-  {"cusolverSpZcsrlsvqrHost",                            {CUDA_0,   CUDA_130, CUDA_0  }},
-  {"cusolverSpScsrlsqvqrHost",                           {CUDA_0,   CUDA_130, CUDA_0  }},
-  {"cusolverSpDcsrlsqvqrHost",                           {CUDA_0,   CUDA_130, CUDA_0  }},
-  {"cusolverSpCcsrlsqvqrHost",                           {CUDA_0,   CUDA_130, CUDA_0  }},
-  {"cusolverSpZcsrlsqvqrHost",                           {CUDA_0,   CUDA_130, CUDA_0  }},
-  {"cusolverSpScsreigvsiHost",                           {CUDA_0,   CUDA_130, CUDA_0  }},
-  {"cusolverSpDcsreigvsiHost",                           {CUDA_0,   CUDA_130, CUDA_0  }},
-  {"cusolverSpCcsreigvsiHost",                           {CUDA_0,   CUDA_130, CUDA_0  }},
-  {"cusolverSpZcsreigvsiHost",                           {CUDA_0,   CUDA_130, CUDA_0  }},
-  {"cusolverSpScsreigvsi",                               {CUDA_0,   CUDA_130, CUDA_0  }},
-  {"cusolverSpDcsreigvsi",                               {CUDA_0,   CUDA_130, CUDA_0  }},
-  {"cusolverSpCcsreigvsi",                               {CUDA_0,   CUDA_130, CUDA_0  }},
-  {"cusolverSpZcsreigvsi",                               {CUDA_0,   CUDA_130, CUDA_0  }},
-  {"cusolverSpScsreigsHost",                             {CUDA_0,   CUDA_130, CUDA_0  }},
-  {"cusolverSpDcsreigsHost",                             {CUDA_0,   CUDA_130, CUDA_0  }},
-  {"cusolverSpCcsreigsHost",                             {CUDA_0,   CUDA_130, CUDA_0  }},
-  {"cusolverSpZcsreigsHost",                             {CUDA_0,   CUDA_130, CUDA_0  }},
-  {"cusolverSpXcsrsymrcmHost",                           {CUDA_0,   CUDA_130, CUDA_0  }},
-  {"cusolverSpXcsrperm_bufferSizeHost",                  {CUDA_0,   CUDA_130, CUDA_0  }},
-  {"cusolverSpXcsrpermHost",                             {CUDA_0,   CUDA_130, CUDA_0  }},
-  {"cusolverSpCreateCsrqrInfo",                          {CUDA_0,   CUDA_130, CUDA_0  }},
-  {"cusolverSpDestroyCsrqrInfo",                         {CUDA_0,   CUDA_130, CUDA_0  }},
-  {"cusolverSpXcsrqrAnalysisBatched",                    {CUDA_0,   CUDA_130, CUDA_0  }},
-  {"cusolverSpScsrqrBufferInfoBatched",                  {CUDA_0,   CUDA_130, CUDA_0  }},
-  {"cusolverSpDcsrqrBufferInfoBatched",                  {CUDA_0,   CUDA_130, CUDA_0  }},
-  {"cusolverSpCcsrqrBufferInfoBatched",                  {CUDA_0,   CUDA_130, CUDA_0  }},
-  {"cusolverSpZcsrqrBufferInfoBatched",                  {CUDA_0,   CUDA_130, CUDA_0  }},
-  {"cusolverSpScsrqrsvBatched",                          {CUDA_0,   CUDA_130, CUDA_0  }},
-  {"cusolverSpDcsrqrsvBatched",                          {CUDA_0,   CUDA_130, CUDA_0  }},
-  {"cusolverSpCcsrqrsvBatched",                          {CUDA_0,   CUDA_130, CUDA_0  }},
-  {"cusolverSpZcsrqrsvBatched",                          {CUDA_0,   CUDA_130, CUDA_0  }},
-};
+const std::map<llvm::StringRef, cudaAPIversions> CUDA_SOLVER_FUNCTION_VER_MAP = [] {
+  std::map<llvm::StringRef, cudaAPIversions> m;
 
-const std::map<llvm::StringRef, hipAPIversions> HIP_SOLVER_FUNCTION_VER_MAP {
-  {"hipsolverDnCreate",                                  {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnDestroy",                                 {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnSgetrf",                                  {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnDgetrf",                                  {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnCgetrf",                                  {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnZgetrf",                                  {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnSgetrf_bufferSize",                       {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnDgetrf_bufferSize",                       {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnCgetrf_bufferSize",                       {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnZgetrf_bufferSize",                       {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnSgetrs",                                  {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnDgetrs",                                  {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnCgetrs",                                  {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnZgetrs",                                  {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverSetStream",                                 {HIP_4050, HIP_0,    HIP_0   }},
-  {"hipsolverGetStream",                                 {HIP_4050, HIP_0,    HIP_0   }},
-  {"hipsolverDnZZgesv",                                  {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnCCgesv",                                  {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnDDgesv",                                  {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnSSgesv",                                  {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnZZgesv_bufferSize",                       {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnCCgesv_bufferSize",                       {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnDDgesv_bufferSize",                       {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnSSgesv_bufferSize",                       {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnZZgels",                                  {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnCCgels",                                  {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnDDgels",                                  {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnSSgels",                                  {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnZZgels_bufferSize",                       {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnCCgels_bufferSize",                       {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnDDgels_bufferSize",                       {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnSSgels_bufferSize",                       {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnSpotrf_bufferSize",                       {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnDpotrf_bufferSize",                       {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnCpotrf_bufferSize",                       {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnZpotrf_bufferSize",                       {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnSpotrf",                                  {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnDpotrf",                                  {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnCpotrf",                                  {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnZpotrf",                                  {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnSpotrs",                                  {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnDpotrs",                                  {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnCpotrs",                                  {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnZpotrs",                                  {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnSpotrfBatched",                           {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnDpotrfBatched",                           {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnCpotrfBatched",                           {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnZpotrfBatched",                           {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnSpotrsBatched",                           {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnDpotrsBatched",                           {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnCpotrsBatched",                           {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnZpotrsBatched",                           {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnSpotri_bufferSize",                       {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnDpotri_bufferSize",                       {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnCpotri_bufferSize",                       {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnZpotri_bufferSize",                       {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnSpotri",                                  {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnDpotri",                                  {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnCpotri",                                  {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnZpotri",                                  {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnSgeqrf_bufferSize",                       {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnDgeqrf_bufferSize",                       {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnCgeqrf_bufferSize",                       {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnZgeqrf_bufferSize",                       {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnSgeqrf",                                  {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnDgeqrf",                                  {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnCgeqrf",                                  {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnZgeqrf",                                  {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnSorgqr_bufferSize",                       {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnDorgqr_bufferSize",                       {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnCungqr_bufferSize",                       {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnZungqr_bufferSize",                       {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnSorgqr",                                  {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnDorgqr",                                  {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnCungqr",                                  {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnZungqr",                                  {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnSormqr_bufferSize",                       {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnDormqr_bufferSize",                       {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnCunmqr_bufferSize",                       {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnZunmqr_bufferSize",                       {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnSormqr",                                  {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnDormqr",                                  {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnCunmqr",                                  {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnZunmqr",                                  {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnSsytrf_bufferSize",                       {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnDsytrf_bufferSize",                       {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnCsytrf_bufferSize",                       {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnZsytrf_bufferSize",                       {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnSsytrf",                                  {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnDsytrf",                                  {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnCsytrf",                                  {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnZsytrf",                                  {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnSgebrd_bufferSize",                       {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnDgebrd_bufferSize",                       {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnCgebrd_bufferSize",                       {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnZgebrd_bufferSize",                       {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnSgebrd",                                  {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnDgebrd",                                  {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnCgebrd",                                  {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnZgebrd",                                  {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnSorgbr_bufferSize",                       {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnDorgbr_bufferSize",                       {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnCungbr_bufferSize",                       {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnZungbr_bufferSize",                       {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnSorgbr",                                  {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnDorgbr",                                  {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnCungbr",                                  {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnZungbr",                                  {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnSsytrd_bufferSize",                       {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnDsytrd_bufferSize",                       {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnChetrd_bufferSize",                       {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnZhetrd_bufferSize",                       {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnSsytrd",                                  {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnDsytrd",                                  {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnChetrd",                                  {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnZhetrd",                                  {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnSorgtr_bufferSize",                       {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnDorgtr_bufferSize",                       {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnCungtr_bufferSize",                       {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnZungtr_bufferSize",                       {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnSorgtr",                                  {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnDorgtr",                                  {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnCungtr",                                  {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnZungtr",                                  {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnSormtr_bufferSize",                       {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnDormtr_bufferSize",                       {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnCunmtr_bufferSize",                       {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnZunmtr_bufferSize",                       {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnSormtr",                                  {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnDormtr",                                  {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnCunmtr",                                  {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnZunmtr",                                  {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnSgesvd_bufferSize",                       {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnDgesvd_bufferSize",                       {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnCgesvd_bufferSize",                       {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnZgesvd_bufferSize",                       {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnSgesvd",                                  {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnDgesvd",                                  {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnCgesvd",                                  {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnZgesvd",                                  {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnSsyevd_bufferSize",                       {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnDsyevd_bufferSize",                       {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnCheevd_bufferSize",                       {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnZheevd_bufferSize",                       {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnSsyevd",                                  {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnDsyevd",                                  {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnCheevd",                                  {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnZheevd",                                  {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnSsyevdx_bufferSize",                      {HIP_5030, HIP_0,    HIP_0   }},
-  {"hipsolverDnDsyevdx_bufferSize",                      {HIP_5030, HIP_0,    HIP_0   }},
-  {"hipsolverDnCheevdx_bufferSize",                      {HIP_5030, HIP_0,    HIP_0   }},
-  {"hipsolverDnZheevdx_bufferSize",                      {HIP_5030, HIP_0,    HIP_0   }},
-  {"hipsolverDnSsyevdx",                                 {HIP_5030, HIP_0,    HIP_0   }},
-  {"hipsolverDnDsyevdx",                                 {HIP_5030, HIP_0,    HIP_0   }},
-  {"hipsolverDnCheevdx",                                 {HIP_5030, HIP_0,    HIP_0   }},
-  {"hipsolverDnZheevdx",                                 {HIP_5030, HIP_0,    HIP_0   }},
-  {"hipsolverDnSsygvdx_bufferSize",                      {HIP_5030, HIP_0,    HIP_0   }},
-  {"hipsolverDnDsygvdx_bufferSize",                      {HIP_5030, HIP_0,    HIP_0   }},
-  {"hipsolverDnChegvdx_bufferSize",                      {HIP_5030, HIP_0,    HIP_0   }},
-  {"hipsolverDnZhegvdx_bufferSize",                      {HIP_5030, HIP_0,    HIP_0   }},
-  {"hipsolverDnSsygvdx",                                 {HIP_5030, HIP_0,    HIP_0   }},
-  {"hipsolverDnDsygvdx",                                 {HIP_5030, HIP_0,    HIP_0   }},
-  {"hipsolverDnChegvdx",                                 {HIP_5030, HIP_0,    HIP_0   }},
-  {"hipsolverDnZhegvdx",                                 {HIP_5030, HIP_0,    HIP_0   }},
-  {"hipsolverDnSsygvd_bufferSize",                       {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnDsygvd_bufferSize",                       {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnChegvd_bufferSize",                       {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnZhegvd_bufferSize",                       {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnSsygvd",                                  {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnDsygvd",                                  {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnChegvd",                                  {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnZhegvd",                                  {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnCreateSyevjInfo",                         {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnDestroySyevjInfo",                        {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnXsyevjSetTolerance",                      {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnXsyevjSetMaxSweeps",                      {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnXsyevjSetSortEig",                        {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnXsyevjGetResidual",                       {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnXsyevjGetSweeps",                         {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnSsyevjBatched_bufferSize",                {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnDsyevjBatched_bufferSize",                {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnCheevjBatched_bufferSize",                {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnZheevjBatched_bufferSize",                {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnSsyevjBatched",                           {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnDsyevjBatched",                           {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnCheevjBatched",                           {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnZheevjBatched",                           {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnSsyevj_bufferSize",                       {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnDsyevj_bufferSize",                       {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnCheevj_bufferSize",                       {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnZheevj_bufferSize",                       {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnSsyevj",                                  {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnDsyevj",                                  {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnCheevj",                                  {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnZheevj",                                  {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnSsygvj_bufferSize",                       {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnDsygvj_bufferSize",                       {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnChegvj_bufferSize",                       {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnZhegvj_bufferSize",                       {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnSsygvj",                                  {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnDsygvj",                                  {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnChegvj",                                  {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnZhegvj",                                  {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnCreateGesvdjInfo",                        {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnDestroyGesvdjInfo",                       {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnXgesvdjSetTolerance",                     {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnXgesvdjSetMaxSweeps",                     {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnXgesvdjSetSortEig",                       {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnXgesvdjGetResidual",                      {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnXgesvdjGetSweeps",                        {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnSgesvdjBatched_bufferSize",               {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnDgesvdjBatched_bufferSize",               {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnCgesvdjBatched_bufferSize",               {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnZgesvdjBatched_bufferSize",               {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnSgesvdjBatched",                          {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnDgesvdjBatched",                          {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnCgesvdjBatched",                          {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnZgesvdjBatched",                          {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnSgesvdj_bufferSize",                      {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnDgesvdj_bufferSize",                      {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnCgesvdj_bufferSize",                      {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnZgesvdj_bufferSize",                      {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnSgesvdj",                                 {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnDgesvdj",                                 {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnCgesvdj",                                 {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnZgesvdj",                                 {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverDnSgesvdaStridedBatched_bufferSize",        {HIP_5040, HIP_0,    HIP_0   }},
-  {"hipsolverDnDgesvdaStridedBatched_bufferSize",        {HIP_5040, HIP_0,    HIP_0   }},
-  {"hipsolverDnCgesvdaStridedBatched_bufferSize",        {HIP_5040, HIP_0,    HIP_0   }},
-  {"hipsolverDnZgesvdaStridedBatched_bufferSize",        {HIP_5040, HIP_0,    HIP_0   }},
-  {"hipsolverDnSgesvdaStridedBatched",                   {HIP_5040, HIP_0,    HIP_0   }},
-  {"hipsolverDnDgesvdaStridedBatched",                   {HIP_5040, HIP_0,    HIP_0   }},
-  {"hipsolverDnCgesvdaStridedBatched",                   {HIP_5040, HIP_0,    HIP_0   }},
-  {"hipsolverDnZgesvdaStridedBatched",                   {HIP_5040, HIP_0,    HIP_0   }},
-  {"hipsolverRfCreate",                                  {HIP_5060, HIP_0,    HIP_0   }},
-  {"hipsolverRfDestroy",                                 {HIP_5060, HIP_0,    HIP_0   }},
-  {"hipsolverRfGetMatrixFormat",                         {HIP_5060, HIP_0,    HIP_0   }},
-  {"hipsolverRfSetMatrixFormat",                         {HIP_5060, HIP_0,    HIP_0   }},
-  {"hipsolverRfSetNumericProperties",                    {HIP_5060, HIP_0,    HIP_0   }},
-  {"hipsolverRfGetNumericProperties",                    {HIP_5060, HIP_0,    HIP_0   }},
-  {"hipsolverRfGetNumericBoostReport",                   {HIP_5060, HIP_0,    HIP_0   }},
-  {"hipsolverRfSetAlgs",                                 {HIP_5060, HIP_0,    HIP_0   }},
-  {"hipsolverRfGetResetValuesFastMode",                  {HIP_5060, HIP_0,    HIP_0   }},
-  {"hipsolverRfSetResetValuesFastMode",                  {HIP_5060, HIP_0,    HIP_0   }},
-  {"hipsolverRfSetupHost",                               {HIP_5060, HIP_0,    HIP_0   }},
-  {"hipsolverRfSetupDevice",                             {HIP_5060, HIP_0,    HIP_0   }},
-  {"hipsolverRfResetValues",                             {HIP_5060, HIP_0,    HIP_0   }},
-  {"hipsolverRfAnalyze",                                 {HIP_5060, HIP_0,    HIP_0   }},
-  {"hipsolverRfRefactor",                                {HIP_5060, HIP_0,    HIP_0   }},
-  {"hipsolverRfAccessBundledFactorsDevice",              {HIP_5060, HIP_0,    HIP_0   }},
-  {"hipsolverRfExtractBundledFactorsHost",               {HIP_5060, HIP_0,    HIP_0   }},
-  {"hipsolverRfExtractSplitFactorsHost",                 {HIP_5060, HIP_0,    HIP_0   }},
-  {"hipsolverRfSolve",                                   {HIP_5060, HIP_0,    HIP_0   }},
-  {"hipsolverRfBatchSetupHost",                          {HIP_5060, HIP_0,    HIP_0   }},
-  {"hipsolverRfBatchResetValues",                        {HIP_5060, HIP_0,    HIP_0   }},
-  {"hipsolverRfBatchAnalyze",                            {HIP_5060, HIP_0,    HIP_0   }},
-  {"hipsolverRfBatchRefactor",                           {HIP_5060, HIP_0,    HIP_0   }},
-  {"hipsolverRfBatchSolve",                              {HIP_5060, HIP_0,    HIP_0   }},
-  {"hipsolverRfBatchZeroPivot",                          {HIP_5060, HIP_0,    HIP_0   }},
-  {"hipsolverSpCreate",                                  {HIP_6010, HIP_0,    HIP_0   }},
-  {"hipsolverSpDestroy",                                 {HIP_6010, HIP_0,    HIP_0   }},
-  {"hipsolverSpSetStream",                               {HIP_6010, HIP_0,    HIP_0   }},
-  {"hipsolverSpScsrlsvchol",                             {HIP_6010, HIP_0,    HIP_0   }},
-  {"hipsolverSpDcsrlsvchol",                             {HIP_6010, HIP_0,    HIP_0   }},
-  {"hipsolverSpScsrlsvcholHost",                         {HIP_6010, HIP_0,    HIP_0   }},
-  {"hipsolverSpDcsrlsvcholHost",                         {HIP_6010, HIP_0,    HIP_0   }},
-  {"hipsolverDnCreateParams",                            {HIP_6020, HIP_0,    HIP_0   }},
-  {"hipsolverDnDestroyParams",                           {HIP_6020, HIP_0,    HIP_0   }},
-  {"hipsolverDnSetAdvOptions",                           {HIP_6020, HIP_0,    HIP_0   }},
-  {"hipsolverDnXgetrf",                                  {HIP_6020, HIP_0,    HIP_0   }},
-  {"hipsolverDnXgetrf_bufferSize",                       {HIP_6020, HIP_0,    HIP_0   }},
-  {"hipsolverDnXgetrs",                                  {HIP_6020, HIP_0,    HIP_0   }},
-  {"hipsolverDnSetDeterministicMode",                    {HIP_6030, HIP_0,    HIP_0   }},
-  {"hipsolverDnGetDeterministicMode",                    {HIP_6030, HIP_0,    HIP_0   }},
-  {"hipsolverDnXgeqrf_bufferSize",                       {HIP_6030, HIP_0,    HIP_0   }},
-  {"hipsolverDnXgeqrf",                                  {HIP_6030, HIP_0,    HIP_0   }},
-  {"hipsolverDnXpotrf_bufferSize",                       {HIP_6030, HIP_0,    HIP_0   }},
-  {"hipsolverDnXpotrf",                                  {HIP_6030, HIP_0,    HIP_0   }},
-  {"hipsolverDnXpotrs",                                  {HIP_6030, HIP_0,    HIP_0   }},
-  {"hipsolverSpScsrlsvqr",                               {HIP_6040, HIP_0,    HIP_0   }},
-  {"hipsolverSpDcsrlsvqr",                               {HIP_6040, HIP_0,    HIP_0   }},
-  {"hipsolverSpCcsrlsvqr",                               {HIP_7000, HIP_0,    HIP_0   }},
-  {"hipsolverSpZcsrlsvqr",                               {HIP_7000, HIP_0,    HIP_0   }},
+  m["cusolverDnCreateParams"]                                         = {CUDA_110, CUDA_0,   CUDA_0  };
+  m["cusolverDnDestroyParams"]                                        = {CUDA_110, CUDA_0,   CUDA_0  };
+  m["cusolverDnSetAdvOptions"]                                        = {CUDA_110, CUDA_0,   CUDA_0  };
+  m["cusolverDnXgetrf"]                                               = {CUDA_111, CUDA_0,   CUDA_0  };
+  m["cusolverDnXgetrf_bufferSize"]                                    = {CUDA_111, CUDA_0,   CUDA_0  };
+  m["cusolverDnXgetrs"]                                               = {CUDA_111, CUDA_0,   CUDA_0  };
+  m["cusolverDnSetDeterministicMode"]                                 = {CUDA_122, CUDA_0,   CUDA_0  };
+  m["cusolverDnGetDeterministicMode"]                                 = {CUDA_122, CUDA_0,   CUDA_0  };
+  m["cusolverDnIRSParamsCreate"]                                      = {CUDA_102, CUDA_0,   CUDA_0  };
+  m["cusolverDnIRSParamsDestroy"]                                     = {CUDA_102, CUDA_0,   CUDA_0  };
+  m["cusolverDnIRSParamsSetRefinementSolver"]                         = {CUDA_102, CUDA_0,   CUDA_0  };
+  m["cusolverDnIRSParamsSetSolverMainPrecision"]                      = {CUDA_102, CUDA_0,   CUDA_0  };
+  m["cusolverDnIRSParamsSetSolverLowestPrecision"]                    = {CUDA_102, CUDA_0,   CUDA_0  };
+  m["cusolverDnIRSParamsSetSolverPrecisions"]                         = {CUDA_102, CUDA_0,   CUDA_0  };
+  m["cusolverDnIRSParamsSetTol"]                                      = {CUDA_102, CUDA_0,   CUDA_0  };
+  m["cusolverDnIRSParamsSetTolInner"]                                 = {CUDA_102, CUDA_0,   CUDA_0  };
+  m["cusolverDnIRSParamsSetMaxIters"]                                 = {CUDA_102, CUDA_0,   CUDA_0  };
+  m["cusolverDnIRSParamsSetMaxItersInner"]                            = {CUDA_102, CUDA_0,   CUDA_0  };
+  m["cusolverDnIRSParamsGetMaxIters"]                                 = {CUDA_102, CUDA_0,   CUDA_0  };
+  m["cusolverDnIRSParamsEnableFallback"]                              = {CUDA_110, CUDA_0,   CUDA_0  };
+  m["cusolverDnIRSParamsDisableFallback"]                             = {CUDA_110, CUDA_0,   CUDA_0  };
+  m["cusolverDnIRSInfosCreate"]                                       = {CUDA_102, CUDA_0,   CUDA_0  };
+  m["cusolverDnIRSInfosDestroy"]                                      = {CUDA_102, CUDA_0,   CUDA_0  };
+  m["cusolverDnIRSInfosGetNiters"]                                    = {CUDA_102, CUDA_0,   CUDA_0  };
+  m["cusolverDnIRSInfosGetOuterNiters"]                               = {CUDA_102, CUDA_0,   CUDA_0  };
+  m["cusolverDnIRSInfosRequestResidual"]                              = {CUDA_102, CUDA_0,   CUDA_0  };
+  m["cusolverDnIRSInfosGetResidualHistory"]                           = {CUDA_102, CUDA_0,   CUDA_0  };
+  m["cusolverDnIRSInfosGetMaxIters"]                                  = {CUDA_102, CUDA_0,   CUDA_0  };
+  m["cusolverDnZZgesv"]                                               = {CUDA_102, CUDA_0,   CUDA_0  };
+  m["cusolverDnZCgesv"]                                               = {CUDA_102, CUDA_0,   CUDA_0  };
+  m["cusolverDnZKgesv"]                                               = {CUDA_102, CUDA_0,   CUDA_0  };
+  m["cusolverDnZEgesv"]                                               = {CUDA_110, CUDA_0,   CUDA_0  };
+  m["cusolverDnZYgesv"]                                               = {CUDA_110, CUDA_0,   CUDA_0  };
+  m["cusolverDnCCgesv"]                                               = {CUDA_102, CUDA_0,   CUDA_0  };
+  m["cusolverDnCEgesv"]                                               = {CUDA_110, CUDA_0,   CUDA_0  };
+  m["cusolverDnCKgesv"]                                               = {CUDA_102, CUDA_0,   CUDA_0  };
+  m["cusolverDnCYgesv"]                                               = {CUDA_110, CUDA_0,   CUDA_0  };
+  m["cusolverDnDDgesv"]                                               = {CUDA_102, CUDA_0,   CUDA_0  };
+  m["cusolverDnDSgesv"]                                               = {CUDA_102, CUDA_0,   CUDA_0  };
+  m["cusolverDnDHgesv"]                                               = {CUDA_102, CUDA_0,   CUDA_0  };
+  m["cusolverDnDBgesv"]                                               = {CUDA_110, CUDA_0,   CUDA_0  };
+  m["cusolverDnDXgesv"]                                               = {CUDA_110, CUDA_0,   CUDA_0  };
+  m["cusolverDnSSgesv"]                                               = {CUDA_102, CUDA_0,   CUDA_0  };
+  m["cusolverDnSHgesv"]                                               = {CUDA_102, CUDA_0,   CUDA_0  };
+  m["cusolverDnSBgesv"]                                               = {CUDA_110, CUDA_0,   CUDA_0  };
+  m["cusolverDnSXgesv"]                                               = {CUDA_110, CUDA_0,   CUDA_0  };
+  m["cusolverDnZZgesv_bufferSize"]                                    = {CUDA_102, CUDA_0,   CUDA_0  };
+  m["cusolverDnZCgesv_bufferSize"]                                    = {CUDA_102, CUDA_0,   CUDA_0  };
+  m["cusolverDnZKgesv_bufferSize"]                                    = {CUDA_102, CUDA_0,   CUDA_0  };
+  m["cusolverDnZEgesv_bufferSize"]                                    = {CUDA_110, CUDA_0,   CUDA_0  };
+  m["cusolverDnZYgesv_bufferSize"]                                    = {CUDA_110, CUDA_0,   CUDA_0  };
+  m["cusolverDnCCgesv_bufferSize"]                                    = {CUDA_102, CUDA_0,   CUDA_0  };
+  m["cusolverDnCKgesv_bufferSize"]                                    = {CUDA_102, CUDA_0,   CUDA_0  };
+  m["cusolverDnCEgesv_bufferSize"]                                    = {CUDA_110, CUDA_0,   CUDA_0  };
+  m["cusolverDnCYgesv_bufferSize"]                                    = {CUDA_110, CUDA_0,   CUDA_0  };
+  m["cusolverDnDDgesv_bufferSize"]                                    = {CUDA_102, CUDA_0,   CUDA_0  };
+  m["cusolverDnDSgesv_bufferSize"]                                    = {CUDA_102, CUDA_0,   CUDA_0  };
+  m["cusolverDnDHgesv_bufferSize"]                                    = {CUDA_102, CUDA_0,   CUDA_0  };
+  m["cusolverDnDBgesv_bufferSize"]                                    = {CUDA_110, CUDA_0,   CUDA_0  };
+  m["cusolverDnDXgesv_bufferSize"]                                    = {CUDA_110, CUDA_0,   CUDA_0  };
+  m["cusolverDnSSgesv_bufferSize"]                                    = {CUDA_102, CUDA_0,   CUDA_0  };
+  m["cusolverDnSHgesv_bufferSize"]                                    = {CUDA_102, CUDA_0,   CUDA_0  };
+  m["cusolverDnSBgesv_bufferSize"]                                    = {CUDA_110, CUDA_0,   CUDA_0  };
+  m["cusolverDnSXgesv_bufferSize"]                                    = {CUDA_110, CUDA_0,   CUDA_0  };
+  m["cusolverDnZZgels"]                                               = {CUDA_110, CUDA_0,   CUDA_0  };
+  m["cusolverDnZCgels"]                                               = {CUDA_110, CUDA_0,   CUDA_0  };
+  m["cusolverDnZKgels"]                                               = {CUDA_110, CUDA_0,   CUDA_0  };
+  m["cusolverDnZEgels"]                                               = {CUDA_110, CUDA_0,   CUDA_0  };
+  m["cusolverDnZYgels"]                                               = {CUDA_110, CUDA_0,   CUDA_0  };
+  m["cusolverDnCCgels"]                                               = {CUDA_110, CUDA_0,   CUDA_0  };
+  m["cusolverDnCKgels"]                                               = {CUDA_110, CUDA_0,   CUDA_0  };
+  m["cusolverDnCEgels"]                                               = {CUDA_110, CUDA_0,   CUDA_0  };
+  m["cusolverDnCYgels"]                                               = {CUDA_110, CUDA_0,   CUDA_0  };
+  m["cusolverDnDDgels"]                                               = {CUDA_110, CUDA_0,   CUDA_0  };
+  m["cusolverDnDSgels"]                                               = {CUDA_110, CUDA_0,   CUDA_0  };
+  m["cusolverDnDHgels"]                                               = {CUDA_110, CUDA_0,   CUDA_0  };
+  m["cusolverDnDBgels"]                                               = {CUDA_110, CUDA_0,   CUDA_0  };
+  m["cusolverDnDXgels"]                                               = {CUDA_110, CUDA_0,   CUDA_0  };
+  m["cusolverDnSSgels"]                                               = {CUDA_110, CUDA_0,   CUDA_0  };
+  m["cusolverDnSHgels"]                                               = {CUDA_110, CUDA_0,   CUDA_0  };
+  m["cusolverDnSBgels"]                                               = {CUDA_110, CUDA_0,   CUDA_0  };
+  m["cusolverDnSXgels"]                                               = {CUDA_110, CUDA_0,   CUDA_0  };
+  m["cusolverDnZZgels_bufferSize"]                                    = {CUDA_110, CUDA_0,   CUDA_0  };
+  m["cusolverDnZCgels_bufferSize"]                                    = {CUDA_110, CUDA_0,   CUDA_0  };
+  m["cusolverDnZKgels_bufferSize"]                                    = {CUDA_110, CUDA_0,   CUDA_0  };
+  m["cusolverDnZEgels_bufferSize"]                                    = {CUDA_110, CUDA_0,   CUDA_0  };
+  m["cusolverDnZYgels_bufferSize"]                                    = {CUDA_110, CUDA_0,   CUDA_0  };
+  m["cusolverDnCCgels_bufferSize"]                                    = {CUDA_110, CUDA_0,   CUDA_0  };
+  m["cusolverDnCKgels_bufferSize"]                                    = {CUDA_110, CUDA_0,   CUDA_0  };
+  m["cusolverDnCEgels_bufferSize"]                                    = {CUDA_110, CUDA_0,   CUDA_0  };
+  m["cusolverDnCYgels_bufferSize"]                                    = {CUDA_110, CUDA_0,   CUDA_0  };
+  m["cusolverDnDDgels_bufferSize"]                                    = {CUDA_110, CUDA_0,   CUDA_0  };
+  m["cusolverDnDSgels_bufferSize"]                                    = {CUDA_110, CUDA_0,   CUDA_0  };
+  m["cusolverDnDHgels_bufferSize"]                                    = {CUDA_110, CUDA_0,   CUDA_0  };
+  m["cusolverDnDBgels_bufferSize"]                                    = {CUDA_110, CUDA_0,   CUDA_0  };
+  m["cusolverDnDXgels_bufferSize"]                                    = {CUDA_110, CUDA_0,   CUDA_0  };
+  m["cusolverDnSSgels_bufferSize"]                                    = {CUDA_110, CUDA_0,   CUDA_0  };
+  m["cusolverDnSHgels_bufferSize"]                                    = {CUDA_110, CUDA_0,   CUDA_0  };
+  m["cusolverDnSBgels_bufferSize"]                                    = {CUDA_110, CUDA_0,   CUDA_0  };
+  m["cusolverDnSXgels_bufferSize"]                                    = {CUDA_110, CUDA_0,   CUDA_0  };
+  m["cusolverDnIRSXgesv"]                                             = {CUDA_102, CUDA_0,   CUDA_0  };
+  m["cusolverDnIRSXgesv_bufferSize"]                                  = {CUDA_102, CUDA_0,   CUDA_0  };
+  m["cusolverDnIRSXgels"]                                             = {CUDA_110, CUDA_0,   CUDA_0  };
+  m["cusolverDnIRSXgels_bufferSize"]                                  = {CUDA_110, CUDA_0,   CUDA_0  };
+  m["cusolverDnSpotrfBatched"]                                        = {CUDA_91,  CUDA_0,   CUDA_0  };
+  m["cusolverDnDpotrfBatched"]                                        = {CUDA_91,  CUDA_0,   CUDA_0  };
+  m["cusolverDnCpotrfBatched"]                                        = {CUDA_91,  CUDA_0,   CUDA_0  };
+  m["cusolverDnZpotrfBatched"]                                        = {CUDA_91,  CUDA_0,   CUDA_0  };
+  m["cusolverDnSpotrsBatched"]                                        = {CUDA_91,  CUDA_0,   CUDA_0  };
+  m["cusolverDnDpotrsBatched"]                                        = {CUDA_91,  CUDA_0,   CUDA_0  };
+  m["cusolverDnCpotrsBatched"]                                        = {CUDA_91,  CUDA_0,   CUDA_0  };
+  m["cusolverDnZpotrsBatched"]                                        = {CUDA_91,  CUDA_0,   CUDA_0  };
+  m["cusolverDnSpotri_bufferSize"]                                    = {CUDA_101, CUDA_0,   CUDA_0  };
+  m["cusolverDnDpotri_bufferSize"]                                    = {CUDA_101, CUDA_0,   CUDA_0  };
+  m["cusolverDnCpotri_bufferSize"]                                    = {CUDA_101, CUDA_0,   CUDA_0  };
+  m["cusolverDnZpotri_bufferSize"]                                    = {CUDA_101, CUDA_0,   CUDA_0  };
+  m["cusolverDnSpotri"]                                               = {CUDA_101, CUDA_0,   CUDA_0  };
+  m["cusolverDnDpotri"]                                               = {CUDA_101, CUDA_0,   CUDA_0  };
+  m["cusolverDnCpotri"]                                               = {CUDA_101, CUDA_0,   CUDA_0  };
+  m["cusolverDnZpotri"]                                               = {CUDA_101, CUDA_0,   CUDA_0  };
+  m["cusolverDnXtrtri_bufferSize"]                                    = {CUDA_114, CUDA_0,   CUDA_0  };
+  m["cusolverDnXtrtri"]                                               = {CUDA_114, CUDA_0,   CUDA_0  };
+  m["cusolverDnSlauum_bufferSize"]                                    = {CUDA_101, CUDA_0,   CUDA_0  };
+  m["cusolverDnDlauum_bufferSize"]                                    = {CUDA_101, CUDA_0,   CUDA_0  };
+  m["cusolverDnClauum_bufferSize"]                                    = {CUDA_101, CUDA_0,   CUDA_0  };
+  m["cusolverDnZlauum_bufferSize"]                                    = {CUDA_101, CUDA_0,   CUDA_0  };
+  m["cusolverDnSlauum"]                                               = {CUDA_101, CUDA_0,   CUDA_0  };
+  m["cusolverDnDlauum"]                                               = {CUDA_101, CUDA_0,   CUDA_0  };
+  m["cusolverDnClauum"]                                               = {CUDA_101, CUDA_0,   CUDA_0  };
+  m["cusolverDnZlauum"]                                               = {CUDA_101, CUDA_0,   CUDA_0  };
+  m["cusolverDnSorgqr_bufferSize"]                                    = {CUDA_80,  CUDA_0,   CUDA_0  };
+  m["cusolverDnDorgqr_bufferSize"]                                    = {CUDA_80,  CUDA_0,   CUDA_0  };
+  m["cusolverDnCungqr_bufferSize"]                                    = {CUDA_80,  CUDA_0,   CUDA_0  };
+  m["cusolverDnZungqr_bufferSize"]                                    = {CUDA_80,  CUDA_0,   CUDA_0  };
+  m["cusolverDnSorgqr"]                                               = {CUDA_80,  CUDA_0,   CUDA_0  };
+  m["cusolverDnDorgqr"]                                               = {CUDA_80,  CUDA_0,   CUDA_0  };
+  m["cusolverDnCungqr"]                                               = {CUDA_80,  CUDA_0,   CUDA_0  };
+  m["cusolverDnZungqr"]                                               = {CUDA_80,  CUDA_0,   CUDA_0  };
+  m["cusolverDnSormqr_bufferSize"]                                    = {CUDA_80,  CUDA_0,   CUDA_0  };
+  m["cusolverDnDormqr_bufferSize"]                                    = {CUDA_80,  CUDA_0,   CUDA_0  };
+  m["cusolverDnCunmqr_bufferSize"]                                    = {CUDA_80,  CUDA_0,   CUDA_0  };
+  m["cusolverDnZunmqr_bufferSize"]                                    = {CUDA_80,  CUDA_0,   CUDA_0  };
+  m["cusolverDnXsytrs_bufferSize"]                                    = {CUDA_113, CUDA_0,   CUDA_0  };
+  m["cusolverDnXsytrs"]                                               = {CUDA_113, CUDA_0,   CUDA_0  };
+  m["cusolverDnSsytri_bufferSize"]                                    = {CUDA_101, CUDA_0,   CUDA_0  };
+  m["cusolverDnDsytri_bufferSize"]                                    = {CUDA_101, CUDA_0,   CUDA_0  };
+  m["cusolverDnCsytri_bufferSize"]                                    = {CUDA_101, CUDA_0,   CUDA_0  };
+  m["cusolverDnZsytri_bufferSize"]                                    = {CUDA_101, CUDA_0,   CUDA_0  };
+  m["cusolverDnSsytri"]                                               = {CUDA_101, CUDA_0,   CUDA_0  };
+  m["cusolverDnDsytri"]                                               = {CUDA_101, CUDA_0,   CUDA_0  };
+  m["cusolverDnCsytri"]                                               = {CUDA_101, CUDA_0,   CUDA_0  };
+  m["cusolverDnZsytri"]                                               = {CUDA_101, CUDA_0,   CUDA_0  };
+  m["cusolverDnSorgbr_bufferSize"]                                    = {CUDA_80,  CUDA_0,   CUDA_0  };
+  m["cusolverDnDorgbr_bufferSize"]                                    = {CUDA_80,  CUDA_0,   CUDA_0  };
+  m["cusolverDnCungbr_bufferSize"]                                    = {CUDA_80,  CUDA_0,   CUDA_0  };
+  m["cusolverDnZungbr_bufferSize"]                                    = {CUDA_80,  CUDA_0,   CUDA_0  };
+  m["cusolverDnSorgbr"]                                               = {CUDA_80,  CUDA_0,   CUDA_0  };
+  m["cusolverDnDorgbr"]                                               = {CUDA_80,  CUDA_0,   CUDA_0  };
+  m["cusolverDnCungbr"]                                               = {CUDA_80,  CUDA_0,   CUDA_0  };
+  m["cusolverDnZungbr"]                                               = {CUDA_80,  CUDA_0,   CUDA_0  };
+  m["cusolverDnSsytrd_bufferSize"]                                    = {CUDA_80,  CUDA_0,   CUDA_0  };
+  m["cusolverDnDsytrd_bufferSize"]                                    = {CUDA_80,  CUDA_0,   CUDA_0  };
+  m["cusolverDnChetrd_bufferSize"]                                    = {CUDA_80,  CUDA_0,   CUDA_0  };
+  m["cusolverDnZhetrd_bufferSize"]                                    = {CUDA_80,  CUDA_0,   CUDA_0  };
+  m["cusolverDnChetrd"]                                               = {CUDA_80,  CUDA_0,   CUDA_0  };
+  m["cusolverDnZhetrd"]                                               = {CUDA_80,  CUDA_0,   CUDA_0  };
+  m["cusolverDnSorgtr_bufferSize"]                                    = {CUDA_80,  CUDA_0,   CUDA_0  };
+  m["cusolverDnDorgtr_bufferSize"]                                    = {CUDA_80,  CUDA_0,   CUDA_0  };
+  m["cusolverDnCungtr_bufferSize"]                                    = {CUDA_80,  CUDA_0,   CUDA_0  };
+  m["cusolverDnZungtr_bufferSize"]                                    = {CUDA_80,  CUDA_0,   CUDA_0  };
+  m["cusolverDnSorgtr"]                                               = {CUDA_80,  CUDA_0,   CUDA_0  };
+  m["cusolverDnDorgtr"]                                               = {CUDA_80,  CUDA_0,   CUDA_0  };
+  m["cusolverDnCungtr"]                                               = {CUDA_80,  CUDA_0,   CUDA_0  };
+  m["cusolverDnZungtr"]                                               = {CUDA_80,  CUDA_0,   CUDA_0  };
+  m["cusolverDnSormtr_bufferSize"]                                    = {CUDA_80,  CUDA_0,   CUDA_0  };
+  m["cusolverDnDormtr_bufferSize"]                                    = {CUDA_80,  CUDA_0,   CUDA_0  };
+  m["cusolverDnCunmtr_bufferSize"]                                    = {CUDA_80,  CUDA_0,   CUDA_0  };
+  m["cusolverDnZunmtr_bufferSize"]                                    = {CUDA_80,  CUDA_0,   CUDA_0  };
+  m["cusolverDnSormtr"]                                               = {CUDA_80,  CUDA_0,   CUDA_0  };
+  m["cusolverDnDormtr"]                                               = {CUDA_80,  CUDA_0,   CUDA_0  };
+  m["cusolverDnCunmtr"]                                               = {CUDA_80,  CUDA_0,   CUDA_0  };
+  m["cusolverDnZunmtr"]                                               = {CUDA_80,  CUDA_0,   CUDA_0  };
+  m["cusolverDnSsyevd_bufferSize"]                                    = {CUDA_80,  CUDA_0,   CUDA_0  };
+  m["cusolverDnDsyevd_bufferSize"]                                    = {CUDA_80,  CUDA_0,   CUDA_0  };
+  m["cusolverDnCheevd_bufferSize"]                                    = {CUDA_80,  CUDA_0,   CUDA_0  };
+  m["cusolverDnZheevd_bufferSize"]                                    = {CUDA_80,  CUDA_0,   CUDA_0  };
+  m["cusolverDnSsyevd"]                                               = {CUDA_80,  CUDA_0,   CUDA_0  };
+  m["cusolverDnDsyevd"]                                               = {CUDA_80,  CUDA_0,   CUDA_0  };
+  m["cusolverDnCheevd"]                                               = {CUDA_80,  CUDA_0,   CUDA_0  };
+  m["cusolverDnZheevd"]                                               = {CUDA_80,  CUDA_0,   CUDA_0  };
+  m["cusolverDnSsyevdx_bufferSize"]                                   = {CUDA_101, CUDA_0,   CUDA_0  };
+  m["cusolverDnDsyevdx_bufferSize"]                                   = {CUDA_101, CUDA_0,   CUDA_0  };
+  m["cusolverDnCheevdx_bufferSize"]                                   = {CUDA_101, CUDA_0,   CUDA_0  };
+  m["cusolverDnZheevdx_bufferSize"]                                   = {CUDA_101, CUDA_0,   CUDA_0  };
+  m["cusolverDnSsyevdx"]                                              = {CUDA_101, CUDA_0,   CUDA_0  };
+  m["cusolverDnDsyevdx"]                                              = {CUDA_101, CUDA_0,   CUDA_0  };
+  m["cusolverDnCheevdx"]                                              = {CUDA_101, CUDA_0,   CUDA_0  };
+  m["cusolverDnZheevdx"]                                              = {CUDA_101, CUDA_0,   CUDA_0  };
+  m["cusolverDnSsygvdx_bufferSize"]                                   = {CUDA_101, CUDA_0,   CUDA_0  };
+  m["cusolverDnDsygvdx_bufferSize"]                                   = {CUDA_101, CUDA_0,   CUDA_0  };
+  m["cusolverDnChegvdx_bufferSize"]                                   = {CUDA_101, CUDA_0,   CUDA_0  };
+  m["cusolverDnZhegvdx_bufferSize"]                                   = {CUDA_101, CUDA_0,   CUDA_0  };
+  m["cusolverDnSsygvdx"]                                              = {CUDA_101, CUDA_0,   CUDA_0  };
+  m["cusolverDnDsygvdx"]                                              = {CUDA_101, CUDA_0,   CUDA_0  };
+  m["cusolverDnChegvdx"]                                              = {CUDA_101, CUDA_0,   CUDA_0  };
+  m["cusolverDnZhegvdx"]                                              = {CUDA_101, CUDA_0,   CUDA_0  };
+  m["cusolverDnSsygvd_bufferSize"]                                    = {CUDA_80,  CUDA_0,   CUDA_0  };
+  m["cusolverDnDsygvd_bufferSize"]                                    = {CUDA_80,  CUDA_0,   CUDA_0  };
+  m["cusolverDnChegvd_bufferSize"]                                    = {CUDA_80,  CUDA_0,   CUDA_0  };
+  m["cusolverDnZhegvd_bufferSize"]                                    = {CUDA_80,  CUDA_0,   CUDA_0  };
+  m["cusolverDnSsygvd"]                                               = {CUDA_80,  CUDA_0,   CUDA_0  };
+  m["cusolverDnDsygvd"]                                               = {CUDA_80,  CUDA_0,   CUDA_0  };
+  m["cusolverDnChegvd"]                                               = {CUDA_80,  CUDA_0,   CUDA_0  };
+  m["cusolverDnZhegvd"]                                               = {CUDA_80,  CUDA_0,   CUDA_0  };
+  m["cusolverDnCreateSyevjInfo"]                                      = {CUDA_90,  CUDA_0,   CUDA_0  };
+  m["cusolverDnDestroySyevjInfo"]                                     = {CUDA_90,  CUDA_0,   CUDA_0  };
+  m["cusolverDnXsyevjSetTolerance"]                                   = {CUDA_90,  CUDA_0,   CUDA_0  };
+  m["cusolverDnXsyevjSetMaxSweeps"]                                   = {CUDA_90,  CUDA_0,   CUDA_0  };
+  m["cusolverDnXsyevjSetSortEig"]                                     = {CUDA_90,  CUDA_0,   CUDA_0  };
+  m["cusolverDnXsyevjGetResidual"]                                    = {CUDA_90,  CUDA_0,   CUDA_0  };
+  m["cusolverDnXsyevjGetSweeps"]                                      = {CUDA_90,  CUDA_0,   CUDA_0  };
+  m["cusolverDnSsyevjBatched_bufferSize"]                             = {CUDA_90,  CUDA_0,   CUDA_0  };
+  m["cusolverDnDsyevjBatched_bufferSize"]                             = {CUDA_90,  CUDA_0,   CUDA_0  };
+  m["cusolverDnCheevjBatched_bufferSize"]                             = {CUDA_90,  CUDA_0,   CUDA_0  };
+  m["cusolverDnZheevjBatched_bufferSize"]                             = {CUDA_90,  CUDA_0,   CUDA_0  };
+  m["cusolverDnSsyevjBatched"]                                        = {CUDA_90,  CUDA_0,   CUDA_0  };
+  m["cusolverDnDsyevjBatched"]                                        = {CUDA_90,  CUDA_0,   CUDA_0  };
+  m["cusolverDnCheevjBatched"]                                        = {CUDA_90,  CUDA_0,   CUDA_0  };
+  m["cusolverDnZheevjBatched"]                                        = {CUDA_90,  CUDA_0,   CUDA_0  };
+  m["cusolverDnSsyevj_bufferSize"]                                    = {CUDA_90,  CUDA_0,   CUDA_0  };
+  m["cusolverDnDsyevj_bufferSize"]                                    = {CUDA_90,  CUDA_0,   CUDA_0  };
+  m["cusolverDnCheevj_bufferSize"]                                    = {CUDA_90,  CUDA_0,   CUDA_0  };
+  m["cusolverDnZheevj_bufferSize"]                                    = {CUDA_90,  CUDA_0,   CUDA_0  };
+  m["cusolverDnSsyevj"]                                               = {CUDA_90,  CUDA_0,   CUDA_0  };
+  m["cusolverDnDsyevj"]                                               = {CUDA_90,  CUDA_0,   CUDA_0  };
+  m["cusolverDnCheevj"]                                               = {CUDA_90,  CUDA_0,   CUDA_0  };
+  m["cusolverDnZheevj"]                                               = {CUDA_90,  CUDA_0,   CUDA_0  };
+  m["cusolverDnSsygvj_bufferSize"]                                    = {CUDA_90,  CUDA_0,   CUDA_0  };
+  m["cusolverDnDsygvj_bufferSize"]                                    = {CUDA_90,  CUDA_0,   CUDA_0  };
+  m["cusolverDnChegvj_bufferSize"]                                    = {CUDA_90,  CUDA_0,   CUDA_0  };
+  m["cusolverDnZhegvj_bufferSize"]                                    = {CUDA_90,  CUDA_0,   CUDA_0  };
+  m["cusolverDnSsygvj"]                                               = {CUDA_90,  CUDA_0,   CUDA_0  };
+  m["cusolverDnDsygvj"]                                               = {CUDA_90,  CUDA_0,   CUDA_0  };
+  m["cusolverDnChegvj"]                                               = {CUDA_90,  CUDA_0,   CUDA_0  };
+  m["cusolverDnZhegvj"]                                               = {CUDA_90,  CUDA_0,   CUDA_0  };
+  m["cusolverDnCreateGesvdjInfo"]                                     = {CUDA_90,  CUDA_0,   CUDA_0  };
+  m["cusolverDnDestroyGesvdjInfo"]                                    = {CUDA_90,  CUDA_0,   CUDA_0  };
+  m["cusolverDnXgesvdjSetTolerance"]                                  = {CUDA_90,  CUDA_0,   CUDA_0  };
+  m["cusolverDnXgesvdjSetMaxSweeps"]                                  = {CUDA_90,  CUDA_0,   CUDA_0  };
+  m["cusolverDnXgesvdjSetSortEig"]                                    = {CUDA_90,  CUDA_0,   CUDA_0  };
+  m["cusolverDnXgesvdjGetResidual"]                                   = {CUDA_90,  CUDA_0,   CUDA_0  };
+  m["cusolverDnXgesvdjGetSweeps"]                                     = {CUDA_90,  CUDA_0,   CUDA_0  };
+  m["cusolverDnSgesvdjBatched_bufferSize"]                            = {CUDA_90,  CUDA_0,   CUDA_0  };
+  m["cusolverDnDgesvdjBatched_bufferSize"]                            = {CUDA_90,  CUDA_0,   CUDA_0  };
+  m["cusolverDnCgesvdjBatched_bufferSize"]                            = {CUDA_90,  CUDA_0,   CUDA_0  };
+  m["cusolverDnZgesvdjBatched_bufferSize"]                            = {CUDA_90,  CUDA_0,   CUDA_0  };
+  m["cusolverDnSgesvdjBatched"]                                       = {CUDA_90,  CUDA_0,   CUDA_0  };
+  m["cusolverDnDgesvdjBatched"]                                       = {CUDA_90,  CUDA_0,   CUDA_0  };
+  m["cusolverDnCgesvdjBatched"]                                       = {CUDA_90,  CUDA_0,   CUDA_0  };
+  m["cusolverDnZgesvdjBatched"]                                       = {CUDA_90,  CUDA_0,   CUDA_0  };
+  m["cusolverDnSgesvdj_bufferSize"]                                   = {CUDA_90,  CUDA_0,   CUDA_0  };
+  m["cusolverDnDgesvdj_bufferSize"]                                   = {CUDA_90,  CUDA_0,   CUDA_0  };
+  m["cusolverDnCgesvdj_bufferSize"]                                   = {CUDA_90,  CUDA_0,   CUDA_0  };
+  m["cusolverDnZgesvdj_bufferSize"]                                   = {CUDA_90,  CUDA_0,   CUDA_0  };
+  m["cusolverDnSgesvdj"]                                              = {CUDA_90,  CUDA_0,   CUDA_0  };
+  m["cusolverDnDgesvdj"]                                              = {CUDA_90,  CUDA_0,   CUDA_0  };
+  m["cusolverDnCgesvdj"]                                              = {CUDA_90,  CUDA_0,   CUDA_0  };
+  m["cusolverDnZgesvdj"]                                              = {CUDA_90,  CUDA_0,   CUDA_0  };
+  m["cusolverDnSgesvdaStridedBatched_bufferSize"]                     = {CUDA_101, CUDA_0,   CUDA_0  };
+  m["cusolverDnDgesvdaStridedBatched_bufferSize"]                     = {CUDA_101, CUDA_0,   CUDA_0  };
+  m["cusolverDnCgesvdaStridedBatched_bufferSize"]                     = {CUDA_101, CUDA_0,   CUDA_0  };
+  m["cusolverDnZgesvdaStridedBatched_bufferSize"]                     = {CUDA_101, CUDA_0,   CUDA_0  };
+  m["cusolverDnSgesvdaStridedBatched"]                                = {CUDA_101, CUDA_0,   CUDA_0  };
+  m["cusolverDnDgesvdaStridedBatched"]                                = {CUDA_101, CUDA_0,   CUDA_0  };
+  m["cusolverDnCgesvdaStridedBatched"]                                = {CUDA_101, CUDA_0,   CUDA_0  };
+  m["cusolverDnZgesvdaStridedBatched"]                                = {CUDA_101, CUDA_0,   CUDA_0  };
+  m["cusolverDnPotrf_bufferSize"]                                     = {CUDA_110, CUDA_111, CUDA_130};
+  m["cusolverDnPotrf"]                                                = {CUDA_110, CUDA_111, CUDA_130};
+  m["cusolverDnPotrs"]                                                = {CUDA_110, CUDA_111, CUDA_130};
+  m["cusolverDnGeqrf_bufferSize"]                                     = {CUDA_110, CUDA_111, CUDA_130};
+  m["cusolverDnGeqrf"]                                                = {CUDA_110, CUDA_111, CUDA_130};
+  m["cusolverDnGetrf_bufferSize"]                                     = {CUDA_110, CUDA_111, CUDA_130};
+  m["cusolverDnGetrf"]                                                = {CUDA_110, CUDA_111, CUDA_130};
+  m["cusolverDnGetrs"]                                                = {CUDA_110, CUDA_111, CUDA_130};
+  m["cusolverDnSyevd_bufferSize"]                                     = {CUDA_110, CUDA_111, CUDA_130};
+  m["cusolverDnSyevd"]                                                = {CUDA_110, CUDA_111, CUDA_130};
+  m["cusolverDnSyevdx_bufferSize"]                                    = {CUDA_110, CUDA_111, CUDA_130};
+  m["cusolverDnSyevdx"]                                               = {CUDA_110, CUDA_111, CUDA_130};
+  m["cusolverDnGesvd_bufferSize"]                                     = {CUDA_110, CUDA_111, CUDA_130};
+  m["cusolverDnGesvd"]                                                = {CUDA_110, CUDA_111, CUDA_130};
+  m["cusolverDnXpotrf_bufferSize"]                                    = {CUDA_111, CUDA_0,   CUDA_0  };
+  m["cusolverDnXpotrf"]                                               = {CUDA_111, CUDA_0,   CUDA_0  };
+  m["cusolverDnXpotrs"]                                               = {CUDA_111, CUDA_0,   CUDA_0  };
+  m["cusolverDnXgeqrf_bufferSize"]                                    = {CUDA_111, CUDA_0,   CUDA_0  };
+  m["cusolverDnXgeqrf"]                                               = {CUDA_111, CUDA_0,   CUDA_0  };
+  m["cusolverDnXsyevd_bufferSize"]                                    = {CUDA_111, CUDA_0,   CUDA_0  };
+  m["cusolverDnXsyevd"]                                               = {CUDA_111, CUDA_0,   CUDA_0  };
+  m["cusolverDnXsyevdx_bufferSize"]                                   = {CUDA_111, CUDA_0,   CUDA_0  };
+  m["cusolverDnXsyevdx"]                                              = {CUDA_111, CUDA_0,   CUDA_0  };
+  m["cusolverDnXgesvd_bufferSize"]                                    = {CUDA_111, CUDA_0,   CUDA_0  };
+  m["cusolverDnXgesvd"]                                               = {CUDA_111, CUDA_0,   CUDA_0  };
+  m["cusolverDnXgesvdp_bufferSize"]                                   = {CUDA_111, CUDA_0,   CUDA_0  };
+  m["cusolverDnXgesvdp"]                                              = {CUDA_111, CUDA_0,   CUDA_0  };
+  m["cusolverDnXgesvdr_bufferSize"]                                   = {CUDA_112, CUDA_0,   CUDA_0  };
+  m["cusolverDnXgesvdr"]                                              = {CUDA_112, CUDA_0,   CUDA_0  };
+  m["cusolverDnLoggerSetCallback"]                                    = {CUDA_117, CUDA_0,   CUDA_0  };
+  m["cusolverDnLoggerSetFile"]                                        = {CUDA_117, CUDA_0,   CUDA_0  };
+  m["cusolverDnLoggerOpenFile"]                                       = {CUDA_117, CUDA_0,   CUDA_0  };
+  m["cusolverDnLoggerSetLevel"]                                       = {CUDA_117, CUDA_0,   CUDA_0  };
+  m["cusolverDnLoggerSetMask"]                                        = {CUDA_117, CUDA_0,   CUDA_0  };
+  m["cusolverDnLoggerForceDisable"]                                   = {CUDA_117, CUDA_0,   CUDA_0  };
+  m["cusolverMgCreate"]                                               = {CUDA_101, CUDA_130, CUDA_0  };
+  m["cusolverMgDestroy"]                                              = {CUDA_101, CUDA_130, CUDA_0  };
+  m["cusolverMgDeviceSelect"]                                         = {CUDA_101, CUDA_130, CUDA_0  };
+  m["cusolverMgCreateDeviceGrid"]                                     = {CUDA_101, CUDA_130, CUDA_0  };
+  m["cusolverMgDestroyGrid"]                                          = {CUDA_101, CUDA_130, CUDA_0  };
+  m["cusolverMgCreateMatrixDesc"]                                     = {CUDA_101, CUDA_130, CUDA_0  };  // A: CUSOLVER_VERSION 10200
+  m["cusolverMgDestroyMatrixDesc"]                                    = {CUDA_101, CUDA_130, CUDA_0  };  // A: CUSOLVER_VERSION 10200
+  m["cusolverMgSyevd_bufferSize"]                                     = {CUDA_101, CUDA_130, CUDA_0  };  // A: CUSOLVER_VERSION 10200
+  m["cusolverMgSyevd"]                                                = {CUDA_101, CUDA_130, CUDA_0  };  // A: CUSOLVER_VERSION 10200
+  m["cusolverMgGetrf_bufferSize"]                                     = {CUDA_102, CUDA_130, CUDA_0  };
+  m["cusolverMgGetrf"]                                                = {CUDA_102, CUDA_130, CUDA_0  };
+  m["cusolverMgGetrs_bufferSize"]                                     = {CUDA_102, CUDA_130, CUDA_0  };
+  m["cusolverMgGetrs"]                                                = {CUDA_102, CUDA_130, CUDA_0  };
+  m["cusolverMgPotrf_bufferSize"]                                     = {CUDA_110, CUDA_130, CUDA_0  };  // A: CUSOLVER_VERSION 10500
+  m["cusolverMgPotrf"]                                                = {CUDA_110, CUDA_130, CUDA_0  };  // A: CUSOLVER_VERSION 10500
+  m["cusolverMgPotrs_bufferSize"]                                     = {CUDA_110, CUDA_130, CUDA_0  };  // A: CUSOLVER_VERSION 10500
+  m["cusolverMgPotrs"]                                                = {CUDA_110, CUDA_130, CUDA_0  };  // A: CUSOLVER_VERSION 10500
+  m["cusolverMgPotri_bufferSize"]                                     = {CUDA_110, CUDA_130, CUDA_0  };  // A: CUSOLVER_VERSION 10500
+  m["cusolverMgPotri"]                                                = {CUDA_110, CUDA_130, CUDA_0  };  // A: CUSOLVER_VERSION 10500
+  m["cusolverSpXcsrsymmdqHost"]                                       = {CUDA_75,  CUDA_130, CUDA_0  };
+  m["cusolverSpXcsrsymamdHost"]                                       = {CUDA_75,  CUDA_130, CUDA_0  };
+  m["cusolverSpXcsrmetisndHost"]                                      = {CUDA_92,  CUDA_130, CUDA_0  };
+  m["cusolverSpScsrzfdHost"]                                          = {CUDA_92,  CUDA_130, CUDA_0  };
+  m["cusolverSpDcsrzfdHost"]                                          = {CUDA_92,  CUDA_130, CUDA_0  };
+  m["cusolverSpCcsrzfdHost"]                                          = {CUDA_92,  CUDA_130, CUDA_0  };
+  m["cusolverSpZcsrzfdHost"]                                          = {CUDA_92,  CUDA_130, CUDA_0  };
+  m["cusolverSpCreateCsrluInfoHost"]                                  = {CUDA_75,  CUDA_0,   CUDA_0  };
+  m["cusolverSpDestroyCsrluInfoHost"]                                 = {CUDA_75,  CUDA_0,   CUDA_0  };
+  m["cusolverSpXcsrluAnalysisHost"]                                   = {CUDA_75,  CUDA_128, CUDA_0  };
+  m["cusolverSpScsrluBufferInfoHost"]                                 = {CUDA_75,  CUDA_128, CUDA_0  };
+  m["cusolverSpDcsrluBufferInfoHost"]                                 = {CUDA_75,  CUDA_128, CUDA_0  };
+  m["cusolverSpCcsrluBufferInfoHost"]                                 = {CUDA_75,  CUDA_128, CUDA_0  };
+  m["cusolverSpZcsrluBufferInfoHost"]                                 = {CUDA_75,  CUDA_128, CUDA_0  };
+  m["cusolverSpScsrluFactorHost"]                                     = {CUDA_75,  CUDA_128, CUDA_0  };
+  m["cusolverSpDcsrluFactorHost"]                                     = {CUDA_75,  CUDA_128, CUDA_0  };
+  m["cusolverSpCcsrluFactorHost"]                                     = {CUDA_75,  CUDA_128, CUDA_0  };
+  m["cusolverSpZcsrluFactorHost"]                                     = {CUDA_75,  CUDA_128, CUDA_0  };
+  m["cusolverSpScsrluZeroPivotHost"]                                  = {CUDA_75,  CUDA_128, CUDA_0  };
+  m["cusolverSpDcsrluZeroPivotHost"]                                  = {CUDA_75,  CUDA_128, CUDA_0  };
+  m["cusolverSpCcsrluZeroPivotHost"]                                  = {CUDA_75,  CUDA_128, CUDA_0  };
+  m["cusolverSpZcsrluZeroPivotHost"]                                  = {CUDA_75,  CUDA_128, CUDA_0  };
+  m["cusolverSpScsrluSolveHost"]                                      = {CUDA_75,  CUDA_128, CUDA_0  };
+  m["cusolverSpDcsrluSolveHost"]                                      = {CUDA_75,  CUDA_128, CUDA_0  };
+  m["cusolverSpCcsrluSolveHost"]                                      = {CUDA_75,  CUDA_128, CUDA_0  };
+  m["cusolverSpZcsrluSolveHost"]                                      = {CUDA_75,  CUDA_128, CUDA_0  };
+  m["cusolverSpXcsrluNnzHost"]                                        = {CUDA_75,  CUDA_128, CUDA_0  };
+  m["cusolverSpScsrluExtractHost"]                                    = {CUDA_75,  CUDA_128, CUDA_0  };
+  m["cusolverSpDcsrluExtractHost"]                                    = {CUDA_75,  CUDA_128, CUDA_0  };
+  m["cusolverSpCcsrluExtractHost"]                                    = {CUDA_75,  CUDA_128, CUDA_0  };
+  m["cusolverSpZcsrluExtractHost"]                                    = {CUDA_75,  CUDA_128, CUDA_0  };
+  m["cusolverSpCreateCsrqrInfoHost"]                                  = {CUDA_75,  CUDA_0,   CUDA_0  };
+  m["cusolverSpDestroyCsrqrInfoHost"]                                 = {CUDA_75,  CUDA_0,   CUDA_0  };
+  m["cusolverSpXcsrqrAnalysisHost"]                                   = {CUDA_75,  CUDA_0,   CUDA_0  };
+  m["cusolverSpScsrqrBufferInfoHost"]                                 = {CUDA_75,  CUDA_0,   CUDA_0  };
+  m["cusolverSpDcsrqrBufferInfoHost"]                                 = {CUDA_75,  CUDA_0,   CUDA_0  };
+  m["cusolverSpCcsrqrBufferInfoHost"]                                 = {CUDA_75,  CUDA_0,   CUDA_0  };
+  m["cusolverSpZcsrqrBufferInfoHost"]                                 = {CUDA_75,  CUDA_0,   CUDA_0  };
+  m["cusolverSpScsrqrSetupHost"]                                      = {CUDA_75,  CUDA_0,   CUDA_0  };
+  m["cusolverSpDcsrqrSetupHost"]                                      = {CUDA_75,  CUDA_0,   CUDA_0  };
+  m["cusolverSpCcsrqrSetupHost"]                                      = {CUDA_75,  CUDA_0,   CUDA_0  };
+  m["cusolverSpZcsrqrSetupHost"]                                      = {CUDA_75,  CUDA_0,   CUDA_0  };
+  m["cusolverSpScsrqrFactorHost"]                                     = {CUDA_75,  CUDA_0,   CUDA_0  };
+  m["cusolverSpDcsrqrFactorHost"]                                     = {CUDA_75,  CUDA_0,   CUDA_0  };
+  m["cusolverSpCcsrqrFactorHost"]                                     = {CUDA_75,  CUDA_0,   CUDA_0  };
+  m["cusolverSpZcsrqrFactorHost"]                                     = {CUDA_75,  CUDA_0,   CUDA_0  };
+  m["cusolverSpScsrqrZeroPivotHost"]                                  = {CUDA_75,  CUDA_0,   CUDA_0  };
+  m["cusolverSpDcsrqrZeroPivotHost"]                                  = {CUDA_75,  CUDA_0,   CUDA_0  };
+  m["cusolverSpCcsrqrZeroPivotHost"]                                  = {CUDA_75,  CUDA_0,   CUDA_0  };
+  m["cusolverSpZcsrqrZeroPivotHost"]                                  = {CUDA_75,  CUDA_0,   CUDA_0  };
+  m["cusolverSpScsrqrSolveHost"]                                      = {CUDA_75,  CUDA_0,   CUDA_0  };
+  m["cusolverSpDcsrqrSolveHost"]                                      = {CUDA_75,  CUDA_0,   CUDA_0  };
+  m["cusolverSpCcsrqrSolveHost"]                                      = {CUDA_75,  CUDA_0,   CUDA_0  };
+  m["cusolverSpZcsrqrSolveHost"]                                      = {CUDA_75,  CUDA_0,   CUDA_0  };
+  m["cusolverSpXcsrqrAnalysis"]                                       = {CUDA_75,  CUDA_0,   CUDA_0  };
+  m["cusolverSpScsrqrBufferInfo"]                                     = {CUDA_75,  CUDA_0,   CUDA_0  };
+  m["cusolverSpDcsrqrBufferInfo"]                                     = {CUDA_75,  CUDA_0,   CUDA_0  };
+  m["cusolverSpCcsrqrBufferInfo"]                                     = {CUDA_75,  CUDA_0,   CUDA_0  };
+  m["cusolverSpZcsrqrBufferInfo"]                                     = {CUDA_75,  CUDA_0,   CUDA_0  };
+  m["cusolverSpScsrqrSetup"]                                          = {CUDA_75,  CUDA_0,   CUDA_0  };
+  m["cusolverSpDcsrqrSetup"]                                          = {CUDA_75,  CUDA_0,   CUDA_0  };
+  m["cusolverSpCcsrqrSetup"]                                          = {CUDA_75,  CUDA_0,   CUDA_0  };
+  m["cusolverSpZcsrqrSetup"]                                          = {CUDA_75,  CUDA_0,   CUDA_0  };
+  m["cusolverSpScsrqrFactor"]                                         = {CUDA_75,  CUDA_0,   CUDA_0  };
+  m["cusolverSpDcsrqrFactor"]                                         = {CUDA_75,  CUDA_0,   CUDA_0  };
+  m["cusolverSpCcsrqrFactor"]                                         = {CUDA_75,  CUDA_0,   CUDA_0  };
+  m["cusolverSpZcsrqrFactor"]                                         = {CUDA_75,  CUDA_0,   CUDA_0  };
+  m["cusolverSpScsrqrZeroPivot"]                                      = {CUDA_75,  CUDA_0,   CUDA_0  };
+  m["cusolverSpDcsrqrZeroPivot"]                                      = {CUDA_75,  CUDA_0,   CUDA_0  };
+  m["cusolverSpCcsrqrZeroPivot"]                                      = {CUDA_75,  CUDA_0,   CUDA_0  };
+  m["cusolverSpZcsrqrZeroPivot"]                                      = {CUDA_75,  CUDA_0,   CUDA_0  };
+  m["cusolverSpScsrqrSolve"]                                          = {CUDA_75,  CUDA_0,   CUDA_0  };
+  m["cusolverSpDcsrqrSolve"]                                          = {CUDA_75,  CUDA_0,   CUDA_0  };
+  m["cusolverSpCcsrqrSolve"]                                          = {CUDA_75,  CUDA_0,   CUDA_0  };
+  m["cusolverSpZcsrqrSolve"]                                          = {CUDA_75,  CUDA_0,   CUDA_0  };
+  m["cusolverSpCreateCsrcholInfoHost"]                                = {CUDA_75,  CUDA_0,   CUDA_0  };
+  m["cusolverSpDestroyCsrcholInfoHost"]                               = {CUDA_75,  CUDA_0,   CUDA_0  };
+  m["cusolverSpXcsrcholAnalysisHost"]                                 = {CUDA_75,  CUDA_128, CUDA_0  };
+  m["cusolverSpScsrcholBufferInfoHost"]                               = {CUDA_75,  CUDA_128, CUDA_0  };
+  m["cusolverSpDcsrcholBufferInfoHost"]                               = {CUDA_75,  CUDA_128, CUDA_0  };
+  m["cusolverSpCcsrcholBufferInfoHost"]                               = {CUDA_75,  CUDA_128, CUDA_0  };
+  m["cusolverSpZcsrcholBufferInfoHost"]                               = {CUDA_75,  CUDA_128, CUDA_0  };
+  m["cusolverSpScsrcholFactorHost"]                                   = {CUDA_75,  CUDA_128, CUDA_0  };
+  m["cusolverSpDcsrcholFactorHost"]                                   = {CUDA_75,  CUDA_128, CUDA_0  };
+  m["cusolverSpCcsrcholFactorHost"]                                   = {CUDA_75,  CUDA_128, CUDA_0  };
+  m["cusolverSpZcsrcholFactorHost"]                                   = {CUDA_75,  CUDA_128, CUDA_0  };
+  m["cusolverSpScsrcholZeroPivotHost"]                                = {CUDA_75,  CUDA_128, CUDA_0  };
+  m["cusolverSpDcsrcholZeroPivotHost"]                                = {CUDA_75,  CUDA_128, CUDA_0  };
+  m["cusolverSpCcsrcholZeroPivotHost"]                                = {CUDA_75,  CUDA_128, CUDA_0  };
+  m["cusolverSpZcsrcholZeroPivotHost"]                                = {CUDA_75,  CUDA_128, CUDA_0  };
+  m["cusolverSpScsrcholSolveHost"]                                    = {CUDA_75,  CUDA_128, CUDA_0  };
+  m["cusolverSpDcsrcholSolveHost"]                                    = {CUDA_75,  CUDA_128, CUDA_0  };
+  m["cusolverSpCcsrcholSolveHost"]                                    = {CUDA_75,  CUDA_128, CUDA_0  };
+  m["cusolverSpZcsrcholSolveHost"]                                    = {CUDA_75,  CUDA_128, CUDA_0  };
+  m["cusolverSpCreateCsrcholInfo"]                                    = {CUDA_75,  CUDA_128, CUDA_0  };
+  m["cusolverSpDestroyCsrcholInfo"]                                   = {CUDA_75,  CUDA_128, CUDA_0  };
+  m["cusolverSpXcsrcholAnalysis"]                                     = {CUDA_75,  CUDA_128, CUDA_0  };
+  m["cusolverSpScsrcholBufferInfo"]                                   = {CUDA_75,  CUDA_128, CUDA_0  };
+  m["cusolverSpDcsrcholBufferInfo"]                                   = {CUDA_75,  CUDA_128, CUDA_0  };
+  m["cusolverSpCcsrcholBufferInfo"]                                   = {CUDA_75,  CUDA_128, CUDA_0  };
+  m["cusolverSpZcsrcholBufferInfo"]                                   = {CUDA_75,  CUDA_128, CUDA_0  };
+  m["cusolverSpScsrcholFactor"]                                       = {CUDA_75,  CUDA_128, CUDA_0  };
+  m["cusolverSpDcsrcholFactor"]                                       = {CUDA_75,  CUDA_128, CUDA_0  };
+  m["cusolverSpCcsrcholFactor"]                                       = {CUDA_75,  CUDA_128, CUDA_0  };
+  m["cusolverSpZcsrcholFactor"]                                       = {CUDA_75,  CUDA_128, CUDA_0  };
+  m["cusolverSpScsrcholZeroPivot"]                                    = {CUDA_75,  CUDA_128, CUDA_0  };
+  m["cusolverSpDcsrcholZeroPivot"]                                    = {CUDA_75,  CUDA_128, CUDA_0  };
+  m["cusolverSpCcsrcholZeroPivot"]                                    = {CUDA_75,  CUDA_128, CUDA_0  };
+  m["cusolverSpZcsrcholZeroPivot"]                                    = {CUDA_75,  CUDA_128, CUDA_0  };
+  m["cusolverSpScsrcholSolve"]                                        = {CUDA_75,  CUDA_128, CUDA_0  };
+  m["cusolverSpDcsrcholSolve"]                                        = {CUDA_75,  CUDA_128, CUDA_0  };
+  m["cusolverSpCcsrcholSolve"]                                        = {CUDA_75,  CUDA_128, CUDA_0  };
+  m["cusolverSpZcsrcholSolve"]                                        = {CUDA_75,  CUDA_128, CUDA_0  };
+  m["cusolverSpScsrcholDiag"]                                         = {CUDA_101, CUDA_128, CUDA_0  }; // CUSOLVER_VERSION 10200
+  m["cusolverSpDcsrcholDiag"]                                         = {CUDA_101, CUDA_128, CUDA_0  }; // CUSOLVER_VERSION 10200
+  m["cusolverSpCcsrcholDiag"]                                         = {CUDA_101, CUDA_128, CUDA_0  }; // CUSOLVER_VERSION 10200
+  m["cusolverSpZcsrcholDiag"]                                         = {CUDA_101, CUDA_128, CUDA_0  }; // CUSOLVER_VERSION 10200
+  m["cusolverDnXlarft"]                                               = {CUDA_124, CUDA_0,   CUDA_0  };
+  m["cusolverDnXlarft_bufferSize"]                                    = {CUDA_124, CUDA_0,   CUDA_0  };
+  m["cusolverDnXgeev"]                                                = {CUDA_126, CUDA_0,   CUDA_0  }; // CUSOLVER_VERSION 11701
+  m["cusolverDnXgeev_bufferSize"]                                     = {CUDA_126, CUDA_0,   CUDA_0  }; // CUSOLVER_VERSION 11701
+  m["cusolverDnXsyevBatched"]                                         = {CUDA_126, CUDA_0,   CUDA_0  }; // CUSOLVER_VERSION 11701
+  m["cusolverDnXsyevBatched_bufferSize"]                              = {CUDA_126, CUDA_0,   CUDA_0  }; // CUSOLVER_VERSION 11701
+  m["cusolverRfSetupHost"]                                            = {CUDA_0,   CUDA_128, CUDA_0  }; // CUSOLVER_VERSION 11702
+  m["cusolverRfSetupDevice"]                                          = {CUDA_0,   CUDA_128, CUDA_0  }; // CUSOLVER_VERSION 11702
+  m["cusolverRfResetValues"]                                          = {CUDA_0,   CUDA_128, CUDA_0  }; // CUSOLVER_VERSION 11702
+  m["cusolverRfAnalyze"]                                              = {CUDA_0,   CUDA_128, CUDA_0  }; // CUSOLVER_VERSION 11702
+  m["cusolverRfRefactor"]                                             = {CUDA_0,   CUDA_128, CUDA_0  }; // CUSOLVER_VERSION 11702
+  m["cusolverRfAccessBundledFactorsDevice"]                           = {CUDA_0,   CUDA_128, CUDA_0  }; // CUSOLVER_VERSION 11702
+  m["cusolverRfExtractBundledFactorsHost"]                            = {CUDA_0,   CUDA_128, CUDA_0  }; // CUSOLVER_VERSION 11702
+  m["cusolverRfExtractSplitFactorsHost"]                              = {CUDA_0,   CUDA_128, CUDA_0  }; // CUSOLVER_VERSION 11702
+  m["cusolverRfSolve"]                                                = {CUDA_0,   CUDA_128, CUDA_0  }; // CUSOLVER_VERSION 11702
+  m["cusolverSpScsrlsvluHost"]                                        = {CUDA_0,   CUDA_128, CUDA_0  }; // CUSOLVER_VERSION 11702
+  m["cusolverSpDcsrlsvluHost"]                                        = {CUDA_0,   CUDA_128, CUDA_0  }; // CUSOLVER_VERSION 11702
+  m["cusolverSpCcsrlsvluHost"]                                        = {CUDA_0,   CUDA_128, CUDA_0  }; // CUSOLVER_VERSION 11702
+  m["cusolverSpZcsrlsvluHost"]                                        = {CUDA_0,   CUDA_128, CUDA_0  }; // CUSOLVER_VERSION 11702
+  m["cusolverSpScsrlsvcholHost"]                                      = {CUDA_0,   CUDA_128, CUDA_0  }; // CUSOLVER_VERSION 11702
+  m["cusolverSpDcsrlsvcholHost"]                                      = {CUDA_0,   CUDA_128, CUDA_0  }; // CUSOLVER_VERSION 11702
+  m["cusolverSpCcsrlsvcholHost"]                                      = {CUDA_0,   CUDA_128, CUDA_0  }; // CUSOLVER_VERSION 11702
+  m["cusolverSpZcsrlsvcholHost"]                                      = {CUDA_0,   CUDA_128, CUDA_0  }; // CUSOLVER_VERSION 11702
+  m["cusolverSpScsrlsvchol"]                                          = {CUDA_0,   CUDA_128, CUDA_0  }; // CUSOLVER_VERSION 11702
+  m["cusolverSpDcsrlsvchol"]                                          = {CUDA_0,   CUDA_128, CUDA_0  }; // CUSOLVER_VERSION 11702
+  m["cusolverSpCcsrlsvchol"]                                          = {CUDA_0,   CUDA_128, CUDA_0  }; // CUSOLVER_VERSION 11702
+  m["cusolverSpZcsrlsvchol"]                                          = {CUDA_0,   CUDA_128, CUDA_0  }; // CUSOLVER_VERSION 11702
+  m["cusolverDnSetMathMode"]                                          = {CUDA_130, CUDA_0,   CUDA_0  };
+  m["cusolverDnGetMathMode"]                                          = {CUDA_130, CUDA_0,   CUDA_0  };
+  m["cusolverDnSetEmulationStrategy"]                                 = {CUDA_130, CUDA_0,   CUDA_0  };
+  m["cusolverDnGetEmulationStrategy"]                                 = {CUDA_130, CUDA_0,   CUDA_0  };
+  m["cusolverRfCreate"]                                               = {CUDA_0,   CUDA_130, CUDA_0  };
+  m["cusolverRfDestroy"]                                              = {CUDA_0,   CUDA_130, CUDA_0  };
+  m["cusolverRfGetMatrixFormat"]                                      = {CUDA_0,   CUDA_130, CUDA_0  };
+  m["cusolverRfSetMatrixFormat"]                                      = {CUDA_0,   CUDA_130, CUDA_0  };
+  m["cusolverRfSetNumericProperties"]                                 = {CUDA_0,   CUDA_130, CUDA_0  };
+  m["cusolverRfGetNumericProperties"]                                 = {CUDA_0,   CUDA_130, CUDA_0  };
+  m["cusolverRfGetNumericBoostReport"]                                = {CUDA_0,   CUDA_130, CUDA_0  };
+  m["cusolverRfSetAlgs"]                                              = {CUDA_0,   CUDA_130, CUDA_0  };
+  m["cusolverRfGetAlgs"]                                              = {CUDA_0,   CUDA_130, CUDA_0  };
+  m["cusolverRfGetResetValuesFastMode"]                               = {CUDA_0,   CUDA_130, CUDA_0  };
+  m["cusolverRfSetResetValuesFastMode"]                               = {CUDA_0,   CUDA_130, CUDA_0  };
+  m["cusolverRfBatchSetupHost"]                                       = {CUDA_0,   CUDA_130, CUDA_0  };
+  m["cusolverRfBatchResetValues"]                                     = {CUDA_0,   CUDA_130, CUDA_0  };
+  m["cusolverRfBatchAnalyze"]                                         = {CUDA_0,   CUDA_130, CUDA_0  };
+  m["cusolverRfBatchRefactor"]                                        = {CUDA_0,   CUDA_130, CUDA_0  };
+  m["cusolverRfBatchSolve"]                                           = {CUDA_0,   CUDA_130, CUDA_0  };
+  m["cusolverRfBatchZeroPivot"]                                       = {CUDA_0,   CUDA_130, CUDA_0  };
+  m["cusolverSpCreate"]                                               = {CUDA_0,   CUDA_130, CUDA_0  };
+  m["cusolverSpDestroy"]                                              = {CUDA_0,   CUDA_130, CUDA_0  };
+  m["cusolverSpSetStream"]                                            = {CUDA_0,   CUDA_130, CUDA_0  };
+  m["cusolverSpGetStream"]                                            = {CUDA_0,   CUDA_130, CUDA_0  };
+  m["cusolverSpXcsrissymHost"]                                        = {CUDA_0,   CUDA_130, CUDA_0  };
+  m["cusolverSpScsrlsvqr"]                                            = {CUDA_0,   CUDA_130, CUDA_0  };
+  m["cusolverSpDcsrlsvqr"]                                            = {CUDA_0,   CUDA_130, CUDA_0  };
+  m["cusolverSpCcsrlsvqr"]                                            = {CUDA_0,   CUDA_130, CUDA_0  };
+  m["cusolverSpZcsrlsvqr"]                                            = {CUDA_0,   CUDA_130, CUDA_0  };
+  m["cusolverSpScsrlsvqrHost"]                                        = {CUDA_0,   CUDA_130, CUDA_0  };
+  m["cusolverSpDcsrlsvqrHost"]                                        = {CUDA_0,   CUDA_130, CUDA_0  };
+  m["cusolverSpCcsrlsvqrHost"]                                        = {CUDA_0,   CUDA_130, CUDA_0  };
+  m["cusolverSpZcsrlsvqrHost"]                                        = {CUDA_0,   CUDA_130, CUDA_0  };
+  m["cusolverSpScsrlsqvqrHost"]                                       = {CUDA_0,   CUDA_130, CUDA_0  };
+  m["cusolverSpDcsrlsqvqrHost"]                                       = {CUDA_0,   CUDA_130, CUDA_0  };
+  m["cusolverSpCcsrlsqvqrHost"]                                       = {CUDA_0,   CUDA_130, CUDA_0  };
+  m["cusolverSpZcsrlsqvqrHost"]                                       = {CUDA_0,   CUDA_130, CUDA_0  };
+  m["cusolverSpScsreigvsiHost"]                                       = {CUDA_0,   CUDA_130, CUDA_0  };
+  m["cusolverSpDcsreigvsiHost"]                                       = {CUDA_0,   CUDA_130, CUDA_0  };
+  m["cusolverSpCcsreigvsiHost"]                                       = {CUDA_0,   CUDA_130, CUDA_0  };
+  m["cusolverSpZcsreigvsiHost"]                                       = {CUDA_0,   CUDA_130, CUDA_0  };
+  m["cusolverSpScsreigvsi"]                                           = {CUDA_0,   CUDA_130, CUDA_0  };
+  m["cusolverSpDcsreigvsi"]                                           = {CUDA_0,   CUDA_130, CUDA_0  };
+  m["cusolverSpCcsreigvsi"]                                           = {CUDA_0,   CUDA_130, CUDA_0  };
+  m["cusolverSpZcsreigvsi"]                                           = {CUDA_0,   CUDA_130, CUDA_0  };
+  m["cusolverSpScsreigsHost"]                                         = {CUDA_0,   CUDA_130, CUDA_0  };
+  m["cusolverSpDcsreigsHost"]                                         = {CUDA_0,   CUDA_130, CUDA_0  };
+  m["cusolverSpCcsreigsHost"]                                         = {CUDA_0,   CUDA_130, CUDA_0  };
+  m["cusolverSpZcsreigsHost"]                                         = {CUDA_0,   CUDA_130, CUDA_0  };
+  m["cusolverSpXcsrsymrcmHost"]                                       = {CUDA_0,   CUDA_130, CUDA_0  };
+  m["cusolverSpXcsrperm_bufferSizeHost"]                              = {CUDA_0,   CUDA_130, CUDA_0  };
+  m["cusolverSpXcsrpermHost"]                                         = {CUDA_0,   CUDA_130, CUDA_0  };
+  m["cusolverSpCreateCsrqrInfo"]                                      = {CUDA_0,   CUDA_130, CUDA_0  };
+  m["cusolverSpDestroyCsrqrInfo"]                                     = {CUDA_0,   CUDA_130, CUDA_0  };
+  m["cusolverSpXcsrqrAnalysisBatched"]                                = {CUDA_0,   CUDA_130, CUDA_0  };
+  m["cusolverSpScsrqrBufferInfoBatched"]                              = {CUDA_0,   CUDA_130, CUDA_0  };
+  m["cusolverSpDcsrqrBufferInfoBatched"]                              = {CUDA_0,   CUDA_130, CUDA_0  };
+  m["cusolverSpCcsrqrBufferInfoBatched"]                              = {CUDA_0,   CUDA_130, CUDA_0  };
+  m["cusolverSpZcsrqrBufferInfoBatched"]                              = {CUDA_0,   CUDA_130, CUDA_0  };
+  m["cusolverSpScsrqrsvBatched"]                                      = {CUDA_0,   CUDA_130, CUDA_0  };
+  m["cusolverSpDcsrqrsvBatched"]                                      = {CUDA_0,   CUDA_130, CUDA_0  };
+  m["cusolverSpCcsrqrsvBatched"]                                      = {CUDA_0,   CUDA_130, CUDA_0  };
+  m["cusolverSpZcsrqrsvBatched"]                                      = {CUDA_0,   CUDA_130, CUDA_0  };
 
-  {"rocsolver_spotrf",                                   {HIP_3020, HIP_0,    HIP_0   }},
-  {"rocsolver_dpotrf",                                   {HIP_3020, HIP_0,    HIP_0   }},
-  {"rocsolver_cpotrf",                                   {HIP_3060, HIP_0,    HIP_0   }},
-  {"rocsolver_zpotrf",                                   {HIP_3060, HIP_0,    HIP_0   }},
-};
+  return m;
+}();
 
-const std::map<unsigned int, llvm::StringRef> CUDA_SOLVER_API_SECTION_MAP {
-  {1, "CUSOLVER Data types"},
-  {2, "CUSOLVER Function Reference"},
-};
+const std::map<llvm::StringRef, hipAPIversions> HIP_SOLVER_FUNCTION_VER_MAP = [] {
+  std::map<llvm::StringRef, hipAPIversions> m;
+
+  m["hipsolverDnCreate"]                                              = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnDestroy"]                                             = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnSgetrf"]                                              = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnDgetrf"]                                              = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnCgetrf"]                                              = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnZgetrf"]                                              = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnSgetrf_bufferSize"]                                   = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnDgetrf_bufferSize"]                                   = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnCgetrf_bufferSize"]                                   = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnZgetrf_bufferSize"]                                   = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnSgetrs"]                                              = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnDgetrs"]                                              = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnCgetrs"]                                              = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnZgetrs"]                                              = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverSetStream"]                                             = {HIP_4050, HIP_0,    HIP_0   };
+  m["hipsolverGetStream"]                                             = {HIP_4050, HIP_0,    HIP_0   };
+  m["hipsolverDnZZgesv"]                                              = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnCCgesv"]                                              = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnDDgesv"]                                              = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnSSgesv"]                                              = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnZZgesv_bufferSize"]                                   = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnCCgesv_bufferSize"]                                   = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnDDgesv_bufferSize"]                                   = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnSSgesv_bufferSize"]                                   = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnZZgels"]                                              = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnCCgels"]                                              = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnDDgels"]                                              = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnSSgels"]                                              = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnZZgels_bufferSize"]                                   = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnCCgels_bufferSize"]                                   = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnDDgels_bufferSize"]                                   = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnSSgels_bufferSize"]                                   = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnSpotrf_bufferSize"]                                   = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnDpotrf_bufferSize"]                                   = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnCpotrf_bufferSize"]                                   = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnZpotrf_bufferSize"]                                   = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnSpotrf"]                                              = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnDpotrf"]                                              = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnCpotrf"]                                              = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnZpotrf"]                                              = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnSpotrs"]                                              = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnDpotrs"]                                              = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnCpotrs"]                                              = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnZpotrs"]                                              = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnSpotrfBatched"]                                       = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnDpotrfBatched"]                                       = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnCpotrfBatched"]                                       = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnZpotrfBatched"]                                       = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnSpotrsBatched"]                                       = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnDpotrsBatched"]                                       = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnCpotrsBatched"]                                       = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnZpotrsBatched"]                                       = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnSpotri_bufferSize"]                                   = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnDpotri_bufferSize"]                                   = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnCpotri_bufferSize"]                                   = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnZpotri_bufferSize"]                                   = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnSpotri"]                                              = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnDpotri"]                                              = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnCpotri"]                                              = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnZpotri"]                                              = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnSgeqrf_bufferSize"]                                   = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnDgeqrf_bufferSize"]                                   = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnCgeqrf_bufferSize"]                                   = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnZgeqrf_bufferSize"]                                   = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnSgeqrf"]                                              = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnDgeqrf"]                                              = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnCgeqrf"]                                              = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnZgeqrf"]                                              = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnSorgqr_bufferSize"]                                   = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnDorgqr_bufferSize"]                                   = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnCungqr_bufferSize"]                                   = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnZungqr_bufferSize"]                                   = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnSorgqr"]                                              = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnDorgqr"]                                              = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnCungqr"]                                              = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnZungqr"]                                              = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnSormqr_bufferSize"]                                   = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnDormqr_bufferSize"]                                   = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnCunmqr_bufferSize"]                                   = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnZunmqr_bufferSize"]                                   = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnSormqr"]                                              = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnDormqr"]                                              = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnCunmqr"]                                              = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnZunmqr"]                                              = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnSsytrf_bufferSize"]                                   = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnDsytrf_bufferSize"]                                   = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnCsytrf_bufferSize"]                                   = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnZsytrf_bufferSize"]                                   = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnSsytrf"]                                              = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnDsytrf"]                                              = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnCsytrf"]                                              = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnZsytrf"]                                              = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnSgebrd_bufferSize"]                                   = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnDgebrd_bufferSize"]                                   = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnCgebrd_bufferSize"]                                   = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnZgebrd_bufferSize"]                                   = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnSgebrd"]                                              = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnDgebrd"]                                              = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnCgebrd"]                                              = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnZgebrd"]                                              = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnSorgbr_bufferSize"]                                   = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnDorgbr_bufferSize"]                                   = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnCungbr_bufferSize"]                                   = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnZungbr_bufferSize"]                                   = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnSorgbr"]                                              = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnDorgbr"]                                              = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnCungbr"]                                              = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnZungbr"]                                              = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnSsytrd_bufferSize"]                                   = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnDsytrd_bufferSize"]                                   = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnChetrd_bufferSize"]                                   = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnZhetrd_bufferSize"]                                   = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnSsytrd"]                                              = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnDsytrd"]                                              = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnChetrd"]                                              = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnZhetrd"]                                              = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnSorgtr_bufferSize"]                                   = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnDorgtr_bufferSize"]                                   = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnCungtr_bufferSize"]                                   = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnZungtr_bufferSize"]                                   = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnSorgtr"]                                              = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnDorgtr"]                                              = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnCungtr"]                                              = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnZungtr"]                                              = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnSormtr_bufferSize"]                                   = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnDormtr_bufferSize"]                                   = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnCunmtr_bufferSize"]                                   = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnZunmtr_bufferSize"]                                   = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnSormtr"]                                              = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnDormtr"]                                              = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnCunmtr"]                                              = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnZunmtr"]                                              = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnSgesvd_bufferSize"]                                   = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnDgesvd_bufferSize"]                                   = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnCgesvd_bufferSize"]                                   = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnZgesvd_bufferSize"]                                   = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnSgesvd"]                                              = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnDgesvd"]                                              = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnCgesvd"]                                              = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnZgesvd"]                                              = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnSsyevd_bufferSize"]                                   = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnDsyevd_bufferSize"]                                   = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnCheevd_bufferSize"]                                   = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnZheevd_bufferSize"]                                   = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnSsyevd"]                                              = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnDsyevd"]                                              = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnCheevd"]                                              = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnZheevd"]                                              = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnSsyevdx_bufferSize"]                                  = {HIP_5030, HIP_0,    HIP_0   };
+  m["hipsolverDnDsyevdx_bufferSize"]                                  = {HIP_5030, HIP_0,    HIP_0   };
+  m["hipsolverDnCheevdx_bufferSize"]                                  = {HIP_5030, HIP_0,    HIP_0   };
+  m["hipsolverDnZheevdx_bufferSize"]                                  = {HIP_5030, HIP_0,    HIP_0   };
+  m["hipsolverDnSsyevdx"]                                             = {HIP_5030, HIP_0,    HIP_0   };
+  m["hipsolverDnDsyevdx"]                                             = {HIP_5030, HIP_0,    HIP_0   };
+  m["hipsolverDnCheevdx"]                                             = {HIP_5030, HIP_0,    HIP_0   };
+  m["hipsolverDnZheevdx"]                                             = {HIP_5030, HIP_0,    HIP_0   };
+  m["hipsolverDnSsygvdx_bufferSize"]                                  = {HIP_5030, HIP_0,    HIP_0   };
+  m["hipsolverDnDsygvdx_bufferSize"]                                  = {HIP_5030, HIP_0,    HIP_0   };
+  m["hipsolverDnChegvdx_bufferSize"]                                  = {HIP_5030, HIP_0,    HIP_0   };
+  m["hipsolverDnZhegvdx_bufferSize"]                                  = {HIP_5030, HIP_0,    HIP_0   };
+  m["hipsolverDnSsygvdx"]                                             = {HIP_5030, HIP_0,    HIP_0   };
+  m["hipsolverDnDsygvdx"]                                             = {HIP_5030, HIP_0,    HIP_0   };
+  m["hipsolverDnChegvdx"]                                             = {HIP_5030, HIP_0,    HIP_0   };
+  m["hipsolverDnZhegvdx"]                                             = {HIP_5030, HIP_0,    HIP_0   };
+  m["hipsolverDnSsygvd_bufferSize"]                                   = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnDsygvd_bufferSize"]                                   = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnChegvd_bufferSize"]                                   = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnZhegvd_bufferSize"]                                   = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnSsygvd"]                                              = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnDsygvd"]                                              = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnChegvd"]                                              = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnZhegvd"]                                              = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnCreateSyevjInfo"]                                     = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnDestroySyevjInfo"]                                    = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnXsyevjSetTolerance"]                                  = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnXsyevjSetMaxSweeps"]                                  = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnXsyevjSetSortEig"]                                    = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnXsyevjGetResidual"]                                   = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnXsyevjGetSweeps"]                                     = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnSsyevjBatched_bufferSize"]                            = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnDsyevjBatched_bufferSize"]                            = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnCheevjBatched_bufferSize"]                            = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnZheevjBatched_bufferSize"]                            = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnSsyevjBatched"]                                       = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnDsyevjBatched"]                                       = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnCheevjBatched"]                                       = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnZheevjBatched"]                                       = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnSsyevj_bufferSize"]                                   = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnDsyevj_bufferSize"]                                   = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnCheevj_bufferSize"]                                   = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnZheevj_bufferSize"]                                   = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnSsyevj"]                                              = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnDsyevj"]                                              = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnCheevj"]                                              = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnZheevj"]                                              = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnSsygvj_bufferSize"]                                   = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnDsygvj_bufferSize"]                                   = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnChegvj_bufferSize"]                                   = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnZhegvj_bufferSize"]                                   = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnSsygvj"]                                              = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnDsygvj"]                                              = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnChegvj"]                                              = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnZhegvj"]                                              = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnCreateGesvdjInfo"]                                    = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnDestroyGesvdjInfo"]                                   = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnXgesvdjSetTolerance"]                                 = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnXgesvdjSetMaxSweeps"]                                 = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnXgesvdjSetSortEig"]                                   = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnXgesvdjGetResidual"]                                  = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnXgesvdjGetSweeps"]                                    = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnSgesvdjBatched_bufferSize"]                           = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnDgesvdjBatched_bufferSize"]                           = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnCgesvdjBatched_bufferSize"]                           = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnZgesvdjBatched_bufferSize"]                           = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnSgesvdjBatched"]                                      = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnDgesvdjBatched"]                                      = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnCgesvdjBatched"]                                      = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnZgesvdjBatched"]                                      = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnSgesvdj_bufferSize"]                                  = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnDgesvdj_bufferSize"]                                  = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnCgesvdj_bufferSize"]                                  = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnZgesvdj_bufferSize"]                                  = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnSgesvdj"]                                             = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnDgesvdj"]                                             = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnCgesvdj"]                                             = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnZgesvdj"]                                             = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverDnSgesvdaStridedBatched_bufferSize"]                    = {HIP_5040, HIP_0,    HIP_0   };
+  m["hipsolverDnDgesvdaStridedBatched_bufferSize"]                    = {HIP_5040, HIP_0,    HIP_0   };
+  m["hipsolverDnCgesvdaStridedBatched_bufferSize"]                    = {HIP_5040, HIP_0,    HIP_0   };
+  m["hipsolverDnZgesvdaStridedBatched_bufferSize"]                    = {HIP_5040, HIP_0,    HIP_0   };
+  m["hipsolverDnSgesvdaStridedBatched"]                               = {HIP_5040, HIP_0,    HIP_0   };
+  m["hipsolverDnDgesvdaStridedBatched"]                               = {HIP_5040, HIP_0,    HIP_0   };
+  m["hipsolverDnCgesvdaStridedBatched"]                               = {HIP_5040, HIP_0,    HIP_0   };
+  m["hipsolverDnZgesvdaStridedBatched"]                               = {HIP_5040, HIP_0,    HIP_0   };
+  m["hipsolverRfCreate"]                                              = {HIP_5060, HIP_0,    HIP_0   };
+  m["hipsolverRfDestroy"]                                             = {HIP_5060, HIP_0,    HIP_0   };
+  m["hipsolverRfGetMatrixFormat"]                                     = {HIP_5060, HIP_0,    HIP_0   };
+  m["hipsolverRfSetMatrixFormat"]                                     = {HIP_5060, HIP_0,    HIP_0   };
+  m["hipsolverRfSetNumericProperties"]                                = {HIP_5060, HIP_0,    HIP_0   };
+  m["hipsolverRfGetNumericProperties"]                                = {HIP_5060, HIP_0,    HIP_0   };
+  m["hipsolverRfGetNumericBoostReport"]                               = {HIP_5060, HIP_0,    HIP_0   };
+  m["hipsolverRfSetAlgs"]                                             = {HIP_5060, HIP_0,    HIP_0   };
+  m["hipsolverRfGetResetValuesFastMode"]                              = {HIP_5060, HIP_0,    HIP_0   };
+  m["hipsolverRfSetResetValuesFastMode"]                              = {HIP_5060, HIP_0,    HIP_0   };
+  m["hipsolverRfSetupHost"]                                           = {HIP_5060, HIP_0,    HIP_0   };
+  m["hipsolverRfSetupDevice"]                                         = {HIP_5060, HIP_0,    HIP_0   };
+  m["hipsolverRfResetValues"]                                         = {HIP_5060, HIP_0,    HIP_0   };
+  m["hipsolverRfAnalyze"]                                             = {HIP_5060, HIP_0,    HIP_0   };
+  m["hipsolverRfRefactor"]                                            = {HIP_5060, HIP_0,    HIP_0   };
+  m["hipsolverRfAccessBundledFactorsDevice"]                          = {HIP_5060, HIP_0,    HIP_0   };
+  m["hipsolverRfExtractBundledFactorsHost"]                           = {HIP_5060, HIP_0,    HIP_0   };
+  m["hipsolverRfExtractSplitFactorsHost"]                             = {HIP_5060, HIP_0,    HIP_0   };
+  m["hipsolverRfSolve"]                                               = {HIP_5060, HIP_0,    HIP_0   };
+  m["hipsolverRfBatchSetupHost"]                                      = {HIP_5060, HIP_0,    HIP_0   };
+  m["hipsolverRfBatchResetValues"]                                    = {HIP_5060, HIP_0,    HIP_0   };
+  m["hipsolverRfBatchAnalyze"]                                        = {HIP_5060, HIP_0,    HIP_0   };
+  m["hipsolverRfBatchRefactor"]                                       = {HIP_5060, HIP_0,    HIP_0   };
+  m["hipsolverRfBatchSolve"]                                          = {HIP_5060, HIP_0,    HIP_0   };
+  m["hipsolverRfBatchZeroPivot"]                                      = {HIP_5060, HIP_0,    HIP_0   };
+  m["hipsolverSpCreate"]                                              = {HIP_6010, HIP_0,    HIP_0   };
+  m["hipsolverSpDestroy"]                                             = {HIP_6010, HIP_0,    HIP_0   };
+  m["hipsolverSpSetStream"]                                           = {HIP_6010, HIP_0,    HIP_0   };
+  m["hipsolverSpScsrlsvchol"]                                         = {HIP_6010, HIP_0,    HIP_0   };
+  m["hipsolverSpDcsrlsvchol"]                                         = {HIP_6010, HIP_0,    HIP_0   };
+  m["hipsolverSpScsrlsvcholHost"]                                     = {HIP_6010, HIP_0,    HIP_0   };
+  m["hipsolverSpDcsrlsvcholHost"]                                     = {HIP_6010, HIP_0,    HIP_0   };
+  m["hipsolverDnCreateParams"]                                        = {HIP_6020, HIP_0,    HIP_0   };
+  m["hipsolverDnDestroyParams"]                                       = {HIP_6020, HIP_0,    HIP_0   };
+  m["hipsolverDnSetAdvOptions"]                                       = {HIP_6020, HIP_0,    HIP_0   };
+  m["hipsolverDnXgetrf"]                                              = {HIP_6020, HIP_0,    HIP_0   };
+  m["hipsolverDnXgetrf_bufferSize"]                                   = {HIP_6020, HIP_0,    HIP_0   };
+  m["hipsolverDnXgetrs"]                                              = {HIP_6020, HIP_0,    HIP_0   };
+  m["hipsolverDnSetDeterministicMode"]                                = {HIP_6030, HIP_0,    HIP_0   };
+  m["hipsolverDnGetDeterministicMode"]                                = {HIP_6030, HIP_0,    HIP_0   };
+  m["hipsolverDnXgeqrf_bufferSize"]                                   = {HIP_6030, HIP_0,    HIP_0   };
+  m["hipsolverDnXgeqrf"]                                              = {HIP_6030, HIP_0,    HIP_0   };
+  m["hipsolverDnXpotrf_bufferSize"]                                   = {HIP_6030, HIP_0,    HIP_0   };
+  m["hipsolverDnXpotrf"]                                              = {HIP_6030, HIP_0,    HIP_0   };
+  m["hipsolverDnXpotrs"]                                              = {HIP_6030, HIP_0,    HIP_0   };
+  m["hipsolverSpScsrlsvqr"]                                           = {HIP_6040, HIP_0,    HIP_0   };
+  m["hipsolverSpDcsrlsvqr"]                                           = {HIP_6040, HIP_0,    HIP_0   };
+  m["hipsolverSpCcsrlsvqr"]                                           = {HIP_7000, HIP_0,    HIP_0   };
+  m["hipsolverSpZcsrlsvqr"]                                           = {HIP_7000, HIP_0,    HIP_0   };
+
+  m["rocsolver_spotrf"]                                               = {HIP_3020, HIP_0,    HIP_0   };
+  m["rocsolver_dpotrf"]                                               = {HIP_3020, HIP_0,    HIP_0   };
+  m["rocsolver_cpotrf"]                                               = {HIP_3060, HIP_0,    HIP_0   };
+  m["rocsolver_zpotrf"]                                               = {HIP_3060, HIP_0,    HIP_0   };
+
+  return m;
+}();
+
+const std::map<unsigned int, llvm::StringRef> CUDA_SOLVER_API_SECTION_MAP = [] {
+  std::map<unsigned int, llvm::StringRef> m;
+
+  m[1]                                                                = "CUSOLVER Data types";
+  m[2]                                                                = "CUSOLVER Function Reference";
+
+  return m;
+}();

--- a/src/CUDA2HIP_SOLVER_API_types.cpp
+++ b/src/CUDA2HIP_SOLVER_API_types.cpp
@@ -23,343 +23,354 @@ THE SOFTWARE.
 #include "CUDA2HIP.h"
 
 // Map of all functions
-const std::map<llvm::StringRef, hipCounter> CUDA_SOLVER_TYPE_NAME_MAP {
-  {"cusolverStatus_t",                                         {"hipsolverStatus_t",                                         "rocblas_status",                                                   CONV_TYPE, API_SOLVER, 1}},
-  {"CUSOLVER_STATUS_SUCCESS",                                  {"HIPSOLVER_STATUS_SUCCESS",                                  "rocblas_status_success",                                           CONV_NUMERIC_LITERAL, API_SOLVER, 1}},
-  {"CUSOLVER_STATUS_NOT_INITIALIZED",                          {"HIPSOLVER_STATUS_NOT_INITIALIZED",                          "rocblas_status_invalid_handle",                                    CONV_NUMERIC_LITERAL, API_SOLVER, 1}},
-  {"CUSOLVER_STATUS_ALLOC_FAILED",                             {"HIPSOLVER_STATUS_ALLOC_FAILED",                             "rocblas_status_memory_error",                                      CONV_NUMERIC_LITERAL, API_SOLVER, 1}},
-  {"CUSOLVER_STATUS_INVALID_VALUE",                            {"HIPSOLVER_STATUS_INVALID_VALUE",                            "rocblas_status_invalid_value",                                     CONV_NUMERIC_LITERAL, API_SOLVER, 1}},
-  {"CUSOLVER_STATUS_ARCH_MISMATCH",                            {"HIPSOLVER_STATUS_ARCH_MISMATCH",                            "rocblas_status_arch_mismatch",                                     CONV_NUMERIC_LITERAL, API_SOLVER, 1}},
-  {"CUSOLVER_STATUS_MAPPING_ERROR",                            {"HIPSOLVER_STATUS_MAPPING_ERROR",                            "rocblas_status_not_implemented",                                   CONV_NUMERIC_LITERAL, API_SOLVER, 1}},
-  {"CUSOLVER_STATUS_EXECUTION_FAILED",                         {"HIPSOLVER_STATUS_EXECUTION_FAILED",                         "rocblas_status_not_implemented",                                   CONV_NUMERIC_LITERAL, API_SOLVER, 1}},
-  {"CUSOLVER_STATUS_INTERNAL_ERROR",                           {"HIPSOLVER_STATUS_INTERNAL_ERROR",                           "rocblas_status_internal_error",                                    CONV_NUMERIC_LITERAL, API_SOLVER, 1}},
-  {"CUSOLVER_STATUS_MATRIX_TYPE_NOT_SUPPORTED",                {"HIPSOLVER_STATUS_MATRIX_TYPE_NOT_SUPPORTED",                "",                                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1, ROC_UNSUPPORTED}},
-  {"CUSOLVER_STATUS_NOT_SUPPORTED",                            {"HIPSOLVER_STATUS_NOT_SUPPORTED",                            "rocblas_status_not_implemented",                                   CONV_NUMERIC_LITERAL, API_SOLVER, 1}},
-  {"CUSOLVER_STATUS_ZERO_PIVOT",                               {"HIPSOLVER_STATUS_ZERO_PIVOT",                               "rocblas_status_not_implemented",                                   CONV_NUMERIC_LITERAL, API_SOLVER, 1}},
-  {"CUSOLVER_STATUS_INVALID_LICENSE",                          {"HIPSOLVER_STATUS_INVALID_LICENSE",                          "",                                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1, UNSUPPORTED}},
-  {"CUSOLVER_STATUS_IRS_PARAMS_NOT_INITIALIZED",               {"HIPSOLVER_STATUS_IRS_PARAMS_NOT_INITIALIZED",               "",                                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1, UNSUPPORTED}},
-  {"CUSOLVER_STATUS_IRS_PARAMS_INVALID",                       {"HIPSOLVER_STATUS_INVALID_VALUE",                            "",                                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1, ROC_UNSUPPORTED}},
-  {"CUSOLVER_STATUS_IRS_PARAMS_INVALID_PREC",                  {"HIPSOLVER_STATUS_IRS_PARAMS_INVALID_PREC",                  "",                                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1, UNSUPPORTED}},
-  {"CUSOLVER_STATUS_IRS_PARAMS_INVALID_REFINE",                {"HIPSOLVER_STATUS_IRS_PARAMS_INVALID_REFINE",                "",                                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1, UNSUPPORTED}},
-  {"CUSOLVER_STATUS_IRS_PARAMS_INVALID_MAXITER",               {"HIPSOLVER_STATUS_IRS_PARAMS_INVALID_MAXITER",               "",                                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1, UNSUPPORTED}},
-  {"CUSOLVER_STATUS_IRS_INTERNAL_ERROR",                       {"HIPSOLVER_STATUS_INTERNAL_ERROR",                           "",                                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1, ROC_UNSUPPORTED}},
-  {"CUSOLVER_STATUS_IRS_NOT_SUPPORTED",                        {"HIPSOLVER_STATUS_NOT_SUPPORTED",                            "",                                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1, ROC_UNSUPPORTED}},
-  {"CUSOLVER_STATUS_IRS_OUT_OF_RANGE",                         {"HIPSOLVER_STATUS_IRS_OUT_OF_RANGE",                         "",                                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1, UNSUPPORTED}},
-  {"CUSOLVER_STATUS_IRS_NRHS_NOT_SUPPORTED_FOR_REFINE_GMRES",  {"HIPSOLVER_STATUS_IRS_NRHS_NOT_SUPPORTED_FOR_REFINE_GMRES",  "",                                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1, UNSUPPORTED}},
-  {"CUSOLVER_STATUS_IRS_INFOS_NOT_INITIALIZED",                {"HIPSOLVER_STATUS_IRS_INFOS_NOT_INITIALIZED",                "",                                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1, UNSUPPORTED}},
-  {"CUSOLVER_STATUS_IRS_INFOS_NOT_DESTROYED",                  {"HIPSOLVER_STATUS_IRS_INFOS_NOT_DESTROYED",                  "",                                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1, UNSUPPORTED}},
-  {"CUSOLVER_STATUS_IRS_MATRIX_SINGULAR",                      {"HIPSOLVER_STATUS_IRS_MATRIX_SINGULAR",                      "",                                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1, UNSUPPORTED}},
-  {"CUSOLVER_STATUS_INVALID_WORKSPACE",                        {"HIPSOLVER_STATUS_INVALID_WORKSPACE",                        "",                                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1, UNSUPPORTED}},
-  {"cusolverDnContext",                                        {"hipsolverDnContext",                                        "",                                                                 CONV_TYPE, API_SOLVER, 1, UNSUPPORTED}},
-  {"cusolverDnHandle_t",                                       {"hipsolverHandle_t",                                         "rocblas_handle",                                                   CONV_TYPE, API_SOLVER, 1}},
-  {"cusolverEigType_t",                                        {"hipsolverEigType_t",                                        "rocblas_eform",                                                    CONV_TYPE, API_SOLVER, 1}},
-  {"CUSOLVER_EIG_TYPE_1",                                      {"HIPSOLVER_EIG_TYPE_1",                                      "rocblas_eform_ax",                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1}},
-  {"CUSOLVER_EIG_TYPE_2",                                      {"HIPSOLVER_EIG_TYPE_2",                                      "rocblas_eform_abx",                                                CONV_NUMERIC_LITERAL, API_SOLVER, 1}},
-  {"CUSOLVER_EIG_TYPE_3",                                      {"HIPSOLVER_EIG_TYPE_3",                                      "rocblas_eform_bax",                                                CONV_NUMERIC_LITERAL, API_SOLVER, 1}},
-  {"cusolverEigMode_t",                                        {"hipsolverEigMode_t",                                        "rocblas_evect",                                                    CONV_TYPE, API_SOLVER, 1}},
-  {"CUSOLVER_EIG_MODE_NOVECTOR",                               {"HIPSOLVER_EIG_MODE_NOVECTOR",                               "rocblas_evect_none",                                               CONV_NUMERIC_LITERAL, API_SOLVER, 1}},
-  {"CUSOLVER_EIG_MODE_VECTOR",                                 {"HIPSOLVER_EIG_MODE_VECTOR",                                 "rocblas_evect_original",                                           CONV_NUMERIC_LITERAL, API_SOLVER, 1}},
-  {"cusolverEigRange_t",                                       {"hipsolverEigRange_t",                                       "rocblas_erange",                                                   CONV_TYPE, API_SOLVER, 1}},
-  {"CUSOLVER_EIG_RANGE_ALL",                                   {"HIPSOLVER_EIG_RANGE_ALL",                                   "rocblas_erange_all",                                               CONV_NUMERIC_LITERAL, API_SOLVER, 1}},
-  {"CUSOLVER_EIG_RANGE_I",                                     {"HIPSOLVER_EIG_RANGE_I",                                     "rocblas_erange_index",                                             CONV_NUMERIC_LITERAL, API_SOLVER, 1}},
-  {"CUSOLVER_EIG_RANGE_V",                                     {"HIPSOLVER_EIG_RANGE_V",                                     "rocblas_erange_value",                                             CONV_NUMERIC_LITERAL, API_SOLVER, 1}},
-  {"cusolverNorm_t",                                           {"hipsolverNorm_t",                                           "",                                                                 CONV_TYPE, API_SOLVER, 1, UNSUPPORTED}},
-  {"CUSOLVER_INF_NORM",                                        {"HIPSOLVER_INF_NORM",                                        "",                                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1, UNSUPPORTED}},
-  {"CUSOLVER_MAX_NORM",                                        {"HIPSOLVER_MAX_NORM",                                        "",                                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1, UNSUPPORTED}},
-  {"CUSOLVER_ONE_NORM",                                        {"HIPSOLVER_ONE_NORM",                                        "",                                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1, UNSUPPORTED}},
-  {"CUSOLVER_FRO_NORM",                                        {"HIPSOLVER_FRO_NORM",                                        "",                                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1, UNSUPPORTED}},
-  {"cusolverIRSRefinement_t",                                  {"hipsolverIRSRefinement_t",                                  "",                                                                 CONV_TYPE, API_SOLVER, 1, UNSUPPORTED}},
-  {"CUSOLVER_IRS_REFINE_NOT_SET",                              {"HIPSOLVER_IRS_REFINE_NOT_SET",                              "",                                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1, UNSUPPORTED}},
-  {"CUSOLVER_IRS_REFINE_NONE",                                 {"HIPSOLVER_IRS_REFINE_NONE",                                 "",                                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1, UNSUPPORTED}},
-  {"CUSOLVER_IRS_REFINE_CLASSICAL",                            {"HIPSOLVER_IRS_REFINE_CLASSICAL",                            "",                                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1, UNSUPPORTED}},
-  {"CUSOLVER_IRS_REFINE_CLASSICAL_GMRES",                      {"HIPSOLVER_IRS_REFINE_CLASSICAL_GMRES",                      "",                                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1, UNSUPPORTED}},
-  {"CUSOLVER_IRS_REFINE_GMRES",                                {"HIPSOLVER_IRS_REFINE_GMRES",                                "",                                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1, UNSUPPORTED}},
-  {"CUSOLVER_IRS_REFINE_GMRES_GMRES",                          {"HIPSOLVER_IRS_REFINE_GMRES_GMRES",                          "",                                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1, UNSUPPORTED}},
-  {"CUSOLVER_IRS_REFINE_GMRES_NOPCOND",                        {"HIPSOLVER_IRS_REFINE_GMRES_NOPCOND",                        "",                                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1, UNSUPPORTED}},
-  {"CUSOLVER_PREC_DD",                                         {"HIPSOLVER_PREC_DD",                                         "",                                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1, UNSUPPORTED}},
-  {"CUSOLVER_PREC_SS",                                         {"HIPSOLVER_PREC_SS",                                         "",                                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1, UNSUPPORTED}},
-  {"CUSOLVER_PREC_SHT",                                        {"HIPSOLVER_PREC_SHT",                                        "",                                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1, UNSUPPORTED}},
-  {"cusolverDirectMode_t",                                     {"hipsolverDirectMode_t",                                     "",                                                                 CONV_TYPE, API_SOLVER, 1, UNSUPPORTED}},
-  {"CUBLAS_DIRECT_FORWARD",                                    {"HIPBLAS_DIRECT_FORWARD",                                    "",                                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1, UNSUPPORTED}},
-  {"CUBLAS_DIRECT_BACKWARD",                                   {"HIPBLAS_DIRECT_BACKWARD",                                   "",                                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1, UNSUPPORTED}},
-  {"cusolverStorevMode_t",                                     {"hipsolverStorevMode_t",                                     "",                                                                 CONV_TYPE, API_SOLVER, 1, UNSUPPORTED}},
-  {"CUBLAS_STOREV_COLUMNWISE",                                 {"HIPBLAS_STOREV_COLUMNWISE",                                 "",                                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1, UNSUPPORTED}},
-  {"CUBLAS_STOREV_ROWWISE",                                    {"HIPBLAS_STOREV_ROWWISE",                                    "",                                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1, UNSUPPORTED}},
-  {"cusolverAlgMode_t",                                        {"hipsolverAlgMode_t",                                        "",                                                                 CONV_TYPE, API_SOLVER, 1, ROC_UNSUPPORTED}},
-  {"CUSOLVER_ALG_0",                                           {"HIPSOLVER_ALG_0",                                           "",                                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1, ROC_UNSUPPORTED}},
-  {"CUSOLVER_ALG_1",                                           {"HIPSOLVER_ALG_1",                                           "",                                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1, ROC_UNSUPPORTED}},
-  {"CUSOLVER_ALG_2",                                           {"HIPSOLVER_ALG_2",                                           "",                                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1, UNSUPPORTED}},
-  {"cusolverPrecType_t",                                       {"hipsolverPrecType_t",                                       "",                                                                 CONV_TYPE, API_SOLVER, 1, UNSUPPORTED}},
-  {"CUSOLVER_R_8I",                                            {"HIPSOLVER_R_8I",                                            "",                                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1, UNSUPPORTED}},
-  {"CUSOLVER_R_8U",                                            {"HIPSOLVER_R_8U",                                            "",                                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1, UNSUPPORTED}},
-  {"CUSOLVER_R_64F",                                           {"HIPSOLVER_R_64F",                                           "",                                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1, UNSUPPORTED}},
-  {"CUSOLVER_R_32F",                                           {"HIPSOLVER_R_32F",                                           "",                                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1, UNSUPPORTED}},
-  {"CUSOLVER_R_16F",                                           {"HIPSOLVER_R_16F",                                           "",                                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1, UNSUPPORTED}},
-  {"CUSOLVER_R_16BF",                                          {"HIPSOLVER_R_16BF",                                          "",                                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1, UNSUPPORTED}},
-  {"CUSOLVER_R_TF32",                                          {"HIPSOLVER_R_TF32",                                          "",                                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1, UNSUPPORTED}},
-  {"CUSOLVER_R_AP",                                            {"HIPSOLVER_R_AP",                                            "",                                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1, UNSUPPORTED}},
-  {"CUSOLVER_C_8I",                                            {"HIPSOLVER_C_8I",                                            "",                                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1, UNSUPPORTED}},
-  {"CUSOLVER_C_8U",                                            {"HIPSOLVER_C_8U",                                            "",                                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1, UNSUPPORTED}},
-  {"CUSOLVER_C_64F",                                           {"HIPSOLVER_C_64F",                                           "",                                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1, UNSUPPORTED}},
-  {"CUSOLVER_C_32F",                                           {"HIPSOLVER_C_32F",                                           "",                                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1, UNSUPPORTED}},
-  {"CUSOLVER_C_16F",                                           {"HIPSOLVER_C_16F",                                           "",                                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1, UNSUPPORTED}},
-  {"CUSOLVER_C_16BF",                                          {"HIPSOLVER_C_16BF",                                          "",                                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1, UNSUPPORTED}},
-  {"CUSOLVER_C_TF32",                                          {"HIPSOLVER_C_TF32",                                          "",                                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1, UNSUPPORTED}},
-  {"CUSOLVER_C_AP",                                            {"HIPSOLVER_C_AP",                                            "",                                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1, UNSUPPORTED}},
-  {"syevjInfo",                                                {"hipsyevjInfo",                                              "",                                                                 CONV_TYPE, API_SOLVER, 1, UNSUPPORTED}},
-  {"syevjInfo_t",                                              {"hipsolverSyevjInfo_t",                                      "",                                                                 CONV_TYPE, API_SOLVER, 1, ROC_UNSUPPORTED}},
-  {"gesvdjInfo",                                               {"hipgesvdjInfo",                                             "",                                                                 CONV_TYPE, API_SOLVER, 1, UNSUPPORTED}},
-  {"gesvdjInfo_t",                                             {"hipsolverGesvdjInfo_t",                                     "",                                                                 CONV_TYPE, API_SOLVER, 1, ROC_UNSUPPORTED}},
-  {"cusolverDnIRSParams",                                      {"hipsolverDnIRSParams",                                      "",                                                                 CONV_TYPE, API_SOLVER, 1, UNSUPPORTED}},
-  {"cusolverDnIRSParams_t",                                    {"hipsolverDnIRSParams_t",                                    "",                                                                 CONV_TYPE, API_SOLVER, 1, UNSUPPORTED}},
-  {"cusolverDnIRSInfos",                                       {"hipsolverDnIRSInfos",                                       "",                                                                 CONV_TYPE, API_SOLVER, 1, UNSUPPORTED}},
-  {"cusolverDnIRSInfos_t",                                     {"hipsolverDnIRSInfos_t",                                     "",                                                                 CONV_TYPE, API_SOLVER, 1, UNSUPPORTED}},
-  {"cusolverDnParams",                                         {"hipsolverDnParams",                                         "",                                                                 CONV_TYPE, API_SOLVER, 1, UNSUPPORTED}},
-  {"cusolverDnParams_t",                                       {"hipsolverDnParams_t",                                       "",                                                                 CONV_TYPE, API_SOLVER, 1, ROC_UNSUPPORTED}},
-  {"cusolverDnFunction_t",                                     {"hipsolverDnFunction_t",                                     "",                                                                 CONV_TYPE, API_SOLVER, 1, ROC_UNSUPPORTED}},
-  {"CUSOLVERDN_GETRF",                                         {"HIPSOLVERDN_GETRF",                                         "",                                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1, ROC_UNSUPPORTED}},
-  {"CUSOLVERDN_POTRF",                                         {"HIPSOLVERDN_POTRF",                                         "",                                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1, UNSUPPORTED}},
-  {"CUSOLVERDN_SYEVBATCHED",                                   {"HIPSOLVERDN_SYEVBATCHED",                                   "",                                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1, UNSUPPORTED}},
-  {"cusolverDeterministicMode_t",                              {"hipsolverDeterministicMode_t",                              "",                                                                 CONV_TYPE, API_SOLVER, 1, ROC_UNSUPPORTED}},
-  {"CUSOLVER_DETERMINISTIC_RESULTS",                           {"HIPSOLVER_DETERMINISTIC_RESULTS",                           "",                                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1, ROC_UNSUPPORTED}},
-  {"CUSOLVER_ALLOW_NON_DETERMINISTIC_RESULTS",                 {"HIPSOLVER_ALLOW_NON_DETERMINISTIC_RESULTS",                 "",                                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1, ROC_UNSUPPORTED}},
-  {"cusolver_int_t",                                           {"int",                                                       "rocblas_int",                                                      CONV_NUMERIC_LITERAL, API_SOLVER, 1}},
-  {"cusolverDnLoggerCallback_t",                               {"hipsolverDnLoggerCallback_t",                               "",                                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1, UNSUPPORTED}},
-  {"cusolverMgContext",                                        {"hipsolverMgContext",                                        "",                                                                 CONV_TYPE, API_SOLVER, 1, UNSUPPORTED}},
-  {"cusolverMgHandle_t",                                       {"hipsolverMgHandle_t",                                       "",                                                                 CONV_TYPE, API_SOLVER, 1, UNSUPPORTED}},
-  {"cusolverMgGridMapping_t",                                  {"hipsolverMgGridMapping_t",                                  "",                                                                 CONV_TYPE, API_SOLVER, 1, UNSUPPORTED}},
-  {"CUDALIBMG_GRID_MAPPING_ROW_MAJOR",                         {"HIP_LIBMG_GRID_MAPPING_ROW_MAJOR",                          "",                                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1, UNSUPPORTED}},
-  {"CUDALIBMG_GRID_MAPPING_COL_MAJOR",                         {"HIP_LIBMG_GRID_MAPPING_COL_MAJOR",                          "",                                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1, UNSUPPORTED}},
-  {"cudaLibMgGrid_t",                                          {"hipLibMgGrid_t",                                            "",                                                                 CONV_TYPE, API_SOLVER, 1, UNSUPPORTED}},
-  {"cudaLibMgMatrixDesc_t",                                    {"hipLibMgMatrixDesc_t",                                      "",                                                                 CONV_TYPE, API_SOLVER, 1, UNSUPPORTED}},
-  {"cusolverRfResetValuesFastMode_t",                          {"hipsolverRfResetValuesFastMode_t",                          "",                                                                 CONV_TYPE, API_SOLVER, 1, ROC_UNSUPPORTED}},
-  {"CUSOLVERRF_RESET_VALUES_FAST_MODE_OFF",                    {"HIPSOLVERRF_RESET_VALUES_FAST_MODE_OFF",                    "",                                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1, ROC_UNSUPPORTED}},
-  {"CUSOLVERRF_RESET_VALUES_FAST_MODE_ON",                     {"HIPSOLVERRF_RESET_VALUES_FAST_MODE_ON",                     "",                                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1, ROC_UNSUPPORTED}},
-  {"cusolverRfMatrixFormat_t",                                 {"hipsolverRfMatrixFormat_t",                                 "",                                                                 CONV_TYPE, API_SOLVER, 1, ROC_UNSUPPORTED}},
-  {"CUSOLVERRF_MATRIX_FORMAT_CSR",                             {"HIPSOLVERRF_MATRIX_FORMAT_CSR",                             "",                                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1, ROC_UNSUPPORTED}},
-  {"CUSOLVERRF_MATRIX_FORMAT_CSC",                             {"HIPSOLVERRF_MATRIX_FORMAT_CSC",                             "",                                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1, ROC_UNSUPPORTED}},
-  {"cusolverRfUnitDiagonal_t",                                 {"hipsolverRfUnitDiagonal_t",                                 "",                                                                 CONV_TYPE, API_SOLVER, 1, ROC_UNSUPPORTED}},
-  {"CUSOLVERRF_UNIT_DIAGONAL_STORED_L",                        {"HIPSOLVERRF_UNIT_DIAGONAL_STORED_L",                        "",                                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1, ROC_UNSUPPORTED}},
-  {"CUSOLVERRF_UNIT_DIAGONAL_STORED_U",                        {"HIPSOLVERRF_UNIT_DIAGONAL_STORED_U",                        "",                                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1, ROC_UNSUPPORTED}},
-  {"CUSOLVERRF_UNIT_DIAGONAL_ASSUMED_L",                       {"HIPSOLVERRF_UNIT_DIAGONAL_ASSUMED_L",                       "",                                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1, ROC_UNSUPPORTED}},
-  {"CUSOLVERRF_UNIT_DIAGONAL_ASSUMED_U",                       {"HIPSOLVERRF_UNIT_DIAGONAL_ASSUMED_U",                       "",                                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1, ROC_UNSUPPORTED}},
-  {"cusolverRfFactorization_t",                                {"hipsolverRfFactorization_t",                                "",                                                                 CONV_TYPE, API_SOLVER, 1, ROC_UNSUPPORTED}},
-  {"CUSOLVERRF_FACTORIZATION_ALG0",                            {"HIPSOLVERRF_FACTORIZATION_ALG0",                            "",                                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1, ROC_UNSUPPORTED}},
-  {"CUSOLVERRF_FACTORIZATION_ALG1",                            {"HIPSOLVERRF_FACTORIZATION_ALG1",                            "",                                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1, ROC_UNSUPPORTED}},
-  {"CUSOLVERRF_FACTORIZATION_ALG2",                            {"HIPSOLVERRF_FACTORIZATION_ALG2",                            "",                                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1, ROC_UNSUPPORTED}},
-  {"cusolverRfTriangularSolve_t",                              {"hipsolverRfTriangularSolve_t",                              "",                                                                 CONV_TYPE, API_SOLVER, 1, ROC_UNSUPPORTED}},
-  {"CUSOLVERRF_TRIANGULAR_SOLVE_ALG1",                         {"HIPSOLVERRF_TRIANGULAR_SOLVE_ALG1",                         "",                                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1, ROC_UNSUPPORTED}},
-  {"CUSOLVERRF_TRIANGULAR_SOLVE_ALG2",                         {"HIPSOLVERRF_TRIANGULAR_SOLVE_ALG2",                         "",                                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1, ROC_UNSUPPORTED}},
-  {"CUSOLVERRF_TRIANGULAR_SOLVE_ALG3",                         {"HIPSOLVERRF_TRIANGULAR_SOLVE_ALG3",                         "",                                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1, ROC_UNSUPPORTED}},
-  {"cusolverRfNumericBoostReport_t",                           {"hipsolverRfNumericBoostReport_t",                           "",                                                                 CONV_TYPE, API_SOLVER, 1, ROC_UNSUPPORTED}},
-  {"CUSOLVERRF_NUMERIC_BOOST_NOT_USED",                        {"HIPSOLVERRF_NUMERIC_BOOST_NOT_USED",                        "",                                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1, ROC_UNSUPPORTED}},
-  {"CUSOLVERRF_NUMERIC_BOOST_USED",                            {"HIPSOLVERRF_NUMERIC_BOOST_USED",                            "",                                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1, ROC_UNSUPPORTED}},
-  {"cusolverRfCommon",                                         {"hipsolverRfCommon",                                         "",                                                                 CONV_TYPE, API_SOLVER, 1, UNSUPPORTED}},
-  {"cusolverRfHandle_t",                                       {"hipsolverRfHandle_t",                                       "",                                                                 CONV_TYPE, API_SOLVER, 1, ROC_UNSUPPORTED}},
-  {"cusolverSpContext",                                        {"hipsolverSpContext",                                        "",                                                                 CONV_TYPE, API_SOLVER, 1, UNSUPPORTED}},
-  {"cusolverSpHandle_t",                                       {"hipsolverSpHandle_t",                                       "",                                                                 CONV_TYPE, API_SOLVER, 1, ROC_UNSUPPORTED}},
-  {"csrqrInfo",                                                {"hipsolvercsrqrInfo",                                        "",                                                                 CONV_TYPE, API_SOLVER, 1, UNSUPPORTED}},
-  {"csrqrInfo_t",                                              {"hipsolvercsrqrInfo_t",                                      "",                                                                 CONV_TYPE, API_SOLVER, 1, UNSUPPORTED}},
-  {"csrluInfoHost",                                            {"hipsolvercsrluInfoHost",                                    "",                                                                 CONV_TYPE, API_SOLVER, 1, UNSUPPORTED}},
-  {"csrluInfoHost_t",                                          {"hipsolvercsrluInfoHost_t",                                  "",                                                                 CONV_TYPE, API_SOLVER, 1, UNSUPPORTED}},
-  {"csrqrInfoHost",                                            {"hipsolvercsrqrInfoHost",                                    "",                                                                 CONV_TYPE, API_SOLVER, 1, UNSUPPORTED}},
-  {"csrqrInfoHost_t",                                          {"hipsolvercsrqrInfoHost_t",                                  "",                                                                 CONV_TYPE, API_SOLVER, 1, UNSUPPORTED}},
-  {"csrcholInfoHost",                                          {"hipsolvercsrcholInfoHost",                                  "",                                                                 CONV_TYPE, API_SOLVER, 1, UNSUPPORTED}},
-  {"csrcholInfoHost_t",                                        {"hipsolvercsrcholInfoHost_t",                                "",                                                                 CONV_TYPE, API_SOLVER, 1, UNSUPPORTED}},
-  {"csrcholInfo",                                              {"hipsolvercsrcholInfo",                                      "",                                                                 CONV_TYPE, API_SOLVER, 1, UNSUPPORTED}},
-  {"csrcholInfo_t",                                            {"hipsolvercsrcholInfo_t",                                    "",                                                                 CONV_TYPE, API_SOLVER, 1, UNSUPPORTED}},
-  {"cusolverMathMode_t",                                       {"hipsolverMathMode_t",                                       "",                                                                 CONV_TYPE, API_SOLVER, 1, UNSUPPORTED}},
-  {"CUSOLVER_DEFAULT_MATH",                                    {"HIPSOLVER_DEFAULT_MATH",                                    "",                                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1, UNSUPPORTED}},
-  {"CUSOLVER_FP32_EMULATED_BF16X9_MATH",                       {"HIPSOLVER_FP32_EMULATED_BF16X9_MATH",                       "",                                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1, UNSUPPORTED}},
-};
+const std::map<llvm::StringRef, hipCounter> CUDA_SOLVER_TYPE_NAME_MAP = [] {
+  std::map<llvm::StringRef, hipCounter> m;
 
-const std::map<llvm::StringRef, cudaAPIversions> CUDA_SOLVER_TYPE_NAME_VER_MAP {
-  {"cusolver_int_t",                                           {CUDA_101, CUDA_0,   CUDA_0  }},
-  {"CUSOLVER_STATUS_IRS_PARAMS_NOT_INITIALIZED",               {CUDA_102, CUDA_0,   CUDA_0  }},
-  {"CUSOLVER_STATUS_IRS_PARAMS_INVALID",                       {CUDA_102, CUDA_0,   CUDA_0  }},
-  {"CUSOLVER_STATUS_IRS_PARAMS_INVALID_PREC",                  {CUDA_110, CUDA_0,   CUDA_0  }},
-  {"CUSOLVER_STATUS_IRS_PARAMS_INVALID_REFINE",                {CUDA_110, CUDA_0,   CUDA_0  }},
-  {"CUSOLVER_STATUS_IRS_PARAMS_INVALID_MAXITER",               {CUDA_110, CUDA_0,   CUDA_0  }},
-  {"CUSOLVER_STATUS_IRS_INTERNAL_ERROR",                       {CUDA_102, CUDA_0,   CUDA_0  }},
-  {"CUSOLVER_STATUS_IRS_NOT_SUPPORTED",                        {CUDA_102, CUDA_0,   CUDA_0  }},
-  {"CUSOLVER_STATUS_IRS_OUT_OF_RANGE",                         {CUDA_102, CUDA_0,   CUDA_0  }},
-  {"CUSOLVER_STATUS_IRS_NRHS_NOT_SUPPORTED_FOR_REFINE_GMRES",  {CUDA_102, CUDA_0,   CUDA_0  }},
-  {"CUSOLVER_STATUS_IRS_INFOS_NOT_INITIALIZED",                {CUDA_102, CUDA_0,   CUDA_0  }},
-  {"CUSOLVER_STATUS_IRS_INFOS_NOT_DESTROYED",                  {CUDA_110, CUDA_0,   CUDA_0  }},
-  {"CUSOLVER_STATUS_IRS_MATRIX_SINGULAR",                      {CUDA_110, CUDA_0,   CUDA_0  }},
-  {"CUSOLVER_STATUS_INVALID_WORKSPACE",                        {CUDA_110, CUDA_0,   CUDA_0  }},
-  {"cusolverEigType_t",                                        {CUDA_80,  CUDA_0,   CUDA_0  }},
-  {"CUSOLVER_EIG_TYPE_1",                                      {CUDA_80,  CUDA_0,   CUDA_0  }},
-  {"CUSOLVER_EIG_TYPE_2",                                      {CUDA_80,  CUDA_0,   CUDA_0  }},
-  {"CUSOLVER_EIG_TYPE_3",                                      {CUDA_80,  CUDA_0,   CUDA_0  }},
-  {"cusolverEigMode_t",                                        {CUDA_80,  CUDA_0,   CUDA_0  }},
-  {"CUSOLVER_EIG_MODE_NOVECTOR",                               {CUDA_80,  CUDA_0,   CUDA_0  }},
-  {"CUSOLVER_EIG_MODE_VECTOR",                                 {CUDA_80,  CUDA_0,   CUDA_0  }},
-  {"cusolverEigRange_t",                                       {CUDA_101, CUDA_0,   CUDA_0  }},
-  {"CUSOLVER_EIG_RANGE_ALL",                                   {CUDA_101, CUDA_0,   CUDA_0  }},
-  {"CUSOLVER_EIG_RANGE_I",                                     {CUDA_101, CUDA_0,   CUDA_0  }},
-  {"CUSOLVER_EIG_RANGE_V",                                     {CUDA_101, CUDA_0,   CUDA_0  }},
-  {"cusolverNorm_t",                                           {CUDA_102, CUDA_0,   CUDA_0  }},
-  {"CUSOLVER_INF_NORM",                                        {CUDA_102, CUDA_0,   CUDA_0  }},
-  {"CUSOLVER_MAX_NORM",                                        {CUDA_102, CUDA_0,   CUDA_0  }},
-  {"CUSOLVER_ONE_NORM",                                        {CUDA_102, CUDA_0,   CUDA_0  }},
-  {"CUSOLVER_FRO_NORM",                                        {CUDA_102, CUDA_0,   CUDA_0  }},
-  {"cusolverIRSRefinement_t",                                  {CUDA_102, CUDA_0,   CUDA_0  }},
-  {"CUSOLVER_IRS_REFINE_NOT_SET",                              {CUDA_102, CUDA_0,   CUDA_0  }},
-  {"CUSOLVER_IRS_REFINE_NONE",                                 {CUDA_102, CUDA_0,   CUDA_0  }},
-  {"CUSOLVER_IRS_REFINE_CLASSICAL",                            {CUDA_102, CUDA_0,   CUDA_0  }},
-  {"CUSOLVER_IRS_REFINE_CLASSICAL_GMRES",                      {CUDA_102, CUDA_0,   CUDA_0  }},
-  {"CUSOLVER_IRS_REFINE_GMRES",                                {CUDA_102, CUDA_0,   CUDA_0  }},
-  {"CUSOLVER_IRS_REFINE_GMRES_GMRES",                          {CUDA_102, CUDA_0,   CUDA_0  }},
-  {"CUSOLVER_IRS_REFINE_GMRES_NOPCOND",                        {CUDA_110, CUDA_0,   CUDA_0  }},
-  {"CUSOLVER_PREC_DD",                                         {CUDA_102, CUDA_0,   CUDA_0  }},
-  {"CUSOLVER_PREC_SS",                                         {CUDA_102, CUDA_0,   CUDA_0  }},
-  {"CUSOLVER_PREC_SHT",                                        {CUDA_102, CUDA_0,   CUDA_0  }},
-  {"cusolverDirectMode_t",                                     {CUDA_110, CUDA_0,   CUDA_0  }},
-  {"CUBLAS_DIRECT_FORWARD",                                    {CUDA_110, CUDA_0,   CUDA_0  }},
-  {"CUBLAS_DIRECT_BACKWARD",                                   {CUDA_110, CUDA_0,   CUDA_0  }},
-  {"cusolverStorevMode_t",                                     {CUDA_110, CUDA_0,   CUDA_0  }},
-  {"CUBLAS_STOREV_COLUMNWISE",                                 {CUDA_110, CUDA_0,   CUDA_0  }},
-  {"CUBLAS_STOREV_ROWWISE",                                    {CUDA_110, CUDA_0,   CUDA_0  }},
-  {"cusolverAlgMode_t",                                        {CUDA_110, CUDA_0,   CUDA_0  }},
-  {"CUSOLVER_ALG_0",                                           {CUDA_110, CUDA_0,   CUDA_0  }},
-  {"CUSOLVER_ALG_1",                                           {CUDA_110, CUDA_0,   CUDA_0  }},
-  {"CUSOLVER_ALG_2",                                           {CUDA_115, CUDA_0,   CUDA_0  }},
-  {"cusolverPrecType_t",                                       {CUDA_110, CUDA_0,   CUDA_0  }},
-  {"CUSOLVER_R_8I",                                            {CUDA_110, CUDA_0,   CUDA_0  }},
-  {"CUSOLVER_R_8U",                                            {CUDA_110, CUDA_0,   CUDA_0  }},
-  {"CUSOLVER_R_64F",                                           {CUDA_110, CUDA_0,   CUDA_0  }},
-  {"CUSOLVER_R_32F",                                           {CUDA_110, CUDA_0,   CUDA_0  }},
-  {"CUSOLVER_R_16F",                                           {CUDA_110, CUDA_0,   CUDA_0  }},
-  {"CUSOLVER_R_16BF",                                          {CUDA_110, CUDA_0,   CUDA_0  }},
-  {"CUSOLVER_R_TF32",                                          {CUDA_110, CUDA_0,   CUDA_0  }},
-  {"CUSOLVER_R_AP",                                            {CUDA_110, CUDA_0,   CUDA_0  }},
-  {"CUSOLVER_C_8I",                                            {CUDA_110, CUDA_0,   CUDA_0  }},
-  {"CUSOLVER_C_8U",                                            {CUDA_110, CUDA_0,   CUDA_0  }},
-  {"CUSOLVER_C_64F",                                           {CUDA_110, CUDA_0,   CUDA_0  }},
-  {"CUSOLVER_C_32F",                                           {CUDA_110, CUDA_0,   CUDA_0  }},
-  {"CUSOLVER_C_16F",                                           {CUDA_110, CUDA_0,   CUDA_0  }},
-  {"CUSOLVER_C_16BF",                                          {CUDA_110, CUDA_0,   CUDA_0  }},
-  {"CUSOLVER_C_TF32",                                          {CUDA_110, CUDA_0,   CUDA_0  }},
-  {"CUSOLVER_C_AP",                                            {CUDA_110, CUDA_0,   CUDA_0  }},
-  {"syevjInfo",                                                {CUDA_90,  CUDA_0,   CUDA_0  }},
-  {"syevjInfo_t",                                              {CUDA_90,  CUDA_0,   CUDA_0  }},
-  {"gesvdjInfo",                                               {CUDA_90,  CUDA_0,   CUDA_0  }},
-  {"gesvdjInfo_t",                                             {CUDA_90,  CUDA_0,   CUDA_0  }},
-  {"cusolverDnIRSParams",                                      {CUDA_102, CUDA_0,   CUDA_0  }},
-  {"cusolverDnIRSParams_t",                                    {CUDA_102, CUDA_0,   CUDA_0  }},
-  {"cusolverDnIRSInfos",                                       {CUDA_102, CUDA_0,   CUDA_0  }},
-  {"cusolverDnIRSInfos_t",                                     {CUDA_102, CUDA_0,   CUDA_0  }},
-  {"cusolverDnParams",                                         {CUDA_110, CUDA_0,   CUDA_0  }},
-  {"cusolverDnParams_t",                                       {CUDA_110, CUDA_0,   CUDA_0  }},
-  {"cusolverDnFunction_t",                                     {CUDA_110, CUDA_0,   CUDA_0  }},
-  {"CUSOLVERDN_GETRF",                                         {CUDA_110, CUDA_0,   CUDA_0  }},
-  {"CUSOLVERDN_POTRF",                                         {CUDA_115, CUDA_0,   CUDA_0  }},
-  {"cusolverDeterministicMode_t",                              {CUDA_122, CUDA_0,   CUDA_0  }},
-  {"CUSOLVER_DETERMINISTIC_RESULTS",                           {CUDA_122, CUDA_0,   CUDA_0  }},
-  {"CUSOLVER_ALLOW_NON_DETERMINISTIC_RESULTS",                 {CUDA_122, CUDA_0,   CUDA_0  }},
-  {"cusolverDnLoggerCallback_t",                               {CUDA_117, CUDA_0,   CUDA_0  }},
-  {"cusolverMgContext",                                        {CUDA_101, CUDA_0,   CUDA_0  }},
-  {"cusolverMgHandle_t",                                       {CUDA_101, CUDA_0,   CUDA_0  }},
-  {"cusolverMgGridMapping_t",                                  {CUDA_101, CUDA_0,   CUDA_0  }},
-  {"CUDALIBMG_GRID_MAPPING_ROW_MAJOR",                         {CUDA_101, CUDA_0,   CUDA_0  }},
-  {"CUDALIBMG_GRID_MAPPING_COL_MAJOR",                         {CUDA_101, CUDA_0,   CUDA_0  }},
-  {"cudaLibMgGrid_t",                                          {CUDA_101, CUDA_0,   CUDA_0  }},
-  {"cudaLibMgMatrixDesc_t",                                    {CUDA_101, CUDA_0,   CUDA_0  }},
-  {"csrluInfoHost",                                            {CUDA_75,  CUDA_0,   CUDA_0  }},
-  {"csrluInfoHost_t",                                          {CUDA_75,  CUDA_0,   CUDA_0  }},
-  {"csrqrInfoHost",                                            {CUDA_75,  CUDA_0,   CUDA_0  }},
-  {"csrqrInfoHost_t",                                          {CUDA_75,  CUDA_0,   CUDA_0  }},
-  {"csrcholInfoHost",                                          {CUDA_75,  CUDA_0,   CUDA_0  }},
-  {"csrcholInfoHost_t",                                        {CUDA_75,  CUDA_0,   CUDA_0  }},
-  {"csrcholInfo",                                              {CUDA_75,  CUDA_0,   CUDA_0  }},
-  {"csrcholInfo_t",                                            {CUDA_75,  CUDA_0,   CUDA_0  }},
-  {"cusolverMathMode_t",                                       {CUDA_130, CUDA_0,   CUDA_0  }},
-  {"CUSOLVER_DEFAULT_MATH",                                    {CUDA_130, CUDA_0,   CUDA_0  }},
-  {"CUSOLVER_FP32_EMULATED_BF16X9_MATH",                       {CUDA_130, CUDA_0,   CUDA_0  }},
-  {"CUSOLVERDN_SYEVBATCHED",                                   {CUDA_130, CUDA_0,   CUDA_0  }},
-};
+  m["cusolverStatus_t"]                                               = {"hipsolverStatus_t",                                         "rocblas_status",                                                   CONV_TYPE, API_SOLVER, 1};
+  m["CUSOLVER_STATUS_SUCCESS"]                                        = {"HIPSOLVER_STATUS_SUCCESS",                                  "rocblas_status_success",                                           CONV_NUMERIC_LITERAL, API_SOLVER, 1};
+  m["CUSOLVER_STATUS_NOT_INITIALIZED"]                                = {"HIPSOLVER_STATUS_NOT_INITIALIZED",                          "rocblas_status_invalid_handle",                                    CONV_NUMERIC_LITERAL, API_SOLVER, 1};
+  m["CUSOLVER_STATUS_ALLOC_FAILED"]                                   = {"HIPSOLVER_STATUS_ALLOC_FAILED",                             "rocblas_status_memory_error",                                      CONV_NUMERIC_LITERAL, API_SOLVER, 1};
+  m["CUSOLVER_STATUS_INVALID_VALUE"]                                  = {"HIPSOLVER_STATUS_INVALID_VALUE",                            "rocblas_status_invalid_value",                                     CONV_NUMERIC_LITERAL, API_SOLVER, 1};
+  m["CUSOLVER_STATUS_ARCH_MISMATCH"]                                  = {"HIPSOLVER_STATUS_ARCH_MISMATCH",                            "rocblas_status_arch_mismatch",                                     CONV_NUMERIC_LITERAL, API_SOLVER, 1};
+  m["CUSOLVER_STATUS_MAPPING_ERROR"]                                  = {"HIPSOLVER_STATUS_MAPPING_ERROR",                            "rocblas_status_not_implemented",                                   CONV_NUMERIC_LITERAL, API_SOLVER, 1};
+  m["CUSOLVER_STATUS_EXECUTION_FAILED"]                               = {"HIPSOLVER_STATUS_EXECUTION_FAILED",                         "rocblas_status_not_implemented",                                   CONV_NUMERIC_LITERAL, API_SOLVER, 1};
+  m["CUSOLVER_STATUS_INTERNAL_ERROR"]                                 = {"HIPSOLVER_STATUS_INTERNAL_ERROR",                           "rocblas_status_internal_error",                                    CONV_NUMERIC_LITERAL, API_SOLVER, 1};
+  m["CUSOLVER_STATUS_MATRIX_TYPE_NOT_SUPPORTED"]                      = {"HIPSOLVER_STATUS_MATRIX_TYPE_NOT_SUPPORTED",                "",                                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1, ROC_UNSUPPORTED};
+  m["CUSOLVER_STATUS_NOT_SUPPORTED"]                                  = {"HIPSOLVER_STATUS_NOT_SUPPORTED",                            "rocblas_status_not_implemented",                                   CONV_NUMERIC_LITERAL, API_SOLVER, 1};
+  m["CUSOLVER_STATUS_ZERO_PIVOT"]                                     = {"HIPSOLVER_STATUS_ZERO_PIVOT",                               "rocblas_status_not_implemented",                                   CONV_NUMERIC_LITERAL, API_SOLVER, 1};
+  m["CUSOLVER_STATUS_INVALID_LICENSE"]                                = {"HIPSOLVER_STATUS_INVALID_LICENSE",                          "",                                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1, UNSUPPORTED};
+  m["CUSOLVER_STATUS_IRS_PARAMS_NOT_INITIALIZED"]                     = {"HIPSOLVER_STATUS_IRS_PARAMS_NOT_INITIALIZED",               "",                                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1, UNSUPPORTED};
+  m["CUSOLVER_STATUS_IRS_PARAMS_INVALID"]                             = {"HIPSOLVER_STATUS_INVALID_VALUE",                            "",                                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1, ROC_UNSUPPORTED};
+  m["CUSOLVER_STATUS_IRS_PARAMS_INVALID_PREC"]                        = {"HIPSOLVER_STATUS_IRS_PARAMS_INVALID_PREC",                  "",                                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1, UNSUPPORTED};
+  m["CUSOLVER_STATUS_IRS_PARAMS_INVALID_REFINE"]                      = {"HIPSOLVER_STATUS_IRS_PARAMS_INVALID_REFINE",                "",                                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1, UNSUPPORTED};
+  m["CUSOLVER_STATUS_IRS_PARAMS_INVALID_MAXITER"]                     = {"HIPSOLVER_STATUS_IRS_PARAMS_INVALID_MAXITER",               "",                                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1, UNSUPPORTED};
+  m["CUSOLVER_STATUS_IRS_INTERNAL_ERROR"]                             = {"HIPSOLVER_STATUS_INTERNAL_ERROR",                           "",                                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1, ROC_UNSUPPORTED};
+  m["CUSOLVER_STATUS_IRS_NOT_SUPPORTED"]                              = {"HIPSOLVER_STATUS_NOT_SUPPORTED",                            "",                                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1, ROC_UNSUPPORTED};
+  m["CUSOLVER_STATUS_IRS_OUT_OF_RANGE"]                               = {"HIPSOLVER_STATUS_IRS_OUT_OF_RANGE",                         "",                                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1, UNSUPPORTED};
+  m["CUSOLVER_STATUS_IRS_NRHS_NOT_SUPPORTED_FOR_REFINE_GMRES"]        = {"HIPSOLVER_STATUS_IRS_NRHS_NOT_SUPPORTED_FOR_REFINE_GMRES",  "",                                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1, UNSUPPORTED};
+  m["CUSOLVER_STATUS_IRS_INFOS_NOT_INITIALIZED"]                      = {"HIPSOLVER_STATUS_IRS_INFOS_NOT_INITIALIZED",                "",                                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1, UNSUPPORTED};
+  m["CUSOLVER_STATUS_IRS_INFOS_NOT_DESTROYED"]                        = {"HIPSOLVER_STATUS_IRS_INFOS_NOT_DESTROYED",                  "",                                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1, UNSUPPORTED};
+  m["CUSOLVER_STATUS_IRS_MATRIX_SINGULAR"]                            = {"HIPSOLVER_STATUS_IRS_MATRIX_SINGULAR",                      "",                                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1, UNSUPPORTED};
+  m["CUSOLVER_STATUS_INVALID_WORKSPACE"]                              = {"HIPSOLVER_STATUS_INVALID_WORKSPACE",                        "",                                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1, UNSUPPORTED};
+  m["cusolverDnContext"]                                              = {"hipsolverDnContext",                                        "",                                                                 CONV_TYPE, API_SOLVER, 1, UNSUPPORTED};
+  m["cusolverDnHandle_t"]                                             = {"hipsolverHandle_t",                                         "rocblas_handle",                                                   CONV_TYPE, API_SOLVER, 1};
+  m["cusolverEigType_t"]                                              = {"hipsolverEigType_t",                                        "rocblas_eform",                                                    CONV_TYPE, API_SOLVER, 1};
+  m["CUSOLVER_EIG_TYPE_1"]                                            = {"HIPSOLVER_EIG_TYPE_1",                                      "rocblas_eform_ax",                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1};
+  m["CUSOLVER_EIG_TYPE_2"]                                            = {"HIPSOLVER_EIG_TYPE_2",                                      "rocblas_eform_abx",                                                CONV_NUMERIC_LITERAL, API_SOLVER, 1};
+  m["CUSOLVER_EIG_TYPE_3"]                                            = {"HIPSOLVER_EIG_TYPE_3",                                      "rocblas_eform_bax",                                                CONV_NUMERIC_LITERAL, API_SOLVER, 1};
+  m["cusolverEigMode_t"]                                              = {"hipsolverEigMode_t",                                        "rocblas_evect",                                                    CONV_TYPE, API_SOLVER, 1};
+  m["CUSOLVER_EIG_MODE_NOVECTOR"]                                     = {"HIPSOLVER_EIG_MODE_NOVECTOR",                               "rocblas_evect_none",                                               CONV_NUMERIC_LITERAL, API_SOLVER, 1};
+  m["CUSOLVER_EIG_MODE_VECTOR"]                                       = {"HIPSOLVER_EIG_MODE_VECTOR",                                 "rocblas_evect_original",                                           CONV_NUMERIC_LITERAL, API_SOLVER, 1};
+  m["cusolverEigRange_t"]                                             = {"hipsolverEigRange_t",                                       "rocblas_erange",                                                   CONV_TYPE, API_SOLVER, 1};
+  m["CUSOLVER_EIG_RANGE_ALL"]                                         = {"HIPSOLVER_EIG_RANGE_ALL",                                   "rocblas_erange_all",                                               CONV_NUMERIC_LITERAL, API_SOLVER, 1};
+  m["CUSOLVER_EIG_RANGE_I"]                                           = {"HIPSOLVER_EIG_RANGE_I",                                     "rocblas_erange_index",                                             CONV_NUMERIC_LITERAL, API_SOLVER, 1};
+  m["CUSOLVER_EIG_RANGE_V"]                                           = {"HIPSOLVER_EIG_RANGE_V",                                     "rocblas_erange_value",                                             CONV_NUMERIC_LITERAL, API_SOLVER, 1};
+  m["cusolverNorm_t"]                                                 = {"hipsolverNorm_t",                                           "",                                                                 CONV_TYPE, API_SOLVER, 1, UNSUPPORTED};
+  m["CUSOLVER_INF_NORM"]                                              = {"HIPSOLVER_INF_NORM",                                        "",                                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1, UNSUPPORTED};
+  m["CUSOLVER_MAX_NORM"]                                              = {"HIPSOLVER_MAX_NORM",                                        "",                                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1, UNSUPPORTED};
+  m["CUSOLVER_ONE_NORM"]                                              = {"HIPSOLVER_ONE_NORM",                                        "",                                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1, UNSUPPORTED};
+  m["CUSOLVER_FRO_NORM"]                                              = {"HIPSOLVER_FRO_NORM",                                        "",                                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1, UNSUPPORTED};
+  m["cusolverIRSRefinement_t"]                                        = {"hipsolverIRSRefinement_t",                                  "",                                                                 CONV_TYPE, API_SOLVER, 1, UNSUPPORTED};
+  m["CUSOLVER_IRS_REFINE_NOT_SET"]                                    = {"HIPSOLVER_IRS_REFINE_NOT_SET",                              "",                                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1, UNSUPPORTED};
+  m["CUSOLVER_IRS_REFINE_NONE"]                                       = {"HIPSOLVER_IRS_REFINE_NONE",                                 "",                                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1, UNSUPPORTED};
+  m["CUSOLVER_IRS_REFINE_CLASSICAL"]                                  = {"HIPSOLVER_IRS_REFINE_CLASSICAL",                            "",                                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1, UNSUPPORTED};
+  m["CUSOLVER_IRS_REFINE_CLASSICAL_GMRES"]                            = {"HIPSOLVER_IRS_REFINE_CLASSICAL_GMRES",                      "",                                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1, UNSUPPORTED};
+  m["CUSOLVER_IRS_REFINE_GMRES"]                                      = {"HIPSOLVER_IRS_REFINE_GMRES",                                "",                                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1, UNSUPPORTED};
+  m["CUSOLVER_IRS_REFINE_GMRES_GMRES"]                                = {"HIPSOLVER_IRS_REFINE_GMRES_GMRES",                          "",                                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1, UNSUPPORTED};
+  m["CUSOLVER_IRS_REFINE_GMRES_NOPCOND"]                              = {"HIPSOLVER_IRS_REFINE_GMRES_NOPCOND",                        "",                                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1, UNSUPPORTED};
+  m["CUSOLVER_PREC_DD"]                                               = {"HIPSOLVER_PREC_DD",                                         "",                                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1, UNSUPPORTED};
+  m["CUSOLVER_PREC_SS"]                                               = {"HIPSOLVER_PREC_SS",                                         "",                                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1, UNSUPPORTED};
+  m["CUSOLVER_PREC_SHT"]                                              = {"HIPSOLVER_PREC_SHT",                                        "",                                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1, UNSUPPORTED};
+  m["cusolverDirectMode_t"]                                           = {"hipsolverDirectMode_t",                                     "",                                                                 CONV_TYPE, API_SOLVER, 1, UNSUPPORTED};
+  m["CUBLAS_DIRECT_FORWARD"]                                          = {"HIPBLAS_DIRECT_FORWARD",                                    "",                                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1, UNSUPPORTED};
+  m["CUBLAS_DIRECT_BACKWARD"]                                         = {"HIPBLAS_DIRECT_BACKWARD",                                   "",                                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1, UNSUPPORTED};
+  m["cusolverStorevMode_t"]                                           = {"hipsolverStorevMode_t",                                     "",                                                                 CONV_TYPE, API_SOLVER, 1, UNSUPPORTED};
+  m["CUBLAS_STOREV_COLUMNWISE"]                                       = {"HIPBLAS_STOREV_COLUMNWISE",                                 "",                                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1, UNSUPPORTED};
+  m["CUBLAS_STOREV_ROWWISE"]                                          = {"HIPBLAS_STOREV_ROWWISE",                                    "",                                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1, UNSUPPORTED};
+  m["cusolverAlgMode_t"]                                              = {"hipsolverAlgMode_t",                                        "",                                                                 CONV_TYPE, API_SOLVER, 1, ROC_UNSUPPORTED};
+  m["CUSOLVER_ALG_0"]                                                 = {"HIPSOLVER_ALG_0",                                           "",                                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1, ROC_UNSUPPORTED};
+  m["CUSOLVER_ALG_1"]                                                 = {"HIPSOLVER_ALG_1",                                           "",                                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1, ROC_UNSUPPORTED};
+  m["CUSOLVER_ALG_2"]                                                 = {"HIPSOLVER_ALG_2",                                           "",                                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1, UNSUPPORTED};
+  m["cusolverPrecType_t"]                                             = {"hipsolverPrecType_t",                                       "",                                                                 CONV_TYPE, API_SOLVER, 1, UNSUPPORTED};
+  m["CUSOLVER_R_8I"]                                                  = {"HIPSOLVER_R_8I",                                            "",                                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1, UNSUPPORTED};
+  m["CUSOLVER_R_8U"]                                                  = {"HIPSOLVER_R_8U",                                            "",                                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1, UNSUPPORTED};
+  m["CUSOLVER_R_64F"]                                                 = {"HIPSOLVER_R_64F",                                           "",                                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1, UNSUPPORTED};
+  m["CUSOLVER_R_32F"]                                                 = {"HIPSOLVER_R_32F",                                           "",                                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1, UNSUPPORTED};
+  m["CUSOLVER_R_16F"]                                                 = {"HIPSOLVER_R_16F",                                           "",                                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1, UNSUPPORTED};
+  m["CUSOLVER_R_16BF"]                                                = {"HIPSOLVER_R_16BF",                                          "",                                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1, UNSUPPORTED};
+  m["CUSOLVER_R_TF32"]                                                = {"HIPSOLVER_R_TF32",                                          "",                                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1, UNSUPPORTED};
+  m["CUSOLVER_R_AP"]                                                  = {"HIPSOLVER_R_AP",                                            "",                                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1, UNSUPPORTED};
+  m["CUSOLVER_C_8I"]                                                  = {"HIPSOLVER_C_8I",                                            "",                                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1, UNSUPPORTED};
+  m["CUSOLVER_C_8U"]                                                  = {"HIPSOLVER_C_8U",                                            "",                                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1, UNSUPPORTED};
+  m["CUSOLVER_C_64F"]                                                 = {"HIPSOLVER_C_64F",                                           "",                                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1, UNSUPPORTED};
+  m["CUSOLVER_C_32F"]                                                 = {"HIPSOLVER_C_32F",                                           "",                                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1, UNSUPPORTED};
+  m["CUSOLVER_C_16F"]                                                 = {"HIPSOLVER_C_16F",                                           "",                                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1, UNSUPPORTED};
+  m["CUSOLVER_C_16BF"]                                                = {"HIPSOLVER_C_16BF",                                          "",                                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1, UNSUPPORTED};
+  m["CUSOLVER_C_TF32"]                                                = {"HIPSOLVER_C_TF32",                                          "",                                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1, UNSUPPORTED};
+  m["CUSOLVER_C_AP"]                                                  = {"HIPSOLVER_C_AP",                                            "",                                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1, UNSUPPORTED};
+  m["syevjInfo"]                                                      = {"hipsyevjInfo",                                              "",                                                                 CONV_TYPE, API_SOLVER, 1, UNSUPPORTED};
+  m["syevjInfo_t"]                                                    = {"hipsolverSyevjInfo_t",                                      "",                                                                 CONV_TYPE, API_SOLVER, 1, ROC_UNSUPPORTED};
+  m["gesvdjInfo"]                                                     = {"hipgesvdjInfo",                                             "",                                                                 CONV_TYPE, API_SOLVER, 1, UNSUPPORTED};
+  m["gesvdjInfo_t"]                                                   = {"hipsolverGesvdjInfo_t",                                     "",                                                                 CONV_TYPE, API_SOLVER, 1, ROC_UNSUPPORTED};
+  m["cusolverDnIRSParams"]                                            = {"hipsolverDnIRSParams",                                      "",                                                                 CONV_TYPE, API_SOLVER, 1, UNSUPPORTED};
+  m["cusolverDnIRSParams_t"]                                          = {"hipsolverDnIRSParams_t",                                    "",                                                                 CONV_TYPE, API_SOLVER, 1, UNSUPPORTED};
+  m["cusolverDnIRSInfos"]                                             = {"hipsolverDnIRSInfos",                                       "",                                                                 CONV_TYPE, API_SOLVER, 1, UNSUPPORTED};
+  m["cusolverDnIRSInfos_t"]                                           = {"hipsolverDnIRSInfos_t",                                     "",                                                                 CONV_TYPE, API_SOLVER, 1, UNSUPPORTED};
+  m["cusolverDnParams"]                                               = {"hipsolverDnParams",                                         "",                                                                 CONV_TYPE, API_SOLVER, 1, UNSUPPORTED};
+  m["cusolverDnParams_t"]                                             = {"hipsolverDnParams_t",                                       "",                                                                 CONV_TYPE, API_SOLVER, 1, ROC_UNSUPPORTED};
+  m["cusolverDnFunction_t"]                                           = {"hipsolverDnFunction_t",                                     "",                                                                 CONV_TYPE, API_SOLVER, 1, ROC_UNSUPPORTED};
+  m["CUSOLVERDN_GETRF"]                                               = {"HIPSOLVERDN_GETRF",                                         "",                                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1, ROC_UNSUPPORTED};
+  m["CUSOLVERDN_POTRF"]                                               = {"HIPSOLVERDN_POTRF",                                         "",                                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1, UNSUPPORTED};
+  m["CUSOLVERDN_SYEVBATCHED"]                                         = {"HIPSOLVERDN_SYEVBATCHED",                                   "",                                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1, UNSUPPORTED};
+  m["cusolverDeterministicMode_t"]                                    = {"hipsolverDeterministicMode_t",                              "",                                                                 CONV_TYPE, API_SOLVER, 1, ROC_UNSUPPORTED};
+  m["CUSOLVER_DETERMINISTIC_RESULTS"]                                 = {"HIPSOLVER_DETERMINISTIC_RESULTS",                           "",                                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1, ROC_UNSUPPORTED};
+  m["CUSOLVER_ALLOW_NON_DETERMINISTIC_RESULTS"]                       = {"HIPSOLVER_ALLOW_NON_DETERMINISTIC_RESULTS",                 "",                                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1, ROC_UNSUPPORTED};
+  m["cusolver_int_t"]                                                 = {"int",                                                       "rocblas_int",                                                      CONV_NUMERIC_LITERAL, API_SOLVER, 1};
+  m["cusolverDnLoggerCallback_t"]                                     = {"hipsolverDnLoggerCallback_t",                               "",                                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1, UNSUPPORTED};
+  m["cusolverMgContext"]                                              = {"hipsolverMgContext",                                        "",                                                                 CONV_TYPE, API_SOLVER, 1, UNSUPPORTED};
+  m["cusolverMgHandle_t"]                                             = {"hipsolverMgHandle_t",                                       "",                                                                 CONV_TYPE, API_SOLVER, 1, UNSUPPORTED};
+  m["cusolverMgGridMapping_t"]                                        = {"hipsolverMgGridMapping_t",                                  "",                                                                 CONV_TYPE, API_SOLVER, 1, UNSUPPORTED};
+  m["CUDALIBMG_GRID_MAPPING_ROW_MAJOR"]                               = {"HIP_LIBMG_GRID_MAPPING_ROW_MAJOR",                          "",                                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1, UNSUPPORTED};
+  m["CUDALIBMG_GRID_MAPPING_COL_MAJOR"]                               = {"HIP_LIBMG_GRID_MAPPING_COL_MAJOR",                          "",                                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1, UNSUPPORTED};
+  m["cudaLibMgGrid_t"]                                                = {"hipLibMgGrid_t",                                            "",                                                                 CONV_TYPE, API_SOLVER, 1, UNSUPPORTED};
+  m["cudaLibMgMatrixDesc_t"]                                          = {"hipLibMgMatrixDesc_t",                                      "",                                                                 CONV_TYPE, API_SOLVER, 1, UNSUPPORTED};
+  m["cusolverRfResetValuesFastMode_t"]                                = {"hipsolverRfResetValuesFastMode_t",                          "",                                                                 CONV_TYPE, API_SOLVER, 1, ROC_UNSUPPORTED};
+  m["CUSOLVERRF_RESET_VALUES_FAST_MODE_OFF"]                          = {"HIPSOLVERRF_RESET_VALUES_FAST_MODE_OFF",                    "",                                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1, ROC_UNSUPPORTED};
+  m["CUSOLVERRF_RESET_VALUES_FAST_MODE_ON"]                           = {"HIPSOLVERRF_RESET_VALUES_FAST_MODE_ON",                     "",                                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1, ROC_UNSUPPORTED};
+  m["cusolverRfMatrixFormat_t"]                                       = {"hipsolverRfMatrixFormat_t",                                 "",                                                                 CONV_TYPE, API_SOLVER, 1, ROC_UNSUPPORTED};
+  m["CUSOLVERRF_MATRIX_FORMAT_CSR"]                                   = {"HIPSOLVERRF_MATRIX_FORMAT_CSR",                             "",                                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1, ROC_UNSUPPORTED};
+  m["CUSOLVERRF_MATRIX_FORMAT_CSC"]                                   = {"HIPSOLVERRF_MATRIX_FORMAT_CSC",                             "",                                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1, ROC_UNSUPPORTED};
+  m["cusolverRfUnitDiagonal_t"]                                       = {"hipsolverRfUnitDiagonal_t",                                 "",                                                                 CONV_TYPE, API_SOLVER, 1, ROC_UNSUPPORTED};
+  m["CUSOLVERRF_UNIT_DIAGONAL_STORED_L"]                              = {"HIPSOLVERRF_UNIT_DIAGONAL_STORED_L",                        "",                                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1, ROC_UNSUPPORTED};
+  m["CUSOLVERRF_UNIT_DIAGONAL_STORED_U"]                              = {"HIPSOLVERRF_UNIT_DIAGONAL_STORED_U",                        "",                                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1, ROC_UNSUPPORTED};
+  m["CUSOLVERRF_UNIT_DIAGONAL_ASSUMED_L"]                             = {"HIPSOLVERRF_UNIT_DIAGONAL_ASSUMED_L",                       "",                                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1, ROC_UNSUPPORTED};
+  m["CUSOLVERRF_UNIT_DIAGONAL_ASSUMED_U"]                             = {"HIPSOLVERRF_UNIT_DIAGONAL_ASSUMED_U",                       "",                                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1, ROC_UNSUPPORTED};
+  m["cusolverRfFactorization_t"]                                      = {"hipsolverRfFactorization_t",                                "",                                                                 CONV_TYPE, API_SOLVER, 1, ROC_UNSUPPORTED};
+  m["CUSOLVERRF_FACTORIZATION_ALG0"]                                  = {"HIPSOLVERRF_FACTORIZATION_ALG0",                            "",                                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1, ROC_UNSUPPORTED};
+  m["CUSOLVERRF_FACTORIZATION_ALG1"]                                  = {"HIPSOLVERRF_FACTORIZATION_ALG1",                            "",                                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1, ROC_UNSUPPORTED};
+  m["CUSOLVERRF_FACTORIZATION_ALG2"]                                  = {"HIPSOLVERRF_FACTORIZATION_ALG2",                            "",                                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1, ROC_UNSUPPORTED};
+  m["cusolverRfTriangularSolve_t"]                                    = {"hipsolverRfTriangularSolve_t",                              "",                                                                 CONV_TYPE, API_SOLVER, 1, ROC_UNSUPPORTED};
+  m["CUSOLVERRF_TRIANGULAR_SOLVE_ALG1"]                               = {"HIPSOLVERRF_TRIANGULAR_SOLVE_ALG1",                         "",                                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1, ROC_UNSUPPORTED};
+  m["CUSOLVERRF_TRIANGULAR_SOLVE_ALG2"]                               = {"HIPSOLVERRF_TRIANGULAR_SOLVE_ALG2",                         "",                                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1, ROC_UNSUPPORTED};
+  m["CUSOLVERRF_TRIANGULAR_SOLVE_ALG3"]                               = {"HIPSOLVERRF_TRIANGULAR_SOLVE_ALG3",                         "",                                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1, ROC_UNSUPPORTED};
+  m["cusolverRfNumericBoostReport_t"]                                 = {"hipsolverRfNumericBoostReport_t",                           "",                                                                 CONV_TYPE, API_SOLVER, 1, ROC_UNSUPPORTED};
+  m["CUSOLVERRF_NUMERIC_BOOST_NOT_USED"]                              = {"HIPSOLVERRF_NUMERIC_BOOST_NOT_USED",                        "",                                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1, ROC_UNSUPPORTED};
+  m["CUSOLVERRF_NUMERIC_BOOST_USED"]                                  = {"HIPSOLVERRF_NUMERIC_BOOST_USED",                            "",                                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1, ROC_UNSUPPORTED};
+  m["cusolverRfCommon"]                                               = {"hipsolverRfCommon",                                         "",                                                                 CONV_TYPE, API_SOLVER, 1, UNSUPPORTED};
+  m["cusolverRfHandle_t"]                                             = {"hipsolverRfHandle_t",                                       "",                                                                 CONV_TYPE, API_SOLVER, 1, ROC_UNSUPPORTED};
+  m["cusolverSpContext"]                                              = {"hipsolverSpContext",                                        "",                                                                 CONV_TYPE, API_SOLVER, 1, UNSUPPORTED};
+  m["cusolverSpHandle_t"]                                             = {"hipsolverSpHandle_t",                                       "",                                                                 CONV_TYPE, API_SOLVER, 1, ROC_UNSUPPORTED};
+  m["csrqrInfo"]                                                      = {"hipsolvercsrqrInfo",                                        "",                                                                 CONV_TYPE, API_SOLVER, 1, UNSUPPORTED};
+  m["csrqrInfo_t"]                                                    = {"hipsolvercsrqrInfo_t",                                      "",                                                                 CONV_TYPE, API_SOLVER, 1, UNSUPPORTED};
+  m["csrluInfoHost"]                                                  = {"hipsolvercsrluInfoHost",                                    "",                                                                 CONV_TYPE, API_SOLVER, 1, UNSUPPORTED};
+  m["csrluInfoHost_t"]                                                = {"hipsolvercsrluInfoHost_t",                                  "",                                                                 CONV_TYPE, API_SOLVER, 1, UNSUPPORTED};
+  m["csrqrInfoHost"]                                                  = {"hipsolvercsrqrInfoHost",                                    "",                                                                 CONV_TYPE, API_SOLVER, 1, UNSUPPORTED};
+  m["csrqrInfoHost_t"]                                                = {"hipsolvercsrqrInfoHost_t",                                  "",                                                                 CONV_TYPE, API_SOLVER, 1, UNSUPPORTED};
+  m["csrcholInfoHost"]                                                = {"hipsolvercsrcholInfoHost",                                  "",                                                                 CONV_TYPE, API_SOLVER, 1, UNSUPPORTED};
+  m["csrcholInfoHost_t"]                                              = {"hipsolvercsrcholInfoHost_t",                                "",                                                                 CONV_TYPE, API_SOLVER, 1, UNSUPPORTED};
+  m["csrcholInfo"]                                                    = {"hipsolvercsrcholInfo",                                      "",                                                                 CONV_TYPE, API_SOLVER, 1, UNSUPPORTED};
+  m["csrcholInfo_t"]                                                  = {"hipsolvercsrcholInfo_t",                                    "",                                                                 CONV_TYPE, API_SOLVER, 1, UNSUPPORTED};
+  m["cusolverMathMode_t"]                                             = {"hipsolverMathMode_t",                                       "",                                                                 CONV_TYPE, API_SOLVER, 1, UNSUPPORTED};
+  m["CUSOLVER_DEFAULT_MATH"]                                          = {"HIPSOLVER_DEFAULT_MATH",                                    "",                                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1, UNSUPPORTED};
+  m["CUSOLVER_FP32_EMULATED_BF16X9_MATH"]                             = {"HIPSOLVER_FP32_EMULATED_BF16X9_MATH",                       "",                                                                 CONV_NUMERIC_LITERAL, API_SOLVER, 1, UNSUPPORTED};
 
-const std::map<llvm::StringRef, hipAPIversions> HIP_SOLVER_TYPE_NAME_VER_MAP {
-  {"hipsolverStatus_t",                                        {HIP_4050, HIP_0,    HIP_0   }},
-  {"HIPSOLVER_STATUS_SUCCESS",                                 {HIP_4050, HIP_0,    HIP_0   }},
-  {"HIPSOLVER_STATUS_NOT_INITIALIZED",                         {HIP_4050, HIP_0,    HIP_0   }},
-  {"HIPSOLVER_STATUS_ALLOC_FAILED",                            {HIP_4050, HIP_0,    HIP_0   }},
-  {"HIPSOLVER_STATUS_INVALID_VALUE",                           {HIP_4050, HIP_0,    HIP_0   }},
-  {"HIPSOLVER_STATUS_ARCH_MISMATCH",                           {HIP_4050, HIP_0,    HIP_0   }},
-  {"HIPSOLVER_STATUS_MAPPING_ERROR",                           {HIP_4050, HIP_0,    HIP_0   }},
-  {"HIPSOLVER_STATUS_EXECUTION_FAILED",                        {HIP_4050, HIP_0,    HIP_0   }},
-  {"HIPSOLVER_STATUS_INTERNAL_ERROR",                          {HIP_4050, HIP_0,    HIP_0   }},
-  {"HIPSOLVER_STATUS_NOT_SUPPORTED",                           {HIP_4050, HIP_0,    HIP_0   }},
-  {"HIPSOLVER_STATUS_ZERO_PIVOT",                              {HIP_5060, HIP_0,    HIP_0   }},
-  {"hipsolverHandle_t",                                        {HIP_4050, HIP_0,    HIP_0   }},
-  {"hipsolverEigType_t",                                       {HIP_4050, HIP_0,    HIP_0   }},
-  {"HIPSOLVER_EIG_TYPE_1",                                     {HIP_4050, HIP_0,    HIP_0   }},
-  {"HIPSOLVER_EIG_TYPE_2",                                     {HIP_4050, HIP_0,    HIP_0   }},
-  {"HIPSOLVER_EIG_TYPE_3",                                     {HIP_4050, HIP_0,    HIP_0   }},
-  {"hipsolverEigMode_t",                                       {HIP_4050, HIP_0,    HIP_0   }},
-  {"HIPSOLVER_EIG_MODE_NOVECTOR",                              {HIP_4050, HIP_0,    HIP_0   }},
-  {"HIPSOLVER_EIG_MODE_VECTOR",                                {HIP_4050, HIP_0,    HIP_0   }},
-  {"hipsolverEigRange_t",                                      {HIP_5030, HIP_0,    HIP_0   }},
-  {"HIPSOLVER_EIG_RANGE_ALL",                                  {HIP_5030, HIP_0,    HIP_0   }},
-  {"HIPSOLVER_EIG_RANGE_I",                                    {HIP_5030, HIP_0,    HIP_0   }},
-  {"HIPSOLVER_EIG_RANGE_V",                                    {HIP_5030, HIP_0,    HIP_0   }},
-  {"hipsolverSyevjInfo_t",                                     {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverGesvdjInfo_t",                                    {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsolverRfResetValuesFastMode_t",                         {HIP_5060, HIP_0,    HIP_0   }},
-  {"HIPSOLVERRF_RESET_VALUES_FAST_MODE_OFF",                   {HIP_5060, HIP_0,    HIP_0   }},
-  {"HIPSOLVERRF_RESET_VALUES_FAST_MODE_ON",                    {HIP_5060, HIP_0,    HIP_0   }},
-  {"hipsolverRfMatrixFormat_t",                                {HIP_5060, HIP_0,    HIP_0   }},
-  {"HIPSOLVERRF_MATRIX_FORMAT_CSR",                            {HIP_5060, HIP_0,    HIP_0   }},
-  {"HIPSOLVERRF_MATRIX_FORMAT_CSC",                            {HIP_5060, HIP_0,    HIP_0   }},
-  {"hipsolverRfUnitDiagonal_t",                                {HIP_5060, HIP_0,    HIP_0   }},
-  {"HIPSOLVERRF_UNIT_DIAGONAL_STORED_L",                       {HIP_5060, HIP_0,    HIP_0   }},
-  {"HIPSOLVERRF_UNIT_DIAGONAL_STORED_U",                       {HIP_5060, HIP_0,    HIP_0   }},
-  {"HIPSOLVERRF_UNIT_DIAGONAL_ASSUMED_L",                      {HIP_5060, HIP_0,    HIP_0   }},
-  {"HIPSOLVERRF_UNIT_DIAGONAL_ASSUMED_U",                      {HIP_5060, HIP_0,    HIP_0   }},
-  {"hipsolverRfFactorization_t",                               {HIP_5060, HIP_0,    HIP_0   }},
-  {"HIPSOLVERRF_FACTORIZATION_ALG0",                           {HIP_5060, HIP_0,    HIP_0   }},
-  {"HIPSOLVERRF_FACTORIZATION_ALG1",                           {HIP_5060, HIP_0,    HIP_0   }},
-  {"HIPSOLVERRF_FACTORIZATION_ALG2",                           {HIP_5060, HIP_0,    HIP_0   }},
-  {"hipsolverRfTriangularSolve_t",                             {HIP_5060, HIP_0,    HIP_0   }},
-  {"HIPSOLVERRF_TRIANGULAR_SOLVE_ALG1",                        {HIP_5060, HIP_0,    HIP_0   }},
-  {"HIPSOLVERRF_TRIANGULAR_SOLVE_ALG2",                        {HIP_5060, HIP_0,    HIP_0   }},
-  {"HIPSOLVERRF_TRIANGULAR_SOLVE_ALG3",                        {HIP_5060, HIP_0,    HIP_0   }},
-  {"hipsolverRfNumericBoostReport_t",                          {HIP_5060, HIP_0,    HIP_0   }},
-  {"HIPSOLVERRF_NUMERIC_BOOST_NOT_USED",                       {HIP_5060, HIP_0,    HIP_0   }},
-  {"HIPSOLVERRF_NUMERIC_BOOST_USED",                           {HIP_5060, HIP_0,    HIP_0   }},
-  {"hipsolverRfHandle_t",                                      {HIP_5060, HIP_0,    HIP_0   }},
-  {"HIPSOLVER_STATUS_MATRIX_TYPE_NOT_SUPPORTED",               {HIP_6010, HIP_0,    HIP_0   }},
-  {"hipsolverSpHandle_t",                                      {HIP_6010, HIP_0,    HIP_0   }},
-  {"hipsolverDnParams_t",                                      {HIP_6020, HIP_0,    HIP_0   }},
-  {"hipsolverAlgMode_t",                                       {HIP_6020, HIP_0,    HIP_0   }},
-  {"HIPSOLVER_ALG_0",                                          {HIP_6020, HIP_0,    HIP_0   }},
-  {"HIPSOLVER_ALG_1",                                          {HIP_6020, HIP_0,    HIP_0   }},
-  {"hipsolverDnFunction_t",                                    {HIP_6020, HIP_0,    HIP_0   }},
-  {"HIPSOLVERDN_GETRF",                                        {HIP_6020, HIP_0,    HIP_0   }},
-  {"hipsolverDeterministicMode_t",                             {HIP_6030, HIP_0,    HIP_0   }},
-  {"HIPSOLVER_DETERMINISTIC_RESULTS",                          {HIP_6030, HIP_0,    HIP_0   }},
-  {"HIPSOLVER_ALLOW_NON_DETERMINISTIC_RESULTS",                {HIP_6030, HIP_0,    HIP_0   }},
+  return m;
+}();
 
-  {"rocblas_int",                                              {HIP_3000, HIP_0,    HIP_0   }},
-  {"rocblas_status",                                           {HIP_3000, HIP_0,    HIP_0   }},
-  {"rocblas_status_success",                                   {HIP_3000, HIP_0,    HIP_0   }},
-  {"rocblas_status_invalid_handle",                            {HIP_5060, HIP_0,    HIP_0   }},
-  {"rocblas_status_memory_error",                              {HIP_5060, HIP_0,    HIP_0   }},
-  {"rocblas_status_invalid_value",                             {HIP_3050, HIP_0,    HIP_0   }},
-  {"rocblas_status_not_implemented",                           {HIP_1050, HIP_0,    HIP_0   }},
-  {"rocblas_status_internal_error",                            {HIP_1050, HIP_0,    HIP_0   }},
-  {"rocblas_status_arch_mismatch",                             {HIP_5070, HIP_0,    HIP_0   }},
-  {"rocblas_handle",                                           {HIP_1050, HIP_0,    HIP_0   }},
-  {"rocblas_eform",                                            {HIP_4020, HIP_0,    HIP_0   }},
-  {"rocblas_eform_ax",                                         {HIP_4020, HIP_0,    HIP_0   }},
-  {"rocblas_eform_abx",                                        {HIP_4020, HIP_0,    HIP_0   }},
-  {"rocblas_eform_bax",                                        {HIP_4020, HIP_0,    HIP_0   }},
-  {"rocblas_evect",                                            {HIP_4010, HIP_0,    HIP_0   }},
-  {"rocblas_evect_none",                                       {HIP_4010, HIP_0,    HIP_0   }},
-  {"rocblas_evect_original",                                   {HIP_4010, HIP_0,    HIP_0   }},
-  {"rocblas_erange",                                           {HIP_5020, HIP_0,    HIP_0   }},
-  {"rocblas_erange_all",                                       {HIP_5020, HIP_0,    HIP_0   }},
-  {"rocblas_erange_index",                                     {HIP_5020, HIP_0,    HIP_0   }},
-  {"rocblas_erange_value",                                     {HIP_5020, HIP_0,    HIP_0   }},
-};
+const std::map<llvm::StringRef, cudaAPIversions> CUDA_SOLVER_TYPE_NAME_VER_MAP = [] {
+  std::map<llvm::StringRef, cudaAPIversions> m;
+
+  m["cusolver_int_t"]                                                 = {CUDA_101, CUDA_0,   CUDA_0  };
+  m["CUSOLVER_STATUS_IRS_PARAMS_NOT_INITIALIZED"]                     = {CUDA_102, CUDA_0,   CUDA_0  };
+  m["CUSOLVER_STATUS_IRS_PARAMS_INVALID"]                             = {CUDA_102, CUDA_0,   CUDA_0  };
+  m["CUSOLVER_STATUS_IRS_PARAMS_INVALID_PREC"]                        = {CUDA_110, CUDA_0,   CUDA_0  };
+  m["CUSOLVER_STATUS_IRS_PARAMS_INVALID_REFINE"]                      = {CUDA_110, CUDA_0,   CUDA_0  };
+  m["CUSOLVER_STATUS_IRS_PARAMS_INVALID_MAXITER"]                     = {CUDA_110, CUDA_0,   CUDA_0  };
+  m["CUSOLVER_STATUS_IRS_INTERNAL_ERROR"]                             = {CUDA_102, CUDA_0,   CUDA_0  };
+  m["CUSOLVER_STATUS_IRS_NOT_SUPPORTED"]                              = {CUDA_102, CUDA_0,   CUDA_0  };
+  m["CUSOLVER_STATUS_IRS_OUT_OF_RANGE"]                               = {CUDA_102, CUDA_0,   CUDA_0  };
+  m["CUSOLVER_STATUS_IRS_NRHS_NOT_SUPPORTED_FOR_REFINE_GMRES"]        = {CUDA_102, CUDA_0,   CUDA_0  };
+  m["CUSOLVER_STATUS_IRS_INFOS_NOT_INITIALIZED"]                      = {CUDA_102, CUDA_0,   CUDA_0  };
+  m["CUSOLVER_STATUS_IRS_INFOS_NOT_DESTROYED"]                        = {CUDA_110, CUDA_0,   CUDA_0  };
+  m["CUSOLVER_STATUS_IRS_MATRIX_SINGULAR"]                            = {CUDA_110, CUDA_0,   CUDA_0  };
+  m["CUSOLVER_STATUS_INVALID_WORKSPACE"]                              = {CUDA_110, CUDA_0,   CUDA_0  };
+  m["cusolverEigType_t"]                                              = {CUDA_80,  CUDA_0,   CUDA_0  };
+  m["CUSOLVER_EIG_TYPE_1"]                                            = {CUDA_80,  CUDA_0,   CUDA_0  };
+  m["CUSOLVER_EIG_TYPE_2"]                                            = {CUDA_80,  CUDA_0,   CUDA_0  };
+  m["CUSOLVER_EIG_TYPE_3"]                                            = {CUDA_80,  CUDA_0,   CUDA_0  };
+  m["cusolverEigMode_t"]                                              = {CUDA_80,  CUDA_0,   CUDA_0  };
+  m["CUSOLVER_EIG_MODE_NOVECTOR"]                                     = {CUDA_80,  CUDA_0,   CUDA_0  };
+  m["CUSOLVER_EIG_MODE_VECTOR"]                                       = {CUDA_80,  CUDA_0,   CUDA_0  };
+  m["cusolverEigRange_t"]                                             = {CUDA_101, CUDA_0,   CUDA_0  };
+  m["CUSOLVER_EIG_RANGE_ALL"]                                         = {CUDA_101, CUDA_0,   CUDA_0  };
+  m["CUSOLVER_EIG_RANGE_I"]                                           = {CUDA_101, CUDA_0,   CUDA_0  };
+  m["CUSOLVER_EIG_RANGE_V"]                                           = {CUDA_101, CUDA_0,   CUDA_0  };
+  m["cusolverNorm_t"]                                                 = {CUDA_102, CUDA_0,   CUDA_0  };
+  m["CUSOLVER_INF_NORM"]                                              = {CUDA_102, CUDA_0,   CUDA_0  };
+  m["CUSOLVER_MAX_NORM"]                                              = {CUDA_102, CUDA_0,   CUDA_0  };
+  m["CUSOLVER_ONE_NORM"]                                              = {CUDA_102, CUDA_0,   CUDA_0  };
+  m["CUSOLVER_FRO_NORM"]                                              = {CUDA_102, CUDA_0,   CUDA_0  };
+  m["cusolverIRSRefinement_t"]                                        = {CUDA_102, CUDA_0,   CUDA_0  };
+  m["CUSOLVER_IRS_REFINE_NOT_SET"]                                    = {CUDA_102, CUDA_0,   CUDA_0  };
+  m["CUSOLVER_IRS_REFINE_NONE"]                                       = {CUDA_102, CUDA_0,   CUDA_0  };
+  m["CUSOLVER_IRS_REFINE_CLASSICAL"]                                  = {CUDA_102, CUDA_0,   CUDA_0  };
+  m["CUSOLVER_IRS_REFINE_CLASSICAL_GMRES"]                            = {CUDA_102, CUDA_0,   CUDA_0  };
+  m["CUSOLVER_IRS_REFINE_GMRES"]                                      = {CUDA_102, CUDA_0,   CUDA_0  };
+  m["CUSOLVER_IRS_REFINE_GMRES_GMRES"]                                = {CUDA_102, CUDA_0,   CUDA_0  };
+  m["CUSOLVER_IRS_REFINE_GMRES_NOPCOND"]                              = {CUDA_110, CUDA_0,   CUDA_0  };
+  m["CUSOLVER_PREC_DD"]                                               = {CUDA_102, CUDA_0,   CUDA_0  };
+  m["CUSOLVER_PREC_SS"]                                               = {CUDA_102, CUDA_0,   CUDA_0  };
+  m["CUSOLVER_PREC_SHT"]                                              = {CUDA_102, CUDA_0,   CUDA_0  };
+  m["cusolverDirectMode_t"]                                           = {CUDA_110, CUDA_0,   CUDA_0  };
+  m["CUBLAS_DIRECT_FORWARD"]                                          = {CUDA_110, CUDA_0,   CUDA_0  };
+  m["CUBLAS_DIRECT_BACKWARD"]                                         = {CUDA_110, CUDA_0,   CUDA_0  };
+  m["cusolverStorevMode_t"]                                           = {CUDA_110, CUDA_0,   CUDA_0  };
+  m["CUBLAS_STOREV_COLUMNWISE"]                                       = {CUDA_110, CUDA_0,   CUDA_0  };
+  m["CUBLAS_STOREV_ROWWISE"]                                          = {CUDA_110, CUDA_0,   CUDA_0  };
+  m["cusolverAlgMode_t"]                                              = {CUDA_110, CUDA_0,   CUDA_0  };
+  m["CUSOLVER_ALG_0"]                                                 = {CUDA_110, CUDA_0,   CUDA_0  };
+  m["CUSOLVER_ALG_1"]                                                 = {CUDA_110, CUDA_0,   CUDA_0  };
+  m["CUSOLVER_ALG_2"]                                                 = {CUDA_115, CUDA_0,   CUDA_0  };
+  m["cusolverPrecType_t"]                                             = {CUDA_110, CUDA_0,   CUDA_0  };
+  m["CUSOLVER_R_8I"]                                                  = {CUDA_110, CUDA_0,   CUDA_0  };
+  m["CUSOLVER_R_8U"]                                                  = {CUDA_110, CUDA_0,   CUDA_0  };
+  m["CUSOLVER_R_64F"]                                                 = {CUDA_110, CUDA_0,   CUDA_0  };
+  m["CUSOLVER_R_32F"]                                                 = {CUDA_110, CUDA_0,   CUDA_0  };
+  m["CUSOLVER_R_16F"]                                                 = {CUDA_110, CUDA_0,   CUDA_0  };
+  m["CUSOLVER_R_16BF"]                                                = {CUDA_110, CUDA_0,   CUDA_0  };
+  m["CUSOLVER_R_TF32"]                                                = {CUDA_110, CUDA_0,   CUDA_0  };
+  m["CUSOLVER_R_AP"]                                                  = {CUDA_110, CUDA_0,   CUDA_0  };
+  m["CUSOLVER_C_8I"]                                                  = {CUDA_110, CUDA_0,   CUDA_0  };
+  m["CUSOLVER_C_8U"]                                                  = {CUDA_110, CUDA_0,   CUDA_0  };
+  m["CUSOLVER_C_64F"]                                                 = {CUDA_110, CUDA_0,   CUDA_0  };
+  m["CUSOLVER_C_32F"]                                                 = {CUDA_110, CUDA_0,   CUDA_0  };
+  m["CUSOLVER_C_16F"]                                                 = {CUDA_110, CUDA_0,   CUDA_0  };
+  m["CUSOLVER_C_16BF"]                                                = {CUDA_110, CUDA_0,   CUDA_0  };
+  m["CUSOLVER_C_TF32"]                                                = {CUDA_110, CUDA_0,   CUDA_0  };
+  m["CUSOLVER_C_AP"]                                                  = {CUDA_110, CUDA_0,   CUDA_0  };
+  m["syevjInfo"]                                                      = {CUDA_90,  CUDA_0,   CUDA_0  };
+  m["syevjInfo_t"]                                                    = {CUDA_90,  CUDA_0,   CUDA_0  };
+  m["gesvdjInfo"]                                                     = {CUDA_90,  CUDA_0,   CUDA_0  };
+  m["gesvdjInfo_t"]                                                   = {CUDA_90,  CUDA_0,   CUDA_0  };
+  m["cusolverDnIRSParams"]                                            = {CUDA_102, CUDA_0,   CUDA_0  };
+  m["cusolverDnIRSParams_t"]                                          = {CUDA_102, CUDA_0,   CUDA_0  };
+  m["cusolverDnIRSInfos"]                                             = {CUDA_102, CUDA_0,   CUDA_0  };
+  m["cusolverDnIRSInfos_t"]                                           = {CUDA_102, CUDA_0,   CUDA_0  };
+  m["cusolverDnParams"]                                               = {CUDA_110, CUDA_0,   CUDA_0  };
+  m["cusolverDnParams_t"]                                             = {CUDA_110, CUDA_0,   CUDA_0  };
+  m["cusolverDnFunction_t"]                                           = {CUDA_110, CUDA_0,   CUDA_0  };
+  m["CUSOLVERDN_GETRF"]                                               = {CUDA_110, CUDA_0,   CUDA_0  };
+  m["CUSOLVERDN_POTRF"]                                               = {CUDA_115, CUDA_0,   CUDA_0  };
+  m["cusolverDeterministicMode_t"]                                    = {CUDA_122, CUDA_0,   CUDA_0  };
+  m["CUSOLVER_DETERMINISTIC_RESULTS"]                                 = {CUDA_122, CUDA_0,   CUDA_0  };
+  m["CUSOLVER_ALLOW_NON_DETERMINISTIC_RESULTS"]                       = {CUDA_122, CUDA_0,   CUDA_0  };
+  m["cusolverDnLoggerCallback_t"]                                     = {CUDA_117, CUDA_0,   CUDA_0  };
+  m["cusolverMgContext"]                                              = {CUDA_101, CUDA_0,   CUDA_0  };
+  m["cusolverMgHandle_t"]                                             = {CUDA_101, CUDA_0,   CUDA_0  };
+  m["cusolverMgGridMapping_t"]                                        = {CUDA_101, CUDA_0,   CUDA_0  };
+  m["CUDALIBMG_GRID_MAPPING_ROW_MAJOR"]                               = {CUDA_101, CUDA_0,   CUDA_0  };
+  m["CUDALIBMG_GRID_MAPPING_COL_MAJOR"]                               = {CUDA_101, CUDA_0,   CUDA_0  };
+  m["cudaLibMgGrid_t"]                                                = {CUDA_101, CUDA_0,   CUDA_0  };
+  m["cudaLibMgMatrixDesc_t"]                                          = {CUDA_101, CUDA_0,   CUDA_0  };
+  m["csrluInfoHost"]                                                  = {CUDA_75,  CUDA_0,   CUDA_0  };
+  m["csrluInfoHost_t"]                                                = {CUDA_75,  CUDA_0,   CUDA_0  };
+  m["csrqrInfoHost"]                                                  = {CUDA_75,  CUDA_0,   CUDA_0  };
+  m["csrqrInfoHost_t"]                                                = {CUDA_75,  CUDA_0,   CUDA_0  };
+  m["csrcholInfoHost"]                                                = {CUDA_75,  CUDA_0,   CUDA_0  };
+  m["csrcholInfoHost_t"]                                              = {CUDA_75,  CUDA_0,   CUDA_0  };
+  m["csrcholInfo"]                                                    = {CUDA_75,  CUDA_0,   CUDA_0  };
+  m["csrcholInfo_t"]                                                  = {CUDA_75,  CUDA_0,   CUDA_0  };
+  m["cusolverMathMode_t"]                                             = {CUDA_130, CUDA_0,   CUDA_0  };
+  m["CUSOLVER_DEFAULT_MATH"]                                          = {CUDA_130, CUDA_0,   CUDA_0  };
+  m["CUSOLVER_FP32_EMULATED_BF16X9_MATH"]                             = {CUDA_130, CUDA_0,   CUDA_0  };
+  m["CUSOLVERDN_SYEVBATCHED"]                                         = {CUDA_130, CUDA_0,   CUDA_0  };
+
+  return m;
+}();
+
+const std::map<llvm::StringRef, hipAPIversions> HIP_SOLVER_TYPE_NAME_VER_MAP = [] {
+  std::map<llvm::StringRef, hipAPIversions> m;
+
+  m["hipsolverStatus_t"]                                              = {HIP_4050, HIP_0,    HIP_0   };
+  m["HIPSOLVER_STATUS_SUCCESS"]                                       = {HIP_4050, HIP_0,    HIP_0   };
+  m["HIPSOLVER_STATUS_NOT_INITIALIZED"]                               = {HIP_4050, HIP_0,    HIP_0   };
+  m["HIPSOLVER_STATUS_ALLOC_FAILED"]                                  = {HIP_4050, HIP_0,    HIP_0   };
+  m["HIPSOLVER_STATUS_INVALID_VALUE"]                                 = {HIP_4050, HIP_0,    HIP_0   };
+  m["HIPSOLVER_STATUS_ARCH_MISMATCH"]                                 = {HIP_4050, HIP_0,    HIP_0   };
+  m["HIPSOLVER_STATUS_MAPPING_ERROR"]                                 = {HIP_4050, HIP_0,    HIP_0   };
+  m["HIPSOLVER_STATUS_EXECUTION_FAILED"]                              = {HIP_4050, HIP_0,    HIP_0   };
+  m["HIPSOLVER_STATUS_INTERNAL_ERROR"]                                = {HIP_4050, HIP_0,    HIP_0   };
+  m["HIPSOLVER_STATUS_NOT_SUPPORTED"]                                 = {HIP_4050, HIP_0,    HIP_0   };
+  m["HIPSOLVER_STATUS_ZERO_PIVOT"]                                    = {HIP_5060, HIP_0,    HIP_0   };
+  m["hipsolverHandle_t"]                                              = {HIP_4050, HIP_0,    HIP_0   };
+  m["hipsolverEigType_t"]                                             = {HIP_4050, HIP_0,    HIP_0   };
+  m["HIPSOLVER_EIG_TYPE_1"]                                           = {HIP_4050, HIP_0,    HIP_0   };
+  m["HIPSOLVER_EIG_TYPE_2"]                                           = {HIP_4050, HIP_0,    HIP_0   };
+  m["HIPSOLVER_EIG_TYPE_3"]                                           = {HIP_4050, HIP_0,    HIP_0   };
+  m["hipsolverEigMode_t"]                                             = {HIP_4050, HIP_0,    HIP_0   };
+  m["HIPSOLVER_EIG_MODE_NOVECTOR"]                                    = {HIP_4050, HIP_0,    HIP_0   };
+  m["HIPSOLVER_EIG_MODE_VECTOR"]                                      = {HIP_4050, HIP_0,    HIP_0   };
+  m["hipsolverEigRange_t"]                                            = {HIP_5030, HIP_0,    HIP_0   };
+  m["HIPSOLVER_EIG_RANGE_ALL"]                                        = {HIP_5030, HIP_0,    HIP_0   };
+  m["HIPSOLVER_EIG_RANGE_I"]                                          = {HIP_5030, HIP_0,    HIP_0   };
+  m["HIPSOLVER_EIG_RANGE_V"]                                          = {HIP_5030, HIP_0,    HIP_0   };
+  m["hipsolverSyevjInfo_t"]                                           = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverGesvdjInfo_t"]                                          = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsolverRfResetValuesFastMode_t"]                               = {HIP_5060, HIP_0,    HIP_0   };
+  m["HIPSOLVERRF_RESET_VALUES_FAST_MODE_OFF"]                         = {HIP_5060, HIP_0,    HIP_0   };
+  m["HIPSOLVERRF_RESET_VALUES_FAST_MODE_ON"]                          = {HIP_5060, HIP_0,    HIP_0   };
+  m["hipsolverRfMatrixFormat_t"]                                      = {HIP_5060, HIP_0,    HIP_0   };
+  m["HIPSOLVERRF_MATRIX_FORMAT_CSR"]                                  = {HIP_5060, HIP_0,    HIP_0   };
+  m["HIPSOLVERRF_MATRIX_FORMAT_CSC"]                                  = {HIP_5060, HIP_0,    HIP_0   };
+  m["hipsolverRfUnitDiagonal_t"]                                      = {HIP_5060, HIP_0,    HIP_0   };
+  m["HIPSOLVERRF_UNIT_DIAGONAL_STORED_L"]                             = {HIP_5060, HIP_0,    HIP_0   };
+  m["HIPSOLVERRF_UNIT_DIAGONAL_STORED_U"]                             = {HIP_5060, HIP_0,    HIP_0   };
+  m["HIPSOLVERRF_UNIT_DIAGONAL_ASSUMED_L"]                            = {HIP_5060, HIP_0,    HIP_0   };
+  m["HIPSOLVERRF_UNIT_DIAGONAL_ASSUMED_U"]                            = {HIP_5060, HIP_0,    HIP_0   };
+  m["hipsolverRfFactorization_t"]                                     = {HIP_5060, HIP_0,    HIP_0   };
+  m["HIPSOLVERRF_FACTORIZATION_ALG0"]                                 = {HIP_5060, HIP_0,    HIP_0   };
+  m["HIPSOLVERRF_FACTORIZATION_ALG1"]                                 = {HIP_5060, HIP_0,    HIP_0   };
+  m["HIPSOLVERRF_FACTORIZATION_ALG2"]                                 = {HIP_5060, HIP_0,    HIP_0   };
+  m["hipsolverRfTriangularSolve_t"]                                   = {HIP_5060, HIP_0,    HIP_0   };
+  m["HIPSOLVERRF_TRIANGULAR_SOLVE_ALG1"]                              = {HIP_5060, HIP_0,    HIP_0   };
+  m["HIPSOLVERRF_TRIANGULAR_SOLVE_ALG2"]                              = {HIP_5060, HIP_0,    HIP_0   };
+  m["HIPSOLVERRF_TRIANGULAR_SOLVE_ALG3"]                              = {HIP_5060, HIP_0,    HIP_0   };
+  m["hipsolverRfNumericBoostReport_t"]                                = {HIP_5060, HIP_0,    HIP_0   };
+  m["HIPSOLVERRF_NUMERIC_BOOST_NOT_USED"]                             = {HIP_5060, HIP_0,    HIP_0   };
+  m["HIPSOLVERRF_NUMERIC_BOOST_USED"]                                 = {HIP_5060, HIP_0,    HIP_0   };
+  m["hipsolverRfHandle_t"]                                            = {HIP_5060, HIP_0,    HIP_0   };
+  m["HIPSOLVER_STATUS_MATRIX_TYPE_NOT_SUPPORTED"]                     = {HIP_6010, HIP_0,    HIP_0   };
+  m["hipsolverSpHandle_t"]                                            = {HIP_6010, HIP_0,    HIP_0   };
+  m["hipsolverDnParams_t"]                                            = {HIP_6020, HIP_0,    HIP_0   };
+  m["hipsolverAlgMode_t"]                                             = {HIP_6020, HIP_0,    HIP_0   };
+  m["HIPSOLVER_ALG_0"]                                                = {HIP_6020, HIP_0,    HIP_0   };
+  m["HIPSOLVER_ALG_1"]                                                = {HIP_6020, HIP_0,    HIP_0   };
+  m["hipsolverDnFunction_t"]                                          = {HIP_6020, HIP_0,    HIP_0   };
+  m["HIPSOLVERDN_GETRF"]                                              = {HIP_6020, HIP_0,    HIP_0   };
+  m["hipsolverDeterministicMode_t"]                                   = {HIP_6030, HIP_0,    HIP_0   };
+  m["HIPSOLVER_DETERMINISTIC_RESULTS"]                                = {HIP_6030, HIP_0,    HIP_0   };
+  m["HIPSOLVER_ALLOW_NON_DETERMINISTIC_RESULTS"]                      = {HIP_6030, HIP_0,    HIP_0   };
+  m["rocblas_int"]                                                    = {HIP_3000, HIP_0,    HIP_0   };
+  m["rocblas_status"]                                                 = {HIP_3000, HIP_0,    HIP_0   };
+  m["rocblas_status_success"]                                         = {HIP_3000, HIP_0,    HIP_0   };
+  m["rocblas_status_invalid_handle"]                                  = {HIP_5060, HIP_0,    HIP_0   };
+  m["rocblas_status_memory_error"]                                    = {HIP_5060, HIP_0,    HIP_0   };
+  m["rocblas_status_invalid_value"]                                   = {HIP_3050, HIP_0,    HIP_0   };
+  m["rocblas_status_not_implemented"]                                 = {HIP_1050, HIP_0,    HIP_0   };
+  m["rocblas_status_internal_error"]                                  = {HIP_1050, HIP_0,    HIP_0   };
+  m["rocblas_status_arch_mismatch"]                                   = {HIP_5070, HIP_0,    HIP_0   };
+  m["rocblas_handle"]                                                 = {HIP_1050, HIP_0,    HIP_0   };
+  m["rocblas_eform"]                                                  = {HIP_4020, HIP_0,    HIP_0   };
+  m["rocblas_eform_ax"]                                               = {HIP_4020, HIP_0,    HIP_0   };
+  m["rocblas_eform_abx"]                                              = {HIP_4020, HIP_0,    HIP_0   };
+  m["rocblas_eform_bax"]                                              = {HIP_4020, HIP_0,    HIP_0   };
+  m["rocblas_evect"]                                                  = {HIP_4010, HIP_0,    HIP_0   };
+  m["rocblas_evect_none"]                                             = {HIP_4010, HIP_0,    HIP_0   };
+  m["rocblas_evect_original"]                                         = {HIP_4010, HIP_0,    HIP_0   };
+  m["rocblas_erange"]                                                 = {HIP_5020, HIP_0,    HIP_0   };
+  m["rocblas_erange_all"]                                             = {HIP_5020, HIP_0,    HIP_0   };
+  m["rocblas_erange_index"]                                           = {HIP_5020, HIP_0,    HIP_0   };
+  m["rocblas_erange_value"]                                           = {HIP_5020, HIP_0,    HIP_0   };
+
+  return m;
+}();

--- a/src/CUDA2HIP_SPARSE_API_functions.cpp
+++ b/src/CUDA2HIP_SPARSE_API_functions.cpp
@@ -23,2581 +23,2603 @@ THE SOFTWARE.
 #include "CUDA2HIP.h"
 
 // Maps the names of CUDA SPARSE API functions to the corresponding HIP functions
-const std::map<llvm::StringRef, hipCounter> CUDA_SPARSE_FUNCTION_MAP {
+const std::map<llvm::StringRef, hipCounter> CUDA_SPARSE_FUNCTION_MAP = [] {
+  std::map<llvm::StringRef, hipCounter> m;
+
   // 5. cuSPARSE Management Function Reference
-  {"cusparseCreate",                                       {"hipsparseCreate",                                    "rocsparse_create_handle",                                          CONV_LIB_FUNC, API_SPARSE, 5}},
-  {"cusparseDestroy",                                      {"hipsparseDestroy",                                   "rocsparse_destroy_handle",                                         CONV_LIB_FUNC, API_SPARSE, 5}},
-  {"cusparseGetPointerMode",                               {"hipsparseGetPointerMode",                            "rocsparse_get_pointer_mode",                                       CONV_LIB_FUNC, API_SPARSE, 5}},
-  {"cusparseGetVersion",                                   {"hipsparseGetVersion",                                "rocsparse_get_version",                                            CONV_LIB_FUNC, API_SPARSE, 5}},
-  {"cusparseSetPointerMode",                               {"hipsparseSetPointerMode",                            "rocsparse_set_pointer_mode",                                       CONV_LIB_FUNC, API_SPARSE, 5}},
-  {"cusparseSetStream",                                    {"hipsparseSetStream",                                 "rocsparse_set_stream",                                             CONV_LIB_FUNC, API_SPARSE, 5}},
-  {"cusparseGetStream",                                    {"hipsparseGetStream",                                 "rocsparse_get_stream",                                             CONV_LIB_FUNC, API_SPARSE, 5}},
-  {"cusparseGetErrorName",                                 {"hipsparseGetErrorName",                              "rocsparse_get_status_name",                                        CONV_LIB_FUNC, API_SPARSE, 5}},
-  {"cusparseGetErrorString",                               {"hipsparseGetErrorString",                            "rocsparse_get_status_description",                                 CONV_LIB_FUNC, API_SPARSE, 5}},
+  m["cusparseCreate"]                                                 = {"hipsparseCreate",                                    "rocsparse_create_handle",                                          CONV_LIB_FUNC, API_SPARSE, 5};
+  m["cusparseDestroy"]                                                = {"hipsparseDestroy",                                   "rocsparse_destroy_handle",                                         CONV_LIB_FUNC, API_SPARSE, 5};
+  m["cusparseGetPointerMode"]                                         = {"hipsparseGetPointerMode",                            "rocsparse_get_pointer_mode",                                       CONV_LIB_FUNC, API_SPARSE, 5};
+  m["cusparseGetVersion"]                                             = {"hipsparseGetVersion",                                "rocsparse_get_version",                                            CONV_LIB_FUNC, API_SPARSE, 5};
+  m["cusparseSetPointerMode"]                                         = {"hipsparseSetPointerMode",                            "rocsparse_set_pointer_mode",                                       CONV_LIB_FUNC, API_SPARSE, 5};
+  m["cusparseSetStream"]                                              = {"hipsparseSetStream",                                 "rocsparse_set_stream",                                             CONV_LIB_FUNC, API_SPARSE, 5};
+  m["cusparseGetStream"]                                              = {"hipsparseGetStream",                                 "rocsparse_get_stream",                                             CONV_LIB_FUNC, API_SPARSE, 5};
+  m["cusparseGetErrorName"]                                           = {"hipsparseGetErrorName",                              "rocsparse_get_status_name",                                        CONV_LIB_FUNC, API_SPARSE, 5};
+  m["cusparseGetErrorString"]                                         = {"hipsparseGetErrorString",                            "rocsparse_get_status_description",                                 CONV_LIB_FUNC, API_SPARSE, 5};
 
   // 6. cuSPARSE Logging
-  {"cusparseLoggerSetCallback",                            {"hipsparseLoggerSetCallback",                         "",                                                                 CONV_LIB_FUNC, API_SPARSE, 6, UNSUPPORTED}},
-  {"cusparseLoggerSetFile",                                {"hipsparseLoggerSetFile",                             "",                                                                 CONV_LIB_FUNC, API_SPARSE, 6, UNSUPPORTED}},
-  {"cusparseLoggerOpenFile",                               {"hipsparseLoggerOpenFile",                            "",                                                                 CONV_LIB_FUNC, API_SPARSE, 6, UNSUPPORTED}},
-  {"cusparseLoggerSetLevel",                               {"hipsparseLoggerSetLevel",                            "",                                                                 CONV_LIB_FUNC, API_SPARSE, 6, UNSUPPORTED}},
-  {"cusparseLoggerSetMask",                                {"hipsparseLoggerSetMask",                             "",                                                                 CONV_LIB_FUNC, API_SPARSE, 6, UNSUPPORTED}},
-  {"cusparseLoggerForceDisable",                           {"hipsparseLoggerForceDisable",                        "",                                                                 CONV_LIB_FUNC, API_SPARSE, 6, UNSUPPORTED}},
+  m["cusparseLoggerSetCallback"]                                      = {"hipsparseLoggerSetCallback",                         "",                                                                 CONV_LIB_FUNC, API_SPARSE, 6, UNSUPPORTED};
+  m["cusparseLoggerSetFile"]                                          = {"hipsparseLoggerSetFile",                             "",                                                                 CONV_LIB_FUNC, API_SPARSE, 6, UNSUPPORTED};
+  m["cusparseLoggerOpenFile"]                                         = {"hipsparseLoggerOpenFile",                            "",                                                                 CONV_LIB_FUNC, API_SPARSE, 6, UNSUPPORTED};
+  m["cusparseLoggerSetLevel"]                                         = {"hipsparseLoggerSetLevel",                            "",                                                                 CONV_LIB_FUNC, API_SPARSE, 6, UNSUPPORTED};
+  m["cusparseLoggerSetMask"]                                          = {"hipsparseLoggerSetMask",                             "",                                                                 CONV_LIB_FUNC, API_SPARSE, 6, UNSUPPORTED};
+  m["cusparseLoggerForceDisable"]                                     = {"hipsparseLoggerForceDisable",                        "",                                                                 CONV_LIB_FUNC, API_SPARSE, 6, UNSUPPORTED};
 
   // 7. cuSPARSE Helper Function Reference
-  {"cusparseCreateSolveAnalysisInfo",                      {"hipsparseCreateSolveAnalysisInfo",                   "",                                                                 CONV_LIB_FUNC, API_SPARSE, 7, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED}},
-  {"cusparseCreateHybMat",                                 {"hipsparseCreateHybMat",                              "rocsparse_create_hyb_mat",                                         CONV_LIB_FUNC, API_SPARSE, 7, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED}},
-  {"cusparseCreateMatDescr",                               {"hipsparseCreateMatDescr",                            "rocsparse_create_mat_descr",                                       CONV_LIB_FUNC, API_SPARSE, 7}},
-  {"cusparseDestroySolveAnalysisInfo",                     {"hipsparseDestroySolveAnalysisInfo",                  "",                                                                 CONV_LIB_FUNC, API_SPARSE, 7, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED}},
-  {"cusparseDestroyHybMat",                                {"hipsparseDestroyHybMat",                             "rocsparse_destroy_hyb_mat",                                        CONV_LIB_FUNC, API_SPARSE, 7, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED}},
-  {"cusparseDestroyMatDescr",                              {"hipsparseDestroyMatDescr",                           "rocsparse_destroy_mat_descr",                                      CONV_LIB_FUNC, API_SPARSE, 7}},
-  {"cusparseCopyMatDescr",                                 {"hipsparseCopyMatDescr",                              "rocsparse_copy_mat_descr",                                         CONV_LIB_FUNC, API_SPARSE, 7, CUDA_REMOVED}},
-  {"cusparseGetLevelInfo",                                 {"hipsparseGetLevelInfo",                              "",                                                                 CONV_LIB_FUNC, API_SPARSE, 7, UNSUPPORTED | CUDA_REMOVED}},
-  {"cusparseGetMatDiagType",                               {"hipsparseGetMatDiagType",                            "rocsparse_get_mat_diag_type",                                      CONV_LIB_FUNC, API_SPARSE, 7}},
-  {"cusparseGetMatFillMode",                               {"hipsparseGetMatFillMode",                            "rocsparse_get_mat_fill_mode",                                      CONV_LIB_FUNC, API_SPARSE, 7}},
-  {"cusparseGetMatIndexBase",                              {"hipsparseGetMatIndexBase",                           "rocsparse_get_mat_index_base",                                     CONV_LIB_FUNC, API_SPARSE, 7}},
-  {"cusparseGetMatType",                                   {"hipsparseGetMatType",                                "rocsparse_get_mat_type",                                           CONV_LIB_FUNC, API_SPARSE, 7}},
-  {"cusparseSetMatDiagType",                               {"hipsparseSetMatDiagType",                            "rocsparse_set_mat_diag_type",                                      CONV_LIB_FUNC, API_SPARSE, 7}},
-  {"cusparseSetMatFillMode",                               {"hipsparseSetMatFillMode",                            "rocsparse_set_mat_fill_mode",                                      CONV_LIB_FUNC, API_SPARSE, 7}},
-  {"cusparseSetMatIndexBase",                              {"hipsparseSetMatIndexBase",                           "rocsparse_set_mat_index_base",                                     CONV_LIB_FUNC, API_SPARSE, 7}},
-  {"cusparseSetMatType",                                   {"hipsparseSetMatType",                                "rocsparse_set_mat_type",                                           CONV_LIB_FUNC, API_SPARSE, 7}},
-  {"cusparseCreateCsrsv2Info",                             {"hipsparseCreateCsrsv2Info",                          "rocsparse_create_mat_info",                                        CONV_LIB_FUNC, API_SPARSE, 7, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED}},
-  {"cusparseDestroyCsrsv2Info",                            {"hipsparseDestroyCsrsv2Info",                         "rocsparse_destroy_mat_info",                                       CONV_LIB_FUNC, API_SPARSE, 7, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED}},
-  {"cusparseCreateCsrsm2Info",                             {"hipsparseCreateCsrsm2Info",                          "rocsparse_create_mat_info",                                        CONV_LIB_FUNC, API_SPARSE, 7, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED}},
-  {"cusparseDestroyCsrsm2Info",                            {"hipsparseDestroyCsrsm2Info",                         "rocsparse_destroy_mat_info",                                       CONV_LIB_FUNC, API_SPARSE, 7, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED}},
-  {"cusparseCreateCsric02Info",                            {"hipsparseCreateCsric02Info",                         "rocsparse_create_mat_info",                                        CONV_LIB_FUNC, API_SPARSE, 7, CUDA_DEPRECATED | HIP_DEPRECATED}},
-  {"cusparseDestroyCsric02Info",                           {"hipsparseDestroyCsric02Info",                        "rocsparse_destroy_mat_info",                                       CONV_LIB_FUNC, API_SPARSE, 7, CUDA_DEPRECATED | HIP_DEPRECATED}},
-  {"cusparseCreateCsrilu02Info",                           {"hipsparseCreateCsrilu02Info",                        "rocsparse_create_mat_info",                                        CONV_LIB_FUNC, API_SPARSE, 7, CUDA_DEPRECATED | HIP_DEPRECATED}},
-  {"cusparseDestroyCsrilu02Info",                          {"hipsparseDestroyCsrilu02Info",                       "rocsparse_destroy_mat_info",                                       CONV_LIB_FUNC, API_SPARSE, 7, CUDA_DEPRECATED | HIP_DEPRECATED}},
-  {"cusparseCreateBsrsv2Info",                             {"hipsparseCreateBsrsv2Info",                          "rocsparse_create_mat_info",                                        CONV_LIB_FUNC, API_SPARSE, 7, CUDA_DEPRECATED | HIP_DEPRECATED}},
-  {"cusparseDestroyBsrsv2Info",                            {"hipsparseDestroyBsrsv2Info",                         "rocsparse_destroy_mat_info",                                       CONV_LIB_FUNC, API_SPARSE, 7, CUDA_DEPRECATED | HIP_DEPRECATED}},
-  {"cusparseCreateBsrsm2Info",                             {"hipsparseCreateBsrsm2Info",                          "rocsparse_create_mat_info",                                        CONV_LIB_FUNC, API_SPARSE, 7, CUDA_DEPRECATED | HIP_DEPRECATED}},
-  {"cusparseDestroyBsrsm2Info",                            {"hipsparseDestroyBsrsm2Info",                         "rocsparse_destroy_mat_info",                                       CONV_LIB_FUNC, API_SPARSE, 7, CUDA_DEPRECATED | HIP_DEPRECATED}},
-  {"cusparseCreateBsric02Info",                            {"hipsparseCreateBsric02Info",                         "rocsparse_create_mat_info",                                        CONV_LIB_FUNC, API_SPARSE, 7, CUDA_DEPRECATED | HIP_DEPRECATED}},
-  {"cusparseDestroyBsric02Info",                           {"hipsparseDestroyBsric02Info",                        "rocsparse_destroy_mat_info",                                       CONV_LIB_FUNC, API_SPARSE, 7, CUDA_DEPRECATED | HIP_DEPRECATED}},
-  {"cusparseCreateBsrilu02Info",                           {"hipsparseCreateBsrilu02Info",                        "rocsparse_create_mat_info",                                        CONV_LIB_FUNC, API_SPARSE, 7, CUDA_DEPRECATED | HIP_DEPRECATED}},
-  {"cusparseDestroyBsrilu02Info",                          {"hipsparseDestroyBsrilu02Info",                       "rocsparse_destroy_mat_info",                                       CONV_LIB_FUNC, API_SPARSE, 7, CUDA_DEPRECATED | HIP_DEPRECATED}},
-  {"cusparseCreateCsrgemm2Info",                           {"hipsparseCreateCsrgemm2Info",                        "rocsparse_create_mat_info",                                        CONV_LIB_FUNC, API_SPARSE, 7, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED}},
-  {"cusparseDestroyCsrgemm2Info",                          {"hipsparseDestroyCsrgemm2Info",                       "rocsparse_destroy_mat_info",                                       CONV_LIB_FUNC, API_SPARSE, 7, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED}},
-  {"cusparseCreatePruneInfo",                              {"hipsparseCreatePruneInfo",                           "rocsparse_create_mat_info",                                        CONV_LIB_FUNC, API_SPARSE, 7, CUDA_DEPRECATED | HIP_DEPRECATED}},
-  {"cusparseDestroyPruneInfo",                             {"hipsparseDestroyPruneInfo",                          "rocsparse_destroy_mat_info",                                       CONV_LIB_FUNC, API_SPARSE, 7, CUDA_DEPRECATED | HIP_DEPRECATED}},
-  {"cusparseCreateColorInfo",                              {"hipsparseCreateColorInfo",                           "rocsparse_create_color_info",                                      CONV_LIB_FUNC, API_SPARSE, 7, CUDA_DEPRECATED | HIP_DEPRECATED}},
-  {"cusparseDestroyColorInfo",                             {"hipsparseDestroyColorInfo",                          "rocsparse_destroy_color_info",                                     CONV_LIB_FUNC, API_SPARSE, 7, CUDA_DEPRECATED | HIP_DEPRECATED}},
+  m["cusparseCreateSolveAnalysisInfo"]                                = {"hipsparseCreateSolveAnalysisInfo",                   "",                                                                 CONV_LIB_FUNC, API_SPARSE, 7, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED};
+  m["cusparseCreateHybMat"]                                           = {"hipsparseCreateHybMat",                              "rocsparse_create_hyb_mat",                                         CONV_LIB_FUNC, API_SPARSE, 7, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED};
+  m["cusparseCreateMatDescr"]                                         = {"hipsparseCreateMatDescr",                            "rocsparse_create_mat_descr",                                       CONV_LIB_FUNC, API_SPARSE, 7};
+  m["cusparseDestroySolveAnalysisInfo"]                               = {"hipsparseDestroySolveAnalysisInfo",                  "",                                                                 CONV_LIB_FUNC, API_SPARSE, 7, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED};
+  m["cusparseDestroyHybMat"]                                          = {"hipsparseDestroyHybMat",                             "rocsparse_destroy_hyb_mat",                                        CONV_LIB_FUNC, API_SPARSE, 7, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED};
+  m["cusparseDestroyMatDescr"]                                        = {"hipsparseDestroyMatDescr",                           "rocsparse_destroy_mat_descr",                                      CONV_LIB_FUNC, API_SPARSE, 7};
+  m["cusparseCopyMatDescr"]                                           = {"hipsparseCopyMatDescr",                              "rocsparse_copy_mat_descr",                                         CONV_LIB_FUNC, API_SPARSE, 7, CUDA_REMOVED};
+  m["cusparseGetLevelInfo"]                                           = {"hipsparseGetLevelInfo",                              "",                                                                 CONV_LIB_FUNC, API_SPARSE, 7, UNSUPPORTED | CUDA_REMOVED};
+  m["cusparseGetMatDiagType"]                                         = {"hipsparseGetMatDiagType",                            "rocsparse_get_mat_diag_type",                                      CONV_LIB_FUNC, API_SPARSE, 7};
+  m["cusparseGetMatFillMode"]                                         = {"hipsparseGetMatFillMode",                            "rocsparse_get_mat_fill_mode",                                      CONV_LIB_FUNC, API_SPARSE, 7};
+  m["cusparseGetMatIndexBase"]                                        = {"hipsparseGetMatIndexBase",                           "rocsparse_get_mat_index_base",                                     CONV_LIB_FUNC, API_SPARSE, 7};
+  m["cusparseGetMatType"]                                             = {"hipsparseGetMatType",                                "rocsparse_get_mat_type",                                           CONV_LIB_FUNC, API_SPARSE, 7};
+  m["cusparseSetMatDiagType"]                                         = {"hipsparseSetMatDiagType",                            "rocsparse_set_mat_diag_type",                                      CONV_LIB_FUNC, API_SPARSE, 7};
+  m["cusparseSetMatFillMode"]                                         = {"hipsparseSetMatFillMode",                            "rocsparse_set_mat_fill_mode",                                      CONV_LIB_FUNC, API_SPARSE, 7};
+  m["cusparseSetMatIndexBase"]                                        = {"hipsparseSetMatIndexBase",                           "rocsparse_set_mat_index_base",                                     CONV_LIB_FUNC, API_SPARSE, 7};
+  m["cusparseSetMatType"]                                             = {"hipsparseSetMatType",                                "rocsparse_set_mat_type",                                           CONV_LIB_FUNC, API_SPARSE, 7};
+  m["cusparseCreateCsrsv2Info"]                                       = {"hipsparseCreateCsrsv2Info",                          "rocsparse_create_mat_info",                                        CONV_LIB_FUNC, API_SPARSE, 7, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED};
+  m["cusparseDestroyCsrsv2Info"]                                      = {"hipsparseDestroyCsrsv2Info",                         "rocsparse_destroy_mat_info",                                       CONV_LIB_FUNC, API_SPARSE, 7, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED};
+  m["cusparseCreateCsrsm2Info"]                                       = {"hipsparseCreateCsrsm2Info",                          "rocsparse_create_mat_info",                                        CONV_LIB_FUNC, API_SPARSE, 7, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED};
+  m["cusparseDestroyCsrsm2Info"]                                      = {"hipsparseDestroyCsrsm2Info",                         "rocsparse_destroy_mat_info",                                       CONV_LIB_FUNC, API_SPARSE, 7, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED};
+  m["cusparseCreateCsric02Info"]                                      = {"hipsparseCreateCsric02Info",                         "rocsparse_create_mat_info",                                        CONV_LIB_FUNC, API_SPARSE, 7, CUDA_DEPRECATED | HIP_DEPRECATED};
+  m["cusparseDestroyCsric02Info"]                                     = {"hipsparseDestroyCsric02Info",                        "rocsparse_destroy_mat_info",                                       CONV_LIB_FUNC, API_SPARSE, 7, CUDA_DEPRECATED | HIP_DEPRECATED};
+  m["cusparseCreateCsrilu02Info"]                                     = {"hipsparseCreateCsrilu02Info",                        "rocsparse_create_mat_info",                                        CONV_LIB_FUNC, API_SPARSE, 7, CUDA_DEPRECATED | HIP_DEPRECATED};
+  m["cusparseDestroyCsrilu02Info"]                                    = {"hipsparseDestroyCsrilu02Info",                       "rocsparse_destroy_mat_info",                                       CONV_LIB_FUNC, API_SPARSE, 7, CUDA_DEPRECATED | HIP_DEPRECATED};
+  m["cusparseCreateBsrsv2Info"]                                       = {"hipsparseCreateBsrsv2Info",                          "rocsparse_create_mat_info",                                        CONV_LIB_FUNC, API_SPARSE, 7, CUDA_DEPRECATED | HIP_DEPRECATED};
+  m["cusparseDestroyBsrsv2Info"]                                      = {"hipsparseDestroyBsrsv2Info",                         "rocsparse_destroy_mat_info",                                       CONV_LIB_FUNC, API_SPARSE, 7, CUDA_DEPRECATED | HIP_DEPRECATED};
+  m["cusparseCreateBsrsm2Info"]                                       = {"hipsparseCreateBsrsm2Info",                          "rocsparse_create_mat_info",                                        CONV_LIB_FUNC, API_SPARSE, 7, CUDA_DEPRECATED | HIP_DEPRECATED};
+  m["cusparseDestroyBsrsm2Info"]                                      = {"hipsparseDestroyBsrsm2Info",                         "rocsparse_destroy_mat_info",                                       CONV_LIB_FUNC, API_SPARSE, 7, CUDA_DEPRECATED | HIP_DEPRECATED};
+  m["cusparseCreateBsric02Info"]                                      = {"hipsparseCreateBsric02Info",                         "rocsparse_create_mat_info",                                        CONV_LIB_FUNC, API_SPARSE, 7, CUDA_DEPRECATED | HIP_DEPRECATED};
+  m["cusparseDestroyBsric02Info"]                                     = {"hipsparseDestroyBsric02Info",                        "rocsparse_destroy_mat_info",                                       CONV_LIB_FUNC, API_SPARSE, 7, CUDA_DEPRECATED | HIP_DEPRECATED};
+  m["cusparseCreateBsrilu02Info"]                                     = {"hipsparseCreateBsrilu02Info",                        "rocsparse_create_mat_info",                                        CONV_LIB_FUNC, API_SPARSE, 7, CUDA_DEPRECATED | HIP_DEPRECATED};
+  m["cusparseDestroyBsrilu02Info"]                                    = {"hipsparseDestroyBsrilu02Info",                       "rocsparse_destroy_mat_info",                                       CONV_LIB_FUNC, API_SPARSE, 7, CUDA_DEPRECATED | HIP_DEPRECATED};
+  m["cusparseCreateCsrgemm2Info"]                                     = {"hipsparseCreateCsrgemm2Info",                        "rocsparse_create_mat_info",                                        CONV_LIB_FUNC, API_SPARSE, 7, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED};
+  m["cusparseDestroyCsrgemm2Info"]                                    = {"hipsparseDestroyCsrgemm2Info",                       "rocsparse_destroy_mat_info",                                       CONV_LIB_FUNC, API_SPARSE, 7, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED};
+  m["cusparseCreatePruneInfo"]                                        = {"hipsparseCreatePruneInfo",                           "rocsparse_create_mat_info",                                        CONV_LIB_FUNC, API_SPARSE, 7, CUDA_DEPRECATED | HIP_DEPRECATED};
+  m["cusparseDestroyPruneInfo"]                                       = {"hipsparseDestroyPruneInfo",                          "rocsparse_destroy_mat_info",                                       CONV_LIB_FUNC, API_SPARSE, 7, CUDA_DEPRECATED | HIP_DEPRECATED};
+  m["cusparseCreateColorInfo"]                                        = {"hipsparseCreateColorInfo",                           "rocsparse_create_color_info",                                      CONV_LIB_FUNC, API_SPARSE, 7, CUDA_DEPRECATED | HIP_DEPRECATED};
+  m["cusparseDestroyColorInfo"]                                       = {"hipsparseDestroyColorInfo",                          "rocsparse_destroy_color_info",                                     CONV_LIB_FUNC, API_SPARSE, 7, CUDA_DEPRECATED | HIP_DEPRECATED};
 
   // 8. cuSPARSE Level 1 Function Reference
-  {"cusparseSaxpyi",                                       {"hipsparseSaxpyi",                                    "rocsparse_saxpyi",                                                 CONV_LIB_FUNC, API_SPARSE, 8, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED}},
-  {"cusparseDaxpyi",                                       {"hipsparseDaxpyi",                                    "rocsparse_daxpyi",                                                 CONV_LIB_FUNC, API_SPARSE, 8, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED}},
-  {"cusparseCaxpyi",                                       {"hipsparseCaxpyi",                                    "rocsparse_caxpyi",                                                 CONV_LIB_FUNC, API_SPARSE, 8, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED}},
-  {"cusparseZaxpyi",                                       {"hipsparseZaxpyi",                                    "rocsparse_zaxpyi",                                                 CONV_LIB_FUNC, API_SPARSE, 8, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED}},
+  m["cusparseSaxpyi"]                                                 = {"hipsparseSaxpyi",                                    "rocsparse_saxpyi",                                                 CONV_LIB_FUNC, API_SPARSE, 8, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED};
+  m["cusparseDaxpyi"]                                                 = {"hipsparseDaxpyi",                                    "rocsparse_daxpyi",                                                 CONV_LIB_FUNC, API_SPARSE, 8, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED};
+  m["cusparseCaxpyi"]                                                 = {"hipsparseCaxpyi",                                    "rocsparse_caxpyi",                                                 CONV_LIB_FUNC, API_SPARSE, 8, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED};
+  m["cusparseZaxpyi"]                                                 = {"hipsparseZaxpyi",                                    "rocsparse_zaxpyi",                                                 CONV_LIB_FUNC, API_SPARSE, 8, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED};
 
   // TODO: rocsparse_get_stream and hipStreamSynchronize need to be added correspondingly before and after rocsparse_(s|d|c|z)doti call, because cusparse(S|D|C|Z)doti is blocking, and rocsparse_(s|d|c|z)doti is not
-  {"cusparseSdoti",                                        {"hipsparseSdoti",                                     "rocsparse_sdoti",                                                  CONV_LIB_FUNC, API_SPARSE, 8, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED}},
-  {"cusparseDdoti",                                        {"hipsparseDdoti",                                     "rocsparse_ddoti",                                                  CONV_LIB_FUNC, API_SPARSE, 8, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED}},
-  {"cusparseCdoti",                                        {"hipsparseCdoti",                                     "rocsparse_cdoti",                                                  CONV_LIB_FUNC, API_SPARSE, 8, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED}},
-  {"cusparseZdoti",                                        {"hipsparseZdoti",                                     "rocsparse_zdoti",                                                  CONV_LIB_FUNC, API_SPARSE, 8, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED}},
+  m["cusparseSdoti"]                                                  = {"hipsparseSdoti",                                     "rocsparse_sdoti",                                                  CONV_LIB_FUNC, API_SPARSE, 8, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED};
+  m["cusparseDdoti"]                                                  = {"hipsparseDdoti",                                     "rocsparse_ddoti",                                                  CONV_LIB_FUNC, API_SPARSE, 8, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED};
+  m["cusparseCdoti"]                                                  = {"hipsparseCdoti",                                     "rocsparse_cdoti",                                                  CONV_LIB_FUNC, API_SPARSE, 8, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED};
+  m["cusparseZdoti"]                                                  = {"hipsparseZdoti",                                     "rocsparse_zdoti",                                                  CONV_LIB_FUNC, API_SPARSE, 8, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED};
 
   // TODO: rocsparse_get_stream and hipStreamSynchronize need to be added correspondingly before and after rocsparse_(c|z)dotci call, because cusparse(C|Z)dotci is blocking, and rocsparse_(c|z)dotci is not
-  {"cusparseCdotci",                                       {"hipsparseCdotci",                                    "rocsparse_cdotci",                                                 CONV_LIB_FUNC, API_SPARSE, 8, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED}},
-  {"cusparseZdotci",                                       {"hipsparseZdotci",                                    "rocsparse_zdotci",                                                 CONV_LIB_FUNC, API_SPARSE, 8, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED}},
+  m["cusparseCdotci"]                                                 = {"hipsparseCdotci",                                    "rocsparse_cdotci",                                                 CONV_LIB_FUNC, API_SPARSE, 8, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED};
+  m["cusparseZdotci"]                                                 = {"hipsparseZdotci",                                    "rocsparse_zdotci",                                                 CONV_LIB_FUNC, API_SPARSE, 8, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED};
 
-  {"cusparseSgthr",                                        {"hipsparseSgthr",                                     "rocsparse_sgthr",                                                  CONV_LIB_FUNC, API_SPARSE, 8, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED}},
-  {"cusparseDgthr",                                        {"hipsparseDgthr",                                     "rocsparse_dgthr",                                                  CONV_LIB_FUNC, API_SPARSE, 8, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED}},
-  {"cusparseCgthr",                                        {"hipsparseCgthr",                                     "rocsparse_cgthr",                                                  CONV_LIB_FUNC, API_SPARSE, 8, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED}},
-  {"cusparseZgthr",                                        {"hipsparseZgthr",                                     "rocsparse_zgthr",                                                  CONV_LIB_FUNC, API_SPARSE, 8, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED}},
+  m["cusparseSgthr"]                                                  = {"hipsparseSgthr",                                     "rocsparse_sgthr",                                                  CONV_LIB_FUNC, API_SPARSE, 8, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED};
+  m["cusparseDgthr"]                                                  = {"hipsparseDgthr",                                     "rocsparse_dgthr",                                                  CONV_LIB_FUNC, API_SPARSE, 8, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED};
+  m["cusparseCgthr"]                                                  = {"hipsparseCgthr",                                     "rocsparse_cgthr",                                                  CONV_LIB_FUNC, API_SPARSE, 8, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED};
+  m["cusparseZgthr"]                                                  = {"hipsparseZgthr",                                     "rocsparse_zgthr",                                                  CONV_LIB_FUNC, API_SPARSE, 8, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED};
 
-  {"cusparseSgthrz",                                       {"hipsparseSgthrz",                                    "rocsparse_sgthrz",                                                 CONV_LIB_FUNC, API_SPARSE, 8, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED}},
-  {"cusparseDgthrz",                                       {"hipsparseDgthrz",                                    "rocsparse_dgthrz",                                                 CONV_LIB_FUNC, API_SPARSE, 8, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED}},
-  {"cusparseCgthrz",                                       {"hipsparseCgthrz",                                    "rocsparse_cgthrz",                                                 CONV_LIB_FUNC, API_SPARSE, 8, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED}},
-  {"cusparseZgthrz",                                       {"hipsparseZgthrz",                                    "rocsparse_zgthrz",                                                 CONV_LIB_FUNC, API_SPARSE, 8, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED}},
+  m["cusparseSgthrz"]                                                 = {"hipsparseSgthrz",                                    "rocsparse_sgthrz",                                                 CONV_LIB_FUNC, API_SPARSE, 8, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED};
+  m["cusparseDgthrz"]                                                 = {"hipsparseDgthrz",                                    "rocsparse_dgthrz",                                                 CONV_LIB_FUNC, API_SPARSE, 8, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED};
+  m["cusparseCgthrz"]                                                 = {"hipsparseCgthrz",                                    "rocsparse_cgthrz",                                                 CONV_LIB_FUNC, API_SPARSE, 8, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED};
+  m["cusparseZgthrz"]                                                 = {"hipsparseZgthrz",                                    "rocsparse_zgthrz",                                                 CONV_LIB_FUNC, API_SPARSE, 8, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED};
 
-  {"cusparseSroti",                                        {"hipsparseSroti",                                     "rocsparse_sroti",                                                  CONV_LIB_FUNC, API_SPARSE, 8, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED}},
-  {"cusparseDroti",                                        {"hipsparseDroti",                                     "rocsparse_droti",                                                  CONV_LIB_FUNC, API_SPARSE, 8, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED}},
+  m["cusparseSroti"]                                                  = {"hipsparseSroti",                                     "rocsparse_sroti",                                                  CONV_LIB_FUNC, API_SPARSE, 8, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED};
+  m["cusparseDroti"]                                                  = {"hipsparseDroti",                                     "rocsparse_droti",                                                  CONV_LIB_FUNC, API_SPARSE, 8, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED};
 
-  {"cusparseSsctr",                                        {"hipsparseSsctr",                                     "rocsparse_ssctr",                                                  CONV_LIB_FUNC, API_SPARSE, 8, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED}},
-  {"cusparseDsctr",                                        {"hipsparseDsctr",                                     "rocsparse_dsctr",                                                  CONV_LIB_FUNC, API_SPARSE, 8, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED}},
-  {"cusparseCsctr",                                        {"hipsparseCsctr",                                     "rocsparse_csctr",                                                  CONV_LIB_FUNC, API_SPARSE, 8, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED}},
-  {"cusparseZsctr",                                        {"hipsparseZsctr",                                     "rocsparse_zsctr",                                                  CONV_LIB_FUNC, API_SPARSE, 8, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED}},
+  m["cusparseSsctr"]                                                  = {"hipsparseSsctr",                                     "rocsparse_ssctr",                                                  CONV_LIB_FUNC, API_SPARSE, 8, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED};
+  m["cusparseDsctr"]                                                  = {"hipsparseDsctr",                                     "rocsparse_dsctr",                                                  CONV_LIB_FUNC, API_SPARSE, 8, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED};
+  m["cusparseCsctr"]                                                  = {"hipsparseCsctr",                                     "rocsparse_csctr",                                                  CONV_LIB_FUNC, API_SPARSE, 8, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED};
+  m["cusparseZsctr"]                                                  = {"hipsparseZsctr",                                     "rocsparse_zsctr",                                                  CONV_LIB_FUNC, API_SPARSE, 8, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED};
 
   // 9. cuSPARSE Level 2 Function Reference
-  {"cusparseSbsrmv",                                       {"hipsparseSbsrmv",                                    "rocsparse_sbsrmv",                                                 CONV_LIB_FUNC, API_SPARSE, 9, ROC_DEPRECATED}},
-  {"cusparseDbsrmv",                                       {"hipsparseDbsrmv",                                    "rocsparse_dbsrmv",                                                 CONV_LIB_FUNC, API_SPARSE, 9, ROC_DEPRECATED}},
-  {"cusparseCbsrmv",                                       {"hipsparseCbsrmv",                                    "rocsparse_cbsrmv",                                                 CONV_LIB_FUNC, API_SPARSE, 9, ROC_DEPRECATED}},
-  {"cusparseZbsrmv",                                       {"hipsparseZbsrmv",                                    "rocsparse_zbsrmv",                                                 CONV_LIB_FUNC, API_SPARSE, 9, ROC_DEPRECATED}},
+  m["cusparseSbsrmv"]                                                 = {"hipsparseSbsrmv",                                    "rocsparse_sbsrmv",                                                 CONV_LIB_FUNC, API_SPARSE, 9, ROC_DEPRECATED};
+  m["cusparseDbsrmv"]                                                 = {"hipsparseDbsrmv",                                    "rocsparse_dbsrmv",                                                 CONV_LIB_FUNC, API_SPARSE, 9, ROC_DEPRECATED};
+  m["cusparseCbsrmv"]                                                 = {"hipsparseCbsrmv",                                    "rocsparse_cbsrmv",                                                 CONV_LIB_FUNC, API_SPARSE, 9, ROC_DEPRECATED};
+  m["cusparseZbsrmv"]                                                 = {"hipsparseZbsrmv",                                    "rocsparse_zbsrmv",                                                 CONV_LIB_FUNC, API_SPARSE, 9, ROC_DEPRECATED};
 
-  {"cusparseSbsrxmv",                                      {"hipsparseSbsrxmv",                                   "rocsparse_sbsrxmv",                                                CONV_LIB_FUNC, API_SPARSE, 9, CUDA_DEPRECATED | HIP_DEPRECATED}},
-  {"cusparseDbsrxmv",                                      {"hipsparseDbsrxmv",                                   "rocsparse_dbsrxmv",                                                CONV_LIB_FUNC, API_SPARSE, 9, CUDA_DEPRECATED | HIP_DEPRECATED}},
-  {"cusparseCbsrxmv",                                      {"hipsparseCbsrxmv",                                   "rocsparse_cbsrxmv",                                                CONV_LIB_FUNC, API_SPARSE, 9, CUDA_DEPRECATED | HIP_DEPRECATED}},
-  {"cusparseZbsrxmv",                                      {"hipsparseZbsrxmv",                                   "rocsparse_zbsrxmv",                                                CONV_LIB_FUNC, API_SPARSE, 9, CUDA_DEPRECATED | HIP_DEPRECATED}},
+  m["cusparseSbsrxmv"]                                                = {"hipsparseSbsrxmv",                                   "rocsparse_sbsrxmv",                                                CONV_LIB_FUNC, API_SPARSE, 9, CUDA_DEPRECATED | HIP_DEPRECATED};
+  m["cusparseDbsrxmv"]                                                = {"hipsparseDbsrxmv",                                   "rocsparse_dbsrxmv",                                                CONV_LIB_FUNC, API_SPARSE, 9, CUDA_DEPRECATED | HIP_DEPRECATED};
+  m["cusparseCbsrxmv"]                                                = {"hipsparseCbsrxmv",                                   "rocsparse_cbsrxmv",                                                CONV_LIB_FUNC, API_SPARSE, 9, CUDA_DEPRECATED | HIP_DEPRECATED};
+  m["cusparseZbsrxmv"]                                                = {"hipsparseZbsrxmv",                                   "rocsparse_zbsrxmv",                                                CONV_LIB_FUNC, API_SPARSE, 9, CUDA_DEPRECATED | HIP_DEPRECATED};
 
-  {"cusparseScsrmv",                                       {"hipsparseScsrmv",                                    "rocsparse_scsrmv",                                                 CONV_LIB_FUNC, API_SPARSE, 9, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED}},
-  {"cusparseDcsrmv",                                       {"hipsparseDcsrmv",                                    "rocsparse_dcsrmv",                                                 CONV_LIB_FUNC, API_SPARSE, 9, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED}},
-  {"cusparseCcsrmv",                                       {"hipsparseCcsrmv",                                    "rocsparse_ccsrmv",                                                 CONV_LIB_FUNC, API_SPARSE, 9, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED}},
-  {"cusparseZcsrmv",                                       {"hipsparseZcsrmv",                                    "rocsparse_zcsrmv",                                                 CONV_LIB_FUNC, API_SPARSE, 9, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED}},
+  m["cusparseScsrmv"]                                                 = {"hipsparseScsrmv",                                    "rocsparse_scsrmv",                                                 CONV_LIB_FUNC, API_SPARSE, 9, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED};
+  m["cusparseDcsrmv"]                                                 = {"hipsparseDcsrmv",                                    "rocsparse_dcsrmv",                                                 CONV_LIB_FUNC, API_SPARSE, 9, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED};
+  m["cusparseCcsrmv"]                                                 = {"hipsparseCcsrmv",                                    "rocsparse_ccsrmv",                                                 CONV_LIB_FUNC, API_SPARSE, 9, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED};
+  m["cusparseZcsrmv"]                                                 = {"hipsparseZcsrmv",                                    "rocsparse_zcsrmv",                                                 CONV_LIB_FUNC, API_SPARSE, 9, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED};
 
-  {"cusparseCsrmvEx",                                      {"hipsparseCsrmvEx",                                   "",                                                                 CONV_LIB_FUNC, API_SPARSE, 9, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED}},
-  {"cusparseCsrmvEx_bufferSize",                           {"hipsparseCsrmvEx_bufferSize",                        "",                                                                 CONV_LIB_FUNC, API_SPARSE, 9, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED}},
+  m["cusparseCsrmvEx"]                                                = {"hipsparseCsrmvEx",                                   "",                                                                 CONV_LIB_FUNC, API_SPARSE, 9, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED};
+  m["cusparseCsrmvEx_bufferSize"]                                     = {"hipsparseCsrmvEx_bufferSize",                        "",                                                                 CONV_LIB_FUNC, API_SPARSE, 9, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED};
 
-  {"cusparseScsrmv_mp",                                    {"hipsparseScsrmv_mp",                                 "",                                                                 CONV_LIB_FUNC, API_SPARSE, 9, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED}},
-  {"cusparseDcsrmv_mp",                                    {"hipsparseDcsrmv_mp",                                 "",                                                                 CONV_LIB_FUNC, API_SPARSE, 9, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED}},
-  {"cusparseCcsrmv_mp",                                    {"hipsparseCcsrmv_mp",                                 "",                                                                 CONV_LIB_FUNC, API_SPARSE, 9, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED}},
-  {"cusparseZcsrmv_mp",                                    {"hipsparseZcsrmv_mp",                                 "",                                                                 CONV_LIB_FUNC, API_SPARSE, 9, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED}},
+  m["cusparseScsrmv_mp"]                                              = {"hipsparseScsrmv_mp",                                 "",                                                                 CONV_LIB_FUNC, API_SPARSE, 9, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED};
+  m["cusparseDcsrmv_mp"]                                              = {"hipsparseDcsrmv_mp",                                 "",                                                                 CONV_LIB_FUNC, API_SPARSE, 9, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED};
+  m["cusparseCcsrmv_mp"]                                              = {"hipsparseCcsrmv_mp",                                 "",                                                                 CONV_LIB_FUNC, API_SPARSE, 9, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED};
+  m["cusparseZcsrmv_mp"]                                              = {"hipsparseZcsrmv_mp",                                 "",                                                                 CONV_LIB_FUNC, API_SPARSE, 9, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED};
 
-  {"cusparseSgemvi",                                       {"hipsparseSgemvi",                                    "rocsparse_sgemvi",                                                 CONV_LIB_FUNC, API_SPARSE, 9, CUDA_DEPRECATED}},
-  {"cusparseDgemvi",                                       {"hipsparseDgemvi",                                    "rocsparse_dgemvi",                                                 CONV_LIB_FUNC, API_SPARSE, 9, CUDA_DEPRECATED}},
-  {"cusparseCgemvi",                                       {"hipsparseCgemvi",                                    "rocsparse_cgemvi",                                                 CONV_LIB_FUNC, API_SPARSE, 9, CUDA_DEPRECATED}},
-  {"cusparseZgemvi",                                       {"hipsparseZgemvi",                                    "rocsparse_zgemvi",                                                 CONV_LIB_FUNC, API_SPARSE, 9, CUDA_DEPRECATED}},
+  m["cusparseSgemvi"]                                                 = {"hipsparseSgemvi",                                    "rocsparse_sgemvi",                                                 CONV_LIB_FUNC, API_SPARSE, 9, CUDA_DEPRECATED};
+  m["cusparseDgemvi"]                                                 = {"hipsparseDgemvi",                                    "rocsparse_dgemvi",                                                 CONV_LIB_FUNC, API_SPARSE, 9, CUDA_DEPRECATED};
+  m["cusparseCgemvi"]                                                 = {"hipsparseCgemvi",                                    "rocsparse_cgemvi",                                                 CONV_LIB_FUNC, API_SPARSE, 9, CUDA_DEPRECATED};
+  m["cusparseZgemvi"]                                                 = {"hipsparseZgemvi",                                    "rocsparse_zgemvi",                                                 CONV_LIB_FUNC, API_SPARSE, 9, CUDA_DEPRECATED};
 
-  {"cusparseSgemvi_bufferSize",                            {"hipsparseSgemvi_bufferSize",                         "rocsparse_sgemvi_buffer_size",                                     CONV_LIB_FUNC, API_SPARSE, 9, CUDA_DEPRECATED}},
-  {"cusparseDgemvi_bufferSize",                            {"hipsparseDgemvi_bufferSize",                         "rocsparse_dgemvi_buffer_size",                                     CONV_LIB_FUNC, API_SPARSE, 9, CUDA_DEPRECATED}},
-  {"cusparseCgemvi_bufferSize",                            {"hipsparseCgemvi_bufferSize",                         "rocsparse_cgemvi_buffer_size",                                     CONV_LIB_FUNC, API_SPARSE, 9, CUDA_DEPRECATED}},
-  {"cusparseZgemvi_bufferSize",                            {"hipsparseZgemvi_bufferSize",                         "rocsparse_zgemvi_buffer_size",                                     CONV_LIB_FUNC, API_SPARSE, 9, CUDA_DEPRECATED}},
+  m["cusparseSgemvi_bufferSize"]                                      = {"hipsparseSgemvi_bufferSize",                         "rocsparse_sgemvi_buffer_size",                                     CONV_LIB_FUNC, API_SPARSE, 9, CUDA_DEPRECATED};
+  m["cusparseDgemvi_bufferSize"]                                      = {"hipsparseDgemvi_bufferSize",                         "rocsparse_dgemvi_buffer_size",                                     CONV_LIB_FUNC, API_SPARSE, 9, CUDA_DEPRECATED};
+  m["cusparseCgemvi_bufferSize"]                                      = {"hipsparseCgemvi_bufferSize",                         "rocsparse_cgemvi_buffer_size",                                     CONV_LIB_FUNC, API_SPARSE, 9, CUDA_DEPRECATED};
+  m["cusparseZgemvi_bufferSize"]                                      = {"hipsparseZgemvi_bufferSize",                         "rocsparse_zgemvi_buffer_size",                                     CONV_LIB_FUNC, API_SPARSE, 9, CUDA_DEPRECATED};
 
-  {"cusparseSbsrsv2_bufferSize",                           {"hipsparseSbsrsv2_bufferSize",                        "rocsparse_sbsrsv_buffer_size",                                     CONV_LIB_FUNC, API_SPARSE, 9, CUDA_DEPRECATED | HIP_DEPRECATED}},
-  {"cusparseSbsrsv2_bufferSizeExt",                        {"hipsparseSbsrsv2_bufferSizeExt",                     "rocsparse_sbsrsv_buffer_size",                                     CONV_LIB_FUNC, API_SPARSE, 9, CUDA_DEPRECATED}},
-  {"cusparseDbsrsv2_bufferSize",                           {"hipsparseDbsrsv2_bufferSize",                        "rocsparse_dbsrsv_buffer_size",                                     CONV_LIB_FUNC, API_SPARSE, 9, CUDA_DEPRECATED | HIP_DEPRECATED}},
-  {"cusparseDbsrsv2_bufferSizeExt",                        {"hipsparseDbsrsv2_bufferSizeExt",                     "rocsparse_dbsrsv_buffer_size",                                     CONV_LIB_FUNC, API_SPARSE, 9, CUDA_DEPRECATED}},
-  {"cusparseCbsrsv2_bufferSize",                           {"hipsparseCbsrsv2_bufferSize",                        "rocsparse_cbsrsv_buffer_size",                                     CONV_LIB_FUNC, API_SPARSE, 9, CUDA_DEPRECATED | HIP_DEPRECATED}},
-  {"cusparseCbsrsv2_bufferSizeExt",                        {"hipsparseCbsrsv2_bufferSizeExt",                     "rocsparse_cbsrsv_buffer_size",                                     CONV_LIB_FUNC, API_SPARSE, 9, CUDA_DEPRECATED}},
-  {"cusparseZbsrsv2_bufferSize",                           {"hipsparseZbsrsv2_bufferSize",                        "rocsparse_zbsrsv_buffer_size",                                     CONV_LIB_FUNC, API_SPARSE, 9, CUDA_DEPRECATED | HIP_DEPRECATED}},
-  {"cusparseZbsrsv2_bufferSizeExt",                        {"hipsparseZbsrsv2_bufferSizeExt",                     "rocsparse_zbsrsv_buffer_size",                                     CONV_LIB_FUNC, API_SPARSE, 9, CUDA_DEPRECATED}},
+  m["cusparseSbsrsv2_bufferSize"]                                     = {"hipsparseSbsrsv2_bufferSize",                        "rocsparse_sbsrsv_buffer_size",                                     CONV_LIB_FUNC, API_SPARSE, 9, CUDA_DEPRECATED | HIP_DEPRECATED};
+  m["cusparseSbsrsv2_bufferSizeExt"]                                  = {"hipsparseSbsrsv2_bufferSizeExt",                     "rocsparse_sbsrsv_buffer_size",                                     CONV_LIB_FUNC, API_SPARSE, 9, CUDA_DEPRECATED};
+  m["cusparseDbsrsv2_bufferSize"]                                     = {"hipsparseDbsrsv2_bufferSize",                        "rocsparse_dbsrsv_buffer_size",                                     CONV_LIB_FUNC, API_SPARSE, 9, CUDA_DEPRECATED | HIP_DEPRECATED};
+  m["cusparseDbsrsv2_bufferSizeExt"]                                  = {"hipsparseDbsrsv2_bufferSizeExt",                     "rocsparse_dbsrsv_buffer_size",                                     CONV_LIB_FUNC, API_SPARSE, 9, CUDA_DEPRECATED};
+  m["cusparseCbsrsv2_bufferSize"]                                     = {"hipsparseCbsrsv2_bufferSize",                        "rocsparse_cbsrsv_buffer_size",                                     CONV_LIB_FUNC, API_SPARSE, 9, CUDA_DEPRECATED | HIP_DEPRECATED};
+  m["cusparseCbsrsv2_bufferSizeExt"]                                  = {"hipsparseCbsrsv2_bufferSizeExt",                     "rocsparse_cbsrsv_buffer_size",                                     CONV_LIB_FUNC, API_SPARSE, 9, CUDA_DEPRECATED};
+  m["cusparseZbsrsv2_bufferSize"]                                     = {"hipsparseZbsrsv2_bufferSize",                        "rocsparse_zbsrsv_buffer_size",                                     CONV_LIB_FUNC, API_SPARSE, 9, CUDA_DEPRECATED | HIP_DEPRECATED};
+  m["cusparseZbsrsv2_bufferSizeExt"]                                  = {"hipsparseZbsrsv2_bufferSizeExt",                     "rocsparse_zbsrsv_buffer_size",                                     CONV_LIB_FUNC, API_SPARSE, 9, CUDA_DEPRECATED};
 
-  {"cusparseSbsrsv2_analysis",                             {"hipsparseSbsrsv2_analysis",                          "rocsparse_sbsrsv_analysis",                                        CONV_LIB_FUNC, API_SPARSE, 9, CUDA_DEPRECATED | HIP_DEPRECATED}},
-  {"cusparseDbsrsv2_analysis",                             {"hipsparseDbsrsv2_analysis",                          "rocsparse_dbsrsv_analysis",                                        CONV_LIB_FUNC, API_SPARSE, 9, CUDA_DEPRECATED | HIP_DEPRECATED}},
-  {"cusparseCbsrsv2_analysis",                             {"hipsparseCbsrsv2_analysis",                          "rocsparse_cbsrsv_analysis",                                        CONV_LIB_FUNC, API_SPARSE, 9, CUDA_DEPRECATED | HIP_DEPRECATED}},
-  {"cusparseZbsrsv2_analysis",                             {"hipsparseZbsrsv2_analysis",                          "rocsparse_zbsrsv_analysis",                                        CONV_LIB_FUNC, API_SPARSE, 9, CUDA_DEPRECATED | HIP_DEPRECATED}},
+  m["cusparseSbsrsv2_analysis"]                                       = {"hipsparseSbsrsv2_analysis",                          "rocsparse_sbsrsv_analysis",                                        CONV_LIB_FUNC, API_SPARSE, 9, CUDA_DEPRECATED | HIP_DEPRECATED};
+  m["cusparseDbsrsv2_analysis"]                                       = {"hipsparseDbsrsv2_analysis",                          "rocsparse_dbsrsv_analysis",                                        CONV_LIB_FUNC, API_SPARSE, 9, CUDA_DEPRECATED | HIP_DEPRECATED};
+  m["cusparseCbsrsv2_analysis"]                                       = {"hipsparseCbsrsv2_analysis",                          "rocsparse_cbsrsv_analysis",                                        CONV_LIB_FUNC, API_SPARSE, 9, CUDA_DEPRECATED | HIP_DEPRECATED};
+  m["cusparseZbsrsv2_analysis"]                                       = {"hipsparseZbsrsv2_analysis",                          "rocsparse_zbsrsv_analysis",                                        CONV_LIB_FUNC, API_SPARSE, 9, CUDA_DEPRECATED | HIP_DEPRECATED};
 
-  {"cusparseScsrsv_solve",                                 {"hipsparseScsrsv_solve",                              "",                                                                 CONV_LIB_FUNC, API_SPARSE, 9, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED}},
-  {"cusparseDcsrsv_solve",                                 {"hipsparseDcsrsv_solve",                              "",                                                                 CONV_LIB_FUNC, API_SPARSE, 9, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED}},
-  {"cusparseCcsrsv_solve",                                 {"hipsparseCcsrsv_solve",                              "",                                                                 CONV_LIB_FUNC, API_SPARSE, 9, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED}},
-  {"cusparseZcsrsv_solve",                                 {"hipsparseZcsrsv_solve",                              "",                                                                 CONV_LIB_FUNC, API_SPARSE, 9, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED}},
+  m["cusparseScsrsv_solve"]                                           = {"hipsparseScsrsv_solve",                              "",                                                                 CONV_LIB_FUNC, API_SPARSE, 9, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED};
+  m["cusparseDcsrsv_solve"]                                           = {"hipsparseDcsrsv_solve",                              "",                                                                 CONV_LIB_FUNC, API_SPARSE, 9, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED};
+  m["cusparseCcsrsv_solve"]                                           = {"hipsparseCcsrsv_solve",                              "",                                                                 CONV_LIB_FUNC, API_SPARSE, 9, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED};
+  m["cusparseZcsrsv_solve"]                                           = {"hipsparseZcsrsv_solve",                              "",                                                                 CONV_LIB_FUNC, API_SPARSE, 9, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED};
 
-  {"cusparseSbsrsv2_solve",                                {"hipsparseSbsrsv2_solve",                             "rocsparse_sbsrsv_solve",                                           CONV_LIB_FUNC, API_SPARSE, 9, CUDA_DEPRECATED | HIP_DEPRECATED}},
-  {"cusparseDbsrsv2_solve",                                {"hipsparseDbsrsv2_solve",                             "rocsparse_dbsrsv_solve",                                           CONV_LIB_FUNC, API_SPARSE, 9, CUDA_DEPRECATED | HIP_DEPRECATED}},
-  {"cusparseCbsrsv2_solve",                                {"hipsparseCbsrsv2_solve",                             "rocsparse_cbsrsv_solve",                                           CONV_LIB_FUNC, API_SPARSE, 9, CUDA_DEPRECATED | HIP_DEPRECATED}},
-  {"cusparseZbsrsv2_solve",                                {"hipsparseZbsrsv2_solve",                             "rocsparse_zbsrsv_solve",                                           CONV_LIB_FUNC, API_SPARSE, 9, CUDA_DEPRECATED | HIP_DEPRECATED}},
-  {"cusparseXbsrsv2_zeroPivot",                            {"hipsparseXbsrsv2_zeroPivot",                         "rocsparse_bsrsv_zero_pivot",                                       CONV_LIB_FUNC, API_SPARSE, 9, CUDA_DEPRECATED | HIP_DEPRECATED}},
+  m["cusparseSbsrsv2_solve"]                                          = {"hipsparseSbsrsv2_solve",                             "rocsparse_sbsrsv_solve",                                           CONV_LIB_FUNC, API_SPARSE, 9, CUDA_DEPRECATED | HIP_DEPRECATED};
+  m["cusparseDbsrsv2_solve"]                                          = {"hipsparseDbsrsv2_solve",                             "rocsparse_dbsrsv_solve",                                           CONV_LIB_FUNC, API_SPARSE, 9, CUDA_DEPRECATED | HIP_DEPRECATED};
+  m["cusparseCbsrsv2_solve"]                                          = {"hipsparseCbsrsv2_solve",                             "rocsparse_cbsrsv_solve",                                           CONV_LIB_FUNC, API_SPARSE, 9, CUDA_DEPRECATED | HIP_DEPRECATED};
+  m["cusparseZbsrsv2_solve"]                                          = {"hipsparseZbsrsv2_solve",                             "rocsparse_zbsrsv_solve",                                           CONV_LIB_FUNC, API_SPARSE, 9, CUDA_DEPRECATED | HIP_DEPRECATED};
+  m["cusparseXbsrsv2_zeroPivot"]                                      = {"hipsparseXbsrsv2_zeroPivot",                         "rocsparse_bsrsv_zero_pivot",                                       CONV_LIB_FUNC, API_SPARSE, 9, CUDA_DEPRECATED | HIP_DEPRECATED};
 
-  {"cusparseScsrsv_analysis",                              {"hipsparseScsrsv_analysis",                           "",                                                                 CONV_LIB_FUNC, API_SPARSE, 9, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED}},
-  {"cusparseDcsrsv_analysis",                              {"hipsparseDcsrsv_analysis",                           "",                                                                 CONV_LIB_FUNC, API_SPARSE, 9, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED}},
-  {"cusparseCcsrsv_analysis",                              {"hipsparseCcsrsv_analysis",                           "",                                                                 CONV_LIB_FUNC, API_SPARSE, 9, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED}},
-  {"cusparseZcsrsv_analysis",                              {"hipsparseZcsrsv_analysis",                           "",                                                                 CONV_LIB_FUNC, API_SPARSE, 9, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED}},
+  m["cusparseScsrsv_analysis"]                                        = {"hipsparseScsrsv_analysis",                           "",                                                                 CONV_LIB_FUNC, API_SPARSE, 9, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED};
+  m["cusparseDcsrsv_analysis"]                                        = {"hipsparseDcsrsv_analysis",                           "",                                                                 CONV_LIB_FUNC, API_SPARSE, 9, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED};
+  m["cusparseCcsrsv_analysis"]                                        = {"hipsparseCcsrsv_analysis",                           "",                                                                 CONV_LIB_FUNC, API_SPARSE, 9, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED};
+  m["cusparseZcsrsv_analysis"]                                        = {"hipsparseZcsrsv_analysis",                           "",                                                                 CONV_LIB_FUNC, API_SPARSE, 9, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED};
 
-  {"cusparseCsrsv_analysisEx",                             {"hipsparseCsrsv_analysisEx",                          "",                                                                 CONV_LIB_FUNC, API_SPARSE, 9, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED}},
-  {"cusparseCsrsv_solveEx",                                {"hipsparseCsrsv_solveEx",                             "",                                                                 CONV_LIB_FUNC, API_SPARSE, 9, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED}},
+  m["cusparseCsrsv_analysisEx"]                                       = {"hipsparseCsrsv_analysisEx",                          "",                                                                 CONV_LIB_FUNC, API_SPARSE, 9, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED};
+  m["cusparseCsrsv_solveEx"]                                          = {"hipsparseCsrsv_solveEx",                             "",                                                                 CONV_LIB_FUNC, API_SPARSE, 9, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED};
 
-  {"cusparseScsrsv2_bufferSize",                           {"hipsparseScsrsv2_bufferSize",                        "rocsparse_scsrsv_buffer_size",                                     CONV_LIB_FUNC, API_SPARSE, 9, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED}},
-  {"cusparseScsrsv2_bufferSizeExt",                        {"hipsparseScsrsv2_bufferSizeExt",                     "rocsparse_scsrsv_buffer_size",                                     CONV_LIB_FUNC, API_SPARSE, 9, CUDA_DEPRECATED | CUDA_REMOVED}},
-  {"cusparseDcsrsv2_bufferSize",                           {"hipsparseDcsrsv2_bufferSize",                        "rocsparse_dcsrsv_buffer_size",                                     CONV_LIB_FUNC, API_SPARSE, 9, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED}},
-  {"cusparseDcsrsv2_bufferSizeExt",                        {"hipsparseDcsrsv2_bufferSizeExt",                     "rocsparse_dcsrsv_buffer_size",                                     CONV_LIB_FUNC, API_SPARSE, 9, CUDA_DEPRECATED | CUDA_REMOVED}},
-  {"cusparseCcsrsv2_bufferSize",                           {"hipsparseCcsrsv2_bufferSize",                        "rocsparse_ccsrsv_buffer_size",                                     CONV_LIB_FUNC, API_SPARSE, 9, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED}},
-  {"cusparseCcsrsv2_bufferSizeExt",                        {"hipsparseCcsrsv2_bufferSizeExt",                     "rocsparse_ccsrsv_buffer_size",                                     CONV_LIB_FUNC, API_SPARSE, 9, CUDA_DEPRECATED | CUDA_REMOVED}},
-  {"cusparseZcsrsv2_bufferSize",                           {"hipsparseZcsrsv2_bufferSize",                        "rocsparse_zcsrsv_buffer_size",                                     CONV_LIB_FUNC, API_SPARSE, 9, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED}},
-  {"cusparseZcsrsv2_bufferSizeExt",                        {"hipsparseZcsrsv2_bufferSizeExt",                     "rocsparse_zcsrsv_buffer_size",                                     CONV_LIB_FUNC, API_SPARSE, 9, CUDA_DEPRECATED | CUDA_REMOVED}},
+  m["cusparseScsrsv2_bufferSize"]                                     = {"hipsparseScsrsv2_bufferSize",                        "rocsparse_scsrsv_buffer_size",                                     CONV_LIB_FUNC, API_SPARSE, 9, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED};
+  m["cusparseScsrsv2_bufferSizeExt"]                                  = {"hipsparseScsrsv2_bufferSizeExt",                     "rocsparse_scsrsv_buffer_size",                                     CONV_LIB_FUNC, API_SPARSE, 9, CUDA_DEPRECATED | CUDA_REMOVED};
+  m["cusparseDcsrsv2_bufferSize"]                                     = {"hipsparseDcsrsv2_bufferSize",                        "rocsparse_dcsrsv_buffer_size",                                     CONV_LIB_FUNC, API_SPARSE, 9, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED};
+  m["cusparseDcsrsv2_bufferSizeExt"]                                  = {"hipsparseDcsrsv2_bufferSizeExt",                     "rocsparse_dcsrsv_buffer_size",                                     CONV_LIB_FUNC, API_SPARSE, 9, CUDA_DEPRECATED | CUDA_REMOVED};
+  m["cusparseCcsrsv2_bufferSize"]                                     = {"hipsparseCcsrsv2_bufferSize",                        "rocsparse_ccsrsv_buffer_size",                                     CONV_LIB_FUNC, API_SPARSE, 9, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED};
+  m["cusparseCcsrsv2_bufferSizeExt"]                                  = {"hipsparseCcsrsv2_bufferSizeExt",                     "rocsparse_ccsrsv_buffer_size",                                     CONV_LIB_FUNC, API_SPARSE, 9, CUDA_DEPRECATED | CUDA_REMOVED};
+  m["cusparseZcsrsv2_bufferSize"]                                     = {"hipsparseZcsrsv2_bufferSize",                        "rocsparse_zcsrsv_buffer_size",                                     CONV_LIB_FUNC, API_SPARSE, 9, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED};
+  m["cusparseZcsrsv2_bufferSizeExt"]                                  = {"hipsparseZcsrsv2_bufferSizeExt",                     "rocsparse_zcsrsv_buffer_size",                                     CONV_LIB_FUNC, API_SPARSE, 9, CUDA_DEPRECATED | CUDA_REMOVED};
 
-  {"cusparseScsrsv2_analysis",                             {"hipsparseScsrsv2_analysis",                          "rocsparse_scsrsv_analysis",                                        CONV_LIB_FUNC, API_SPARSE, 9, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED}},
-  {"cusparseDcsrsv2_analysis",                             {"hipsparseDcsrsv2_analysis",                          "rocsparse_dcsrsv_analysis",                                        CONV_LIB_FUNC, API_SPARSE, 9, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED}},
-  {"cusparseCcsrsv2_analysis",                             {"hipsparseCcsrsv2_analysis",                          "rocsparse_ccsrsv_analysis",                                        CONV_LIB_FUNC, API_SPARSE, 9, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED}},
-  {"cusparseZcsrsv2_analysis",                             {"hipsparseZcsrsv2_analysis",                          "rocsparse_zcsrsv_analysis",                                        CONV_LIB_FUNC, API_SPARSE, 9, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED}},
+  m["cusparseScsrsv2_analysis"]                                       = {"hipsparseScsrsv2_analysis",                          "rocsparse_scsrsv_analysis",                                        CONV_LIB_FUNC, API_SPARSE, 9, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED};
+  m["cusparseDcsrsv2_analysis"]                                       = {"hipsparseDcsrsv2_analysis",                          "rocsparse_dcsrsv_analysis",                                        CONV_LIB_FUNC, API_SPARSE, 9, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED};
+  m["cusparseCcsrsv2_analysis"]                                       = {"hipsparseCcsrsv2_analysis",                          "rocsparse_ccsrsv_analysis",                                        CONV_LIB_FUNC, API_SPARSE, 9, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED};
+  m["cusparseZcsrsv2_analysis"]                                       = {"hipsparseZcsrsv2_analysis",                          "rocsparse_zcsrsv_analysis",                                        CONV_LIB_FUNC, API_SPARSE, 9, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED};
 
-  {"cusparseScsrsv2_solve",                                {"hipsparseScsrsv2_solve",                             "rocsparse_scsrsv_solve",                                           CONV_LIB_FUNC, API_SPARSE, 9, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED}},
-  {"cusparseDcsrsv2_solve",                                {"hipsparseDcsrsv2_solve",                             "rocsparse_dcsrsv_solve",                                           CONV_LIB_FUNC, API_SPARSE, 9, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED}},
-  {"cusparseCcsrsv2_solve",                                {"hipsparseCcsrsv2_solve",                             "rocsparse_ccsrsv_solve",                                           CONV_LIB_FUNC, API_SPARSE, 9, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED}},
-  {"cusparseZcsrsv2_solve",                                {"hipsparseZcsrsv2_solve",                             "rocsparse_zcsrsv_solve",                                           CONV_LIB_FUNC, API_SPARSE, 9, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED}},
+  m["cusparseScsrsv2_solve"]                                          = {"hipsparseScsrsv2_solve",                             "rocsparse_scsrsv_solve",                                           CONV_LIB_FUNC, API_SPARSE, 9, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED};
+  m["cusparseDcsrsv2_solve"]                                          = {"hipsparseDcsrsv2_solve",                             "rocsparse_dcsrsv_solve",                                           CONV_LIB_FUNC, API_SPARSE, 9, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED};
+  m["cusparseCcsrsv2_solve"]                                          = {"hipsparseCcsrsv2_solve",                             "rocsparse_ccsrsv_solve",                                           CONV_LIB_FUNC, API_SPARSE, 9, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED};
+  m["cusparseZcsrsv2_solve"]                                          = {"hipsparseZcsrsv2_solve",                             "rocsparse_zcsrsv_solve",                                           CONV_LIB_FUNC, API_SPARSE, 9, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED};
+
   // TODO: rocsparse_get_stream and hipStreamSynchronize need to be added correspondingly before and after rocsparse_csrsv_zero_pivot call, because cusparseXcsrsv2_zeroPivot is blocking, and rocsparse_csrsv_zero_pivot is not
-  {"cusparseXcsrsv2_zeroPivot",                            {"hipsparseXcsrsv2_zeroPivot",                         "rocsparse_csrsv_zero_pivot",                                       CONV_LIB_FUNC, API_SPARSE, 9, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED}},
+  m["cusparseXcsrsv2_zeroPivot"]                                      = {"hipsparseXcsrsv2_zeroPivot",                         "rocsparse_csrsv_zero_pivot",                                       CONV_LIB_FUNC, API_SPARSE, 9, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED};
 
-  {"cusparseShybmv",                                       {"hipsparseShybmv",                                    "rocsparse_shybmv",                                                 CONV_LIB_FUNC, API_SPARSE, 9, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED}},
-  {"cusparseDhybmv",                                       {"hipsparseDhybmv",                                    "rocsparse_dhybmv",                                                 CONV_LIB_FUNC, API_SPARSE, 9, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED}},
-  {"cusparseChybmv",                                       {"hipsparseChybmv",                                    "rocsparse_chybmv",                                                 CONV_LIB_FUNC, API_SPARSE, 9, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED}},
-  {"cusparseZhybmv",                                       {"hipsparseZhybmv",                                    "rocsparse_zhybmv",                                                 CONV_LIB_FUNC, API_SPARSE, 9, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED}},
+  m["cusparseShybmv"]                                                 = {"hipsparseShybmv",                                    "rocsparse_shybmv",                                                 CONV_LIB_FUNC, API_SPARSE, 9, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED};
+  m["cusparseDhybmv"]                                                 = {"hipsparseDhybmv",                                    "rocsparse_dhybmv",                                                 CONV_LIB_FUNC, API_SPARSE, 9, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED};
+  m["cusparseChybmv"]                                                 = {"hipsparseChybmv",                                    "rocsparse_chybmv",                                                 CONV_LIB_FUNC, API_SPARSE, 9, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED};
+  m["cusparseZhybmv"]                                                 = {"hipsparseZhybmv",                                    "rocsparse_zhybmv",                                                 CONV_LIB_FUNC, API_SPARSE, 9, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED};
 
-  {"cusparseShybsv_analysis",                              {"hipsparseShybsv_analysis",                           "",                                                                 CONV_LIB_FUNC, API_SPARSE, 9, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED}},
-  {"cusparseDhybsv_analysis",                              {"hipsparseDhybsv_analysis",                           "",                                                                 CONV_LIB_FUNC, API_SPARSE, 9, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED}},
-  {"cusparseChybsv_analysis",                              {"hipsparseChybsv_analysis",                           "",                                                                 CONV_LIB_FUNC, API_SPARSE, 9, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED}},
-  {"cusparseZhybsv_analysis",                              {"hipsparseZhybsv_analysis",                           "",                                                                 CONV_LIB_FUNC, API_SPARSE, 9, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED}},
+  m["cusparseShybsv_analysis"]                                        = {"hipsparseShybsv_analysis",                           "",                                                                 CONV_LIB_FUNC, API_SPARSE, 9, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED};
+  m["cusparseDhybsv_analysis"]                                        = {"hipsparseDhybsv_analysis",                           "",                                                                 CONV_LIB_FUNC, API_SPARSE, 9, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED};
+  m["cusparseChybsv_analysis"]                                        = {"hipsparseChybsv_analysis",                           "",                                                                 CONV_LIB_FUNC, API_SPARSE, 9, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED};
+  m["cusparseZhybsv_analysis"]                                        = {"hipsparseZhybsv_analysis",                           "",                                                                 CONV_LIB_FUNC, API_SPARSE, 9, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED};
 
-  {"cusparseShybsv_solve",                                 {"hipsparseShybsv_solve",                              "",                                                                 CONV_LIB_FUNC, API_SPARSE, 9, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED}},
-  {"cusparseDhybsv_solve",                                 {"hipsparseDhybsv_solve",                              "",                                                                 CONV_LIB_FUNC, API_SPARSE, 9, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED}},
-  {"cusparseChybsv_solve",                                 {"hipsparseChybsv_solve",                              "",                                                                 CONV_LIB_FUNC, API_SPARSE, 9, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED}},
-  {"cusparseZhybsv_solve",                                 {"hipsparseZhybsv_solve",                              "",                                                                 CONV_LIB_FUNC, API_SPARSE, 9, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED}},
+  m["cusparseShybsv_solve"]                                           = {"hipsparseShybsv_solve",                              "",                                                                 CONV_LIB_FUNC, API_SPARSE, 9, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED};
+  m["cusparseDhybsv_solve"]                                           = {"hipsparseDhybsv_solve",                              "",                                                                 CONV_LIB_FUNC, API_SPARSE, 9, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED};
+  m["cusparseChybsv_solve"]                                           = {"hipsparseChybsv_solve",                              "",                                                                 CONV_LIB_FUNC, API_SPARSE, 9, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED};
+  m["cusparseZhybsv_solve"]                                           = {"hipsparseZhybsv_solve",                              "",                                                                 CONV_LIB_FUNC, API_SPARSE, 9, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED};
 
   // 10. cuSPARSE Level 3 Function Reference
-  {"cusparseScsrmm",                                       {"hipsparseScsrmm",                                    "rocsparse_scsrmm",                                                 CONV_LIB_FUNC, API_SPARSE, 10, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED}},
-  {"cusparseDcsrmm",                                       {"hipsparseDcsrmm",                                    "rocsparse_dcsrmm",                                                 CONV_LIB_FUNC, API_SPARSE, 10, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED}},
-  {"cusparseCcsrmm",                                       {"hipsparseCcsrmm",                                    "rocsparse_ccsrmm",                                                 CONV_LIB_FUNC, API_SPARSE, 10, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED}},
-  {"cusparseZcsrmm",                                       {"hipsparseZcsrmm",                                    "rocsparse_zcsrmm",                                                 CONV_LIB_FUNC, API_SPARSE, 10, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED}},
+  m["cusparseScsrmm"]                                                 = {"hipsparseScsrmm",                                    "rocsparse_scsrmm",                                                 CONV_LIB_FUNC, API_SPARSE, 10, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED};
+  m["cusparseDcsrmm"]                                                 = {"hipsparseDcsrmm",                                    "rocsparse_dcsrmm",                                                 CONV_LIB_FUNC, API_SPARSE, 10, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED};
+  m["cusparseCcsrmm"]                                                 = {"hipsparseCcsrmm",                                    "rocsparse_ccsrmm",                                                 CONV_LIB_FUNC, API_SPARSE, 10, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED};
+  m["cusparseZcsrmm"]                                                 = {"hipsparseZcsrmm",                                    "rocsparse_zcsrmm",                                                 CONV_LIB_FUNC, API_SPARSE, 10, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED};
 
-  {"cusparseScsrmm2",                                      {"hipsparseScsrmm2",                                   "rocsparse_scsrmm",                                                 CONV_LIB_FUNC, API_SPARSE, 10, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED}},
-  {"cusparseDcsrmm2",                                      {"hipsparseDcsrmm2",                                   "rocsparse_dcsrmm",                                                 CONV_LIB_FUNC, API_SPARSE, 10, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED}},
-  {"cusparseCcsrmm2",                                      {"hipsparseCcsrmm2",                                   "rocsparse_ccsrmm",                                                 CONV_LIB_FUNC, API_SPARSE, 10, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED}},
-  {"cusparseZcsrmm2",                                      {"hipsparseZcsrmm2",                                   "rocsparse_zcsrmm",                                                 CONV_LIB_FUNC, API_SPARSE, 10, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED}},
+  m["cusparseScsrmm2"]                                                = {"hipsparseScsrmm2",                                   "rocsparse_scsrmm",                                                 CONV_LIB_FUNC, API_SPARSE, 10, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED};
+  m["cusparseDcsrmm2"]                                                = {"hipsparseDcsrmm2",                                   "rocsparse_dcsrmm",                                                 CONV_LIB_FUNC, API_SPARSE, 10, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED};
+  m["cusparseCcsrmm2"]                                                = {"hipsparseCcsrmm2",                                   "rocsparse_ccsrmm",                                                 CONV_LIB_FUNC, API_SPARSE, 10, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED};
+  m["cusparseZcsrmm2"]                                                = {"hipsparseZcsrmm2",                                   "rocsparse_zcsrmm",                                                 CONV_LIB_FUNC, API_SPARSE, 10, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED};
 
-  {"cusparseScsrsm_analysis",                              {"hipsparseScsrsm_analysis",                           "",                                                                 CONV_LIB_FUNC, API_SPARSE, 10, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED}},
-  {"cusparseDcsrsm_analysis",                              {"hipsparseDcsrsm_analysis",                           "",                                                                 CONV_LIB_FUNC, API_SPARSE, 10, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED}},
-  {"cusparseCcsrsm_analysis",                              {"hipsparseCcsrsm_analysis",                           "",                                                                 CONV_LIB_FUNC, API_SPARSE, 10, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED}},
-  {"cusparseZcsrsm_analysis",                              {"hipsparseZcsrsm_analysis",                           "",                                                                 CONV_LIB_FUNC, API_SPARSE, 10, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED}},
+  m["cusparseScsrsm_analysis"]                                        = {"hipsparseScsrsm_analysis",                           "",                                                                 CONV_LIB_FUNC, API_SPARSE, 10, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED};
+  m["cusparseDcsrsm_analysis"]                                        = {"hipsparseDcsrsm_analysis",                           "",                                                                 CONV_LIB_FUNC, API_SPARSE, 10, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED};
+  m["cusparseCcsrsm_analysis"]                                        = {"hipsparseCcsrsm_analysis",                           "",                                                                 CONV_LIB_FUNC, API_SPARSE, 10, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED};
+  m["cusparseZcsrsm_analysis"]                                        = {"hipsparseZcsrsm_analysis",                           "",                                                                 CONV_LIB_FUNC, API_SPARSE, 10, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED};
 
-  {"cusparseScsrsm_solve",                                 {"hipsparseScsrsm_solve",                              "",                                                                 CONV_LIB_FUNC, API_SPARSE, 10, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED}},
-  {"cusparseDcsrsm_solve",                                 {"hipsparseDcsrsm_solve",                              "",                                                                 CONV_LIB_FUNC, API_SPARSE, 10, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED}},
-  {"cusparseCcsrsm_solve",                                 {"hipsparseCcsrsm_solve",                              "",                                                                 CONV_LIB_FUNC, API_SPARSE, 10, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED}},
-  {"cusparseZcsrsm_solve",                                 {"hipsparseZcsrsm_solve",                              "",                                                                 CONV_LIB_FUNC, API_SPARSE, 10, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED}},
+  m["cusparseScsrsm_solve"]                                           = {"hipsparseScsrsm_solve",                              "",                                                                 CONV_LIB_FUNC, API_SPARSE, 10, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED};
+  m["cusparseDcsrsm_solve"]                                           = {"hipsparseDcsrsm_solve",                              "",                                                                 CONV_LIB_FUNC, API_SPARSE, 10, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED};
+  m["cusparseCcsrsm_solve"]                                           = {"hipsparseCcsrsm_solve",                              "",                                                                 CONV_LIB_FUNC, API_SPARSE, 10, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED};
+  m["cusparseZcsrsm_solve"]                                           = {"hipsparseZcsrsm_solve",                              "",                                                                 CONV_LIB_FUNC, API_SPARSE, 10, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED};
 
-  {"cusparseScsrsm2_bufferSizeExt",                        {"hipsparseScsrsm2_bufferSizeExt",                     "rocsparse_scsrsm_buffer_size",                                     CONV_LIB_FUNC, API_SPARSE, 10, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED}},
-  {"cusparseDcsrsm2_bufferSizeExt",                        {"hipsparseDcsrsm2_bufferSizeExt",                     "rocsparse_dcsrsm_buffer_size",                                     CONV_LIB_FUNC, API_SPARSE, 10, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED}},
-  {"cusparseCcsrsm2_bufferSizeExt",                        {"hipsparseCcsrsm2_bufferSizeExt",                     "rocsparse_ccsrsm_buffer_size",                                     CONV_LIB_FUNC, API_SPARSE, 10, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED}},
-  {"cusparseZcsrsm2_bufferSizeExt",                        {"hipsparseZcsrsm2_bufferSizeExt",                     "rocsparse_zcsrsm_buffer_size",                                     CONV_LIB_FUNC, API_SPARSE, 10, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED}},
+  m["cusparseScsrsm2_bufferSizeExt"]                                  = {"hipsparseScsrsm2_bufferSizeExt",                     "rocsparse_scsrsm_buffer_size",                                     CONV_LIB_FUNC, API_SPARSE, 10, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED};
+  m["cusparseDcsrsm2_bufferSizeExt"]                                  = {"hipsparseDcsrsm2_bufferSizeExt",                     "rocsparse_dcsrsm_buffer_size",                                     CONV_LIB_FUNC, API_SPARSE, 10, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED};
+  m["cusparseCcsrsm2_bufferSizeExt"]                                  = {"hipsparseCcsrsm2_bufferSizeExt",                     "rocsparse_ccsrsm_buffer_size",                                     CONV_LIB_FUNC, API_SPARSE, 10, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED};
+  m["cusparseZcsrsm2_bufferSizeExt"]                                  = {"hipsparseZcsrsm2_bufferSizeExt",                     "rocsparse_zcsrsm_buffer_size",                                     CONV_LIB_FUNC, API_SPARSE, 10, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED};
 
-  {"cusparseScsrsm2_analysis",                             {"hipsparseScsrsm2_analysis",                          "rocsparse_scsrsm_analysis",                                        CONV_LIB_FUNC, API_SPARSE, 10, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED}},
-  {"cusparseDcsrsm2_analysis",                             {"hipsparseDcsrsm2_analysis",                          "rocsparse_dcsrsm_analysis",                                        CONV_LIB_FUNC, API_SPARSE, 10, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED}},
-  {"cusparseCcsrsm2_analysis",                             {"hipsparseCcsrsm2_analysis",                          "rocsparse_ccsrsm_analysis",                                        CONV_LIB_FUNC, API_SPARSE, 10, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED}},
-  {"cusparseZcsrsm2_analysis",                             {"hipsparseZcsrsm2_analysis",                          "rocsparse_zcsrsm_analysis",                                        CONV_LIB_FUNC, API_SPARSE, 10, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED}},
+  m["cusparseScsrsm2_analysis"]                                       = {"hipsparseScsrsm2_analysis",                          "rocsparse_scsrsm_analysis",                                        CONV_LIB_FUNC, API_SPARSE, 10, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED};
+  m["cusparseDcsrsm2_analysis"]                                       = {"hipsparseDcsrsm2_analysis",                          "rocsparse_dcsrsm_analysis",                                        CONV_LIB_FUNC, API_SPARSE, 10, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED};
+  m["cusparseCcsrsm2_analysis"]                                       = {"hipsparseCcsrsm2_analysis",                          "rocsparse_ccsrsm_analysis",                                        CONV_LIB_FUNC, API_SPARSE, 10, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED};
+  m["cusparseZcsrsm2_analysis"]                                       = {"hipsparseZcsrsm2_analysis",                          "rocsparse_zcsrsm_analysis",                                        CONV_LIB_FUNC, API_SPARSE, 10, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED};
 
-  {"cusparseScsrsm2_solve",                                {"hipsparseScsrsm2_solve",                             "rocsparse_scsrsm_solve",                                           CONV_LIB_FUNC, API_SPARSE, 10, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED}},
-  {"cusparseDcsrsm2_solve",                                {"hipsparseDcsrsm2_solve",                             "rocsparse_dcsrsm_solve",                                           CONV_LIB_FUNC, API_SPARSE, 10, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED}},
-  {"cusparseCcsrsm2_solve",                                {"hipsparseCcsrsm2_solve",                             "rocsparse_ccsrsm_solve",                                           CONV_LIB_FUNC, API_SPARSE, 10, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED}},
-  {"cusparseZcsrsm2_solve",                                {"hipsparseZcsrsm2_solve",                             "rocsparse_zcsrsm_solve",                                           CONV_LIB_FUNC, API_SPARSE, 10, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED}},
-  {"cusparseXcsrsm2_zeroPivot",                            {"hipsparseXcsrsm2_zeroPivot",                         "rocsparse_csrsm_zero_pivot",                                       CONV_LIB_FUNC, API_SPARSE, 10, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED}},
+  m["cusparseScsrsm2_solve"]                                          = {"hipsparseScsrsm2_solve",                             "rocsparse_scsrsm_solve",                                           CONV_LIB_FUNC, API_SPARSE, 10, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED};
+  m["cusparseDcsrsm2_solve"]                                          = {"hipsparseDcsrsm2_solve",                             "rocsparse_dcsrsm_solve",                                           CONV_LIB_FUNC, API_SPARSE, 10, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED};
+  m["cusparseCcsrsm2_solve"]                                          = {"hipsparseCcsrsm2_solve",                             "rocsparse_ccsrsm_solve",                                           CONV_LIB_FUNC, API_SPARSE, 10, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED};
+  m["cusparseZcsrsm2_solve"]                                          = {"hipsparseZcsrsm2_solve",                             "rocsparse_zcsrsm_solve",                                           CONV_LIB_FUNC, API_SPARSE, 10, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED};
+  m["cusparseXcsrsm2_zeroPivot"]                                      = {"hipsparseXcsrsm2_zeroPivot",                         "rocsparse_csrsm_zero_pivot",                                       CONV_LIB_FUNC, API_SPARSE, 10, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED};
 
-  {"cusparseSbsrmm",                                       {"hipsparseSbsrmm",                                    "rocsparse_sbsrmm",                                                 CONV_LIB_FUNC, API_SPARSE, 10, CUDA_DEPRECATED}},
-  {"cusparseDbsrmm",                                       {"hipsparseDbsrmm",                                    "rocsparse_dbsrmm",                                                 CONV_LIB_FUNC, API_SPARSE, 10, CUDA_DEPRECATED}},
-  {"cusparseCbsrmm",                                       {"hipsparseCbsrmm",                                    "rocsparse_cbsrmm",                                                 CONV_LIB_FUNC, API_SPARSE, 10, CUDA_DEPRECATED}},
-  {"cusparseZbsrmm",                                       {"hipsparseZbsrmm",                                    "rocsparse_zbsrmm",                                                 CONV_LIB_FUNC, API_SPARSE, 10, CUDA_DEPRECATED}},
+  m["cusparseSbsrmm"]                                                 = {"hipsparseSbsrmm",                                    "rocsparse_sbsrmm",                                                 CONV_LIB_FUNC, API_SPARSE, 10, CUDA_DEPRECATED};
+  m["cusparseDbsrmm"]                                                 = {"hipsparseDbsrmm",                                    "rocsparse_dbsrmm",                                                 CONV_LIB_FUNC, API_SPARSE, 10, CUDA_DEPRECATED};
+  m["cusparseCbsrmm"]                                                 = {"hipsparseCbsrmm",                                    "rocsparse_cbsrmm",                                                 CONV_LIB_FUNC, API_SPARSE, 10, CUDA_DEPRECATED};
+  m["cusparseZbsrmm"]                                                 = {"hipsparseZbsrmm",                                    "rocsparse_zbsrmm",                                                 CONV_LIB_FUNC, API_SPARSE, 10, CUDA_DEPRECATED};
 
-  {"cusparseSbsrsm2_bufferSize",                           {"hipsparseSbsrsm2_bufferSize",                        "rocsparse_sbsrsm_buffer_size",                                     CONV_LIB_FUNC, API_SPARSE, 10, CUDA_DEPRECATED | HIP_DEPRECATED}},
-  {"cusparseSbsrsm2_bufferSizeExt",                        {"hipsparseSbsrsm2_bufferSizeExt",                     "",                                                                 CONV_LIB_FUNC, API_SPARSE, 10, UNSUPPORTED | CUDA_DEPRECATED}},
-  {"cusparseDbsrsm2_bufferSize",                           {"hipsparseDbsrsm2_bufferSize",                        "rocsparse_dbsrsm_buffer_size",                                     CONV_LIB_FUNC, API_SPARSE, 10, CUDA_DEPRECATED | HIP_DEPRECATED}},
-  {"cusparseDbsrsm2_bufferSizeExt",                        {"hipsparseDbsrsm2_bufferSizeExt",                     "",                                                                 CONV_LIB_FUNC, API_SPARSE, 10, UNSUPPORTED | CUDA_DEPRECATED}},
-  {"cusparseCbsrsm2_bufferSize",                           {"hipsparseCbsrsm2_bufferSize",                        "rocsparse_cbsrsm_buffer_size",                                     CONV_LIB_FUNC, API_SPARSE, 10, CUDA_DEPRECATED | HIP_DEPRECATED}},
-  {"cusparseCbsrsm2_bufferSizeExt",                        {"hipsparseCbsrsm2_bufferSizeExt",                     "",                                                                 CONV_LIB_FUNC, API_SPARSE, 10, UNSUPPORTED | CUDA_DEPRECATED}},
-  {"cusparseZbsrsm2_bufferSize",                           {"hipsparseZbsrsm2_bufferSize",                        "rocsparse_zbsrsm_buffer_size",                                     CONV_LIB_FUNC, API_SPARSE, 10, CUDA_DEPRECATED | HIP_DEPRECATED}},
-  {"cusparseZbsrsm2_bufferSizeExt",                        {"hipsparseZbsrsm2_bufferSizeExt",                     "",                                                                 CONV_LIB_FUNC, API_SPARSE, 10, UNSUPPORTED | CUDA_DEPRECATED}},
+  m["cusparseSbsrsm2_bufferSize"]                                     = {"hipsparseSbsrsm2_bufferSize",                        "rocsparse_sbsrsm_buffer_size",                                     CONV_LIB_FUNC, API_SPARSE, 10, CUDA_DEPRECATED | HIP_DEPRECATED};
+  m["cusparseSbsrsm2_bufferSizeExt"]                                  = {"hipsparseSbsrsm2_bufferSizeExt",                     "",                                                                 CONV_LIB_FUNC, API_SPARSE, 10, UNSUPPORTED | CUDA_DEPRECATED};
+  m["cusparseDbsrsm2_bufferSize"]                                     = {"hipsparseDbsrsm2_bufferSize",                        "rocsparse_dbsrsm_buffer_size",                                     CONV_LIB_FUNC, API_SPARSE, 10, CUDA_DEPRECATED | HIP_DEPRECATED};
+  m["cusparseDbsrsm2_bufferSizeExt"]                                  = {"hipsparseDbsrsm2_bufferSizeExt",                     "",                                                                 CONV_LIB_FUNC, API_SPARSE, 10, UNSUPPORTED | CUDA_DEPRECATED};
+  m["cusparseCbsrsm2_bufferSize"]                                     = {"hipsparseCbsrsm2_bufferSize",                        "rocsparse_cbsrsm_buffer_size",                                     CONV_LIB_FUNC, API_SPARSE, 10, CUDA_DEPRECATED | HIP_DEPRECATED};
+  m["cusparseCbsrsm2_bufferSizeExt"]                                  = {"hipsparseCbsrsm2_bufferSizeExt",                     "",                                                                 CONV_LIB_FUNC, API_SPARSE, 10, UNSUPPORTED | CUDA_DEPRECATED};
+  m["cusparseZbsrsm2_bufferSize"]                                     = {"hipsparseZbsrsm2_bufferSize",                        "rocsparse_zbsrsm_buffer_size",                                     CONV_LIB_FUNC, API_SPARSE, 10, CUDA_DEPRECATED | HIP_DEPRECATED};
+  m["cusparseZbsrsm2_bufferSizeExt"]                                  = {"hipsparseZbsrsm2_bufferSizeExt",                     "",                                                                 CONV_LIB_FUNC, API_SPARSE, 10, UNSUPPORTED | CUDA_DEPRECATED};
 
-  {"cusparseSbsrsm2_analysis",                             {"hipsparseSbsrsm2_analysis",                          "rocsparse_sbsrsm_analysis",                                        CONV_LIB_FUNC, API_SPARSE, 10, CUDA_DEPRECATED | HIP_DEPRECATED}},
-  {"cusparseDbsrsm2_analysis",                             {"hipsparseDbsrsm2_analysis",                          "rocsparse_dbsrsm_analysis",                                        CONV_LIB_FUNC, API_SPARSE, 10, CUDA_DEPRECATED | HIP_DEPRECATED}},
-  {"cusparseCbsrsm2_analysis",                             {"hipsparseCbsrsm2_analysis",                          "rocsparse_cbsrsm_analysis",                                        CONV_LIB_FUNC, API_SPARSE, 10, CUDA_DEPRECATED | HIP_DEPRECATED}},
-  {"cusparseZbsrsm2_analysis",                             {"hipsparseZbsrsm2_analysis",                          "rocsparse_zbsrsm_analysis",                                        CONV_LIB_FUNC, API_SPARSE, 10, CUDA_DEPRECATED | HIP_DEPRECATED}},
+  m["cusparseSbsrsm2_analysis"]                                       = {"hipsparseSbsrsm2_analysis",                          "rocsparse_sbsrsm_analysis",                                        CONV_LIB_FUNC, API_SPARSE, 10, CUDA_DEPRECATED | HIP_DEPRECATED};
+  m["cusparseDbsrsm2_analysis"]                                       = {"hipsparseDbsrsm2_analysis",                          "rocsparse_dbsrsm_analysis",                                        CONV_LIB_FUNC, API_SPARSE, 10, CUDA_DEPRECATED | HIP_DEPRECATED};
+  m["cusparseCbsrsm2_analysis"]                                       = {"hipsparseCbsrsm2_analysis",                          "rocsparse_cbsrsm_analysis",                                        CONV_LIB_FUNC, API_SPARSE, 10, CUDA_DEPRECATED | HIP_DEPRECATED};
+  m["cusparseZbsrsm2_analysis"]                                       = {"hipsparseZbsrsm2_analysis",                          "rocsparse_zbsrsm_analysis",                                        CONV_LIB_FUNC, API_SPARSE, 10, CUDA_DEPRECATED | HIP_DEPRECATED};
 
-  {"cusparseSbsrsm2_solve",                                {"hipsparseSbsrsm2_solve",                             "rocsparse_sbsrsm_solve",                                           CONV_LIB_FUNC, API_SPARSE, 10, CUDA_DEPRECATED | HIP_DEPRECATED}},
-  {"cusparseDbsrsm2_solve",                                {"hipsparseDbsrsm2_solve",                             "rocsparse_dbsrsm_solve",                                           CONV_LIB_FUNC, API_SPARSE, 10, CUDA_DEPRECATED | HIP_DEPRECATED}},
-  {"cusparseCbsrsm2_solve",                                {"hipsparseCbsrsm2_solve",                             "rocsparse_cbsrsm_solve",                                           CONV_LIB_FUNC, API_SPARSE, 10, CUDA_DEPRECATED | HIP_DEPRECATED}},
-  {"cusparseZbsrsm2_solve",                                {"hipsparseZbsrsm2_solve",                             "rocsparse_zbsrsm_solve",                                           CONV_LIB_FUNC, API_SPARSE, 10, CUDA_DEPRECATED | HIP_DEPRECATED}},
-  {"cusparseXbsrsm2_zeroPivot",                            {"hipsparseXbsrsm2_zeroPivot",                         "rocsparse_bsrsm_zero_pivot",                                       CONV_LIB_FUNC, API_SPARSE, 10, CUDA_DEPRECATED | HIP_DEPRECATED}},
+  m["cusparseSbsrsm2_solve"]                                          = {"hipsparseSbsrsm2_solve",                             "rocsparse_sbsrsm_solve",                                           CONV_LIB_FUNC, API_SPARSE, 10, CUDA_DEPRECATED | HIP_DEPRECATED};
+  m["cusparseDbsrsm2_solve"]                                          = {"hipsparseDbsrsm2_solve",                             "rocsparse_dbsrsm_solve",                                           CONV_LIB_FUNC, API_SPARSE, 10, CUDA_DEPRECATED | HIP_DEPRECATED};
+  m["cusparseCbsrsm2_solve"]                                          = {"hipsparseCbsrsm2_solve",                             "rocsparse_cbsrsm_solve",                                           CONV_LIB_FUNC, API_SPARSE, 10, CUDA_DEPRECATED | HIP_DEPRECATED};
+  m["cusparseZbsrsm2_solve"]                                          = {"hipsparseZbsrsm2_solve",                             "rocsparse_zbsrsm_solve",                                           CONV_LIB_FUNC, API_SPARSE, 10, CUDA_DEPRECATED | HIP_DEPRECATED};
+  m["cusparseXbsrsm2_zeroPivot"]                                      = {"hipsparseXbsrsm2_zeroPivot",                         "rocsparse_bsrsm_zero_pivot",                                       CONV_LIB_FUNC, API_SPARSE, 10, CUDA_DEPRECATED | HIP_DEPRECATED};
 
   // NOTE: rocsparse_(s|d|c|z)gemmi have additional argument: rocsparse_mat_descr
   // TODO: Add rocsparse_create_mat_descr() call before rocsparse_(s|d|c|z)gemmi call and rocsparse_destroy_mat_descr() after
-  {"cusparseSgemmi",                                       {"hipsparseSgemmi",                                    "",                                                                 CONV_LIB_FUNC, API_SPARSE, 10, ROC_UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED}},
-  {"cusparseDgemmi",                                       {"hipsparseDgemmi",                                    "",                                                                 CONV_LIB_FUNC, API_SPARSE, 10, ROC_UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED}},
-  {"cusparseCgemmi",                                       {"hipsparseCgemmi",                                    "",                                                                 CONV_LIB_FUNC, API_SPARSE, 10, ROC_UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED}},
-  {"cusparseZgemmi",                                       {"hipsparseZgemmi",                                    "",                                                                 CONV_LIB_FUNC, API_SPARSE, 10, ROC_UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED}},
+  m["cusparseSgemmi"]                                                 = {"hipsparseSgemmi",                                    "",                                                                 CONV_LIB_FUNC, API_SPARSE, 10, ROC_UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED};
+  m["cusparseDgemmi"]                                                 = {"hipsparseDgemmi",                                    "",                                                                 CONV_LIB_FUNC, API_SPARSE, 10, ROC_UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED};
+  m["cusparseCgemmi"]                                                 = {"hipsparseCgemmi",                                    "",                                                                 CONV_LIB_FUNC, API_SPARSE, 10, ROC_UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED};
+  m["cusparseZgemmi"]                                                 = {"hipsparseZgemmi",                                    "",                                                                 CONV_LIB_FUNC, API_SPARSE, 10, ROC_UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED};
 
   // 11. cuSPARSE Extra Function Reference
-  {"cusparseScsrgeam",                                     {"hipsparseScsrgeam",                                  "rocsparse_scsrgeam",                                               CONV_LIB_FUNC, API_SPARSE, 11, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED}},
-  {"cusparseDcsrgeam",                                     {"hipsparseDcsrgeam",                                  "rocsparse_dcsrgeam",                                               CONV_LIB_FUNC, API_SPARSE, 11, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED}},
-  {"cusparseCcsrgeam",                                     {"hipsparseCcsrgeam",                                  "rocsparse_ccsrgeam",                                               CONV_LIB_FUNC, API_SPARSE, 11, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED}},
-  {"cusparseZcsrgeam",                                     {"hipsparseZcsrgeam",                                  "rocsparse_zcsrgeam",                                               CONV_LIB_FUNC, API_SPARSE, 11, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED}},
-  {"cusparseXcsrgeamNnz",                                  {"hipsparseXcsrgeamNnz",                               "rocsparse_csrgeam_nnz",                                            CONV_LIB_FUNC, API_SPARSE, 11, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED}},
+  m["cusparseScsrgeam"]                                               = {"hipsparseScsrgeam",                                  "rocsparse_scsrgeam",                                               CONV_LIB_FUNC, API_SPARSE, 11, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED};
+  m["cusparseDcsrgeam"]                                               = {"hipsparseDcsrgeam",                                  "rocsparse_dcsrgeam",                                               CONV_LIB_FUNC, API_SPARSE, 11, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED};
+  m["cusparseCcsrgeam"]                                               = {"hipsparseCcsrgeam",                                  "rocsparse_ccsrgeam",                                               CONV_LIB_FUNC, API_SPARSE, 11, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED};
+  m["cusparseZcsrgeam"]                                               = {"hipsparseZcsrgeam",                                  "rocsparse_zcsrgeam",                                               CONV_LIB_FUNC, API_SPARSE, 11, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED};
+  m["cusparseXcsrgeamNnz"]                                            = {"hipsparseXcsrgeamNnz",                               "rocsparse_csrgeam_nnz",                                            CONV_LIB_FUNC, API_SPARSE, 11, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED};
 
-  {"cusparseScsrgeam2",                                    {"hipsparseScsrgeam2",                                 "rocsparse_scsrgeam",                                               CONV_LIB_FUNC, API_SPARSE, 11}},
-  {"cusparseDcsrgeam2",                                    {"hipsparseDcsrgeam2",                                 "rocsparse_dcsrgeam",                                               CONV_LIB_FUNC, API_SPARSE, 11}},
-  {"cusparseCcsrgeam2",                                    {"hipsparseCcsrgeam2",                                 "rocsparse_ccsrgeam",                                               CONV_LIB_FUNC, API_SPARSE, 11}},
-  {"cusparseZcsrgeam2",                                    {"hipsparseZcsrgeam2",                                 "rocsparse_zcsrgeam",                                               CONV_LIB_FUNC, API_SPARSE, 11}},
-  {"cusparseXcsrgeam2Nnz",                                 {"hipsparseXcsrgeam2Nnz",                              "rocsparse_csrgeam_nnz",                                            CONV_LIB_FUNC, API_SPARSE, 11}},
+  m["cusparseScsrgeam2"]                                              = {"hipsparseScsrgeam2",                                 "rocsparse_scsrgeam",                                               CONV_LIB_FUNC, API_SPARSE, 11};
+  m["cusparseDcsrgeam2"]                                              = {"hipsparseDcsrgeam2",                                 "rocsparse_dcsrgeam",                                               CONV_LIB_FUNC, API_SPARSE, 11};
+  m["cusparseCcsrgeam2"]                                              = {"hipsparseCcsrgeam2",                                 "rocsparse_ccsrgeam",                                               CONV_LIB_FUNC, API_SPARSE, 11};
+  m["cusparseZcsrgeam2"]                                              = {"hipsparseZcsrgeam2",                                 "rocsparse_zcsrgeam",                                               CONV_LIB_FUNC, API_SPARSE, 11};
+  m["cusparseXcsrgeam2Nnz"]                                           = {"hipsparseXcsrgeam2Nnz",                              "rocsparse_csrgeam_nnz",                                            CONV_LIB_FUNC, API_SPARSE, 11};
 
-  {"cusparseScsrgeam2_bufferSizeExt",                      {"hipsparseScsrgeam2_bufferSizeExt",                   "",                                                                 CONV_LIB_FUNC, API_SPARSE, 11, ROC_UNSUPPORTED}},
-  {"cusparseDcsrgeam2_bufferSizeExt",                      {"hipsparseDcsrgeam2_bufferSizeExt",                   "",                                                                 CONV_LIB_FUNC, API_SPARSE, 11, ROC_UNSUPPORTED}},
-  {"cusparseCcsrgeam2_bufferSizeExt",                      {"hipsparseCcsrgeam2_bufferSizeExt",                   "",                                                                 CONV_LIB_FUNC, API_SPARSE, 11, ROC_UNSUPPORTED}},
-  {"cusparseZcsrgeam2_bufferSizeExt",                      {"hipsparseZcsrgeam2_bufferSizeExt",                   "",                                                                 CONV_LIB_FUNC, API_SPARSE, 11, ROC_UNSUPPORTED}},
+  m["cusparseScsrgeam2_bufferSizeExt"]                                = {"hipsparseScsrgeam2_bufferSizeExt",                   "",                                                                 CONV_LIB_FUNC, API_SPARSE, 11, ROC_UNSUPPORTED};
+  m["cusparseDcsrgeam2_bufferSizeExt"]                                = {"hipsparseDcsrgeam2_bufferSizeExt",                   "",                                                                 CONV_LIB_FUNC, API_SPARSE, 11, ROC_UNSUPPORTED};
+  m["cusparseCcsrgeam2_bufferSizeExt"]                                = {"hipsparseCcsrgeam2_bufferSizeExt",                   "",                                                                 CONV_LIB_FUNC, API_SPARSE, 11, ROC_UNSUPPORTED};
+  m["cusparseZcsrgeam2_bufferSizeExt"]                                = {"hipsparseZcsrgeam2_bufferSizeExt",                   "",                                                                 CONV_LIB_FUNC, API_SPARSE, 11, ROC_UNSUPPORTED};
 
   // NOTE: rocsparse_(s|d|c|z)csrgemm have different signatures, thus they are unsupported yet
-  {"cusparseScsrgemm",                                     {"hipsparseScsrgemm",                                  "",                                                                 CONV_LIB_FUNC, API_SPARSE, 11, ROC_UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED}},
-  {"cusparseDcsrgemm",                                     {"hipsparseDcsrgemm",                                  "",                                                                 CONV_LIB_FUNC, API_SPARSE, 11, ROC_UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED}},
-  {"cusparseCcsrgemm",                                     {"hipsparseCcsrgemm",                                  "",                                                                 CONV_LIB_FUNC, API_SPARSE, 11, ROC_UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED}},
-  {"cusparseZcsrgemm",                                     {"hipsparseZcsrgemm",                                  "",                                                                 CONV_LIB_FUNC, API_SPARSE, 11, ROC_UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED}},
+  m["cusparseScsrgemm"]                                               = {"hipsparseScsrgemm",                                  "",                                                                 CONV_LIB_FUNC, API_SPARSE, 11, ROC_UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED};
+  m["cusparseDcsrgemm"]                                               = {"hipsparseDcsrgemm",                                  "",                                                                 CONV_LIB_FUNC, API_SPARSE, 11, ROC_UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED};
+  m["cusparseCcsrgemm"]                                               = {"hipsparseCcsrgemm",                                  "",                                                                 CONV_LIB_FUNC, API_SPARSE, 11, ROC_UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED};
+  m["cusparseZcsrgemm"]                                               = {"hipsparseZcsrgemm",                                  "",                                                                 CONV_LIB_FUNC, API_SPARSE, 11, ROC_UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED};
+
   // NOTE: rocsparse_csrgemm_nnz has different signature, thus it is unsupported yet
-  {"cusparseXcsrgemmNnz",                                  {"hipsparseXcsrgemmNnz",                               "",                                                                 CONV_LIB_FUNC, API_SPARSE, 11, ROC_UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED}},
+  m["cusparseXcsrgemmNnz"]                                            = {"hipsparseXcsrgemmNnz",                               "",                                                                 CONV_LIB_FUNC, API_SPARSE, 11, ROC_UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED};
+  m["cusparseScsrgemm2"]                                              = {"hipsparseScsrgemm2",                                 "rocsparse_scsrgemm",                                               CONV_LIB_FUNC, API_SPARSE, 11, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED};
+  m["cusparseDcsrgemm2"]                                              = {"hipsparseDcsrgemm2",                                 "rocsparse_dcsrgemm",                                               CONV_LIB_FUNC, API_SPARSE, 11, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED};
+  m["cusparseCcsrgemm2"]                                              = {"hipsparseCcsrgemm2",                                 "rocsparse_ccsrgemm",                                               CONV_LIB_FUNC, API_SPARSE, 11, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED};
+  m["cusparseZcsrgemm2"]                                              = {"hipsparseZcsrgemm2",                                 "rocsparse_zcsrgemm",                                               CONV_LIB_FUNC, API_SPARSE, 11, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED};
+  m["cusparseXcsrgemm2Nnz"]                                           = {"hipsparseXcsrgemm2Nnz",                              "rocsparse_csrgemm_nnz",                                            CONV_LIB_FUNC, API_SPARSE, 11, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED};
 
-  {"cusparseScsrgemm2",                                    {"hipsparseScsrgemm2",                                 "rocsparse_scsrgemm",                                               CONV_LIB_FUNC, API_SPARSE, 11, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED}},
-  {"cusparseDcsrgemm2",                                    {"hipsparseDcsrgemm2",                                 "rocsparse_dcsrgemm",                                               CONV_LIB_FUNC, API_SPARSE, 11, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED}},
-  {"cusparseCcsrgemm2",                                    {"hipsparseCcsrgemm2",                                 "rocsparse_ccsrgemm",                                               CONV_LIB_FUNC, API_SPARSE, 11, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED}},
-  {"cusparseZcsrgemm2",                                    {"hipsparseZcsrgemm2",                                 "rocsparse_zcsrgemm",                                               CONV_LIB_FUNC, API_SPARSE, 11, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED}},
-  {"cusparseXcsrgemm2Nnz",                                 {"hipsparseXcsrgemm2Nnz",                              "rocsparse_csrgemm_nnz",                                            CONV_LIB_FUNC, API_SPARSE, 11, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED}},
-
-  {"cusparseScsrgemm2_bufferSizeExt",                      {"hipsparseScsrgemm2_bufferSizeExt",                   "rocsparse_scsrgemm_buffer_size",                                   CONV_LIB_FUNC, API_SPARSE, 11, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED}},
-  {"cusparseDcsrgemm2_bufferSizeExt",                      {"hipsparseDcsrgemm2_bufferSizeExt",                   "rocsparse_dcsrgemm_buffer_size",                                   CONV_LIB_FUNC, API_SPARSE, 11, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED}},
-  {"cusparseCcsrgemm2_bufferSizeExt",                      {"hipsparseCcsrgemm2_bufferSizeExt",                   "rocsparse_ccsrgemm_buffer_size",                                   CONV_LIB_FUNC, API_SPARSE, 11, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED}},
-  {"cusparseZcsrgemm2_bufferSizeExt",                      {"hipsparseZcsrgemm2_bufferSizeExt",                   "rocsparse_zcsrgemm_buffer_size",                                   CONV_LIB_FUNC, API_SPARSE, 11, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED}},
+  m["cusparseScsrgemm2_bufferSizeExt"]                                = {"hipsparseScsrgemm2_bufferSizeExt",                   "rocsparse_scsrgemm_buffer_size",                                   CONV_LIB_FUNC, API_SPARSE, 11, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED};
+  m["cusparseDcsrgemm2_bufferSizeExt"]                                = {"hipsparseDcsrgemm2_bufferSizeExt",                   "rocsparse_dcsrgemm_buffer_size",                                   CONV_LIB_FUNC, API_SPARSE, 11, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED};
+  m["cusparseCcsrgemm2_bufferSizeExt"]                                = {"hipsparseCcsrgemm2_bufferSizeExt",                   "rocsparse_ccsrgemm_buffer_size",                                   CONV_LIB_FUNC, API_SPARSE, 11, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED};
+  m["cusparseZcsrgemm2_bufferSizeExt"]                                = {"hipsparseZcsrgemm2_bufferSizeExt",                   "rocsparse_zcsrgemm_buffer_size",                                   CONV_LIB_FUNC, API_SPARSE, 11, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED};
 
   // 12. cuSPARSE Preconditioners Reference
   // 12.1. Incomplete Cholesky Factorization : level 0
-  {"cusparseScsric0",                                      {"hipsparseScsric0",                                   "",                                                                 CONV_LIB_FUNC, API_SPARSE, 12, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED}},
-  {"cusparseDcsric0",                                      {"hipsparseDcsric0",                                   "",                                                                 CONV_LIB_FUNC, API_SPARSE, 12, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED}},
-  {"cusparseCcsric0",                                      {"hipsparseCcsric0",                                   "",                                                                 CONV_LIB_FUNC, API_SPARSE, 12, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED}},
-  {"cusparseZcsric0",                                      {"hipsparseZcsric0",                                   "",                                                                 CONV_LIB_FUNC, API_SPARSE, 12, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED}},
+  m["cusparseScsric0"]                                                = {"hipsparseScsric0",                                   "",                                                                 CONV_LIB_FUNC, API_SPARSE, 12, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED};
+  m["cusparseDcsric0"]                                                = {"hipsparseDcsric0",                                   "",                                                                 CONV_LIB_FUNC, API_SPARSE, 12, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED};
+  m["cusparseCcsric0"]                                                = {"hipsparseCcsric0",                                   "",                                                                 CONV_LIB_FUNC, API_SPARSE, 12, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED};
+  m["cusparseZcsric0"]                                                = {"hipsparseZcsric0",                                   "",                                                                 CONV_LIB_FUNC, API_SPARSE, 12, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED};
 
-  {"cusparseScsric02_bufferSize",                          {"hipsparseScsric02_bufferSize",                       "rocsparse_scsric0_buffer_size",                                    CONV_LIB_FUNC, API_SPARSE, 12, CUDA_DEPRECATED | HIP_DEPRECATED}},
-  {"cusparseScsric02_bufferSizeExt",                       {"hipsparseScsric02_bufferSizeExt",                    "rocsparse_scsric0_buffer_size",                                    CONV_LIB_FUNC, API_SPARSE, 12, CUDA_DEPRECATED}},
-  {"cusparseDcsric02_bufferSize",                          {"hipsparseDcsric02_bufferSize",                       "rocsparse_dcsric0_buffer_size",                                    CONV_LIB_FUNC, API_SPARSE, 12, CUDA_DEPRECATED | HIP_DEPRECATED}},
-  {"cusparseDcsric02_bufferSizeExt",                       {"hipsparseDcsric02_bufferSizeExt",                    "rocsparse_dcsric0_buffer_size",                                    CONV_LIB_FUNC, API_SPARSE, 12, CUDA_DEPRECATED}},
-  {"cusparseCcsric02_bufferSize",                          {"hipsparseCcsric02_bufferSize",                       "rocsparse_ccsric0_buffer_size",                                    CONV_LIB_FUNC, API_SPARSE, 12, CUDA_DEPRECATED | HIP_DEPRECATED}},
-  {"cusparseCcsric02_bufferSizeExt",                       {"hipsparseCcsric02_bufferSizeExt",                    "rocsparse_ccsric0_buffer_size",                                    CONV_LIB_FUNC, API_SPARSE, 12, CUDA_DEPRECATED}},
-  {"cusparseZcsric02_bufferSize",                          {"hipsparseZcsric02_bufferSize",                       "rocsparse_zcsric0_buffer_size",                                    CONV_LIB_FUNC, API_SPARSE, 12, CUDA_DEPRECATED | HIP_DEPRECATED}},
-  {"cusparseZcsric02_bufferSizeExt",                       {"hipsparseZcsric02_bufferSizeExt",                    "rocsparse_zcsric0_buffer_size",                                    CONV_LIB_FUNC, API_SPARSE, 12, CUDA_DEPRECATED}},
+  m["cusparseScsric02_bufferSize"]                                    = {"hipsparseScsric02_bufferSize",                       "rocsparse_scsric0_buffer_size",                                    CONV_LIB_FUNC, API_SPARSE, 12, CUDA_DEPRECATED | HIP_DEPRECATED};
+  m["cusparseScsric02_bufferSizeExt"]                                 = {"hipsparseScsric02_bufferSizeExt",                    "rocsparse_scsric0_buffer_size",                                    CONV_LIB_FUNC, API_SPARSE, 12, CUDA_DEPRECATED};
+  m["cusparseDcsric02_bufferSize"]                                    = {"hipsparseDcsric02_bufferSize",                       "rocsparse_dcsric0_buffer_size",                                    CONV_LIB_FUNC, API_SPARSE, 12, CUDA_DEPRECATED | HIP_DEPRECATED};
+  m["cusparseDcsric02_bufferSizeExt"]                                 = {"hipsparseDcsric02_bufferSizeExt",                    "rocsparse_dcsric0_buffer_size",                                    CONV_LIB_FUNC, API_SPARSE, 12, CUDA_DEPRECATED};
+  m["cusparseCcsric02_bufferSize"]                                    = {"hipsparseCcsric02_bufferSize",                       "rocsparse_ccsric0_buffer_size",                                    CONV_LIB_FUNC, API_SPARSE, 12, CUDA_DEPRECATED | HIP_DEPRECATED};
+  m["cusparseCcsric02_bufferSizeExt"]                                 = {"hipsparseCcsric02_bufferSizeExt",                    "rocsparse_ccsric0_buffer_size",                                    CONV_LIB_FUNC, API_SPARSE, 12, CUDA_DEPRECATED};
+  m["cusparseZcsric02_bufferSize"]                                    = {"hipsparseZcsric02_bufferSize",                       "rocsparse_zcsric0_buffer_size",                                    CONV_LIB_FUNC, API_SPARSE, 12, CUDA_DEPRECATED | HIP_DEPRECATED};
+  m["cusparseZcsric02_bufferSizeExt"]                                 = {"hipsparseZcsric02_bufferSizeExt",                    "rocsparse_zcsric0_buffer_size",                                    CONV_LIB_FUNC, API_SPARSE, 12, CUDA_DEPRECATED};
 
-  {"cusparseScsric02_analysis",                            {"hipsparseScsric02_analysis",                         "rocsparse_scsric0_analysis",                                       CONV_LIB_FUNC, API_SPARSE, 12, CUDA_DEPRECATED | HIP_DEPRECATED}},
-  {"cusparseDcsric02_analysis",                            {"hipsparseDcsric02_analysis",                         "rocsparse_dcsric0_analysis",                                       CONV_LIB_FUNC, API_SPARSE, 12, CUDA_DEPRECATED | HIP_DEPRECATED}},
-  {"cusparseCcsric02_analysis",                            {"hipsparseCcsric02_analysis",                         "rocsparse_ccsric0_analysis",                                       CONV_LIB_FUNC, API_SPARSE, 12, CUDA_DEPRECATED | HIP_DEPRECATED}},
-  {"cusparseZcsric02_analysis",                            {"hipsparseZcsric02_analysis",                         "rocsparse_zcsric0_analysis",                                       CONV_LIB_FUNC, API_SPARSE, 12, CUDA_DEPRECATED | HIP_DEPRECATED}},
+  m["cusparseScsric02_analysis"]                                      = {"hipsparseScsric02_analysis",                         "rocsparse_scsric0_analysis",                                       CONV_LIB_FUNC, API_SPARSE, 12, CUDA_DEPRECATED | HIP_DEPRECATED};
+  m["cusparseDcsric02_analysis"]                                      = {"hipsparseDcsric02_analysis",                         "rocsparse_dcsric0_analysis",                                       CONV_LIB_FUNC, API_SPARSE, 12, CUDA_DEPRECATED | HIP_DEPRECATED};
+  m["cusparseCcsric02_analysis"]                                      = {"hipsparseCcsric02_analysis",                         "rocsparse_ccsric0_analysis",                                       CONV_LIB_FUNC, API_SPARSE, 12, CUDA_DEPRECATED | HIP_DEPRECATED};
+  m["cusparseZcsric02_analysis"]                                      = {"hipsparseZcsric02_analysis",                         "rocsparse_zcsric0_analysis",                                       CONV_LIB_FUNC, API_SPARSE, 12, CUDA_DEPRECATED | HIP_DEPRECATED};
 
-  {"cusparseScsric02",                                     {"hipsparseScsric02",                                  "rocsparse_scsric0",                                                CONV_LIB_FUNC, API_SPARSE, 12, CUDA_DEPRECATED | HIP_DEPRECATED}},
-  {"cusparseDcsric02",                                     {"hipsparseDcsric02",                                  "rocsparse_dcsric0",                                                CONV_LIB_FUNC, API_SPARSE, 12, CUDA_DEPRECATED | HIP_DEPRECATED}},
-  {"cusparseCcsric02",                                     {"hipsparseCcsric02",                                  "rocsparse_ccsric0",                                                CONV_LIB_FUNC, API_SPARSE, 12, CUDA_DEPRECATED | HIP_DEPRECATED}},
-  {"cusparseZcsric02",                                     {"hipsparseZcsric02",                                  "rocsparse_zcsric0",                                                CONV_LIB_FUNC, API_SPARSE, 12, CUDA_DEPRECATED | HIP_DEPRECATED}},
+  m["cusparseScsric02"]                                               = {"hipsparseScsric02",                                  "rocsparse_scsric0",                                                CONV_LIB_FUNC, API_SPARSE, 12, CUDA_DEPRECATED | HIP_DEPRECATED};
+  m["cusparseDcsric02"]                                               = {"hipsparseDcsric02",                                  "rocsparse_dcsric0",                                                CONV_LIB_FUNC, API_SPARSE, 12, CUDA_DEPRECATED | HIP_DEPRECATED};
+  m["cusparseCcsric02"]                                               = {"hipsparseCcsric02",                                  "rocsparse_ccsric0",                                                CONV_LIB_FUNC, API_SPARSE, 12, CUDA_DEPRECATED | HIP_DEPRECATED};
+  m["cusparseZcsric02"]                                               = {"hipsparseZcsric02",                                  "rocsparse_zcsric0",                                                CONV_LIB_FUNC, API_SPARSE, 12, CUDA_DEPRECATED | HIP_DEPRECATED};
 
-  {"cusparseXcsric02_zeroPivot",                           {"hipsparseXcsric02_zeroPivot",                        "rocsparse_csric0_zero_pivot",                                      CONV_LIB_FUNC, API_SPARSE, 12, CUDA_DEPRECATED | HIP_DEPRECATED}},
-  {"cusparseSbsric02_bufferSize",                          {"hipsparseSbsric02_bufferSize",                       "rocsparse_sbsric0_buffer_size",                                    CONV_LIB_FUNC, API_SPARSE, 12, CUDA_DEPRECATED | HIP_DEPRECATED}},
-  {"cusparseSbsric02_bufferSizeExt",                       {"hipsparseSbsric02_bufferSizeExt",                    "",                                                                 CONV_LIB_FUNC, API_SPARSE, 12, UNSUPPORTED | CUDA_DEPRECATED}},
-  {"cusparseDbsric02_bufferSize",                          {"hipsparseDbsric02_bufferSize",                       "rocsparse_dbsric0_buffer_size",                                    CONV_LIB_FUNC, API_SPARSE, 12, CUDA_DEPRECATED | HIP_DEPRECATED}},
-  {"cusparseDbsric02_bufferSizeExt",                       {"hipsparseDbsric02_bufferSizeExt",                    "",                                                                 CONV_LIB_FUNC, API_SPARSE, 12, UNSUPPORTED | CUDA_DEPRECATED}},
-  {"cusparseCbsric02_bufferSize",                          {"hipsparseCbsric02_bufferSize",                       "rocsparse_cbsric0_buffer_size",                                    CONV_LIB_FUNC, API_SPARSE, 12, CUDA_DEPRECATED | HIP_DEPRECATED}},
-  {"cusparseCbsric02_bufferSizeExt",                       {"hipsparseCbsric02_bufferSizeExt",                    "",                                                                 CONV_LIB_FUNC, API_SPARSE, 12, UNSUPPORTED | CUDA_DEPRECATED}},
-  {"cusparseZbsric02_bufferSize",                          {"hipsparseZbsric02_bufferSize",                       "rocsparse_zbsric0_buffer_size",                                    CONV_LIB_FUNC, API_SPARSE, 12, CUDA_DEPRECATED | HIP_DEPRECATED}},
-  {"cusparseZbsric02_bufferSizeExt",                       {"hipsparseZbsric02_bufferSizeExt",                    "",                                                                 CONV_LIB_FUNC, API_SPARSE, 12, UNSUPPORTED | CUDA_DEPRECATED}},
+  m["cusparseXcsric02_zeroPivot"]                                     = {"hipsparseXcsric02_zeroPivot",                        "rocsparse_csric0_zero_pivot",                                      CONV_LIB_FUNC, API_SPARSE, 12, CUDA_DEPRECATED | HIP_DEPRECATED};
+  m["cusparseSbsric02_bufferSize"]                                    = {"hipsparseSbsric02_bufferSize",                       "rocsparse_sbsric0_buffer_size",                                    CONV_LIB_FUNC, API_SPARSE, 12, CUDA_DEPRECATED | HIP_DEPRECATED};
+  m["cusparseSbsric02_bufferSizeExt"]                                 = {"hipsparseSbsric02_bufferSizeExt",                    "",                                                                 CONV_LIB_FUNC, API_SPARSE, 12, UNSUPPORTED | CUDA_DEPRECATED};
+  m["cusparseDbsric02_bufferSize"]                                    = {"hipsparseDbsric02_bufferSize",                       "rocsparse_dbsric0_buffer_size",                                    CONV_LIB_FUNC, API_SPARSE, 12, CUDA_DEPRECATED | HIP_DEPRECATED};
+  m["cusparseDbsric02_bufferSizeExt"]                                 = {"hipsparseDbsric02_bufferSizeExt",                    "",                                                                 CONV_LIB_FUNC, API_SPARSE, 12, UNSUPPORTED | CUDA_DEPRECATED};
+  m["cusparseCbsric02_bufferSize"]                                    = {"hipsparseCbsric02_bufferSize",                       "rocsparse_cbsric0_buffer_size",                                    CONV_LIB_FUNC, API_SPARSE, 12, CUDA_DEPRECATED | HIP_DEPRECATED};
+  m["cusparseCbsric02_bufferSizeExt"]                                 = {"hipsparseCbsric02_bufferSizeExt",                    "",                                                                 CONV_LIB_FUNC, API_SPARSE, 12, UNSUPPORTED | CUDA_DEPRECATED};
+  m["cusparseZbsric02_bufferSize"]                                    = {"hipsparseZbsric02_bufferSize",                       "rocsparse_zbsric0_buffer_size",                                    CONV_LIB_FUNC, API_SPARSE, 12, CUDA_DEPRECATED | HIP_DEPRECATED};
+  m["cusparseZbsric02_bufferSizeExt"]                                 = {"hipsparseZbsric02_bufferSizeExt",                    "",                                                                 CONV_LIB_FUNC, API_SPARSE, 12, UNSUPPORTED | CUDA_DEPRECATED};
 
-  {"cusparseSbsric02_analysis",                            {"hipsparseSbsric02_analysis",                         "rocsparse_sbsric0_analysis",                                       CONV_LIB_FUNC, API_SPARSE, 12, CUDA_DEPRECATED | HIP_DEPRECATED}},
-  {"cusparseDbsric02_analysis",                            {"hipsparseDbsric02_analysis",                         "rocsparse_dbsric0_analysis",                                       CONV_LIB_FUNC, API_SPARSE, 12, CUDA_DEPRECATED | HIP_DEPRECATED}},
-  {"cusparseCbsric02_analysis",                            {"hipsparseCbsric02_analysis",                         "rocsparse_cbsric0_analysis",                                       CONV_LIB_FUNC, API_SPARSE, 12, CUDA_DEPRECATED | HIP_DEPRECATED}},
-  {"cusparseZbsric02_analysis",                            {"hipsparseZbsric02_analysis",                         "rocsparse_zbsric0_analysis",                                       CONV_LIB_FUNC, API_SPARSE, 12, CUDA_DEPRECATED | HIP_DEPRECATED}},
+  m["cusparseSbsric02_analysis"]                                      = {"hipsparseSbsric02_analysis",                         "rocsparse_sbsric0_analysis",                                       CONV_LIB_FUNC, API_SPARSE, 12, CUDA_DEPRECATED | HIP_DEPRECATED};
+  m["cusparseDbsric02_analysis"]                                      = {"hipsparseDbsric02_analysis",                         "rocsparse_dbsric0_analysis",                                       CONV_LIB_FUNC, API_SPARSE, 12, CUDA_DEPRECATED | HIP_DEPRECATED};
+  m["cusparseCbsric02_analysis"]                                      = {"hipsparseCbsric02_analysis",                         "rocsparse_cbsric0_analysis",                                       CONV_LIB_FUNC, API_SPARSE, 12, CUDA_DEPRECATED | HIP_DEPRECATED};
+  m["cusparseZbsric02_analysis"]                                      = {"hipsparseZbsric02_analysis",                         "rocsparse_zbsric0_analysis",                                       CONV_LIB_FUNC, API_SPARSE, 12, CUDA_DEPRECATED | HIP_DEPRECATED};
 
-  {"cusparseSbsric02",                                     {"hipsparseSbsric02",                                  "rocsparse_sbsric0",                                                CONV_LIB_FUNC, API_SPARSE, 12, CUDA_DEPRECATED | HIP_DEPRECATED}},
-  {"cusparseDbsric02",                                     {"hipsparseDbsric02",                                  "rocsparse_dbsric0",                                                CONV_LIB_FUNC, API_SPARSE, 12, CUDA_DEPRECATED | HIP_DEPRECATED}},
-  {"cusparseCbsric02",                                     {"hipsparseCbsric02",                                  "rocsparse_cbsric0",                                                CONV_LIB_FUNC, API_SPARSE, 12, CUDA_DEPRECATED | HIP_DEPRECATED}},
-  {"cusparseZbsric02",                                     {"hipsparseZbsric02",                                  "rocsparse_zbsric0",                                                CONV_LIB_FUNC, API_SPARSE, 12, CUDA_DEPRECATED | HIP_DEPRECATED}},
+  m["cusparseSbsric02"]                                               = {"hipsparseSbsric02",                                  "rocsparse_sbsric0",                                                CONV_LIB_FUNC, API_SPARSE, 12, CUDA_DEPRECATED | HIP_DEPRECATED};
+  m["cusparseDbsric02"]                                               = {"hipsparseDbsric02",                                  "rocsparse_dbsric0",                                                CONV_LIB_FUNC, API_SPARSE, 12, CUDA_DEPRECATED | HIP_DEPRECATED};
+  m["cusparseCbsric02"]                                               = {"hipsparseCbsric02",                                  "rocsparse_cbsric0",                                                CONV_LIB_FUNC, API_SPARSE, 12, CUDA_DEPRECATED | HIP_DEPRECATED};
+  m["cusparseZbsric02"]                                               = {"hipsparseZbsric02",                                  "rocsparse_zbsric0",                                                CONV_LIB_FUNC, API_SPARSE, 12, CUDA_DEPRECATED | HIP_DEPRECATED};
   // TODO: rocsparse_get_stream and hipStreamSynchronize need to be added correspondingly before and after rocsparse_bsric0_zero_pivot call, because cusparseXbsric02_zeroPivot is blocking, and rocsparse_bsric0_zero_pivot is not
-  {"cusparseXbsric02_zeroPivot",                           {"hipsparseXbsric02_zeroPivot",                        "rocsparse_bsric0_zero_pivot",                                      CONV_LIB_FUNC, API_SPARSE, 12, CUDA_DEPRECATED | HIP_DEPRECATED}},
+  m["cusparseXbsric02_zeroPivot"]                                     = {"hipsparseXbsric02_zeroPivot",                        "rocsparse_bsric0_zero_pivot",                                      CONV_LIB_FUNC, API_SPARSE, 12, CUDA_DEPRECATED | HIP_DEPRECATED};
 
   // 12.2. Incomplete LU Factorization: level 0
   // NOTE: rocsparse_(s|d|c|z)csrilu0 have different signatures, thus they are also unsupported yet
-  {"cusparseScsrilu0",                                     {"hipsparseScsrilu0",                                  "",                                                                 CONV_LIB_FUNC, API_SPARSE, 12, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED}},
-  {"cusparseDcsrilu0",                                     {"hipsparseDcsrilu0",                                  "",                                                                 CONV_LIB_FUNC, API_SPARSE, 12, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED}},
-  {"cusparseCcsrilu0",                                     {"hipsparseCcsrilu0",                                  "",                                                                 CONV_LIB_FUNC, API_SPARSE, 12, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED}},
-  {"cusparseZcsrilu0",                                     {"hipsparseZcsrilu0",                                  "",                                                                 CONV_LIB_FUNC, API_SPARSE, 12, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED}},
-  {"cusparseCsrilu0Ex",                                    {"hipsparseCsrilu0Ex",                                 "",                                                                 CONV_LIB_FUNC, API_SPARSE, 12, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED}},
+  m["cusparseScsrilu0"]                                               = {"hipsparseScsrilu0",                                  "",                                                                 CONV_LIB_FUNC, API_SPARSE, 12, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED};
+  m["cusparseDcsrilu0"]                                               = {"hipsparseDcsrilu0",                                  "",                                                                 CONV_LIB_FUNC, API_SPARSE, 12, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED};
+  m["cusparseCcsrilu0"]                                               = {"hipsparseCcsrilu0",                                  "",                                                                 CONV_LIB_FUNC, API_SPARSE, 12, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED};
+  m["cusparseZcsrilu0"]                                               = {"hipsparseZcsrilu0",                                  "",                                                                 CONV_LIB_FUNC, API_SPARSE, 12, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED};
+  m["cusparseCsrilu0Ex"]                                              = {"hipsparseCsrilu0Ex",                                 "",                                                                 CONV_LIB_FUNC, API_SPARSE, 12, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED};
 
-  {"cusparseScsrilu02_numericBoost",                       {"hipsparseScsrilu02_numericBoost",                    "rocsparse_dscsrilu0_numeric_boost",                                CONV_LIB_FUNC, API_SPARSE, 12, CUDA_DEPRECATED | HIP_DEPRECATED}},
-  {"cusparseDcsrilu02_numericBoost",                       {"hipsparseDcsrilu02_numericBoost",                    "rocsparse_dcsrilu0_numeric_boost",                                 CONV_LIB_FUNC, API_SPARSE, 12, CUDA_DEPRECATED | HIP_DEPRECATED}},
-  {"cusparseCcsrilu02_numericBoost",                       {"hipsparseCcsrilu02_numericBoost",                    "rocsparse_dccsrilu0_numeric_boost",                                CONV_LIB_FUNC, API_SPARSE, 12, CUDA_DEPRECATED | HIP_DEPRECATED}},
-  {"cusparseZcsrilu02_numericBoost",                       {"hipsparseZcsrilu02_numericBoost",                    "rocsparse_zcsrilu0_numeric_boost",                                 CONV_LIB_FUNC, API_SPARSE, 12, CUDA_DEPRECATED | HIP_DEPRECATED}},
+  m["cusparseScsrilu02_numericBoost"]                                 = {"hipsparseScsrilu02_numericBoost",                    "rocsparse_dscsrilu0_numeric_boost",                                CONV_LIB_FUNC, API_SPARSE, 12, CUDA_DEPRECATED | HIP_DEPRECATED};
+  m["cusparseDcsrilu02_numericBoost"]                                 = {"hipsparseDcsrilu02_numericBoost",                    "rocsparse_dcsrilu0_numeric_boost",                                 CONV_LIB_FUNC, API_SPARSE, 12, CUDA_DEPRECATED | HIP_DEPRECATED};
+  m["cusparseCcsrilu02_numericBoost"]                                 = {"hipsparseCcsrilu02_numericBoost",                    "rocsparse_dccsrilu0_numeric_boost",                                CONV_LIB_FUNC, API_SPARSE, 12, CUDA_DEPRECATED | HIP_DEPRECATED};
+  m["cusparseZcsrilu02_numericBoost"]                                 = {"hipsparseZcsrilu02_numericBoost",                    "rocsparse_zcsrilu0_numeric_boost",                                 CONV_LIB_FUNC, API_SPARSE, 12, CUDA_DEPRECATED | HIP_DEPRECATED};
 
-  {"cusparseScsrilu02_bufferSize",                         {"hipsparseScsrilu02_bufferSize",                      "rocsparse_scsrilu0_buffer_size",                                   CONV_LIB_FUNC, API_SPARSE, 12, CUDA_DEPRECATED | HIP_DEPRECATED}},
-  {"cusparseScsrilu02_bufferSizeExt",                      {"hipsparseScsrilu02_bufferSizeExt",                   "rocsparse_scsrilu0_buffer_size",                                   CONV_LIB_FUNC, API_SPARSE, 12, CUDA_DEPRECATED}},
-  {"cusparseDcsrilu02_bufferSize",                         {"hipsparseDcsrilu02_bufferSize",                      "rocsparse_dcsrilu0_buffer_size",                                   CONV_LIB_FUNC, API_SPARSE, 12, CUDA_DEPRECATED | HIP_DEPRECATED}},
-  {"cusparseDcsrilu02_bufferSizeExt",                      {"hipsparseDcsrilu02_bufferSizeExt",                   "rocsparse_dcsrilu0_buffer_size",                                   CONV_LIB_FUNC, API_SPARSE, 12, CUDA_DEPRECATED}},
-  {"cusparseCcsrilu02_bufferSize",                         {"hipsparseCcsrilu02_bufferSize",                      "rocsparse_ccsrilu0_buffer_size",                                   CONV_LIB_FUNC, API_SPARSE, 12, CUDA_DEPRECATED | HIP_DEPRECATED}},
-  {"cusparseCcsrilu02_bufferSizeExt",                      {"hipsparseCcsrilu02_bufferSizeExt",                   "rocsparse_ccsrilu0_buffer_size",                                   CONV_LIB_FUNC, API_SPARSE, 12, CUDA_DEPRECATED}},
-  {"cusparseZcsrilu02_bufferSize",                         {"hipsparseZcsrilu02_bufferSize",                      "rocsparse_zcsrilu0_buffer_size",                                   CONV_LIB_FUNC, API_SPARSE, 12, CUDA_DEPRECATED | HIP_DEPRECATED}},
-  {"cusparseZcsrilu02_bufferSizeExt",                      {"hipsparseZcsrilu02_bufferSizeExt",                   "rocsparse_zcsrilu0_buffer_size",                                   CONV_LIB_FUNC, API_SPARSE, 12, CUDA_DEPRECATED}},
+  m["cusparseScsrilu02_bufferSize"]                                   = {"hipsparseScsrilu02_bufferSize",                      "rocsparse_scsrilu0_buffer_size",                                   CONV_LIB_FUNC, API_SPARSE, 12, CUDA_DEPRECATED | HIP_DEPRECATED};
+  m["cusparseScsrilu02_bufferSizeExt"]                                = {"hipsparseScsrilu02_bufferSizeExt",                   "rocsparse_scsrilu0_buffer_size",                                   CONV_LIB_FUNC, API_SPARSE, 12, CUDA_DEPRECATED};
+  m["cusparseDcsrilu02_bufferSize"]                                   = {"hipsparseDcsrilu02_bufferSize",                      "rocsparse_dcsrilu0_buffer_size",                                   CONV_LIB_FUNC, API_SPARSE, 12, CUDA_DEPRECATED | HIP_DEPRECATED};
+  m["cusparseDcsrilu02_bufferSizeExt"]                                = {"hipsparseDcsrilu02_bufferSizeExt",                   "rocsparse_dcsrilu0_buffer_size",                                   CONV_LIB_FUNC, API_SPARSE, 12, CUDA_DEPRECATED};
+  m["cusparseCcsrilu02_bufferSize"]                                   = {"hipsparseCcsrilu02_bufferSize",                      "rocsparse_ccsrilu0_buffer_size",                                   CONV_LIB_FUNC, API_SPARSE, 12, CUDA_DEPRECATED | HIP_DEPRECATED};
+  m["cusparseCcsrilu02_bufferSizeExt"]                                = {"hipsparseCcsrilu02_bufferSizeExt",                   "rocsparse_ccsrilu0_buffer_size",                                   CONV_LIB_FUNC, API_SPARSE, 12, CUDA_DEPRECATED};
+  m["cusparseZcsrilu02_bufferSize"]                                   = {"hipsparseZcsrilu02_bufferSize",                      "rocsparse_zcsrilu0_buffer_size",                                   CONV_LIB_FUNC, API_SPARSE, 12, CUDA_DEPRECATED | HIP_DEPRECATED};
+  m["cusparseZcsrilu02_bufferSizeExt"]                                = {"hipsparseZcsrilu02_bufferSizeExt",                   "rocsparse_zcsrilu0_buffer_size",                                   CONV_LIB_FUNC, API_SPARSE, 12, CUDA_DEPRECATED};
 
-  {"cusparseScsrilu02_analysis",                           {"hipsparseScsrilu02_analysis",                        "rocsparse_scsrilu0_analysis",                                      CONV_LIB_FUNC, API_SPARSE, 12, CUDA_DEPRECATED | HIP_DEPRECATED}},
-  {"cusparseDcsrilu02_analysis",                           {"hipsparseDcsrilu02_analysis",                        "rocsparse_dcsrilu0_analysis",                                      CONV_LIB_FUNC, API_SPARSE, 12, CUDA_DEPRECATED | HIP_DEPRECATED}},
-  {"cusparseCcsrilu02_analysis",                           {"hipsparseCcsrilu02_analysis",                        "rocsparse_ccsrilu0_analysis",                                      CONV_LIB_FUNC, API_SPARSE, 12, CUDA_DEPRECATED | HIP_DEPRECATED}},
-  {"cusparseZcsrilu02_analysis",                           {"hipsparseZcsrilu02_analysis",                        "rocsparse_zcsrilu0_analysis",                                      CONV_LIB_FUNC, API_SPARSE, 12, CUDA_DEPRECATED | HIP_DEPRECATED}},
+  m["cusparseScsrilu02_analysis"]                                     = {"hipsparseScsrilu02_analysis",                        "rocsparse_scsrilu0_analysis",                                      CONV_LIB_FUNC, API_SPARSE, 12, CUDA_DEPRECATED | HIP_DEPRECATED};
+  m["cusparseDcsrilu02_analysis"]                                     = {"hipsparseDcsrilu02_analysis",                        "rocsparse_dcsrilu0_analysis",                                      CONV_LIB_FUNC, API_SPARSE, 12, CUDA_DEPRECATED | HIP_DEPRECATED};
+  m["cusparseCcsrilu02_analysis"]                                     = {"hipsparseCcsrilu02_analysis",                        "rocsparse_ccsrilu0_analysis",                                      CONV_LIB_FUNC, API_SPARSE, 12, CUDA_DEPRECATED | HIP_DEPRECATED};
+  m["cusparseZcsrilu02_analysis"]                                     = {"hipsparseZcsrilu02_analysis",                        "rocsparse_zcsrilu0_analysis",                                      CONV_LIB_FUNC, API_SPARSE, 12, CUDA_DEPRECATED | HIP_DEPRECATED};
 
-  {"cusparseScsrilu02",                                    {"hipsparseScsrilu02",                                 "rocsparse_scsrilu0",                                               CONV_LIB_FUNC, API_SPARSE, 12, CUDA_DEPRECATED | HIP_DEPRECATED}},
-  {"cusparseDcsrilu02",                                    {"hipsparseDcsrilu02",                                 "rocsparse_dcsrilu0",                                               CONV_LIB_FUNC, API_SPARSE, 12, CUDA_DEPRECATED | HIP_DEPRECATED}},
-  {"cusparseCcsrilu02",                                    {"hipsparseCcsrilu02",                                 "rocsparse_ccsrilu0",                                               CONV_LIB_FUNC, API_SPARSE, 12, CUDA_DEPRECATED | HIP_DEPRECATED}},
-  {"cusparseZcsrilu02",                                    {"hipsparseZcsrilu02",                                 "rocsparse_zcsrilu0",                                               CONV_LIB_FUNC, API_SPARSE, 12, CUDA_DEPRECATED | HIP_DEPRECATED}},
-  {"cusparseXcsrilu02_zeroPivot",                          {"hipsparseXcsrilu02_zeroPivot",                       "rocsparse_csrilu0_zero_pivot",                                     CONV_LIB_FUNC, API_SPARSE, 12, CUDA_DEPRECATED | HIP_DEPRECATED}},
+  m["cusparseScsrilu02"]                                              = {"hipsparseScsrilu02",                                 "rocsparse_scsrilu0",                                               CONV_LIB_FUNC, API_SPARSE, 12, CUDA_DEPRECATED | HIP_DEPRECATED};
+  m["cusparseDcsrilu02"]                                              = {"hipsparseDcsrilu02",                                 "rocsparse_dcsrilu0",                                               CONV_LIB_FUNC, API_SPARSE, 12, CUDA_DEPRECATED | HIP_DEPRECATED};
+  m["cusparseCcsrilu02"]                                              = {"hipsparseCcsrilu02",                                 "rocsparse_ccsrilu0",                                               CONV_LIB_FUNC, API_SPARSE, 12, CUDA_DEPRECATED | HIP_DEPRECATED};
+  m["cusparseZcsrilu02"]                                              = {"hipsparseZcsrilu02",                                 "rocsparse_zcsrilu0",                                               CONV_LIB_FUNC, API_SPARSE, 12, CUDA_DEPRECATED | HIP_DEPRECATED};
+  m["cusparseXcsrilu02_zeroPivot"]                                    = {"hipsparseXcsrilu02_zeroPivot",                       "rocsparse_csrilu0_zero_pivot",                                     CONV_LIB_FUNC, API_SPARSE, 12, CUDA_DEPRECATED | HIP_DEPRECATED};
 
-  {"cusparseSbsrilu02_numericBoost",                       {"hipsparseSbsrilu02_numericBoost",                    "rocsparse_dsbsrilu0_numeric_boost",                                CONV_LIB_FUNC, API_SPARSE, 12, CUDA_DEPRECATED | HIP_DEPRECATED}},
-  {"cusparseDbsrilu02_numericBoost",                       {"hipsparseDbsrilu02_numericBoost",                    "rocsparse_dbsrilu0_numeric_boost",                                 CONV_LIB_FUNC, API_SPARSE, 12, CUDA_DEPRECATED | HIP_DEPRECATED}},
-  {"cusparseCbsrilu02_numericBoost",                       {"hipsparseCbsrilu02_numericBoost",                    "rocsparse_dcbsrilu0_numeric_boost",                                CONV_LIB_FUNC, API_SPARSE, 12, CUDA_DEPRECATED | HIP_DEPRECATED}},
-  {"cusparseZbsrilu02_numericBoost",                       {"hipsparseZbsrilu02_numericBoost",                    "rocsparse_zbsrilu0_numeric_boost",                                 CONV_LIB_FUNC, API_SPARSE, 12, CUDA_DEPRECATED | HIP_DEPRECATED}},
+  m["cusparseSbsrilu02_numericBoost"]                                 = {"hipsparseSbsrilu02_numericBoost",                    "rocsparse_dsbsrilu0_numeric_boost",                                CONV_LIB_FUNC, API_SPARSE, 12, CUDA_DEPRECATED | HIP_DEPRECATED};
+  m["cusparseDbsrilu02_numericBoost"]                                 = {"hipsparseDbsrilu02_numericBoost",                    "rocsparse_dbsrilu0_numeric_boost",                                 CONV_LIB_FUNC, API_SPARSE, 12, CUDA_DEPRECATED | HIP_DEPRECATED};
+  m["cusparseCbsrilu02_numericBoost"]                                 = {"hipsparseCbsrilu02_numericBoost",                    "rocsparse_dcbsrilu0_numeric_boost",                                CONV_LIB_FUNC, API_SPARSE, 12, CUDA_DEPRECATED | HIP_DEPRECATED};
+  m["cusparseZbsrilu02_numericBoost"]                                 = {"hipsparseZbsrilu02_numericBoost",                    "rocsparse_zbsrilu0_numeric_boost",                                 CONV_LIB_FUNC, API_SPARSE, 12, CUDA_DEPRECATED | HIP_DEPRECATED};
 
-  {"cusparseSbsrilu02_bufferSize",                         {"hipsparseSbsrilu02_bufferSize",                      "rocsparse_sbsrilu0_buffer_size",                                   CONV_LIB_FUNC, API_SPARSE, 12, CUDA_DEPRECATED | HIP_DEPRECATED}},
-  {"cusparseSbsrilu02_bufferSizeExt",                      {"hipsparseSbsrilu02_bufferSizeExt",                   "",                                                                 CONV_LIB_FUNC, API_SPARSE, 12, UNSUPPORTED | CUDA_DEPRECATED}},
-  {"cusparseDbsrilu02_bufferSize",                         {"hipsparseDbsrilu02_bufferSize",                      "rocsparse_dbsrilu0_buffer_size",                                   CONV_LIB_FUNC, API_SPARSE, 12, CUDA_DEPRECATED | HIP_DEPRECATED}},
-  {"cusparseDbsrilu02_bufferSizeExt",                      {"hipsparseDbsrilu02_bufferSizeExt",                   "",                                                                 CONV_LIB_FUNC, API_SPARSE, 12, UNSUPPORTED | CUDA_DEPRECATED}},
-  {"cusparseCbsrilu02_bufferSize",                         {"hipsparseCbsrilu02_bufferSize",                      "rocsparse_cbsrilu0_buffer_size",                                   CONV_LIB_FUNC, API_SPARSE, 12, CUDA_DEPRECATED | HIP_DEPRECATED}},
-  {"cusparseCbsrilu02_bufferSizeExt",                      {"hipsparseCbsrilu02_bufferSizeExt",                   "",                                                                 CONV_LIB_FUNC, API_SPARSE, 12, UNSUPPORTED | CUDA_DEPRECATED}},
-  {"cusparseZbsrilu02_bufferSize",                         {"hipsparseZbsrilu02_bufferSize",                      "rocsparse_zbsrilu0_buffer_size",                                   CONV_LIB_FUNC, API_SPARSE, 12, CUDA_DEPRECATED | HIP_DEPRECATED}},
-  {"cusparseZbsrilu02_bufferSizeExt",                      {"hipsparseZbsrilu02_bufferSizeExt",                   "",                                                                 CONV_LIB_FUNC, API_SPARSE, 12, UNSUPPORTED | CUDA_DEPRECATED}},
+  m["cusparseSbsrilu02_bufferSize"]                                   = {"hipsparseSbsrilu02_bufferSize",                      "rocsparse_sbsrilu0_buffer_size",                                   CONV_LIB_FUNC, API_SPARSE, 12, CUDA_DEPRECATED | HIP_DEPRECATED};
+  m["cusparseSbsrilu02_bufferSizeExt"]                                = {"hipsparseSbsrilu02_bufferSizeExt",                   "",                                                                 CONV_LIB_FUNC, API_SPARSE, 12, UNSUPPORTED | CUDA_DEPRECATED};
+  m["cusparseDbsrilu02_bufferSize"]                                   = {"hipsparseDbsrilu02_bufferSize",                      "rocsparse_dbsrilu0_buffer_size",                                   CONV_LIB_FUNC, API_SPARSE, 12, CUDA_DEPRECATED | HIP_DEPRECATED};
+  m["cusparseDbsrilu02_bufferSizeExt"]                                = {"hipsparseDbsrilu02_bufferSizeExt",                   "",                                                                 CONV_LIB_FUNC, API_SPARSE, 12, UNSUPPORTED | CUDA_DEPRECATED};
+  m["cusparseCbsrilu02_bufferSize"]                                   = {"hipsparseCbsrilu02_bufferSize",                      "rocsparse_cbsrilu0_buffer_size",                                   CONV_LIB_FUNC, API_SPARSE, 12, CUDA_DEPRECATED | HIP_DEPRECATED};
+  m["cusparseCbsrilu02_bufferSizeExt"]                                = {"hipsparseCbsrilu02_bufferSizeExt",                   "",                                                                 CONV_LIB_FUNC, API_SPARSE, 12, UNSUPPORTED | CUDA_DEPRECATED};
+  m["cusparseZbsrilu02_bufferSize"]                                   = {"hipsparseZbsrilu02_bufferSize",                      "rocsparse_zbsrilu0_buffer_size",                                   CONV_LIB_FUNC, API_SPARSE, 12, CUDA_DEPRECATED | HIP_DEPRECATED};
+  m["cusparseZbsrilu02_bufferSizeExt"]                                = {"hipsparseZbsrilu02_bufferSizeExt",                   "",                                                                 CONV_LIB_FUNC, API_SPARSE, 12, UNSUPPORTED | CUDA_DEPRECATED};
 
-  {"cusparseSbsrilu02_analysis",                           {"hipsparseSbsrilu02_analysis",                        "rocsparse_sbsrilu0_analysis",                                      CONV_LIB_FUNC, API_SPARSE, 12, CUDA_DEPRECATED | HIP_DEPRECATED}},
-  {"cusparseDbsrilu02_analysis",                           {"hipsparseDbsrilu02_analysis",                        "rocsparse_dbsrilu0_analysis",                                      CONV_LIB_FUNC, API_SPARSE, 12, CUDA_DEPRECATED | HIP_DEPRECATED}},
-  {"cusparseCbsrilu02_analysis",                           {"hipsparseCbsrilu02_analysis",                        "rocsparse_cbsrilu0_analysis",                                      CONV_LIB_FUNC, API_SPARSE, 12, CUDA_DEPRECATED | HIP_DEPRECATED}},
-  {"cusparseZbsrilu02_analysis",                           {"hipsparseZbsrilu02_analysis",                        "rocsparse_zbsrilu0_analysis",                                      CONV_LIB_FUNC, API_SPARSE, 12, CUDA_DEPRECATED | HIP_DEPRECATED}},
+  m["cusparseSbsrilu02_analysis"]                                     = {"hipsparseSbsrilu02_analysis",                        "rocsparse_sbsrilu0_analysis",                                      CONV_LIB_FUNC, API_SPARSE, 12, CUDA_DEPRECATED | HIP_DEPRECATED};
+  m["cusparseDbsrilu02_analysis"]                                     = {"hipsparseDbsrilu02_analysis",                        "rocsparse_dbsrilu0_analysis",                                      CONV_LIB_FUNC, API_SPARSE, 12, CUDA_DEPRECATED | HIP_DEPRECATED};
+  m["cusparseCbsrilu02_analysis"]                                     = {"hipsparseCbsrilu02_analysis",                        "rocsparse_cbsrilu0_analysis",                                      CONV_LIB_FUNC, API_SPARSE, 12, CUDA_DEPRECATED | HIP_DEPRECATED};
+  m["cusparseZbsrilu02_analysis"]                                     = {"hipsparseZbsrilu02_analysis",                        "rocsparse_zbsrilu0_analysis",                                      CONV_LIB_FUNC, API_SPARSE, 12, CUDA_DEPRECATED | HIP_DEPRECATED};
 
-  {"cusparseSbsrilu02",                                    {"hipsparseSbsrilu02",                                 "rocsparse_sbsrilu0",                                               CONV_LIB_FUNC, API_SPARSE, 12, CUDA_DEPRECATED | HIP_DEPRECATED}},
-  {"cusparseDbsrilu02",                                    {"hipsparseDbsrilu02",                                 "rocsparse_dbsrilu0",                                               CONV_LIB_FUNC, API_SPARSE, 12, CUDA_DEPRECATED | HIP_DEPRECATED}},
-  {"cusparseCbsrilu02",                                    {"hipsparseCbsrilu02",                                 "rocsparse_cbsrilu0",                                               CONV_LIB_FUNC, API_SPARSE, 12, CUDA_DEPRECATED | HIP_DEPRECATED}},
-  {"cusparseZbsrilu02",                                    {"hipsparseZbsrilu02",                                 "rocsparse_zbsrilu0",                                               CONV_LIB_FUNC, API_SPARSE, 12, CUDA_DEPRECATED | HIP_DEPRECATED}},
-  {"cusparseXbsrilu02_zeroPivot",                          {"hipsparseXbsrilu02_zeroPivot",                       "rocsparse_bsrilu0_zero_pivot",                                     CONV_LIB_FUNC, API_SPARSE, 12, CUDA_DEPRECATED | HIP_DEPRECATED}},
+  m["cusparseSbsrilu02"]                                              = {"hipsparseSbsrilu02",                                 "rocsparse_sbsrilu0",                                               CONV_LIB_FUNC, API_SPARSE, 12, CUDA_DEPRECATED | HIP_DEPRECATED};
+  m["cusparseDbsrilu02"]                                              = {"hipsparseDbsrilu02",                                 "rocsparse_dbsrilu0",                                               CONV_LIB_FUNC, API_SPARSE, 12, CUDA_DEPRECATED | HIP_DEPRECATED};
+  m["cusparseCbsrilu02"]                                              = {"hipsparseCbsrilu02",                                 "rocsparse_cbsrilu0",                                               CONV_LIB_FUNC, API_SPARSE, 12, CUDA_DEPRECATED | HIP_DEPRECATED};
+  m["cusparseZbsrilu02"]                                              = {"hipsparseZbsrilu02",                                 "rocsparse_zbsrilu0",                                               CONV_LIB_FUNC, API_SPARSE, 12, CUDA_DEPRECATED | HIP_DEPRECATED};
+  m["cusparseXbsrilu02_zeroPivot"]                                    = {"hipsparseXbsrilu02_zeroPivot",                       "rocsparse_bsrilu0_zero_pivot",                                     CONV_LIB_FUNC, API_SPARSE, 12, CUDA_DEPRECATED | HIP_DEPRECATED};
 
   // 12.3. Tridiagonal Solve
   // NOTE: rocsparse_(s|d|c|z)gtsv have an additional parameter void* temp_buffer
-  {"cusparseSgtsv",                                        {"hipsparseSgtsv",                                     "",                                                                 CONV_LIB_FUNC, API_SPARSE, 12, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED}},
-  {"cusparseDgtsv",                                        {"hipsparseDgtsv",                                     "",                                                                 CONV_LIB_FUNC, API_SPARSE, 12, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED}},
-  {"cusparseCgtsv",                                        {"hipsparseCgtsv",                                     "",                                                                 CONV_LIB_FUNC, API_SPARSE, 12, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED}},
-  {"cusparseZgtsv",                                        {"hipsparseZgtsv",                                     "",                                                                 CONV_LIB_FUNC, API_SPARSE, 12, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED}},
+  m["cusparseSgtsv"]                                                  = {"hipsparseSgtsv",                                     "",                                                                 CONV_LIB_FUNC, API_SPARSE, 12, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED};
+  m["cusparseDgtsv"]                                                  = {"hipsparseDgtsv",                                     "",                                                                 CONV_LIB_FUNC, API_SPARSE, 12, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED};
+  m["cusparseCgtsv"]                                                  = {"hipsparseCgtsv",                                     "",                                                                 CONV_LIB_FUNC, API_SPARSE, 12, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED};
+  m["cusparseZgtsv"]                                                  = {"hipsparseZgtsv",                                     "",                                                                 CONV_LIB_FUNC, API_SPARSE, 12, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED};
 
   // NOTE: rocsparse_(s|d|c|z)gtsv_no_pivot have an additional parameter void* temp_buffer
-  {"cusparseSgtsv_nopivot",                                {"hipsparseSgtsv_nopivot",                             "",                                                                 CONV_LIB_FUNC, API_SPARSE, 12, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED}},
-  {"cusparseDgtsv_nopivot",                                {"hipsparseDgtsv_nopivot",                             "",                                                                 CONV_LIB_FUNC, API_SPARSE, 12, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED}},
-  {"cusparseCgtsv_nopivot",                                {"hipsparseCgtsv_nopivot",                             "",                                                                 CONV_LIB_FUNC, API_SPARSE, 12, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED}},
-  {"cusparseZgtsv_nopivot",                                {"hipsparseZgtsv_nopivot",                             "",                                                                 CONV_LIB_FUNC, API_SPARSE, 12, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED}},
+  m["cusparseSgtsv_nopivot"]                                          = {"hipsparseSgtsv_nopivot",                             "",                                                                 CONV_LIB_FUNC, API_SPARSE, 12, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED};
+  m["cusparseDgtsv_nopivot"]                                          = {"hipsparseDgtsv_nopivot",                             "",                                                                 CONV_LIB_FUNC, API_SPARSE, 12, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED};
+  m["cusparseCgtsv_nopivot"]                                          = {"hipsparseCgtsv_nopivot",                             "",                                                                 CONV_LIB_FUNC, API_SPARSE, 12, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED};
+  m["cusparseZgtsv_nopivot"]                                          = {"hipsparseZgtsv_nopivot",                             "",                                                                 CONV_LIB_FUNC, API_SPARSE, 12, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED};
 
-  {"cusparseSgtsv2_bufferSizeExt",                         {"hipsparseSgtsv2_bufferSizeExt",                      "rocsparse_sgtsv_buffer_size",                                      CONV_LIB_FUNC, API_SPARSE, 12}},
-  {"cusparseDgtsv2_bufferSizeExt",                         {"hipsparseDgtsv2_bufferSizeExt",                      "rocsparse_dgtsv_buffer_size",                                      CONV_LIB_FUNC, API_SPARSE, 12}},
-  {"cusparseCgtsv2_bufferSizeExt",                         {"hipsparseCgtsv2_bufferSizeExt",                      "rocsparse_cgtsv_buffer_size",                                      CONV_LIB_FUNC, API_SPARSE, 12}},
-  {"cusparseZgtsv2_bufferSizeExt",                         {"hipsparseZgtsv2_bufferSizeExt",                      "rocsparse_zgtsv_buffer_size",                                      CONV_LIB_FUNC, API_SPARSE, 12}},
+  m["cusparseSgtsv2_bufferSizeExt"]                                   = {"hipsparseSgtsv2_bufferSizeExt",                      "rocsparse_sgtsv_buffer_size",                                      CONV_LIB_FUNC, API_SPARSE, 12};
+  m["cusparseDgtsv2_bufferSizeExt"]                                   = {"hipsparseDgtsv2_bufferSizeExt",                      "rocsparse_dgtsv_buffer_size",                                      CONV_LIB_FUNC, API_SPARSE, 12};
+  m["cusparseCgtsv2_bufferSizeExt"]                                   = {"hipsparseCgtsv2_bufferSizeExt",                      "rocsparse_cgtsv_buffer_size",                                      CONV_LIB_FUNC, API_SPARSE, 12};
+  m["cusparseZgtsv2_bufferSizeExt"]                                   = {"hipsparseZgtsv2_bufferSizeExt",                      "rocsparse_zgtsv_buffer_size",                                      CONV_LIB_FUNC, API_SPARSE, 12};
 
-  {"cusparseSgtsv2",                                       {"hipsparseSgtsv2",                                    "rocsparse_sgtsv",                                                  CONV_LIB_FUNC, API_SPARSE, 12}},
-  {"cusparseDgtsv2",                                       {"hipsparseDgtsv2",                                    "rocsparse_dgtsv",                                                  CONV_LIB_FUNC, API_SPARSE, 12}},
-  {"cusparseCgtsv2",                                       {"hipsparseCgtsv2",                                    "rocsparse_cgtsv",                                                  CONV_LIB_FUNC, API_SPARSE, 12}},
-  {"cusparseZgtsv2",                                       {"hipsparseZgtsv2",                                    "rocsparse_zgtsv",                                                  CONV_LIB_FUNC, API_SPARSE, 12}},
+  m["cusparseSgtsv2"]                                                 = {"hipsparseSgtsv2",                                    "rocsparse_sgtsv",                                                  CONV_LIB_FUNC, API_SPARSE, 12};
+  m["cusparseDgtsv2"]                                                 = {"hipsparseDgtsv2",                                    "rocsparse_dgtsv",                                                  CONV_LIB_FUNC, API_SPARSE, 12};
+  m["cusparseCgtsv2"]                                                 = {"hipsparseCgtsv2",                                    "rocsparse_cgtsv",                                                  CONV_LIB_FUNC, API_SPARSE, 12};
+  m["cusparseZgtsv2"]                                                 = {"hipsparseZgtsv2",                                    "rocsparse_zgtsv",                                                  CONV_LIB_FUNC, API_SPARSE, 12};
 
-  {"cusparseSgtsv2_nopivot_bufferSizeExt",                 {"hipsparseSgtsv2_nopivot_bufferSizeExt",              "rocsparse_sgtsv_no_pivot_buffer_size",                             CONV_LIB_FUNC, API_SPARSE, 12}},
-  {"cusparseDgtsv2_nopivot_bufferSizeExt",                 {"hipsparseDgtsv2_nopivot_bufferSizeExt",              "rocsparse_dgtsv_no_pivot_buffer_size",                             CONV_LIB_FUNC, API_SPARSE, 12}},
-  {"cusparseCgtsv2_nopivot_bufferSizeExt",                 {"hipsparseCgtsv2_nopivot_bufferSizeExt",              "rocsparse_cgtsv_no_pivot_buffer_size",                             CONV_LIB_FUNC, API_SPARSE, 12}},
-  {"cusparseZgtsv2_nopivot_bufferSizeExt",                 {"hipsparseZgtsv2_nopivot_bufferSizeExt",              "rocsparse_zgtsv_no_pivot_buffer_size",                             CONV_LIB_FUNC, API_SPARSE, 12}},
+  m["cusparseSgtsv2_nopivot_bufferSizeExt"]                           = {"hipsparseSgtsv2_nopivot_bufferSizeExt",              "rocsparse_sgtsv_no_pivot_buffer_size",                             CONV_LIB_FUNC, API_SPARSE, 12};
+  m["cusparseDgtsv2_nopivot_bufferSizeExt"]                           = {"hipsparseDgtsv2_nopivot_bufferSizeExt",              "rocsparse_dgtsv_no_pivot_buffer_size",                             CONV_LIB_FUNC, API_SPARSE, 12};
+  m["cusparseCgtsv2_nopivot_bufferSizeExt"]                           = {"hipsparseCgtsv2_nopivot_bufferSizeExt",              "rocsparse_cgtsv_no_pivot_buffer_size",                             CONV_LIB_FUNC, API_SPARSE, 12};
+  m["cusparseZgtsv2_nopivot_bufferSizeExt"]                           = {"hipsparseZgtsv2_nopivot_bufferSizeExt",              "rocsparse_zgtsv_no_pivot_buffer_size",                             CONV_LIB_FUNC, API_SPARSE, 12};
 
-  {"cusparseSgtsv2_nopivot",                               {"hipsparseSgtsv2_nopivot",                            "rocsparse_sgtsv_no_pivot",                                         CONV_LIB_FUNC, API_SPARSE, 12}},
-  {"cusparseDgtsv2_nopivot",                               {"hipsparseDgtsv2_nopivot",                            "rocsparse_dgtsv_no_pivot",                                         CONV_LIB_FUNC, API_SPARSE, 12}},
-  {"cusparseCgtsv2_nopivot",                               {"hipsparseCgtsv2_nopivot",                            "rocsparse_cgtsv_no_pivot",                                         CONV_LIB_FUNC, API_SPARSE, 12}},
-  {"cusparseZgtsv2_nopivot",                               {"hipsparseZgtsv2_nopivot",                            "rocsparse_zgtsv_no_pivot",                                         CONV_LIB_FUNC, API_SPARSE, 12}},
+  m["cusparseSgtsv2_nopivot"]                                         = {"hipsparseSgtsv2_nopivot",                            "rocsparse_sgtsv_no_pivot",                                         CONV_LIB_FUNC, API_SPARSE, 12};
+  m["cusparseDgtsv2_nopivot"]                                         = {"hipsparseDgtsv2_nopivot",                            "rocsparse_dgtsv_no_pivot",                                         CONV_LIB_FUNC, API_SPARSE, 12};
+  m["cusparseCgtsv2_nopivot"]                                         = {"hipsparseCgtsv2_nopivot",                            "rocsparse_cgtsv_no_pivot",                                         CONV_LIB_FUNC, API_SPARSE, 12};
+  m["cusparseZgtsv2_nopivot"]                                         = {"hipsparseZgtsv2_nopivot",                            "rocsparse_zgtsv_no_pivot",                                         CONV_LIB_FUNC, API_SPARSE, 12};
 
   // 12.4. Batched Tridiagonal Solve
-  {"cusparseSgtsvStridedBatch",                            {"hipsparseSgtsvStridedBatch",                         "",                                                                 CONV_LIB_FUNC, API_SPARSE, 12, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED}},
-  {"cusparseDgtsvStridedBatch",                            {"hipsparseDgtsvStridedBatch",                         "",                                                                 CONV_LIB_FUNC, API_SPARSE, 12, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED}},
-  {"cusparseCgtsvStridedBatch",                            {"hipsparseCgtsvStridedBatch",                         "",                                                                 CONV_LIB_FUNC, API_SPARSE, 12, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED}},
-  {"cusparseZgtsvStridedBatch",                            {"hipsparseZgtsvStridedBatch",                         "",                                                                 CONV_LIB_FUNC, API_SPARSE, 12, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED}},
+  m["cusparseSgtsvStridedBatch"]                                      = {"hipsparseSgtsvStridedBatch",                         "",                                                                 CONV_LIB_FUNC, API_SPARSE, 12, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED};
+  m["cusparseDgtsvStridedBatch"]                                      = {"hipsparseDgtsvStridedBatch",                         "",                                                                 CONV_LIB_FUNC, API_SPARSE, 12, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED};
+  m["cusparseCgtsvStridedBatch"]                                      = {"hipsparseCgtsvStridedBatch",                         "",                                                                 CONV_LIB_FUNC, API_SPARSE, 12, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED};
+  m["cusparseZgtsvStridedBatch"]                                      = {"hipsparseZgtsvStridedBatch",                         "",                                                                 CONV_LIB_FUNC, API_SPARSE, 12, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED};
 
-  {"cusparseSgtsv2StridedBatch_bufferSizeExt",             {"hipsparseSgtsv2StridedBatch_bufferSizeExt",          "rocsparse_sgtsv_no_pivot_strided_batch_buffer_size",               CONV_LIB_FUNC, API_SPARSE, 12}},
-  {"cusparseDgtsv2StridedBatch_bufferSizeExt",             {"hipsparseDgtsv2StridedBatch_bufferSizeExt",          "rocsparse_dgtsv_no_pivot_strided_batch_buffer_size",               CONV_LIB_FUNC, API_SPARSE, 12}},
-  {"cusparseCgtsv2StridedBatch_bufferSizeExt",             {"hipsparseCgtsv2StridedBatch_bufferSizeExt",          "rocsparse_cgtsv_no_pivot_strided_batch_buffer_size",               CONV_LIB_FUNC, API_SPARSE, 12}},
-  {"cusparseZgtsv2StridedBatch_bufferSizeExt",             {"hipsparseZgtsv2StridedBatch_bufferSizeExt",          "rocsparse_zgtsv_no_pivot_strided_batch_buffer_size",               CONV_LIB_FUNC, API_SPARSE, 12}},
+  m["cusparseSgtsv2StridedBatch_bufferSizeExt"]                       = {"hipsparseSgtsv2StridedBatch_bufferSizeExt",          "rocsparse_sgtsv_no_pivot_strided_batch_buffer_size",               CONV_LIB_FUNC, API_SPARSE, 12};
+  m["cusparseDgtsv2StridedBatch_bufferSizeExt"]                       = {"hipsparseDgtsv2StridedBatch_bufferSizeExt",          "rocsparse_dgtsv_no_pivot_strided_batch_buffer_size",               CONV_LIB_FUNC, API_SPARSE, 12};
+  m["cusparseCgtsv2StridedBatch_bufferSizeExt"]                       = {"hipsparseCgtsv2StridedBatch_bufferSizeExt",          "rocsparse_cgtsv_no_pivot_strided_batch_buffer_size",               CONV_LIB_FUNC, API_SPARSE, 12};
+  m["cusparseZgtsv2StridedBatch_bufferSizeExt"]                       = {"hipsparseZgtsv2StridedBatch_bufferSizeExt",          "rocsparse_zgtsv_no_pivot_strided_batch_buffer_size",               CONV_LIB_FUNC, API_SPARSE, 12};
 
-  {"cusparseSgtsv2StridedBatch",                           {"hipsparseSgtsv2StridedBatch",                        "rocsparse_sgtsv_no_pivot_strided_batch",                           CONV_LIB_FUNC, API_SPARSE, 12}},
-  {"cusparseDgtsv2StridedBatch",                           {"hipsparseDgtsv2StridedBatch",                        "rocsparse_dgtsv_no_pivot_strided_batch",                           CONV_LIB_FUNC, API_SPARSE, 12}},
-  {"cusparseCgtsv2StridedBatch",                           {"hipsparseCgtsv2StridedBatch",                        "rocsparse_cgtsv_no_pivot_strided_batch",                           CONV_LIB_FUNC, API_SPARSE, 12}},
-  {"cusparseZgtsv2StridedBatch",                           {"hipsparseZgtsv2StridedBatch",                        "rocsparse_zgtsv_no_pivot_strided_batch",                           CONV_LIB_FUNC, API_SPARSE, 12}},
+  m["cusparseSgtsv2StridedBatch"]                                     = {"hipsparseSgtsv2StridedBatch",                        "rocsparse_sgtsv_no_pivot_strided_batch",                           CONV_LIB_FUNC, API_SPARSE, 12};
+  m["cusparseDgtsv2StridedBatch"]                                     = {"hipsparseDgtsv2StridedBatch",                        "rocsparse_dgtsv_no_pivot_strided_batch",                           CONV_LIB_FUNC, API_SPARSE, 12};
+  m["cusparseCgtsv2StridedBatch"]                                     = {"hipsparseCgtsv2StridedBatch",                        "rocsparse_cgtsv_no_pivot_strided_batch",                           CONV_LIB_FUNC, API_SPARSE, 12};
+  m["cusparseZgtsv2StridedBatch"]                                     = {"hipsparseZgtsv2StridedBatch",                        "rocsparse_zgtsv_no_pivot_strided_batch",                           CONV_LIB_FUNC, API_SPARSE, 12};
 
-  {"cusparseSgtsvInterleavedBatch_bufferSizeExt",          {"hipsparseSgtsvInterleavedBatch_bufferSizeExt",       "rocsparse_sgtsv_interleaved_batch_buffer_size",                    CONV_LIB_FUNC, API_SPARSE, 12}},
-  {"cusparseDgtsvInterleavedBatch_bufferSizeExt",          {"hipsparseDgtsvInterleavedBatch_bufferSizeExt",       "rocsparse_dgtsv_interleaved_batch_buffer_size",                    CONV_LIB_FUNC, API_SPARSE, 12}},
-  {"cusparseCgtsvInterleavedBatch_bufferSizeExt",          {"hipsparseCgtsvInterleavedBatch_bufferSizeExt",       "rocsparse_cgtsv_interleaved_batch_buffer_size",                    CONV_LIB_FUNC, API_SPARSE, 12}},
-  {"cusparseZgtsvInterleavedBatch_bufferSizeExt",          {"hipsparseZgtsvInterleavedBatch_bufferSizeExt",       "rocsparse_zgtsv_interleaved_batch_buffer_size",                    CONV_LIB_FUNC, API_SPARSE, 12}},
+  m["cusparseSgtsvInterleavedBatch_bufferSizeExt"]                    = {"hipsparseSgtsvInterleavedBatch_bufferSizeExt",       "rocsparse_sgtsv_interleaved_batch_buffer_size",                    CONV_LIB_FUNC, API_SPARSE, 12};
+  m["cusparseDgtsvInterleavedBatch_bufferSizeExt"]                    = {"hipsparseDgtsvInterleavedBatch_bufferSizeExt",       "rocsparse_dgtsv_interleaved_batch_buffer_size",                    CONV_LIB_FUNC, API_SPARSE, 12};
+  m["cusparseCgtsvInterleavedBatch_bufferSizeExt"]                    = {"hipsparseCgtsvInterleavedBatch_bufferSizeExt",       "rocsparse_cgtsv_interleaved_batch_buffer_size",                    CONV_LIB_FUNC, API_SPARSE, 12};
+  m["cusparseZgtsvInterleavedBatch_bufferSizeExt"]                    = {"hipsparseZgtsvInterleavedBatch_bufferSizeExt",       "rocsparse_zgtsv_interleaved_batch_buffer_size",                    CONV_LIB_FUNC, API_SPARSE, 12};
 
-  {"cusparseSgtsvInterleavedBatch",                        {"hipsparseSgtsvInterleavedBatch",                     "rocsparse_sgtsv_interleaved_batch",                                CONV_LIB_FUNC, API_SPARSE, 12}},
-  {"cusparseDgtsvInterleavedBatch",                        {"hipsparseDgtsvInterleavedBatch",                     "rocsparse_dgtsv_interleaved_batch",                                CONV_LIB_FUNC, API_SPARSE, 12}},
-  {"cusparseCgtsvInterleavedBatch",                        {"hipsparseCgtsvInterleavedBatch",                     "rocsparse_cgtsv_interleaved_batch",                                CONV_LIB_FUNC, API_SPARSE, 12}},
-  {"cusparseZgtsvInterleavedBatch",                        {"hipsparseZgtsvInterleavedBatch",                     "rocsparse_zgtsv_interleaved_batch",                                CONV_LIB_FUNC, API_SPARSE, 12}},
+  m["cusparseSgtsvInterleavedBatch"]                                  = {"hipsparseSgtsvInterleavedBatch",                     "rocsparse_sgtsv_interleaved_batch",                                CONV_LIB_FUNC, API_SPARSE, 12};
+  m["cusparseDgtsvInterleavedBatch"]                                  = {"hipsparseDgtsvInterleavedBatch",                     "rocsparse_dgtsv_interleaved_batch",                                CONV_LIB_FUNC, API_SPARSE, 12};
+  m["cusparseCgtsvInterleavedBatch"]                                  = {"hipsparseCgtsvInterleavedBatch",                     "rocsparse_cgtsv_interleaved_batch",                                CONV_LIB_FUNC, API_SPARSE, 12};
+  m["cusparseZgtsvInterleavedBatch"]                                  = {"hipsparseZgtsvInterleavedBatch",                     "rocsparse_zgtsv_interleaved_batch",                                CONV_LIB_FUNC, API_SPARSE, 12};
 
   // 12.5. Batched Pentadiagonal Solve
-  {"cusparseSgpsvInterleavedBatch_bufferSizeExt",          {"hipsparseSgpsvInterleavedBatch_bufferSizeExt",       "rocsparse_sgpsv_interleaved_batch_buffer_size",                    CONV_LIB_FUNC, API_SPARSE, 12}},
-  {"cusparseDgpsvInterleavedBatch_bufferSizeExt",          {"hipsparseDgpsvInterleavedBatch_bufferSizeExt",       "rocsparse_dgpsv_interleaved_batch_buffer_size",                    CONV_LIB_FUNC, API_SPARSE, 12}},
-  {"cusparseCgpsvInterleavedBatch_bufferSizeExt",          {"hipsparseCgpsvInterleavedBatch_bufferSizeExt",       "rocsparse_cgpsv_interleaved_batch_buffer_size",                    CONV_LIB_FUNC, API_SPARSE, 12}},
-  {"cusparseZgpsvInterleavedBatch_bufferSizeExt",          {"hipsparseZgpsvInterleavedBatch_bufferSizeExt",       "rocsparse_zgpsv_interleaved_batch_buffer_size",                    CONV_LIB_FUNC, API_SPARSE, 12}},
+  m["cusparseSgpsvInterleavedBatch_bufferSizeExt"]                    = {"hipsparseSgpsvInterleavedBatch_bufferSizeExt",       "rocsparse_sgpsv_interleaved_batch_buffer_size",                    CONV_LIB_FUNC, API_SPARSE, 12};
+  m["cusparseDgpsvInterleavedBatch_bufferSizeExt"]                    = {"hipsparseDgpsvInterleavedBatch_bufferSizeExt",       "rocsparse_dgpsv_interleaved_batch_buffer_size",                    CONV_LIB_FUNC, API_SPARSE, 12};
+  m["cusparseCgpsvInterleavedBatch_bufferSizeExt"]                    = {"hipsparseCgpsvInterleavedBatch_bufferSizeExt",       "rocsparse_cgpsv_interleaved_batch_buffer_size",                    CONV_LIB_FUNC, API_SPARSE, 12};
+  m["cusparseZgpsvInterleavedBatch_bufferSizeExt"]                    = {"hipsparseZgpsvInterleavedBatch_bufferSizeExt",       "rocsparse_zgpsv_interleaved_batch_buffer_size",                    CONV_LIB_FUNC, API_SPARSE, 12};
 
-  {"cusparseSgpsvInterleavedBatch",                        {"hipsparseSgpsvInterleavedBatch",                     "rocsparse_sgpsv_interleaved_batch",                                CONV_LIB_FUNC, API_SPARSE, 12}},
-  {"cusparseDgpsvInterleavedBatch",                        {"hipsparseDgpsvInterleavedBatch",                     "rocsparse_dgpsv_interleaved_batch",                                CONV_LIB_FUNC, API_SPARSE, 12}},
-  {"cusparseCgpsvInterleavedBatch",                        {"hipsparseCgpsvInterleavedBatch",                     "rocsparse_cgpsv_interleaved_batch",                                CONV_LIB_FUNC, API_SPARSE, 12}},
-  {"cusparseZgpsvInterleavedBatch",                        {"hipsparseZgpsvInterleavedBatch",                     "rocsparse_zgpsv_interleaved_batch",                                CONV_LIB_FUNC, API_SPARSE, 12}},
+  m["cusparseSgpsvInterleavedBatch"]                                  = {"hipsparseSgpsvInterleavedBatch",                     "rocsparse_sgpsv_interleaved_batch",                                CONV_LIB_FUNC, API_SPARSE, 12};
+  m["cusparseDgpsvInterleavedBatch"]                                  = {"hipsparseDgpsvInterleavedBatch",                     "rocsparse_dgpsv_interleaved_batch",                                CONV_LIB_FUNC, API_SPARSE, 12};
+  m["cusparseCgpsvInterleavedBatch"]                                  = {"hipsparseCgpsvInterleavedBatch",                     "rocsparse_cgpsv_interleaved_batch",                                CONV_LIB_FUNC, API_SPARSE, 12};
+  m["cusparseZgpsvInterleavedBatch"]                                  = {"hipsparseZgpsvInterleavedBatch",                     "rocsparse_zgpsv_interleaved_batch",                                CONV_LIB_FUNC, API_SPARSE, 12};
 
   // 13. cuSPARSE Matrix Reorderings Reference
-  {"cusparseScsrcolor",                                    {"hipsparseScsrcolor",                                 "rocsparse_scsrcolor",                                              CONV_LIB_FUNC, API_SPARSE, 13, CUDA_DEPRECATED | HIP_DEPRECATED}},
-  {"cusparseDcsrcolor",                                    {"hipsparseDcsrcolor",                                 "rocsparse_dcsrcolor",                                              CONV_LIB_FUNC, API_SPARSE, 13, CUDA_DEPRECATED | HIP_DEPRECATED}},
-  {"cusparseCcsrcolor",                                    {"hipsparseCcsrcolor",                                 "rocsparse_ccsrcolor",                                              CONV_LIB_FUNC, API_SPARSE, 13, CUDA_DEPRECATED | HIP_DEPRECATED}},
-  {"cusparseZcsrcolor",                                    {"hipsparseZcsrcolor",                                 "rocsparse_zcsrcolor",                                              CONV_LIB_FUNC, API_SPARSE, 13, CUDA_DEPRECATED | HIP_DEPRECATED}},
+  m["cusparseScsrcolor"]                                              = {"hipsparseScsrcolor",                                 "rocsparse_scsrcolor",                                              CONV_LIB_FUNC, API_SPARSE, 13, CUDA_DEPRECATED | HIP_DEPRECATED};
+  m["cusparseDcsrcolor"]                                              = {"hipsparseDcsrcolor",                                 "rocsparse_dcsrcolor",                                              CONV_LIB_FUNC, API_SPARSE, 13, CUDA_DEPRECATED | HIP_DEPRECATED};
+  m["cusparseCcsrcolor"]                                              = {"hipsparseCcsrcolor",                                 "rocsparse_ccsrcolor",                                              CONV_LIB_FUNC, API_SPARSE, 13, CUDA_DEPRECATED | HIP_DEPRECATED};
+  m["cusparseZcsrcolor"]                                              = {"hipsparseZcsrcolor",                                 "rocsparse_zcsrcolor",                                              CONV_LIB_FUNC, API_SPARSE, 13, CUDA_DEPRECATED | HIP_DEPRECATED};
 
   // 14. cuSPARSE Format Conversion Reference
-  {"cusparseSbsr2csr",                                     {"hipsparseSbsr2csr",                                  "rocsparse_sbsr2csr",                                               CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED}},
-  {"cusparseDbsr2csr",                                     {"hipsparseDbsr2csr",                                  "rocsparse_dbsr2csr",                                               CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED}},
-  {"cusparseCbsr2csr",                                     {"hipsparseCbsr2csr",                                  "rocsparse_cbsr2csr",                                               CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED}},
-  {"cusparseZbsr2csr",                                     {"hipsparseZbsr2csr",                                  "rocsparse_zbsr2csr",                                               CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED}},
+  m["cusparseSbsr2csr"]                                               = {"hipsparseSbsr2csr",                                  "rocsparse_sbsr2csr",                                               CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED};
+  m["cusparseDbsr2csr"]                                               = {"hipsparseDbsr2csr",                                  "rocsparse_dbsr2csr",                                               CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED};
+  m["cusparseCbsr2csr"]                                               = {"hipsparseCbsr2csr",                                  "rocsparse_cbsr2csr",                                               CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED};
+  m["cusparseZbsr2csr"]                                               = {"hipsparseZbsr2csr",                                  "rocsparse_zbsr2csr",                                               CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED};
 
-  {"cusparseSgebsr2gebsc_bufferSize",                      {"hipsparseSgebsr2gebsc_bufferSize",                   "rocsparse_sgebsr2gebsc_buffer_size",                               CONV_LIB_FUNC, API_SPARSE, 14}},
-  {"cusparseSgebsr2gebsc_bufferSizeExt",                   {"hipsparseSgebsr2gebsc_bufferSizeExt",                "",                                                                 CONV_LIB_FUNC, API_SPARSE, 14, UNSUPPORTED}},
-  {"cusparseDgebsr2gebsc_bufferSize",                      {"hipsparseDgebsr2gebsc_bufferSize",                   "rocsparse_dgebsr2gebsc_buffer_size",                               CONV_LIB_FUNC, API_SPARSE, 14}},
-  {"cusparseDgebsr2gebsc_bufferSizeExt",                   {"hipsparseDgebsr2gebsc_bufferSizeExt",                "",                                                                 CONV_LIB_FUNC, API_SPARSE, 14, UNSUPPORTED}},
-  {"cusparseCgebsr2gebsc_bufferSize",                      {"hipsparseCgebsr2gebsc_bufferSize",                   "rocsparse_cgebsr2gebsc_buffer_size",                               CONV_LIB_FUNC, API_SPARSE, 14}},
-  {"cusparseCgebsr2gebsc_bufferSizeExt",                   {"hipsparseCgebsr2gebsc_bufferSizeExt",                "",                                                                 CONV_LIB_FUNC, API_SPARSE, 14, UNSUPPORTED}},
-  {"cusparseZgebsr2gebsc_bufferSize",                      {"hipsparseZgebsr2gebsc_bufferSize",                   "rocsparse_zgebsr2gebsc_buffer_size",                               CONV_LIB_FUNC, API_SPARSE, 14}},
-  {"cusparseZgebsr2gebsc_bufferSizeExt",                   {"hipsparseZgebsr2gebsc_bufferSizeExt",                "",                                                                 CONV_LIB_FUNC, API_SPARSE, 14, UNSUPPORTED}},
+  m["cusparseSgebsr2gebsc_bufferSize"]                                = {"hipsparseSgebsr2gebsc_bufferSize",                   "rocsparse_sgebsr2gebsc_buffer_size",                               CONV_LIB_FUNC, API_SPARSE, 14};
+  m["cusparseSgebsr2gebsc_bufferSizeExt"]                             = {"hipsparseSgebsr2gebsc_bufferSizeExt",                "",                                                                 CONV_LIB_FUNC, API_SPARSE, 14, UNSUPPORTED};
+  m["cusparseDgebsr2gebsc_bufferSize"]                                = {"hipsparseDgebsr2gebsc_bufferSize",                   "rocsparse_dgebsr2gebsc_buffer_size",                               CONV_LIB_FUNC, API_SPARSE, 14};
+  m["cusparseDgebsr2gebsc_bufferSizeExt"]                             = {"hipsparseDgebsr2gebsc_bufferSizeExt",                "",                                                                 CONV_LIB_FUNC, API_SPARSE, 14, UNSUPPORTED};
+  m["cusparseCgebsr2gebsc_bufferSize"]                                = {"hipsparseCgebsr2gebsc_bufferSize",                   "rocsparse_cgebsr2gebsc_buffer_size",                               CONV_LIB_FUNC, API_SPARSE, 14};
+  m["cusparseCgebsr2gebsc_bufferSizeExt"]                             = {"hipsparseCgebsr2gebsc_bufferSizeExt",                "",                                                                 CONV_LIB_FUNC, API_SPARSE, 14, UNSUPPORTED};
+  m["cusparseZgebsr2gebsc_bufferSize"]                                = {"hipsparseZgebsr2gebsc_bufferSize",                   "rocsparse_zgebsr2gebsc_buffer_size",                               CONV_LIB_FUNC, API_SPARSE, 14};
+  m["cusparseZgebsr2gebsc_bufferSizeExt"]                             = {"hipsparseZgebsr2gebsc_bufferSizeExt",                "",                                                                 CONV_LIB_FUNC, API_SPARSE, 14, UNSUPPORTED};
 
-  {"cusparseSgebsr2gebsc",                                 {"hipsparseSgebsr2gebsc",                              "rocsparse_sgebsr2gebsc",                                           CONV_LIB_FUNC, API_SPARSE, 14}},
-  {"cusparseDgebsr2gebsc",                                 {"hipsparseDgebsr2gebsc",                              "rocsparse_dgebsr2gebsc",                                           CONV_LIB_FUNC, API_SPARSE, 14}},
-  {"cusparseCgebsr2gebsc",                                 {"hipsparseCgebsr2gebsc",                              "rocsparse_cgebsr2gebsc",                                           CONV_LIB_FUNC, API_SPARSE, 14}},
-  {"cusparseZgebsr2gebsc",                                 {"hipsparseZgebsr2gebsc",                              "rocsparse_zgebsr2gebsc",                                           CONV_LIB_FUNC, API_SPARSE, 14}},
+  m["cusparseSgebsr2gebsc"]                                           = {"hipsparseSgebsr2gebsc",                              "rocsparse_sgebsr2gebsc",                                           CONV_LIB_FUNC, API_SPARSE, 14};
+  m["cusparseDgebsr2gebsc"]                                           = {"hipsparseDgebsr2gebsc",                              "rocsparse_dgebsr2gebsc",                                           CONV_LIB_FUNC, API_SPARSE, 14};
+  m["cusparseCgebsr2gebsc"]                                           = {"hipsparseCgebsr2gebsc",                              "rocsparse_cgebsr2gebsc",                                           CONV_LIB_FUNC, API_SPARSE, 14};
+  m["cusparseZgebsr2gebsc"]                                           = {"hipsparseZgebsr2gebsc",                              "rocsparse_zgebsr2gebsc",                                           CONV_LIB_FUNC, API_SPARSE, 14};
 
-  {"cusparseSgebsr2gebsr_bufferSize",                      {"hipsparseSgebsr2gebsr_bufferSize",                   "rocsparse_sgebsr2gebsr_buffer_size",                               CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED}},
-  {"cusparseSgebsr2gebsr_bufferSizeExt",                   {"hipsparseSgebsr2gebsr_bufferSizeExt",                "",                                                                 CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED | UNSUPPORTED}},
-  {"cusparseDgebsr2gebsr_bufferSize",                      {"hipsparseDgebsr2gebsr_bufferSize",                   "rocsparse_dgebsr2gebsr_buffer_size",                               CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED}},
-  {"cusparseDgebsr2gebsr_bufferSizeExt",                   {"hipsparseDgebsr2gebsr_bufferSizeExt",                "",                                                                 CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED | UNSUPPORTED}},
-  {"cusparseCgebsr2gebsr_bufferSize",                      {"hipsparseCgebsr2gebsr_bufferSize",                   "rocsparse_cgebsr2gebsr_buffer_size",                               CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED}},
-  {"cusparseCgebsr2gebsr_bufferSizeExt",                   {"hipsparseCgebsr2gebsr_bufferSizeExt",                "",                                                                 CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED | UNSUPPORTED}},
-  {"cusparseZgebsr2gebsr_bufferSize",                      {"hipsparseZgebsr2gebsr_bufferSize",                   "rocsparse_zgebsr2gebsr_buffer_size",                               CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED}},
-  {"cusparseZgebsr2gebsr_bufferSizeExt",                   {"hipsparseZgebsr2gebsr_bufferSizeExt",                "",                                                                 CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED | UNSUPPORTED}},
+  m["cusparseSgebsr2gebsr_bufferSize"]                                = {"hipsparseSgebsr2gebsr_bufferSize",                   "rocsparse_sgebsr2gebsr_buffer_size",                               CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED};
+  m["cusparseSgebsr2gebsr_bufferSizeExt"]                             = {"hipsparseSgebsr2gebsr_bufferSizeExt",                "",                                                                 CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED | UNSUPPORTED};
+  m["cusparseDgebsr2gebsr_bufferSize"]                                = {"hipsparseDgebsr2gebsr_bufferSize",                   "rocsparse_dgebsr2gebsr_buffer_size",                               CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED};
+  m["cusparseDgebsr2gebsr_bufferSizeExt"]                             = {"hipsparseDgebsr2gebsr_bufferSizeExt",                "",                                                                 CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED | UNSUPPORTED};
+  m["cusparseCgebsr2gebsr_bufferSize"]                                = {"hipsparseCgebsr2gebsr_bufferSize",                   "rocsparse_cgebsr2gebsr_buffer_size",                               CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED};
+  m["cusparseCgebsr2gebsr_bufferSizeExt"]                             = {"hipsparseCgebsr2gebsr_bufferSizeExt",                "",                                                                 CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED | UNSUPPORTED};
+  m["cusparseZgebsr2gebsr_bufferSize"]                                = {"hipsparseZgebsr2gebsr_bufferSize",                   "rocsparse_zgebsr2gebsr_buffer_size",                               CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED};
+  m["cusparseZgebsr2gebsr_bufferSizeExt"]                             = {"hipsparseZgebsr2gebsr_bufferSizeExt",                "",                                                                 CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED | UNSUPPORTED};
 
-  {"cusparseXgebsr2csr",                                   {"hipsparseXgebsr2csr",                                "",                                                                 CONV_LIB_FUNC, API_SPARSE, 14, UNSUPPORTED | CUDA_DEPRECATED}},
-  {"cusparseSgebsr2csr",                                   {"hipsparseSgebsr2csr",                                "rocsparse_sgebsr2csr",                                             CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED}},
-  {"cusparseDgebsr2csr",                                   {"hipsparseDgebsr2csr",                                "rocsparse_dgebsr2csr",                                             CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED}},
-  {"cusparseCgebsr2csr",                                   {"hipsparseCgebsr2csr",                                "rocsparse_cgebsr2csr",                                             CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED}},
-  {"cusparseZgebsr2csr",                                   {"hipsparseZgebsr2csr",                                "rocsparse_zgebsr2csr",                                             CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED}},
+  m["cusparseXgebsr2csr"]                                             = {"hipsparseXgebsr2csr",                                "",                                                                 CONV_LIB_FUNC, API_SPARSE, 14, UNSUPPORTED | CUDA_DEPRECATED};
+  m["cusparseSgebsr2csr"]                                             = {"hipsparseSgebsr2csr",                                "rocsparse_sgebsr2csr",                                             CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED};
+  m["cusparseDgebsr2csr"]                                             = {"hipsparseDgebsr2csr",                                "rocsparse_dgebsr2csr",                                             CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED};
+  m["cusparseCgebsr2csr"]                                             = {"hipsparseCgebsr2csr",                                "rocsparse_cgebsr2csr",                                             CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED};
+  m["cusparseZgebsr2csr"]                                             = {"hipsparseZgebsr2csr",                                "rocsparse_zgebsr2csr",                                             CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED};
 
-  {"cusparseXgebsr2gebsrNnz",                              {"hipsparseXgebsr2gebsrNnz",                           "rocsparse_gebsr2gebsr_nnz",                                        CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED}},
-  {"cusparseSgebsr2gebsr",                                 {"hipsparseSgebsr2gebsr",                              "rocsparse_sgebsr2gebsr",                                           CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED}},
-  {"cusparseDgebsr2gebsr",                                 {"hipsparseDgebsr2gebsr",                              "rocsparse_dgebsr2gebsr",                                           CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED}},
-  {"cusparseCgebsr2gebsr",                                 {"hipsparseCgebsr2gebsr",                              "rocsparse_cgebsr2gebsr",                                           CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED}},
-  {"cusparseZgebsr2gebsr",                                 {"hipsparseZgebsr2gebsr",                              "rocsparse_zgebsr2gebsr",                                           CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED}},
+  m["cusparseXgebsr2gebsrNnz"]                                        = {"hipsparseXgebsr2gebsrNnz",                           "rocsparse_gebsr2gebsr_nnz",                                        CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED};
+  m["cusparseSgebsr2gebsr"]                                           = {"hipsparseSgebsr2gebsr",                              "rocsparse_sgebsr2gebsr",                                           CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED};
+  m["cusparseDgebsr2gebsr"]                                           = {"hipsparseDgebsr2gebsr",                              "rocsparse_dgebsr2gebsr",                                           CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED};
+  m["cusparseCgebsr2gebsr"]                                           = {"hipsparseCgebsr2gebsr",                              "rocsparse_cgebsr2gebsr",                                           CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED};
+  m["cusparseZgebsr2gebsr"]                                           = {"hipsparseZgebsr2gebsr",                              "rocsparse_zgebsr2gebsr",                                           CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED};
 
-  {"cusparseScsr2gebsr_bufferSize",                        {"hipsparseScsr2gebsr_bufferSize",                     "rocsparse_scsr2gebsr_buffer_size",                                 CONV_LIB_FUNC, API_SPARSE, 14}},
-  {"cusparseScsr2gebsr_bufferSizeExt",                     {"hipsparseScsr2gebsr_bufferSizeExt",                  "",                                                                 CONV_LIB_FUNC, API_SPARSE, 14, UNSUPPORTED}},
-  {"cusparseDcsr2gebsr_bufferSize",                        {"hipsparseDcsr2gebsr_bufferSize",                     "rocsparse_dcsr2gebsr_buffer_size",                                 CONV_LIB_FUNC, API_SPARSE, 14}},
-  {"cusparseDcsr2gebsr_bufferSizeExt",                     {"hipsparseDcsr2gebsr_bufferSizeExt",                  "",                                                                 CONV_LIB_FUNC, API_SPARSE, 14, UNSUPPORTED}},
-  {"cusparseCcsr2gebsr_bufferSize",                        {"hipsparseCcsr2gebsr_bufferSize",                     "rocsparse_ccsr2gebsr_buffer_size",                                 CONV_LIB_FUNC, API_SPARSE, 14}},
-  {"cusparseCcsr2gebsr_bufferSizeExt",                     {"hipsparseCcsr2gebsr_bufferSizeExt",                  "",                                                                 CONV_LIB_FUNC, API_SPARSE, 14, UNSUPPORTED}},
-  {"cusparseZcsr2gebsr_bufferSize",                        {"hipsparseZcsr2gebsr_bufferSize",                     "rocsparse_zcsr2gebsr_buffer_size",                                 CONV_LIB_FUNC, API_SPARSE, 14}},
-  {"cusparseZcsr2gebsr_bufferSizeExt",                     {"hipsparseZcsr2gebsr_bufferSizeExt",                  "",                                                                 CONV_LIB_FUNC, API_SPARSE, 14, UNSUPPORTED}},
+  m["cusparseScsr2gebsr_bufferSize"]                                  = {"hipsparseScsr2gebsr_bufferSize",                     "rocsparse_scsr2gebsr_buffer_size",                                 CONV_LIB_FUNC, API_SPARSE, 14};
+  m["cusparseScsr2gebsr_bufferSizeExt"]                               = {"hipsparseScsr2gebsr_bufferSizeExt",                  "",                                                                 CONV_LIB_FUNC, API_SPARSE, 14, UNSUPPORTED};
+  m["cusparseDcsr2gebsr_bufferSize"]                                  = {"hipsparseDcsr2gebsr_bufferSize",                     "rocsparse_dcsr2gebsr_buffer_size",                                 CONV_LIB_FUNC, API_SPARSE, 14};
+  m["cusparseDcsr2gebsr_bufferSizeExt"]                               = {"hipsparseDcsr2gebsr_bufferSizeExt",                  "",                                                                 CONV_LIB_FUNC, API_SPARSE, 14, UNSUPPORTED};
+  m["cusparseCcsr2gebsr_bufferSize"]                                  = {"hipsparseCcsr2gebsr_bufferSize",                     "rocsparse_ccsr2gebsr_buffer_size",                                 CONV_LIB_FUNC, API_SPARSE, 14};
+  m["cusparseCcsr2gebsr_bufferSizeExt"]                               = {"hipsparseCcsr2gebsr_bufferSizeExt",                  "",                                                                 CONV_LIB_FUNC, API_SPARSE, 14, UNSUPPORTED};
+  m["cusparseZcsr2gebsr_bufferSize"]                                  = {"hipsparseZcsr2gebsr_bufferSize",                     "rocsparse_zcsr2gebsr_buffer_size",                                 CONV_LIB_FUNC, API_SPARSE, 14};
+  m["cusparseZcsr2gebsr_bufferSizeExt"]                               = {"hipsparseZcsr2gebsr_bufferSizeExt",                  "",                                                                 CONV_LIB_FUNC, API_SPARSE, 14, UNSUPPORTED};
 
-  {"cusparseXcsr2gebsrNnz",                                {"hipsparseXcsr2gebsrNnz",                             "rocsparse_csr2gebsr_nnz",                                          CONV_LIB_FUNC, API_SPARSE, 14}},
-  {"cusparseScsr2gebsr",                                   {"hipsparseScsr2gebsr",                                "rocsparse_scsr2gebsr",                                             CONV_LIB_FUNC, API_SPARSE, 14}},
-  {"cusparseDcsr2gebsr",                                   {"hipsparseDcsr2gebsr",                                "rocsparse_dcsr2gebsr",                                             CONV_LIB_FUNC, API_SPARSE, 14}},
-  {"cusparseCcsr2gebsr",                                   {"hipsparseCcsr2gebsr",                                "rocsparse_ccsr2gebsr",                                             CONV_LIB_FUNC, API_SPARSE, 14}},
-  {"cusparseZcsr2gebsr",                                   {"hipsparseZcsr2gebsr",                                "rocsparse_zcsr2gebsr",                                             CONV_LIB_FUNC, API_SPARSE, 14}},
+  m["cusparseXcsr2gebsrNnz"]                                          = {"hipsparseXcsr2gebsrNnz",                             "rocsparse_csr2gebsr_nnz",                                          CONV_LIB_FUNC, API_SPARSE, 14};
+  m["cusparseScsr2gebsr"]                                             = {"hipsparseScsr2gebsr",                                "rocsparse_scsr2gebsr",                                             CONV_LIB_FUNC, API_SPARSE, 14};
+  m["cusparseDcsr2gebsr"]                                             = {"hipsparseDcsr2gebsr",                                "rocsparse_dcsr2gebsr",                                             CONV_LIB_FUNC, API_SPARSE, 14};
+  m["cusparseCcsr2gebsr"]                                             = {"hipsparseCcsr2gebsr",                                "rocsparse_ccsr2gebsr",                                             CONV_LIB_FUNC, API_SPARSE, 14};
+  m["cusparseZcsr2gebsr"]                                             = {"hipsparseZcsr2gebsr",                                "rocsparse_zcsr2gebsr",                                             CONV_LIB_FUNC, API_SPARSE, 14};
 
-  {"cusparseXcoo2csr",                                     {"hipsparseXcoo2csr",                                  "rocsparse_coo2csr",                                                CONV_LIB_FUNC, API_SPARSE, 14}},
+  m["cusparseXcoo2csr"]                                               = {"hipsparseXcoo2csr",                                  "rocsparse_coo2csr",                                                CONV_LIB_FUNC, API_SPARSE, 14};
 
-  {"cusparseScsc2dense",                                   {"hipsparseScsc2dense",                                "rocsparse_scsc2dense",                                             CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED}},
-  {"cusparseDcsc2dense",                                   {"hipsparseDcsc2dense",                                "rocsparse_dcsc2dense",                                             CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED}},
-  {"cusparseCcsc2dense",                                   {"hipsparseCcsc2dense",                                "rocsparse_ccsc2dense",                                             CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED}},
-  {"cusparseZcsc2dense",                                   {"hipsparseZcsc2dense",                                "rocsparse_zcsc2dense",                                             CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED}},
+  m["cusparseScsc2dense"]                                             = {"hipsparseScsc2dense",                                "rocsparse_scsc2dense",                                             CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED};
+  m["cusparseDcsc2dense"]                                             = {"hipsparseDcsc2dense",                                "rocsparse_dcsc2dense",                                             CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED};
+  m["cusparseCcsc2dense"]                                             = {"hipsparseCcsc2dense",                                "rocsparse_ccsc2dense",                                             CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED};
+  m["cusparseZcsc2dense"]                                             = {"hipsparseZcsc2dense",                                "rocsparse_zcsc2dense",                                             CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED};
 
-  {"cusparseScsc2hyb",                                     {"hipsparseScsc2hyb",                                  "",                                                                 CONV_LIB_FUNC, API_SPARSE, 14, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED}},
-  {"cusparseDcsc2hyb",                                     {"hipsparseDcsc2hyb",                                  "",                                                                 CONV_LIB_FUNC, API_SPARSE, 14, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED}},
-  {"cusparseCcsc2hyb",                                     {"hipsparseCcsc2hyb",                                  "",                                                                 CONV_LIB_FUNC, API_SPARSE, 14, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED}},
-  {"cusparseZcsc2hyb",                                     {"hipsparseZcsc2hyb",                                  "",                                                                 CONV_LIB_FUNC, API_SPARSE, 14, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED}},
+  m["cusparseScsc2hyb"]                                               = {"hipsparseScsc2hyb",                                  "",                                                                 CONV_LIB_FUNC, API_SPARSE, 14, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED};
+  m["cusparseDcsc2hyb"]                                               = {"hipsparseDcsc2hyb",                                  "",                                                                 CONV_LIB_FUNC, API_SPARSE, 14, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED};
+  m["cusparseCcsc2hyb"]                                               = {"hipsparseCcsc2hyb",                                  "",                                                                 CONV_LIB_FUNC, API_SPARSE, 14, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED};
+  m["cusparseZcsc2hyb"]                                               = {"hipsparseZcsc2hyb",                                  "",                                                                 CONV_LIB_FUNC, API_SPARSE, 14, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED};
 
-  {"cusparseXcsr2bsrNnz",                                  {"hipsparseXcsr2bsrNnz",                               "rocsparse_csr2bsr_nnz",                                            CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED}},
-  {"cusparseScsr2bsr",                                     {"hipsparseScsr2bsr",                                  "rocsparse_scsr2bsr",                                               CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED}},
-  {"cusparseDcsr2bsr",                                     {"hipsparseDcsr2bsr",                                  "rocsparse_dcsr2bsr",                                               CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED}},
-  {"cusparseCcsr2bsr",                                     {"hipsparseCcsr2bsr",                                  "rocsparse_ccsr2bsr",                                               CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED}},
-  {"cusparseZcsr2bsr",                                     {"hipsparseZcsr2bsr",                                  "rocsparse_zcsr2bsr",                                               CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED}},
+  m["cusparseXcsr2bsrNnz"]                                            = {"hipsparseXcsr2bsrNnz",                               "rocsparse_csr2bsr_nnz",                                            CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED};
+  m["cusparseScsr2bsr"]                                               = {"hipsparseScsr2bsr",                                  "rocsparse_scsr2bsr",                                               CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED};
+  m["cusparseDcsr2bsr"]                                               = {"hipsparseDcsr2bsr",                                  "rocsparse_dcsr2bsr",                                               CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED};
+  m["cusparseCcsr2bsr"]                                               = {"hipsparseCcsr2bsr",                                  "rocsparse_ccsr2bsr",                                               CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED};
+  m["cusparseZcsr2bsr"]                                               = {"hipsparseZcsr2bsr",                                  "rocsparse_zcsr2bsr",                                               CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED};
 
-  {"cusparseXcsr2coo",                                     {"hipsparseXcsr2coo",                                  "rocsparse_csr2coo",                                                CONV_LIB_FUNC, API_SPARSE, 14}},
+  m["cusparseXcsr2coo"]                                               = {"hipsparseXcsr2coo",                                  "rocsparse_csr2coo",                                                CONV_LIB_FUNC, API_SPARSE, 14};
   // NOTE: rocsparse_(s|d|c|z)csr2csc have an additional parameter void* temp_buffer
-  {"cusparseScsr2csc",                                     {"hipsparseScsr2csc",                                  "",                                                                 CONV_LIB_FUNC, API_SPARSE, 14, ROC_UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED}},
-  {"cusparseDcsr2csc",                                     {"hipsparseDcsr2csc",                                  "",                                                                 CONV_LIB_FUNC, API_SPARSE, 14, ROC_UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED}},
-  {"cusparseCcsr2csc",                                     {"hipsparseCcsr2csc",                                  "",                                                                 CONV_LIB_FUNC, API_SPARSE, 14, ROC_UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED}},
-  {"cusparseZcsr2csc",                                     {"hipsparseZcsr2csc",                                  "",                                                                 CONV_LIB_FUNC, API_SPARSE, 14, ROC_UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED}},
+  m["cusparseScsr2csc"]                                               = {"hipsparseScsr2csc",                                  "",                                                                 CONV_LIB_FUNC, API_SPARSE, 14, ROC_UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED};
+  m["cusparseDcsr2csc"]                                               = {"hipsparseDcsr2csc",                                  "",                                                                 CONV_LIB_FUNC, API_SPARSE, 14, ROC_UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED};
+  m["cusparseCcsr2csc"]                                               = {"hipsparseCcsr2csc",                                  "",                                                                 CONV_LIB_FUNC, API_SPARSE, 14, ROC_UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED};
+  m["cusparseZcsr2csc"]                                               = {"hipsparseZcsr2csc",                                  "",                                                                 CONV_LIB_FUNC, API_SPARSE, 14, ROC_UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED};
 
-  {"cusparseCsr2cscEx",                                    {"hipsparseCsr2cscEx",                                 "",                                                                 CONV_LIB_FUNC, API_SPARSE, 14, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED}},
-  {"cusparseCsr2cscEx2",                                   {"hipsparseCsr2cscEx2",                                "",                                                                 CONV_LIB_FUNC, API_SPARSE, 14, ROC_UNSUPPORTED}},
-  {"cusparseCsr2cscEx2_bufferSize",                        {"hipsparseCsr2cscEx2_bufferSize",                     "rocsparse_csr2csc_buffer_size",                                    CONV_LIB_FUNC, API_SPARSE, 14}},
+  m["cusparseCsr2cscEx"]                                              = {"hipsparseCsr2cscEx",                                 "",                                                                 CONV_LIB_FUNC, API_SPARSE, 14, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED};
+  m["cusparseCsr2cscEx2"]                                             = {"hipsparseCsr2cscEx2",                                "",                                                                 CONV_LIB_FUNC, API_SPARSE, 14, ROC_UNSUPPORTED};
+  m["cusparseCsr2cscEx2_bufferSize"]                                  = {"hipsparseCsr2cscEx2_bufferSize",                     "rocsparse_csr2csc_buffer_size",                                    CONV_LIB_FUNC, API_SPARSE, 14};
 
-  {"cusparseScsr2dense",                                   {"hipsparseScsr2dense",                                "rocsparse_scsr2dense",                                             CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED}},
-  {"cusparseDcsr2dense",                                   {"hipsparseDcsr2dense",                                "rocsparse_dcsr2dense",                                             CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED}},
-  {"cusparseCcsr2dense",                                   {"hipsparseCcsr2dense",                                "rocsparse_ccsr2dense",                                             CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED}},
-  {"cusparseZcsr2dense",                                   {"hipsparseZcsr2dense",                                "rocsparse_zcsr2dense",                                             CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED}},
+  m["cusparseScsr2dense"]                                             = {"hipsparseScsr2dense",                                "rocsparse_scsr2dense",                                             CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED};
+  m["cusparseDcsr2dense"]                                             = {"hipsparseDcsr2dense",                                "rocsparse_dcsr2dense",                                             CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED};
+  m["cusparseCcsr2dense"]                                             = {"hipsparseCcsr2dense",                                "rocsparse_ccsr2dense",                                             CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED};
+  m["cusparseZcsr2dense"]                                             = {"hipsparseZcsr2dense",                                "rocsparse_zcsr2dense",                                             CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED};
 
-  {"cusparseScsr2csr_compress",                            {"hipsparseScsr2csr_compress",                         "rocsparse_scsr2csr_compress",                                      CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED}},
-  {"cusparseDcsr2csr_compress",                            {"hipsparseDcsr2csr_compress",                         "rocsparse_dcsr2csr_compress",                                      CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED}},
-  {"cusparseCcsr2csr_compress",                            {"hipsparseCcsr2csr_compress",                         "rocsparse_ccsr2csr_compress",                                      CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED}},
-  {"cusparseZcsr2csr_compress",                            {"hipsparseZcsr2csr_compress",                         "rocsparse_zcsr2csr_compress",                                      CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED}},
+  m["cusparseScsr2csr_compress"]                                      = {"hipsparseScsr2csr_compress",                         "rocsparse_scsr2csr_compress",                                      CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED};
+  m["cusparseDcsr2csr_compress"]                                      = {"hipsparseDcsr2csr_compress",                         "rocsparse_dcsr2csr_compress",                                      CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED};
+  m["cusparseCcsr2csr_compress"]                                      = {"hipsparseCcsr2csr_compress",                         "rocsparse_ccsr2csr_compress",                                      CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED};
+  m["cusparseZcsr2csr_compress"]                                      = {"hipsparseZcsr2csr_compress",                         "rocsparse_zcsr2csr_compress",                                      CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED};
 
-  {"cusparseScsr2hyb",                                     {"hipsparseScsr2hyb",                                  "rocsparse_scsr2hyb",                                               CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED}},
-  {"cusparseDcsr2hyb",                                     {"hipsparseDcsr2hyb",                                  "rocsparse_dcsr2hyb",                                               CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED}},
-  {"cusparseCcsr2hyb",                                     {"hipsparseCcsr2hyb",                                  "rocsparse_ccsr2hyb",                                               CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED}},
-  {"cusparseZcsr2hyb",                                     {"hipsparseZcsr2hyb",                                  "rocsparse_zcsr2hyb",                                               CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED}},
+  m["cusparseScsr2hyb"]                                               = {"hipsparseScsr2hyb",                                  "rocsparse_scsr2hyb",                                               CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED};
+  m["cusparseDcsr2hyb"]                                               = {"hipsparseDcsr2hyb",                                  "rocsparse_dcsr2hyb",                                               CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED};
+  m["cusparseCcsr2hyb"]                                               = {"hipsparseCcsr2hyb",                                  "rocsparse_ccsr2hyb",                                               CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED};
+  m["cusparseZcsr2hyb"]                                               = {"hipsparseZcsr2hyb",                                  "rocsparse_zcsr2hyb",                                               CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED};
 
-  {"cusparseSdense2csc",                                   {"hipsparseSdense2csc",                                "rocsparse_sdense2csc",                                             CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED}},
-  {"cusparseDdense2csc",                                   {"hipsparseDdense2csc",                                "rocsparse_ddense2csc",                                             CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED}},
-  {"cusparseCdense2csc",                                   {"hipsparseCdense2csc",                                "rocsparse_cdense2csc",                                             CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED}},
-  {"cusparseZdense2csc",                                   {"hipsparseZdense2csc",                                "rocsparse_zdense2csc",                                             CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED}},
+  m["cusparseSdense2csc"]                                             = {"hipsparseSdense2csc",                                "rocsparse_sdense2csc",                                             CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED};
+  m["cusparseDdense2csc"]                                             = {"hipsparseDdense2csc",                                "rocsparse_ddense2csc",                                             CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED};
+  m["cusparseCdense2csc"]                                             = {"hipsparseCdense2csc",                                "rocsparse_cdense2csc",                                             CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED};
+  m["cusparseZdense2csc"]                                             = {"hipsparseZdense2csc",                                "rocsparse_zdense2csc",                                             CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED};
 
-  {"cusparseSdense2csr",                                   {"hipsparseSdense2csr",                                "rocsparse_sdense2csr",                                             CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED | CUDA_REMOVED}},
-  {"cusparseDdense2csr",                                   {"hipsparseDdense2csr",                                "rocsparse_ddense2csr",                                             CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED | CUDA_REMOVED}},
-  {"cusparseCdense2csr",                                   {"hipsparseCdense2csr",                                "rocsparse_cdense2csr",                                             CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED | CUDA_REMOVED}},
-  {"cusparseZdense2csr",                                   {"hipsparseZdense2csr",                                "rocsparse_zdense2csr",                                             CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED | CUDA_REMOVED}},
+  m["cusparseSdense2csr"]                                             = {"hipsparseSdense2csr",                                "rocsparse_sdense2csr",                                             CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED | CUDA_REMOVED};
+  m["cusparseDdense2csr"]                                             = {"hipsparseDdense2csr",                                "rocsparse_ddense2csr",                                             CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED | CUDA_REMOVED};
+  m["cusparseCdense2csr"]                                             = {"hipsparseCdense2csr",                                "rocsparse_cdense2csr",                                             CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED | CUDA_REMOVED};
+  m["cusparseZdense2csr"]                                             = {"hipsparseZdense2csr",                                "rocsparse_zdense2csr",                                             CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED | CUDA_REMOVED};
 
-  {"cusparseSdense2hyb",                                   {"hipsparseSdense2hyb",                                "",                                                                 CONV_LIB_FUNC, API_SPARSE, 14, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED}},
-  {"cusparseDdense2hyb",                                   {"hipsparseDdense2hyb",                                "",                                                                 CONV_LIB_FUNC, API_SPARSE, 14, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED}},
-  {"cusparseCdense2hyb",                                   {"hipsparseCdense2hyb",                                "",                                                                 CONV_LIB_FUNC, API_SPARSE, 14, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED}},
-  {"cusparseZdense2hyb",                                   {"hipsparseZdense2hyb",                                "",                                                                 CONV_LIB_FUNC, API_SPARSE, 14, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED}},
+  m["cusparseSdense2hyb"]                                             = {"hipsparseSdense2hyb",                                "",                                                                 CONV_LIB_FUNC, API_SPARSE, 14, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED};
+  m["cusparseDdense2hyb"]                                             = {"hipsparseDdense2hyb",                                "",                                                                 CONV_LIB_FUNC, API_SPARSE, 14, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED};
+  m["cusparseCdense2hyb"]                                             = {"hipsparseCdense2hyb",                                "",                                                                 CONV_LIB_FUNC, API_SPARSE, 14, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED};
+  m["cusparseZdense2hyb"]                                             = {"hipsparseZdense2hyb",                                "",                                                                 CONV_LIB_FUNC, API_SPARSE, 14, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED};
 
-  {"cusparseShyb2csc",                                     {"hipsparseShyb2csc",                                  "",                                                                 CONV_LIB_FUNC, API_SPARSE, 14, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED}},
-  {"cusparseDhyb2csc",                                     {"hipsparseDhyb2csc",                                  "",                                                                 CONV_LIB_FUNC, API_SPARSE, 14, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED}},
-  {"cusparseChyb2csc",                                     {"hipsparseChyb2csc",                                  "",                                                                 CONV_LIB_FUNC, API_SPARSE, 14, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED}},
-  {"cusparseZhyb2csc",                                     {"hipsparseZhyb2csc",                                  "",                                                                 CONV_LIB_FUNC, API_SPARSE, 14, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED}},
+  m["cusparseShyb2csc"]                                               = {"hipsparseShyb2csc",                                  "",                                                                 CONV_LIB_FUNC, API_SPARSE, 14, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED};
+  m["cusparseDhyb2csc"]                                               = {"hipsparseDhyb2csc",                                  "",                                                                 CONV_LIB_FUNC, API_SPARSE, 14, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED};
+  m["cusparseChyb2csc"]                                               = {"hipsparseChyb2csc",                                  "",                                                                 CONV_LIB_FUNC, API_SPARSE, 14, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED};
+  m["cusparseZhyb2csc"]                                               = {"hipsparseZhyb2csc",                                  "",                                                                 CONV_LIB_FUNC, API_SPARSE, 14, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED};
 
   // NOTE: rocsparse_shyb2csr has one additioanl attribute void* temp_buffer; see hipsparseShyb2csr implementation, which wraps rocsparse_hyb2csr_buffer_size + rocsparse_shyb2csr
-  {"cusparseShyb2csr",                                     {"hipsparseShyb2csr",                                  "",                                                                 CONV_LIB_FUNC, API_SPARSE, 14, ROC_UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED}},
+  m["cusparseShyb2csr"]                                               = {"hipsparseShyb2csr",                                  "",                                                                 CONV_LIB_FUNC, API_SPARSE, 14, ROC_UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED};
   // NOTE: rocsparse_dhyb2csr has one additioanl attribute void* temp_buffer; see hipsparseDhyb2csr implementation, which wraps rocsparse_hyb2csr_buffer_size + rocsparse_dhyb2csr
-  {"cusparseDhyb2csr",                                     {"hipsparseDhyb2csr",                                  "",                                                                 CONV_LIB_FUNC, API_SPARSE, 14, ROC_UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED}},
+  m["cusparseDhyb2csr"]                                               = {"hipsparseDhyb2csr",                                  "",                                                                 CONV_LIB_FUNC, API_SPARSE, 14, ROC_UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED};
   // NOTE: rocsparse_chyb2csr has one additioanl attribute void* temp_buffer; see hipsparseChyb2csr implementation, which wraps rocsparse_hyb2csr_buffer_size + rocsparse_chyb2csr
-  {"cusparseChyb2csr",                                     {"hipsparseChyb2csr",                                  "",                                                                 CONV_LIB_FUNC, API_SPARSE, 14, ROC_UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED}},
+  m["cusparseChyb2csr"]                                               = {"hipsparseChyb2csr",                                  "",                                                                 CONV_LIB_FUNC, API_SPARSE, 14, ROC_UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED};
   // NOTE: rocsparse_zhyb2csr has one additioanl attribute void* temp_buffer; see hipsparseZhyb2csr implementation, which wraps rocsparse_hyb2csr_buffer_size + rocsparse_zhyb2csr
-  {"cusparseZhyb2csr",                                     {"hipsparseZhyb2csr",                                  "",                                                                 CONV_LIB_FUNC, API_SPARSE, 14, ROC_UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED}},
+  m["cusparseZhyb2csr"]                                               = {"hipsparseZhyb2csr",                                  "",                                                                 CONV_LIB_FUNC, API_SPARSE, 14, ROC_UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED};
 
-  {"cusparseShyb2dense",                                   {"hipsparseShyb2dense",                                "",                                                                 CONV_LIB_FUNC, API_SPARSE, 14, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED}},
-  {"cusparseDhyb2dense",                                   {"hipsparseDhyb2dense",                                "",                                                                 CONV_LIB_FUNC, API_SPARSE, 14, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED}},
-  {"cusparseChyb2dense",                                   {"hipsparseChyb2dense",                                "",                                                                 CONV_LIB_FUNC, API_SPARSE, 14, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED}},
-  {"cusparseZhyb2dense",                                   {"hipsparseZhyb2dense",                                "",                                                                 CONV_LIB_FUNC, API_SPARSE, 14, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED}},
+  m["cusparseShyb2dense"]                                             = {"hipsparseShyb2dense",                                "",                                                                 CONV_LIB_FUNC, API_SPARSE, 14, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED};
+  m["cusparseDhyb2dense"]                                             = {"hipsparseDhyb2dense",                                "",                                                                 CONV_LIB_FUNC, API_SPARSE, 14, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED};
+  m["cusparseChyb2dense"]                                             = {"hipsparseChyb2dense",                                "",                                                                 CONV_LIB_FUNC, API_SPARSE, 14, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED};
+  m["cusparseZhyb2dense"]                                             = {"hipsparseZhyb2dense",                                "",                                                                 CONV_LIB_FUNC, API_SPARSE, 14, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED};
 
-  {"cusparseSnnz",                                         {"hipsparseSnnz",                                      "rocsparse_snnz",                                                   CONV_LIB_FUNC, API_SPARSE, 14}},
-  {"cusparseDnnz",                                         {"hipsparseDnnz",                                      "rocsparse_dnnz",                                                   CONV_LIB_FUNC, API_SPARSE, 14}},
-  {"cusparseCnnz",                                         {"hipsparseCnnz",                                      "rocsparse_cnnz",                                                   CONV_LIB_FUNC, API_SPARSE, 14}},
-  {"cusparseZnnz",                                         {"hipsparseZnnz",                                      "rocsparse_znnz",                                                   CONV_LIB_FUNC, API_SPARSE, 14}},
+  m["cusparseSnnz"]                                                   = {"hipsparseSnnz",                                      "rocsparse_snnz",                                                   CONV_LIB_FUNC, API_SPARSE, 14};
+  m["cusparseDnnz"]                                                   = {"hipsparseDnnz",                                      "rocsparse_dnnz",                                                   CONV_LIB_FUNC, API_SPARSE, 14};
+  m["cusparseCnnz"]                                                   = {"hipsparseCnnz",                                      "rocsparse_cnnz",                                                   CONV_LIB_FUNC, API_SPARSE, 14};
+  m["cusparseZnnz"]                                                   = {"hipsparseZnnz",                                      "rocsparse_znnz",                                                   CONV_LIB_FUNC, API_SPARSE, 14};
 
-  {"cusparseCreateIdentityPermutation",                    {"hipsparseCreateIdentityPermutation",                 "rocsparse_create_identity_permutation",                            CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED | HIP_DEPRECATED}},
+  m["cusparseCreateIdentityPermutation"]                              = {"hipsparseCreateIdentityPermutation",                 "rocsparse_create_identity_permutation",                            CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED | HIP_DEPRECATED};
 
-  {"cusparseXcoosort_bufferSizeExt",                       {"hipsparseXcoosort_bufferSizeExt",                    "rocsparse_coosort_buffer_size",                                    CONV_LIB_FUNC, API_SPARSE, 14}},
-  {"cusparseXcoosortByRow",                                {"hipsparseXcoosortByRow",                             "rocsparse_coosort_by_row",                                         CONV_LIB_FUNC, API_SPARSE, 14}},
-  {"cusparseXcoosortByColumn",                             {"hipsparseXcoosortByColumn",                          "rocsparse_coosort_by_column",                                      CONV_LIB_FUNC, API_SPARSE, 14}},
+  m["cusparseXcoosort_bufferSizeExt"]                                 = {"hipsparseXcoosort_bufferSizeExt",                    "rocsparse_coosort_buffer_size",                                    CONV_LIB_FUNC, API_SPARSE, 14};
+  m["cusparseXcoosortByRow"]                                          = {"hipsparseXcoosortByRow",                             "rocsparse_coosort_by_row",                                         CONV_LIB_FUNC, API_SPARSE, 14};
+  m["cusparseXcoosortByColumn"]                                       = {"hipsparseXcoosortByColumn",                          "rocsparse_coosort_by_column",                                      CONV_LIB_FUNC, API_SPARSE, 14};
 
-  {"cusparseXcsrsort_bufferSizeExt",                       {"hipsparseXcsrsort_bufferSizeExt",                    "rocsparse_csrsort_buffer_size",                                    CONV_LIB_FUNC, API_SPARSE, 14}},
-  {"cusparseXcsrsort",                                     {"hipsparseXcsrsort",                                  "rocsparse_csrsort",                                                CONV_LIB_FUNC, API_SPARSE, 14}},
+  m["cusparseXcsrsort_bufferSizeExt"]                                 = {"hipsparseXcsrsort_bufferSizeExt",                    "rocsparse_csrsort_buffer_size",                                    CONV_LIB_FUNC, API_SPARSE, 14};
+  m["cusparseXcsrsort"]                                               = {"hipsparseXcsrsort",                                  "rocsparse_csrsort",                                                CONV_LIB_FUNC, API_SPARSE, 14};
 
-  {"cusparseXcscsort_bufferSizeExt",                       {"hipsparseXcscsort_bufferSizeExt",                    "rocsparse_cscsort_buffer_size",                                    CONV_LIB_FUNC, API_SPARSE, 14}},
-  {"cusparseXcscsort",                                     {"hipsparseXcscsort",                                  "rocsparse_cscsort",                                                CONV_LIB_FUNC, API_SPARSE, 14}},
+  m["cusparseXcscsort_bufferSizeExt"]                                 = {"hipsparseXcscsort_bufferSizeExt",                    "rocsparse_cscsort_buffer_size",                                    CONV_LIB_FUNC, API_SPARSE, 14};
+  m["cusparseXcscsort"]                                               = {"hipsparseXcscsort",                                  "rocsparse_cscsort",                                                CONV_LIB_FUNC, API_SPARSE, 14};
 
-  {"cusparseCreateCsru2csrInfo",                           {"hipsparseCreateCsru2csrInfo",                        "",                                                                 CONV_LIB_FUNC, API_SPARSE, 14, ROC_UNSUPPORTED | CUDA_DEPRECATED}},
-  {"cusparseDestroyCsru2csrInfo",                          {"hipsparseDestroyCsru2csrInfo",                       "",                                                                 CONV_LIB_FUNC, API_SPARSE, 14, ROC_UNSUPPORTED | CUDA_DEPRECATED}},
+  m["cusparseCreateCsru2csrInfo"]                                     = {"hipsparseCreateCsru2csrInfo",                        "",                                                                 CONV_LIB_FUNC, API_SPARSE, 14, ROC_UNSUPPORTED | CUDA_DEPRECATED};
+  m["cusparseDestroyCsru2csrInfo"]                                    = {"hipsparseDestroyCsru2csrInfo",                       "",                                                                 CONV_LIB_FUNC, API_SPARSE, 14, ROC_UNSUPPORTED | CUDA_DEPRECATED};
 
-  {"cusparseScsru2csr",                                    {"hipsparseScsru2csr",                                 "",                                                                 CONV_LIB_FUNC, API_SPARSE, 14, ROC_UNSUPPORTED | CUDA_DEPRECATED | HIP_DEPRECATED}},
-  {"cusparseDcsru2csr",                                    {"hipsparseDcsru2csr",                                 "",                                                                 CONV_LIB_FUNC, API_SPARSE, 14, ROC_UNSUPPORTED | CUDA_DEPRECATED | HIP_DEPRECATED}},
-  {"cusparseCcsru2csr",                                    {"hipsparseCcsru2csr",                                 "",                                                                 CONV_LIB_FUNC, API_SPARSE, 14, ROC_UNSUPPORTED | CUDA_DEPRECATED | HIP_DEPRECATED}},
-  {"cusparseZcsru2csr",                                    {"hipsparseZcsru2csr",                                 "",                                                                 CONV_LIB_FUNC, API_SPARSE, 14, ROC_UNSUPPORTED | CUDA_DEPRECATED | HIP_DEPRECATED}},
+  m["cusparseScsru2csr"]                                              = {"hipsparseScsru2csr",                                 "",                                                                 CONV_LIB_FUNC, API_SPARSE, 14, ROC_UNSUPPORTED | CUDA_DEPRECATED | HIP_DEPRECATED};
+  m["cusparseDcsru2csr"]                                              = {"hipsparseDcsru2csr",                                 "",                                                                 CONV_LIB_FUNC, API_SPARSE, 14, ROC_UNSUPPORTED | CUDA_DEPRECATED | HIP_DEPRECATED};
+  m["cusparseCcsru2csr"]                                              = {"hipsparseCcsru2csr",                                 "",                                                                 CONV_LIB_FUNC, API_SPARSE, 14, ROC_UNSUPPORTED | CUDA_DEPRECATED | HIP_DEPRECATED};
+  m["cusparseZcsru2csr"]                                              = {"hipsparseZcsru2csr",                                 "",                                                                 CONV_LIB_FUNC, API_SPARSE, 14, ROC_UNSUPPORTED | CUDA_DEPRECATED | HIP_DEPRECATED};
 
-  {"cusparseScsru2csr_bufferSizeExt",                      {"hipsparseScsru2csr_bufferSizeExt",                   "",                                                                 CONV_LIB_FUNC, API_SPARSE, 14, ROC_UNSUPPORTED | CUDA_DEPRECATED | HIP_DEPRECATED}},
-  {"cusparseDcsru2csr_bufferSizeExt",                      {"hipsparseDcsru2csr_bufferSizeExt",                   "",                                                                 CONV_LIB_FUNC, API_SPARSE, 14, ROC_UNSUPPORTED | CUDA_DEPRECATED | HIP_DEPRECATED}},
-  {"cusparseCcsru2csr_bufferSizeExt",                      {"hipsparseCcsru2csr_bufferSizeExt",                   "",                                                                 CONV_LIB_FUNC, API_SPARSE, 14, ROC_UNSUPPORTED | CUDA_DEPRECATED | HIP_DEPRECATED}},
-  {"cusparseZcsru2csr_bufferSizeExt",                      {"hipsparseZcsru2csr_bufferSizeExt",                   "",                                                                 CONV_LIB_FUNC, API_SPARSE, 14, ROC_UNSUPPORTED | CUDA_DEPRECATED | HIP_DEPRECATED}},
+  m["cusparseScsru2csr_bufferSizeExt"]                                = {"hipsparseScsru2csr_bufferSizeExt",                   "",                                                                 CONV_LIB_FUNC, API_SPARSE, 14, ROC_UNSUPPORTED | CUDA_DEPRECATED | HIP_DEPRECATED};
+  m["cusparseDcsru2csr_bufferSizeExt"]                                = {"hipsparseDcsru2csr_bufferSizeExt",                   "",                                                                 CONV_LIB_FUNC, API_SPARSE, 14, ROC_UNSUPPORTED | CUDA_DEPRECATED | HIP_DEPRECATED};
+  m["cusparseCcsru2csr_bufferSizeExt"]                                = {"hipsparseCcsru2csr_bufferSizeExt",                   "",                                                                 CONV_LIB_FUNC, API_SPARSE, 14, ROC_UNSUPPORTED | CUDA_DEPRECATED | HIP_DEPRECATED};
+  m["cusparseZcsru2csr_bufferSizeExt"]                                = {"hipsparseZcsru2csr_bufferSizeExt",                   "",                                                                 CONV_LIB_FUNC, API_SPARSE, 14, ROC_UNSUPPORTED | CUDA_DEPRECATED | HIP_DEPRECATED};
 
-  {"cusparseScsr2csru",                                    {"hipsparseScsr2csru",                                 "",                                                                 CONV_LIB_FUNC, API_SPARSE, 14, ROC_UNSUPPORTED | CUDA_DEPRECATED | HIP_DEPRECATED}},
-  {"cusparseDcsr2csru",                                    {"hipsparseDcsr2csru",                                 "",                                                                 CONV_LIB_FUNC, API_SPARSE, 14, ROC_UNSUPPORTED | CUDA_DEPRECATED | HIP_DEPRECATED}},
-  {"cusparseCcsr2csru",                                    {"hipsparseCcsr2csru",                                 "",                                                                 CONV_LIB_FUNC, API_SPARSE, 14, ROC_UNSUPPORTED | CUDA_DEPRECATED | HIP_DEPRECATED}},
-  {"cusparseZcsr2csru",                                    {"hipsparseZcsr2csru",                                 "",                                                                 CONV_LIB_FUNC, API_SPARSE, 14, ROC_UNSUPPORTED | CUDA_DEPRECATED | HIP_DEPRECATED}},
+  m["cusparseScsr2csru"]                                              = {"hipsparseScsr2csru",                                 "",                                                                 CONV_LIB_FUNC, API_SPARSE, 14, ROC_UNSUPPORTED | CUDA_DEPRECATED | HIP_DEPRECATED};
+  m["cusparseDcsr2csru"]                                              = {"hipsparseDcsr2csru",                                 "",                                                                 CONV_LIB_FUNC, API_SPARSE, 14, ROC_UNSUPPORTED | CUDA_DEPRECATED | HIP_DEPRECATED};
+  m["cusparseCcsr2csru"]                                              = {"hipsparseCcsr2csru",                                 "",                                                                 CONV_LIB_FUNC, API_SPARSE, 14, ROC_UNSUPPORTED | CUDA_DEPRECATED | HIP_DEPRECATED};
+  m["cusparseZcsr2csru"]                                              = {"hipsparseZcsr2csru",                                 "",                                                                 CONV_LIB_FUNC, API_SPARSE, 14, ROC_UNSUPPORTED | CUDA_DEPRECATED | HIP_DEPRECATED};
 
-  {"cusparseHpruneDense2csr",                              {"hipsparseHpruneDense2csr",                           "",                                                                 CONV_LIB_FUNC, API_SPARSE, 14, UNSUPPORTED | CUDA_DEPRECATED}},
-  {"cusparseSpruneDense2csr",                              {"hipsparseSpruneDense2csr",                           "rocsparse_sprune_dense2csr",                                       CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED | HIP_DEPRECATED}},
-  {"cusparseDpruneDense2csr",                              {"hipsparseDpruneDense2csr",                           "rocsparse_dprune_dense2csr",                                       CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED | HIP_DEPRECATED}},
+  m["cusparseHpruneDense2csr"]                                        = {"hipsparseHpruneDense2csr",                           "",                                                                 CONV_LIB_FUNC, API_SPARSE, 14, UNSUPPORTED | CUDA_DEPRECATED};
+  m["cusparseSpruneDense2csr"]                                        = {"hipsparseSpruneDense2csr",                           "rocsparse_sprune_dense2csr",                                       CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED | HIP_DEPRECATED};
+  m["cusparseDpruneDense2csr"]                                        = {"hipsparseDpruneDense2csr",                           "rocsparse_dprune_dense2csr",                                       CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED | HIP_DEPRECATED};
+  
+  m["cusparseHpruneDense2csr_bufferSizeExt"]                          = {"hipsparseHpruneDense2csr_bufferSizeExt",             "",                                                                 CONV_LIB_FUNC, API_SPARSE, 14, UNSUPPORTED | CUDA_DEPRECATED};
+  m["cusparseSpruneDense2csr_bufferSizeExt"]                          = {"hipsparseSpruneDense2csr_bufferSizeExt",             "rocsparse_sprune_dense2csr_buffer_size",                           CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED | HIP_DEPRECATED};
+  m["cusparseDpruneDense2csr_bufferSizeExt"]                          = {"hipsparseDpruneDense2csr_bufferSizeExt",             "rocsparse_dprune_dense2csr_buffer_size",                           CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED | HIP_DEPRECATED};
 
-  {"cusparseHpruneDense2csr_bufferSizeExt",                {"hipsparseHpruneDense2csr_bufferSizeExt",             "",                                                                 CONV_LIB_FUNC, API_SPARSE, 14, UNSUPPORTED | CUDA_DEPRECATED}},
-  {"cusparseSpruneDense2csr_bufferSizeExt",                {"hipsparseSpruneDense2csr_bufferSizeExt",             "rocsparse_sprune_dense2csr_buffer_size",                           CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED | HIP_DEPRECATED}},
-  {"cusparseDpruneDense2csr_bufferSizeExt",                {"hipsparseDpruneDense2csr_bufferSizeExt",             "rocsparse_dprune_dense2csr_buffer_size",                           CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED | HIP_DEPRECATED}},
+  m["cusparseHpruneDense2csrNnz"]                                     = {"hipsparseHpruneDense2csrNnz",                        "",                                                                 CONV_LIB_FUNC, API_SPARSE, 14, UNSUPPORTED | CUDA_DEPRECATED};
+  m["cusparseSpruneDense2csrNnz"]                                     = {"hipsparseSpruneDense2csrNnz",                        "rocsparse_sprune_dense2csr_nnz",                                   CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED | HIP_DEPRECATED};
+  m["cusparseDpruneDense2csrNnz"]                                     = {"hipsparseDpruneDense2csrNnz",                        "rocsparse_dprune_dense2csr_nnz",                                   CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED | HIP_DEPRECATED};
 
-  {"cusparseHpruneDense2csrNnz",                           {"hipsparseHpruneDense2csrNnz",                        "",                                                                 CONV_LIB_FUNC, API_SPARSE, 14, UNSUPPORTED | CUDA_DEPRECATED}},
-  {"cusparseSpruneDense2csrNnz",                           {"hipsparseSpruneDense2csrNnz",                        "rocsparse_sprune_dense2csr_nnz",                                   CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED | HIP_DEPRECATED}},
-  {"cusparseDpruneDense2csrNnz",                           {"hipsparseDpruneDense2csrNnz",                        "rocsparse_dprune_dense2csr_nnz",                                   CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED | HIP_DEPRECATED}},
+  m["cusparseHpruneCsr2csr"]                                          = {"hipsparseHpruneCsr2csr",                             "",                                                                 CONV_LIB_FUNC, API_SPARSE, 14, UNSUPPORTED | CUDA_DEPRECATED};
+  m["cusparseSpruneCsr2csr"]                                          = {"hipsparseSpruneCsr2csr",                             "rocsparse_sprune_csr2csr",                                         CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED | HIP_DEPRECATED};
+  m["cusparseDpruneCsr2csr"]                                          = {"hipsparseDpruneCsr2csr",                             "rocsparse_dprune_csr2csr",                                         CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED | HIP_DEPRECATED};
 
-  {"cusparseHpruneCsr2csr",                                {"hipsparseHpruneCsr2csr",                             "",                                                                 CONV_LIB_FUNC, API_SPARSE, 14, UNSUPPORTED | CUDA_DEPRECATED}},
-  {"cusparseSpruneCsr2csr",                                {"hipsparseSpruneCsr2csr",                             "rocsparse_sprune_csr2csr",                                         CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED | HIP_DEPRECATED}},
-  {"cusparseDpruneCsr2csr",                                {"hipsparseDpruneCsr2csr",                             "rocsparse_dprune_csr2csr",                                         CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED | HIP_DEPRECATED}},
+  m["cusparseHpruneCsr2csr_bufferSizeExt"]                            = {"hipsparseHpruneCsr2csr_bufferSizeExt",               "",                                                                 CONV_LIB_FUNC, API_SPARSE, 14, UNSUPPORTED | CUDA_DEPRECATED};
+  m["cusparseSpruneCsr2csr_bufferSizeExt"]                            = {"hipsparseSpruneCsr2csr_bufferSizeExt",               "rocsparse_sprune_csr2csr_buffer_size",                             CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED | HIP_DEPRECATED};
+  m["cusparseDpruneCsr2csr_bufferSizeExt"]                            = {"hipsparseDpruneCsr2csr_bufferSizeExt",               "rocsparse_dprune_csr2csr_buffer_size",                             CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED | HIP_DEPRECATED};
 
-  {"cusparseHpruneCsr2csr_bufferSizeExt",                  {"hipsparseHpruneCsr2csr_bufferSizeExt",               "",                                                                 CONV_LIB_FUNC, API_SPARSE, 14, UNSUPPORTED | CUDA_DEPRECATED}},
-  {"cusparseSpruneCsr2csr_bufferSizeExt",                  {"hipsparseSpruneCsr2csr_bufferSizeExt",               "rocsparse_sprune_csr2csr_buffer_size",                             CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED | HIP_DEPRECATED}},
-  {"cusparseDpruneCsr2csr_bufferSizeExt",                  {"hipsparseDpruneCsr2csr_bufferSizeExt",               "rocsparse_dprune_csr2csr_buffer_size",                             CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED | HIP_DEPRECATED}},
+  m["cusparseHpruneCsr2csrNnz"]                                       = {"hipsparseHpruneCsr2csrNnz",                          "",                                                                 CONV_LIB_FUNC, API_SPARSE, 14, UNSUPPORTED | CUDA_DEPRECATED};
+  m["cusparseSpruneCsr2csrNnz"]                                       = {"hipsparseSpruneCsr2csrNnz",                          "rocsparse_sprune_csr2csr_nnz",                                     CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED | HIP_DEPRECATED};
+  m["cusparseDpruneCsr2csrNnz"]                                       = {"hipsparseDpruneCsr2csrNnz",                          "rocsparse_dprune_csr2csr_nnz",                                     CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED | HIP_DEPRECATED};
 
-  {"cusparseHpruneCsr2csrNnz",                             {"hipsparseHpruneCsr2csrNnz",                          "",                                                                 CONV_LIB_FUNC, API_SPARSE, 14, UNSUPPORTED | CUDA_DEPRECATED}},
-  {"cusparseSpruneCsr2csrNnz",                             {"hipsparseSpruneCsr2csrNnz",                          "rocsparse_sprune_csr2csr_nnz",                                     CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED | HIP_DEPRECATED}},
-  {"cusparseDpruneCsr2csrNnz",                             {"hipsparseDpruneCsr2csrNnz",                          "rocsparse_dprune_csr2csr_nnz",                                     CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED | HIP_DEPRECATED}},
+  m["cusparseHpruneDense2csrByPercentage"]                            = {"hipsparseHpruneDense2csrByPercentage",               "",                                                                 CONV_LIB_FUNC, API_SPARSE, 14, UNSUPPORTED | CUDA_DEPRECATED};
+  m["cusparseSpruneDense2csrByPercentage"]                            = {"hipsparseSpruneDense2csrByPercentage",               "rocsparse_sprune_dense2csr_by_percentage",                         CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED | HIP_DEPRECATED};
+  m["cusparseDpruneDense2csrByPercentage"]                            = {"hipsparseDpruneDense2csrByPercentage",               "rocsparse_dprune_dense2csr_by_percentage",                         CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED | HIP_DEPRECATED};
 
-  {"cusparseHpruneDense2csrByPercentage",                  {"hipsparseHpruneDense2csrByPercentage",               "",                                                                 CONV_LIB_FUNC, API_SPARSE, 14, UNSUPPORTED | CUDA_DEPRECATED}},
-  {"cusparseSpruneDense2csrByPercentage",                  {"hipsparseSpruneDense2csrByPercentage",               "rocsparse_sprune_dense2csr_by_percentage",                         CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED | HIP_DEPRECATED}},
-  {"cusparseDpruneDense2csrByPercentage",                  {"hipsparseDpruneDense2csrByPercentage",               "rocsparse_dprune_dense2csr_by_percentage",                         CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED | HIP_DEPRECATED}},
+  m["cusparseHpruneDense2csrByPercentage_bufferSizeExt"]              = {"hipsparseHpruneDense2csrByPercentage_bufferSizeExt", "",                                                                 CONV_LIB_FUNC, API_SPARSE, 14, UNSUPPORTED | CUDA_DEPRECATED};
+  m["cusparseSpruneDense2csrByPercentage_bufferSizeExt"]              = {"hipsparseSpruneDense2csrByPercentage_bufferSizeExt", "rocsparse_sprune_dense2csr_by_percentage_buffer_size",             CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED | HIP_DEPRECATED};
+  m["cusparseDpruneDense2csrByPercentage_bufferSizeExt"]              = {"hipsparseDpruneDense2csrByPercentage_bufferSizeExt", "rocsparse_dprune_dense2csr_by_percentage_buffer_size",             CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED | HIP_DEPRECATED};
 
-  {"cusparseHpruneDense2csrByPercentage_bufferSizeExt",    {"hipsparseHpruneDense2csrByPercentage_bufferSizeExt", "",                                                                 CONV_LIB_FUNC, API_SPARSE, 14, UNSUPPORTED | CUDA_DEPRECATED}},
-  {"cusparseSpruneDense2csrByPercentage_bufferSizeExt",    {"hipsparseSpruneDense2csrByPercentage_bufferSizeExt", "rocsparse_sprune_dense2csr_by_percentage_buffer_size",             CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED | HIP_DEPRECATED}},
-  {"cusparseDpruneDense2csrByPercentage_bufferSizeExt",    {"hipsparseDpruneDense2csrByPercentage_bufferSizeExt", "rocsparse_dprune_dense2csr_by_percentage_buffer_size",             CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED | HIP_DEPRECATED}},
+  m["cusparseHpruneDense2csrNnzByPercentage"]                         = {"hipsparseHpruneDense2csrNnzByPercentage",            "",                                                                 CONV_LIB_FUNC, API_SPARSE, 14, UNSUPPORTED | CUDA_DEPRECATED};
+  m["cusparseSpruneDense2csrNnzByPercentage"]                         = {"hipsparseSpruneDense2csrNnzByPercentage",            "rocsparse_sprune_dense2csr_nnz_by_percentage",                     CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED | HIP_DEPRECATED};
+  m["cusparseDpruneDense2csrNnzByPercentage"]                         = {"hipsparseDpruneDense2csrNnzByPercentage",            "rocsparse_dprune_dense2csr_nnz_by_percentage",                     CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED | HIP_DEPRECATED};
 
-  {"cusparseHpruneDense2csrNnzByPercentage",               {"hipsparseHpruneDense2csrNnzByPercentage",            "",                                                                 CONV_LIB_FUNC, API_SPARSE, 14, UNSUPPORTED | CUDA_DEPRECATED}},
-  {"cusparseSpruneDense2csrNnzByPercentage",               {"hipsparseSpruneDense2csrNnzByPercentage",            "rocsparse_sprune_dense2csr_nnz_by_percentage",                     CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED | HIP_DEPRECATED}},
-  {"cusparseDpruneDense2csrNnzByPercentage",               {"hipsparseDpruneDense2csrNnzByPercentage",            "rocsparse_dprune_dense2csr_nnz_by_percentage",                     CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED | HIP_DEPRECATED}},
+  m["cusparseHpruneCsr2csrByPercentage"]                              = {"hipsparseHpruneCsr2csrByPercentage",                 "",                                                                 CONV_LIB_FUNC, API_SPARSE, 14, UNSUPPORTED | CUDA_DEPRECATED};
+  m["cusparseSpruneCsr2csrByPercentage"]                              = {"hipsparseSpruneCsr2csrByPercentage",                 "rocsparse_sprune_csr2csr_by_percentage",                           CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED | HIP_DEPRECATED};
+  m["cusparseDpruneCsr2csrByPercentage"]                              = {"hipsparseDpruneCsr2csrByPercentage",                 "rocsparse_dprune_csr2csr_by_percentage",                           CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED | HIP_DEPRECATED};
 
-  {"cusparseHpruneCsr2csrByPercentage",                    {"hipsparseHpruneCsr2csrByPercentage",                 "",                                                                 CONV_LIB_FUNC, API_SPARSE, 14, UNSUPPORTED | CUDA_DEPRECATED}},
-  {"cusparseSpruneCsr2csrByPercentage",                    {"hipsparseSpruneCsr2csrByPercentage",                 "rocsparse_sprune_csr2csr_by_percentage",                           CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED | HIP_DEPRECATED}},
-  {"cusparseDpruneCsr2csrByPercentage",                    {"hipsparseDpruneCsr2csrByPercentage",                 "rocsparse_dprune_csr2csr_by_percentage",                           CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED | HIP_DEPRECATED}},
+  m["cusparseHpruneCsr2csrByPercentage_bufferSizeExt"]                = {"hipsparseHpruneCsr2csrByPercentage_bufferSizeExt",   "",                                                                 CONV_LIB_FUNC, API_SPARSE, 14, UNSUPPORTED | CUDA_DEPRECATED};
+  m["cusparseSpruneCsr2csrByPercentage_bufferSizeExt"]                = {"hipsparseSpruneCsr2csrByPercentage_bufferSizeExt",   "rocsparse_sprune_csr2csr_by_percentage_buffer_size",               CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED | HIP_DEPRECATED};
+  m["cusparseDpruneCsr2csrByPercentage_bufferSizeExt"]                = {"hipsparseDpruneCsr2csrByPercentage_bufferSizeExt",   "rocsparse_dprune_csr2csr_by_percentage_buffer_size",               CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED | HIP_DEPRECATED};
 
-  {"cusparseHpruneCsr2csrByPercentage_bufferSizeExt",      {"hipsparseHpruneCsr2csrByPercentage_bufferSizeExt",   "",                                                                 CONV_LIB_FUNC, API_SPARSE, 14, UNSUPPORTED | CUDA_DEPRECATED}},
-  {"cusparseSpruneCsr2csrByPercentage_bufferSizeExt",      {"hipsparseSpruneCsr2csrByPercentage_bufferSizeExt",   "rocsparse_sprune_csr2csr_by_percentage_buffer_size",               CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED | HIP_DEPRECATED}},
-  {"cusparseDpruneCsr2csrByPercentage_bufferSizeExt",      {"hipsparseDpruneCsr2csrByPercentage_bufferSizeExt",   "rocsparse_dprune_csr2csr_by_percentage_buffer_size",               CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED | HIP_DEPRECATED}},
+  m["cusparseHpruneCsr2csrNnzByPercentage"]                           = {"hipsparseHpruneCsr2csrNnzByPercentage",              "",                                                                 CONV_LIB_FUNC, API_SPARSE, 14, UNSUPPORTED | CUDA_DEPRECATED};
+  m["cusparseSpruneCsr2csrNnzByPercentage"]                           = {"hipsparseSpruneCsr2csrNnzByPercentage",              "rocsparse_sprune_csr2csr_nnz_by_percentage",                       CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED | HIP_DEPRECATED};
+  m["cusparseDpruneCsr2csrNnzByPercentage"]                           = {"hipsparseDpruneCsr2csrNnzByPercentage",              "rocsparse_dprune_csr2csr_nnz_by_percentage",                       CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED | HIP_DEPRECATED};
 
-  {"cusparseHpruneCsr2csrNnzByPercentage",                 {"hipsparseHpruneCsr2csrNnzByPercentage",              "",                                                                 CONV_LIB_FUNC, API_SPARSE, 14, UNSUPPORTED | CUDA_DEPRECATED}},
-  {"cusparseSpruneCsr2csrNnzByPercentage",                 {"hipsparseSpruneCsr2csrNnzByPercentage",              "rocsparse_sprune_csr2csr_nnz_by_percentage",                       CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED | HIP_DEPRECATED}},
-  {"cusparseDpruneCsr2csrNnzByPercentage",                 {"hipsparseDpruneCsr2csrNnzByPercentage",              "rocsparse_dprune_csr2csr_nnz_by_percentage",                       CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED | HIP_DEPRECATED}},
-
-  {"cusparseSnnz_compress",                                {"hipsparseSnnz_compress",                             "rocsparse_snnz_compress",                                          CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED | HIP_DEPRECATED}},
-  {"cusparseDnnz_compress",                                {"hipsparseDnnz_compress",                             "rocsparse_dnnz_compress",                                          CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED | HIP_DEPRECATED}},
-  {"cusparseCnnz_compress",                                {"hipsparseCnnz_compress",                             "rocsparse_cnnz_compress",                                          CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED | HIP_DEPRECATED}},
-  {"cusparseZnnz_compress",                                {"hipsparseZnnz_compress",                             "rocsparse_znnz_compress",                                          CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED | HIP_DEPRECATED}},
+  m["cusparseSnnz_compress"]                                          = {"hipsparseSnnz_compress",                             "rocsparse_snnz_compress",                                          CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED | HIP_DEPRECATED};
+  m["cusparseDnnz_compress"]                                          = {"hipsparseDnnz_compress",                             "rocsparse_dnnz_compress",                                          CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED | HIP_DEPRECATED};
+  m["cusparseCnnz_compress"]                                          = {"hipsparseCnnz_compress",                             "rocsparse_cnnz_compress",                                          CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED | HIP_DEPRECATED};
+  m["cusparseZnnz_compress"]                                          = {"hipsparseZnnz_compress",                             "rocsparse_znnz_compress",                                          CONV_LIB_FUNC, API_SPARSE, 14, CUDA_DEPRECATED | HIP_DEPRECATED};
 
   // 15. cuSPARSE Generic API Reference
   // Generic Sparse API helper functions
   // Sparse Matrix descriptor
-  {"cusparseCreateCoo",                                    {"hipsparseCreateCoo",                                 "rocsparse_create_coo_descr",                                       CONV_LIB_FUNC, API_SPARSE, 15}},
-  {"cusparseCreateConstCoo",                               {"hipsparseCreateConstCoo",                            "rocsparse_create_const_coo_descr",                                 CONV_LIB_FUNC, API_SPARSE, 15}},
-  {"cusparseCreateCooAoS",                                 {"hipsparseCreateCooAoS",                              "rocsparse_create_coo_aos_descr",                                   CONV_LIB_FUNC, API_SPARSE, 15, CUDA_DEPRECATED | CUDA_REMOVED}},
-  {"cusparseCreateCsr",                                    {"hipsparseCreateCsr",                                 "rocsparse_create_csr_descr",                                       CONV_LIB_FUNC, API_SPARSE, 15}},
-  {"cusparseCreateConstCsr",                               {"hipsparseCreateConstCsr",                            "rocsparse_create_const_csr_descr",                                 CONV_LIB_FUNC, API_SPARSE, 15}},
-  {"cusparseCreateCsc",                                    {"hipsparseCreateCsc",                                 "rocsparse_create_csc_descr",                                       CONV_LIB_FUNC, API_SPARSE, 15}},
-  {"cusparseCreateConstCsc",                               {"hipsparseCreateConstCsc",                            "rocsparse_create_const_csc_descr",                                 CONV_LIB_FUNC, API_SPARSE, 15}},
-  {"cusparseDestroySpMat",                                 {"hipsparseDestroySpMat",                              "rocsparse_destroy_spmat_descr",                                    CONV_LIB_FUNC, API_SPARSE, 15}},
-  {"cusparseCooGet",                                       {"hipsparseCooGet",                                    "rocsparse_coo_get",                                                CONV_LIB_FUNC, API_SPARSE, 15}},
-  {"cusparseCooAoSGet",                                    {"hipsparseCooAoSGet",                                 "rocsparse_coo_aos_get",                                            CONV_LIB_FUNC, API_SPARSE, 15, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED}},
-  {"cusparseConstCooGet",                                  {"hipsparseConstCooGet",                               "rocsparse_const_coo_get",                                          CONV_LIB_FUNC, API_SPARSE, 15}},
-  {"cusparseCooSetStridedBatch",                           {"hipsparseCooSetStridedBatch",                        "rocsparse_coo_set_strided_batch",                                  CONV_LIB_FUNC, API_SPARSE, 15}},
-  {"cusparseCsrGet",                                       {"hipsparseCsrGet",                                    "rocsparse_csr_get",                                                CONV_LIB_FUNC, API_SPARSE, 15}},
-  {"cusparseConstCsrGet",                                  {"hipsparseConstCsrGet",                               "rocsparse_const_csr_get",                                          CONV_LIB_FUNC, API_SPARSE, 15}},
-  {"cusparseCsrSetPointers",                               {"hipsparseCsrSetPointers",                            "rocsparse_csr_set_pointers",                                       CONV_LIB_FUNC, API_SPARSE, 15}},
-  {"cusparseCscSetPointers",                               {"hipsparseCscSetPointers",                            "rocsparse_csc_set_pointers",                                       CONV_LIB_FUNC, API_SPARSE, 15}},
-  {"cusparseCscGet",                                       {"hipsparseCscGet",                                    "rocsparse_csc_get",                                                CONV_LIB_FUNC, API_SPARSE, 15}},
-  {"cusparseConstCscGet",                                  {"hipsparseConstCscGet",                               "rocsparse_const_csc_get",                                          CONV_LIB_FUNC, API_SPARSE, 15}},
-  {"cusparseCooSetPointers",                               {"hipsparseCooSetPointers",                            "rocsparse_coo_set_pointers",                                       CONV_LIB_FUNC, API_SPARSE, 15}},
-  {"cusparseCsrSetStridedBatch",                           {"hipsparseCsrSetStridedBatch",                        "rocsparse_csr_set_strided_batch",                                  CONV_LIB_FUNC, API_SPARSE, 15}},
-  {"cusparseSpMatGetFormat",                               {"hipsparseSpMatGetFormat",                            "rocsparse_spmat_get_format",                                       CONV_LIB_FUNC, API_SPARSE, 15}},
-  {"cusparseSpMatGetIndexBase",                            {"hipsparseSpMatGetIndexBase",                         "rocsparse_spmat_get_index_base",                                   CONV_LIB_FUNC, API_SPARSE, 15}},
-  {"cusparseSpMatGetValues",                               {"hipsparseSpMatGetValues",                            "rocsparse_spmat_get_values",                                       CONV_LIB_FUNC, API_SPARSE, 15}},
-  {"cusparseConstSpMatGetValues",                          {"hipsparseConstSpMatGetValues",                       "rocsparse_const_spmat_get_values",                                 CONV_LIB_FUNC, API_SPARSE, 15}},
-  {"cusparseSpMatSetValues",                               {"hipsparseSpMatSetValues",                            "rocsparse_spmat_set_values",                                       CONV_LIB_FUNC, API_SPARSE, 15}},
-  {"cusparseSpMatGetStridedBatch",                         {"hipsparseSpMatGetStridedBatch",                      "rocsparse_spmat_get_strided_batch",                                CONV_LIB_FUNC, API_SPARSE, 15}},
-  {"cusparseSpMatSetStridedBatch",                         {"hipsparseSpMatSetStridedBatch",                      "rocsparse_spmat_set_strided_batch",                                CONV_LIB_FUNC, API_SPARSE, 15, CUDA_REMOVED | HIP_DEPRECATED}},
-  {"cusparseSpMatSetNumBatches",                           {"hipsparseSpMatSetNumBatches",                        "",                                                                 CONV_LIB_FUNC, API_SPARSE, 15, UNSUPPORTED}},
-  {"cusparseSpMatGetNumBatches",                           {"hipsparseSpMatGetNumBatches",                        "",                                                                 CONV_LIB_FUNC, API_SPARSE, 15, UNSUPPORTED}},
-  {"cusparseSpMatGetSize",                                 {"hipsparseSpMatGetSize",                              "rocsparse_spmat_get_size",                                         CONV_LIB_FUNC, API_SPARSE, 15}},
-  {"cusparseSpMatGetAttribute",                            {"hipsparseSpMatGetAttribute",                         "rocsparse_spmat_get_attribute",                                    CONV_LIB_FUNC, API_SPARSE, 15}},
-  {"cusparseSpMatSetAttribute",                            {"hipsparseSpMatSetAttribute",                         "rocsparse_spmat_set_attribute",                                    CONV_LIB_FUNC, API_SPARSE, 15}},
-  {"cusparseBlockedEllGet",                                {"hipsparseBlockedEllGet",                             "rocsparse_bell_get",                                               CONV_LIB_FUNC, API_SPARSE, 15}},
-  {"cusparseConstBlockedEllGet",                           {"hipsparseConstBlockedEllGet",                        "rocsparse_const_bell_get",                                         CONV_LIB_FUNC, API_SPARSE, 15}},
-  {"cusparseCreateBlockedEll",                             {"hipsparseCreateBlockedEll",                          "rocsparse_create_bell_descr",                                      CONV_LIB_FUNC, API_SPARSE, 15}},
-  {"cusparseCreateConstBlockedEll",                        {"hipsparseCreateConstBlockedEll",                     "rocsparse_create_const_bell_descr",                                CONV_LIB_FUNC, API_SPARSE, 15}},
-  {"cusparseBsrSetStridedBatch",                           {"hipsparseBsrSetStridedBatch",                        "",                                                                 CONV_LIB_FUNC, API_SPARSE, 15, UNSUPPORTED}},
+  m["cusparseCreateCoo"]                                              = {"hipsparseCreateCoo",                                 "rocsparse_create_coo_descr",                                       CONV_LIB_FUNC, API_SPARSE, 15};
+  m["cusparseCreateConstCoo"]                                         = {"hipsparseCreateConstCoo",                            "rocsparse_create_const_coo_descr",                                 CONV_LIB_FUNC, API_SPARSE, 15};
+  m["cusparseCreateCooAoS"]                                           = {"hipsparseCreateCooAoS",                              "rocsparse_create_coo_aos_descr",                                   CONV_LIB_FUNC, API_SPARSE, 15, CUDA_DEPRECATED | CUDA_REMOVED};
+  m["cusparseCreateCsr"]                                              = {"hipsparseCreateCsr",                                 "rocsparse_create_csr_descr",                                       CONV_LIB_FUNC, API_SPARSE, 15};
+  m["cusparseCreateConstCsr"]                                         = {"hipsparseCreateConstCsr",                            "rocsparse_create_const_csr_descr",                                 CONV_LIB_FUNC, API_SPARSE, 15};
+  m["cusparseCreateCsc"]                                              = {"hipsparseCreateCsc",                                 "rocsparse_create_csc_descr",                                       CONV_LIB_FUNC, API_SPARSE, 15};
+  m["cusparseCreateConstCsc"]                                         = {"hipsparseCreateConstCsc",                            "rocsparse_create_const_csc_descr",                                 CONV_LIB_FUNC, API_SPARSE, 15};
+  m["cusparseDestroySpMat"]                                           = {"hipsparseDestroySpMat",                              "rocsparse_destroy_spmat_descr",                                    CONV_LIB_FUNC, API_SPARSE, 15};
+  m["cusparseCooGet"]                                                 = {"hipsparseCooGet",                                    "rocsparse_coo_get",                                                CONV_LIB_FUNC, API_SPARSE, 15};
+  m["cusparseCooAoSGet"]                                              = {"hipsparseCooAoSGet",                                 "rocsparse_coo_aos_get",                                            CONV_LIB_FUNC, API_SPARSE, 15, CUDA_DEPRECATED | CUDA_REMOVED | HIP_DEPRECATED};
+  m["cusparseConstCooGet"]                                            = {"hipsparseConstCooGet",                               "rocsparse_const_coo_get",                                          CONV_LIB_FUNC, API_SPARSE, 15};
+  m["cusparseCooSetStridedBatch"]                                     = {"hipsparseCooSetStridedBatch",                        "rocsparse_coo_set_strided_batch",                                  CONV_LIB_FUNC, API_SPARSE, 15};
+  m["cusparseCsrGet"]                                                 = {"hipsparseCsrGet",                                    "rocsparse_csr_get",                                                CONV_LIB_FUNC, API_SPARSE, 15};
+  m["cusparseConstCsrGet"]                                            = {"hipsparseConstCsrGet",                               "rocsparse_const_csr_get",                                          CONV_LIB_FUNC, API_SPARSE, 15};
+  m["cusparseCsrSetPointers"]                                         = {"hipsparseCsrSetPointers",                            "rocsparse_csr_set_pointers",                                       CONV_LIB_FUNC, API_SPARSE, 15};
+  m["cusparseCscSetPointers"]                                         = {"hipsparseCscSetPointers",                            "rocsparse_csc_set_pointers",                                       CONV_LIB_FUNC, API_SPARSE, 15};
+  m["cusparseCscGet"]                                                 = {"hipsparseCscGet",                                    "rocsparse_csc_get",                                                CONV_LIB_FUNC, API_SPARSE, 15};
+  m["cusparseConstCscGet"]                                            = {"hipsparseConstCscGet",                               "rocsparse_const_csc_get",                                          CONV_LIB_FUNC, API_SPARSE, 15};
+  m["cusparseCooSetPointers"]                                         = {"hipsparseCooSetPointers",                            "rocsparse_coo_set_pointers",                                       CONV_LIB_FUNC, API_SPARSE, 15};
+  m["cusparseCsrSetStridedBatch"]                                     = {"hipsparseCsrSetStridedBatch",                        "rocsparse_csr_set_strided_batch",                                  CONV_LIB_FUNC, API_SPARSE, 15};
+  m["cusparseSpMatGetFormat"]                                         = {"hipsparseSpMatGetFormat",                            "rocsparse_spmat_get_format",                                       CONV_LIB_FUNC, API_SPARSE, 15};
+  m["cusparseSpMatGetIndexBase"]                                      = {"hipsparseSpMatGetIndexBase",                         "rocsparse_spmat_get_index_base",                                   CONV_LIB_FUNC, API_SPARSE, 15};
+  m["cusparseSpMatGetValues"]                                         = {"hipsparseSpMatGetValues",                            "rocsparse_spmat_get_values",                                       CONV_LIB_FUNC, API_SPARSE, 15};
+  m["cusparseConstSpMatGetValues"]                                    = {"hipsparseConstSpMatGetValues",                       "rocsparse_const_spmat_get_values",                                 CONV_LIB_FUNC, API_SPARSE, 15};
+  m["cusparseSpMatSetValues"]                                         = {"hipsparseSpMatSetValues",                            "rocsparse_spmat_set_values",                                       CONV_LIB_FUNC, API_SPARSE, 15};
+  m["cusparseSpMatGetStridedBatch"]                                   = {"hipsparseSpMatGetStridedBatch",                      "rocsparse_spmat_get_strided_batch",                                CONV_LIB_FUNC, API_SPARSE, 15};
+  m["cusparseSpMatSetStridedBatch"]                                   = {"hipsparseSpMatSetStridedBatch",                      "rocsparse_spmat_set_strided_batch",                                CONV_LIB_FUNC, API_SPARSE, 15, CUDA_REMOVED | HIP_DEPRECATED};
+  m["cusparseSpMatSetNumBatches"]                                     = {"hipsparseSpMatSetNumBatches",                        "",                                                                 CONV_LIB_FUNC, API_SPARSE, 15, UNSUPPORTED};
+  m["cusparseSpMatGetNumBatches"]                                     = {"hipsparseSpMatGetNumBatches",                        "",                                                                 CONV_LIB_FUNC, API_SPARSE, 15, UNSUPPORTED};
+  m["cusparseSpMatGetSize"]                                           = {"hipsparseSpMatGetSize",                              "rocsparse_spmat_get_size",                                         CONV_LIB_FUNC, API_SPARSE, 15};
+  m["cusparseSpMatGetAttribute"]                                      = {"hipsparseSpMatGetAttribute",                         "rocsparse_spmat_get_attribute",                                    CONV_LIB_FUNC, API_SPARSE, 15};
+  m["cusparseSpMatSetAttribute"]                                      = {"hipsparseSpMatSetAttribute",                         "rocsparse_spmat_set_attribute",                                    CONV_LIB_FUNC, API_SPARSE, 15};
+  m["cusparseBlockedEllGet"]                                          = {"hipsparseBlockedEllGet",                             "rocsparse_bell_get",                                               CONV_LIB_FUNC, API_SPARSE, 15};
+  m["cusparseConstBlockedEllGet"]                                     = {"hipsparseConstBlockedEllGet",                        "rocsparse_const_bell_get",                                         CONV_LIB_FUNC, API_SPARSE, 15};
+  m["cusparseCreateBlockedEll"]                                       = {"hipsparseCreateBlockedEll",                          "rocsparse_create_bell_descr",                                      CONV_LIB_FUNC, API_SPARSE, 15};
+  m["cusparseCreateConstBlockedEll"]                                  = {"hipsparseCreateConstBlockedEll",                     "rocsparse_create_const_bell_descr",                                CONV_LIB_FUNC, API_SPARSE, 15};
+  m["cusparseBsrSetStridedBatch"]                                     = {"hipsparseBsrSetStridedBatch",                        "",                                                                 CONV_LIB_FUNC, API_SPARSE, 15, UNSUPPORTED};
   // NOTE: rocsparse_create_bsr_descr has appeared earlier than cusparseCreateBsr and has a different signature
-  {"cusparseCreateBsr",                                    {"hipsparseCreateBsr",                                 "",                                                                 CONV_LIB_FUNC, API_SPARSE, 15, UNSUPPORTED}},
-  {"cusparseCreateConstBsr",                               {"hipsparseCreateConstBsr",                            "",                                                                 CONV_LIB_FUNC, API_SPARSE, 15, UNSUPPORTED}},
-  {"cusparseCreateSlicedEll",                              {"hipsparseCreateSlicedEll",                           "",                                                                 CONV_LIB_FUNC, API_SPARSE, 15, UNSUPPORTED}},
-  {"cusparseCreateConstSlicedEll",                         {"hipsparseCreateConstSlicedEll",                      "",                                                                 CONV_LIB_FUNC, API_SPARSE, 15, UNSUPPORTED}},
+  m["cusparseCreateBsr"]                                              = {"hipsparseCreateBsr",                                 "",                                                                 CONV_LIB_FUNC, API_SPARSE, 15, UNSUPPORTED};
+  m["cusparseCreateConstBsr"]                                         = {"hipsparseCreateConstBsr",                            "",                                                                 CONV_LIB_FUNC, API_SPARSE, 15, UNSUPPORTED};
+  m["cusparseCreateSlicedEll"]                                        = {"hipsparseCreateSlicedEll",                           "",                                                                 CONV_LIB_FUNC, API_SPARSE, 15, UNSUPPORTED};
+  m["cusparseCreateConstSlicedEll"]                                   = {"hipsparseCreateConstSlicedEll",                      "",                                                                 CONV_LIB_FUNC, API_SPARSE, 15, UNSUPPORTED};
   // Sparse Vector descriptor
-  {"cusparseCreateSpVec",                                  {"hipsparseCreateSpVec",                               "rocsparse_create_spvec_descr",                                     CONV_LIB_FUNC, API_SPARSE, 15}},
-  {"cusparseCreateConstSpVec",                             {"hipsparseCreateConstSpVec",                          "rocsparse_create_const_spvec_descr",                               CONV_LIB_FUNC, API_SPARSE, 15}},
-  {"cusparseDestroySpVec",                                 {"hipsparseDestroySpVec",                              "rocsparse_destroy_spvec_descr",                                    CONV_LIB_FUNC, API_SPARSE, 15}},
-  {"cusparseSpVecGet",                                     {"hipsparseSpVecGet",                                  "rocsparse_spvec_get",                                              CONV_LIB_FUNC, API_SPARSE, 15}},
-  {"cusparseConstSpVecGet",                                {"hipsparseConstSpVecGet",                             "rocsparse_const_spvec_get",                                        CONV_LIB_FUNC, API_SPARSE, 15}},
-  {"cusparseSpVecGetIndexBase",                            {"hipsparseSpVecGetIndexBase",                         "rocsparse_spvec_get_index_base",                                   CONV_LIB_FUNC, API_SPARSE, 15}},
-  {"cusparseSpVecGetValues",                               {"hipsparseSpVecGetValues",                            "rocsparse_spvec_get_values",                                       CONV_LIB_FUNC, API_SPARSE, 15}},
-  {"cusparseConstSpVecGetValues",                          {"hipsparseConstSpVecGetValues",                       "rocsparse_const_spvec_get_values",                                 CONV_LIB_FUNC, API_SPARSE, 15}},
-  {"cusparseSpVecSetValues",                               {"hipsparseSpVecSetValues",                            "rocsparse_spvec_set_values",                                       CONV_LIB_FUNC, API_SPARSE, 15}},
+  m["cusparseCreateSpVec"]                                            = {"hipsparseCreateSpVec",                               "rocsparse_create_spvec_descr",                                     CONV_LIB_FUNC, API_SPARSE, 15};
+  m["cusparseCreateConstSpVec"]                                       = {"hipsparseCreateConstSpVec",                          "rocsparse_create_const_spvec_descr",                               CONV_LIB_FUNC, API_SPARSE, 15};
+  m["cusparseDestroySpVec"]                                           = {"hipsparseDestroySpVec",                              "rocsparse_destroy_spvec_descr",                                    CONV_LIB_FUNC, API_SPARSE, 15};
+  m["cusparseSpVecGet"]                                               = {"hipsparseSpVecGet",                                  "rocsparse_spvec_get",                                              CONV_LIB_FUNC, API_SPARSE, 15};
+  m["cusparseConstSpVecGet"]                                          = {"hipsparseConstSpVecGet",                             "rocsparse_const_spvec_get",                                        CONV_LIB_FUNC, API_SPARSE, 15};
+  m["cusparseSpVecGetIndexBase"]                                      = {"hipsparseSpVecGetIndexBase",                         "rocsparse_spvec_get_index_base",                                   CONV_LIB_FUNC, API_SPARSE, 15};
+  m["cusparseSpVecGetValues"]                                         = {"hipsparseSpVecGetValues",                            "rocsparse_spvec_get_values",                                       CONV_LIB_FUNC, API_SPARSE, 15};
+  m["cusparseConstSpVecGetValues"]                                    = {"hipsparseConstSpVecGetValues",                       "rocsparse_const_spvec_get_values",                                 CONV_LIB_FUNC, API_SPARSE, 15};
+  m["cusparseSpVecSetValues"]                                         = {"hipsparseSpVecSetValues",                            "rocsparse_spvec_set_values",                                       CONV_LIB_FUNC, API_SPARSE, 15};
 
   // Generic Dense API helper functions
   // Dense Matrix descriptor
-  {"cusparseCreateDnMat",                                  {"hipsparseCreateDnMat",                               "rocsparse_create_dnmat_descr",                                     CONV_LIB_FUNC, API_SPARSE, 15}},
-  {"cusparseCreateConstDnMat",                             {"hipsparseCreateConstDnMat",                          "rocsparse_create_const_dnmat_descr",                               CONV_LIB_FUNC, API_SPARSE, 15}},
-  {"cusparseDestroyDnMat",                                 {"hipsparseDestroyDnMat",                              "rocsparse_destroy_dnmat_descr",                                    CONV_LIB_FUNC, API_SPARSE, 15}},
-  {"cusparseDnMatGet",                                     {"hipsparseDnMatGet",                                  "rocsparse_dnmat_get",                                              CONV_LIB_FUNC, API_SPARSE, 15}},
-  {"cusparseConstDnMatGet",                                {"hipsparseConstDnMatGet",                             "rocsparse_const_dnmat_get",                                        CONV_LIB_FUNC, API_SPARSE, 15}},
-  {"cusparseDnMatGetValues",                               {"hipsparseDnMatGetValues",                            "rocsparse_dnmat_get_values",                                       CONV_LIB_FUNC, API_SPARSE, 15}},
-  {"cusparseConstDnMatGetValues",                          {"hipsparseConstDnMatGetValues",                       "rocsparse_const_dnmat_get_values",                                 CONV_LIB_FUNC, API_SPARSE, 15}},
-  {"cusparseDnMatSetValues",                               {"hipsparseDnMatSetValues",                            "rocsparse_dnmat_set_values",                                       CONV_LIB_FUNC, API_SPARSE, 15}},
-  {"cusparseDnMatSetStridedBatch",                         {"hipsparseDnMatSetStridedBatch",                      "rocsparse_dnmat_set_strided_batch",                                CONV_LIB_FUNC, API_SPARSE, 15}},
-  {"cusparseDnMatGetStridedBatch",                         {"hipsparseDnMatGetStridedBatch",                      "rocsparse_dnmat_get_strided_batch",                                CONV_LIB_FUNC, API_SPARSE, 15}},
+  m["cusparseCreateDnMat"]                                            = {"hipsparseCreateDnMat",                               "rocsparse_create_dnmat_descr",                                     CONV_LIB_FUNC, API_SPARSE, 15};
+  m["cusparseCreateConstDnMat"]                                       = {"hipsparseCreateConstDnMat",                          "rocsparse_create_const_dnmat_descr",                               CONV_LIB_FUNC, API_SPARSE, 15};
+  m["cusparseDestroyDnMat"]                                           = {"hipsparseDestroyDnMat",                              "rocsparse_destroy_dnmat_descr",                                    CONV_LIB_FUNC, API_SPARSE, 15};
+  m["cusparseDnMatGet"]                                               = {"hipsparseDnMatGet",                                  "rocsparse_dnmat_get",                                              CONV_LIB_FUNC, API_SPARSE, 15};
+  m["cusparseConstDnMatGet"]                                          = {"hipsparseConstDnMatGet",                             "rocsparse_const_dnmat_get",                                        CONV_LIB_FUNC, API_SPARSE, 15};
+  m["cusparseDnMatGetValues"]                                         = {"hipsparseDnMatGetValues",                            "rocsparse_dnmat_get_values",                                       CONV_LIB_FUNC, API_SPARSE, 15};
+  m["cusparseConstDnMatGetValues"]                                    = {"hipsparseConstDnMatGetValues",                       "rocsparse_const_dnmat_get_values",                                 CONV_LIB_FUNC, API_SPARSE, 15};
+  m["cusparseDnMatSetValues"]                                         = {"hipsparseDnMatSetValues",                            "rocsparse_dnmat_set_values",                                       CONV_LIB_FUNC, API_SPARSE, 15};
+  m["cusparseDnMatSetStridedBatch"]                                   = {"hipsparseDnMatSetStridedBatch",                      "rocsparse_dnmat_set_strided_batch",                                CONV_LIB_FUNC, API_SPARSE, 15};
+  m["cusparseDnMatGetStridedBatch"]                                   = {"hipsparseDnMatGetStridedBatch",                      "rocsparse_dnmat_get_strided_batch",                                CONV_LIB_FUNC, API_SPARSE, 15};
   // Dense Vector descriptor
-  {"cusparseCreateDnVec",                                  {"hipsparseCreateDnVec",                               "rocsparse_create_dnvec_descr",                                     CONV_LIB_FUNC, API_SPARSE, 15}},
-  {"cusparseCreateConstDnVec",                             {"hipsparseCreateConstDnVec",                          "rocsparse_create_const_dnvec_descr",                               CONV_LIB_FUNC, API_SPARSE, 15}},
-  {"cusparseDestroyDnVec",                                 {"hipsparseDestroyDnVec",                              "rocsparse_destroy_dnvec_descr",                                    CONV_LIB_FUNC, API_SPARSE, 15}},
-  {"cusparseDnVecGet",                                     {"hipsparseDnVecGet",                                  "rocsparse_dnvec_get",                                              CONV_LIB_FUNC, API_SPARSE, 15}},
-  {"cusparseConstDnVecGet",                                {"hipsparseConstDnVecGet",                             "rocsparse_const_dnvec_get",                                        CONV_LIB_FUNC, API_SPARSE, 15}},
-  {"cusparseDnVecGetValues",                               {"hipsparseDnVecGetValues",                            "rocsparse_dnvec_get_values",                                       CONV_LIB_FUNC, API_SPARSE, 15}},
-  {"cusparseConstDnVecGetValues",                          {"hipsparseConstDnVecGetValues",                       "rocsparse_const_dnvec_get_values",                                 CONV_LIB_FUNC, API_SPARSE, 15}},
-  {"cusparseDnVecSetValues",                               {"hipsparseDnVecSetValues",                            "rocsparse_dnvec_set_values",                                       CONV_LIB_FUNC, API_SPARSE, 15}},
+  m["cusparseCreateDnVec"]                                            = {"hipsparseCreateDnVec",                               "rocsparse_create_dnvec_descr",                                     CONV_LIB_FUNC, API_SPARSE, 15};
+  m["cusparseCreateConstDnVec"]                                       = {"hipsparseCreateConstDnVec",                          "rocsparse_create_const_dnvec_descr",                               CONV_LIB_FUNC, API_SPARSE, 15};
+  m["cusparseDestroyDnVec"]                                           = {"hipsparseDestroyDnVec",                              "rocsparse_destroy_dnvec_descr",                                    CONV_LIB_FUNC, API_SPARSE, 15};
+  m["cusparseDnVecGet"]                                               = {"hipsparseDnVecGet",                                  "rocsparse_dnvec_get",                                              CONV_LIB_FUNC, API_SPARSE, 15};
+  m["cusparseConstDnVecGet"]                                          = {"hipsparseConstDnVecGet",                             "rocsparse_const_dnvec_get",                                        CONV_LIB_FUNC, API_SPARSE, 15};
+  m["cusparseDnVecGetValues"]                                         = {"hipsparseDnVecGetValues",                            "rocsparse_dnvec_get_values",                                       CONV_LIB_FUNC, API_SPARSE, 15};
+  m["cusparseConstDnVecGetValues"]                                    = {"hipsparseConstDnVecGetValues",                       "rocsparse_const_dnvec_get_values",                                 CONV_LIB_FUNC, API_SPARSE, 15};
+  m["cusparseDnVecSetValues"]                                         = {"hipsparseDnVecSetValues",                            "rocsparse_dnvec_set_values",                                       CONV_LIB_FUNC, API_SPARSE, 15};
 
-  {"cusparseSpGEMM_createDescr",                           {"hipsparseSpGEMM_createDescr",                        "",                                                                 CONV_LIB_FUNC, API_SPARSE, 15, ROC_UNSUPPORTED}},
-  {"cusparseSpGEMM_destroyDescr",                          {"hipsparseSpGEMM_destroyDescr",                       "",                                                                 CONV_LIB_FUNC, API_SPARSE, 15, ROC_UNSUPPORTED}},
-  {"cusparseSpGEMM_workEstimation",                        {"hipsparseSpGEMM_workEstimation",                     "",                                                                 CONV_LIB_FUNC, API_SPARSE, 15, ROC_UNSUPPORTED}},
-  {"cusparseSpGEMM_compute",                               {"hipsparseSpGEMM_compute",                            "",                                                                 CONV_LIB_FUNC, API_SPARSE, 15, ROC_UNSUPPORTED}},
-  {"cusparseSpGEMM_copy",                                  {"hipsparseSpGEMM_copy",                               "",                                                                 CONV_LIB_FUNC, API_SPARSE, 15, ROC_UNSUPPORTED}},
-  {"cusparseSpGEMM_getNumProducts",                        {"hipsparseSpGEMM_getNumProducts",                     "",                                                                 CONV_LIB_FUNC, API_SPARSE, 15, UNSUPPORTED}},
-  {"cusparseSpGEMM_estimateMemory",                        {"hipsparseSpGEMM_estimateMemory",                     "",                                                                 CONV_LIB_FUNC, API_SPARSE, 15, UNSUPPORTED}},
+  m["cusparseSpGEMM_createDescr"]                                     = {"hipsparseSpGEMM_createDescr",                        "",                                                                 CONV_LIB_FUNC, API_SPARSE, 15, ROC_UNSUPPORTED};
+  m["cusparseSpGEMM_destroyDescr"]                                    = {"hipsparseSpGEMM_destroyDescr",                       "",                                                                 CONV_LIB_FUNC, API_SPARSE, 15, ROC_UNSUPPORTED};
+  m["cusparseSpGEMM_workEstimation"]                                  = {"hipsparseSpGEMM_workEstimation",                     "",                                                                 CONV_LIB_FUNC, API_SPARSE, 15, ROC_UNSUPPORTED};
+  m["cusparseSpGEMM_compute"]                                         = {"hipsparseSpGEMM_compute",                            "",                                                                 CONV_LIB_FUNC, API_SPARSE, 15, ROC_UNSUPPORTED};
+  m["cusparseSpGEMM_copy"]                                            = {"hipsparseSpGEMM_copy",                               "",                                                                 CONV_LIB_FUNC, API_SPARSE, 15, ROC_UNSUPPORTED};
+  m["cusparseSpGEMM_getNumProducts"]                                  = {"hipsparseSpGEMM_getNumProducts",                     "",                                                                 CONV_LIB_FUNC, API_SPARSE, 15, UNSUPPORTED};
+  m["cusparseSpGEMM_estimateMemory"]                                  = {"hipsparseSpGEMM_estimateMemory",                     "",                                                                 CONV_LIB_FUNC, API_SPARSE, 15, UNSUPPORTED};
 
   // Sparse Triangular Vector Solve
-  {"cusparseSpSV_createDescr",                             {"hipsparseSpSV_createDescr",                          "",                                                                 CONV_LIB_FUNC, API_SPARSE, 15, ROC_UNSUPPORTED}},
-  {"cusparseSpSV_destroyDescr",                            {"hipsparseSpSV_destroyDescr",                         "",                                                                 CONV_LIB_FUNC, API_SPARSE, 15, ROC_UNSUPPORTED}},
-  {"cusparseSpSV_bufferSize",                              {"hipsparseSpSV_bufferSize",                           "rocsparse_spsv",                                                   CONV_LIB_FUNC, API_SPARSE, 15}},
-  {"cusparseSpSV_analysis",                                {"hipsparseSpSV_analysis",                             "",                                                                 CONV_LIB_FUNC, API_SPARSE, 15, ROC_UNSUPPORTED}},
-  {"cusparseSpSV_solve",                                   {"hipsparseSpSV_solve",                                "",                                                                 CONV_LIB_FUNC, API_SPARSE, 15, ROC_UNSUPPORTED}},
-  {"cusparseSpSV_updateMatrix",                            {"hipsparseSpSV_updateMatrix",                         "",                                                                 CONV_LIB_FUNC, API_SPARSE, 15, UNSUPPORTED}},
+  m["cusparseSpSV_createDescr"]                                       = {"hipsparseSpSV_createDescr",                          "",                                                                 CONV_LIB_FUNC, API_SPARSE, 15, ROC_UNSUPPORTED};
+  m["cusparseSpSV_destroyDescr"]                                      = {"hipsparseSpSV_destroyDescr",                         "",                                                                 CONV_LIB_FUNC, API_SPARSE, 15, ROC_UNSUPPORTED};
+  m["cusparseSpSV_bufferSize"]                                        = {"hipsparseSpSV_bufferSize",                           "rocsparse_spsv",                                                   CONV_LIB_FUNC, API_SPARSE, 15};
+  m["cusparseSpSV_analysis"]                                          = {"hipsparseSpSV_analysis",                             "",                                                                 CONV_LIB_FUNC, API_SPARSE, 15, ROC_UNSUPPORTED};
+  m["cusparseSpSV_solve"]                                             = {"hipsparseSpSV_solve",                                "",                                                                 CONV_LIB_FUNC, API_SPARSE, 15, ROC_UNSUPPORTED};
+  m["cusparseSpSV_updateMatrix"]                                      = {"hipsparseSpSV_updateMatrix",                         "",                                                                 CONV_LIB_FUNC, API_SPARSE, 15, UNSUPPORTED};
 
   // Sparse Matrix * Matrix Multiplication
-  {"cusparseSpMM",                                         {"hipsparseSpMM",                                      "rocsparse_spmm",                                                   CONV_LIB_FUNC, API_SPARSE, 15}},
-  {"cusparseSpMM_bufferSize",                              {"hipsparseSpMM_bufferSize",                           "rocsparse_spmm",                                                   CONV_LIB_FUNC, API_SPARSE, 15}},
-  {"cusparseSpMM_preprocess",                              {"hipsparseSpMM_preprocess",                           "rocsparse_spmm",                                                   CONV_LIB_FUNC, API_SPARSE, 15}},
-  {"cusparseSpMMOp",                                       {"hipsparseSpMMOp",                                    "",                                                                 CONV_LIB_FUNC, API_SPARSE, 15, UNSUPPORTED}},
-  {"cusparseSpMMOp_createPlan",                            {"hipsparseSpMMOp_createPlan",                         "",                                                                 CONV_LIB_FUNC, API_SPARSE, 15, UNSUPPORTED}},
-  {"cusparseSpMMOp_destroyPlan",                           {"hipsparseSpMMOp_destroyPlan",                        "",                                                                 CONV_LIB_FUNC, API_SPARSE, 15, UNSUPPORTED}},
+  m["cusparseSpMM"]                                                   = {"hipsparseSpMM",                                      "rocsparse_spmm",                                                   CONV_LIB_FUNC, API_SPARSE, 15};
+  m["cusparseSpMM_bufferSize"]                                        = {"hipsparseSpMM_bufferSize",                           "rocsparse_spmm",                                                   CONV_LIB_FUNC, API_SPARSE, 15};
+  m["cusparseSpMM_preprocess"]                                        = {"hipsparseSpMM_preprocess",                           "rocsparse_spmm",                                                   CONV_LIB_FUNC, API_SPARSE, 15};
+  m["cusparseSpMMOp"]                                                 = {"hipsparseSpMMOp",                                    "",                                                                 CONV_LIB_FUNC, API_SPARSE, 15, UNSUPPORTED};
+  m["cusparseSpMMOp_createPlan"]                                      = {"hipsparseSpMMOp_createPlan",                         "",                                                                 CONV_LIB_FUNC, API_SPARSE, 15, UNSUPPORTED};
+  m["cusparseSpMMOp_destroyPlan"]                                     = {"hipsparseSpMMOp_destroyPlan",                        "",                                                                 CONV_LIB_FUNC, API_SPARSE, 15, UNSUPPORTED};
 
   // Sparse Triangular Matrix Solve
-  {"cusparseSpSM_createDescr",                             {"hipsparseSpSM_createDescr",                          "",                                                                 CONV_LIB_FUNC, API_SPARSE, 15, ROC_UNSUPPORTED}},
-  {"cusparseSpSM_destroyDescr",                            {"hipsparseSpSM_destroyDescr",                         "",                                                                 CONV_LIB_FUNC, API_SPARSE, 15, ROC_UNSUPPORTED}},
+  m["cusparseSpSM_createDescr"]                                       = {"hipsparseSpSM_createDescr",                          "",                                                                 CONV_LIB_FUNC, API_SPARSE, 15, ROC_UNSUPPORTED};
+  m["cusparseSpSM_destroyDescr"]                                      = {"hipsparseSpSM_destroyDescr",                         "",                                                                 CONV_LIB_FUNC, API_SPARSE, 15, ROC_UNSUPPORTED};
   // NTOE: Additional calculations are needed after calling rocsparse_spsm
-  {"cusparseSpSM_bufferSize",                              {"hipsparseSpSM_bufferSize",                           "",                                                                 CONV_LIB_FUNC, API_SPARSE, 15, ROC_UNSUPPORTED}},
-  {"cusparseSpSM_analysis",                                {"hipsparseSpSM_analysis",                             "rocsparse_spsm",                                                   CONV_LIB_FUNC, API_SPARSE, 15}},
-  {"cusparseSpSM_solve",                                   {"hipsparseSpSM_solve",                                "rocsparse_spsm",                                                   CONV_LIB_FUNC, API_SPARSE, 15}},
-  {"cusparseSpSM_updateMatrix",                            {"hipsparseSpSM_updateMatrix",                         "",                                                                 CONV_LIB_FUNC, API_SPARSE, 15, UNSUPPORTED}},
+  m["cusparseSpSM_bufferSize"]                                        = {"hipsparseSpSM_bufferSize",                           "",                                                                 CONV_LIB_FUNC, API_SPARSE, 15, ROC_UNSUPPORTED};
+  m["cusparseSpSM_analysis"]                                          = {"hipsparseSpSM_analysis",                             "rocsparse_spsm",                                                   CONV_LIB_FUNC, API_SPARSE, 15};
+  m["cusparseSpSM_solve"]                                             = {"hipsparseSpSM_solve",                                "rocsparse_spsm",                                                   CONV_LIB_FUNC, API_SPARSE, 15};
+  m["cusparseSpSM_updateMatrix"]                                      = {"hipsparseSpSM_updateMatrix",                         "",                                                                 CONV_LIB_FUNC, API_SPARSE, 15, UNSUPPORTED};
 
   // Sparse Matrix Multiplication (SpGEMM) Structure Reuse
-  {"cusparseSpGEMMreuse_workEstimation",                   {"hipsparseSpGEMMreuse_workEstimation",                "",                                                                 CONV_LIB_FUNC, API_SPARSE, 15, ROC_UNSUPPORTED}},
-  {"cusparseSpGEMMreuse_nnz",                              {"hipsparseSpGEMMreuse_nnz",                           "",                                                                 CONV_LIB_FUNC, API_SPARSE, 15, ROC_UNSUPPORTED}},
-  {"cusparseSpGEMMreuse_copy",                             {"hipsparseSpGEMMreuse_copy",                          "",                                                                 CONV_LIB_FUNC, API_SPARSE, 15, ROC_UNSUPPORTED}},
-  {"cusparseSpGEMMreuse_compute",                          {"hipsparseSpGEMMreuse_compute",                       "",                                                                 CONV_LIB_FUNC, API_SPARSE, 15, ROC_UNSUPPORTED}},
+  m["cusparseSpGEMMreuse_workEstimation"]                             = {"hipsparseSpGEMMreuse_workEstimation",                "",                                                                 CONV_LIB_FUNC, API_SPARSE, 15, ROC_UNSUPPORTED};
+  m["cusparseSpGEMMreuse_nnz"]                                        = {"hipsparseSpGEMMreuse_nnz",                           "",                                                                 CONV_LIB_FUNC, API_SPARSE, 15, ROC_UNSUPPORTED};
+  m["cusparseSpGEMMreuse_copy"]                                       = {"hipsparseSpGEMMreuse_copy",                          "",                                                                 CONV_LIB_FUNC, API_SPARSE, 15, ROC_UNSUPPORTED};
+  m["cusparseSpGEMMreuse_compute"]                                    = {"hipsparseSpGEMMreuse_compute",                       "",                                                                 CONV_LIB_FUNC, API_SPARSE, 15, ROC_UNSUPPORTED};
 
   // Sparse Matrix * Matrix Pattern-constrained Multiplication
-  {"cusparseConstrainedGeMM",                              {"hipsparseConstrainedGeMM",                           "",                                                                 CONV_LIB_FUNC, API_SPARSE, 15, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED}},
-  {"cusparseConstrainedGeMM_bufferSize",                   {"hipsparseConstrainedGeMM_bufferSize",                "",                                                                 CONV_LIB_FUNC, API_SPARSE, 15, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED}},
+  m["cusparseConstrainedGeMM"]                                        = {"hipsparseConstrainedGeMM",                           "",                                                                 CONV_LIB_FUNC, API_SPARSE, 15, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED};
+  m["cusparseConstrainedGeMM_bufferSize"]                             = {"hipsparseConstrainedGeMM_bufferSize",                "",                                                                 CONV_LIB_FUNC, API_SPARSE, 15, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED};
 
   // Sparse Vector * Vector Operations
-  {"cusparseSpVV",                                         {"hipsparseSpVV",                                      "rocsparse_spvv",                                                   CONV_LIB_FUNC, API_SPARSE, 15, CUDA_DEPRECATED}},
-  {"cusparseSpVV_bufferSize",                              {"hipsparseSpVV_bufferSize",                           "rocsparse_spvv",                                                   CONV_LIB_FUNC, API_SPARSE, 15, CUDA_DEPRECATED}},
+  m["cusparseSpVV"]                                                   = {"hipsparseSpVV",                                      "rocsparse_spvv",                                                   CONV_LIB_FUNC, API_SPARSE, 15, CUDA_DEPRECATED};
+  m["cusparseSpVV_bufferSize"]                                        = {"hipsparseSpVV_bufferSize",                           "rocsparse_spvv",                                                   CONV_LIB_FUNC, API_SPARSE, 15, CUDA_DEPRECATED};
 
-  {"cusparseAxpby",                                        {"hipsparseAxpby",                                     "rocsparse_axpby",                                                  CONV_LIB_FUNC, API_SPARSE, 15, CUDA_DEPRECATED}},
-  {"cusparseGather",                                       {"hipsparseGather",                                    "rocsparse_gather",                                                 CONV_LIB_FUNC, API_SPARSE, 15}},
-  {"cusparseScatter",                                      {"hipsparseScatter",                                   "rocsparse_scatter",                                                CONV_LIB_FUNC, API_SPARSE, 15}},
-  {"cusparseRot",                                          {"hipsparseRot",                                       "rocsparse_rot",                                                    CONV_LIB_FUNC, API_SPARSE, 15, CUDA_DEPRECATED | HIP_DEPRECATED}},
+  m["cusparseAxpby"]                                                  = {"hipsparseAxpby",                                     "rocsparse_axpby",                                                  CONV_LIB_FUNC, API_SPARSE, 15, CUDA_DEPRECATED};
+  m["cusparseGather"]                                                 = {"hipsparseGather",                                    "rocsparse_gather",                                                 CONV_LIB_FUNC, API_SPARSE, 15};
+  m["cusparseScatter"]                                                = {"hipsparseScatter",                                   "rocsparse_scatter",                                                CONV_LIB_FUNC, API_SPARSE, 15};
+  m["cusparseRot"]                                                    = {"hipsparseRot",                                       "rocsparse_rot",                                                    CONV_LIB_FUNC, API_SPARSE, 15, CUDA_DEPRECATED | HIP_DEPRECATED};
 
   // Sparse Matrix * Vector Multiplication
-  {"cusparseSpMV",                                         {"hipsparseSpMV",                                      "rocsparse_spmv",                                                   CONV_LIB_FUNC, API_SPARSE, 15}},
-  {"cusparseSpMV_bufferSize",                              {"hipsparseSpMV_bufferSize",                           "rocsparse_spmv",                                                   CONV_LIB_FUNC, API_SPARSE, 15}},
-  {"cusparseSpMV_preprocess",                              {"hipsparseSpMV_preprocess",                           "",                                                                 CONV_LIB_FUNC, API_SPARSE, 15, ROC_UNSUPPORTED}},
+  m["cusparseSpMV"]                                                   = {"hipsparseSpMV",                                      "rocsparse_spmv",                                                   CONV_LIB_FUNC, API_SPARSE, 15};
+  m["cusparseSpMV_bufferSize"]                                        = {"hipsparseSpMV_bufferSize",                           "rocsparse_spmv",                                                   CONV_LIB_FUNC, API_SPARSE, 15};
+  m["cusparseSpMV_preprocess"]                                        = {"hipsparseSpMV_preprocess",                           "",                                                                 CONV_LIB_FUNC, API_SPARSE, 15, ROC_UNSUPPORTED};
 
-  {"cusparseSparseToDense",                                {"hipsparseSparseToDense",                             "rocsparse_sparse_to_dense",                                        CONV_LIB_FUNC, API_SPARSE, 15}},
-  {"cusparseSparseToDense_bufferSize",                     {"hipsparseSparseToDense_bufferSize",                  "rocsparse_sparse_to_dense",                                        CONV_LIB_FUNC, API_SPARSE, 15}},
-  {"cusparseDenseToSparse_bufferSize",                     {"hipsparseDenseToSparse_bufferSize",                  "rocsparse_dense_to_sparse",                                        CONV_LIB_FUNC, API_SPARSE, 15}},
-  {"cusparseDenseToSparse_analysis",                       {"hipsparseDenseToSparse_analysis",                    "rocsparse_dense_to_sparse",                                        CONV_LIB_FUNC, API_SPARSE, 15}},
+  m["cusparseSparseToDense"]                                          = {"hipsparseSparseToDense",                             "rocsparse_sparse_to_dense",                                        CONV_LIB_FUNC, API_SPARSE, 15};
+  m["cusparseSparseToDense_bufferSize"]                               = {"hipsparseSparseToDense_bufferSize",                  "rocsparse_sparse_to_dense",                                        CONV_LIB_FUNC, API_SPARSE, 15};
+  m["cusparseDenseToSparse_bufferSize"]                               = {"hipsparseDenseToSparse_bufferSize",                  "rocsparse_dense_to_sparse",                                        CONV_LIB_FUNC, API_SPARSE, 15};
+  m["cusparseDenseToSparse_analysis"]                                 = {"hipsparseDenseToSparse_analysis",                    "rocsparse_dense_to_sparse",                                        CONV_LIB_FUNC, API_SPARSE, 15};
   // TODO: hipification cusparseDenseToSparse_convert into rocsparse_dense_to_sparse needs additional variable declared and allocated
-  {"cusparseDenseToSparse_convert",                        {"hipsparseDenseToSparse_convert",                     "",                                                                 CONV_LIB_FUNC, API_SPARSE, 15, ROC_UNSUPPORTED}},
+  m["cusparseDenseToSparse_convert"]                                  = {"hipsparseDenseToSparse_convert",                     "",                                                                 CONV_LIB_FUNC, API_SPARSE, 15, ROC_UNSUPPORTED};
 
   // Sampled Dense-dense Matrix Multiplication
-  {"cusparseSDDMM",                                        {"hipsparseSDDMM",                                     "rocsparse_sddmm",                                                  CONV_LIB_FUNC, API_SPARSE, 15}},
-  {"cusparseSDDMM_bufferSize",                             {"hipsparseSDDMM_bufferSize",                          "rocsparse_sddmm_buffer_size",                                      CONV_LIB_FUNC, API_SPARSE, 15}},
-  {"cusparseSDDMM_preprocess",                             {"hipsparseSDDMM_preprocess",                          "rocsparse_sddmm_preprocess",                                       CONV_LIB_FUNC, API_SPARSE, 15}},
-};
+  m["cusparseSDDMM"]                                                  = {"hipsparseSDDMM",                                     "rocsparse_sddmm",                                                  CONV_LIB_FUNC, API_SPARSE, 15};
+  m["cusparseSDDMM_bufferSize"]                                       = {"hipsparseSDDMM_bufferSize",                          "rocsparse_sddmm_buffer_size",                                      CONV_LIB_FUNC, API_SPARSE, 15};
+  m["cusparseSDDMM_preprocess"]                                       = {"hipsparseSDDMM_preprocess",                          "rocsparse_sddmm_preprocess",                                       CONV_LIB_FUNC, API_SPARSE, 15};
 
-const std::map<llvm::StringRef, cudaAPIversions> CUDA_SPARSE_FUNCTION_VER_MAP {
-  {"cusparseCreateCsrgemm2Info",                           {CUDA_0,   CUDA_110, CUDA_120}}, // D: CUSPARSE_VERSION 11000, R: CUSPARSE_VERSION 12000
-  {"cusparseDestroyCsrgemm2Info",                          {CUDA_0,   CUDA_110, CUDA_120}}, // D: CUSPARSE_VERSION 11000, R: CUSPARSE_VERSION 12000
-  {"cusparseCreateCsrsm2Info",                             {CUDA_92,  CUDA_113, CUDA_120}}, // D: CUSPARSE_VERSION 11600, R: CUSPARSE_VERSION 12000
-  {"cusparseDestroyCsrsm2Info",                            {CUDA_92,  CUDA_113, CUDA_120}}, // D: CUSPARSE_VERSION 11600, R: CUSPARSE_VERSION 12000
-  {"cusparseCreateHybMat",                                 {CUDA_0,   CUDA_102, CUDA_110}},
-  {"cusparseDestroyHybMat",                                {CUDA_0,   CUDA_102, CUDA_110}},
-  {"cusparseCreatePruneInfo",                              {CUDA_90,  CUDA_122, CUDA_0  }}, // D: CUSPARSE_VERSION 12102
-  {"cusparseDestroyPruneInfo",                             {CUDA_90,  CUDA_122, CUDA_0  }}, // D: CUSPARSE_VERSION 12102
-  {"cusparseCreateSolveAnalysisInfo",                      {CUDA_0,   CUDA_102, CUDA_110}},
-  {"cusparseDestroySolveAnalysisInfo",                     {CUDA_0,   CUDA_102, CUDA_110}},
-  {"cusparseGetLevelInfo",                                 {CUDA_0,   CUDA_0,   CUDA_110}},
-  {"cusparseSdoti",                                        {CUDA_0,   CUDA_102, CUDA_110}},
-  {"cusparseDdoti",                                        {CUDA_0,   CUDA_102, CUDA_110}},
-  {"cusparseCdoti",                                        {CUDA_0,   CUDA_102, CUDA_110}},
-  {"cusparseZdoti",                                        {CUDA_0,   CUDA_102, CUDA_110}},
-  {"cusparseCdotci",                                       {CUDA_0,   CUDA_102, CUDA_110}},
-  {"cusparseZdotci",                                       {CUDA_0,   CUDA_102, CUDA_110}},
-  {"cusparseScsrmv",                                       {CUDA_0,   CUDA_102, CUDA_110}},
-  {"cusparseDcsrmv",                                       {CUDA_0,   CUDA_102, CUDA_110}},
-  {"cusparseCcsrmv",                                       {CUDA_0,   CUDA_102, CUDA_110}},
-  {"cusparseZcsrmv",                                       {CUDA_0,   CUDA_102, CUDA_110}},
-  {"cusparseCsrmvEx",                                      {CUDA_80,  CUDA_112, CUDA_120}},
-  {"cusparseCsrmvEx_bufferSize",                           {CUDA_80,  CUDA_112, CUDA_120}},
-  {"cusparseScsrmv_mp",                                    {CUDA_80,  CUDA_102, CUDA_110}},
-  {"cusparseDcsrmv_mp",                                    {CUDA_80,  CUDA_102, CUDA_110}},
-  {"cusparseCcsrmv_mp",                                    {CUDA_80,  CUDA_102, CUDA_110}},
-  {"cusparseZcsrmv_mp",                                    {CUDA_80,  CUDA_102, CUDA_110}},
-  {"cusparseSgemvi",                                       {CUDA_75,  CUDA_128, CUDA_0  }},
-  {"cusparseDgemvi",                                       {CUDA_75,  CUDA_128, CUDA_0  }},
-  {"cusparseCgemvi",                                       {CUDA_75,  CUDA_128, CUDA_0  }},
-  {"cusparseZgemvi",                                       {CUDA_75,  CUDA_128, CUDA_0  }},
-  {"cusparseSgemvi_bufferSize",                            {CUDA_75,  CUDA_128, CUDA_0  }},
-  {"cusparseDgemvi_bufferSize",                            {CUDA_75,  CUDA_128, CUDA_0  }},
-  {"cusparseCgemvi_bufferSize",                            {CUDA_75,  CUDA_128, CUDA_0  }},
-  {"cusparseZgemvi_bufferSize",                            {CUDA_75,  CUDA_128, CUDA_0  }},
-  {"cusparseScsrsv_solve",                                 {CUDA_0,   CUDA_102, CUDA_110}},
-  {"cusparseDcsrsv_solve",                                 {CUDA_0,   CUDA_102, CUDA_110}},
-  {"cusparseCcsrsv_solve",                                 {CUDA_0,   CUDA_102, CUDA_110}},
-  {"cusparseZcsrsv_solve",                                 {CUDA_0,   CUDA_102, CUDA_110}},
-  {"cusparseScsrsv_analysis",                              {CUDA_0,   CUDA_102, CUDA_110}},
-  {"cusparseDcsrsv_analysis",                              {CUDA_0,   CUDA_102, CUDA_110}},
-  {"cusparseCcsrsv_analysis",                              {CUDA_0,   CUDA_102, CUDA_110}},
-  {"cusparseZcsrsv_analysis",                              {CUDA_0,   CUDA_102, CUDA_110}},
-  {"cusparseCsrsv_analysisEx",                             {CUDA_80,  CUDA_102, CUDA_110}},
-  {"cusparseCsrsv_solveEx",                                {CUDA_80,  CUDA_102, CUDA_110}},
-  {"cusparseShybmv",                                       {CUDA_0,   CUDA_102, CUDA_110}},
-  {"cusparseDhybmv",                                       {CUDA_0,   CUDA_102, CUDA_110}},
-  {"cusparseChybmv",                                       {CUDA_0,   CUDA_102, CUDA_110}},
-  {"cusparseZhybmv",                                       {CUDA_0,   CUDA_102, CUDA_110}},
-  {"cusparseShybsv_analysis",                              {CUDA_0,   CUDA_102, CUDA_110}},
-  {"cusparseDhybsv_analysis",                              {CUDA_0,   CUDA_102, CUDA_110}},
-  {"cusparseChybsv_analysis",                              {CUDA_0,   CUDA_102, CUDA_110}},
-  {"cusparseZhybsv_analysis",                              {CUDA_0,   CUDA_102, CUDA_110}},
-  {"cusparseShybsv_solve",                                 {CUDA_0,   CUDA_102, CUDA_110}},
-  {"cusparseDhybsv_solve",                                 {CUDA_0,   CUDA_102, CUDA_110}},
-  {"cusparseChybsv_solve",                                 {CUDA_0,   CUDA_102, CUDA_110}},
-  {"cusparseZhybsv_solve",                                 {CUDA_0,   CUDA_102, CUDA_110}},
-  {"cusparseScsrmm",                                       {CUDA_0,   CUDA_102, CUDA_110}},
-  {"cusparseDcsrmm",                                       {CUDA_0,   CUDA_102, CUDA_110}},
-  {"cusparseCcsrmm",                                       {CUDA_0,   CUDA_102, CUDA_110}},
-  {"cusparseZcsrmm",                                       {CUDA_0,   CUDA_102, CUDA_110}},
-  {"cusparseScsrmm2",                                      {CUDA_0,   CUDA_102, CUDA_110}},
-  {"cusparseDcsrmm2",                                      {CUDA_0,   CUDA_102, CUDA_110}},
-  {"cusparseCcsrmm2",                                      {CUDA_0,   CUDA_102, CUDA_110}},
-  {"cusparseZcsrmm2",                                      {CUDA_0,   CUDA_102, CUDA_110}},
-  {"cusparseScsrsm_analysis",                              {CUDA_0,   CUDA_102, CUDA_110}},
-  {"cusparseDcsrsm_analysis",                              {CUDA_0,   CUDA_102, CUDA_110}},
-  {"cusparseCcsrsm_analysis",                              {CUDA_0,   CUDA_102, CUDA_110}},
-  {"cusparseZcsrsm_analysis",                              {CUDA_0,   CUDA_102, CUDA_110}},
-  {"cusparseScsrsm_solve",                                 {CUDA_0,   CUDA_102, CUDA_110}},
-  {"cusparseDcsrsm_solve",                                 {CUDA_0,   CUDA_102, CUDA_110}},
-  {"cusparseCcsrsm_solve",                                 {CUDA_0,   CUDA_102, CUDA_110}},
-  {"cusparseZcsrsm_solve",                                 {CUDA_0,   CUDA_102, CUDA_110}},
-  {"cusparseScsrsm2_bufferSizeExt",                        {CUDA_92,  CUDA_113, CUDA_120}},
-  {"cusparseDcsrsm2_bufferSizeExt",                        {CUDA_92,  CUDA_113, CUDA_120}},
-  {"cusparseCcsrsm2_bufferSizeExt",                        {CUDA_92,  CUDA_113, CUDA_120}},
-  {"cusparseZcsrsm2_bufferSizeExt",                        {CUDA_92,  CUDA_113, CUDA_120}},
-  {"cusparseScsrsm2_analysis",                             {CUDA_92,  CUDA_113, CUDA_120}},
-  {"cusparseDcsrsm2_analysis",                             {CUDA_92,  CUDA_113, CUDA_120}},
-  {"cusparseCcsrsm2_analysis",                             {CUDA_92,  CUDA_113, CUDA_120}},
-  {"cusparseZcsrsm2_analysis",                             {CUDA_92,  CUDA_113, CUDA_120}},
-  {"cusparseScsrsm2_solve",                                {CUDA_92,  CUDA_113, CUDA_120}},
-  {"cusparseDcsrsm2_solve",                                {CUDA_92,  CUDA_113, CUDA_120}},
-  {"cusparseCcsrsm2_solve",                                {CUDA_92,  CUDA_113, CUDA_120}},
-  {"cusparseZcsrsm2_solve",                                {CUDA_92,  CUDA_113, CUDA_120}},
-  {"cusparseXcsrsm2_zeroPivot",                            {CUDA_92,  CUDA_113, CUDA_120}},
-  {"cusparseSgemmi",                                       {CUDA_80,  CUDA_110, CUDA_120}},
-  {"cusparseDgemmi",                                       {CUDA_80,  CUDA_110, CUDA_120}},
-  {"cusparseCgemmi",                                       {CUDA_80,  CUDA_110, CUDA_120}},
-  {"cusparseZgemmi",                                       {CUDA_80,  CUDA_110, CUDA_120}},
-  {"cusparseScsrgeam",                                     {CUDA_0,   CUDA_102, CUDA_110}},
-  {"cusparseDcsrgeam",                                     {CUDA_0,   CUDA_102, CUDA_110}},
-  {"cusparseCcsrgeam",                                     {CUDA_0,   CUDA_102, CUDA_110}},
-  {"cusparseZcsrgeam",                                     {CUDA_0,   CUDA_102, CUDA_110}},
-  {"cusparseXcsrgeamNnz",                                  {CUDA_0,   CUDA_102, CUDA_110}},
-  {"cusparseScsrgeam2",                                    {CUDA_100, CUDA_0,   CUDA_0  }},
-  {"cusparseDcsrgeam2",                                    {CUDA_100, CUDA_0,   CUDA_0  }},
-  {"cusparseCcsrgeam2",                                    {CUDA_100, CUDA_0,   CUDA_0  }},
-  {"cusparseZcsrgeam2",                                    {CUDA_100, CUDA_0,   CUDA_0  }},
-  {"cusparseXcsrgeam2Nnz",                                 {CUDA_100, CUDA_0,   CUDA_0  }},
-  {"cusparseScsrgeam2_bufferSizeExt",                      {CUDA_100, CUDA_0,   CUDA_0  }},
-  {"cusparseDcsrgeam2_bufferSizeExt",                      {CUDA_100, CUDA_0,   CUDA_0  }},
-  {"cusparseCcsrgeam2_bufferSizeExt",                      {CUDA_100, CUDA_0,   CUDA_0  }},
-  {"cusparseZcsrgeam2_bufferSizeExt",                      {CUDA_100, CUDA_0,   CUDA_0  }},
-  {"cusparseScsrgemm",                                     {CUDA_0,   CUDA_102, CUDA_110}},
-  {"cusparseDcsrgemm",                                     {CUDA_0,   CUDA_102, CUDA_110}},
-  {"cusparseCcsrgemm",                                     {CUDA_0,   CUDA_102, CUDA_110}},
-  {"cusparseZcsrgemm",                                     {CUDA_0,   CUDA_102, CUDA_110}},
-  {"cusparseXcsrgemmNnz",                                  {CUDA_0,   CUDA_102, CUDA_110}},
-  {"cusparseScsrgemm2",                                    {CUDA_0,   CUDA_110, CUDA_120}},
-  {"cusparseDcsrgemm2",                                    {CUDA_0,   CUDA_110, CUDA_120}},
-  {"cusparseCcsrgemm2",                                    {CUDA_0,   CUDA_110, CUDA_120}},
-  {"cusparseZcsrgemm2",                                    {CUDA_0,   CUDA_110, CUDA_120}},
-  {"cusparseXcsrgemm2Nnz",                                 {CUDA_0,   CUDA_110, CUDA_120}},
-  {"cusparseScsrgemm2_bufferSizeExt",                      {CUDA_0,   CUDA_110, CUDA_120}},
-  {"cusparseDcsrgemm2_bufferSizeExt",                      {CUDA_0,   CUDA_110, CUDA_120}},
-  {"cusparseCcsrgemm2_bufferSizeExt",                      {CUDA_0,   CUDA_110, CUDA_120}},
-  {"cusparseZcsrgemm2_bufferSizeExt",                      {CUDA_0,   CUDA_110, CUDA_120}},
-  {"cusparseScsric0",                                      {CUDA_0,   CUDA_102, CUDA_110}},
-  {"cusparseDcsric0",                                      {CUDA_0,   CUDA_102, CUDA_110}},
-  {"cusparseCcsric0",                                      {CUDA_0,   CUDA_102, CUDA_110}},
-  {"cusparseZcsric0",                                      {CUDA_0,   CUDA_102, CUDA_110}},
-  {"cusparseScsrilu0",                                     {CUDA_0,   CUDA_102, CUDA_110}},
-  {"cusparseDcsrilu0",                                     {CUDA_0,   CUDA_102, CUDA_110}},
-  {"cusparseCcsrilu0",                                     {CUDA_0,   CUDA_102, CUDA_110}},
-  {"cusparseZcsrilu0",                                     {CUDA_0,   CUDA_102, CUDA_110}},
-  {"cusparseCsrilu0Ex",                                    {CUDA_80,  CUDA_102, CUDA_110}},
-  {"cusparseSgtsv",                                        {CUDA_0,   CUDA_102, CUDA_110}},
-  {"cusparseDgtsv",                                        {CUDA_0,   CUDA_102, CUDA_110}},
-  {"cusparseCgtsv",                                        {CUDA_0,   CUDA_102, CUDA_110}},
-  {"cusparseZgtsv",                                        {CUDA_0,   CUDA_102, CUDA_110}},
-  {"cusparseSgtsv_nopivot",                                {CUDA_0,   CUDA_102, CUDA_110}},
-  {"cusparseDgtsv_nopivot",                                {CUDA_0,   CUDA_102, CUDA_110}},
-  {"cusparseCgtsv_nopivot",                                {CUDA_0,   CUDA_102, CUDA_110}},
-  {"cusparseZgtsv_nopivot",                                {CUDA_0,   CUDA_102, CUDA_110}},
-  {"cusparseSgtsv2_bufferSizeExt",                         {CUDA_90,  CUDA_0,   CUDA_0  }},
-  {"cusparseDgtsv2_bufferSizeExt",                         {CUDA_90,  CUDA_0,   CUDA_0  }},
-  {"cusparseCgtsv2_bufferSizeExt",                         {CUDA_90,  CUDA_0,   CUDA_0  }},
-  {"cusparseZgtsv2_bufferSizeExt",                         {CUDA_90,  CUDA_0,   CUDA_0  }},
-  {"cusparseSgtsv2",                                       {CUDA_90,  CUDA_0,   CUDA_0  }},
-  {"cusparseDgtsv2",                                       {CUDA_90,  CUDA_0,   CUDA_0  }},
-  {"cusparseCgtsv2",                                       {CUDA_90,  CUDA_0,   CUDA_0  }},
-  {"cusparseZgtsv2",                                       {CUDA_90,  CUDA_0,   CUDA_0  }},
-  {"cusparseSgtsv2_nopivot_bufferSizeExt",                 {CUDA_90,  CUDA_0,   CUDA_0  }},
-  {"cusparseDgtsv2_nopivot_bufferSizeExt",                 {CUDA_90,  CUDA_0,   CUDA_0  }},
-  {"cusparseCgtsv2_nopivot_bufferSizeExt",                 {CUDA_90,  CUDA_0,   CUDA_0  }},
-  {"cusparseZgtsv2_nopivot_bufferSizeExt",                 {CUDA_90,  CUDA_0,   CUDA_0  }},
-  {"cusparseSgtsv2_nopivot",                               {CUDA_90,  CUDA_0,   CUDA_0  }},
-  {"cusparseDgtsv2_nopivot",                               {CUDA_90,  CUDA_0,   CUDA_0  }},
-  {"cusparseCgtsv2_nopivot",                               {CUDA_90,  CUDA_0,   CUDA_0  }},
-  {"cusparseZgtsv2_nopivot",                               {CUDA_90,  CUDA_0,   CUDA_0  }},
-  {"cusparseSgtsvStridedBatch",                            {CUDA_0,   CUDA_102, CUDA_110}},
-  {"cusparseDgtsvStridedBatch",                            {CUDA_0,   CUDA_102, CUDA_110}},
-  {"cusparseCgtsvStridedBatch",                            {CUDA_0,   CUDA_102, CUDA_110}},
-  {"cusparseZgtsvStridedBatch",                            {CUDA_0,   CUDA_102, CUDA_110}},
-  {"cusparseSgtsv2StridedBatch_bufferSizeExt",             {CUDA_90,  CUDA_0,   CUDA_0  }},
-  {"cusparseDgtsv2StridedBatch_bufferSizeExt",             {CUDA_90,  CUDA_0,   CUDA_0  }},
-  {"cusparseCgtsv2StridedBatch_bufferSizeExt",             {CUDA_90,  CUDA_0,   CUDA_0  }},
-  {"cusparseZgtsv2StridedBatch_bufferSizeExt",             {CUDA_90,  CUDA_0,   CUDA_0  }},
-  {"cusparseSgtsv2StridedBatch",                           {CUDA_90,  CUDA_0,   CUDA_0  }},
-  {"cusparseDgtsv2StridedBatch",                           {CUDA_90,  CUDA_0,   CUDA_0  }},
-  {"cusparseCgtsv2StridedBatch",                           {CUDA_90,  CUDA_0,   CUDA_0  }},
-  {"cusparseZgtsv2StridedBatch",                           {CUDA_90,  CUDA_0,   CUDA_0  }},
-  {"cusparseSgtsvInterleavedBatch_bufferSizeExt",          {CUDA_92,  CUDA_0,   CUDA_0  }},
-  {"cusparseDgtsvInterleavedBatch_bufferSizeExt",          {CUDA_92,  CUDA_0,   CUDA_0  }},
-  {"cusparseCgtsvInterleavedBatch_bufferSizeExt",          {CUDA_92,  CUDA_0,   CUDA_0  }},
-  {"cusparseZgtsvInterleavedBatch_bufferSizeExt",          {CUDA_92,  CUDA_0,   CUDA_0  }},
-  {"cusparseSgtsvInterleavedBatch",                        {CUDA_92,  CUDA_0,   CUDA_0  }},
-  {"cusparseDgtsvInterleavedBatch",                        {CUDA_92,  CUDA_0,   CUDA_0  }},
-  {"cusparseCgtsvInterleavedBatch",                        {CUDA_92,  CUDA_0,   CUDA_0  }},
-  {"cusparseZgtsvInterleavedBatch",                        {CUDA_92,  CUDA_0,   CUDA_0  }},
-  {"cusparseSgpsvInterleavedBatch_bufferSizeExt",          {CUDA_92,  CUDA_0,   CUDA_0  }},
-  {"cusparseDgpsvInterleavedBatch_bufferSizeExt",          {CUDA_92,  CUDA_0,   CUDA_0  }},
-  {"cusparseCgpsvInterleavedBatch_bufferSizeExt",          {CUDA_92,  CUDA_0,   CUDA_0  }},
-  {"cusparseZgpsvInterleavedBatch_bufferSizeExt",          {CUDA_92,  CUDA_0,   CUDA_0  }},
-  {"cusparseSgpsvInterleavedBatch",                        {CUDA_92,  CUDA_0,   CUDA_0  }},
-  {"cusparseDgpsvInterleavedBatch",                        {CUDA_92,  CUDA_0,   CUDA_0  }},
-  {"cusparseCgpsvInterleavedBatch",                        {CUDA_92,  CUDA_0,   CUDA_0  }},
-  {"cusparseZgpsvInterleavedBatch",                        {CUDA_92,  CUDA_0,   CUDA_0  }},
-  {"cusparseScsc2hyb",                                     {CUDA_0,   CUDA_102, CUDA_110}},
-  {"cusparseDcsc2hyb",                                     {CUDA_0,   CUDA_102, CUDA_110}},
-  {"cusparseCcsc2hyb",                                     {CUDA_0,   CUDA_102, CUDA_110}},
-  {"cusparseZcsc2hyb",                                     {CUDA_0,   CUDA_102, CUDA_110}},
-  {"cusparseCsr2cscEx",                                    {CUDA_80,  CUDA_102, CUDA_110}},
-  {"cusparseCsr2cscEx2",                                   {CUDA_101, CUDA_0,   CUDA_0  }},
-  {"cusparseCsr2cscEx2_bufferSize",                        {CUDA_101, CUDA_0,   CUDA_0  }},
-  {"cusparseScsr2csr_compress",                            {CUDA_80,  CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseDcsr2csr_compress",                            {CUDA_80,  CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseCcsr2csr_compress",                            {CUDA_80,  CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseZcsr2csr_compress",                            {CUDA_80,  CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseScsr2hyb",                                     {CUDA_0,   CUDA_102, CUDA_110}},
-  {"cusparseDcsr2hyb",                                     {CUDA_0,   CUDA_102, CUDA_110}},
-  {"cusparseCcsr2hyb",                                     {CUDA_0,   CUDA_102, CUDA_110}},
-  {"cusparseZcsr2hyb",                                     {CUDA_0,   CUDA_102, CUDA_110}},
-  {"cusparseSdense2hyb",                                   {CUDA_0,   CUDA_102, CUDA_110}},
-  {"cusparseDdense2hyb",                                   {CUDA_0,   CUDA_102, CUDA_110}},
-  {"cusparseCdense2hyb",                                   {CUDA_0,   CUDA_102, CUDA_110}},
-  {"cusparseZdense2hyb",                                   {CUDA_0,   CUDA_102, CUDA_110}},
-  {"cusparseShyb2csc",                                     {CUDA_0,   CUDA_102, CUDA_110}},
-  {"cusparseDhyb2csc",                                     {CUDA_0,   CUDA_102, CUDA_110}},
-  {"cusparseChyb2csc",                                     {CUDA_0,   CUDA_102, CUDA_110}},
-  {"cusparseZhyb2csc",                                     {CUDA_0,   CUDA_102, CUDA_110}},
-  {"cusparseShyb2csr",                                     {CUDA_0,   CUDA_102, CUDA_110}},
-  {"cusparseDhyb2csr",                                     {CUDA_0,   CUDA_102, CUDA_110}},
-  {"cusparseChyb2csr",                                     {CUDA_0,   CUDA_102, CUDA_110}},
-  {"cusparseZhyb2csr",                                     {CUDA_0,   CUDA_102, CUDA_110}},
-  {"cusparseShyb2dense",                                   {CUDA_0,   CUDA_102, CUDA_110}},
-  {"cusparseDhyb2dense",                                   {CUDA_0,   CUDA_102, CUDA_110}},
-  {"cusparseChyb2dense",                                   {CUDA_0,   CUDA_102, CUDA_110}},
-  {"cusparseZhyb2dense",                                   {CUDA_0,   CUDA_102, CUDA_110}},
-  {"cusparseHpruneDense2csr",                              {CUDA_90,  CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseSpruneDense2csr",                              {CUDA_90,  CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseDpruneDense2csr",                              {CUDA_90,  CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseHpruneDense2csr_bufferSizeExt",                {CUDA_90,  CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseSpruneDense2csr_bufferSizeExt",                {CUDA_90,  CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseDpruneDense2csr_bufferSizeExt",                {CUDA_90,  CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseHpruneDense2csrNnz",                           {CUDA_90,  CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseSpruneDense2csrNnz",                           {CUDA_90,  CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseDpruneDense2csrNnz",                           {CUDA_90,  CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseHpruneCsr2csr",                                {CUDA_90,  CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseSpruneCsr2csr",                                {CUDA_90,  CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseDpruneCsr2csr",                                {CUDA_90,  CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseHpruneCsr2csr_bufferSizeExt",                  {CUDA_90,  CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseSpruneCsr2csr_bufferSizeExt",                  {CUDA_90,  CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseDpruneCsr2csr_bufferSizeExt",                  {CUDA_90,  CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseHpruneCsr2csrNnz",                             {CUDA_90,  CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseSpruneCsr2csrNnz",                             {CUDA_90,  CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseDpruneCsr2csrNnz",                             {CUDA_90,  CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseHpruneDense2csrByPercentage",                  {CUDA_90,  CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseSpruneDense2csrByPercentage",                  {CUDA_90,  CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseDpruneDense2csrByPercentage",                  {CUDA_90,  CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseHpruneDense2csrByPercentage_bufferSizeExt",    {CUDA_90,  CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseSpruneDense2csrByPercentage_bufferSizeExt",    {CUDA_90,  CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseDpruneDense2csrByPercentage_bufferSizeExt",    {CUDA_90,  CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseHpruneDense2csrNnzByPercentage",               {CUDA_90,  CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseSpruneDense2csrNnzByPercentage",               {CUDA_90,  CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseDpruneDense2csrNnzByPercentage",               {CUDA_90,  CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseHpruneCsr2csrByPercentage",                    {CUDA_90,  CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseSpruneCsr2csrByPercentage",                    {CUDA_90,  CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseDpruneCsr2csrByPercentage",                    {CUDA_90,  CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseHpruneCsr2csrByPercentage_bufferSizeExt",      {CUDA_90,  CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseSpruneCsr2csrByPercentage_bufferSizeExt",      {CUDA_90,  CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseDpruneCsr2csrByPercentage_bufferSizeExt",      {CUDA_90,  CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseHpruneCsr2csrNnzByPercentage",                 {CUDA_90,  CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseSpruneCsr2csrNnzByPercentage",                 {CUDA_90,  CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseDpruneCsr2csrNnzByPercentage",                 {CUDA_90,  CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseSnnz_compress",                                {CUDA_80,  CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseDnnz_compress",                                {CUDA_80,  CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseCnnz_compress",                                {CUDA_80,  CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseZnnz_compress",                                {CUDA_80,  CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseGetStream",                                    {CUDA_80,  CUDA_0,   CUDA_0  }},
-  {"cusparseCreateCoo",                                    {CUDA_101, CUDA_0,   CUDA_0  }},
-  {"cusparseCreateCooAoS",                                 {CUDA_102, CUDA_112, CUDA_120}},
-  {"cusparseCreateCsr",                                    {CUDA_102, CUDA_0,   CUDA_0  }},
-  {"cusparseDestroySpMat",                                 {CUDA_101, CUDA_0,   CUDA_0  }},
-  {"cusparseCooGet",                                       {CUDA_101, CUDA_0,   CUDA_0  }},
-  {"cusparseCooAoSGet",                                    {CUDA_102, CUDA_112, CUDA_120}},
-  {"cusparseCsrGet",                                       {CUDA_102, CUDA_0,   CUDA_0  }},
-  {"cusparseSpMatGetFormat",                               {CUDA_101, CUDA_0,   CUDA_0  }},
-  {"cusparseSpMatGetIndexBase",                            {CUDA_101, CUDA_0,   CUDA_0  }},
-  {"cusparseSpMatGetValues",                               {CUDA_102, CUDA_0,   CUDA_0  }},
-  {"cusparseSpMatSetValues",                               {CUDA_102, CUDA_0,   CUDA_0  }},
-  {"cusparseSpMatGetStridedBatch",                         {CUDA_102, CUDA_0,   CUDA_0  }},
-  {"cusparseSpMatSetStridedBatch",                         {CUDA_102, CUDA_0,   CUDA_120}},
-  {"cusparseSpMatSetNumBatches",                           {CUDA_101, CUDA_0,   CUDA_102}},
-  {"cusparseSpMatGetNumBatches",                           {CUDA_101, CUDA_0,   CUDA_102}},
-  {"cusparseCreateSpVec",                                  {CUDA_102, CUDA_0,   CUDA_0  }},
-  {"cusparseDestroySpVec",                                 {CUDA_102, CUDA_0,   CUDA_0  }},
-  {"cusparseSpVecGet",                                     {CUDA_102, CUDA_0,   CUDA_0  }},
-  {"cusparseSpVecGetIndexBase",                            {CUDA_102, CUDA_0,   CUDA_0  }},
-  {"cusparseSpVecGetValues",                               {CUDA_102, CUDA_0,   CUDA_0  }},
-  {"cusparseSpVecSetValues",                               {CUDA_102, CUDA_0,   CUDA_0  }},
-  {"cusparseCreateDnMat",                                  {CUDA_101, CUDA_0,   CUDA_0  }},
-  {"cusparseDestroyDnMat",                                 {CUDA_101, CUDA_0,   CUDA_0  }},
-  {"cusparseDnMatGet",                                     {CUDA_101, CUDA_0,   CUDA_0  }},
-  {"cusparseDnMatGetValues",                               {CUDA_102, CUDA_0,   CUDA_0  }},
-  {"cusparseDnMatSetValues",                               {CUDA_102, CUDA_0,   CUDA_0  }},
-  {"cusparseDnMatSetStridedBatch",                         {CUDA_101, CUDA_0,   CUDA_0  }},
-  {"cusparseDnMatGetStridedBatch",                         {CUDA_101, CUDA_0,   CUDA_0  }},
-  {"cusparseCreateDnVec",                                  {CUDA_102, CUDA_0,   CUDA_0  }},
-  {"cusparseDestroyDnVec",                                 {CUDA_102, CUDA_0,   CUDA_0  }},
-  {"cusparseDnVecGet",                                     {CUDA_102, CUDA_0,   CUDA_0  }},
-  {"cusparseDnVecGetValues",                               {CUDA_102, CUDA_0,   CUDA_0  }},
-  {"cusparseDnVecSetValues",                               {CUDA_102, CUDA_0,   CUDA_0  }},
-  {"cusparseSpMM",                                         {CUDA_101, CUDA_0,   CUDA_0  }}, // A: CUDA_VERSION 10010 C: CUSPARSE_VERSION 12000
-  {"cusparseSpMM_bufferSize",                              {CUDA_101, CUDA_0,   CUDA_0  }}, // A: CUDA_VERSION 10010 C: CUSPARSE_VERSION 12000
-  {"cusparseSpVV",                                         {CUDA_101, CUDA_128, CUDA_0  }}, // A: CUSPARSE_VERSION 10200 C: CUSPARSE_VERSION 12000
-  {"cusparseSpVV_bufferSize",                              {CUDA_101, CUDA_128, CUDA_0  }}, // A: CUSPARSE_VERSION 10200 C: CUSPARSE_VERSION 12000
-  {"cusparseSpMV",                                         {CUDA_101, CUDA_0,   CUDA_0  }}, // A: CUSPARSE_VERSION 10200 C: CUSPARSE_VERSION 12000
-  {"cusparseSpMV_bufferSize",                              {CUDA_101, CUDA_0,   CUDA_0  }}, // A: CUSPARSE_VERSION 10200 C: CUSPARSE_VERSION 12000
-  {"cusparseSaxpyi",                                       {CUDA_0,   CUDA_110, CUDA_120}},
-  {"cusparseDaxpyi",                                       {CUDA_0,   CUDA_110, CUDA_120}},
-  {"cusparseCaxpyi",                                       {CUDA_0,   CUDA_110, CUDA_120}},
-  {"cusparseZaxpyi",                                       {CUDA_0,   CUDA_110, CUDA_120}},
-  {"cusparseSgthr",                                        {CUDA_0,   CUDA_110, CUDA_120}},
-  {"cusparseDgthr",                                        {CUDA_0,   CUDA_110, CUDA_120}},
-  {"cusparseCgthr",                                        {CUDA_0,   CUDA_110, CUDA_120}},
-  {"cusparseZgthr",                                        {CUDA_0,   CUDA_110, CUDA_120}},
-  {"cusparseSgthrz",                                       {CUDA_0,   CUDA_110, CUDA_120}},
-  {"cusparseDgthrz",                                       {CUDA_0,   CUDA_110, CUDA_120}},
-  {"cusparseCgthrz",                                       {CUDA_0,   CUDA_110, CUDA_120}},
-  {"cusparseZgthrz",                                       {CUDA_0,   CUDA_110, CUDA_120}},
-  {"cusparseSsctr",                                        {CUDA_0,   CUDA_110, CUDA_120}},
-  {"cusparseDsctr",                                        {CUDA_0,   CUDA_110, CUDA_120}},
-  {"cusparseCsctr",                                        {CUDA_0,   CUDA_110, CUDA_120}},
-  {"cusparseZsctr",                                        {CUDA_0,   CUDA_110, CUDA_120}},
-  {"cusparseSroti",                                        {CUDA_0,   CUDA_110, CUDA_120}},
-  {"cusparseDroti",                                        {CUDA_0,   CUDA_110, CUDA_120}},
-  {"cusparseScsr2csc",                                     {CUDA_0,   CUDA_102, CUDA_110}},
-  {"cusparseDcsr2csc",                                     {CUDA_0,   CUDA_102, CUDA_110}},
-  {"cusparseCcsr2csc",                                     {CUDA_0,   CUDA_102, CUDA_110}},
-  {"cusparseZcsr2csc",                                     {CUDA_0,   CUDA_102, CUDA_110}},
-  {"cusparseSpMatGetSize",                                 {CUDA_110, CUDA_0,   CUDA_0  }},
-  {"cusparseCooSetStridedBatch",                           {CUDA_110, CUDA_0,   CUDA_0  }},
-  {"cusparseCsrSetStridedBatch",                           {CUDA_110, CUDA_0,   CUDA_0  }},
-  {"cusparseAxpby",                                        {CUDA_110, CUDA_128, CUDA_0  }},
-  {"cusparseGather",                                       {CUDA_110, CUDA_0,   CUDA_0  }},
-  {"cusparseScatter",                                      {CUDA_110, CUDA_0,   CUDA_0  }},
-  {"cusparseRot",                                          {CUDA_110, CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseSpGEMM_createDescr",                           {CUDA_110, CUDA_0,   CUDA_0  }},
-  {"cusparseSpGEMM_destroyDescr",                          {CUDA_110, CUDA_0,   CUDA_0  }},
-  {"cusparseSpGEMM_compute",                               {CUDA_110, CUDA_0,   CUDA_0  }},
-  {"cusparseSpGEMM_copy",                                  {CUDA_110, CUDA_0,   CUDA_0  }},
-  {"cusparseSpGEMM_workEstimation",                        {CUDA_110, CUDA_0,   CUDA_0  }},
-  {"cusparseConstrainedGeMM",                              {CUDA_102, CUDA_112, CUDA_120}},
-  {"cusparseConstrainedGeMM_bufferSize",                   {CUDA_102, CUDA_112, CUDA_120}},
-  {"cusparseSdense2csr",                                   {CUDA_0,   CUDA_111, CUDA_120}},
-  {"cusparseDdense2csr",                                   {CUDA_0,   CUDA_111, CUDA_120}},
-  {"cusparseCdense2csr",                                   {CUDA_0,   CUDA_111, CUDA_120}},
-  {"cusparseZdense2csr",                                   {CUDA_0,   CUDA_111, CUDA_120}},
-  {"cusparseScsr2dense",                                   {CUDA_0,   CUDA_111, CUDA_120}},
-  {"cusparseDcsr2dense",                                   {CUDA_0,   CUDA_111, CUDA_120}},
-  {"cusparseCcsr2dense",                                   {CUDA_0,   CUDA_111, CUDA_120}},
-  {"cusparseZcsr2dense",                                   {CUDA_0,   CUDA_111, CUDA_120}},
-  {"cusparseSdense2csc",                                   {CUDA_0,   CUDA_111, CUDA_120}},
-  {"cusparseDdense2csc",                                   {CUDA_0,   CUDA_111, CUDA_120}},
-  {"cusparseCdense2csc",                                   {CUDA_0,   CUDA_111, CUDA_120}},
-  {"cusparseZdense2csc",                                   {CUDA_0,   CUDA_111, CUDA_120}},
-  {"cusparseScsc2dense",                                   {CUDA_0,   CUDA_111, CUDA_120}},
-  {"cusparseDcsc2dense",                                   {CUDA_0,   CUDA_111, CUDA_120}},
-  {"cusparseCcsc2dense",                                   {CUDA_0,   CUDA_111, CUDA_120}},
-  {"cusparseZcsc2dense",                                   {CUDA_0,   CUDA_111, CUDA_120}},
-  {"cusparseCreateCsc",                                    {CUDA_111, CUDA_0,   CUDA_0  }},
-  {"cusparseCsrSetPointers",                               {CUDA_110, CUDA_0,   CUDA_0  }},
-  {"cusparseCscSetPointers",                               {CUDA_111, CUDA_0,   CUDA_0  }},
-  {"cusparseCooSetPointers",                               {CUDA_111, CUDA_0,   CUDA_0  }},
-  {"cusparseSparseToDense_bufferSize",                     {CUDA_111, CUDA_0,   CUDA_0  }}, // A: CUSPARSE_VERSION 11300 C: CUSPARSE_VERSION 12000
-  {"cusparseSparseToDense",                                {CUDA_111, CUDA_0,   CUDA_0  }}, // A: CUSPARSE_VERSION 11300 C: CUSPARSE_VERSION 12000
-  {"cusparseDenseToSparse_bufferSize",                     {CUDA_111, CUDA_0,   CUDA_0  }}, // A: CUSPARSE_VERSION 11300 C: CUSPARSE_VERSION 12000
-  {"cusparseDenseToSparse_analysis",                       {CUDA_111, CUDA_0,   CUDA_0  }}, // A: CUSPARSE_VERSION 11300 C: CUSPARSE_VERSION 12000
-  {"cusparseDenseToSparse_convert",                        {CUDA_111, CUDA_0,   CUDA_0  }},
-  {"cusparseCreateCsrsv2Info",                             {CUDA_0,   CUDA_113, CUDA_120}}, // D: CUSPARSE_VERSION 11500 R: CUSPARSE_VERSION 12000
-  {"cusparseDestroyCsrsv2Info",                            {CUDA_0,   CUDA_113, CUDA_120}}, // D: CUSPARSE_VERSION 11500 R: CUSPARSE_VERSION 12000
-  {"cusparseXcsrsv2_zeroPivot",                            {CUDA_0,   CUDA_113, CUDA_120}},
-  {"cusparseScsrsv2_bufferSize",                           {CUDA_0,   CUDA_113, CUDA_120}}, // D: CUSPARSE_VERSION 11500 R: CUSPARSE_VERSION 12000
-  {"cusparseDcsrsv2_bufferSize",                           {CUDA_0,   CUDA_113, CUDA_120}}, // D: CUSPARSE_VERSION 11500 R: CUSPARSE_VERSION 12000
-  {"cusparseCcsrsv2_bufferSize",                           {CUDA_0,   CUDA_113, CUDA_120}}, // D: CUSPARSE_VERSION 11500 R: CUSPARSE_VERSION 12000
-  {"cusparseZcsrsv2_bufferSize",                           {CUDA_0,   CUDA_113, CUDA_120}}, // D: CUSPARSE_VERSION 11500 R: CUSPARSE_VERSION 12000
-  {"cusparseScsrsv2_bufferSizeExt",                        {CUDA_0,   CUDA_113, CUDA_120}},
-  {"cusparseDcsrsv2_bufferSizeExt",                        {CUDA_0,   CUDA_113, CUDA_120}},
-  {"cusparseCcsrsv2_bufferSizeExt",                        {CUDA_0,   CUDA_113, CUDA_120}},
-  {"cusparseZcsrsv2_bufferSizeExt",                        {CUDA_0,   CUDA_113, CUDA_120}},
-  {"cusparseScsrsv2_analysis",                             {CUDA_0,   CUDA_113, CUDA_120}},
-  {"cusparseDcsrsv2_analysis",                             {CUDA_0,   CUDA_113, CUDA_120}},
-  {"cusparseCcsrsv2_analysis",                             {CUDA_0,   CUDA_113, CUDA_120}},
-  {"cusparseZcsrsv2_analysis",                             {CUDA_0,   CUDA_113, CUDA_120}},
-  {"cusparseScsrsv2_solve",                                {CUDA_0,   CUDA_113, CUDA_120}},
-  {"cusparseDcsrsv2_solve",                                {CUDA_0,   CUDA_113, CUDA_120}},
-  {"cusparseCcsrsv2_solve",                                {CUDA_0,   CUDA_113, CUDA_120}},
-  {"cusparseZcsrsv2_solve",                                {CUDA_0,   CUDA_113, CUDA_120}},
-  {"cusparseSpMatGetAttribute",                            {CUDA_113, CUDA_0,   CUDA_0  }},
-  {"cusparseSpMatSetAttribute",                            {CUDA_113, CUDA_0,   CUDA_0  }},
-  {"cusparseSpSV_createDescr",                             {CUDA_113, CUDA_0,   CUDA_0  }},
-  {"cusparseSpSV_destroyDescr",                            {CUDA_113, CUDA_0,   CUDA_0  }},
-  {"cusparseSpSV_bufferSize",                              {CUDA_113, CUDA_0,   CUDA_0  }},
-  {"cusparseSpSV_analysis",                                {CUDA_113, CUDA_0,   CUDA_0  }},
-  {"cusparseSpSV_solve",                                   {CUDA_113, CUDA_0,   CUDA_0  }},
-  {"cusparseSpSM_createDescr",                             {CUDA_113, CUDA_0,   CUDA_0  }},
-  {"cusparseSpSM_destroyDescr",                            {CUDA_113, CUDA_0,   CUDA_0  }},
-  {"cusparseSpSM_bufferSize",                              {CUDA_113, CUDA_0,   CUDA_0  }},
-  {"cusparseSpSM_analysis",                                {CUDA_113, CUDA_0,   CUDA_0  }},
-  {"cusparseSpSM_solve",                                   {CUDA_113, CUDA_0,   CUDA_0  }},
-  {"cusparseSpGEMMreuse_workEstimation",                   {CUDA_113, CUDA_0,   CUDA_0  }},
-  {"cusparseSpGEMMreuse_nnz",                              {CUDA_113, CUDA_0,   CUDA_0  }},
-  {"cusparseSpGEMMreuse_copy",                             {CUDA_113, CUDA_0,   CUDA_0  }},
-  {"cusparseSpGEMMreuse_compute",                          {CUDA_113, CUDA_0,   CUDA_0  }},
-  {"cusparseSDDMM",                                        {CUDA_112, CUDA_0,   CUDA_0  }},
-  {"cusparseSDDMM_bufferSize",                             {CUDA_112, CUDA_0,   CUDA_0  }},
-  {"cusparseSDDMM_preprocess",                             {CUDA_112, CUDA_0,   CUDA_0  }},
-  {"cusparseCreateBlockedEll",                             {CUDA_112, CUDA_0,   CUDA_0  }},
-  {"cusparseBlockedEllGet",                                {CUDA_112, CUDA_0,   CUDA_0  }},
-  {"cusparseSpMM_preprocess",                              {CUDA_112, CUDA_0,   CUDA_0  }},
-  {"cusparseLoggerSetCallback",                            {CUDA_115, CUDA_0,   CUDA_0  }},
-  {"cusparseLoggerSetFile",                                {CUDA_115, CUDA_0,   CUDA_0  }},
-  {"cusparseLoggerOpenFile",                               {CUDA_115, CUDA_0,   CUDA_0  }},
-  {"cusparseLoggerSetLevel",                               {CUDA_115, CUDA_0,   CUDA_0  }},
-  {"cusparseLoggerSetMask",                                {CUDA_115, CUDA_0,   CUDA_0  }},
-  {"cusparseLoggerForceDisable",                           {CUDA_115, CUDA_0,   CUDA_0  }},
-  {"cusparseSpMMOp",                                       {CUDA_115, CUDA_0,   CUDA_0  }},
-  {"cusparseSpMMOp_createPlan",                            {CUDA_115, CUDA_0,   CUDA_0  }},
-  {"cusparseSpMMOp_destroyPlan",                           {CUDA_115, CUDA_0,   CUDA_0  }},
-  {"cusparseCscGet",                                       {CUDA_117, CUDA_0,   CUDA_0  }},
-  {"cusparseCopyMatDescr",                                 {CUDA_80,  CUDA_0,   CUDA_120}},
-  {"cusparseCreateConstSpVec",                             {CUDA_120, CUDA_0,   CUDA_0  }},
-  {"cusparseConstSpVecGet",                                {CUDA_120, CUDA_0,   CUDA_0  }},
-  {"cusparseConstSpVecGetValues",                          {CUDA_120, CUDA_0,   CUDA_0  }},
-  {"cusparseCreateConstDnVec",                             {CUDA_120, CUDA_0,   CUDA_0  }},
-  {"cusparseConstDnVecGet",                                {CUDA_120, CUDA_0,   CUDA_0  }},
-  {"cusparseConstDnVecGetValues",                          {CUDA_120, CUDA_0,   CUDA_0  }},
-  {"cusparseConstSpMatGetValues",                          {CUDA_120, CUDA_0,   CUDA_0  }},
-  {"cusparseCreateConstCsr",                               {CUDA_120, CUDA_0,   CUDA_0  }},
-  {"cusparseCreateConstCsc",                               {CUDA_120, CUDA_0,   CUDA_0  }},
-  {"cusparseConstCsrGet",                                  {CUDA_120, CUDA_0,   CUDA_0  }},
-  {"cusparseConstCscGet",                                  {CUDA_120, CUDA_0,   CUDA_0  }},
-  {"cusparseCreateConstCoo",                               {CUDA_120, CUDA_0,   CUDA_0  }},
-  {"cusparseConstCooGet",                                  {CUDA_120, CUDA_0,   CUDA_0  }},
-  {"cusparseCreateConstBlockedEll",                        {CUDA_120, CUDA_0,   CUDA_0  }},
-  {"cusparseConstBlockedEllGet",                           {CUDA_120, CUDA_0,   CUDA_0  }},
-  {"cusparseCreateConstDnMat",                             {CUDA_120, CUDA_0,   CUDA_0  }},
-  {"cusparseConstDnMatGet",                                {CUDA_120, CUDA_0,   CUDA_0  }},
-  {"cusparseConstDnMatGetValues",                          {CUDA_120, CUDA_0,   CUDA_0  }},
-  {"cusparseSpGEMM_getNumProducts",                        {CUDA_120, CUDA_0,   CUDA_0  }},
-  {"cusparseSpGEMM_estimateMemory",                        {CUDA_120, CUDA_0,   CUDA_0  }},
-  {"cusparseBsrSetStridedBatch",                           {CUDA_121, CUDA_0,   CUDA_0  }}, // CUSPARSE_VERSION 12100
-  {"cusparseCreateBsr",                                    {CUDA_121, CUDA_0,   CUDA_0  }}, // CUSPARSE_VERSION 12100
-  {"cusparseCreateConstBsr",                               {CUDA_121, CUDA_0,   CUDA_0  }}, // CUSPARSE_VERSION 12100
-  {"cusparseCreateSlicedEll",                              {CUDA_121, CUDA_0,   CUDA_0  }}, // CUSPARSE_VERSION 12100
-  {"cusparseCreateConstSlicedEll",                         {CUDA_121, CUDA_0,   CUDA_0  }}, // CUSPARSE_VERSION 12100
-  {"cusparseSpSV_updateMatrix",                            {CUDA_121, CUDA_0,   CUDA_0  }}, // CUSPARSE_VERSION 12100
-  {"cusparseCreateCsric02Info",                            {CUDA_0,   CUDA_122, CUDA_0  }}, // D: CUSPARSE_VERSION 12102
-  {"cusparseDestroyCsric02Info",                           {CUDA_0,   CUDA_122, CUDA_0  }}, // D: CUSPARSE_VERSION 12102
-  {"cusparseCreateBsric02Info",                            {CUDA_0,   CUDA_122, CUDA_0  }}, // D: CUSPARSE_VERSION 12102
-  {"cusparseDestroyBsric02Info",                           {CUDA_0,   CUDA_122, CUDA_0  }}, // D: CUSPARSE_VERSION 12102
-  {"cusparseCreateCsrilu02Info",                           {CUDA_0,   CUDA_122, CUDA_0  }}, // D: CUSPARSE_VERSION 12102
-  {"cusparseDestroyCsrilu02Info",                          {CUDA_0,   CUDA_122, CUDA_0  }}, // D: CUSPARSE_VERSION 12102
-  {"cusparseCreateBsrilu02Info",                           {CUDA_0,   CUDA_122, CUDA_0  }}, // D: CUSPARSE_VERSION 12102
-  {"cusparseDestroyBsrilu02Info",                          {CUDA_0,   CUDA_122, CUDA_0  }}, // D: CUSPARSE_VERSION 12102
-  {"cusparseCreateBsrsv2Info",                             {CUDA_0,   CUDA_122, CUDA_0  }}, // D: CUSPARSE_VERSION 12102
-  {"cusparseDestroyBsrsv2Info",                            {CUDA_0,   CUDA_122, CUDA_0  }}, // D: CUSPARSE_VERSION 12102
-  {"cusparseCreateBsrsm2Info",                             {CUDA_0,   CUDA_122, CUDA_0  }}, // D: CUSPARSE_VERSION 12102
-  {"cusparseDestroyBsrsm2Info",                            {CUDA_0,   CUDA_122, CUDA_0  }}, // D: CUSPARSE_VERSION 12102
-  {"cusparseCreateCsru2csrInfo",                           {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseDestroyCsru2csrInfo",                          {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseCreateColorInfo",                              {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseDestroyColorInfo",                             {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseSbsrxmv",                                      {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseDbsrxmv",                                      {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseCbsrxmv",                                      {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseZbsrxmv",                                      {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseXbsrsv2_zeroPivot",                            {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseSbsrsv2_bufferSize",                           {CUDA_0,   CUDA_122, CUDA_0  }}, // D: CUSPARSE_VERSION 12102
-  {"cusparseDbsrsv2_bufferSize",                           {CUDA_0,   CUDA_122, CUDA_0  }}, // D: CUSPARSE_VERSION 12102
-  {"cusparseCbsrsv2_bufferSize",                           {CUDA_0,   CUDA_122, CUDA_0  }}, // D: CUSPARSE_VERSION 12102
-  {"cusparseZbsrsv2_bufferSize",                           {CUDA_0,   CUDA_122, CUDA_0  }}, // D: CUSPARSE_VERSION 12102
-  {"cusparseSbsrsv2_bufferSizeExt",                        {CUDA_0,   CUDA_122, CUDA_0  }}, // D: CUSPARSE_VERSION 12102
-  {"cusparseDbsrsv2_bufferSizeExt",                        {CUDA_0,   CUDA_122, CUDA_0  }}, // D: CUSPARSE_VERSION 12102
-  {"cusparseCbsrsv2_bufferSizeExt",                        {CUDA_0,   CUDA_122, CUDA_0  }}, // D: CUSPARSE_VERSION 12102
-  {"cusparseZbsrsv2_bufferSizeExt",                        {CUDA_0,   CUDA_122, CUDA_0  }}, // D: CUSPARSE_VERSION 12102
-  {"cusparseSbsrsv2_analysis",                             {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseDbsrsv2_analysis",                             {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseCbsrsv2_analysis",                             {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseZbsrsv2_analysis",                             {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseSbsrsv2_solve",                                {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseDbsrsv2_solve",                                {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseCbsrsv2_solve",                                {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseZbsrsv2_solve",                                {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseXbsrsm2_zeroPivot",                            {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseSbsrsm2_bufferSize",                           {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseDbsrsm2_bufferSize",                           {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseCbsrsm2_bufferSize",                           {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseZbsrsm2_bufferSize",                           {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseSbsrsm2_bufferSizeExt",                        {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseDbsrsm2_bufferSizeExt",                        {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseCbsrsm2_bufferSizeExt",                        {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseZbsrsm2_bufferSizeExt",                        {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseSbsrsm2_analysis",                             {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseDbsrsm2_analysis",                             {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseCbsrsm2_analysis",                             {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseZbsrsm2_analysis",                             {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseSbsrsm2_solve",                                {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseDbsrsm2_solve",                                {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseCbsrsm2_solve",                                {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseZbsrsm2_solve",                                {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseScsrilu02_numericBoost",                       {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseDcsrilu02_numericBoost",                       {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseCcsrilu02_numericBoost",                       {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseZcsrilu02_numericBoost",                       {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseXcsrilu02_zeroPivot",                          {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseScsrilu02_bufferSize",                         {CUDA_0,   CUDA_122, CUDA_0  }}, // D: CUSPARSE_VERSION 12102
-  {"cusparseDcsrilu02_bufferSize",                         {CUDA_0,   CUDA_122, CUDA_0  }}, // D: CUSPARSE_VERSION 12102
-  {"cusparseCcsrilu02_bufferSize",                         {CUDA_0,   CUDA_122, CUDA_0  }}, // D: CUSPARSE_VERSION 12102
-  {"cusparseZcsrilu02_bufferSize",                         {CUDA_0,   CUDA_122, CUDA_0  }}, // D: CUSPARSE_VERSION 12102
-  {"cusparseScsrilu02_bufferSizeExt",                      {CUDA_0,   CUDA_122, CUDA_0  }}, // D: CUSPARSE_VERSION 12102
-  {"cusparseDcsrilu02_bufferSizeExt",                      {CUDA_0,   CUDA_122, CUDA_0  }}, // D: CUSPARSE_VERSION 12102
-  {"cusparseCcsrilu02_bufferSizeExt",                      {CUDA_0,   CUDA_122, CUDA_0  }}, // D: CUSPARSE_VERSION 12102
-  {"cusparseZcsrilu02_bufferSizeExt",                      {CUDA_0,   CUDA_122, CUDA_0  }}, // D: CUSPARSE_VERSION 12102
-  {"cusparseScsrilu02_analysis",                           {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseDcsrilu02_analysis",                           {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseCcsrilu02_analysis",                           {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseZcsrilu02_analysis",                           {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseScsrilu02",                                    {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseDcsrilu02",                                    {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseCcsrilu02",                                    {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseZcsrilu02",                                    {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseSbsrilu02_numericBoost",                       {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseDbsrilu02_numericBoost",                       {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseCbsrilu02_numericBoost",                       {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseZbsrilu02_numericBoost",                       {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseXbsrilu02_zeroPivot",                          {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseSbsrilu02_bufferSize",                         {CUDA_0,   CUDA_122, CUDA_0  }}, // D: CUSPARSE_VERSION 12102
-  {"cusparseDbsrilu02_bufferSize",                         {CUDA_0,   CUDA_122, CUDA_0  }}, // D: CUSPARSE_VERSION 12102
-  {"cusparseCbsrilu02_bufferSize",                         {CUDA_0,   CUDA_122, CUDA_0  }}, // D: CUSPARSE_VERSION 12102
-  {"cusparseZbsrilu02_bufferSize",                         {CUDA_0,   CUDA_122, CUDA_0  }}, // D: CUSPARSE_VERSION 12102
-  {"cusparseSbsrilu02_bufferSizeExt",                      {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseDbsrilu02_bufferSizeExt",                      {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseCbsrilu02_bufferSizeExt",                      {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseZbsrilu02_bufferSizeExt",                      {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseSbsrilu02_analysis",                           {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseDbsrilu02_analysis",                           {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseCbsrilu02_analysis",                           {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseZbsrilu02_analysis",                           {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseSbsrilu02",                                    {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseDbsrilu02",                                    {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseCbsrilu02",                                    {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseZbsrilu02",                                    {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseXcsric02_zeroPivot",                           {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseScsric02_bufferSize",                          {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseDcsric02_bufferSize",                          {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseCcsric02_bufferSize",                          {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseZcsric02_bufferSize",                          {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseScsric02_bufferSizeExt",                       {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseDcsric02_bufferSizeExt",                       {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseCcsric02_bufferSizeExt",                       {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseZcsric02_bufferSizeExt",                       {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseScsric02_analysis",                            {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseDcsric02_analysis",                            {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseCcsric02_analysis",                            {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseZcsric02_analysis",                            {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseScsric02",                                     {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseDcsric02",                                     {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseCcsric02",                                     {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseZcsric02",                                     {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseXcsric02_zeroPivot",                           {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseSbsric02_bufferSize",                          {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseDbsric02_bufferSize",                          {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseCbsric02_bufferSize",                          {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseZbsric02_bufferSize",                          {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseSbsric02_bufferSizeExt",                       {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseDbsric02_bufferSizeExt",                       {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseCbsric02_bufferSizeExt",                       {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseZbsric02_bufferSizeExt",                       {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseSbsric02_analysis",                            {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseDbsric02_analysis",                            {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseCbsric02_analysis",                            {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseZbsric02_analysis",                            {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseSbsric02",                                     {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseDbsric02",                                     {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseCbsric02",                                     {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseZbsric02",                                     {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseScsrcolor",                                    {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseDcsrcolor",                                    {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseCcsrcolor",                                    {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseZcsrcolor",                                    {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseCreateIdentityPermutation",                    {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseScsru2csr_bufferSizeExt",                      {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseDcsru2csr_bufferSizeExt",                      {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseCcsru2csr_bufferSizeExt",                      {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseZcsru2csr_bufferSizeExt",                      {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseScsru2csr",                                    {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseDcsru2csr",                                    {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseCcsru2csr",                                    {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseZcsru2csr",                                    {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseScsr2csru",                                    {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseDcsr2csru",                                    {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseCcsr2csru",                                    {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseZcsr2csru",                                    {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseXbsric02_zeroPivot",                           {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseGetErrorName",                                 {CUDA_102, CUDA_0,   CUDA_0  }}, // CUSPARSE_VERSION 10301
-  {"cusparseGetErrorString",                               {CUDA_102, CUDA_0,   CUDA_0  }}, // CUSPARSE_VERSION 10301
-  {"cusparseXcsr2bsrNnz",                                  {CUDA_0,   CUDA_124, CUDA_0  }},
-  {"cusparseScsr2bsr",                                     {CUDA_0,   CUDA_124, CUDA_0  }},
-  {"cusparseDcsr2bsr",                                     {CUDA_0,   CUDA_124, CUDA_0  }},
-  {"cusparseCcsr2bsr",                                     {CUDA_0,   CUDA_124, CUDA_0  }},
-  {"cusparseZcsr2bsr",                                     {CUDA_0,   CUDA_124, CUDA_0  }},
-  {"cusparseXgebsr2csr",                                   {CUDA_0,   CUDA_124, CUDA_0  }},
-  {"cusparseSgebsr2csr",                                   {CUDA_0,   CUDA_124, CUDA_0  }},
-  {"cusparseDgebsr2csr",                                   {CUDA_0,   CUDA_124, CUDA_0  }},
-  {"cusparseCgebsr2csr",                                   {CUDA_0,   CUDA_124, CUDA_0  }},
-  {"cusparseZgebsr2csr",                                   {CUDA_0,   CUDA_124, CUDA_0  }},
-  {"cusparseSpMV_preprocess",                              {CUDA_124, CUDA_0,   CUDA_0  }},
-  {"cusparseSpSM_updateMatrix",                            {CUDA_124, CUDA_0,   CUDA_0  }},
-  {"cusparseSbsrmm",                                       {CUDA_0,   CUDA_128, CUDA_0  }},
-  {"cusparseDbsrmm",                                       {CUDA_0,   CUDA_128, CUDA_0  }},
-  {"cusparseCbsrmm",                                       {CUDA_0,   CUDA_128, CUDA_0  }},
-  {"cusparseZbsrmm",                                       {CUDA_0,   CUDA_128, CUDA_0  }},
-  {"cusparseSbsr2csr",                                     {CUDA_0,   CUDA_128, CUDA_0  }},
-  {"cusparseDbsr2csr",                                     {CUDA_0,   CUDA_128, CUDA_0  }},
-  {"cusparseCbsr2csr",                                     {CUDA_0,   CUDA_128, CUDA_0  }},
-  {"cusparseZbsr2csr",                                     {CUDA_0,   CUDA_128, CUDA_0  }},
-  {"cusparseSgebsr2gebsr_bufferSize",                      {CUDA_0,   CUDA_128, CUDA_0  }},
-  {"cusparseSgebsr2gebsr_bufferSizeExt",                   {CUDA_0,   CUDA_128, CUDA_0  }},
-  {"cusparseDgebsr2gebsr_bufferSize",                      {CUDA_0,   CUDA_128, CUDA_0  }},
-  {"cusparseDgebsr2gebsr_bufferSizeExt",                   {CUDA_0,   CUDA_128, CUDA_0  }},
-  {"cusparseCgebsr2gebsr_bufferSize",                      {CUDA_0,   CUDA_128, CUDA_0  }},
-  {"cusparseCgebsr2gebsr_bufferSizeExt",                   {CUDA_0,   CUDA_128, CUDA_0  }},
-  {"cusparseZgebsr2gebsr_bufferSize",                      {CUDA_0,   CUDA_128, CUDA_0  }},
-  {"cusparseZgebsr2gebsr_bufferSizeExt",                   {CUDA_0,   CUDA_128, CUDA_0  }},
-  { "cusparseXgebsr2gebsrNnz",                             {CUDA_0,   CUDA_128, CUDA_0  }},
-  {"cusparseSgebsr2gebsr",                                 {CUDA_0,   CUDA_128, CUDA_0  }},
-  {"cusparseDgebsr2gebsr",                                 {CUDA_0,   CUDA_128, CUDA_0  }},
-  {"cusparseCgebsr2gebsr",                                 {CUDA_0,   CUDA_128, CUDA_0  }},
-  {"cusparseZgebsr2gebsr",                                 {CUDA_0,   CUDA_128, CUDA_0  }},
-};
+  return m;
+}();
 
-const std::map<llvm::StringRef, hipAPIversions> HIP_SPARSE_FUNCTION_VER_MAP {
-  {"hipsparseCreate",                                      {HIP_1092, HIP_0,    HIP_0   }},
-  {"hipsparseDestroy",                                     {HIP_1092, HIP_0,    HIP_0   }},
-  {"hipsparseGetPointerMode",                              {HIP_1092, HIP_0,    HIP_0   }},
-  {"hipsparseGetVersion",                                  {HIP_1092, HIP_0,    HIP_0   }},
-  {"hipsparseSetPointerMode",                              {HIP_1092, HIP_0,    HIP_0   }},
-  {"hipsparseSetStream",                                   {HIP_1092, HIP_0,    HIP_0   }},
-  {"hipsparseGetStream",                                   {HIP_1092, HIP_0,    HIP_0   }},
-  {"hipsparseCreateHybMat",                                {HIP_1092, HIP_3090, HIP_0   }},
-  {"hipsparseCreateMatDescr",                              {HIP_1092, HIP_0,    HIP_0   }},
-  {"hipsparseDestroyHybMat",                               {HIP_1092, HIP_3090, HIP_0   }},
-  {"hipsparseDestroyMatDescr",                             {HIP_1092, HIP_0,    HIP_0   }},
-  {"hipsparseGetMatDiagType",                              {HIP_1092, HIP_0,    HIP_0   }},
-  {"hipsparseGetMatFillMode",                              {HIP_1092, HIP_0,    HIP_0   }},
-  {"hipsparseGetMatIndexBase",                             {HIP_1092, HIP_0,    HIP_0   }},
-  {"hipsparseGetMatType",                                  {HIP_1092, HIP_0,    HIP_0   }},
-  {"hipsparseSetMatDiagType",                              {HIP_1092, HIP_0,    HIP_0   }},
-  {"hipsparseSetMatFillMode",                              {HIP_1092, HIP_0,    HIP_0   }},
-  {"hipsparseSetMatIndexBase",                             {HIP_1092, HIP_0,    HIP_0   }},
-  {"hipsparseSetMatType",                                  {HIP_1092, HIP_0,    HIP_0   }},
-  {"hipsparseCreateCsrsv2Info",                            {HIP_1092, HIP_5060, HIP_0   }},
-  {"hipsparseDestroyCsrsv2Info",                           {HIP_1092, HIP_5060, HIP_0   }},
-  {"hipsparseCreateCsrsm2Info",                            {HIP_3010, HIP_5060, HIP_0   }},
-  {"hipsparseDestroyCsrsm2Info",                           {HIP_3010, HIP_5060, HIP_0   }},
-  {"hipsparseCreateCsric02Info",                           {HIP_3010, HIP_6020, HIP_0   }},
-  {"hipsparseDestroyCsric02Info",                          {HIP_3010, HIP_6020, HIP_0   }},
-  {"hipsparseCreateCsrilu02Info",                          {HIP_1092, HIP_6020, HIP_0   }},
-  {"hipsparseDestroyCsrilu02Info",                         {HIP_1092, HIP_6020, HIP_0   }},
-  {"hipsparseCreateBsrsv2Info",                            {HIP_3060, HIP_6020, HIP_0   }},
-  {"hipsparseDestroyBsrsv2Info",                           {HIP_3060, HIP_6020, HIP_0   }},
-  {"hipsparseCreateBsric02Info",                           {HIP_3080, HIP_6020, HIP_0   }},
-  {"hipsparseDestroyBsric02Info",                          {HIP_3080, HIP_6020, HIP_0   }},
-  {"hipsparseCreateBsrilu02Info",                          {HIP_3090, HIP_6020, HIP_0   }},
-  {"hipsparseDestroyBsrilu02Info",                         {HIP_3090, HIP_6020, HIP_0   }},
-  {"hipsparseCreateCsrgemm2Info",                          {HIP_2080, HIP_3090, HIP_0   }},
-  {"hipsparseDestroyCsrgemm2Info",                         {HIP_2080, HIP_3090, HIP_0   }},
-  {"hipsparseCreatePruneInfo",                             {HIP_3090, HIP_6020, HIP_0   }},
-  {"hipsparseDestroyPruneInfo",                            {HIP_3090, HIP_6020, HIP_0   }},
-  {"hipsparseSaxpyi",                                      {HIP_1092, HIP_3090, HIP_0   }},
-  {"hipsparseDaxpyi",                                      {HIP_1092, HIP_3090, HIP_0   }},
-  {"hipsparseCaxpyi",                                      {HIP_3010, HIP_3090, HIP_0   }},
-  {"hipsparseZaxpyi",                                      {HIP_3010, HIP_3090, HIP_0   }},
-  {"hipsparseSdoti",                                       {HIP_1092, HIP_3090, HIP_0   }},
-  {"hipsparseDdoti",                                       {HIP_1092, HIP_3090, HIP_0   }},
-  {"hipsparseCdoti",                                       {HIP_3010, HIP_3090, HIP_0   }},
-  {"hipsparseZdoti",                                       {HIP_3010, HIP_3090, HIP_0   }},
-  {"hipsparseCdotci",                                      {HIP_3010, HIP_3090, HIP_0   }},
-  {"hipsparseZdotci",                                      {HIP_3010, HIP_3090, HIP_0   }},
-  {"hipsparseSgthr",                                       {HIP_1092, HIP_3090, HIP_0   }},
-  {"hipsparseDgthr",                                       {HIP_1092, HIP_3090, HIP_0   }},
-  {"hipsparseCgthr",                                       {HIP_3010, HIP_3090, HIP_0   }},
-  {"hipsparseZgthr",                                       {HIP_3010, HIP_3090, HIP_0   }},
-  {"hipsparseSgthrz",                                      {HIP_1092, HIP_3090, HIP_0   }},
-  {"hipsparseDgthrz",                                      {HIP_1092, HIP_3090, HIP_0   }},
-  {"hipsparseCgthrz",                                      {HIP_3010, HIP_3090, HIP_0   }},
-  {"hipsparseZgthrz",                                      {HIP_3010, HIP_3090, HIP_0   }},
-  {"hipsparseSroti",                                       {HIP_1092, HIP_3090, HIP_0   }},
-  {"hipsparseDroti",                                       {HIP_1092, HIP_3090, HIP_0   }},
-  {"hipsparseSsctr",                                       {HIP_1092, HIP_3090, HIP_0   }},
-  {"hipsparseDsctr",                                       {HIP_1092, HIP_3090, HIP_0   }},
-  {"hipsparseCsctr",                                       {HIP_3010, HIP_3090, HIP_0   }},
-  {"hipsparseZsctr",                                       {HIP_3010, HIP_3090, HIP_0   }},
-  {"hipsparseSbsrmv",                                      {HIP_3050, HIP_0,    HIP_0   }},
-  {"hipsparseDbsrmv",                                      {HIP_3050, HIP_0,    HIP_0   }},
-  {"hipsparseCbsrmv",                                      {HIP_3050, HIP_0,    HIP_0   }},
-  {"hipsparseZbsrmv",                                      {HIP_3050, HIP_0,    HIP_0   }},
-  {"hipsparseScsrmv",                                      {HIP_1092, HIP_3090, HIP_0   }},
-  {"hipsparseDcsrmv",                                      {HIP_1092, HIP_3090, HIP_0   }},
-  {"hipsparseCcsrmv",                                      {HIP_3010, HIP_3090, HIP_0   }},
-  {"hipsparseZcsrmv",                                      {HIP_3010, HIP_3090, HIP_0   }},
-  {"hipsparseSbsrsv2_bufferSize",                          {HIP_3060, HIP_6020, HIP_0   }},
-  {"hipsparseSbsrsv2_bufferSizeExt",                       {HIP_3060, HIP_0,    HIP_0   }},
-  {"hipsparseDbsrsv2_bufferSize",                          {HIP_3060, HIP_6020, HIP_0   }},
-  {"hipsparseDbsrsv2_bufferSizeExt",                       {HIP_3060, HIP_0,    HIP_0   }},
-  {"hipsparseCbsrsv2_bufferSize",                          {HIP_3060, HIP_6020, HIP_0   }},
-  {"hipsparseCbsrsv2_bufferSizeExt",                       {HIP_3060, HIP_0,    HIP_0   }},
-  {"hipsparseZbsrsv2_bufferSize",                          {HIP_3060, HIP_6020, HIP_0   }},
-  {"hipsparseZbsrsv2_bufferSizeExt",                       {HIP_3060, HIP_0,    HIP_0   }},
-  {"hipsparseSbsrsv2_analysis",                            {HIP_3060, HIP_6020, HIP_0   }},
-  {"hipsparseDbsrsv2_analysis",                            {HIP_3060, HIP_6020, HIP_0   }},
-  {"hipsparseCbsrsv2_analysis",                            {HIP_3060, HIP_6020, HIP_0   }},
-  {"hipsparseZbsrsv2_analysis",                            {HIP_3060, HIP_6020, HIP_0   }},
-  {"hipsparseSbsrsv2_solve",                               {HIP_3060, HIP_6020, HIP_0   }},
-  {"hipsparseDbsrsv2_solve",                               {HIP_3060, HIP_6020, HIP_0   }},
-  {"hipsparseCbsrsv2_solve",                               {HIP_3060, HIP_6020, HIP_0   }},
-  {"hipsparseZbsrsv2_solve",                               {HIP_3060, HIP_6020, HIP_0   }},
-  {"hipsparseXbsrsv2_zeroPivot",                           {HIP_3060, HIP_6020, HIP_0   }},
-  {"hipsparseScsrsv2_bufferSize",                          {HIP_1092, HIP_5060, HIP_0   }},
-  {"hipsparseScsrsv2_bufferSizeExt",                       {HIP_1092, HIP_0,    HIP_0   }},
-  {"hipsparseDcsrsv2_bufferSize",                          {HIP_1092, HIP_5060, HIP_0   }},
-  {"hipsparseDcsrsv2_bufferSizeExt",                       {HIP_1092, HIP_0,    HIP_0   }},
-  {"hipsparseCcsrsv2_bufferSize",                          {HIP_3010, HIP_5060, HIP_0   }},
-  {"hipsparseCcsrsv2_bufferSizeExt",                       {HIP_3010, HIP_0,    HIP_0   }},
-  {"hipsparseZcsrsv2_bufferSize",                          {HIP_3010, HIP_5060, HIP_0   }},
-  {"hipsparseZcsrsv2_bufferSizeExt",                       {HIP_3010, HIP_0,    HIP_0   }},
-  {"hipsparseScsrsv2_analysis",                            {HIP_1092, HIP_5060, HIP_0   }},
-  {"hipsparseDcsrsv2_analysis",                            {HIP_1092, HIP_5060, HIP_0   }},
-  {"hipsparseCcsrsv2_analysis",                            {HIP_3010, HIP_5060, HIP_0   }},
-  {"hipsparseZcsrsv2_analysis",                            {HIP_3010, HIP_5060, HIP_0   }},
-  {"hipsparseScsrsv2_solve",                               {HIP_1092, HIP_5060, HIP_0   }},
-  {"hipsparseDcsrsv2_solve",                               {HIP_1092, HIP_5060, HIP_0   }},
-  {"hipsparseCcsrsv2_solve",                               {HIP_3010, HIP_5060, HIP_0   }},
-  {"hipsparseZcsrsv2_solve",                               {HIP_3010, HIP_5060, HIP_0   }},
-  {"hipsparseXcsrsv2_zeroPivot",                           {HIP_1092, HIP_5060, HIP_0   }},
-  {"hipsparseShybmv",                                      {HIP_1092, HIP_3090, HIP_0   }},
-  {"hipsparseDhybmv",                                      {HIP_1092, HIP_3090, HIP_0   }},
-  {"hipsparseChybmv",                                      {HIP_3010, HIP_3090, HIP_0   }},
-  {"hipsparseZhybmv",                                      {HIP_3010, HIP_3090, HIP_0   }},
-  {"hipsparseScsrmm",                                      {HIP_1092, HIP_3090, HIP_0   }},
-  {"hipsparseDcsrmm",                                      {HIP_1092, HIP_3090, HIP_0   }},
-  {"hipsparseCcsrmm",                                      {HIP_3010, HIP_3090, HIP_0   }},
-  {"hipsparseZcsrmm",                                      {HIP_3010, HIP_3090, HIP_0   }},
-  {"hipsparseScsrmm2",                                     {HIP_1092, HIP_3090, HIP_0   }},
-  {"hipsparseDcsrmm2",                                     {HIP_1092, HIP_3090, HIP_0   }},
-  {"hipsparseCcsrmm2",                                     {HIP_3010, HIP_3090, HIP_0   }},
-  {"hipsparseZcsrmm2",                                     {HIP_3010, HIP_3090, HIP_0   }},
-  {"hipsparseScsrsm2_bufferSizeExt",                       {HIP_3010, HIP_5060, HIP_0   }},
-  {"hipsparseDcsrsm2_bufferSizeExt",                       {HIP_3010, HIP_5060, HIP_0   }},
-  {"hipsparseCcsrsm2_bufferSizeExt",                       {HIP_3010, HIP_5060, HIP_0   }},
-  {"hipsparseZcsrsm2_bufferSizeExt",                       {HIP_3010, HIP_5060, HIP_0   }},
-  {"hipsparseScsrsm2_analysis",                            {HIP_3010, HIP_5060, HIP_0   }},
-  {"hipsparseDcsrsm2_analysis",                            {HIP_3010, HIP_5060, HIP_0   }},
-  {"hipsparseCcsrsm2_analysis",                            {HIP_3010, HIP_5060, HIP_0   }},
-  {"hipsparseZcsrsm2_analysis",                            {HIP_3010, HIP_5060, HIP_0   }},
-  {"hipsparseScsrsm2_solve",                               {HIP_3010, HIP_5060, HIP_0   }},
-  {"hipsparseDcsrsm2_solve",                               {HIP_3010, HIP_5060, HIP_0   }},
-  {"hipsparseCcsrsm2_solve",                               {HIP_3010, HIP_5060, HIP_0   }},
-  {"hipsparseZcsrsm2_solve",                               {HIP_3010, HIP_5060, HIP_0   }},
-  {"hipsparseXcsrsm2_zeroPivot",                           {HIP_3010, HIP_5060, HIP_0   }},
-  {"hipsparseSbsrmm",                                      {HIP_3070, HIP_0,    HIP_0   }},
-  {"hipsparseDbsrmm",                                      {HIP_3070, HIP_0,    HIP_0   }},
-  {"hipsparseCbsrmm",                                      {HIP_3070, HIP_0,    HIP_0   }},
-  {"hipsparseZbsrmm",                                      {HIP_3070, HIP_0,    HIP_0   }},
-  {"hipsparseSgemmi",                                      {HIP_3070, HIP_3090, HIP_0   }},
-  {"hipsparseDgemmi",                                      {HIP_3070, HIP_3090, HIP_0   }},
-  {"hipsparseCgemmi",                                      {HIP_3070, HIP_3090, HIP_0   }},
-  {"hipsparseZgemmi",                                      {HIP_3070, HIP_3090, HIP_0   }},
-  {"hipsparseScsrgeam",                                    {HIP_3050, HIP_3090, HIP_0   }},
-  {"hipsparseDcsrgeam",                                    {HIP_3050, HIP_3090, HIP_0   }},
-  {"hipsparseCcsrgeam",                                    {HIP_3050, HIP_3090, HIP_0   }},
-  {"hipsparseZcsrgeam",                                    {HIP_3050, HIP_3090, HIP_0   }},
-  {"hipsparseXcsrgeamNnz",                                 {HIP_3050, HIP_3090, HIP_0   }},
-  {"hipsparseScsrgeam2",                                   {HIP_3050, HIP_0,    HIP_0   }},
-  {"hipsparseDcsrgeam2",                                   {HIP_3050, HIP_0,    HIP_0   }},
-  {"hipsparseCcsrgeam2",                                   {HIP_3050, HIP_0,    HIP_0   }},
-  {"hipsparseZcsrgeam2",                                   {HIP_3050, HIP_0,    HIP_0   }},
-  {"hipsparseXcsrgeam2Nnz",                                {HIP_3050, HIP_0,    HIP_0   }},
-  {"hipsparseScsrgeam2_bufferSizeExt",                     {HIP_3050, HIP_0,    HIP_0   }},
-  {"hipsparseDcsrgeam2_bufferSizeExt",                     {HIP_3050, HIP_0,    HIP_0   }},
-  {"hipsparseCcsrgeam2_bufferSizeExt",                     {HIP_3050, HIP_0,    HIP_0   }},
-  {"hipsparseZcsrgeam2_bufferSizeExt",                     {HIP_3050, HIP_0,    HIP_0   }},
-  {"hipsparseScsrgemm",                                    {HIP_2080, HIP_3090, HIP_0   }},
-  {"hipsparseDcsrgemm",                                    {HIP_2080, HIP_3090, HIP_0   }},
-  {"hipsparseCcsrgemm",                                    {HIP_3010, HIP_3090, HIP_0   }},
-  {"hipsparseZcsrgemm",                                    {HIP_3010, HIP_3090, HIP_0   }},
-  {"hipsparseXcsrgemmNnz",                                 {HIP_2080, HIP_3090, HIP_0   }},
-  {"hipsparseScsrgemm2",                                   {HIP_2080, HIP_3090, HIP_0   }},
-  {"hipsparseDcsrgemm2",                                   {HIP_2080, HIP_3090, HIP_0   }},
-  {"hipsparseCcsrgemm2",                                   {HIP_3010, HIP_3090, HIP_0   }},
-  {"hipsparseZcsrgemm2",                                   {HIP_3010, HIP_3090, HIP_0   }},
-  {"hipsparseXcsrgemm2Nnz",                                {HIP_2080, HIP_3090, HIP_0   }},
-  {"hipsparseScsrgemm2_bufferSizeExt",                     {HIP_2080, HIP_3090, HIP_0   }},
-  {"hipsparseDcsrgemm2_bufferSizeExt",                     {HIP_2080, HIP_3090, HIP_0   }},
-  {"hipsparseCcsrgemm2_bufferSizeExt",                     {HIP_3010, HIP_3090, HIP_0   }},
-  {"hipsparseZcsrgemm2_bufferSizeExt",                     {HIP_3010, HIP_3090, HIP_0   }},
-  {"hipsparseScsric02_bufferSize",                         {HIP_3010, HIP_6020, HIP_0   }},
-  {"hipsparseScsric02_bufferSizeExt",                      {HIP_3010, HIP_0,    HIP_0   }},
-  {"hipsparseDcsric02_bufferSize",                         {HIP_3010, HIP_6020, HIP_0   }},
-  {"hipsparseDcsric02_bufferSizeExt",                      {HIP_3010, HIP_0,    HIP_0   }},
-  {"hipsparseCcsric02_bufferSize",                         {HIP_3010, HIP_6020, HIP_0   }},
-  {"hipsparseCcsric02_bufferSizeExt",                      {HIP_3010, HIP_0,    HIP_0   }},
-  {"hipsparseZcsric02_bufferSize",                         {HIP_3010, HIP_6020, HIP_0   }},
-  {"hipsparseZcsric02_bufferSizeExt",                      {HIP_3010, HIP_0,    HIP_0   }},
-  {"hipsparseScsric02_analysis",                           {HIP_3010, HIP_6020, HIP_0   }},
-  {"hipsparseDcsric02_analysis",                           {HIP_3010, HIP_6020, HIP_0   }},
-  {"hipsparseCcsric02_analysis",                           {HIP_3010, HIP_6020, HIP_0   }},
-  {"hipsparseZcsric02_analysis",                           {HIP_3010, HIP_6020, HIP_0   }},
-  {"hipsparseScsric02",                                    {HIP_3010, HIP_6020, HIP_0   }},
-  {"hipsparseDcsric02",                                    {HIP_3010, HIP_6020, HIP_0   }},
-  {"hipsparseCcsric02",                                    {HIP_3010, HIP_6020, HIP_0   }},
-  {"hipsparseZcsric02",                                    {HIP_3010, HIP_6020, HIP_0   }},
-  {"hipsparseXcsric02_zeroPivot",                          {HIP_3010, HIP_6020, HIP_0   }},
-  {"hipsparseSbsric02_bufferSize",                         {HIP_3080, HIP_6020, HIP_0   }},
-  {"hipsparseDbsric02_bufferSize",                         {HIP_3080, HIP_6020, HIP_0   }},
-  {"hipsparseCbsric02_bufferSize",                         {HIP_3080, HIP_6020, HIP_0   }},
-  {"hipsparseZbsric02_bufferSize",                         {HIP_3080, HIP_6020, HIP_0   }},
-  {"hipsparseSbsric02_analysis",                           {HIP_3080, HIP_6020, HIP_0   }},
-  {"hipsparseDbsric02_analysis",                           {HIP_3080, HIP_6020, HIP_0   }},
-  {"hipsparseCbsric02_analysis",                           {HIP_3080, HIP_6020, HIP_0   }},
-  {"hipsparseZbsric02_analysis",                           {HIP_3080, HIP_6020, HIP_0   }},
-  {"hipsparseSbsric02",                                    {HIP_3080, HIP_6020, HIP_0   }},
-  {"hipsparseDbsric02",                                    {HIP_3080, HIP_6020, HIP_0   }},
-  {"hipsparseCbsric02",                                    {HIP_3080, HIP_6020, HIP_0   }},
-  {"hipsparseZbsric02",                                    {HIP_3080, HIP_6020, HIP_0   }},
-  {"hipsparseXbsric02_zeroPivot",                          {HIP_3080, HIP_6020, HIP_0   }},
-  {"hipsparseScsrilu02_numericBoost",                      {HIP_3100, HIP_6020, HIP_0   }},
-  {"hipsparseDcsrilu02_numericBoost",                      {HIP_3100, HIP_6020, HIP_0   }},
-  {"hipsparseCcsrilu02_numericBoost",                      {HIP_3100, HIP_6020, HIP_0   }},
-  {"hipsparseZcsrilu02_numericBoost",                      {HIP_3100, HIP_6020, HIP_0   }},
-  {"hipsparseXcsrilu02_zeroPivot",                         {HIP_1092, HIP_6020, HIP_0   }},
-  {"hipsparseScsrilu02_bufferSize",                        {HIP_1092, HIP_6020, HIP_0   }},
-  {"hipsparseScsrilu02_bufferSizeExt",                     {HIP_1092, HIP_0,    HIP_0   }},
-  {"hipsparseDcsrilu02_bufferSize",                        {HIP_1092, HIP_6020, HIP_0   }},
-  {"hipsparseDcsrilu02_bufferSizeExt",                     {HIP_1092, HIP_0,    HIP_0   }},
-  {"hipsparseCcsrilu02_bufferSize",                        {HIP_3010, HIP_6020, HIP_0   }},
-  {"hipsparseCcsrilu02_bufferSizeExt",                     {HIP_3010, HIP_0,    HIP_0   }},
-  {"hipsparseZcsrilu02_bufferSize",                        {HIP_3010, HIP_6020, HIP_0   }},
-  {"hipsparseZcsrilu02_bufferSizeExt",                     {HIP_3010, HIP_0,    HIP_0   }},
-  {"hipsparseScsrilu02_analysis",                          {HIP_1092, HIP_6020, HIP_0   }},
-  {"hipsparseDcsrilu02_analysis",                          {HIP_1092, HIP_6020, HIP_0   }},
-  {"hipsparseCcsrilu02_analysis",                          {HIP_3010, HIP_6020, HIP_0   }},
-  {"hipsparseZcsrilu02_analysis",                          {HIP_3010, HIP_6020, HIP_0   }},
-  {"hipsparseScsrilu02",                                   {HIP_1092, HIP_6020, HIP_0   }},
-  {"hipsparseDcsrilu02",                                   {HIP_1092, HIP_6020, HIP_0   }},
-  {"hipsparseCcsrilu02",                                   {HIP_3010, HIP_6020, HIP_0   }},
-  {"hipsparseZcsrilu02",                                   {HIP_3010, HIP_6020, HIP_0   }},
-  {"hipsparseSbsrilu02_numericBoost",                      {HIP_3090, HIP_6020, HIP_0   }},
-  {"hipsparseDbsrilu02_numericBoost",                      {HIP_3090, HIP_6020, HIP_0   }},
-  {"hipsparseCbsrilu02_numericBoost",                      {HIP_3090, HIP_6020, HIP_0   }},
-  {"hipsparseZbsrilu02_numericBoost",                      {HIP_3090, HIP_6020, HIP_0   }},
-  {"hipsparseSbsrilu02_bufferSize",                        {HIP_3090, HIP_6020, HIP_0   }},
-  {"hipsparseDbsrilu02_bufferSize",                        {HIP_3090, HIP_6020, HIP_0   }},
-  {"hipsparseCbsrilu02_bufferSize",                        {HIP_3090, HIP_6020, HIP_0   }},
-  {"hipsparseZbsrilu02_bufferSize",                        {HIP_3090, HIP_6020, HIP_0   }},
-  {"hipsparseSbsrilu02_analysis",                          {HIP_3090, HIP_6020, HIP_0   }},
-  {"hipsparseDbsrilu02_analysis",                          {HIP_3090, HIP_6020, HIP_0   }},
-  {"hipsparseCbsrilu02_analysis",                          {HIP_3090, HIP_6020, HIP_0   }},
-  {"hipsparseZbsrilu02_analysis",                          {HIP_3090, HIP_6020, HIP_0   }},
-  {"hipsparseSbsrilu02",                                   {HIP_3090, HIP_6020, HIP_0   }},
-  {"hipsparseDbsrilu02",                                   {HIP_3090, HIP_6020, HIP_0   }},
-  {"hipsparseCbsrilu02",                                   {HIP_3090, HIP_6020, HIP_0   }},
-  {"hipsparseZbsrilu02",                                   {HIP_3090, HIP_6020, HIP_0   }},
-  {"hipsparseXbsrilu02_zeroPivot",                         {HIP_3090, HIP_6020, HIP_0   }},
-  {"hipsparseSbsr2csr",                                    {HIP_3050, HIP_0,    HIP_0   }},
-  {"hipsparseDbsr2csr",                                    {HIP_3050, HIP_0,    HIP_0   }},
-  {"hipsparseCbsr2csr",                                    {HIP_3050, HIP_0,    HIP_0   }},
-  {"hipsparseZbsr2csr",                                    {HIP_3050, HIP_0,    HIP_0   }},
-  {"hipsparseXcoo2csr",                                    {HIP_1092, HIP_0,    HIP_0   }},
-  {"hipsparseScsc2dense",                                  {HIP_3050, HIP_5060, HIP_0   }},
-  {"hipsparseDcsc2dense",                                  {HIP_3050, HIP_5060, HIP_0   }},
-  {"hipsparseCcsc2dense",                                  {HIP_3050, HIP_5060, HIP_0   }},
-  {"hipsparseZcsc2dense",                                  {HIP_3050, HIP_5060, HIP_0   }},
-  {"hipsparseXcsr2bsrNnz",                                 {HIP_3050, HIP_0,    HIP_0   }},
-  {"hipsparseScsr2bsr",                                    {HIP_3050, HIP_0,    HIP_0   }},
-  {"hipsparseDcsr2bsr",                                    {HIP_3050, HIP_0,    HIP_0   }},
-  {"hipsparseCcsr2bsr",                                    {HIP_3050, HIP_0,    HIP_0   }},
-  {"hipsparseZcsr2bsr",                                    {HIP_3050, HIP_0,    HIP_0   }},
-  {"hipsparseXcsr2coo",                                    {HIP_1092, HIP_0,    HIP_0   }},
-  {"hipsparseScsr2csc",                                    {HIP_1092, HIP_3090, HIP_0   }},
-  {"hipsparseDcsr2csc",                                    {HIP_1092, HIP_3090, HIP_0   }},
-  {"hipsparseCcsr2csc",                                    {HIP_3010, HIP_3090, HIP_0   }},
-  {"hipsparseZcsr2csc",                                    {HIP_3010, HIP_3090, HIP_0   }},
-  {"hipsparseScsr2dense",                                  {HIP_3050, HIP_5060, HIP_0   }},
-  {"hipsparseDcsr2dense",                                  {HIP_3050, HIP_5060, HIP_0   }},
-  {"hipsparseCcsr2dense",                                  {HIP_3050, HIP_5060, HIP_0   }},
-  {"hipsparseZcsr2dense",                                  {HIP_3050, HIP_5060, HIP_0   }},
-  {"hipsparseScsr2csr_compress",                           {HIP_3050, HIP_0,    HIP_0   }},
-  {"hipsparseDcsr2csr_compress",                           {HIP_3050, HIP_0,    HIP_0   }},
-  {"hipsparseCcsr2csr_compress",                           {HIP_3050, HIP_0,    HIP_0   }},
-  {"hipsparseZcsr2csr_compress",                           {HIP_3050, HIP_0,    HIP_0   }},
-  {"hipsparseScsr2hyb",                                    {HIP_1092, HIP_3090, HIP_0   }},
-  {"hipsparseDcsr2hyb",                                    {HIP_1092, HIP_3090, HIP_0   }},
-  {"hipsparseCcsr2hyb",                                    {HIP_3010, HIP_3090, HIP_0   }},
-  {"hipsparseZcsr2hyb",                                    {HIP_3010, HIP_3090, HIP_0   }},
-  {"hipsparseSdense2csc",                                  {HIP_3050, HIP_5060, HIP_0   }},
-  {"hipsparseDdense2csc",                                  {HIP_3050, HIP_5060, HIP_0   }},
-  {"hipsparseCdense2csc",                                  {HIP_3050, HIP_5060, HIP_0   }},
-  {"hipsparseZdense2csc",                                  {HIP_3050, HIP_5060, HIP_0   }},
-  {"hipsparseSdense2csr",                                  {HIP_3050, HIP_0,    HIP_0   }},
-  {"hipsparseDdense2csr",                                  {HIP_3050, HIP_0,    HIP_0   }},
-  {"hipsparseCdense2csr",                                  {HIP_3050, HIP_0,    HIP_0   }},
-  {"hipsparseZdense2csr",                                  {HIP_3050, HIP_0,    HIP_0   }},
-  {"hipsparseShyb2csr",                                    {HIP_3010, HIP_3090, HIP_0   }},
-  {"hipsparseDhyb2csr",                                    {HIP_3010, HIP_3090, HIP_0   }},
-  {"hipsparseChyb2csr",                                    {HIP_3010, HIP_3090, HIP_0   }},
-  {"hipsparseZhyb2csr",                                    {HIP_3010, HIP_3090, HIP_0   }},
-  {"hipsparseSnnz",                                        {HIP_3020, HIP_0,    HIP_0   }},
-  {"hipsparseDnnz",                                        {HIP_3020, HIP_0,    HIP_0   }},
-  {"hipsparseCnnz",                                        {HIP_3020, HIP_0,    HIP_0   }},
-  {"hipsparseZnnz",                                        {HIP_3020, HIP_0,    HIP_0   }},
-  {"hipsparseCreateIdentityPermutation",                   {HIP_1092, HIP_6020, HIP_0   }},
-  {"hipsparseXcoosort_bufferSizeExt",                      {HIP_1092, HIP_0,    HIP_0   }},
-  {"hipsparseXcoosortByRow",                               {HIP_1092, HIP_0,    HIP_0   }},
-  {"hipsparseXcoosortByColumn",                            {HIP_1092, HIP_0,    HIP_0   }},
-  {"hipsparseXcsrsort_bufferSizeExt",                      {HIP_1092, HIP_0,    HIP_0   }},
-  {"hipsparseXcsrsort",                                    {HIP_1092, HIP_0,    HIP_0   }},
-  {"hipsparseXcscsort_bufferSizeExt",                      {HIP_2100, HIP_0,    HIP_0   }},
-  {"hipsparseXcscsort",                                    {HIP_2100, HIP_0,    HIP_0   }},
-  {"hipsparseSpruneDense2csr",                             {HIP_3090, HIP_6020, HIP_0   }},
-  {"hipsparseDpruneDense2csr",                             {HIP_3090, HIP_6020, HIP_0   }},
-  {"hipsparseSpruneDense2csr_bufferSizeExt",               {HIP_3090, HIP_6020, HIP_0   }},
-  {"hipsparseDpruneDense2csr_bufferSizeExt",               {HIP_3090, HIP_6020, HIP_0   }},
-  {"hipsparseSpruneDense2csrNnz",                          {HIP_3090, HIP_6020, HIP_0   }},
-  {"hipsparseDpruneDense2csrNnz",                          {HIP_3090, HIP_6020, HIP_0   }},
-  {"hipsparseSpruneCsr2csr",                               {HIP_3090, HIP_6020, HIP_0   }},
-  {"hipsparseDpruneCsr2csr",                               {HIP_3090, HIP_6020, HIP_0   }},
-  {"hipsparseSpruneCsr2csr_bufferSizeExt",                 {HIP_3090, HIP_6020, HIP_0   }},
-  {"hipsparseDpruneCsr2csr_bufferSizeExt",                 {HIP_3090, HIP_6020, HIP_0   }},
-  {"hipsparseSpruneCsr2csrNnz",                            {HIP_3090, HIP_6020, HIP_0   }},
-  {"hipsparseDpruneCsr2csrNnz",                            {HIP_3090, HIP_6020, HIP_0   }},
-  {"hipsparseSpruneDense2csrByPercentage",                 {HIP_3090, HIP_6020, HIP_0   }},
-  {"hipsparseDpruneDense2csrByPercentage",                 {HIP_3090, HIP_6020, HIP_0   }},
-  {"hipsparseSpruneDense2csrByPercentage_bufferSizeExt",   {HIP_3090, HIP_6020, HIP_0   }},
-  {"hipsparseDpruneDense2csrByPercentage_bufferSizeExt",   {HIP_3090, HIP_6020, HIP_0   }},
-  {"hipsparseSpruneDense2csrNnzByPercentage",              {HIP_3090, HIP_6020, HIP_0   }},
-  {"hipsparseDpruneDense2csrNnzByPercentage",              {HIP_3090, HIP_6020, HIP_0   }},
-  {"hipsparseSpruneCsr2csrByPercentage",                   {HIP_3090, HIP_6020, HIP_0   }},
-  {"hipsparseDpruneCsr2csrByPercentage",                   {HIP_3090, HIP_6020, HIP_0   }},
-  {"hipsparseSpruneCsr2csrByPercentage_bufferSizeExt",     {HIP_3090, HIP_6020, HIP_0   }},
-  {"hipsparseDpruneCsr2csrByPercentage_bufferSizeExt",     {HIP_3090, HIP_6020, HIP_0   }},
-  {"hipsparseSpruneCsr2csrNnzByPercentage",                {HIP_3090, HIP_6020, HIP_0   }},
-  {"hipsparseDpruneCsr2csrNnzByPercentage",                {HIP_3090, HIP_6020, HIP_0   }},
-  {"hipsparseSnnz_compress",                               {HIP_3050, HIP_6020, HIP_0   }},
-  {"hipsparseDnnz_compress",                               {HIP_3050, HIP_6020, HIP_0   }},
-  {"hipsparseCnnz_compress",                               {HIP_3050, HIP_6020, HIP_0   }},
-  {"hipsparseZnnz_compress",                               {HIP_3050, HIP_6020, HIP_0   }},
-  {"hipsparseSgebsr2gebsc_bufferSize",                     {HIP_4010, HIP_0,    HIP_0   }},
-  {"hipsparseDgebsr2gebsc_bufferSize",                     {HIP_4010, HIP_0,    HIP_0   }},
-  {"hipsparseCgebsr2gebsc_bufferSize",                     {HIP_4010, HIP_0,    HIP_0   }},
-  {"hipsparseZgebsr2gebsc_bufferSize",                     {HIP_4010, HIP_0,    HIP_0   }},
-  {"hipsparseSgebsr2gebsc",                                {HIP_4010, HIP_0,    HIP_0   }},
-  {"hipsparseDgebsr2gebsc",                                {HIP_4010, HIP_0,    HIP_0   }},
-  {"hipsparseCgebsr2gebsc",                                {HIP_4010, HIP_0,    HIP_0   }},
-  {"hipsparseZgebsr2gebsc",                                {HIP_4010, HIP_0,    HIP_0   }},
-  {"hipsparseSgebsr2gebsr_bufferSize",                     {HIP_4010, HIP_0,    HIP_0   }},
-  {"hipsparseDgebsr2gebsr_bufferSize",                     {HIP_4010, HIP_0,    HIP_0   }},
-  {"hipsparseCgebsr2gebsr_bufferSize",                     {HIP_4010, HIP_0,    HIP_0   }},
-  {"hipsparseZgebsr2gebsr_bufferSize",                     {HIP_4010, HIP_0,    HIP_0   }},
-  {"hipsparseSgebsr2csr",                                  {HIP_4010, HIP_0,    HIP_0   }},
-  {"hipsparseDgebsr2csr",                                  {HIP_4010, HIP_0,    HIP_0   }},
-  {"hipsparseCgebsr2csr",                                  {HIP_4010, HIP_0,    HIP_0   }},
-  {"hipsparseZgebsr2csr",                                  {HIP_4010, HIP_0,    HIP_0   }},
-  {"hipsparseXgebsr2gebsrNnz",                             {HIP_4010, HIP_0,    HIP_0   }},
-  {"hipsparseSgebsr2gebsr",                                {HIP_4010, HIP_0,    HIP_0   }},
-  {"hipsparseDgebsr2gebsr",                                {HIP_4010, HIP_0,    HIP_0   }},
-  {"hipsparseCgebsr2gebsr",                                {HIP_4010, HIP_0,    HIP_0   }},
-  {"hipsparseZgebsr2gebsr",                                {HIP_4010, HIP_0,    HIP_0   }},
-  {"hipsparseScsr2gebsr_bufferSize",                       {HIP_4010, HIP_0,    HIP_0   }},
-  {"hipsparseDcsr2gebsr_bufferSize",                       {HIP_4010, HIP_0,    HIP_0   }},
-  {"hipsparseCcsr2gebsr_bufferSize",                       {HIP_4010, HIP_0,    HIP_0   }},
-  {"hipsparseZcsr2gebsr_bufferSize",                       {HIP_4010, HIP_0,    HIP_0   }},
-  {"hipsparseXcsr2gebsrNnz",                               {HIP_4010, HIP_0,    HIP_0   }},
-  {"hipsparseScsr2gebsr",                                  {HIP_4010, HIP_0,    HIP_0   }},
-  {"hipsparseDcsr2gebsr",                                  {HIP_4010, HIP_0,    HIP_0   }},
-  {"hipsparseCcsr2gebsr",                                  {HIP_4010, HIP_0,    HIP_0   }},
-  {"hipsparseZcsr2gebsr",                                  {HIP_4010, HIP_0,    HIP_0   }},
-  {"hipsparseCreateCoo",                                   {HIP_4010, HIP_0,    HIP_0   }},
-  {"hipsparseCreateCooAoS",                                {HIP_4010, HIP_0,    HIP_0   }},
-  {"hipsparseCreateCsr",                                   {HIP_4010, HIP_0,    HIP_0   }},
-  {"hipsparseDestroySpMat",                                {HIP_4010, HIP_0,    HIP_0   }},
-  {"hipsparseCooGet",                                      {HIP_4010, HIP_0,    HIP_0   }},
-  {"hipsparseCooAoSGet",                                   {HIP_4010, HIP_5060, HIP_0   }},
-  {"hipsparseCsrGet",                                      {HIP_4010, HIP_0,    HIP_0   }},
-  {"hipsparseCsrSetPointers",                              {HIP_4010, HIP_0,    HIP_0   }},
-  {"hipsparseSpMatGetFormat",                              {HIP_4010, HIP_0,    HIP_0   }},
-  {"hipsparseSpMatGetIndexBase",                           {HIP_4010, HIP_0,    HIP_0   }},
-  {"hipsparseSpMatGetValues",                              {HIP_4010, HIP_0,    HIP_0   }},
-  {"hipsparseSpMatSetValues",                              {HIP_4010, HIP_0,    HIP_0   }},
-  {"hipsparseSpMatGetSize",                                {HIP_4010, HIP_0,    HIP_0   }},
-  {"hipsparseCreateSpVec",                                 {HIP_4010, HIP_0,    HIP_0   }},
-  {"hipsparseDestroySpVec",                                {HIP_4010, HIP_0,    HIP_0   }},
-  {"hipsparseSpVecGet",                                    {HIP_4010, HIP_0,    HIP_0   }},
-  {"hipsparseSpVecGetIndexBase",                           {HIP_4010, HIP_0,    HIP_0   }},
-  {"hipsparseSpVecGetValues",                              {HIP_4010, HIP_0,    HIP_0   }},
-  {"hipsparseSpVecSetValues",                              {HIP_4010, HIP_0,    HIP_0   }},
-  {"hipsparseCreateDnVec",                                 {HIP_4010, HIP_0,    HIP_0   }},
-  {"hipsparseDestroyDnVec",                                {HIP_4010, HIP_0,    HIP_0   }},
-  {"hipsparseDnVecGet",                                    {HIP_4010, HIP_0,    HIP_0   }},
-  {"hipsparseDnVecGetValues",                              {HIP_4010, HIP_0,    HIP_0   }},
-  {"hipsparseDnVecSetValues",                              {HIP_4010, HIP_0,    HIP_0   }},
-  {"hipsparseSpGEMM_createDescr",                          {HIP_4010, HIP_0,    HIP_0   }},
-  {"hipsparseSpGEMM_destroyDescr",                         {HIP_4010, HIP_0,    HIP_0   }},
-  {"hipsparseSpGEMM_workEstimation",                       {HIP_4010, HIP_0,    HIP_0   }},
-  {"hipsparseSpGEMM_compute",                              {HIP_4010, HIP_0,    HIP_0   }},
-  {"hipsparseSpGEMM_copy",                                 {HIP_4010, HIP_0,    HIP_0   }},
-  {"hipsparseSpVV",                                        {HIP_4010, HIP_0,    HIP_0   }},
-  {"hipsparseSpVV_bufferSize",                             {HIP_4010, HIP_0,    HIP_0   }},
-  {"hipsparseAxpby",                                       {HIP_4010, HIP_0,    HIP_0   }},
-  {"hipsparseGather",                                      {HIP_4010, HIP_0,    HIP_0   }},
-  {"hipsparseScatter",                                     {HIP_4010, HIP_0,    HIP_0   }},
-  {"hipsparseRot",                                         {HIP_4010, HIP_6020, HIP_0   }},
-  {"hipsparseSpMV",                                        {HIP_4010, HIP_0,    HIP_0   }},
-  {"hipsparseSpMV_bufferSize",                             {HIP_4010, HIP_0,    HIP_0   }},
-  {"hipsparseCreateCsru2csrInfo",                          {HIP_4020, HIP_0,    HIP_0   }},
-  {"hipsparseDestroyCsru2csrInfo",                         {HIP_4020, HIP_0,    HIP_0   }},
-  {"hipsparseScsru2csr_bufferSizeExt",                     {HIP_4020, HIP_6020, HIP_0   }},
-  {"hipsparseDcsru2csr_bufferSizeExt",                     {HIP_4020, HIP_6020, HIP_0   }},
-  {"hipsparseCcsru2csr_bufferSizeExt",                     {HIP_4020, HIP_6020, HIP_0   }},
-  {"hipsparseZcsru2csr_bufferSizeExt",                     {HIP_4020, HIP_6020, HIP_0   }},
-  {"hipsparseScsru2csr",                                   {HIP_4020, HIP_6020, HIP_0   }},
-  {"hipsparseDcsru2csr",                                   {HIP_4020, HIP_6020, HIP_0   }},
-  {"hipsparseCcsru2csr",                                   {HIP_4020, HIP_6020, HIP_0   }},
-  {"hipsparseZcsru2csr",                                   {HIP_4020, HIP_6020, HIP_0   }},
-  {"hipsparseScsr2csru",                                   {HIP_4020, HIP_6020, HIP_0   }},
-  {"hipsparseDcsr2csru",                                   {HIP_4020, HIP_6020, HIP_0   }},
-  {"hipsparseCcsr2csru",                                   {HIP_4020, HIP_6020, HIP_0   }},
-  {"hipsparseZcsr2csru",                                   {HIP_4020, HIP_6020, HIP_0   }},
-  {"hipsparseCreateCsc",                                   {HIP_4020, HIP_0,    HIP_0   }},
-  {"hipsparseCscSetPointers",                              {HIP_4020, HIP_0,    HIP_0   }},
-  {"hipsparseCooSetPointers",                              {HIP_4020, HIP_0,    HIP_0   }},
-  {"hipsparseCreateDnMat",                                 {HIP_4020, HIP_0,    HIP_0   }},
-  {"hipsparseDestroyDnMat",                                {HIP_4020, HIP_0,    HIP_0   }},
-  {"hipsparseDnMatGet",                                    {HIP_4020, HIP_0,    HIP_0   }},
-  {"hipsparseDnMatGetValues",                              {HIP_4020, HIP_0,    HIP_0   }},
-  {"hipsparseDnMatSetValues",                              {HIP_4020, HIP_0,    HIP_0   }},
-  {"hipsparseSparseToDense_bufferSize",                    {HIP_4020, HIP_0,    HIP_0   }},
-  {"hipsparseSparseToDense",                               {HIP_4020, HIP_0,    HIP_0   }},
-  {"hipsparseDenseToSparse_bufferSize",                    {HIP_4020, HIP_0,    HIP_0   }},
-  {"hipsparseDenseToSparse_analysis",                      {HIP_4020, HIP_0,    HIP_0   }},
-  {"hipsparseDenseToSparse_convert",                       {HIP_4020, HIP_0,    HIP_0   }},
-  {"hipsparseSpMM_bufferSize",                             {HIP_4020, HIP_0,    HIP_0   }},
-  {"hipsparseSpMM",                                        {HIP_4020, HIP_0,    HIP_0   }},
-  {"hipsparseSgemvi_bufferSize",                           {HIP_4030, HIP_0,    HIP_0   }},
-  {"hipsparseDgemvi_bufferSize",                           {HIP_4030, HIP_0,    HIP_0   }},
-  {"hipsparseCgemvi_bufferSize",                           {HIP_4030, HIP_0,    HIP_0   }},
-  {"hipsparseZgemvi_bufferSize",                           {HIP_4030, HIP_0,    HIP_0   }},
-  {"hipsparseSgemvi",                                      {HIP_4030, HIP_0,    HIP_0   }},
-  {"hipsparseDgemvi",                                      {HIP_4030, HIP_0,    HIP_0   }},
-  {"hipsparseCgemvi",                                      {HIP_4030, HIP_0,    HIP_0   }},
-  {"hipsparseZgemvi",                                      {HIP_4030, HIP_0,    HIP_0   }},
-  {"hipsparseSgtsv2_bufferSizeExt",                        {HIP_4030, HIP_0,    HIP_0   }},
-  {"hipsparseDgtsv2_bufferSizeExt",                        {HIP_4030, HIP_0,    HIP_0   }},
-  {"hipsparseCgtsv2_bufferSizeExt",                        {HIP_4030, HIP_0,    HIP_0   }},
-  {"hipsparseZgtsv2_bufferSizeExt",                        {HIP_4030, HIP_0,    HIP_0   }},
-  {"hipsparseSgtsv2",                                      {HIP_4030, HIP_0,    HIP_0   }},
-  {"hipsparseDgtsv2",                                      {HIP_4030, HIP_0,    HIP_0   }},
-  {"hipsparseCgtsv2",                                      {HIP_4030, HIP_0,    HIP_0   }},
-  {"hipsparseZgtsv2",                                      {HIP_4030, HIP_0,    HIP_0   }},
-  {"hipsparseSgtsv2_nopivot_bufferSizeExt",                {HIP_4030, HIP_0,    HIP_0   }},
-  {"hipsparseDgtsv2_nopivot_bufferSizeExt",                {HIP_4030, HIP_0,    HIP_0   }},
-  {"hipsparseCgtsv2_nopivot_bufferSizeExt",                {HIP_4030, HIP_0,    HIP_0   }},
-  {"hipsparseZgtsv2_nopivot_bufferSizeExt",                {HIP_4030, HIP_0,    HIP_0   }},
-  {"hipsparseSgtsv2_nopivot",                              {HIP_4030, HIP_0,    HIP_0   }},
-  {"hipsparseDgtsv2_nopivot",                              {HIP_4030, HIP_0,    HIP_0   }},
-  {"hipsparseCgtsv2_nopivot",                              {HIP_4030, HIP_0,    HIP_0   }},
-  {"hipsparseZgtsv2_nopivot",                              {HIP_4030, HIP_0,    HIP_0   }},
-  {"hipsparseSDDMM",                                       {HIP_4030, HIP_0,    HIP_0   }},
-  {"hipsparseSDDMM_bufferSize",                            {HIP_4030, HIP_0,    HIP_0   }},
-  {"hipsparseSDDMM_preprocess",                            {HIP_4030, HIP_0,    HIP_0   }},
-  {"hipsparseCreateBsrsm2Info",                            {HIP_4050, HIP_6020, HIP_0   }},
-  {"hipsparseDestroyBsrsm2Info",                           {HIP_4050, HIP_6020, HIP_0   }},
-  {"hipsparseCreateColorInfo",                             {HIP_4050, HIP_6020, HIP_0   }},
-  {"hipsparseDestroyColorInfo",                            {HIP_4050, HIP_6020, HIP_0   }},
-  {"hipsparseSbsrxmv",                                     {HIP_4050, HIP_6020, HIP_0   }},
-  {"hipsparseDbsrxmv",                                     {HIP_4050, HIP_6020, HIP_0   }},
-  {"hipsparseCbsrxmv",                                     {HIP_4050, HIP_6020, HIP_0   }},
-  {"hipsparseZbsrxmv",                                     {HIP_4050, HIP_6020, HIP_0   }},
-  {"hipsparseXbsrsm2_zeroPivot",                           {HIP_4050, HIP_6020, HIP_0   }},
-  {"hipsparseSbsrsm2_bufferSize",                          {HIP_4050, HIP_6020, HIP_0   }},
-  {"hipsparseDbsrsm2_bufferSize",                          {HIP_4050, HIP_6020, HIP_0   }},
-  {"hipsparseCbsrsm2_bufferSize",                          {HIP_4050, HIP_6020, HIP_0   }},
-  {"hipsparseZbsrsm2_bufferSize",                          {HIP_4050, HIP_6020, HIP_0   }},
-  {"hipsparseSbsrsm2_analysis",                            {HIP_4050, HIP_6020, HIP_0   }},
-  {"hipsparseDbsrsm2_analysis",                            {HIP_4050, HIP_6020, HIP_0   }},
-  {"hipsparseCbsrsm2_analysis",                            {HIP_4050, HIP_6020, HIP_0   }},
-  {"hipsparseZbsrsm2_analysis",                            {HIP_4050, HIP_6020, HIP_0   }},
-  {"hipsparseSbsrsm2_solve",                               {HIP_4050, HIP_6020, HIP_0   }},
-  {"hipsparseDbsrsm2_solve",                               {HIP_4050, HIP_6020, HIP_0   }},
-  {"hipsparseCbsrsm2_solve",                               {HIP_4050, HIP_6020, HIP_0   }},
-  {"hipsparseZbsrsm2_solve",                               {HIP_4050, HIP_6020, HIP_0   }},
-  {"hipsparseScsrcolor",                                   {HIP_4050, HIP_6020, HIP_0   }},
-  {"hipsparseDcsrcolor",                                   {HIP_4050, HIP_6020, HIP_0   }},
-  {"hipsparseCcsrcolor",                                   {HIP_4050, HIP_6020, HIP_0   }},
-  {"hipsparseZcsrcolor",                                   {HIP_4050, HIP_6020, HIP_0   }},
-  {"hipsparseCreateBlockedEll",                            {HIP_4050, HIP_0,    HIP_0   }},
-  {"hipsparseBlockedEllGet",                               {HIP_4050, HIP_0,    HIP_0   }},
-  {"hipsparseSpMatGetAttribute",                           {HIP_4050, HIP_0,    HIP_0   }},
-  {"hipsparseSpMatSetAttribute",                           {HIP_4050, HIP_0,    HIP_0   }},
-  {"hipsparseSpMM_preprocess",                             {HIP_4050, HIP_0,    HIP_0   }},
-  {"hipsparseSpSV_createDescr",                            {HIP_4050, HIP_0,    HIP_0   }},
-  {"hipsparseSpSV_destroyDescr",                           {HIP_4050, HIP_0,    HIP_0   }},
-  {"hipsparseSpSV_bufferSize",                             {HIP_4050, HIP_0,    HIP_0   }},
-  {"hipsparseSpSV_analysis",                               {HIP_4050, HIP_0,    HIP_0   }},
-  {"hipsparseSpSV_solve",                                  {HIP_4050, HIP_0,    HIP_0   }},
-  {"hipsparseSpSM_createDescr",                            {HIP_4050, HIP_0,    HIP_0   }},
-  {"hipsparseSpSM_destroyDescr",                           {HIP_4050, HIP_0,    HIP_0   }},
-  {"hipsparseSpSM_bufferSize",                             {HIP_4050, HIP_0,    HIP_0   }},
-  {"hipsparseSpSM_analysis",                               {HIP_4050, HIP_0,    HIP_0   }},
-  {"hipsparseSpSM_solve",                                  {HIP_4050, HIP_0,    HIP_0   }},
-  {"hipsparseSgtsv2StridedBatch_bufferSizeExt",            {HIP_4050, HIP_0,    HIP_0   }},
-  {"hipsparseDgtsv2StridedBatch_bufferSizeExt",            {HIP_4050, HIP_0,    HIP_0   }},
-  {"hipsparseCgtsv2StridedBatch_bufferSizeExt",            {HIP_4050, HIP_0,    HIP_0   }},
-  {"hipsparseZgtsv2StridedBatch_bufferSizeExt",            {HIP_4050, HIP_0,    HIP_0   }},
-  {"hipsparseSgtsv2StridedBatch",                          {HIP_4050, HIP_0,    HIP_0   }},
-  {"hipsparseDgtsv2StridedBatch",                          {HIP_4050, HIP_0,    HIP_0   }},
-  {"hipsparseCgtsv2StridedBatch",                          {HIP_4050, HIP_0,    HIP_0   }},
-  {"hipsparseZgtsv2StridedBatch",                          {HIP_4050, HIP_0,    HIP_0   }},
-  {"hipsparseSgtsvInterleavedBatch_bufferSizeExt",         {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsparseDgtsvInterleavedBatch_bufferSizeExt",         {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsparseCgtsvInterleavedBatch_bufferSizeExt",         {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsparseZgtsvInterleavedBatch_bufferSizeExt",         {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsparseSgtsvInterleavedBatch",                       {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsparseDgtsvInterleavedBatch",                       {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsparseCgtsvInterleavedBatch",                       {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsparseZgtsvInterleavedBatch",                       {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsparseSgpsvInterleavedBatch_bufferSizeExt",         {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsparseDgpsvInterleavedBatch_bufferSizeExt",         {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsparseCgpsvInterleavedBatch_bufferSizeExt",         {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsparseZgpsvInterleavedBatch_bufferSizeExt",         {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsparseSgpsvInterleavedBatch",                       {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsparseDgpsvInterleavedBatch",                       {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsparseCgpsvInterleavedBatch",                       {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsparseZgpsvInterleavedBatch",                       {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsparseSpGEMMreuse_workEstimation",                  {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsparseSpGEMMreuse_nnz",                             {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsparseSpGEMMreuse_compute",                         {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsparseSpGEMMreuse_copy",                            {HIP_5010, HIP_0,    HIP_0   }},
-  {"hipsparseSpMatGetStridedBatch",                        {HIP_5020, HIP_0,    HIP_0   }},
-  {"hipsparseSpMatSetStridedBatch",                        {HIP_5020, HIP_5020, HIP_0   }},
-  {"hipsparseCooSetStridedBatch",                          {HIP_5020, HIP_0,    HIP_0   }},
-  {"hipsparseCsrSetStridedBatch",                          {HIP_5020, HIP_0,    HIP_0   }},
-  {"hipsparseDnMatGetStridedBatch",                        {HIP_5020, HIP_0,    HIP_0   }},
-  {"hipsparseDnMatSetStridedBatch",                        {HIP_5020, HIP_0,    HIP_0   }},
-  {"hipsparseCsr2cscEx2_bufferSize",                       {HIP_5040, HIP_0,    HIP_0   }},
-  {"hipsparseCsr2cscEx2",                                  {HIP_5040, HIP_0,    HIP_0   }},
-  {"hipsparseCopyMatDescr",                                {HIP_1092, HIP_0,    HIP_0   }},
-  {"hipsparseGetErrorName",                                {HIP_6000, HIP_0,    HIP_0   }},
-  {"hipsparseGetErrorString",                              {HIP_6000, HIP_0,    HIP_0   }},
-  {"hipsparseCreateConstSpVec",                            {HIP_6000, HIP_0,    HIP_0   }},
-  {"hipsparseConstSpVecGet",                               {HIP_6000, HIP_0,    HIP_0   }},
-  {"hipsparseConstSpVecGetValues",                         {HIP_6000, HIP_0,    HIP_0   }},
-  {"hipsparseCreateConstCoo",                              {HIP_6000, HIP_0,    HIP_0   }},
-  {"hipsparseCreateConstCsr",                              {HIP_6000, HIP_0,    HIP_0   }},
-  {"hipsparseCreateConstCsc",                              {HIP_6000, HIP_0,    HIP_0   }},
-  {"hipsparseCreateConstBlockedEll",                       {HIP_6000, HIP_0,    HIP_0   }},
-  {"hipsparseConstCooGet",                                 {HIP_6000, HIP_0,    HIP_0   }},
-  {"hipsparseConstCsrGet",                                 {HIP_6000, HIP_0,    HIP_0   }},
-  {"hipsparseConstBlockedEllGet",                          {HIP_6000, HIP_0,    HIP_0   }},
-  {"hipsparseConstSpMatGetValues",                         {HIP_6000, HIP_0,    HIP_0   }},
-  {"hipsparseCreateConstDnVec",                            {HIP_6000, HIP_0,    HIP_0   }},
-  {"hipsparseConstDnVecGet",                               {HIP_6000, HIP_0,    HIP_0   }},
-  {"hipsparseConstDnVecGetValues",                         {HIP_6000, HIP_0,    HIP_0   }},
-  {"hipsparseCreateConstDnMat",                            {HIP_6000, HIP_0,    HIP_0   }},
-  {"hipsparseConstDnMatGet",                               {HIP_6000, HIP_0,    HIP_0   }},
-  {"hipsparseConstDnMatGetValues",                         {HIP_6000, HIP_0,    HIP_0   }},
-  {"hipsparseCscGet",                                      {HIP_6020, HIP_0,    HIP_0   }},
-  {"hipsparseConstCscGet",                                 {HIP_6020, HIP_0,    HIP_0   }},
-  {"hipsparseSpMV_preprocess",                             {HIP_5020, HIP_0,    HIP_0   }},
+const std::map<llvm::StringRef, cudaAPIversions> CUDA_SPARSE_FUNCTION_VER_MAP = [] {
+  std::map<llvm::StringRef, cudaAPIversions> m;
 
-  {"rocsparse_create_handle",                              {HIP_1090, HIP_0,    HIP_0   }},
-  {"rocsparse_destroy_handle",                             {HIP_1090, HIP_0,    HIP_0   }},
-  {"rocsparse_set_stream",                                 {HIP_1090, HIP_0,    HIP_0   }},
-  {"rocsparse_get_stream",                                 {HIP_1090, HIP_0,    HIP_0   }},
-  {"rocsparse_set_pointer_mode",                           {HIP_1090, HIP_0,    HIP_0   }},
-  {"rocsparse_get_pointer_mode",                           {HIP_1090, HIP_0,    HIP_0   }},
-  {"rocsparse_get_version",                                {HIP_1090, HIP_0,    HIP_0   }},
-  {"rocsparse_create_mat_descr",                           {HIP_1090, HIP_0,    HIP_0   }},
-  {"rocsparse_copy_mat_descr",                             {HIP_1090, HIP_0,    HIP_0   }},
-  {"rocsparse_destroy_mat_descr",                          {HIP_1090, HIP_0,    HIP_0   }},
-  {"rocsparse_set_mat_index_base",                         {HIP_1090, HIP_0,    HIP_0   }},
-  {"rocsparse_get_mat_index_base",                         {HIP_1090, HIP_0,    HIP_0   }},
-  {"rocsparse_set_mat_type",                               {HIP_1090, HIP_0,    HIP_0   }},
-  {"rocsparse_get_mat_type",                               {HIP_1090, HIP_0,    HIP_0   }},
-  {"rocsparse_set_mat_fill_mode",                          {HIP_1090, HIP_0,    HIP_0   }},
-  {"rocsparse_get_mat_fill_mode",                          {HIP_1090, HIP_0,    HIP_0   }},
-  {"rocsparse_set_mat_diag_type",                          {HIP_1090, HIP_0,    HIP_0   }},
-  {"rocsparse_get_mat_diag_type",                          {HIP_1090, HIP_0,    HIP_0   }},
-  {"rocsparse_create_hyb_mat",                             {HIP_1090, HIP_0,    HIP_0   }},
-  {"rocsparse_destroy_hyb_mat",                            {HIP_1090, HIP_0,    HIP_0   }},
-  {"rocsparse_create_color_info",                          {HIP_4050, HIP_0,    HIP_0   }},
-  {"rocsparse_destroy_color_info",                         {HIP_4050, HIP_0,    HIP_0   }},
-  {"rocsparse_create_spvec_descr",                         {HIP_4010, HIP_0,    HIP_0   }},
-  {"rocsparse_destroy_spvec_descr",                        {HIP_4010, HIP_0,    HIP_0   }},
-  {"rocsparse_spvec_get",                                  {HIP_4010, HIP_0,    HIP_0   }},
-  {"rocsparse_spvec_get_index_base",                       {HIP_4010, HIP_0,    HIP_0   }},
-  {"rocsparse_spvec_get_values",                           {HIP_4010, HIP_0,    HIP_0   }},
-  {"rocsparse_spvec_set_values",                           {HIP_4010, HIP_0,    HIP_0   }},
-  {"rocsparse_create_coo_descr",                           {HIP_4010, HIP_0,    HIP_0   }},
-  {"rocsparse_create_coo_aos_descr",                       {HIP_4010, HIP_0,    HIP_0   }},
-  {"rocsparse_create_csr_descr",                           {HIP_4010, HIP_0,    HIP_0   }},
-  {"rocsparse_create_csc_descr",                           {HIP_4010, HIP_0,    HIP_0   }},
-  {"rocsparse_create_bell_descr",                          {HIP_4050, HIP_0,    HIP_0   }},
-  {"rocsparse_destroy_spmat_descr",                        {HIP_4010, HIP_0,    HIP_0   }},
-  {"rocsparse_coo_get",                                    {HIP_4010, HIP_0,    HIP_0   }},
-  {"rocsparse_coo_aos_get",                                {HIP_4010, HIP_0,    HIP_0   }},
-  {"rocsparse_csr_get",                                    {HIP_4010, HIP_0,    HIP_0   }},
-  {"rocsparse_bell_get",                                   {HIP_4010, HIP_0,    HIP_0   }},
-  {"rocsparse_coo_set_pointers",                           {HIP_4010, HIP_0,    HIP_0   }},
-  {"rocsparse_csr_set_pointers",                           {HIP_4010, HIP_0,    HIP_0   }},
-  {"rocsparse_csc_set_pointers",                           {HIP_4010, HIP_0,    HIP_0   }},
-  {"rocsparse_spmat_get_size",                             {HIP_4010, HIP_0,    HIP_0   }},
-  {"rocsparse_spmat_get_format",                           {HIP_4010, HIP_0,    HIP_0   }},
-  {"rocsparse_spmat_get_index_base",                       {HIP_4010, HIP_0,    HIP_0   }},
-  {"rocsparse_spmat_get_values",                           {HIP_4010, HIP_0,    HIP_0   }},
-  {"rocsparse_spmat_set_values",                           {HIP_4010, HIP_0,    HIP_0   }},
-  {"rocsparse_spmat_get_strided_batch",                    {HIP_5020, HIP_0,    HIP_0   }},
-  {"rocsparse_spmat_set_strided_batch",                    {HIP_5020, HIP_0,    HIP_0   }},
-  {"rocsparse_coo_set_strided_batch",                      {HIP_5020, HIP_0,    HIP_0   }},
-  {"rocsparse_csr_set_strided_batch",                      {HIP_5020, HIP_0,    HIP_0   }},
-  {"rocsparse_spmat_get_attribute",                        {HIP_4050, HIP_0,    HIP_0   }},
-  {"rocsparse_spmat_set_attribute",                        {HIP_4050, HIP_0,    HIP_0   }},
-  {"rocsparse_create_dnvec_descr",                         {HIP_4010, HIP_0,    HIP_0   }},
-  {"rocsparse_destroy_dnvec_descr",                        {HIP_4010, HIP_0,    HIP_0   }},
-  {"rocsparse_dnvec_get",                                  {HIP_4010, HIP_0,    HIP_0   }},
-  {"rocsparse_dnvec_get_values",                           {HIP_4010, HIP_0,    HIP_0   }},
-  {"rocsparse_dnvec_set_values",                           {HIP_4010, HIP_0,    HIP_0   }},
-  {"rocsparse_create_dnmat_descr",                         {HIP_4010, HIP_0,    HIP_0   }},
-  {"rocsparse_destroy_dnmat_descr",                        {HIP_4010, HIP_0,    HIP_0   }},
-  {"rocsparse_dnmat_get",                                  {HIP_4010, HIP_0,    HIP_0   }},
-  {"rocsparse_dnmat_get_values",                           {HIP_4010, HIP_0,    HIP_0   }},
-  {"rocsparse_dnmat_set_values",                           {HIP_4010, HIP_0,    HIP_0   }},
-  {"rocsparse_dnmat_get_strided_batch",                    {HIP_5020, HIP_0,    HIP_0   }},
-  {"rocsparse_dnmat_set_strided_batch",                    {HIP_5020, HIP_0,    HIP_0   }},
-  {"rocsparse_zcsrcolor",                                  {HIP_4050, HIP_0,    HIP_0   }},
-  {"rocsparse_ccsrcolor",                                  {HIP_4050, HIP_0,    HIP_0   }},
-  {"rocsparse_dcsrcolor",                                  {HIP_4050, HIP_0,    HIP_0   }},
-  {"rocsparse_scsrcolor",                                  {HIP_4050, HIP_0,    HIP_0   }},
-  {"rocsparse_sddmm_preprocess",                           {HIP_4030, HIP_0,    HIP_0   }},
-  {"rocsparse_sddmm_buffer_size",                          {HIP_4030, HIP_0,    HIP_0   }},
-  {"rocsparse_sddmm",                                      {HIP_4030, HIP_0,    HIP_0   }},
-  {"rocsparse_spmv",                                       {HIP_4010, HIP_0,    HIP_0   }},
-  {"rocsparse_rot",                                        {HIP_4010, HIP_0,    HIP_0   }},
-  {"rocsparse_scatter",                                    {HIP_4010, HIP_0,    HIP_0   }},
-  {"rocsparse_gather",                                     {HIP_4010, HIP_0,    HIP_0   }},
-  {"rocsparse_axpby",                                      {HIP_4010, HIP_0,    HIP_0   }},
-  {"rocsparse_zgebsr2gebsr",                               {HIP_4010, HIP_0,    HIP_0   }},
-  {"rocsparse_zgebsr2gebsr_buffer_size",                   {HIP_4010, HIP_0,    HIP_0   }},
-  {"rocsparse_cgebsr2gebsr",                               {HIP_4010, HIP_0,    HIP_0   }},
-  {"rocsparse_cgebsr2gebsr_buffer_size",                   {HIP_4010, HIP_0,    HIP_0   }},
-  {"rocsparse_dgebsr2gebsr",                               {HIP_4010, HIP_0,    HIP_0   }},
-  {"rocsparse_dgebsr2gebsr_buffer_size",                   {HIP_4010, HIP_0,    HIP_0   }},
-  {"rocsparse_sgebsr2gebsr",                               {HIP_4010, HIP_0,    HIP_0   }},
-  {"rocsparse_sgebsr2gebsr_buffer_size",                   {HIP_4010, HIP_0,    HIP_0   }},
-  {"rocsparse_gebsr2gebsr_nnz",                            {HIP_4010, HIP_0,    HIP_0   }},
-  {"rocsparse_zgebsr2csr",                                 {HIP_3100, HIP_0,    HIP_0   }},
-  {"rocsparse_cgebsr2csr",                                 {HIP_3100, HIP_0,    HIP_0   }},
-  {"rocsparse_dgebsr2csr",                                 {HIP_3100, HIP_0,    HIP_0   }},
-  {"rocsparse_sgebsr2csr",                                 {HIP_3100, HIP_0,    HIP_0   }},
-  {"rocsparse_zbsr2csr",                                   {HIP_3100, HIP_0,    HIP_0   }},
-  {"rocsparse_cbsr2csr",                                   {HIP_3100, HIP_0,    HIP_0   }},
-  {"rocsparse_dbsr2csr",                                   {HIP_3100, HIP_0,    HIP_0   }},
-  {"rocsparse_sbsr2csr",                                   {HIP_3100, HIP_0,    HIP_0   }},
-  {"rocsparse_coosort_by_column",                          {HIP_1090, HIP_0,    HIP_0   }},
-  {"rocsparse_coosort_by_row",                             {HIP_1090, HIP_0,    HIP_0   }},
-  {"rocsparse_coosort_buffer_size",                        {HIP_1090, HIP_0,    HIP_0   }},
-  {"rocsparse_cscsort",                                    {HIP_2100, HIP_0,    HIP_0   }},
-  {"rocsparse_cscsort_buffer_size",                        {HIP_2100, HIP_0,    HIP_0   }},
-  {"rocsparse_csrsort",                                    {HIP_1090, HIP_0,    HIP_0   }},
-  {"rocsparse_csrsort_buffer_size",                        {HIP_1090, HIP_0,    HIP_0   }},
-  {"rocsparse_create_identity_permutation",                {HIP_1090, HIP_0,    HIP_0   }},
-  {"rocsparse_coo2csr",                                    {HIP_1090, HIP_0,    HIP_0   }},
-  {"rocsparse_dprune_csr2csr_by_percentage",               {HIP_3090, HIP_0,    HIP_0   }},
-  {"rocsparse_sprune_csr2csr_by_percentage",               {HIP_3090, HIP_0,    HIP_0   }},
-  {"rocsparse_dprune_csr2csr_nnz_by_percentage",           {HIP_3090, HIP_0,    HIP_0   }},
-  {"rocsparse_sprune_csr2csr_nnz_by_percentage",           {HIP_3090, HIP_0,    HIP_0   }},
-  {"rocsparse_dprune_csr2csr_by_percentage_buffer_size",   {HIP_3090, HIP_0,    HIP_0   }},
-  {"rocsparse_sprune_csr2csr_by_percentage_buffer_size",   {HIP_3090, HIP_0,    HIP_0   }},
-  {"rocsparse_dprune_csr2csr",                             {HIP_3090, HIP_0,    HIP_0   }},
-  {"rocsparse_sprune_csr2csr",                             {HIP_3090, HIP_0,    HIP_0   }},
-  {"rocsparse_dprune_csr2csr_nnz",                         {HIP_3090, HIP_0,    HIP_0   }},
-  {"rocsparse_sprune_csr2csr_nnz",                         {HIP_3090, HIP_0,    HIP_0   }},
-  {"rocsparse_dprune_csr2csr_buffer_size",                 {HIP_3090, HIP_0,    HIP_0   }},
-  {"rocsparse_sprune_csr2csr_buffer_size",                 {HIP_3090, HIP_0,    HIP_0   }},
-  {"rocsparse_zcsr2csr_compress",                          {HIP_3050, HIP_0,    HIP_0   }},
-  {"rocsparse_ccsr2csr_compress",                          {HIP_3050, HIP_0,    HIP_0   }},
-  {"rocsparse_dcsr2csr_compress",                          {HIP_3050, HIP_0,    HIP_0   }},
-  {"rocsparse_scsr2csr_compress",                          {HIP_3050, HIP_0,    HIP_0   }},
-  {"rocsparse_zcsr2gebsr",                                 {HIP_4010, HIP_0,    HIP_0   }},
-  {"rocsparse_ccsr2gebsr",                                 {HIP_4010, HIP_0,    HIP_0   }},
-  {"rocsparse_dcsr2gebsr",                                 {HIP_4010, HIP_0,    HIP_0   }},
-  {"rocsparse_scsr2gebsr",                                 {HIP_4010, HIP_0,    HIP_0   }},
-  {"rocsparse_csr2gebsr_nnz",                              {HIP_4010, HIP_0,    HIP_0   }},
-  {"rocsparse_zcsr2gebsr_buffer_size",                     {HIP_4010, HIP_0,    HIP_0   }},
-  {"rocsparse_ccsr2gebsr_buffer_size",                     {HIP_4010, HIP_0,    HIP_0   }},
-  {"rocsparse_dcsr2gebsr_buffer_size",                     {HIP_4010, HIP_0,    HIP_0   }},
-  {"rocsparse_scsr2gebsr_buffer_size",                     {HIP_4010, HIP_0,    HIP_0   }},
-  {"rocsparse_zcsr2bsr",                                   {HIP_3050, HIP_0,    HIP_0   }},
-  {"rocsparse_ccsr2bsr",                                   {HIP_3050, HIP_0,    HIP_0   }},
-  {"rocsparse_dcsr2bsr",                                   {HIP_3050, HIP_0,    HIP_0   }},
-  {"rocsparse_scsr2bsr",                                   {HIP_3050, HIP_0,    HIP_0   }},
-  {"rocsparse_csr2bsr_nnz",                                {HIP_3050, HIP_0,    HIP_0   }},
-  {"rocsparse_zcsr2hyb",                                   {HIP_2100, HIP_0,    HIP_0   }},
-  {"rocsparse_ccsr2hyb",                                   {HIP_2100, HIP_0,    HIP_0   }},
-  {"rocsparse_dcsr2hyb",                                   {HIP_1090, HIP_0,    HIP_0   }},
-  {"rocsparse_scsr2hyb",                                   {HIP_1090, HIP_0,    HIP_0   }},
-  {"rocsparse_zgebsr2gebsc",                               {HIP_4010, HIP_0,    HIP_0   }},
-  {"rocsparse_cgebsr2gebsc",                               {HIP_4010, HIP_0,    HIP_0   }},
-  {"rocsparse_dgebsr2gebsc",                               {HIP_4010, HIP_0,    HIP_0   }},
-  {"rocsparse_sgebsr2gebsc",                               {HIP_4010, HIP_0,    HIP_0   }},
-  {"rocsparse_zgebsr2gebsc_buffer_size",                   {HIP_4010, HIP_0,    HIP_0   }},
-  {"rocsparse_cgebsr2gebsc_buffer_size",                   {HIP_4010, HIP_0,    HIP_0   }},
-  {"rocsparse_dgebsr2gebsc_buffer_size",                   {HIP_4010, HIP_0,    HIP_0   }},
-  {"rocsparse_sgebsr2gebsc_buffer_size",                   {HIP_4010, HIP_0,    HIP_0   }},
-  {"rocsparse_csr2coo",                                    {HIP_1090, HIP_0,    HIP_0   }},
-  {"rocsparse_znnz_compress",                              {HIP_3050, HIP_0,    HIP_0   }},
-  {"rocsparse_cnnz_compress",                              {HIP_3050, HIP_0,    HIP_0   }},
-  {"rocsparse_dnnz_compress",                              {HIP_3050, HIP_0,    HIP_0   }},
-  {"rocsparse_snnz_compress",                              {HIP_3050, HIP_0,    HIP_0   }},
-  {"rocsparse_zcsc2dense",                                 {HIP_3050, HIP_0,    HIP_0   }},
-  {"rocsparse_ccsc2dense",                                 {HIP_3050, HIP_0,    HIP_0   }},
-  {"rocsparse_dcsc2dense",                                 {HIP_3050, HIP_0,    HIP_0   }},
-  {"rocsparse_scsc2dense",                                 {HIP_3050, HIP_0,    HIP_0   }},
-  {"rocsparse_zcsr2dense",                                 {HIP_3050, HIP_0,    HIP_0   }},
-  {"rocsparse_ccsr2dense",                                 {HIP_3050, HIP_0,    HIP_0   }},
-  {"rocsparse_dcsr2dense",                                 {HIP_3050, HIP_0,    HIP_0   }},
-  {"rocsparse_scsr2dense",                                 {HIP_3050, HIP_0,    HIP_0   }},
-  {"rocsparse_zdense2csc",                                 {HIP_3020, HIP_0,    HIP_0   }},
-  {"rocsparse_cdense2csc",                                 {HIP_3020, HIP_0,    HIP_0   }},
-  {"rocsparse_ddense2csc",                                 {HIP_3020, HIP_0,    HIP_0   }},
-  {"rocsparse_sdense2csc",                                 {HIP_3020, HIP_0,    HIP_0   }},
-  {"rocsparse_dprune_dense2csr_by_percentage",             {HIP_3090, HIP_0,    HIP_0   }},
-  {"rocsparse_sprune_dense2csr_by_percentage",             {HIP_3090, HIP_0,    HIP_0   }},
-  {"rocsparse_dprune_dense2csr_nnz_by_percentage",         {HIP_3090, HIP_0,    HIP_0   }},
-  {"rocsparse_sprune_dense2csr_nnz_by_percentage",         {HIP_3090, HIP_0,    HIP_0   }},
-  {"rocsparse_dprune_dense2csr_by_percentage_buffer_size", {HIP_3090, HIP_0,    HIP_0   }},
-  {"rocsparse_sprune_dense2csr_by_percentage_buffer_size", {HIP_3090, HIP_0,    HIP_0   }},
-  {"rocsparse_dprune_dense2csr",                           {HIP_3090, HIP_0,    HIP_0   }},
-  {"rocsparse_sprune_dense2csr",                           {HIP_3090, HIP_0,    HIP_0   }},
-  {"rocsparse_dprune_dense2csr_nnz",                       {HIP_3090, HIP_0,    HIP_0   }},
-  {"rocsparse_sprune_dense2csr_nnz",                       {HIP_3090, HIP_0,    HIP_0   }},
-  {"rocsparse_dprune_dense2csr_buffer_size",               {HIP_3090, HIP_0,    HIP_0   }},
-  {"rocsparse_sprune_dense2csr_buffer_size",               {HIP_3090, HIP_0,    HIP_0   }},
-  {"rocsparse_zdense2csr",                                 {HIP_3020, HIP_0,    HIP_0   }},
-  {"rocsparse_cdense2csr",                                 {HIP_3020, HIP_0,    HIP_0   }},
-  {"rocsparse_ddense2csr",                                 {HIP_3020, HIP_0,    HIP_0   }},
-  {"rocsparse_sdense2csr",                                 {HIP_3020, HIP_0,    HIP_0   }},
-  {"rocsparse_znnz",                                       {HIP_3020, HIP_0,    HIP_0   }},
-  {"rocsparse_cnnz",                                       {HIP_3020, HIP_0,    HIP_0   }},
-  {"rocsparse_dnnz",                                       {HIP_3020, HIP_0,    HIP_0   }},
-  {"rocsparse_snnz",                                       {HIP_3020, HIP_0,    HIP_0   }},
-  {"rocsparse_zgpsv_interleaved_batch",                    {HIP_5010, HIP_0,    HIP_0   }},
-  {"rocsparse_cgpsv_interleaved_batch",                    {HIP_5010, HIP_0,    HIP_0   }},
-  {"rocsparse_dgpsv_interleaved_batch",                    {HIP_5010, HIP_0,    HIP_0   }},
-  {"rocsparse_sgpsv_interleaved_batch",                    {HIP_5010, HIP_0,    HIP_0   }},
-  {"rocsparse_zgpsv_interleaved_batch_buffer_size",        {HIP_5010, HIP_0,    HIP_0   }},
-  {"rocsparse_cgpsv_interleaved_batch_buffer_size",        {HIP_5010, HIP_0,    HIP_0   }},
-  {"rocsparse_dgpsv_interleaved_batch_buffer_size",        {HIP_5010, HIP_0,    HIP_0   }},
-  {"rocsparse_sgpsv_interleaved_batch_buffer_size",        {HIP_5010, HIP_0,    HIP_0   }},
-  {"rocsparse_zgtsv_interleaved_batch",                    {HIP_5010, HIP_0,    HIP_0   }},
-  {"rocsparse_cgtsv_interleaved_batch",                    {HIP_5010, HIP_0,    HIP_0   }},
-  {"rocsparse_dgtsv_interleaved_batch",                    {HIP_5010, HIP_0,    HIP_0   }},
-  {"rocsparse_sgtsv_interleaved_batch",                    {HIP_5010, HIP_0,    HIP_0   }},
-  {"rocsparse_zgtsv_interleaved_batch_buffer_size",        {HIP_5010, HIP_0,    HIP_0   }},
-  {"rocsparse_cgtsv_interleaved_batch_buffer_size",        {HIP_5010, HIP_0,    HIP_0   }},
-  {"rocsparse_dgtsv_interleaved_batch_buffer_size",        {HIP_5010, HIP_0,    HIP_0   }},
-  {"rocsparse_sgtsv_interleaved_batch_buffer_size",        {HIP_5010, HIP_0,    HIP_0   }},
-  {"rocsparse_zgtsv_no_pivot_strided_batch",               {HIP_4030, HIP_0,    HIP_0   }},
-  {"rocsparse_cgtsv_no_pivot_strided_batch",               {HIP_4030, HIP_0,    HIP_0   }},
-  {"rocsparse_dgtsv_no_pivot_strided_batch",               {HIP_4030, HIP_0,    HIP_0   }},
-  {"rocsparse_sgtsv_no_pivot_strided_batch",               {HIP_4030, HIP_0,    HIP_0   }},
-  {"rocsparse_zgtsv_no_pivot_strided_batch_buffer_size",   {HIP_4030, HIP_0,    HIP_0   }},
-  {"rocsparse_cgtsv_no_pivot_strided_batch_buffer_size",   {HIP_4030, HIP_0,    HIP_0   }},
-  {"rocsparse_dgtsv_no_pivot_strided_batch_buffer_size",   {HIP_4030, HIP_0,    HIP_0   }},
-  {"rocsparse_sgtsv_no_pivot_strided_batch_buffer_size",   {HIP_4030, HIP_0,    HIP_0   }},
-  {"rocsparse_zgtsv_no_pivot",                             {HIP_4030, HIP_0,    HIP_0   }},
-  {"rocsparse_cgtsv_no_pivot",                             {HIP_4030, HIP_0,    HIP_0   }},
-  {"rocsparse_dgtsv_no_pivot",                             {HIP_4030, HIP_0,    HIP_0   }},
-  {"rocsparse_sgtsv_no_pivot",                             {HIP_4030, HIP_0,    HIP_0   }},
-  {"rocsparse_zgtsv_no_pivot_buffer_size",                 {HIP_4030, HIP_0,    HIP_0   }},
-  {"rocsparse_cgtsv_no_pivot_buffer_size",                 {HIP_4030, HIP_0,    HIP_0   }},
-  {"rocsparse_dgtsv_no_pivot_buffer_size",                 {HIP_4030, HIP_0,    HIP_0   }},
-  {"rocsparse_sgtsv_no_pivot_buffer_size",                 {HIP_4030, HIP_0,    HIP_0   }},
-  {"rocsparse_zgtsv",                                      {HIP_4030, HIP_0,    HIP_0   }},
-  {"rocsparse_cgtsv",                                      {HIP_4030, HIP_0,    HIP_0   }},
-  {"rocsparse_dgtsv",                                      {HIP_4030, HIP_0,    HIP_0   }},
-  {"rocsparse_sgtsv",                                      {HIP_4030, HIP_0,    HIP_0   }},
-  {"rocsparse_zgtsv_buffer_size",                          {HIP_4030, HIP_0,    HIP_0   }},
-  {"rocsparse_cgtsv_buffer_size",                          {HIP_4030, HIP_0,    HIP_0   }},
-  {"rocsparse_dgtsv_buffer_size",                          {HIP_4030, HIP_0,    HIP_0   }},
-  {"rocsparse_sgtsv_buffer_size",                          {HIP_4030, HIP_0,    HIP_0   }},
-  {"rocsparse_zcsrilu0",                                   {HIP_2100, HIP_0,    HIP_0   }},
-  {"rocsparse_ccsrilu0",                                   {HIP_2100, HIP_0,    HIP_0   }},
-  {"rocsparse_dcsrilu0",                                   {HIP_1090, HIP_0,    HIP_0   }},
-  {"rocsparse_scsrilu0",                                   {HIP_1090, HIP_0,    HIP_0   }},
-  {"rocsparse_zcsrilu0_analysis",                          {HIP_2100, HIP_0,    HIP_0   }},
-  {"rocsparse_ccsrilu0_analysis",                          {HIP_2100, HIP_0,    HIP_0   }},
-  {"rocsparse_dcsrilu0_analysis",                          {HIP_1090, HIP_0,    HIP_0   }},
-  {"rocsparse_scsrilu0_analysis",                          {HIP_1090, HIP_0,    HIP_0   }},
-  {"rocsparse_zcsrilu0_buffer_size",                       {HIP_2100, HIP_0,    HIP_0   }},
-  {"rocsparse_ccsrilu0_buffer_size",                       {HIP_2100, HIP_0,    HIP_0   }},
-  {"rocsparse_dcsrilu0_buffer_size",                       {HIP_1090, HIP_0,    HIP_0   }},
-  {"rocsparse_scsrilu0_buffer_size",                       {HIP_1090, HIP_0,    HIP_0   }},
-  {"rocsparse_zcsrilu0_numeric_boost",                     {HIP_3090, HIP_0,    HIP_0   }},
-  {"rocsparse_dccsrilu0_numeric_boost",                    {HIP_4050, HIP_0,    HIP_0   }},
-  {"rocsparse_dcsrilu0_numeric_boost",                     {HIP_3090, HIP_0,    HIP_0   }},
-  {"rocsparse_dscsrilu0_numeric_boost",                    {HIP_4050, HIP_0,    HIP_0   }},
-  {"rocsparse_csrilu0_zero_pivot",                         {HIP_1090, HIP_0,    HIP_0   }},
-  {"rocsparse_zcsric0",                                    {HIP_3010, HIP_0,    HIP_0   }},
-  {"rocsparse_ccsric0",                                    {HIP_3010, HIP_0,    HIP_0   }},
-  {"rocsparse_dcsric0",                                    {HIP_3010, HIP_0,    HIP_0   }},
-  {"rocsparse_scsric0",                                    {HIP_3010, HIP_0,    HIP_0   }},
-  {"rocsparse_zcsric0_analysis",                           {HIP_3010, HIP_0,    HIP_0   }},
-  {"rocsparse_ccsric0_analysis",                           {HIP_3010, HIP_0,    HIP_0   }},
-  {"rocsparse_dcsric0_analysis",                           {HIP_3010, HIP_0,    HIP_0   }},
-  {"rocsparse_scsric0_analysis",                           {HIP_3010, HIP_0,    HIP_0   }},
-  {"rocsparse_zcsric0_buffer_size",                        {HIP_3010, HIP_0,    HIP_0   }},
-  {"rocsparse_ccsric0_buffer_size",                        {HIP_3010, HIP_0,    HIP_0   }},
-  {"rocsparse_dcsric0_buffer_size",                        {HIP_3010, HIP_0,    HIP_0   }},
-  {"rocsparse_scsric0_buffer_size",                        {HIP_3010, HIP_0,    HIP_0   }},
-  {"rocsparse_csric0_zero_pivot",                          {HIP_3010, HIP_0,    HIP_0   }},
-  {"rocsparse_zbsrilu0",                                   {HIP_3090, HIP_0,    HIP_0   }},
-  {"rocsparse_cbsrilu0",                                   {HIP_3090, HIP_0,    HIP_0   }},
-  {"rocsparse_dbsrilu0",                                   {HIP_3090, HIP_0,    HIP_0   }},
-  {"rocsparse_sbsrilu0",                                   {HIP_3090, HIP_0,    HIP_0   }},
-  {"rocsparse_bsrilu0_zero_pivot",                         {HIP_3090, HIP_0,    HIP_0   }},
-  {"rocsparse_zbsrilu0_analysis",                          {HIP_3060, HIP_0,    HIP_0   }},
-  {"rocsparse_cbsrilu0_analysis",                          {HIP_3060, HIP_0,    HIP_0   }},
-  {"rocsparse_dbsrilu0_analysis",                          {HIP_3060, HIP_0,    HIP_0   }},
-  {"rocsparse_sbsrilu0_analysis",                          {HIP_3060, HIP_0,    HIP_0   }},
-  {"rocsparse_dcbsrilu0_numeric_boost",                    {HIP_4050, HIP_0,    HIP_0   }},
-  {"rocsparse_dsbsrilu0_numeric_boost",                    {HIP_4050, HIP_0,    HIP_0   }},
-  {"rocsparse_zbsrilu0_numeric_boost",                     {HIP_3090, HIP_0,    HIP_0   }},
-  {"rocsparse_dbsrilu0_numeric_boost",                     {HIP_3090, HIP_0,    HIP_0   }},
-  {"rocsparse_zbsric0",                                    {HIP_3080, HIP_0,    HIP_0   }},
-  {"rocsparse_cbsric0",                                    {HIP_3080, HIP_0,    HIP_0   }},
-  {"rocsparse_dbsric0",                                    {HIP_3080, HIP_0,    HIP_0   }},
-  {"rocsparse_sbsric0",                                    {HIP_3080, HIP_0,    HIP_0   }},
-  {"rocsparse_zbsric0_analysis",                           {HIP_3060, HIP_0,    HIP_0   }},
-  {"rocsparse_cbsric0_analysis",                           {HIP_3060, HIP_0,    HIP_0   }},
-  {"rocsparse_dbsric0_analysis",                           {HIP_3060, HIP_0,    HIP_0   }},
-  {"rocsparse_sbsric0_analysis",                           {HIP_3060, HIP_0,    HIP_0   }},
-  {"rocsparse_zbsric0_buffer_size",                        {HIP_3080, HIP_0,    HIP_0   }},
-  {"rocsparse_cbsric0_buffer_size",                        {HIP_3080, HIP_0,    HIP_0   }},
-  {"rocsparse_dbsric0_buffer_size",                        {HIP_3080, HIP_0,    HIP_0   }},
-  {"rocsparse_sbsric0_buffer_size",                        {HIP_3080, HIP_0,    HIP_0   }},
-  {"rocsparse_bsric0_zero_pivot",                          {HIP_3080, HIP_0,    HIP_0   }},
-  {"rocsparse_csrgemm_nnz",                                {HIP_2080, HIP_0,    HIP_0   }},
-  {"rocsparse_zcsrgemm_buffer_size",                       {HIP_2080, HIP_0,    HIP_0   }},
-  {"rocsparse_ccsrgemm_buffer_size",                       {HIP_2080, HIP_0,    HIP_0   }},
-  {"rocsparse_dcsrgemm_buffer_size",                       {HIP_2080, HIP_0,    HIP_0   }},
-  {"rocsparse_scsrgemm_buffer_size",                       {HIP_2080, HIP_0,    HIP_0   }},
-  {"rocsparse_zcsrgeam",                                   {HIP_3050, HIP_0,    HIP_0   }},
-  {"rocsparse_ccsrgeam",                                   {HIP_3050, HIP_0,    HIP_0   }},
-  {"rocsparse_dcsrgeam",                                   {HIP_3050, HIP_0,    HIP_0   }},
-  {"rocsparse_scsrgeam",                                   {HIP_3050, HIP_0,    HIP_0   }},
-  {"rocsparse_csrgeam_nnz",                                {HIP_3050, HIP_0,    HIP_0   }},
-  {"rocsparse_zbsrsm_solve",                               {HIP_4050, HIP_0,    HIP_0   }},
-  {"rocsparse_cbsrsm_solve",                               {HIP_4050, HIP_0,    HIP_0   }},
-  {"rocsparse_dbsrsm_solve",                               {HIP_4050, HIP_0,    HIP_0   }},
-  {"rocsparse_sbsrsm_solve",                               {HIP_4050, HIP_0,    HIP_0   }},
-  {"rocsparse_zbsrsm_analysis",                            {HIP_3060, HIP_0,    HIP_0   }},
-  {"rocsparse_cbsrsm_analysis",                            {HIP_3060, HIP_0,    HIP_0   }},
-  {"rocsparse_dbsrsm_analysis",                            {HIP_3060, HIP_0,    HIP_0   }},
-  {"rocsparse_sbsrsm_analysis",                            {HIP_3060, HIP_0,    HIP_0   }},
-  {"rocsparse_zbsrsm_buffer_size",                         {HIP_4050, HIP_0,    HIP_0   }},
-  {"rocsparse_cbsrsm_buffer_size",                         {HIP_4050, HIP_0,    HIP_0   }},
-  {"rocsparse_dbsrsm_buffer_size",                         {HIP_4050, HIP_0,    HIP_0   }},
-  {"rocsparse_sbsrsm_buffer_size",                         {HIP_4050, HIP_0,    HIP_0   }},
-  {"rocsparse_bsrsm_zero_pivot",                           {HIP_4050, HIP_0,    HIP_0   }},
-  {"rocsparse_zcsrsm_solve",                               {HIP_3010, HIP_0,    HIP_0   }},
-  {"rocsparse_ccsrsm_solve",                               {HIP_3010, HIP_0,    HIP_0   }},
-  {"rocsparse_dcsrsm_solve",                               {HIP_3010, HIP_0,    HIP_0   }},
-  {"rocsparse_scsrsm_solve",                               {HIP_3010, HIP_0,    HIP_0   }},
-  {"rocsparse_scsrsm_analysis",                            {HIP_3010, HIP_0,    HIP_0   }},
-  {"rocsparse_dcsrsm_analysis",                            {HIP_3010, HIP_0,    HIP_0   }},
-  {"rocsparse_ccsrsm_analysis",                            {HIP_3010, HIP_0,    HIP_0   }},
-  {"rocsparse_zcsrsm_analysis",                            {HIP_3010, HIP_0,    HIP_0   }},
-  {"rocsparse_scsrsm_buffer_size",                         {HIP_3010, HIP_0,    HIP_0   }},
-  {"rocsparse_dcsrsm_buffer_size",                         {HIP_3010, HIP_0,    HIP_0   }},
-  {"rocsparse_ccsrsm_buffer_size",                         {HIP_3010, HIP_0,    HIP_0   }},
-  {"rocsparse_zcsrsm_buffer_size",                         {HIP_3010, HIP_0,    HIP_0   }},
-  {"rocsparse_csrsm_zero_pivot",                           {HIP_3010, HIP_0,    HIP_0   }},
-  {"rocsparse_zcsrmm",                                     {HIP_1090, HIP_0,    HIP_0   }},
-  {"rocsparse_ccsrmm",                                     {HIP_1090, HIP_0,    HIP_0   }},
-  {"rocsparse_dcsrmm",                                     {HIP_1090, HIP_0,    HIP_0   }},
-  {"rocsparse_scsrmm",                                     {HIP_1090, HIP_0,    HIP_0   }},
-  {"rocsparse_zbsrmm",                                     {HIP_3070, HIP_0,    HIP_0   }},
-  {"rocsparse_cbsrmm",                                     {HIP_3070, HIP_0,    HIP_0   }},
-  {"rocsparse_dbsrmm",                                     {HIP_3070, HIP_0,    HIP_0   }},
-  {"rocsparse_sbsrmm",                                     {HIP_3070, HIP_0,    HIP_0   }},
-  {"rocsparse_sgemvi",                                     {HIP_4030, HIP_0,    HIP_0   }},
-  {"rocsparse_dgemvi",                                     {HIP_4030, HIP_0,    HIP_0   }},
-  {"rocsparse_cgemvi",                                     {HIP_4030, HIP_0,    HIP_0   }},
-  {"rocsparse_zgemvi",                                     {HIP_4030, HIP_0,    HIP_0   }},
-  {"rocsparse_sgemvi_buffer_size",                         {HIP_4030, HIP_0,    HIP_0   }},
-  {"rocsparse_dgemvi_buffer_size",                         {HIP_4030, HIP_0,    HIP_0   }},
-  {"rocsparse_cgemvi_buffer_size",                         {HIP_4030, HIP_0,    HIP_0   }},
-  {"rocsparse_zgemvi_buffer_size",                         {HIP_4030, HIP_0,    HIP_0   }},
-  {"rocsparse_zhybmv",                                     {HIP_2100, HIP_0,    HIP_0   }},
-  {"rocsparse_chybmv",                                     {HIP_2100, HIP_0,    HIP_0   }},
-  {"rocsparse_dhybmv",                                     {HIP_1090, HIP_0,    HIP_0   }},
-  {"rocsparse_shybmv",                                     {HIP_1090, HIP_0,    HIP_0   }},
-  {"rocsparse_zcsrsv_solve",                               {HIP_2100, HIP_0,    HIP_0   }},
-  {"rocsparse_ccsrsv_solve",                               {HIP_2100, HIP_0,    HIP_0   }},
-  {"rocsparse_dcsrsv_solve",                               {HIP_1090, HIP_0,    HIP_0   }},
-  {"rocsparse_scsrsv_solve",                               {HIP_1090, HIP_0,    HIP_0   }},
-  {"rocsparse_zcsrsv_analysis",                            {HIP_2100, HIP_0,    HIP_0   }},
-  {"rocsparse_ccsrsv_analysis",                            {HIP_2100, HIP_0,    HIP_0   }},
-  {"rocsparse_dcsrsv_analysis",                            {HIP_1090, HIP_0,    HIP_0   }},
-  {"rocsparse_scsrsv_analysis",                            {HIP_1090, HIP_0,    HIP_0   }},
-  {"rocsparse_zcsrsv_buffer_size",                         {HIP_2100, HIP_0,    HIP_0   }},
-  {"rocsparse_ccsrsv_buffer_size",                         {HIP_2100, HIP_0,    HIP_0   }},
-  {"rocsparse_dcsrsv_buffer_size",                         {HIP_1090, HIP_0,    HIP_0   }},
-  {"rocsparse_scsrsv_buffer_size",                         {HIP_1090, HIP_0,    HIP_0   }},
-  {"rocsparse_csrsv_zero_pivot",                           {HIP_1090, HIP_0,    HIP_0   }},
-  {"rocsparse_zcsrmv",                                     {HIP_1090, HIP_0,    HIP_0   }},
-  {"rocsparse_ccsrmv",                                     {HIP_1090, HIP_0,    HIP_0   }},
-  {"rocsparse_dcsrmv",                                     {HIP_1090, HIP_0,    HIP_0   }},
-  {"rocsparse_scsrmv",                                     {HIP_1090, HIP_0,    HIP_0   }},
-  {"rocsparse_zbsrsv_solve",                               {HIP_3060, HIP_0,    HIP_0   }},
-  {"rocsparse_cbsrsv_solve",                               {HIP_3060, HIP_0,    HIP_0   }},
-  {"rocsparse_dbsrsv_solve",                               {HIP_3060, HIP_0,    HIP_0   }},
-  {"rocsparse_sbsrsv_solve",                               {HIP_3060, HIP_0,    HIP_0   }},
-  {"rocsparse_zbsrsv_analysis",                            {HIP_3060, HIP_0,    HIP_0   }},
-  {"rocsparse_cbsrsv_analysis",                            {HIP_3060, HIP_0,    HIP_0   }},
-  {"rocsparse_dbsrsv_analysis",                            {HIP_3060, HIP_0,    HIP_0   }},
-  {"rocsparse_sbsrsv_analysis",                            {HIP_3060, HIP_0,    HIP_0   }},
-  {"rocsparse_zbsrsv_buffer_size",                         {HIP_3060, HIP_0,    HIP_0   }},
-  {"rocsparse_cbsrsv_buffer_size",                         {HIP_3060, HIP_0,    HIP_0   }},
-  {"rocsparse_dbsrsv_buffer_size",                         {HIP_3060, HIP_0,    HIP_0   }},
-  {"rocsparse_sbsrsv_buffer_size",                         {HIP_3060, HIP_0,    HIP_0   }},
-  {"rocsparse_bsrsv_zero_pivot",                           {HIP_3060, HIP_0,    HIP_0   }},
-  {"rocsparse_zbsrxmv",                                    {HIP_4050, HIP_0,    HIP_0   }},
-  {"rocsparse_cbsrxmv",                                    {HIP_4050, HIP_0,    HIP_0   }},
-  {"rocsparse_dbsrxmv",                                    {HIP_4050, HIP_0,    HIP_0   }},
-  {"rocsparse_sbsrxmv",                                    {HIP_4050, HIP_0,    HIP_0   }},
-  {"rocsparse_zbsrmv",                                     {HIP_3050, HIP_5040, HIP_0   }},
-  {"rocsparse_cbsrmv",                                     {HIP_3050, HIP_5040, HIP_0   }},
-  {"rocsparse_dbsrmv",                                     {HIP_3050, HIP_5040, HIP_0   }},
-  {"rocsparse_sbsrmv",                                     {HIP_3050, HIP_5040, HIP_0   }},
-  {"rocsparse_zsctr",                                      {HIP_1090, HIP_0,    HIP_0   }},
-  {"rocsparse_csctr",                                      {HIP_1090, HIP_0,    HIP_0   }},
-  {"rocsparse_dsctr",                                      {HIP_1090, HIP_0,    HIP_0   }},
-  {"rocsparse_ssctr",                                      {HIP_1090, HIP_0,    HIP_0   }},
-  {"rocsparse_droti",                                      {HIP_1090, HIP_0,    HIP_0   }},
-  {"rocsparse_sroti",                                      {HIP_1090, HIP_0,    HIP_0   }},
-  {"rocsparse_zgthrz",                                     {HIP_1090, HIP_0,    HIP_0   }},
-  {"rocsparse_cgthrz",                                     {HIP_1090, HIP_0,    HIP_0   }},
-  {"rocsparse_dgthrz",                                     {HIP_1090, HIP_0,    HIP_0   }},
-  {"rocsparse_sgthrz",                                     {HIP_1090, HIP_0,    HIP_0   }},
-  {"rocsparse_sgthr",                                      {HIP_1090, HIP_0,    HIP_0   }},
-  {"rocsparse_dgthr",                                      {HIP_1090, HIP_0,    HIP_0   }},
-  {"rocsparse_cgthr",                                      {HIP_1090, HIP_0,    HIP_0   }},
-  {"rocsparse_zgthr",                                      {HIP_1090, HIP_0,    HIP_0   }},
-  {"rocsparse_cdotci",                                     {HIP_3000, HIP_0,    HIP_0   }},
-  {"rocsparse_zdotci",                                     {HIP_3000, HIP_0,    HIP_0   }},
-  {"rocsparse_sdoti",                                      {HIP_1090, HIP_0,    HIP_0   }},
-  {"rocsparse_ddoti",                                      {HIP_1090, HIP_0,    HIP_0   }},
-  {"rocsparse_cdoti",                                      {HIP_1090, HIP_0,    HIP_0   }},
-  {"rocsparse_zdoti",                                      {HIP_1090, HIP_0,    HIP_0   }},
-  {"rocsparse_saxpyi",                                     {HIP_1090, HIP_0,    HIP_0   }},
-  {"rocsparse_daxpyi",                                     {HIP_1090, HIP_0,    HIP_0   }},
-  {"rocsparse_caxpyi",                                     {HIP_1090, HIP_0,    HIP_0   }},
-  {"rocsparse_zaxpyi",                                     {HIP_1090, HIP_0,    HIP_0   }},
-  {"rocsparse_get_status_name",                            {HIP_6000, HIP_0,    HIP_0   }},
-  {"rocsparse_get_status_description",                     {HIP_6000, HIP_0,    HIP_0   }},
-  {"rocsparse_create_const_spvec_descr",                   {HIP_6000, HIP_0,    HIP_0   }},
-  {"rocsparse_const_spvec_get",                            {HIP_6000, HIP_0,    HIP_0   }},
-  {"rocsparse_const_spvec_get_values",                     {HIP_6000, HIP_0,    HIP_0   }},
-  {"rocsparse_create_const_coo_descr",                     {HIP_6000, HIP_0,    HIP_0   }},
-  {"rocsparse_create_const_csr_descr",                     {HIP_6000, HIP_0,    HIP_0   }},
-  {"rocsparse_create_const_csc_descr",                     {HIP_6000, HIP_0,    HIP_0   }},
-  {"rocsparse_create_const_bell_descr",                    {HIP_6000, HIP_0,    HIP_0   }},
-  {"rocsparse_const_coo_get",                              {HIP_6000, HIP_0,    HIP_0   }},
-  {"rocsparse_const_csr_get",                              {HIP_6000, HIP_0,    HIP_0   }},
-  {"rocsparse_const_csc_get",                              {HIP_6000, HIP_0,    HIP_0   }},
-  {"rocsparse_const_bell_get",                             {HIP_6000, HIP_0,    HIP_0   }},
-  {"rocsparse_const_spmat_get_values",                     {HIP_6000, HIP_0,    HIP_0   }},
-  {"rocsparse_create_const_dnvec_descr",                   {HIP_6000, HIP_0,    HIP_0   }},
-  {"rocsparse_const_dnvec_get",                            {HIP_6000, HIP_0,    HIP_0   }},
-  {"rocsparse_const_dnvec_get_values",                     {HIP_6000, HIP_0,    HIP_0   }},
-  {"rocsparse_create_const_dnmat_descr",                   {HIP_6000, HIP_0,    HIP_0   }},
-  {"rocsparse_const_dnmat_get",                            {HIP_6000, HIP_0,    HIP_0   }},
-  {"rocsparse_const_dnmat_get_values",                     {HIP_6000, HIP_0,    HIP_0   }},
-  {"rocsparse_create_mat_info",                            {HIP_1090, HIP_0,    HIP_0   }},
-  {"rocsparse_destroy_mat_info",                           {HIP_1090, HIP_0,    HIP_0   }},
-  {"rocsparse_scsrmm",                                     {HIP_1090, HIP_0,    HIP_0   }},
-  {"rocsparse_dcsrmm",                                     {HIP_1090, HIP_0,    HIP_0   }},
-  {"rocsparse_ccsrmm",                                     {HIP_1090, HIP_0,    HIP_0   }},
-  {"rocsparse_zcsrmm",                                     {HIP_1090, HIP_0,    HIP_0   }},
-  {"rocsparse_scsrgemm",                                   {HIP_2080, HIP_0,    HIP_0   }},
-  {"rocsparse_dcsrgemm",                                   {HIP_2080, HIP_0,    HIP_0   }},
-  {"rocsparse_ccsrgemm",                                   {HIP_2080, HIP_0,    HIP_0   }},
-  {"rocsparse_zcsrgemm",                                   {HIP_2080, HIP_0,    HIP_0   }},
-  {"rocsparse_sbsrilu0_buffer_size",                       {HIP_3080, HIP_0,    HIP_0   }},
-  {"rocsparse_dbsrilu0_buffer_size",                       {HIP_3080, HIP_0,    HIP_0   }},
-  {"rocsparse_cbsrilu0_buffer_size",                       {HIP_3080, HIP_0,    HIP_0   }},
-  {"rocsparse_zbsrilu0_buffer_size",                       {HIP_3080, HIP_0,    HIP_0   }},
-  {"rocsparse_csr2csc_buffer_size",                        {HIP_1090, HIP_0,    HIP_0   }},
-  {"rocsparse_sparse_to_dense",                            {HIP_4010, HIP_0,    HIP_0   }},
-  {"rocsparse_dense_to_sparse",                            {HIP_4010, HIP_0,    HIP_0   }},
-  {"rocsparse_spmm",                                       {HIP_4020, HIP_0,    HIP_0   }},
-  {"rocsparse_spsm",                                       {HIP_4050, HIP_0,    HIP_0   }},
-  {"rocsparse_spvv",                                       {HIP_4010, HIP_0,    HIP_0   }},
-  {"rocsparse_spsv",                                       {HIP_4050, HIP_0,    HIP_0   }},
-  {"rocsparse_csc_get",                                    {HIP_6010, HIP_0,    HIP_0   }},
-};
+  m["cusparseCreateCsrgemm2Info"]                                     = {CUDA_0,   CUDA_110, CUDA_120}; // D: CUSPARSE_VERSION 11000, R: CUSPARSE_VERSION 12000
+  m["cusparseDestroyCsrgemm2Info"]                                    = {CUDA_0,   CUDA_110, CUDA_120}; // D: CUSPARSE_VERSION 11000, R: CUSPARSE_VERSION 12000
+  m["cusparseCreateCsrsm2Info"]                                       = {CUDA_92,  CUDA_113, CUDA_120}; // D: CUSPARSE_VERSION 11600, R: CUSPARSE_VERSION 12000
+  m["cusparseDestroyCsrsm2Info"]                                      = {CUDA_92,  CUDA_113, CUDA_120}; // D: CUSPARSE_VERSION 11600, R: CUSPARSE_VERSION 12000
+  m["cusparseCreateHybMat"]                                           = {CUDA_0,   CUDA_102, CUDA_110};
+  m["cusparseDestroyHybMat"]                                          = {CUDA_0,   CUDA_102, CUDA_110};
+  m["cusparseCreatePruneInfo"]                                        = {CUDA_90,  CUDA_122, CUDA_0  }; // D: CUSPARSE_VERSION 12102
+  m["cusparseDestroyPruneInfo"]                                       = {CUDA_90,  CUDA_122, CUDA_0  }; // D: CUSPARSE_VERSION 12102
+  m["cusparseCreateSolveAnalysisInfo"]                                = {CUDA_0,   CUDA_102, CUDA_110};
+  m["cusparseDestroySolveAnalysisInfo"]                               = {CUDA_0,   CUDA_102, CUDA_110};
+  m["cusparseGetLevelInfo"]                                           = {CUDA_0,   CUDA_0,   CUDA_110};
+  m["cusparseSdoti"]                                                  = {CUDA_0,   CUDA_102, CUDA_110};
+  m["cusparseDdoti"]                                                  = {CUDA_0,   CUDA_102, CUDA_110};
+  m["cusparseCdoti"]                                                  = {CUDA_0,   CUDA_102, CUDA_110};
+  m["cusparseZdoti"]                                                  = {CUDA_0,   CUDA_102, CUDA_110};
+  m["cusparseCdotci"]                                                 = {CUDA_0,   CUDA_102, CUDA_110};
+  m["cusparseZdotci"]                                                 = {CUDA_0,   CUDA_102, CUDA_110};
+  m["cusparseScsrmv"]                                                 = {CUDA_0,   CUDA_102, CUDA_110};
+  m["cusparseDcsrmv"]                                                 = {CUDA_0,   CUDA_102, CUDA_110};
+  m["cusparseCcsrmv"]                                                 = {CUDA_0,   CUDA_102, CUDA_110};
+  m["cusparseZcsrmv"]                                                 = {CUDA_0,   CUDA_102, CUDA_110};
+  m["cusparseCsrmvEx"]                                                = {CUDA_80,  CUDA_112, CUDA_120};
+  m["cusparseCsrmvEx_bufferSize"]                                     = {CUDA_80,  CUDA_112, CUDA_120};
+  m["cusparseScsrmv_mp"]                                              = {CUDA_80,  CUDA_102, CUDA_110};
+  m["cusparseDcsrmv_mp"]                                              = {CUDA_80,  CUDA_102, CUDA_110};
+  m["cusparseCcsrmv_mp"]                                              = {CUDA_80,  CUDA_102, CUDA_110};
+  m["cusparseZcsrmv_mp"]                                              = {CUDA_80,  CUDA_102, CUDA_110};
+  m["cusparseSgemvi"]                                                 = {CUDA_75,  CUDA_128, CUDA_0  };
+  m["cusparseDgemvi"]                                                 = {CUDA_75,  CUDA_128, CUDA_0  };
+  m["cusparseCgemvi"]                                                 = {CUDA_75,  CUDA_128, CUDA_0  };
+  m["cusparseZgemvi"]                                                 = {CUDA_75,  CUDA_128, CUDA_0  };
+  m["cusparseSgemvi_bufferSize"]                                      = {CUDA_75,  CUDA_128, CUDA_0  };
+  m["cusparseDgemvi_bufferSize"]                                      = {CUDA_75,  CUDA_128, CUDA_0  };
+  m["cusparseCgemvi_bufferSize"]                                      = {CUDA_75,  CUDA_128, CUDA_0  };
+  m["cusparseZgemvi_bufferSize"]                                      = {CUDA_75,  CUDA_128, CUDA_0  };
+  m["cusparseScsrsv_solve"]                                           = {CUDA_0,   CUDA_102, CUDA_110};
+  m["cusparseDcsrsv_solve"]                                           = {CUDA_0,   CUDA_102, CUDA_110};
+  m["cusparseCcsrsv_solve"]                                           = {CUDA_0,   CUDA_102, CUDA_110};
+  m["cusparseZcsrsv_solve"]                                           = {CUDA_0,   CUDA_102, CUDA_110};
+  m["cusparseScsrsv_analysis"]                                        = {CUDA_0,   CUDA_102, CUDA_110};
+  m["cusparseDcsrsv_analysis"]                                        = {CUDA_0,   CUDA_102, CUDA_110};
+  m["cusparseCcsrsv_analysis"]                                        = {CUDA_0,   CUDA_102, CUDA_110};
+  m["cusparseZcsrsv_analysis"]                                        = {CUDA_0,   CUDA_102, CUDA_110};
+  m["cusparseCsrsv_analysisEx"]                                       = {CUDA_80,  CUDA_102, CUDA_110};
+  m["cusparseCsrsv_solveEx"]                                          = {CUDA_80,  CUDA_102, CUDA_110};
+  m["cusparseShybmv"]                                                 = {CUDA_0,   CUDA_102, CUDA_110};
+  m["cusparseDhybmv"]                                                 = {CUDA_0,   CUDA_102, CUDA_110};
+  m["cusparseChybmv"]                                                 = {CUDA_0,   CUDA_102, CUDA_110};
+  m["cusparseZhybmv"]                                                 = {CUDA_0,   CUDA_102, CUDA_110};
+  m["cusparseShybsv_analysis"]                                        = {CUDA_0,   CUDA_102, CUDA_110};
+  m["cusparseDhybsv_analysis"]                                        = {CUDA_0,   CUDA_102, CUDA_110};
+  m["cusparseChybsv_analysis"]                                        = {CUDA_0,   CUDA_102, CUDA_110};
+  m["cusparseZhybsv_analysis"]                                        = {CUDA_0,   CUDA_102, CUDA_110};
+  m["cusparseShybsv_solve"]                                           = {CUDA_0,   CUDA_102, CUDA_110};
+  m["cusparseDhybsv_solve"]                                           = {CUDA_0,   CUDA_102, CUDA_110};
+  m["cusparseChybsv_solve"]                                           = {CUDA_0,   CUDA_102, CUDA_110};
+  m["cusparseZhybsv_solve"]                                           = {CUDA_0,   CUDA_102, CUDA_110};
+  m["cusparseScsrmm"]                                                 = {CUDA_0,   CUDA_102, CUDA_110};
+  m["cusparseDcsrmm"]                                                 = {CUDA_0,   CUDA_102, CUDA_110};
+  m["cusparseCcsrmm"]                                                 = {CUDA_0,   CUDA_102, CUDA_110};
+  m["cusparseZcsrmm"]                                                 = {CUDA_0,   CUDA_102, CUDA_110};
+  m["cusparseScsrmm2"]                                                = {CUDA_0,   CUDA_102, CUDA_110};
+  m["cusparseDcsrmm2"]                                                = {CUDA_0,   CUDA_102, CUDA_110};
+  m["cusparseCcsrmm2"]                                                = {CUDA_0,   CUDA_102, CUDA_110};
+  m["cusparseZcsrmm2"]                                                = {CUDA_0,   CUDA_102, CUDA_110};
+  m["cusparseScsrsm_analysis"]                                        = {CUDA_0,   CUDA_102, CUDA_110};
+  m["cusparseDcsrsm_analysis"]                                        = {CUDA_0,   CUDA_102, CUDA_110};
+  m["cusparseCcsrsm_analysis"]                                        = {CUDA_0,   CUDA_102, CUDA_110};
+  m["cusparseZcsrsm_analysis"]                                        = {CUDA_0,   CUDA_102, CUDA_110};
+  m["cusparseScsrsm_solve"]                                           = {CUDA_0,   CUDA_102, CUDA_110};
+  m["cusparseDcsrsm_solve"]                                           = {CUDA_0,   CUDA_102, CUDA_110};
+  m["cusparseCcsrsm_solve"]                                           = {CUDA_0,   CUDA_102, CUDA_110};
+  m["cusparseZcsrsm_solve"]                                           = {CUDA_0,   CUDA_102, CUDA_110};
+  m["cusparseScsrsm2_bufferSizeExt"]                                  = {CUDA_92,  CUDA_113, CUDA_120};
+  m["cusparseDcsrsm2_bufferSizeExt"]                                  = {CUDA_92,  CUDA_113, CUDA_120};
+  m["cusparseCcsrsm2_bufferSizeExt"]                                  = {CUDA_92,  CUDA_113, CUDA_120};
+  m["cusparseZcsrsm2_bufferSizeExt"]                                  = {CUDA_92,  CUDA_113, CUDA_120};
+  m["cusparseScsrsm2_analysis"]                                       = {CUDA_92,  CUDA_113, CUDA_120};
+  m["cusparseDcsrsm2_analysis"]                                       = {CUDA_92,  CUDA_113, CUDA_120};
+  m["cusparseCcsrsm2_analysis"]                                       = {CUDA_92,  CUDA_113, CUDA_120};
+  m["cusparseZcsrsm2_analysis"]                                       = {CUDA_92,  CUDA_113, CUDA_120};
+  m["cusparseScsrsm2_solve"]                                          = {CUDA_92,  CUDA_113, CUDA_120};
+  m["cusparseDcsrsm2_solve"]                                          = {CUDA_92,  CUDA_113, CUDA_120};
+  m["cusparseCcsrsm2_solve"]                                          = {CUDA_92,  CUDA_113, CUDA_120};
+  m["cusparseZcsrsm2_solve"]                                          = {CUDA_92,  CUDA_113, CUDA_120};
+  m["cusparseXcsrsm2_zeroPivot"]                                      = {CUDA_92,  CUDA_113, CUDA_120};
+  m["cusparseSgemmi"]                                                 = {CUDA_80,  CUDA_110, CUDA_120};
+  m["cusparseDgemmi"]                                                 = {CUDA_80,  CUDA_110, CUDA_120};
+  m["cusparseCgemmi"]                                                 = {CUDA_80,  CUDA_110, CUDA_120};
+  m["cusparseZgemmi"]                                                 = {CUDA_80,  CUDA_110, CUDA_120};
+  m["cusparseScsrgeam"]                                               = {CUDA_0,   CUDA_102, CUDA_110};
+  m["cusparseDcsrgeam"]                                               = {CUDA_0,   CUDA_102, CUDA_110};
+  m["cusparseCcsrgeam"]                                               = {CUDA_0,   CUDA_102, CUDA_110};
+  m["cusparseZcsrgeam"]                                               = {CUDA_0,   CUDA_102, CUDA_110};
+  m["cusparseXcsrgeamNnz"]                                            = {CUDA_0,   CUDA_102, CUDA_110};
+  m["cusparseScsrgeam2"]                                              = {CUDA_100, CUDA_0,   CUDA_0  };
+  m["cusparseDcsrgeam2"]                                              = {CUDA_100, CUDA_0,   CUDA_0  };
+  m["cusparseCcsrgeam2"]                                              = {CUDA_100, CUDA_0,   CUDA_0  };
+  m["cusparseZcsrgeam2"]                                              = {CUDA_100, CUDA_0,   CUDA_0  };
+  m["cusparseXcsrgeam2Nnz"]                                           = {CUDA_100, CUDA_0,   CUDA_0  };
+  m["cusparseScsrgeam2_bufferSizeExt"]                                = {CUDA_100, CUDA_0,   CUDA_0  };
+  m["cusparseDcsrgeam2_bufferSizeExt"]                                = {CUDA_100, CUDA_0,   CUDA_0  };
+  m["cusparseCcsrgeam2_bufferSizeExt"]                                = {CUDA_100, CUDA_0,   CUDA_0  };
+  m["cusparseZcsrgeam2_bufferSizeExt"]                                = {CUDA_100, CUDA_0,   CUDA_0  };
+  m["cusparseScsrgemm"]                                               = {CUDA_0,   CUDA_102, CUDA_110};
+  m["cusparseDcsrgemm"]                                               = {CUDA_0,   CUDA_102, CUDA_110};
+  m["cusparseCcsrgemm"]                                               = {CUDA_0,   CUDA_102, CUDA_110};
+  m["cusparseZcsrgemm"]                                               = {CUDA_0,   CUDA_102, CUDA_110};
+  m["cusparseXcsrgemmNnz"]                                            = {CUDA_0,   CUDA_102, CUDA_110};
+  m["cusparseScsrgemm2"]                                              = {CUDA_0,   CUDA_110, CUDA_120};
+  m["cusparseDcsrgemm2"]                                              = {CUDA_0,   CUDA_110, CUDA_120};
+  m["cusparseCcsrgemm2"]                                              = {CUDA_0,   CUDA_110, CUDA_120};
+  m["cusparseZcsrgemm2"]                                              = {CUDA_0,   CUDA_110, CUDA_120};
+  m["cusparseXcsrgemm2Nnz"]                                           = {CUDA_0,   CUDA_110, CUDA_120};
+  m["cusparseScsrgemm2_bufferSizeExt"]                                = {CUDA_0,   CUDA_110, CUDA_120};
+  m["cusparseDcsrgemm2_bufferSizeExt"]                                = {CUDA_0,   CUDA_110, CUDA_120};
+  m["cusparseCcsrgemm2_bufferSizeExt"]                                = {CUDA_0,   CUDA_110, CUDA_120};
+  m["cusparseZcsrgemm2_bufferSizeExt"]                                = {CUDA_0,   CUDA_110, CUDA_120};
+  m["cusparseScsric0"]                                                = {CUDA_0,   CUDA_102, CUDA_110};
+  m["cusparseDcsric0"]                                                = {CUDA_0,   CUDA_102, CUDA_110};
+  m["cusparseCcsric0"]                                                = {CUDA_0,   CUDA_102, CUDA_110};
+  m["cusparseZcsric0"]                                                = {CUDA_0,   CUDA_102, CUDA_110};
+  m["cusparseScsrilu0"]                                               = {CUDA_0,   CUDA_102, CUDA_110};
+  m["cusparseDcsrilu0"]                                               = {CUDA_0,   CUDA_102, CUDA_110};
+  m["cusparseCcsrilu0"]                                               = {CUDA_0,   CUDA_102, CUDA_110};
+  m["cusparseZcsrilu0"]                                               = {CUDA_0,   CUDA_102, CUDA_110};
+  m["cusparseCsrilu0Ex"]                                              = {CUDA_80,  CUDA_102, CUDA_110};
+  m["cusparseSgtsv"]                                                  = {CUDA_0,   CUDA_102, CUDA_110};
+  m["cusparseDgtsv"]                                                  = {CUDA_0,   CUDA_102, CUDA_110};
+  m["cusparseCgtsv"]                                                  = {CUDA_0,   CUDA_102, CUDA_110};
+  m["cusparseZgtsv"]                                                  = {CUDA_0,   CUDA_102, CUDA_110};
+  m["cusparseSgtsv_nopivot"]                                          = {CUDA_0,   CUDA_102, CUDA_110};
+  m["cusparseDgtsv_nopivot"]                                          = {CUDA_0,   CUDA_102, CUDA_110};
+  m["cusparseCgtsv_nopivot"]                                          = {CUDA_0,   CUDA_102, CUDA_110};
+  m["cusparseZgtsv_nopivot"]                                          = {CUDA_0,   CUDA_102, CUDA_110};
+  m["cusparseSgtsv2_bufferSizeExt"]                                   = {CUDA_90,  CUDA_0,   CUDA_0  };
+  m["cusparseDgtsv2_bufferSizeExt"]                                   = {CUDA_90,  CUDA_0,   CUDA_0  };
+  m["cusparseCgtsv2_bufferSizeExt"]                                   = {CUDA_90,  CUDA_0,   CUDA_0  };
+  m["cusparseZgtsv2_bufferSizeExt"]                                   = {CUDA_90,  CUDA_0,   CUDA_0  };
+  m["cusparseSgtsv2"]                                                 = {CUDA_90,  CUDA_0,   CUDA_0  };
+  m["cusparseDgtsv2"]                                                 = {CUDA_90,  CUDA_0,   CUDA_0  };
+  m["cusparseCgtsv2"]                                                 = {CUDA_90,  CUDA_0,   CUDA_0  };
+  m["cusparseZgtsv2"]                                                 = {CUDA_90,  CUDA_0,   CUDA_0  };
+  m["cusparseSgtsv2_nopivot_bufferSizeExt"]                           = {CUDA_90,  CUDA_0,   CUDA_0  };
+  m["cusparseDgtsv2_nopivot_bufferSizeExt"]                           = {CUDA_90,  CUDA_0,   CUDA_0  };
+  m["cusparseCgtsv2_nopivot_bufferSizeExt"]                           = {CUDA_90,  CUDA_0,   CUDA_0  };
+  m["cusparseZgtsv2_nopivot_bufferSizeExt"]                           = {CUDA_90,  CUDA_0,   CUDA_0  };
+  m["cusparseSgtsv2_nopivot"]                                         = {CUDA_90,  CUDA_0,   CUDA_0  };
+  m["cusparseDgtsv2_nopivot"]                                         = {CUDA_90,  CUDA_0,   CUDA_0  };
+  m["cusparseCgtsv2_nopivot"]                                         = {CUDA_90,  CUDA_0,   CUDA_0  };
+  m["cusparseZgtsv2_nopivot"]                                         = {CUDA_90,  CUDA_0,   CUDA_0  };
+  m["cusparseSgtsvStridedBatch"]                                      = {CUDA_0,   CUDA_102, CUDA_110};
+  m["cusparseDgtsvStridedBatch"]                                      = {CUDA_0,   CUDA_102, CUDA_110};
+  m["cusparseCgtsvStridedBatch"]                                      = {CUDA_0,   CUDA_102, CUDA_110};
+  m["cusparseZgtsvStridedBatch"]                                      = {CUDA_0,   CUDA_102, CUDA_110};
+  m["cusparseSgtsv2StridedBatch_bufferSizeExt"]                       = {CUDA_90,  CUDA_0,   CUDA_0  };
+  m["cusparseDgtsv2StridedBatch_bufferSizeExt"]                       = {CUDA_90,  CUDA_0,   CUDA_0  };
+  m["cusparseCgtsv2StridedBatch_bufferSizeExt"]                       = {CUDA_90,  CUDA_0,   CUDA_0  };
+  m["cusparseZgtsv2StridedBatch_bufferSizeExt"]                       = {CUDA_90,  CUDA_0,   CUDA_0  };
+  m["cusparseSgtsv2StridedBatch"]                                     = {CUDA_90,  CUDA_0,   CUDA_0  };
+  m["cusparseDgtsv2StridedBatch"]                                     = {CUDA_90,  CUDA_0,   CUDA_0  };
+  m["cusparseCgtsv2StridedBatch"]                                     = {CUDA_90,  CUDA_0,   CUDA_0  };
+  m["cusparseZgtsv2StridedBatch"]                                     = {CUDA_90,  CUDA_0,   CUDA_0  };
+  m["cusparseSgtsvInterleavedBatch_bufferSizeExt"]                    = {CUDA_92,  CUDA_0,   CUDA_0  };
+  m["cusparseDgtsvInterleavedBatch_bufferSizeExt"]                    = {CUDA_92,  CUDA_0,   CUDA_0  };
+  m["cusparseCgtsvInterleavedBatch_bufferSizeExt"]                    = {CUDA_92,  CUDA_0,   CUDA_0  };
+  m["cusparseZgtsvInterleavedBatch_bufferSizeExt"]                    = {CUDA_92,  CUDA_0,   CUDA_0  };
+  m["cusparseSgtsvInterleavedBatch"]                                  = {CUDA_92,  CUDA_0,   CUDA_0  };
+  m["cusparseDgtsvInterleavedBatch"]                                  = {CUDA_92,  CUDA_0,   CUDA_0  };
+  m["cusparseCgtsvInterleavedBatch"]                                  = {CUDA_92,  CUDA_0,   CUDA_0  };
+  m["cusparseZgtsvInterleavedBatch"]                                  = {CUDA_92,  CUDA_0,   CUDA_0  };
+  m["cusparseSgpsvInterleavedBatch_bufferSizeExt"]                    = {CUDA_92,  CUDA_0,   CUDA_0  };
+  m["cusparseDgpsvInterleavedBatch_bufferSizeExt"]                    = {CUDA_92,  CUDA_0,   CUDA_0  };
+  m["cusparseCgpsvInterleavedBatch_bufferSizeExt"]                    = {CUDA_92,  CUDA_0,   CUDA_0  };
+  m["cusparseZgpsvInterleavedBatch_bufferSizeExt"]                    = {CUDA_92,  CUDA_0,   CUDA_0  };
+  m["cusparseSgpsvInterleavedBatch"]                                  = {CUDA_92,  CUDA_0,   CUDA_0  };
+  m["cusparseDgpsvInterleavedBatch"]                                  = {CUDA_92,  CUDA_0,   CUDA_0  };
+  m["cusparseCgpsvInterleavedBatch"]                                  = {CUDA_92,  CUDA_0,   CUDA_0  };
+  m["cusparseZgpsvInterleavedBatch"]                                  = {CUDA_92,  CUDA_0,   CUDA_0  };
+  m["cusparseScsc2hyb"]                                               = {CUDA_0,   CUDA_102, CUDA_110};
+  m["cusparseDcsc2hyb"]                                               = {CUDA_0,   CUDA_102, CUDA_110};
+  m["cusparseCcsc2hyb"]                                               = {CUDA_0,   CUDA_102, CUDA_110};
+  m["cusparseZcsc2hyb"]                                               = {CUDA_0,   CUDA_102, CUDA_110};
+  m["cusparseCsr2cscEx"]                                              = {CUDA_80,  CUDA_102, CUDA_110};
+  m["cusparseCsr2cscEx2"]                                             = {CUDA_101, CUDA_0,   CUDA_0  };
+  m["cusparseCsr2cscEx2_bufferSize"]                                  = {CUDA_101, CUDA_0,   CUDA_0  };
+  m["cusparseScsr2csr_compress"]                                      = {CUDA_80,  CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseDcsr2csr_compress"]                                      = {CUDA_80,  CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseCcsr2csr_compress"]                                      = {CUDA_80,  CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseZcsr2csr_compress"]                                      = {CUDA_80,  CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseScsr2hyb"]                                               = {CUDA_0,   CUDA_102, CUDA_110};
+  m["cusparseDcsr2hyb"]                                               = {CUDA_0,   CUDA_102, CUDA_110};
+  m["cusparseCcsr2hyb"]                                               = {CUDA_0,   CUDA_102, CUDA_110};
+  m["cusparseZcsr2hyb"]                                               = {CUDA_0,   CUDA_102, CUDA_110};
+  m["cusparseSdense2hyb"]                                             = {CUDA_0,   CUDA_102, CUDA_110};
+  m["cusparseDdense2hyb"]                                             = {CUDA_0,   CUDA_102, CUDA_110};
+  m["cusparseCdense2hyb"]                                             = {CUDA_0,   CUDA_102, CUDA_110};
+  m["cusparseZdense2hyb"]                                             = {CUDA_0,   CUDA_102, CUDA_110};
+  m["cusparseShyb2csc"]                                               = {CUDA_0,   CUDA_102, CUDA_110};
+  m["cusparseDhyb2csc"]                                               = {CUDA_0,   CUDA_102, CUDA_110};
+  m["cusparseChyb2csc"]                                               = {CUDA_0,   CUDA_102, CUDA_110};
+  m["cusparseZhyb2csc"]                                               = {CUDA_0,   CUDA_102, CUDA_110};
+  m["cusparseShyb2csr"]                                               = {CUDA_0,   CUDA_102, CUDA_110};
+  m["cusparseDhyb2csr"]                                               = {CUDA_0,   CUDA_102, CUDA_110};
+  m["cusparseChyb2csr"]                                               = {CUDA_0,   CUDA_102, CUDA_110};
+  m["cusparseZhyb2csr"]                                               = {CUDA_0,   CUDA_102, CUDA_110};
+  m["cusparseShyb2dense"]                                             = {CUDA_0,   CUDA_102, CUDA_110};
+  m["cusparseDhyb2dense"]                                             = {CUDA_0,   CUDA_102, CUDA_110};
+  m["cusparseChyb2dense"]                                             = {CUDA_0,   CUDA_102, CUDA_110};
+  m["cusparseZhyb2dense"]                                             = {CUDA_0,   CUDA_102, CUDA_110};
+  m["cusparseHpruneDense2csr"]                                        = {CUDA_90,  CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseSpruneDense2csr"]                                        = {CUDA_90,  CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseDpruneDense2csr"]                                        = {CUDA_90,  CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseHpruneDense2csr_bufferSizeExt"]                          = {CUDA_90,  CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseSpruneDense2csr_bufferSizeExt"]                          = {CUDA_90,  CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseDpruneDense2csr_bufferSizeExt"]                          = {CUDA_90,  CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseHpruneDense2csrNnz"]                                     = {CUDA_90,  CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseSpruneDense2csrNnz"]                                     = {CUDA_90,  CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseDpruneDense2csrNnz"]                                     = {CUDA_90,  CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseHpruneCsr2csr"]                                          = {CUDA_90,  CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseSpruneCsr2csr"]                                          = {CUDA_90,  CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseDpruneCsr2csr"]                                          = {CUDA_90,  CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseHpruneCsr2csr_bufferSizeExt"]                            = {CUDA_90,  CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseSpruneCsr2csr_bufferSizeExt"]                            = {CUDA_90,  CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseDpruneCsr2csr_bufferSizeExt"]                            = {CUDA_90,  CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseHpruneCsr2csrNnz"]                                       = {CUDA_90,  CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseSpruneCsr2csrNnz"]                                       = {CUDA_90,  CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseDpruneCsr2csrNnz"]                                       = {CUDA_90,  CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseHpruneDense2csrByPercentage"]                            = {CUDA_90,  CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseSpruneDense2csrByPercentage"]                            = {CUDA_90,  CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseDpruneDense2csrByPercentage"]                            = {CUDA_90,  CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseHpruneDense2csrByPercentage_bufferSizeExt"]              = {CUDA_90,  CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseSpruneDense2csrByPercentage_bufferSizeExt"]              = {CUDA_90,  CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseDpruneDense2csrByPercentage_bufferSizeExt"]              = {CUDA_90,  CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseHpruneDense2csrNnzByPercentage"]                         = {CUDA_90,  CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseSpruneDense2csrNnzByPercentage"]                         = {CUDA_90,  CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseDpruneDense2csrNnzByPercentage"]                         = {CUDA_90,  CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseHpruneCsr2csrByPercentage"]                              = {CUDA_90,  CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseSpruneCsr2csrByPercentage"]                              = {CUDA_90,  CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseDpruneCsr2csrByPercentage"]                              = {CUDA_90,  CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseHpruneCsr2csrByPercentage_bufferSizeExt"]                = {CUDA_90,  CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseSpruneCsr2csrByPercentage_bufferSizeExt"]                = {CUDA_90,  CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseDpruneCsr2csrByPercentage_bufferSizeExt"]                = {CUDA_90,  CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseHpruneCsr2csrNnzByPercentage"]                           = {CUDA_90,  CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseSpruneCsr2csrNnzByPercentage"]                           = {CUDA_90,  CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseDpruneCsr2csrNnzByPercentage"]                           = {CUDA_90,  CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseSnnz_compress"]                                          = {CUDA_80,  CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseDnnz_compress"]                                          = {CUDA_80,  CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseCnnz_compress"]                                          = {CUDA_80,  CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseZnnz_compress"]                                          = {CUDA_80,  CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseGetStream"]                                              = {CUDA_80,  CUDA_0,   CUDA_0  };
+  m["cusparseCreateCoo"]                                              = {CUDA_101, CUDA_0,   CUDA_0  };
+  m["cusparseCreateCooAoS"]                                           = {CUDA_102, CUDA_112, CUDA_120};
+  m["cusparseCreateCsr"]                                              = {CUDA_102, CUDA_0,   CUDA_0  };
+  m["cusparseDestroySpMat"]                                           = {CUDA_101, CUDA_0,   CUDA_0  };
+  m["cusparseCooGet"]                                                 = {CUDA_101, CUDA_0,   CUDA_0  };
+  m["cusparseCooAoSGet"]                                              = {CUDA_102, CUDA_112, CUDA_120};
+  m["cusparseCsrGet"]                                                 = {CUDA_102, CUDA_0,   CUDA_0  };
+  m["cusparseSpMatGetFormat"]                                         = {CUDA_101, CUDA_0,   CUDA_0  };
+  m["cusparseSpMatGetIndexBase"]                                      = {CUDA_101, CUDA_0,   CUDA_0  };
+  m["cusparseSpMatGetValues"]                                         = {CUDA_102, CUDA_0,   CUDA_0  };
+  m["cusparseSpMatSetValues"]                                         = {CUDA_102, CUDA_0,   CUDA_0  };
+  m["cusparseSpMatGetStridedBatch"]                                   = {CUDA_102, CUDA_0,   CUDA_0  };
+  m["cusparseSpMatSetStridedBatch"]                                   = {CUDA_102, CUDA_0,   CUDA_120};
+  m["cusparseSpMatSetNumBatches"]                                     = {CUDA_101, CUDA_0,   CUDA_102};
+  m["cusparseSpMatGetNumBatches"]                                     = {CUDA_101, CUDA_0,   CUDA_102};
+  m["cusparseCreateSpVec"]                                            = {CUDA_102, CUDA_0,   CUDA_0  };
+  m["cusparseDestroySpVec"]                                           = {CUDA_102, CUDA_0,   CUDA_0  };
+  m["cusparseSpVecGet"]                                               = {CUDA_102, CUDA_0,   CUDA_0  };
+  m["cusparseSpVecGetIndexBase"]                                      = {CUDA_102, CUDA_0,   CUDA_0  };
+  m["cusparseSpVecGetValues"]                                         = {CUDA_102, CUDA_0,   CUDA_0  };
+  m["cusparseSpVecSetValues"]                                         = {CUDA_102, CUDA_0,   CUDA_0  };
+  m["cusparseCreateDnMat"]                                            = {CUDA_101, CUDA_0,   CUDA_0  };
+  m["cusparseDestroyDnMat"]                                           = {CUDA_101, CUDA_0,   CUDA_0  };
+  m["cusparseDnMatGet"]                                               = {CUDA_101, CUDA_0,   CUDA_0  };
+  m["cusparseDnMatGetValues"]                                         = {CUDA_102, CUDA_0,   CUDA_0  };
+  m["cusparseDnMatSetValues"]                                         = {CUDA_102, CUDA_0,   CUDA_0  };
+  m["cusparseDnMatSetStridedBatch"]                                   = {CUDA_101, CUDA_0,   CUDA_0  };
+  m["cusparseDnMatGetStridedBatch"]                                   = {CUDA_101, CUDA_0,   CUDA_0  };
+  m["cusparseCreateDnVec"]                                            = {CUDA_102, CUDA_0,   CUDA_0  };
+  m["cusparseDestroyDnVec"]                                           = {CUDA_102, CUDA_0,   CUDA_0  };
+  m["cusparseDnVecGet"]                                               = {CUDA_102, CUDA_0,   CUDA_0  };
+  m["cusparseDnVecGetValues"]                                         = {CUDA_102, CUDA_0,   CUDA_0  };
+  m["cusparseDnVecSetValues"]                                         = {CUDA_102, CUDA_0,   CUDA_0  };
+  m["cusparseSpMM"]                                                   = {CUDA_101, CUDA_0,   CUDA_0  }; // A: CUDA_VERSION 10010 C: CUSPARSE_VERSION 12000
+  m["cusparseSpMM_bufferSize"]                                        = {CUDA_101, CUDA_0,   CUDA_0  }; // A: CUDA_VERSION 10010 C: CUSPARSE_VERSION 12000
+  m["cusparseSpVV"]                                                   = {CUDA_101, CUDA_128, CUDA_0  }; // A: CUSPARSE_VERSION 10200 C: CUSPARSE_VERSION 12000
+  m["cusparseSpVV_bufferSize"]                                        = {CUDA_101, CUDA_128, CUDA_0  }; // A: CUSPARSE_VERSION 10200 C: CUSPARSE_VERSION 12000
+  m["cusparseSpMV"]                                                   = {CUDA_101, CUDA_0,   CUDA_0  }; // A: CUSPARSE_VERSION 10200 C: CUSPARSE_VERSION 12000
+  m["cusparseSpMV_bufferSize"]                                        = {CUDA_101, CUDA_0,   CUDA_0  }; // A: CUSPARSE_VERSION 10200 C: CUSPARSE_VERSION 12000
+  m["cusparseSaxpyi"]                                                 = {CUDA_0,   CUDA_110, CUDA_120};
+  m["cusparseDaxpyi"]                                                 = {CUDA_0,   CUDA_110, CUDA_120};
+  m["cusparseCaxpyi"]                                                 = {CUDA_0,   CUDA_110, CUDA_120};
+  m["cusparseZaxpyi"]                                                 = {CUDA_0,   CUDA_110, CUDA_120};
+  m["cusparseSgthr"]                                                  = {CUDA_0,   CUDA_110, CUDA_120};
+  m["cusparseDgthr"]                                                  = {CUDA_0,   CUDA_110, CUDA_120};
+  m["cusparseCgthr"]                                                  = {CUDA_0,   CUDA_110, CUDA_120};
+  m["cusparseZgthr"]                                                  = {CUDA_0,   CUDA_110, CUDA_120};
+  m["cusparseSgthrz"]                                                 = {CUDA_0,   CUDA_110, CUDA_120};
+  m["cusparseDgthrz"]                                                 = {CUDA_0,   CUDA_110, CUDA_120};
+  m["cusparseCgthrz"]                                                 = {CUDA_0,   CUDA_110, CUDA_120};
+  m["cusparseZgthrz"]                                                 = {CUDA_0,   CUDA_110, CUDA_120};
+  m["cusparseSsctr"]                                                  = {CUDA_0,   CUDA_110, CUDA_120};
+  m["cusparseDsctr"]                                                  = {CUDA_0,   CUDA_110, CUDA_120};
+  m["cusparseCsctr"]                                                  = {CUDA_0,   CUDA_110, CUDA_120};
+  m["cusparseZsctr"]                                                  = {CUDA_0,   CUDA_110, CUDA_120};
+  m["cusparseSroti"]                                                  = {CUDA_0,   CUDA_110, CUDA_120};
+  m["cusparseDroti"]                                                  = {CUDA_0,   CUDA_110, CUDA_120};
+  m["cusparseScsr2csc"]                                               = {CUDA_0,   CUDA_102, CUDA_110};
+  m["cusparseDcsr2csc"]                                               = {CUDA_0,   CUDA_102, CUDA_110};
+  m["cusparseCcsr2csc"]                                               = {CUDA_0,   CUDA_102, CUDA_110};
+  m["cusparseZcsr2csc"]                                               = {CUDA_0,   CUDA_102, CUDA_110};
+  m["cusparseSpMatGetSize"]                                           = {CUDA_110, CUDA_0,   CUDA_0  };
+  m["cusparseCooSetStridedBatch"]                                     = {CUDA_110, CUDA_0,   CUDA_0  };
+  m["cusparseCsrSetStridedBatch"]                                     = {CUDA_110, CUDA_0,   CUDA_0  };
+  m["cusparseAxpby"]                                                  = {CUDA_110, CUDA_128, CUDA_0  };
+  m["cusparseGather"]                                                 = {CUDA_110, CUDA_0,   CUDA_0  };
+  m["cusparseScatter"]                                                = {CUDA_110, CUDA_0,   CUDA_0  };
+  m["cusparseRot"]                                                    = {CUDA_110, CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseSpGEMM_createDescr"]                                     = {CUDA_110, CUDA_0,   CUDA_0  };
+  m["cusparseSpGEMM_destroyDescr"]                                    = {CUDA_110, CUDA_0,   CUDA_0  };
+  m["cusparseSpGEMM_compute"]                                         = {CUDA_110, CUDA_0,   CUDA_0  };
+  m["cusparseSpGEMM_copy"]                                            = {CUDA_110, CUDA_0,   CUDA_0  };
+  m["cusparseSpGEMM_workEstimation"]                                  = {CUDA_110, CUDA_0,   CUDA_0  };
+  m["cusparseConstrainedGeMM"]                                        = {CUDA_102, CUDA_112, CUDA_120};
+  m["cusparseConstrainedGeMM_bufferSize"]                             = {CUDA_102, CUDA_112, CUDA_120};
+  m["cusparseSdense2csr"]                                             = {CUDA_0,   CUDA_111, CUDA_120};
+  m["cusparseDdense2csr"]                                             = {CUDA_0,   CUDA_111, CUDA_120};
+  m["cusparseCdense2csr"]                                             = {CUDA_0,   CUDA_111, CUDA_120};
+  m["cusparseZdense2csr"]                                             = {CUDA_0,   CUDA_111, CUDA_120};
+  m["cusparseScsr2dense"]                                             = {CUDA_0,   CUDA_111, CUDA_120};
+  m["cusparseDcsr2dense"]                                             = {CUDA_0,   CUDA_111, CUDA_120};
+  m["cusparseCcsr2dense"]                                             = {CUDA_0,   CUDA_111, CUDA_120};
+  m["cusparseZcsr2dense"]                                             = {CUDA_0,   CUDA_111, CUDA_120};
+  m["cusparseSdense2csc"]                                             = {CUDA_0,   CUDA_111, CUDA_120};
+  m["cusparseDdense2csc"]                                             = {CUDA_0,   CUDA_111, CUDA_120};
+  m["cusparseCdense2csc"]                                             = {CUDA_0,   CUDA_111, CUDA_120};
+  m["cusparseZdense2csc"]                                             = {CUDA_0,   CUDA_111, CUDA_120};
+  m["cusparseScsc2dense"]                                             = {CUDA_0,   CUDA_111, CUDA_120};
+  m["cusparseDcsc2dense"]                                             = {CUDA_0,   CUDA_111, CUDA_120};
+  m["cusparseCcsc2dense"]                                             = {CUDA_0,   CUDA_111, CUDA_120};
+  m["cusparseZcsc2dense"]                                             = {CUDA_0,   CUDA_111, CUDA_120};
+  m["cusparseCreateCsc"]                                              = {CUDA_111, CUDA_0,   CUDA_0  };
+  m["cusparseCsrSetPointers"]                                         = {CUDA_110, CUDA_0,   CUDA_0  };
+  m["cusparseCscSetPointers"]                                         = {CUDA_111, CUDA_0,   CUDA_0  };
+  m["cusparseCooSetPointers"]                                         = {CUDA_111, CUDA_0,   CUDA_0  };
+  m["cusparseSparseToDense_bufferSize"]                               = {CUDA_111, CUDA_0,   CUDA_0  }; // A: CUSPARSE_VERSION 11300 C: CUSPARSE_VERSION 12000
+  m["cusparseSparseToDense"]                                          = {CUDA_111, CUDA_0,   CUDA_0  }; // A: CUSPARSE_VERSION 11300 C: CUSPARSE_VERSION 12000
+  m["cusparseDenseToSparse_bufferSize"]                               = {CUDA_111, CUDA_0,   CUDA_0  }; // A: CUSPARSE_VERSION 11300 C: CUSPARSE_VERSION 12000
+  m["cusparseDenseToSparse_analysis"]                                 = {CUDA_111, CUDA_0,   CUDA_0  }; // A: CUSPARSE_VERSION 11300 C: CUSPARSE_VERSION 12000
+  m["cusparseDenseToSparse_convert"]                                  = {CUDA_111, CUDA_0,   CUDA_0  };
+  m["cusparseCreateCsrsv2Info"]                                       = {CUDA_0,   CUDA_113, CUDA_120}; // D: CUSPARSE_VERSION 11500 R: CUSPARSE_VERSION 12000
+  m["cusparseDestroyCsrsv2Info"]                                      = {CUDA_0,   CUDA_113, CUDA_120}; // D: CUSPARSE_VERSION 11500 R: CUSPARSE_VERSION 12000
+  m["cusparseXcsrsv2_zeroPivot"]                                      = {CUDA_0,   CUDA_113, CUDA_120};
+  m["cusparseScsrsv2_bufferSize"]                                     = {CUDA_0,   CUDA_113, CUDA_120}; // D: CUSPARSE_VERSION 11500 R: CUSPARSE_VERSION 12000
+  m["cusparseDcsrsv2_bufferSize"]                                     = {CUDA_0,   CUDA_113, CUDA_120}; // D: CUSPARSE_VERSION 11500 R: CUSPARSE_VERSION 12000
+  m["cusparseCcsrsv2_bufferSize"]                                     = {CUDA_0,   CUDA_113, CUDA_120}; // D: CUSPARSE_VERSION 11500 R: CUSPARSE_VERSION 12000
+  m["cusparseZcsrsv2_bufferSize"]                                     = {CUDA_0,   CUDA_113, CUDA_120}; // D: CUSPARSE_VERSION 11500 R: CUSPARSE_VERSION 12000
+  m["cusparseScsrsv2_bufferSizeExt"]                                  = {CUDA_0,   CUDA_113, CUDA_120};
+  m["cusparseDcsrsv2_bufferSizeExt"]                                  = {CUDA_0,   CUDA_113, CUDA_120};
+  m["cusparseCcsrsv2_bufferSizeExt"]                                  = {CUDA_0,   CUDA_113, CUDA_120};
+  m["cusparseZcsrsv2_bufferSizeExt"]                                  = {CUDA_0,   CUDA_113, CUDA_120};
+  m["cusparseScsrsv2_analysis"]                                       = {CUDA_0,   CUDA_113, CUDA_120};
+  m["cusparseDcsrsv2_analysis"]                                       = {CUDA_0,   CUDA_113, CUDA_120};
+  m["cusparseCcsrsv2_analysis"]                                       = {CUDA_0,   CUDA_113, CUDA_120};
+  m["cusparseZcsrsv2_analysis"]                                       = {CUDA_0,   CUDA_113, CUDA_120};
+  m["cusparseScsrsv2_solve"]                                          = {CUDA_0,   CUDA_113, CUDA_120};
+  m["cusparseDcsrsv2_solve"]                                          = {CUDA_0,   CUDA_113, CUDA_120};
+  m["cusparseCcsrsv2_solve"]                                          = {CUDA_0,   CUDA_113, CUDA_120};
+  m["cusparseZcsrsv2_solve"]                                          = {CUDA_0,   CUDA_113, CUDA_120};
+  m["cusparseSpMatGetAttribute"]                                      = {CUDA_113, CUDA_0,   CUDA_0  };
+  m["cusparseSpMatSetAttribute"]                                      = {CUDA_113, CUDA_0,   CUDA_0  };
+  m["cusparseSpSV_createDescr"]                                       = {CUDA_113, CUDA_0,   CUDA_0  };
+  m["cusparseSpSV_destroyDescr"]                                      = {CUDA_113, CUDA_0,   CUDA_0  };
+  m["cusparseSpSV_bufferSize"]                                        = {CUDA_113, CUDA_0,   CUDA_0  };
+  m["cusparseSpSV_analysis"]                                          = {CUDA_113, CUDA_0,   CUDA_0  };
+  m["cusparseSpSV_solve"]                                             = {CUDA_113, CUDA_0,   CUDA_0  };
+  m["cusparseSpSM_createDescr"]                                       = {CUDA_113, CUDA_0,   CUDA_0  };
+  m["cusparseSpSM_destroyDescr"]                                      = {CUDA_113, CUDA_0,   CUDA_0  };
+  m["cusparseSpSM_bufferSize"]                                        = {CUDA_113, CUDA_0,   CUDA_0  };
+  m["cusparseSpSM_analysis"]                                          = {CUDA_113, CUDA_0,   CUDA_0  };
+  m["cusparseSpSM_solve"]                                             = {CUDA_113, CUDA_0,   CUDA_0  };
+  m["cusparseSpGEMMreuse_workEstimation"]                             = {CUDA_113, CUDA_0,   CUDA_0  };
+  m["cusparseSpGEMMreuse_nnz"]                                        = {CUDA_113, CUDA_0,   CUDA_0  };
+  m["cusparseSpGEMMreuse_copy"]                                       = {CUDA_113, CUDA_0,   CUDA_0  };
+  m["cusparseSpGEMMreuse_compute"]                                    = {CUDA_113, CUDA_0,   CUDA_0  };
+  m["cusparseSDDMM"]                                                  = {CUDA_112, CUDA_0,   CUDA_0  };
+  m["cusparseSDDMM_bufferSize"]                                       = {CUDA_112, CUDA_0,   CUDA_0  };
+  m["cusparseSDDMM_preprocess"]                                       = {CUDA_112, CUDA_0,   CUDA_0  };
+  m["cusparseCreateBlockedEll"]                                       = {CUDA_112, CUDA_0,   CUDA_0  };
+  m["cusparseBlockedEllGet"]                                          = {CUDA_112, CUDA_0,   CUDA_0  };
+  m["cusparseSpMM_preprocess"]                                        = {CUDA_112, CUDA_0,   CUDA_0  };
+  m["cusparseLoggerSetCallback"]                                      = {CUDA_115, CUDA_0,   CUDA_0  };
+  m["cusparseLoggerSetFile"]                                          = {CUDA_115, CUDA_0,   CUDA_0  };
+  m["cusparseLoggerOpenFile"]                                         = {CUDA_115, CUDA_0,   CUDA_0  };
+  m["cusparseLoggerSetLevel"]                                         = {CUDA_115, CUDA_0,   CUDA_0  };
+  m["cusparseLoggerSetMask"]                                          = {CUDA_115, CUDA_0,   CUDA_0  };
+  m["cusparseLoggerForceDisable"]                                     = {CUDA_115, CUDA_0,   CUDA_0  };
+  m["cusparseSpMMOp"]                                                 = {CUDA_115, CUDA_0,   CUDA_0  };
+  m["cusparseSpMMOp_createPlan"]                                      = {CUDA_115, CUDA_0,   CUDA_0  };
+  m["cusparseSpMMOp_destroyPlan"]                                     = {CUDA_115, CUDA_0,   CUDA_0  };
+  m["cusparseCscGet"]                                                 = {CUDA_117, CUDA_0,   CUDA_0  };
+  m["cusparseCopyMatDescr"]                                           = {CUDA_80,  CUDA_0,   CUDA_120};
+  m["cusparseCreateConstSpVec"]                                       = {CUDA_120, CUDA_0,   CUDA_0  };
+  m["cusparseConstSpVecGet"]                                          = {CUDA_120, CUDA_0,   CUDA_0  };
+  m["cusparseConstSpVecGetValues"]                                    = {CUDA_120, CUDA_0,   CUDA_0  };
+  m["cusparseCreateConstDnVec"]                                       = {CUDA_120, CUDA_0,   CUDA_0  };
+  m["cusparseConstDnVecGet"]                                          = {CUDA_120, CUDA_0,   CUDA_0  };
+  m["cusparseConstDnVecGetValues"]                                    = {CUDA_120, CUDA_0,   CUDA_0  };
+  m["cusparseConstSpMatGetValues"]                                    = {CUDA_120, CUDA_0,   CUDA_0  };
+  m["cusparseCreateConstCsr"]                                         = {CUDA_120, CUDA_0,   CUDA_0  };
+  m["cusparseCreateConstCsc"]                                         = {CUDA_120, CUDA_0,   CUDA_0  };
+  m["cusparseConstCsrGet"]                                            = {CUDA_120, CUDA_0,   CUDA_0  };
+  m["cusparseConstCscGet"]                                            = {CUDA_120, CUDA_0,   CUDA_0  };
+  m["cusparseCreateConstCoo"]                                         = {CUDA_120, CUDA_0,   CUDA_0  };
+  m["cusparseConstCooGet"]                                            = {CUDA_120, CUDA_0,   CUDA_0  };
+  m["cusparseCreateConstBlockedEll"]                                  = {CUDA_120, CUDA_0,   CUDA_0  };
+  m["cusparseConstBlockedEllGet"]                                     = {CUDA_120, CUDA_0,   CUDA_0  };
+  m["cusparseCreateConstDnMat"]                                       = {CUDA_120, CUDA_0,   CUDA_0  };
+  m["cusparseConstDnMatGet"]                                          = {CUDA_120, CUDA_0,   CUDA_0  };
+  m["cusparseConstDnMatGetValues"]                                    = {CUDA_120, CUDA_0,   CUDA_0  };
+  m["cusparseSpGEMM_getNumProducts"]                                  = {CUDA_120, CUDA_0,   CUDA_0  };
+  m["cusparseSpGEMM_estimateMemory"]                                  = {CUDA_120, CUDA_0,   CUDA_0  };
+  m["cusparseBsrSetStridedBatch"]                                     = {CUDA_121, CUDA_0,   CUDA_0  }; // CUSPARSE_VERSION 12100
+  m["cusparseCreateBsr"]                                              = {CUDA_121, CUDA_0,   CUDA_0  }; // CUSPARSE_VERSION 12100
+  m["cusparseCreateConstBsr"]                                         = {CUDA_121, CUDA_0,   CUDA_0  }; // CUSPARSE_VERSION 12100
+  m["cusparseCreateSlicedEll"]                                        = {CUDA_121, CUDA_0,   CUDA_0  }; // CUSPARSE_VERSION 12100
+  m["cusparseCreateConstSlicedEll"]                                   = {CUDA_121, CUDA_0,   CUDA_0  }; // CUSPARSE_VERSION 12100
+  m["cusparseSpSV_updateMatrix"]                                      = {CUDA_121, CUDA_0,   CUDA_0  }; // CUSPARSE_VERSION 12100
+  m["cusparseCreateCsric02Info"]                                      = {CUDA_0,   CUDA_122, CUDA_0  }; // D: CUSPARSE_VERSION 12102
+  m["cusparseDestroyCsric02Info"]                                     = {CUDA_0,   CUDA_122, CUDA_0  }; // D: CUSPARSE_VERSION 12102
+  m["cusparseCreateBsric02Info"]                                      = {CUDA_0,   CUDA_122, CUDA_0  }; // D: CUSPARSE_VERSION 12102
+  m["cusparseDestroyBsric02Info"]                                     = {CUDA_0,   CUDA_122, CUDA_0  }; // D: CUSPARSE_VERSION 12102
+  m["cusparseCreateCsrilu02Info"]                                     = {CUDA_0,   CUDA_122, CUDA_0  }; // D: CUSPARSE_VERSION 12102
+  m["cusparseDestroyCsrilu02Info"]                                    = {CUDA_0,   CUDA_122, CUDA_0  }; // D: CUSPARSE_VERSION 12102
+  m["cusparseCreateBsrilu02Info"]                                     = {CUDA_0,   CUDA_122, CUDA_0  }; // D: CUSPARSE_VERSION 12102
+  m["cusparseDestroyBsrilu02Info"]                                    = {CUDA_0,   CUDA_122, CUDA_0  }; // D: CUSPARSE_VERSION 12102
+  m["cusparseCreateBsrsv2Info"]                                       = {CUDA_0,   CUDA_122, CUDA_0  }; // D: CUSPARSE_VERSION 12102
+  m["cusparseDestroyBsrsv2Info"]                                      = {CUDA_0,   CUDA_122, CUDA_0  }; // D: CUSPARSE_VERSION 12102
+  m["cusparseCreateBsrsm2Info"]                                       = {CUDA_0,   CUDA_122, CUDA_0  }; // D: CUSPARSE_VERSION 12102
+  m["cusparseDestroyBsrsm2Info"]                                      = {CUDA_0,   CUDA_122, CUDA_0  }; // D: CUSPARSE_VERSION 12102
+  m["cusparseCreateCsru2csrInfo"]                                     = {CUDA_0,   CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseDestroyCsru2csrInfo"]                                    = {CUDA_0,   CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseCreateColorInfo"]                                        = {CUDA_0,   CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseDestroyColorInfo"]                                       = {CUDA_0,   CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseSbsrxmv"]                                                = {CUDA_0,   CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseDbsrxmv"]                                                = {CUDA_0,   CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseCbsrxmv"]                                                = {CUDA_0,   CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseZbsrxmv"]                                                = {CUDA_0,   CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseXbsrsv2_zeroPivot"]                                      = {CUDA_0,   CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseSbsrsv2_bufferSize"]                                     = {CUDA_0,   CUDA_122, CUDA_0  }; // D: CUSPARSE_VERSION 12102
+  m["cusparseDbsrsv2_bufferSize"]                                     = {CUDA_0,   CUDA_122, CUDA_0  }; // D: CUSPARSE_VERSION 12102
+  m["cusparseCbsrsv2_bufferSize"]                                     = {CUDA_0,   CUDA_122, CUDA_0  }; // D: CUSPARSE_VERSION 12102
+  m["cusparseZbsrsv2_bufferSize"]                                     = {CUDA_0,   CUDA_122, CUDA_0  }; // D: CUSPARSE_VERSION 12102
+  m["cusparseSbsrsv2_bufferSizeExt"]                                  = {CUDA_0,   CUDA_122, CUDA_0  }; // D: CUSPARSE_VERSION 12102
+  m["cusparseDbsrsv2_bufferSizeExt"]                                  = {CUDA_0,   CUDA_122, CUDA_0  }; // D: CUSPARSE_VERSION 12102
+  m["cusparseCbsrsv2_bufferSizeExt"]                                  = {CUDA_0,   CUDA_122, CUDA_0  }; // D: CUSPARSE_VERSION 12102
+  m["cusparseZbsrsv2_bufferSizeExt"]                                  = {CUDA_0,   CUDA_122, CUDA_0  }; // D: CUSPARSE_VERSION 12102
+  m["cusparseSbsrsv2_analysis"]                                       = {CUDA_0,   CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseDbsrsv2_analysis"]                                       = {CUDA_0,   CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseCbsrsv2_analysis"]                                       = {CUDA_0,   CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseZbsrsv2_analysis"]                                       = {CUDA_0,   CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseSbsrsv2_solve"]                                          = {CUDA_0,   CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseDbsrsv2_solve"]                                          = {CUDA_0,   CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseCbsrsv2_solve"]                                          = {CUDA_0,   CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseZbsrsv2_solve"]                                          = {CUDA_0,   CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseXbsrsm2_zeroPivot"]                                      = {CUDA_0,   CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseSbsrsm2_bufferSize"]                                     = {CUDA_0,   CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseDbsrsm2_bufferSize"]                                     = {CUDA_0,   CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseCbsrsm2_bufferSize"]                                     = {CUDA_0,   CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseZbsrsm2_bufferSize"]                                     = {CUDA_0,   CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseSbsrsm2_bufferSizeExt"]                                  = {CUDA_0,   CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseDbsrsm2_bufferSizeExt"]                                  = {CUDA_0,   CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseCbsrsm2_bufferSizeExt"]                                  = {CUDA_0,   CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseZbsrsm2_bufferSizeExt"]                                  = {CUDA_0,   CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseSbsrsm2_analysis"]                                       = {CUDA_0,   CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseDbsrsm2_analysis"]                                       = {CUDA_0,   CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseCbsrsm2_analysis"]                                       = {CUDA_0,   CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseZbsrsm2_analysis"]                                       = {CUDA_0,   CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseSbsrsm2_solve"]                                          = {CUDA_0,   CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseDbsrsm2_solve"]                                          = {CUDA_0,   CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseCbsrsm2_solve"]                                          = {CUDA_0,   CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseZbsrsm2_solve"]                                          = {CUDA_0,   CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseScsrilu02_numericBoost"]                                 = {CUDA_0,   CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseDcsrilu02_numericBoost"]                                 = {CUDA_0,   CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseCcsrilu02_numericBoost"]                                 = {CUDA_0,   CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseZcsrilu02_numericBoost"]                                 = {CUDA_0,   CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseXcsrilu02_zeroPivot"]                                    = {CUDA_0,   CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseScsrilu02_bufferSize"]                                   = {CUDA_0,   CUDA_122, CUDA_0  }; // D: CUSPARSE_VERSION 12102
+  m["cusparseDcsrilu02_bufferSize"]                                   = {CUDA_0,   CUDA_122, CUDA_0  }; // D: CUSPARSE_VERSION 12102
+  m["cusparseCcsrilu02_bufferSize"]                                   = {CUDA_0,   CUDA_122, CUDA_0  }; // D: CUSPARSE_VERSION 12102
+  m["cusparseZcsrilu02_bufferSize"]                                   = {CUDA_0,   CUDA_122, CUDA_0  }; // D: CUSPARSE_VERSION 12102
+  m["cusparseScsrilu02_bufferSizeExt"]                                = {CUDA_0,   CUDA_122, CUDA_0  }; // D: CUSPARSE_VERSION 12102
+  m["cusparseDcsrilu02_bufferSizeExt"]                                = {CUDA_0,   CUDA_122, CUDA_0  }; // D: CUSPARSE_VERSION 12102
+  m["cusparseCcsrilu02_bufferSizeExt"]                                = {CUDA_0,   CUDA_122, CUDA_0  }; // D: CUSPARSE_VERSION 12102
+  m["cusparseZcsrilu02_bufferSizeExt"]                                = {CUDA_0,   CUDA_122, CUDA_0  }; // D: CUSPARSE_VERSION 12102
+  m["cusparseScsrilu02_analysis"]                                     = {CUDA_0,   CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseDcsrilu02_analysis"]                                     = {CUDA_0,   CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseCcsrilu02_analysis"]                                     = {CUDA_0,   CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseZcsrilu02_analysis"]                                     = {CUDA_0,   CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseScsrilu02"]                                              = {CUDA_0,   CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseDcsrilu02"]                                              = {CUDA_0,   CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseCcsrilu02"]                                              = {CUDA_0,   CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseZcsrilu02"]                                              = {CUDA_0,   CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseSbsrilu02_numericBoost"]                                 = {CUDA_0,   CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseDbsrilu02_numericBoost"]                                 = {CUDA_0,   CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseCbsrilu02_numericBoost"]                                 = {CUDA_0,   CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseZbsrilu02_numericBoost"]                                 = {CUDA_0,   CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseXbsrilu02_zeroPivot"]                                    = {CUDA_0,   CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseSbsrilu02_bufferSize"]                                   = {CUDA_0,   CUDA_122, CUDA_0  }; // D: CUSPARSE_VERSION 12102
+  m["cusparseDbsrilu02_bufferSize"]                                   = {CUDA_0,   CUDA_122, CUDA_0  }; // D: CUSPARSE_VERSION 12102
+  m["cusparseCbsrilu02_bufferSize"]                                   = {CUDA_0,   CUDA_122, CUDA_0  }; // D: CUSPARSE_VERSION 12102
+  m["cusparseZbsrilu02_bufferSize"]                                   = {CUDA_0,   CUDA_122, CUDA_0  }; // D: CUSPARSE_VERSION 12102
+  m["cusparseSbsrilu02_bufferSizeExt"]                                = {CUDA_0,   CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseDbsrilu02_bufferSizeExt"]                                = {CUDA_0,   CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseCbsrilu02_bufferSizeExt"]                                = {CUDA_0,   CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseZbsrilu02_bufferSizeExt"]                                = {CUDA_0,   CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseSbsrilu02_analysis"]                                     = {CUDA_0,   CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseDbsrilu02_analysis"]                                     = {CUDA_0,   CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseCbsrilu02_analysis"]                                     = {CUDA_0,   CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseZbsrilu02_analysis"]                                     = {CUDA_0,   CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseSbsrilu02"]                                              = {CUDA_0,   CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseDbsrilu02"]                                              = {CUDA_0,   CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseCbsrilu02"]                                              = {CUDA_0,   CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseZbsrilu02"]                                              = {CUDA_0,   CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseXcsric02_zeroPivot"]                                     = {CUDA_0,   CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseScsric02_bufferSize"]                                    = {CUDA_0,   CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseDcsric02_bufferSize"]                                    = {CUDA_0,   CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseCcsric02_bufferSize"]                                    = {CUDA_0,   CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseZcsric02_bufferSize"]                                    = {CUDA_0,   CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseScsric02_bufferSizeExt"]                                 = {CUDA_0,   CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseDcsric02_bufferSizeExt"]                                 = {CUDA_0,   CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseCcsric02_bufferSizeExt"]                                 = {CUDA_0,   CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseZcsric02_bufferSizeExt"]                                 = {CUDA_0,   CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseScsric02_analysis"]                                      = {CUDA_0,   CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseDcsric02_analysis"]                                      = {CUDA_0,   CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseCcsric02_analysis"]                                      = {CUDA_0,   CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseZcsric02_analysis"]                                      = {CUDA_0,   CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseScsric02"]                                               = {CUDA_0,   CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseDcsric02"]                                               = {CUDA_0,   CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseCcsric02"]                                               = {CUDA_0,   CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseZcsric02"]                                               = {CUDA_0,   CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseXcsric02_zeroPivot"]                                     = {CUDA_0,   CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseSbsric02_bufferSize"]                                    = {CUDA_0,   CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseDbsric02_bufferSize"]                                    = {CUDA_0,   CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseCbsric02_bufferSize"]                                    = {CUDA_0,   CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseZbsric02_bufferSize"]                                    = {CUDA_0,   CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseSbsric02_bufferSizeExt"]                                 = {CUDA_0,   CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseDbsric02_bufferSizeExt"]                                 = {CUDA_0,   CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseCbsric02_bufferSizeExt"]                                 = {CUDA_0,   CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseZbsric02_bufferSizeExt"]                                 = {CUDA_0,   CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseSbsric02_analysis"]                                      = {CUDA_0,   CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseDbsric02_analysis"]                                      = {CUDA_0,   CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseCbsric02_analysis"]                                      = {CUDA_0,   CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseZbsric02_analysis"]                                      = {CUDA_0,   CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseSbsric02"]                                               = {CUDA_0,   CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseDbsric02"]                                               = {CUDA_0,   CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseCbsric02"]                                               = {CUDA_0,   CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseZbsric02"]                                               = {CUDA_0,   CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseScsrcolor"]                                              = {CUDA_0,   CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseDcsrcolor"]                                              = {CUDA_0,   CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseCcsrcolor"]                                              = {CUDA_0,   CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseZcsrcolor"]                                              = {CUDA_0,   CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseCreateIdentityPermutation"]                              = {CUDA_0,   CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseScsru2csr_bufferSizeExt"]                                = {CUDA_0,   CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseDcsru2csr_bufferSizeExt"]                                = {CUDA_0,   CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseCcsru2csr_bufferSizeExt"]                                = {CUDA_0,   CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseZcsru2csr_bufferSizeExt"]                                = {CUDA_0,   CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseScsru2csr"]                                              = {CUDA_0,   CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseDcsru2csr"]                                              = {CUDA_0,   CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseCcsru2csr"]                                              = {CUDA_0,   CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseZcsru2csr"]                                              = {CUDA_0,   CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseScsr2csru"]                                              = {CUDA_0,   CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseDcsr2csru"]                                              = {CUDA_0,   CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseCcsr2csru"]                                              = {CUDA_0,   CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseZcsr2csru"]                                              = {CUDA_0,   CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseXbsric02_zeroPivot"]                                     = {CUDA_0,   CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseGetErrorName"]                                           = {CUDA_102, CUDA_0,   CUDA_0  }; // CUSPARSE_VERSION 10301
+  m["cusparseGetErrorString"]                                         = {CUDA_102, CUDA_0,   CUDA_0  }; // CUSPARSE_VERSION 10301
+  m["cusparseXcsr2bsrNnz"]                                            = {CUDA_0,   CUDA_124, CUDA_0  };
+  m["cusparseScsr2bsr"]                                               = {CUDA_0,   CUDA_124, CUDA_0  };
+  m["cusparseDcsr2bsr"]                                               = {CUDA_0,   CUDA_124, CUDA_0  };
+  m["cusparseCcsr2bsr"]                                               = {CUDA_0,   CUDA_124, CUDA_0  };
+  m["cusparseZcsr2bsr"]                                               = {CUDA_0,   CUDA_124, CUDA_0  };
+  m["cusparseXgebsr2csr"]                                             = {CUDA_0,   CUDA_124, CUDA_0  };
+  m["cusparseSgebsr2csr"]                                             = {CUDA_0,   CUDA_124, CUDA_0  };
+  m["cusparseDgebsr2csr"]                                             = {CUDA_0,   CUDA_124, CUDA_0  };
+  m["cusparseCgebsr2csr"]                                             = {CUDA_0,   CUDA_124, CUDA_0  };
+  m["cusparseZgebsr2csr"]                                             = {CUDA_0,   CUDA_124, CUDA_0  };
+  m["cusparseSpMV_preprocess"]                                        = {CUDA_124, CUDA_0,   CUDA_0  };
+  m["cusparseSpSM_updateMatrix"]                                      = {CUDA_124, CUDA_0,   CUDA_0  };
+  m["cusparseSbsrmm"]                                                 = {CUDA_0,   CUDA_128, CUDA_0  };
+  m["cusparseDbsrmm"]                                                 = {CUDA_0,   CUDA_128, CUDA_0  };
+  m["cusparseCbsrmm"]                                                 = {CUDA_0,   CUDA_128, CUDA_0  };
+  m["cusparseZbsrmm"]                                                 = {CUDA_0,   CUDA_128, CUDA_0  };
+  m["cusparseSbsr2csr"]                                               = {CUDA_0,   CUDA_128, CUDA_0  };
+  m["cusparseDbsr2csr"]                                               = {CUDA_0,   CUDA_128, CUDA_0  };
+  m["cusparseCbsr2csr"]                                               = {CUDA_0,   CUDA_128, CUDA_0  };
+  m["cusparseZbsr2csr"]                                               = {CUDA_0,   CUDA_128, CUDA_0  };
+  m["cusparseSgebsr2gebsr_bufferSize"]                                = {CUDA_0,   CUDA_128, CUDA_0  };
+  m["cusparseSgebsr2gebsr_bufferSizeExt"]                             = {CUDA_0,   CUDA_128, CUDA_0  };
+  m["cusparseDgebsr2gebsr_bufferSize"]                                = {CUDA_0,   CUDA_128, CUDA_0  };
+  m["cusparseDgebsr2gebsr_bufferSizeExt"]                             = {CUDA_0,   CUDA_128, CUDA_0  };
+  m["cusparseCgebsr2gebsr_bufferSize"]                                = {CUDA_0,   CUDA_128, CUDA_0  };
+  m["cusparseCgebsr2gebsr_bufferSizeExt"]                             = {CUDA_0,   CUDA_128, CUDA_0  };
+  m["cusparseZgebsr2gebsr_bufferSize"]                                = {CUDA_0,   CUDA_128, CUDA_0  };
+  m["cusparseZgebsr2gebsr_bufferSizeExt"]                             = {CUDA_0,   CUDA_128, CUDA_0  };
+  m[ "cusparseXgebsr2gebsrNnz"]                                       = {CUDA_0,   CUDA_128, CUDA_0  };
+  m["cusparseSgebsr2gebsr"]                                           = {CUDA_0,   CUDA_128, CUDA_0  };
+  m["cusparseDgebsr2gebsr"]                                           = {CUDA_0,   CUDA_128, CUDA_0  };
+  m["cusparseCgebsr2gebsr"]                                           = {CUDA_0,   CUDA_128, CUDA_0  };
+  m["cusparseZgebsr2gebsr"]                                           = {CUDA_0,   CUDA_128, CUDA_0  };
 
-const std::map<llvm::StringRef, cudaAPIChangedVersions> CUDA_SPARSE_FUNCTION_CHANGED_VER_MAP {
-  {"cusparseSpVecGetIndexBase",                            {CUDA_120}},
-  {"cusparseDestroySpVec",                                 {CUDA_120}},
-  {"cusparseDestroyDnVec",                                 {CUDA_120}},
-  {"cusparseSpMatGetAttribute",                            {CUDA_120}},
-  {"cusparseSpMatGetFormat",                               {CUDA_120}},
-  {"cusparseSpMatGetSize",                                 {CUDA_120}},
-  {"cusparseSpMatGetIndexBase",                            {CUDA_120}},
-  {"cusparseSpMatGetStridedBatch",                         {CUDA_120}},
-  {"cusparseDestroySpMat",                                 {CUDA_120}},
-  {"cusparseSpGEMM_compute",                               {CUDA_120}},
-  {"cusparseSpGEMM_copy",                                  {CUDA_120}},
-  {"cusparseSpGEMM_workEstimation",                        {CUDA_120}},
-  {"cusparseSpGEMMreuse_compute",                          {CUDA_120}},
-  {"cusparseSpGEMMreuse_copy",                             {CUDA_120}},
-  {"cusparseSpGEMMreuse_nnz",                              {CUDA_120}},
-  {"cusparseSpGEMMreuse_workEstimation",                   {CUDA_120}},
-  {"cusparseDnMatGetStridedBatch",                         {CUDA_120}},
-  {"cusparseDestroyDnMat",                                 {CUDA_120}},
-  {"cusparseSpMM",                                         {CUDA_120}},
-  {"cusparseSpMM_bufferSize",                              {CUDA_120}},
-  {"cusparseSpMM_preprocess",                              {CUDA_120}},
-  {"cusparseSpMV",                                         {CUDA_120}},
-  {"cusparseSpMV_bufferSize",                              {CUDA_120}},
-  {"cusparseSpSM_analysis",                                {CUDA_120}},
-  {"cusparseSpSM_bufferSize",                              {CUDA_120}},
-  {"cusparseSpSM_solve",                                   {CUDA_120}},
-  {"cusparseSpSV_analysis",                                {CUDA_120}},
-  {"cusparseSpSV_bufferSize",                              {CUDA_120}},
-  {"cusparseSpSV_solve",                                   {CUDA_120}},
-  {"cusparseSpVV",                                         {CUDA_120}},
-  {"cusparseSpVV_bufferSize",                              {CUDA_120}},
-  {"cusparseSDDMM",                                        {CUDA_120}},
-  {"cusparseSDDMM_bufferSize",                             {CUDA_120}},
-  {"cusparseSDDMM_preprocess",                             {CUDA_120}},
-  {"cusparseAxpby",                                        {CUDA_120}},
-  {"cusparseGather",                                       {CUDA_120}},
-  {"cusparseScatter",                                      {CUDA_120}},
-  {"cusparseSparseToDense",                                {CUDA_120}}, // C: CUSPARSE_VERSION 12000
-  {"cusparseSparseToDense_bufferSize",                     {CUDA_120}},
-  {"cusparseDenseToSparse_analysis",                       {CUDA_120}},
-  {"cusparseDenseToSparse_bufferSize",                     {CUDA_120}},
-  {"cusparseDenseToSparse_convert",                        {CUDA_120}},
-};
+  return m;
+}();
 
-const std::map<llvm::StringRef, hipAPIChangedVersions> HIP_SPARSE_FUNCTION_CHANGED_VER_MAP {
-  {"hipsparseSpVecGetIndexBase",                           {HIP_6000}},
-  {"hipsparseDestroySpVec",                                {HIP_6000}},
-  {"hipsparseDestroyDnVec",                                {HIP_6000}},
-  {"hipsparseSpMatGetAttribute",                           {HIP_6000}},
-  {"hipsparseSpMatGetFormat",                              {HIP_6000}},
-  {"hipsparseSpMatGetSize",                                {HIP_6000}},
-  {"hipsparseSpMatGetIndexBase",                           {HIP_6000}},
-  {"hipsparseSpMatGetStridedBatch",                        {HIP_6000}},
-  {"hipsparseDestroySpMat",                                {HIP_6000}},
-  {"hipsparseSpGEMM_compute",                              {HIP_6000}},
-  {"hipsparseSpGEMM_copy",                                 {HIP_6000}},
-  {"hipsparseSpGEMM_workEstimation",                       {HIP_6000}},
-  {"hipsparseSpGEMMreuse_compute",                         {HIP_6000}},
-  {"hipsparseSpGEMMreuse_copy",                            {HIP_6000}},
-  {"hipsparseSpGEMMreuse_nnz",                             {HIP_6000}},
-  {"hipsparseSpGEMMreuse_workEstimation",                  {HIP_6000}},
-  {"hipsparseDnMatGetStridedBatch",                        {HIP_6000}},
-  {"hipsparseDestroyDnMat",                                {HIP_6000}},
-  {"hipsparseSpMM",                                        {HIP_6000}},
-  {"hipsparseSpMM_bufferSize",                             {HIP_6000}},
-  {"hipsparseSpMM_preprocess",                             {HIP_6000}},
-  {"hipsparseSpMV",                                        {HIP_6000}},
-  {"hipsparseSpMV_bufferSize",                             {HIP_6000}},
-  {"hipsparseSpSM_analysis",                               {HIP_6000}},
-  {"hipsparseSpSM_bufferSize",                             {HIP_6000}},
-  {"hipsparseSpSM_solve",                                  {HIP_6000}},
-  {"hipsparseSpSV_analysis",                               {HIP_6000}},
-  {"hipsparseSpSV_bufferSize",                             {HIP_6000}},
-  {"hipsparseSpSV_solve",                                  {HIP_6000}},
-  {"hipsparseSpVV",                                        {HIP_6000}},
-  {"hipsparseSpVV_bufferSize",                             {HIP_6000}},
-  {"hipsparseSDDMM",                                       {HIP_6000}},
-  {"hipsparseSDDMM_bufferSize",                            {HIP_6000}},
-  {"hipsparseSDDMM_preprocess",                            {HIP_6000}},
-  {"hipsparseAxpby",                                       {HIP_6000}},
-  {"hipsparseGather",                                      {HIP_6000}},
-  {"hipsparseScatter",                                     {HIP_6000}},
-  {"hipsparseSparseToDense",                               {HIP_6000}},
-  {"hipsparseSparseToDense_bufferSize",                    {HIP_6000}},
-  {"hipsparseDenseToSparse_analysis",                      {HIP_6000}},
-  {"hipsparseDenseToSparse_bufferSize",                    {HIP_6000}},
-  {"hipsparseDenseToSparse_convert",                       {HIP_6000}},
-  {"hipsparseSpMV_preprocess",                             {HIP_6000}},
+const std::map<llvm::StringRef, hipAPIversions> HIP_SPARSE_FUNCTION_VER_MAP = [] {
+  std::map<llvm::StringRef, hipAPIversions> m;
 
-  {"rocsparse_destroy_spvec_descr",                        {HIP_6000}},
-  {"rocsparse_spvec_get_index_base",                       {HIP_6000}},
-  {"rocsparse_destroy_spmat_descr",                        {HIP_6000}},
-  {"rocsparse_spmat_get_size",                             {HIP_6000}},
-  {"rocsparse_spmat_get_format",                           {HIP_6000}},
-  {"rocsparse_spmat_get_index_base",                       {HIP_6000}},
-  {"rocsparse_spmat_get_strided_batch",                    {HIP_6000}},
-  {"rocsparse_spmat_get_attribute",                        {HIP_6000}},
-  {"rocsparse_destroy_dnvec_descr",                        {HIP_6000}},
-  {"rocsparse_destroy_dnmat_descr",                        {HIP_6000}},
-  {"rocsparse_dnmat_get_strided_batch",                    {HIP_6000}},
-  {"rocsparse_sparse_to_dense",                            {HIP_6000}},
-  {"rocsparse_dense_to_sparse",                            {HIP_6000}},
-  {"rocsparse_spmm",                                       {HIP_6000}},
-  {"rocsparse_spsm",                                       {HIP_6000}},
-  {"rocsparse_spvv",                                       {HIP_6000}},
-  {"rocsparse_spmv",                                       {HIP_6000}},
-  {"rocsparse_scatter",                                    {HIP_6000}},
-  {"rocsparse_gather",                                     {HIP_6000}},
-  {"rocsparse_axpby",                                      {HIP_6000}},
-  {"rocsparse_sddmm",                                      {HIP_6000}},
-  {"rocsparse_sddmm_buffer_size",                          {HIP_6000}},
-  {"rocsparse_sddmm_preprocess",                           {HIP_6000}},
-  {"rocsparse_spsv",                                       {HIP_6000}},
-};
+  m["hipsparseCreate"]                                                = {HIP_1092, HIP_0,    HIP_0   };
+  m["hipsparseDestroy"]                                               = {HIP_1092, HIP_0,    HIP_0   };
+  m["hipsparseGetPointerMode"]                                        = {HIP_1092, HIP_0,    HIP_0   };
+  m["hipsparseGetVersion"]                                            = {HIP_1092, HIP_0,    HIP_0   };
+  m["hipsparseSetPointerMode"]                                        = {HIP_1092, HIP_0,    HIP_0   };
+  m["hipsparseSetStream"]                                             = {HIP_1092, HIP_0,    HIP_0   };
+  m["hipsparseGetStream"]                                             = {HIP_1092, HIP_0,    HIP_0   };
+  m["hipsparseCreateHybMat"]                                          = {HIP_1092, HIP_3090, HIP_0   };
+  m["hipsparseCreateMatDescr"]                                        = {HIP_1092, HIP_0,    HIP_0   };
+  m["hipsparseDestroyHybMat"]                                         = {HIP_1092, HIP_3090, HIP_0   };
+  m["hipsparseDestroyMatDescr"]                                       = {HIP_1092, HIP_0,    HIP_0   };
+  m["hipsparseGetMatDiagType"]                                        = {HIP_1092, HIP_0,    HIP_0   };
+  m["hipsparseGetMatFillMode"]                                        = {HIP_1092, HIP_0,    HIP_0   };
+  m["hipsparseGetMatIndexBase"]                                       = {HIP_1092, HIP_0,    HIP_0   };
+  m["hipsparseGetMatType"]                                            = {HIP_1092, HIP_0,    HIP_0   };
+  m["hipsparseSetMatDiagType"]                                        = {HIP_1092, HIP_0,    HIP_0   };
+  m["hipsparseSetMatFillMode"]                                        = {HIP_1092, HIP_0,    HIP_0   };
+  m["hipsparseSetMatIndexBase"]                                       = {HIP_1092, HIP_0,    HIP_0   };
+  m["hipsparseSetMatType"]                                            = {HIP_1092, HIP_0,    HIP_0   };
+  m["hipsparseCreateCsrsv2Info"]                                      = {HIP_1092, HIP_5060, HIP_0   };
+  m["hipsparseDestroyCsrsv2Info"]                                     = {HIP_1092, HIP_5060, HIP_0   };
+  m["hipsparseCreateCsrsm2Info"]                                      = {HIP_3010, HIP_5060, HIP_0   };
+  m["hipsparseDestroyCsrsm2Info"]                                     = {HIP_3010, HIP_5060, HIP_0   };
+  m["hipsparseCreateCsric02Info"]                                     = {HIP_3010, HIP_6020, HIP_0   };
+  m["hipsparseDestroyCsric02Info"]                                    = {HIP_3010, HIP_6020, HIP_0   };
+  m["hipsparseCreateCsrilu02Info"]                                    = {HIP_1092, HIP_6020, HIP_0   };
+  m["hipsparseDestroyCsrilu02Info"]                                   = {HIP_1092, HIP_6020, HIP_0   };
+  m["hipsparseCreateBsrsv2Info"]                                      = {HIP_3060, HIP_6020, HIP_0   };
+  m["hipsparseDestroyBsrsv2Info"]                                     = {HIP_3060, HIP_6020, HIP_0   };
+  m["hipsparseCreateBsric02Info"]                                     = {HIP_3080, HIP_6020, HIP_0   };
+  m["hipsparseDestroyBsric02Info"]                                    = {HIP_3080, HIP_6020, HIP_0   };
+  m["hipsparseCreateBsrilu02Info"]                                    = {HIP_3090, HIP_6020, HIP_0   };
+  m["hipsparseDestroyBsrilu02Info"]                                   = {HIP_3090, HIP_6020, HIP_0   };
+  m["hipsparseCreateCsrgemm2Info"]                                    = {HIP_2080, HIP_3090, HIP_0   };
+  m["hipsparseDestroyCsrgemm2Info"]                                   = {HIP_2080, HIP_3090, HIP_0   };
+  m["hipsparseCreatePruneInfo"]                                       = {HIP_3090, HIP_6020, HIP_0   };
+  m["hipsparseDestroyPruneInfo"]                                      = {HIP_3090, HIP_6020, HIP_0   };
+  m["hipsparseSaxpyi"]                                                = {HIP_1092, HIP_3090, HIP_0   };
+  m["hipsparseDaxpyi"]                                                = {HIP_1092, HIP_3090, HIP_0   };
+  m["hipsparseCaxpyi"]                                                = {HIP_3010, HIP_3090, HIP_0   };
+  m["hipsparseZaxpyi"]                                                = {HIP_3010, HIP_3090, HIP_0   };
+  m["hipsparseSdoti"]                                                 = {HIP_1092, HIP_3090, HIP_0   };
+  m["hipsparseDdoti"]                                                 = {HIP_1092, HIP_3090, HIP_0   };
+  m["hipsparseCdoti"]                                                 = {HIP_3010, HIP_3090, HIP_0   };
+  m["hipsparseZdoti"]                                                 = {HIP_3010, HIP_3090, HIP_0   };
+  m["hipsparseCdotci"]                                                = {HIP_3010, HIP_3090, HIP_0   };
+  m["hipsparseZdotci"]                                                = {HIP_3010, HIP_3090, HIP_0   };
+  m["hipsparseSgthr"]                                                 = {HIP_1092, HIP_3090, HIP_0   };
+  m["hipsparseDgthr"]                                                 = {HIP_1092, HIP_3090, HIP_0   };
+  m["hipsparseCgthr"]                                                 = {HIP_3010, HIP_3090, HIP_0   };
+  m["hipsparseZgthr"]                                                 = {HIP_3010, HIP_3090, HIP_0   };
+  m["hipsparseSgthrz"]                                                = {HIP_1092, HIP_3090, HIP_0   };
+  m["hipsparseDgthrz"]                                                = {HIP_1092, HIP_3090, HIP_0   };
+  m["hipsparseCgthrz"]                                                = {HIP_3010, HIP_3090, HIP_0   };
+  m["hipsparseZgthrz"]                                                = {HIP_3010, HIP_3090, HIP_0   };
+  m["hipsparseSroti"]                                                 = {HIP_1092, HIP_3090, HIP_0   };
+  m["hipsparseDroti"]                                                 = {HIP_1092, HIP_3090, HIP_0   };
+  m["hipsparseSsctr"]                                                 = {HIP_1092, HIP_3090, HIP_0   };
+  m["hipsparseDsctr"]                                                 = {HIP_1092, HIP_3090, HIP_0   };
+  m["hipsparseCsctr"]                                                 = {HIP_3010, HIP_3090, HIP_0   };
+  m["hipsparseZsctr"]                                                 = {HIP_3010, HIP_3090, HIP_0   };
+  m["hipsparseSbsrmv"]                                                = {HIP_3050, HIP_0,    HIP_0   };
+  m["hipsparseDbsrmv"]                                                = {HIP_3050, HIP_0,    HIP_0   };
+  m["hipsparseCbsrmv"]                                                = {HIP_3050, HIP_0,    HIP_0   };
+  m["hipsparseZbsrmv"]                                                = {HIP_3050, HIP_0,    HIP_0   };
+  m["hipsparseScsrmv"]                                                = {HIP_1092, HIP_3090, HIP_0   };
+  m["hipsparseDcsrmv"]                                                = {HIP_1092, HIP_3090, HIP_0   };
+  m["hipsparseCcsrmv"]                                                = {HIP_3010, HIP_3090, HIP_0   };
+  m["hipsparseZcsrmv"]                                                = {HIP_3010, HIP_3090, HIP_0   };
+  m["hipsparseSbsrsv2_bufferSize"]                                    = {HIP_3060, HIP_6020, HIP_0   };
+  m["hipsparseSbsrsv2_bufferSizeExt"]                                 = {HIP_3060, HIP_0,    HIP_0   };
+  m["hipsparseDbsrsv2_bufferSize"]                                    = {HIP_3060, HIP_6020, HIP_0   };
+  m["hipsparseDbsrsv2_bufferSizeExt"]                                 = {HIP_3060, HIP_0,    HIP_0   };
+  m["hipsparseCbsrsv2_bufferSize"]                                    = {HIP_3060, HIP_6020, HIP_0   };
+  m["hipsparseCbsrsv2_bufferSizeExt"]                                 = {HIP_3060, HIP_0,    HIP_0   };
+  m["hipsparseZbsrsv2_bufferSize"]                                    = {HIP_3060, HIP_6020, HIP_0   };
+  m["hipsparseZbsrsv2_bufferSizeExt"]                                 = {HIP_3060, HIP_0,    HIP_0   };
+  m["hipsparseSbsrsv2_analysis"]                                      = {HIP_3060, HIP_6020, HIP_0   };
+  m["hipsparseDbsrsv2_analysis"]                                      = {HIP_3060, HIP_6020, HIP_0   };
+  m["hipsparseCbsrsv2_analysis"]                                      = {HIP_3060, HIP_6020, HIP_0   };
+  m["hipsparseZbsrsv2_analysis"]                                      = {HIP_3060, HIP_6020, HIP_0   };
+  m["hipsparseSbsrsv2_solve"]                                         = {HIP_3060, HIP_6020, HIP_0   };
+  m["hipsparseDbsrsv2_solve"]                                         = {HIP_3060, HIP_6020, HIP_0   };
+  m["hipsparseCbsrsv2_solve"]                                         = {HIP_3060, HIP_6020, HIP_0   };
+  m["hipsparseZbsrsv2_solve"]                                         = {HIP_3060, HIP_6020, HIP_0   };
+  m["hipsparseXbsrsv2_zeroPivot"]                                     = {HIP_3060, HIP_6020, HIP_0   };
+  m["hipsparseScsrsv2_bufferSize"]                                    = {HIP_1092, HIP_5060, HIP_0   };
+  m["hipsparseScsrsv2_bufferSizeExt"]                                 = {HIP_1092, HIP_0,    HIP_0   };
+  m["hipsparseDcsrsv2_bufferSize"]                                    = {HIP_1092, HIP_5060, HIP_0   };
+  m["hipsparseDcsrsv2_bufferSizeExt"]                                 = {HIP_1092, HIP_0,    HIP_0   };
+  m["hipsparseCcsrsv2_bufferSize"]                                    = {HIP_3010, HIP_5060, HIP_0   };
+  m["hipsparseCcsrsv2_bufferSizeExt"]                                 = {HIP_3010, HIP_0,    HIP_0   };
+  m["hipsparseZcsrsv2_bufferSize"]                                    = {HIP_3010, HIP_5060, HIP_0   };
+  m["hipsparseZcsrsv2_bufferSizeExt"]                                 = {HIP_3010, HIP_0,    HIP_0   };
+  m["hipsparseScsrsv2_analysis"]                                      = {HIP_1092, HIP_5060, HIP_0   };
+  m["hipsparseDcsrsv2_analysis"]                                      = {HIP_1092, HIP_5060, HIP_0   };
+  m["hipsparseCcsrsv2_analysis"]                                      = {HIP_3010, HIP_5060, HIP_0   };
+  m["hipsparseZcsrsv2_analysis"]                                      = {HIP_3010, HIP_5060, HIP_0   };
+  m["hipsparseScsrsv2_solve"]                                         = {HIP_1092, HIP_5060, HIP_0   };
+  m["hipsparseDcsrsv2_solve"]                                         = {HIP_1092, HIP_5060, HIP_0   };
+  m["hipsparseCcsrsv2_solve"]                                         = {HIP_3010, HIP_5060, HIP_0   };
+  m["hipsparseZcsrsv2_solve"]                                         = {HIP_3010, HIP_5060, HIP_0   };
+  m["hipsparseXcsrsv2_zeroPivot"]                                     = {HIP_1092, HIP_5060, HIP_0   };
+  m["hipsparseShybmv"]                                                = {HIP_1092, HIP_3090, HIP_0   };
+  m["hipsparseDhybmv"]                                                = {HIP_1092, HIP_3090, HIP_0   };
+  m["hipsparseChybmv"]                                                = {HIP_3010, HIP_3090, HIP_0   };
+  m["hipsparseZhybmv"]                                                = {HIP_3010, HIP_3090, HIP_0   };
+  m["hipsparseScsrmm"]                                                = {HIP_1092, HIP_3090, HIP_0   };
+  m["hipsparseDcsrmm"]                                                = {HIP_1092, HIP_3090, HIP_0   };
+  m["hipsparseCcsrmm"]                                                = {HIP_3010, HIP_3090, HIP_0   };
+  m["hipsparseZcsrmm"]                                                = {HIP_3010, HIP_3090, HIP_0   };
+  m["hipsparseScsrmm2"]                                               = {HIP_1092, HIP_3090, HIP_0   };
+  m["hipsparseDcsrmm2"]                                               = {HIP_1092, HIP_3090, HIP_0   };
+  m["hipsparseCcsrmm2"]                                               = {HIP_3010, HIP_3090, HIP_0   };
+  m["hipsparseZcsrmm2"]                                               = {HIP_3010, HIP_3090, HIP_0   };
+  m["hipsparseScsrsm2_bufferSizeExt"]                                 = {HIP_3010, HIP_5060, HIP_0   };
+  m["hipsparseDcsrsm2_bufferSizeExt"]                                 = {HIP_3010, HIP_5060, HIP_0   };
+  m["hipsparseCcsrsm2_bufferSizeExt"]                                 = {HIP_3010, HIP_5060, HIP_0   };
+  m["hipsparseZcsrsm2_bufferSizeExt"]                                 = {HIP_3010, HIP_5060, HIP_0   };
+  m["hipsparseScsrsm2_analysis"]                                      = {HIP_3010, HIP_5060, HIP_0   };
+  m["hipsparseDcsrsm2_analysis"]                                      = {HIP_3010, HIP_5060, HIP_0   };
+  m["hipsparseCcsrsm2_analysis"]                                      = {HIP_3010, HIP_5060, HIP_0   };
+  m["hipsparseZcsrsm2_analysis"]                                      = {HIP_3010, HIP_5060, HIP_0   };
+  m["hipsparseScsrsm2_solve"]                                         = {HIP_3010, HIP_5060, HIP_0   };
+  m["hipsparseDcsrsm2_solve"]                                         = {HIP_3010, HIP_5060, HIP_0   };
+  m["hipsparseCcsrsm2_solve"]                                         = {HIP_3010, HIP_5060, HIP_0   };
+  m["hipsparseZcsrsm2_solve"]                                         = {HIP_3010, HIP_5060, HIP_0   };
+  m["hipsparseXcsrsm2_zeroPivot"]                                     = {HIP_3010, HIP_5060, HIP_0   };
+  m["hipsparseSbsrmm"]                                                = {HIP_3070, HIP_0,    HIP_0   };
+  m["hipsparseDbsrmm"]                                                = {HIP_3070, HIP_0,    HIP_0   };
+  m["hipsparseCbsrmm"]                                                = {HIP_3070, HIP_0,    HIP_0   };
+  m["hipsparseZbsrmm"]                                                = {HIP_3070, HIP_0,    HIP_0   };
+  m["hipsparseSgemmi"]                                                = {HIP_3070, HIP_3090, HIP_0   };
+  m["hipsparseDgemmi"]                                                = {HIP_3070, HIP_3090, HIP_0   };
+  m["hipsparseCgemmi"]                                                = {HIP_3070, HIP_3090, HIP_0   };
+  m["hipsparseZgemmi"]                                                = {HIP_3070, HIP_3090, HIP_0   };
+  m["hipsparseScsrgeam"]                                              = {HIP_3050, HIP_3090, HIP_0   };
+  m["hipsparseDcsrgeam"]                                              = {HIP_3050, HIP_3090, HIP_0   };
+  m["hipsparseCcsrgeam"]                                              = {HIP_3050, HIP_3090, HIP_0   };
+  m["hipsparseZcsrgeam"]                                              = {HIP_3050, HIP_3090, HIP_0   };
+  m["hipsparseXcsrgeamNnz"]                                           = {HIP_3050, HIP_3090, HIP_0   };
+  m["hipsparseScsrgeam2"]                                             = {HIP_3050, HIP_0,    HIP_0   };
+  m["hipsparseDcsrgeam2"]                                             = {HIP_3050, HIP_0,    HIP_0   };
+  m["hipsparseCcsrgeam2"]                                             = {HIP_3050, HIP_0,    HIP_0   };
+  m["hipsparseZcsrgeam2"]                                             = {HIP_3050, HIP_0,    HIP_0   };
+  m["hipsparseXcsrgeam2Nnz"]                                          = {HIP_3050, HIP_0,    HIP_0   };
+  m["hipsparseScsrgeam2_bufferSizeExt"]                               = {HIP_3050, HIP_0,    HIP_0   };
+  m["hipsparseDcsrgeam2_bufferSizeExt"]                               = {HIP_3050, HIP_0,    HIP_0   };
+  m["hipsparseCcsrgeam2_bufferSizeExt"]                               = {HIP_3050, HIP_0,    HIP_0   };
+  m["hipsparseZcsrgeam2_bufferSizeExt"]                               = {HIP_3050, HIP_0,    HIP_0   };
+  m["hipsparseScsrgemm"]                                              = {HIP_2080, HIP_3090, HIP_0   };
+  m["hipsparseDcsrgemm"]                                              = {HIP_2080, HIP_3090, HIP_0   };
+  m["hipsparseCcsrgemm"]                                              = {HIP_3010, HIP_3090, HIP_0   };
+  m["hipsparseZcsrgemm"]                                              = {HIP_3010, HIP_3090, HIP_0   };
+  m["hipsparseXcsrgemmNnz"]                                           = {HIP_2080, HIP_3090, HIP_0   };
+  m["hipsparseScsrgemm2"]                                             = {HIP_2080, HIP_3090, HIP_0   };
+  m["hipsparseDcsrgemm2"]                                             = {HIP_2080, HIP_3090, HIP_0   };
+  m["hipsparseCcsrgemm2"]                                             = {HIP_3010, HIP_3090, HIP_0   };
+  m["hipsparseZcsrgemm2"]                                             = {HIP_3010, HIP_3090, HIP_0   };
+  m["hipsparseXcsrgemm2Nnz"]                                          = {HIP_2080, HIP_3090, HIP_0   };
+  m["hipsparseScsrgemm2_bufferSizeExt"]                               = {HIP_2080, HIP_3090, HIP_0   };
+  m["hipsparseDcsrgemm2_bufferSizeExt"]                               = {HIP_2080, HIP_3090, HIP_0   };
+  m["hipsparseCcsrgemm2_bufferSizeExt"]                               = {HIP_3010, HIP_3090, HIP_0   };
+  m["hipsparseZcsrgemm2_bufferSizeExt"]                               = {HIP_3010, HIP_3090, HIP_0   };
+  m["hipsparseScsric02_bufferSize"]                                   = {HIP_3010, HIP_6020, HIP_0   };
+  m["hipsparseScsric02_bufferSizeExt"]                                = {HIP_3010, HIP_0,    HIP_0   };
+  m["hipsparseDcsric02_bufferSize"]                                   = {HIP_3010, HIP_6020, HIP_0   };
+  m["hipsparseDcsric02_bufferSizeExt"]                                = {HIP_3010, HIP_0,    HIP_0   };
+  m["hipsparseCcsric02_bufferSize"]                                   = {HIP_3010, HIP_6020, HIP_0   };
+  m["hipsparseCcsric02_bufferSizeExt"]                                = {HIP_3010, HIP_0,    HIP_0   };
+  m["hipsparseZcsric02_bufferSize"]                                   = {HIP_3010, HIP_6020, HIP_0   };
+  m["hipsparseZcsric02_bufferSizeExt"]                                = {HIP_3010, HIP_0,    HIP_0   };
+  m["hipsparseScsric02_analysis"]                                     = {HIP_3010, HIP_6020, HIP_0   };
+  m["hipsparseDcsric02_analysis"]                                     = {HIP_3010, HIP_6020, HIP_0   };
+  m["hipsparseCcsric02_analysis"]                                     = {HIP_3010, HIP_6020, HIP_0   };
+  m["hipsparseZcsric02_analysis"]                                     = {HIP_3010, HIP_6020, HIP_0   };
+  m["hipsparseScsric02"]                                              = {HIP_3010, HIP_6020, HIP_0   };
+  m["hipsparseDcsric02"]                                              = {HIP_3010, HIP_6020, HIP_0   };
+  m["hipsparseCcsric02"]                                              = {HIP_3010, HIP_6020, HIP_0   };
+  m["hipsparseZcsric02"]                                              = {HIP_3010, HIP_6020, HIP_0   };
+  m["hipsparseXcsric02_zeroPivot"]                                    = {HIP_3010, HIP_6020, HIP_0   };
+  m["hipsparseSbsric02_bufferSize"]                                   = {HIP_3080, HIP_6020, HIP_0   };
+  m["hipsparseDbsric02_bufferSize"]                                   = {HIP_3080, HIP_6020, HIP_0   };
+  m["hipsparseCbsric02_bufferSize"]                                   = {HIP_3080, HIP_6020, HIP_0   };
+  m["hipsparseZbsric02_bufferSize"]                                   = {HIP_3080, HIP_6020, HIP_0   };
+  m["hipsparseSbsric02_analysis"]                                     = {HIP_3080, HIP_6020, HIP_0   };
+  m["hipsparseDbsric02_analysis"]                                     = {HIP_3080, HIP_6020, HIP_0   };
+  m["hipsparseCbsric02_analysis"]                                     = {HIP_3080, HIP_6020, HIP_0   };
+  m["hipsparseZbsric02_analysis"]                                     = {HIP_3080, HIP_6020, HIP_0   };
+  m["hipsparseSbsric02"]                                              = {HIP_3080, HIP_6020, HIP_0   };
+  m["hipsparseDbsric02"]                                              = {HIP_3080, HIP_6020, HIP_0   };
+  m["hipsparseCbsric02"]                                              = {HIP_3080, HIP_6020, HIP_0   };
+  m["hipsparseZbsric02"]                                              = {HIP_3080, HIP_6020, HIP_0   };
+  m["hipsparseXbsric02_zeroPivot"]                                    = {HIP_3080, HIP_6020, HIP_0   };
+  m["hipsparseScsrilu02_numericBoost"]                                = {HIP_3100, HIP_6020, HIP_0   };
+  m["hipsparseDcsrilu02_numericBoost"]                                = {HIP_3100, HIP_6020, HIP_0   };
+  m["hipsparseCcsrilu02_numericBoost"]                                = {HIP_3100, HIP_6020, HIP_0   };
+  m["hipsparseZcsrilu02_numericBoost"]                                = {HIP_3100, HIP_6020, HIP_0   };
+  m["hipsparseXcsrilu02_zeroPivot"]                                   = {HIP_1092, HIP_6020, HIP_0   };
+  m["hipsparseScsrilu02_bufferSize"]                                  = {HIP_1092, HIP_6020, HIP_0   };
+  m["hipsparseScsrilu02_bufferSizeExt"]                               = {HIP_1092, HIP_0,    HIP_0   };
+  m["hipsparseDcsrilu02_bufferSize"]                                  = {HIP_1092, HIP_6020, HIP_0   };
+  m["hipsparseDcsrilu02_bufferSizeExt"]                               = {HIP_1092, HIP_0,    HIP_0   };
+  m["hipsparseCcsrilu02_bufferSize"]                                  = {HIP_3010, HIP_6020, HIP_0   };
+  m["hipsparseCcsrilu02_bufferSizeExt"]                               = {HIP_3010, HIP_0,    HIP_0   };
+  m["hipsparseZcsrilu02_bufferSize"]                                  = {HIP_3010, HIP_6020, HIP_0   };
+  m["hipsparseZcsrilu02_bufferSizeExt"]                               = {HIP_3010, HIP_0,    HIP_0   };
+  m["hipsparseScsrilu02_analysis"]                                    = {HIP_1092, HIP_6020, HIP_0   };
+  m["hipsparseDcsrilu02_analysis"]                                    = {HIP_1092, HIP_6020, HIP_0   };
+  m["hipsparseCcsrilu02_analysis"]                                    = {HIP_3010, HIP_6020, HIP_0   };
+  m["hipsparseZcsrilu02_analysis"]                                    = {HIP_3010, HIP_6020, HIP_0   };
+  m["hipsparseScsrilu02"]                                             = {HIP_1092, HIP_6020, HIP_0   };
+  m["hipsparseDcsrilu02"]                                             = {HIP_1092, HIP_6020, HIP_0   };
+  m["hipsparseCcsrilu02"]                                             = {HIP_3010, HIP_6020, HIP_0   };
+  m["hipsparseZcsrilu02"]                                             = {HIP_3010, HIP_6020, HIP_0   };
+  m["hipsparseSbsrilu02_numericBoost"]                                = {HIP_3090, HIP_6020, HIP_0   };
+  m["hipsparseDbsrilu02_numericBoost"]                                = {HIP_3090, HIP_6020, HIP_0   };
+  m["hipsparseCbsrilu02_numericBoost"]                                = {HIP_3090, HIP_6020, HIP_0   };
+  m["hipsparseZbsrilu02_numericBoost"]                                = {HIP_3090, HIP_6020, HIP_0   };
+  m["hipsparseSbsrilu02_bufferSize"]                                  = {HIP_3090, HIP_6020, HIP_0   };
+  m["hipsparseDbsrilu02_bufferSize"]                                  = {HIP_3090, HIP_6020, HIP_0   };
+  m["hipsparseCbsrilu02_bufferSize"]                                  = {HIP_3090, HIP_6020, HIP_0   };
+  m["hipsparseZbsrilu02_bufferSize"]                                  = {HIP_3090, HIP_6020, HIP_0   };
+  m["hipsparseSbsrilu02_analysis"]                                    = {HIP_3090, HIP_6020, HIP_0   };
+  m["hipsparseDbsrilu02_analysis"]                                    = {HIP_3090, HIP_6020, HIP_0   };
+  m["hipsparseCbsrilu02_analysis"]                                    = {HIP_3090, HIP_6020, HIP_0   };
+  m["hipsparseZbsrilu02_analysis"]                                    = {HIP_3090, HIP_6020, HIP_0   };
+  m["hipsparseSbsrilu02"]                                             = {HIP_3090, HIP_6020, HIP_0   };
+  m["hipsparseDbsrilu02"]                                             = {HIP_3090, HIP_6020, HIP_0   };
+  m["hipsparseCbsrilu02"]                                             = {HIP_3090, HIP_6020, HIP_0   };
+  m["hipsparseZbsrilu02"]                                             = {HIP_3090, HIP_6020, HIP_0   };
+  m["hipsparseXbsrilu02_zeroPivot"]                                   = {HIP_3090, HIP_6020, HIP_0   };
+  m["hipsparseSbsr2csr"]                                              = {HIP_3050, HIP_0,    HIP_0   };
+  m["hipsparseDbsr2csr"]                                              = {HIP_3050, HIP_0,    HIP_0   };
+  m["hipsparseCbsr2csr"]                                              = {HIP_3050, HIP_0,    HIP_0   };
+  m["hipsparseZbsr2csr"]                                              = {HIP_3050, HIP_0,    HIP_0   };
+  m["hipsparseXcoo2csr"]                                              = {HIP_1092, HIP_0,    HIP_0   };
+  m["hipsparseScsc2dense"]                                            = {HIP_3050, HIP_5060, HIP_0   };
+  m["hipsparseDcsc2dense"]                                            = {HIP_3050, HIP_5060, HIP_0   };
+  m["hipsparseCcsc2dense"]                                            = {HIP_3050, HIP_5060, HIP_0   };
+  m["hipsparseZcsc2dense"]                                            = {HIP_3050, HIP_5060, HIP_0   };
+  m["hipsparseXcsr2bsrNnz"]                                           = {HIP_3050, HIP_0,    HIP_0   };
+  m["hipsparseScsr2bsr"]                                              = {HIP_3050, HIP_0,    HIP_0   };
+  m["hipsparseDcsr2bsr"]                                              = {HIP_3050, HIP_0,    HIP_0   };
+  m["hipsparseCcsr2bsr"]                                              = {HIP_3050, HIP_0,    HIP_0   };
+  m["hipsparseZcsr2bsr"]                                              = {HIP_3050, HIP_0,    HIP_0   };
+  m["hipsparseXcsr2coo"]                                              = {HIP_1092, HIP_0,    HIP_0   };
+  m["hipsparseScsr2csc"]                                              = {HIP_1092, HIP_3090, HIP_0   };
+  m["hipsparseDcsr2csc"]                                              = {HIP_1092, HIP_3090, HIP_0   };
+  m["hipsparseCcsr2csc"]                                              = {HIP_3010, HIP_3090, HIP_0   };
+  m["hipsparseZcsr2csc"]                                              = {HIP_3010, HIP_3090, HIP_0   };
+  m["hipsparseScsr2dense"]                                            = {HIP_3050, HIP_5060, HIP_0   };
+  m["hipsparseDcsr2dense"]                                            = {HIP_3050, HIP_5060, HIP_0   };
+  m["hipsparseCcsr2dense"]                                            = {HIP_3050, HIP_5060, HIP_0   };
+  m["hipsparseZcsr2dense"]                                            = {HIP_3050, HIP_5060, HIP_0   };
+  m["hipsparseScsr2csr_compress"]                                     = {HIP_3050, HIP_0,    HIP_0   };
+  m["hipsparseDcsr2csr_compress"]                                     = {HIP_3050, HIP_0,    HIP_0   };
+  m["hipsparseCcsr2csr_compress"]                                     = {HIP_3050, HIP_0,    HIP_0   };
+  m["hipsparseZcsr2csr_compress"]                                     = {HIP_3050, HIP_0,    HIP_0   };
+  m["hipsparseScsr2hyb"]                                              = {HIP_1092, HIP_3090, HIP_0   };
+  m["hipsparseDcsr2hyb"]                                              = {HIP_1092, HIP_3090, HIP_0   };
+  m["hipsparseCcsr2hyb"]                                              = {HIP_3010, HIP_3090, HIP_0   };
+  m["hipsparseZcsr2hyb"]                                              = {HIP_3010, HIP_3090, HIP_0   };
+  m["hipsparseSdense2csc"]                                            = {HIP_3050, HIP_5060, HIP_0   };
+  m["hipsparseDdense2csc"]                                            = {HIP_3050, HIP_5060, HIP_0   };
+  m["hipsparseCdense2csc"]                                            = {HIP_3050, HIP_5060, HIP_0   };
+  m["hipsparseZdense2csc"]                                            = {HIP_3050, HIP_5060, HIP_0   };
+  m["hipsparseSdense2csr"]                                            = {HIP_3050, HIP_0,    HIP_0   };
+  m["hipsparseDdense2csr"]                                            = {HIP_3050, HIP_0,    HIP_0   };
+  m["hipsparseCdense2csr"]                                            = {HIP_3050, HIP_0,    HIP_0   };
+  m["hipsparseZdense2csr"]                                            = {HIP_3050, HIP_0,    HIP_0   };
+  m["hipsparseShyb2csr"]                                              = {HIP_3010, HIP_3090, HIP_0   };
+  m["hipsparseDhyb2csr"]                                              = {HIP_3010, HIP_3090, HIP_0   };
+  m["hipsparseChyb2csr"]                                              = {HIP_3010, HIP_3090, HIP_0   };
+  m["hipsparseZhyb2csr"]                                              = {HIP_3010, HIP_3090, HIP_0   };
+  m["hipsparseSnnz"]                                                  = {HIP_3020, HIP_0,    HIP_0   };
+  m["hipsparseDnnz"]                                                  = {HIP_3020, HIP_0,    HIP_0   };
+  m["hipsparseCnnz"]                                                  = {HIP_3020, HIP_0,    HIP_0   };
+  m["hipsparseZnnz"]                                                  = {HIP_3020, HIP_0,    HIP_0   };
+  m["hipsparseCreateIdentityPermutation"]                             = {HIP_1092, HIP_6020, HIP_0   };
+  m["hipsparseXcoosort_bufferSizeExt"]                                = {HIP_1092, HIP_0,    HIP_0   };
+  m["hipsparseXcoosortByRow"]                                         = {HIP_1092, HIP_0,    HIP_0   };
+  m["hipsparseXcoosortByColumn"]                                      = {HIP_1092, HIP_0,    HIP_0   };
+  m["hipsparseXcsrsort_bufferSizeExt"]                                = {HIP_1092, HIP_0,    HIP_0   };
+  m["hipsparseXcsrsort"]                                              = {HIP_1092, HIP_0,    HIP_0   };
+  m["hipsparseXcscsort_bufferSizeExt"]                                = {HIP_2100, HIP_0,    HIP_0   };
+  m["hipsparseXcscsort"]                                              = {HIP_2100, HIP_0,    HIP_0   };
+  m["hipsparseSpruneDense2csr"]                                       = {HIP_3090, HIP_6020, HIP_0   };
+  m["hipsparseDpruneDense2csr"]                                       = {HIP_3090, HIP_6020, HIP_0   };
+  m["hipsparseSpruneDense2csr_bufferSizeExt"]                         = {HIP_3090, HIP_6020, HIP_0   };
+  m["hipsparseDpruneDense2csr_bufferSizeExt"]                         = {HIP_3090, HIP_6020, HIP_0   };
+  m["hipsparseSpruneDense2csrNnz"]                                    = {HIP_3090, HIP_6020, HIP_0   };
+  m["hipsparseDpruneDense2csrNnz"]                                    = {HIP_3090, HIP_6020, HIP_0   };
+  m["hipsparseSpruneCsr2csr"]                                         = {HIP_3090, HIP_6020, HIP_0   };
+  m["hipsparseDpruneCsr2csr"]                                         = {HIP_3090, HIP_6020, HIP_0   };
+  m["hipsparseSpruneCsr2csr_bufferSizeExt"]                           = {HIP_3090, HIP_6020, HIP_0   };
+  m["hipsparseDpruneCsr2csr_bufferSizeExt"]                           = {HIP_3090, HIP_6020, HIP_0   };
+  m["hipsparseSpruneCsr2csrNnz"]                                      = {HIP_3090, HIP_6020, HIP_0   };
+  m["hipsparseDpruneCsr2csrNnz"]                                      = {HIP_3090, HIP_6020, HIP_0   };
+  m["hipsparseSpruneDense2csrByPercentage"]                           = {HIP_3090, HIP_6020, HIP_0   };
+  m["hipsparseDpruneDense2csrByPercentage"]                           = {HIP_3090, HIP_6020, HIP_0   };
+  m["hipsparseSpruneDense2csrByPercentage_bufferSizeExt"]             = {HIP_3090, HIP_6020, HIP_0   };
+  m["hipsparseDpruneDense2csrByPercentage_bufferSizeExt"]             = {HIP_3090, HIP_6020, HIP_0   };
+  m["hipsparseSpruneDense2csrNnzByPercentage"]                        = {HIP_3090, HIP_6020, HIP_0   };
+  m["hipsparseDpruneDense2csrNnzByPercentage"]                        = {HIP_3090, HIP_6020, HIP_0   };
+  m["hipsparseSpruneCsr2csrByPercentage"]                             = {HIP_3090, HIP_6020, HIP_0   };
+  m["hipsparseDpruneCsr2csrByPercentage"]                             = {HIP_3090, HIP_6020, HIP_0   };
+  m["hipsparseSpruneCsr2csrByPercentage_bufferSizeExt"]               = {HIP_3090, HIP_6020, HIP_0   };
+  m["hipsparseDpruneCsr2csrByPercentage_bufferSizeExt"]               = {HIP_3090, HIP_6020, HIP_0   };
+  m["hipsparseSpruneCsr2csrNnzByPercentage"]                          = {HIP_3090, HIP_6020, HIP_0   };
+  m["hipsparseDpruneCsr2csrNnzByPercentage"]                          = {HIP_3090, HIP_6020, HIP_0   };
+  m["hipsparseSnnz_compress"]                                         = {HIP_3050, HIP_6020, HIP_0   };
+  m["hipsparseDnnz_compress"]                                         = {HIP_3050, HIP_6020, HIP_0   };
+  m["hipsparseCnnz_compress"]                                         = {HIP_3050, HIP_6020, HIP_0   };
+  m["hipsparseZnnz_compress"]                                         = {HIP_3050, HIP_6020, HIP_0   };
+  m["hipsparseSgebsr2gebsc_bufferSize"]                               = {HIP_4010, HIP_0,    HIP_0   };
+  m["hipsparseDgebsr2gebsc_bufferSize"]                               = {HIP_4010, HIP_0,    HIP_0   };
+  m["hipsparseCgebsr2gebsc_bufferSize"]                               = {HIP_4010, HIP_0,    HIP_0   };
+  m["hipsparseZgebsr2gebsc_bufferSize"]                               = {HIP_4010, HIP_0,    HIP_0   };
+  m["hipsparseSgebsr2gebsc"]                                          = {HIP_4010, HIP_0,    HIP_0   };
+  m["hipsparseDgebsr2gebsc"]                                          = {HIP_4010, HIP_0,    HIP_0   };
+  m["hipsparseCgebsr2gebsc"]                                          = {HIP_4010, HIP_0,    HIP_0   };
+  m["hipsparseZgebsr2gebsc"]                                          = {HIP_4010, HIP_0,    HIP_0   };
+  m["hipsparseSgebsr2gebsr_bufferSize"]                               = {HIP_4010, HIP_0,    HIP_0   };
+  m["hipsparseDgebsr2gebsr_bufferSize"]                               = {HIP_4010, HIP_0,    HIP_0   };
+  m["hipsparseCgebsr2gebsr_bufferSize"]                               = {HIP_4010, HIP_0,    HIP_0   };
+  m["hipsparseZgebsr2gebsr_bufferSize"]                               = {HIP_4010, HIP_0,    HIP_0   };
+  m["hipsparseSgebsr2csr"]                                            = {HIP_4010, HIP_0,    HIP_0   };
+  m["hipsparseDgebsr2csr"]                                            = {HIP_4010, HIP_0,    HIP_0   };
+  m["hipsparseCgebsr2csr"]                                            = {HIP_4010, HIP_0,    HIP_0   };
+  m["hipsparseZgebsr2csr"]                                            = {HIP_4010, HIP_0,    HIP_0   };
+  m["hipsparseXgebsr2gebsrNnz"]                                       = {HIP_4010, HIP_0,    HIP_0   };
+  m["hipsparseSgebsr2gebsr"]                                          = {HIP_4010, HIP_0,    HIP_0   };
+  m["hipsparseDgebsr2gebsr"]                                          = {HIP_4010, HIP_0,    HIP_0   };
+  m["hipsparseCgebsr2gebsr"]                                          = {HIP_4010, HIP_0,    HIP_0   };
+  m["hipsparseZgebsr2gebsr"]                                          = {HIP_4010, HIP_0,    HIP_0   };
+  m["hipsparseScsr2gebsr_bufferSize"]                                 = {HIP_4010, HIP_0,    HIP_0   };
+  m["hipsparseDcsr2gebsr_bufferSize"]                                 = {HIP_4010, HIP_0,    HIP_0   };
+  m["hipsparseCcsr2gebsr_bufferSize"]                                 = {HIP_4010, HIP_0,    HIP_0   };
+  m["hipsparseZcsr2gebsr_bufferSize"]                                 = {HIP_4010, HIP_0,    HIP_0   };
+  m["hipsparseXcsr2gebsrNnz"]                                         = {HIP_4010, HIP_0,    HIP_0   };
+  m["hipsparseScsr2gebsr"]                                            = {HIP_4010, HIP_0,    HIP_0   };
+  m["hipsparseDcsr2gebsr"]                                            = {HIP_4010, HIP_0,    HIP_0   };
+  m["hipsparseCcsr2gebsr"]                                            = {HIP_4010, HIP_0,    HIP_0   };
+  m["hipsparseZcsr2gebsr"]                                            = {HIP_4010, HIP_0,    HIP_0   };
+  m["hipsparseCreateCoo"]                                             = {HIP_4010, HIP_0,    HIP_0   };
+  m["hipsparseCreateCooAoS"]                                          = {HIP_4010, HIP_0,    HIP_0   };
+  m["hipsparseCreateCsr"]                                             = {HIP_4010, HIP_0,    HIP_0   };
+  m["hipsparseDestroySpMat"]                                          = {HIP_4010, HIP_0,    HIP_0   };
+  m["hipsparseCooGet"]                                                = {HIP_4010, HIP_0,    HIP_0   };
+  m["hipsparseCooAoSGet"]                                             = {HIP_4010, HIP_5060, HIP_0   };
+  m["hipsparseCsrGet"]                                                = {HIP_4010, HIP_0,    HIP_0   };
+  m["hipsparseCsrSetPointers"]                                        = {HIP_4010, HIP_0,    HIP_0   };
+  m["hipsparseSpMatGetFormat"]                                        = {HIP_4010, HIP_0,    HIP_0   };
+  m["hipsparseSpMatGetIndexBase"]                                     = {HIP_4010, HIP_0,    HIP_0   };
+  m["hipsparseSpMatGetValues"]                                        = {HIP_4010, HIP_0,    HIP_0   };
+  m["hipsparseSpMatSetValues"]                                        = {HIP_4010, HIP_0,    HIP_0   };
+  m["hipsparseSpMatGetSize"]                                          = {HIP_4010, HIP_0,    HIP_0   };
+  m["hipsparseCreateSpVec"]                                           = {HIP_4010, HIP_0,    HIP_0   };
+  m["hipsparseDestroySpVec"]                                          = {HIP_4010, HIP_0,    HIP_0   };
+  m["hipsparseSpVecGet"]                                              = {HIP_4010, HIP_0,    HIP_0   };
+  m["hipsparseSpVecGetIndexBase"]                                     = {HIP_4010, HIP_0,    HIP_0   };
+  m["hipsparseSpVecGetValues"]                                        = {HIP_4010, HIP_0,    HIP_0   };
+  m["hipsparseSpVecSetValues"]                                        = {HIP_4010, HIP_0,    HIP_0   };
+  m["hipsparseCreateDnVec"]                                           = {HIP_4010, HIP_0,    HIP_0   };
+  m["hipsparseDestroyDnVec"]                                          = {HIP_4010, HIP_0,    HIP_0   };
+  m["hipsparseDnVecGet"]                                              = {HIP_4010, HIP_0,    HIP_0   };
+  m["hipsparseDnVecGetValues"]                                        = {HIP_4010, HIP_0,    HIP_0   };
+  m["hipsparseDnVecSetValues"]                                        = {HIP_4010, HIP_0,    HIP_0   };
+  m["hipsparseSpGEMM_createDescr"]                                    = {HIP_4010, HIP_0,    HIP_0   };
+  m["hipsparseSpGEMM_destroyDescr"]                                   = {HIP_4010, HIP_0,    HIP_0   };
+  m["hipsparseSpGEMM_workEstimation"]                                 = {HIP_4010, HIP_0,    HIP_0   };
+  m["hipsparseSpGEMM_compute"]                                        = {HIP_4010, HIP_0,    HIP_0   };
+  m["hipsparseSpGEMM_copy"]                                           = {HIP_4010, HIP_0,    HIP_0   };
+  m["hipsparseSpVV"]                                                  = {HIP_4010, HIP_0,    HIP_0   };
+  m["hipsparseSpVV_bufferSize"]                                       = {HIP_4010, HIP_0,    HIP_0   };
+  m["hipsparseAxpby"]                                                 = {HIP_4010, HIP_0,    HIP_0   };
+  m["hipsparseGather"]                                                = {HIP_4010, HIP_0,    HIP_0   };
+  m["hipsparseScatter"]                                               = {HIP_4010, HIP_0,    HIP_0   };
+  m["hipsparseRot"]                                                   = {HIP_4010, HIP_6020, HIP_0   };
+  m["hipsparseSpMV"]                                                  = {HIP_4010, HIP_0,    HIP_0   };
+  m["hipsparseSpMV_bufferSize"]                                       = {HIP_4010, HIP_0,    HIP_0   };
+  m["hipsparseCreateCsru2csrInfo"]                                    = {HIP_4020, HIP_0,    HIP_0   };
+  m["hipsparseDestroyCsru2csrInfo"]                                   = {HIP_4020, HIP_0,    HIP_0   };
+  m["hipsparseScsru2csr_bufferSizeExt"]                               = {HIP_4020, HIP_6020, HIP_0   };
+  m["hipsparseDcsru2csr_bufferSizeExt"]                               = {HIP_4020, HIP_6020, HIP_0   };
+  m["hipsparseCcsru2csr_bufferSizeExt"]                               = {HIP_4020, HIP_6020, HIP_0   };
+  m["hipsparseZcsru2csr_bufferSizeExt"]                               = {HIP_4020, HIP_6020, HIP_0   };
+  m["hipsparseScsru2csr"]                                             = {HIP_4020, HIP_6020, HIP_0   };
+  m["hipsparseDcsru2csr"]                                             = {HIP_4020, HIP_6020, HIP_0   };
+  m["hipsparseCcsru2csr"]                                             = {HIP_4020, HIP_6020, HIP_0   };
+  m["hipsparseZcsru2csr"]                                             = {HIP_4020, HIP_6020, HIP_0   };
+  m["hipsparseScsr2csru"]                                             = {HIP_4020, HIP_6020, HIP_0   };
+  m["hipsparseDcsr2csru"]                                             = {HIP_4020, HIP_6020, HIP_0   };
+  m["hipsparseCcsr2csru"]                                             = {HIP_4020, HIP_6020, HIP_0   };
+  m["hipsparseZcsr2csru"]                                             = {HIP_4020, HIP_6020, HIP_0   };
+  m["hipsparseCreateCsc"]                                             = {HIP_4020, HIP_0,    HIP_0   };
+  m["hipsparseCscSetPointers"]                                        = {HIP_4020, HIP_0,    HIP_0   };
+  m["hipsparseCooSetPointers"]                                        = {HIP_4020, HIP_0,    HIP_0   };
+  m["hipsparseCreateDnMat"]                                           = {HIP_4020, HIP_0,    HIP_0   };
+  m["hipsparseDestroyDnMat"]                                          = {HIP_4020, HIP_0,    HIP_0   };
+  m["hipsparseDnMatGet"]                                              = {HIP_4020, HIP_0,    HIP_0   };
+  m["hipsparseDnMatGetValues"]                                        = {HIP_4020, HIP_0,    HIP_0   };
+  m["hipsparseDnMatSetValues"]                                        = {HIP_4020, HIP_0,    HIP_0   };
+  m["hipsparseSparseToDense_bufferSize"]                              = {HIP_4020, HIP_0,    HIP_0   };
+  m["hipsparseSparseToDense"]                                         = {HIP_4020, HIP_0,    HIP_0   };
+  m["hipsparseDenseToSparse_bufferSize"]                              = {HIP_4020, HIP_0,    HIP_0   };
+  m["hipsparseDenseToSparse_analysis"]                                = {HIP_4020, HIP_0,    HIP_0   };
+  m["hipsparseDenseToSparse_convert"]                                 = {HIP_4020, HIP_0,    HIP_0   };
+  m["hipsparseSpMM_bufferSize"]                                       = {HIP_4020, HIP_0,    HIP_0   };
+  m["hipsparseSpMM"]                                                  = {HIP_4020, HIP_0,    HIP_0   };
+  m["hipsparseSgemvi_bufferSize"]                                     = {HIP_4030, HIP_0,    HIP_0   };
+  m["hipsparseDgemvi_bufferSize"]                                     = {HIP_4030, HIP_0,    HIP_0   };
+  m["hipsparseCgemvi_bufferSize"]                                     = {HIP_4030, HIP_0,    HIP_0   };
+  m["hipsparseZgemvi_bufferSize"]                                     = {HIP_4030, HIP_0,    HIP_0   };
+  m["hipsparseSgemvi"]                                                = {HIP_4030, HIP_0,    HIP_0   };
+  m["hipsparseDgemvi"]                                                = {HIP_4030, HIP_0,    HIP_0   };
+  m["hipsparseCgemvi"]                                                = {HIP_4030, HIP_0,    HIP_0   };
+  m["hipsparseZgemvi"]                                                = {HIP_4030, HIP_0,    HIP_0   };
+  m["hipsparseSgtsv2_bufferSizeExt"]                                  = {HIP_4030, HIP_0,    HIP_0   };
+  m["hipsparseDgtsv2_bufferSizeExt"]                                  = {HIP_4030, HIP_0,    HIP_0   };
+  m["hipsparseCgtsv2_bufferSizeExt"]                                  = {HIP_4030, HIP_0,    HIP_0   };
+  m["hipsparseZgtsv2_bufferSizeExt"]                                  = {HIP_4030, HIP_0,    HIP_0   };
+  m["hipsparseSgtsv2"]                                                = {HIP_4030, HIP_0,    HIP_0   };
+  m["hipsparseDgtsv2"]                                                = {HIP_4030, HIP_0,    HIP_0   };
+  m["hipsparseCgtsv2"]                                                = {HIP_4030, HIP_0,    HIP_0   };
+  m["hipsparseZgtsv2"]                                                = {HIP_4030, HIP_0,    HIP_0   };
+  m["hipsparseSgtsv2_nopivot_bufferSizeExt"]                          = {HIP_4030, HIP_0,    HIP_0   };
+  m["hipsparseDgtsv2_nopivot_bufferSizeExt"]                          = {HIP_4030, HIP_0,    HIP_0   };
+  m["hipsparseCgtsv2_nopivot_bufferSizeExt"]                          = {HIP_4030, HIP_0,    HIP_0   };
+  m["hipsparseZgtsv2_nopivot_bufferSizeExt"]                          = {HIP_4030, HIP_0,    HIP_0   };
+  m["hipsparseSgtsv2_nopivot"]                                        = {HIP_4030, HIP_0,    HIP_0   };
+  m["hipsparseDgtsv2_nopivot"]                                        = {HIP_4030, HIP_0,    HIP_0   };
+  m["hipsparseCgtsv2_nopivot"]                                        = {HIP_4030, HIP_0,    HIP_0   };
+  m["hipsparseZgtsv2_nopivot"]                                        = {HIP_4030, HIP_0,    HIP_0   };
+  m["hipsparseSDDMM"]                                                 = {HIP_4030, HIP_0,    HIP_0   };
+  m["hipsparseSDDMM_bufferSize"]                                      = {HIP_4030, HIP_0,    HIP_0   };
+  m["hipsparseSDDMM_preprocess"]                                      = {HIP_4030, HIP_0,    HIP_0   };
+  m["hipsparseCreateBsrsm2Info"]                                      = {HIP_4050, HIP_6020, HIP_0   };
+  m["hipsparseDestroyBsrsm2Info"]                                     = {HIP_4050, HIP_6020, HIP_0   };
+  m["hipsparseCreateColorInfo"]                                       = {HIP_4050, HIP_6020, HIP_0   };
+  m["hipsparseDestroyColorInfo"]                                      = {HIP_4050, HIP_6020, HIP_0   };
+  m["hipsparseSbsrxmv"]                                               = {HIP_4050, HIP_6020, HIP_0   };
+  m["hipsparseDbsrxmv"]                                               = {HIP_4050, HIP_6020, HIP_0   };
+  m["hipsparseCbsrxmv"]                                               = {HIP_4050, HIP_6020, HIP_0   };
+  m["hipsparseZbsrxmv"]                                               = {HIP_4050, HIP_6020, HIP_0   };
+  m["hipsparseXbsrsm2_zeroPivot"]                                     = {HIP_4050, HIP_6020, HIP_0   };
+  m["hipsparseSbsrsm2_bufferSize"]                                    = {HIP_4050, HIP_6020, HIP_0   };
+  m["hipsparseDbsrsm2_bufferSize"]                                    = {HIP_4050, HIP_6020, HIP_0   };
+  m["hipsparseCbsrsm2_bufferSize"]                                    = {HIP_4050, HIP_6020, HIP_0   };
+  m["hipsparseZbsrsm2_bufferSize"]                                    = {HIP_4050, HIP_6020, HIP_0   };
+  m["hipsparseSbsrsm2_analysis"]                                      = {HIP_4050, HIP_6020, HIP_0   };
+  m["hipsparseDbsrsm2_analysis"]                                      = {HIP_4050, HIP_6020, HIP_0   };
+  m["hipsparseCbsrsm2_analysis"]                                      = {HIP_4050, HIP_6020, HIP_0   };
+  m["hipsparseZbsrsm2_analysis"]                                      = {HIP_4050, HIP_6020, HIP_0   };
+  m["hipsparseSbsrsm2_solve"]                                         = {HIP_4050, HIP_6020, HIP_0   };
+  m["hipsparseDbsrsm2_solve"]                                         = {HIP_4050, HIP_6020, HIP_0   };
+  m["hipsparseCbsrsm2_solve"]                                         = {HIP_4050, HIP_6020, HIP_0   };
+  m["hipsparseZbsrsm2_solve"]                                         = {HIP_4050, HIP_6020, HIP_0   };
+  m["hipsparseScsrcolor"]                                             = {HIP_4050, HIP_6020, HIP_0   };
+  m["hipsparseDcsrcolor"]                                             = {HIP_4050, HIP_6020, HIP_0   };
+  m["hipsparseCcsrcolor"]                                             = {HIP_4050, HIP_6020, HIP_0   };
+  m["hipsparseZcsrcolor"]                                             = {HIP_4050, HIP_6020, HIP_0   };
+  m["hipsparseCreateBlockedEll"]                                      = {HIP_4050, HIP_0,    HIP_0   };
+  m["hipsparseBlockedEllGet"]                                         = {HIP_4050, HIP_0,    HIP_0   };
+  m["hipsparseSpMatGetAttribute"]                                     = {HIP_4050, HIP_0,    HIP_0   };
+  m["hipsparseSpMatSetAttribute"]                                     = {HIP_4050, HIP_0,    HIP_0   };
+  m["hipsparseSpMM_preprocess"]                                       = {HIP_4050, HIP_0,    HIP_0   };
+  m["hipsparseSpSV_createDescr"]                                      = {HIP_4050, HIP_0,    HIP_0   };
+  m["hipsparseSpSV_destroyDescr"]                                     = {HIP_4050, HIP_0,    HIP_0   };
+  m["hipsparseSpSV_bufferSize"]                                       = {HIP_4050, HIP_0,    HIP_0   };
+  m["hipsparseSpSV_analysis"]                                         = {HIP_4050, HIP_0,    HIP_0   };
+  m["hipsparseSpSV_solve"]                                            = {HIP_4050, HIP_0,    HIP_0   };
+  m["hipsparseSpSM_createDescr"]                                      = {HIP_4050, HIP_0,    HIP_0   };
+  m["hipsparseSpSM_destroyDescr"]                                     = {HIP_4050, HIP_0,    HIP_0   };
+  m["hipsparseSpSM_bufferSize"]                                       = {HIP_4050, HIP_0,    HIP_0   };
+  m["hipsparseSpSM_analysis"]                                         = {HIP_4050, HIP_0,    HIP_0   };
+  m["hipsparseSpSM_solve"]                                            = {HIP_4050, HIP_0,    HIP_0   };
+  m["hipsparseSgtsv2StridedBatch_bufferSizeExt"]                      = {HIP_4050, HIP_0,    HIP_0   };
+  m["hipsparseDgtsv2StridedBatch_bufferSizeExt"]                      = {HIP_4050, HIP_0,    HIP_0   };
+  m["hipsparseCgtsv2StridedBatch_bufferSizeExt"]                      = {HIP_4050, HIP_0,    HIP_0   };
+  m["hipsparseZgtsv2StridedBatch_bufferSizeExt"]                      = {HIP_4050, HIP_0,    HIP_0   };
+  m["hipsparseSgtsv2StridedBatch"]                                    = {HIP_4050, HIP_0,    HIP_0   };
+  m["hipsparseDgtsv2StridedBatch"]                                    = {HIP_4050, HIP_0,    HIP_0   };
+  m["hipsparseCgtsv2StridedBatch"]                                    = {HIP_4050, HIP_0,    HIP_0   };
+  m["hipsparseZgtsv2StridedBatch"]                                    = {HIP_4050, HIP_0,    HIP_0   };
+  m["hipsparseSgtsvInterleavedBatch_bufferSizeExt"]                   = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsparseDgtsvInterleavedBatch_bufferSizeExt"]                   = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsparseCgtsvInterleavedBatch_bufferSizeExt"]                   = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsparseZgtsvInterleavedBatch_bufferSizeExt"]                   = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsparseSgtsvInterleavedBatch"]                                 = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsparseDgtsvInterleavedBatch"]                                 = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsparseCgtsvInterleavedBatch"]                                 = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsparseZgtsvInterleavedBatch"]                                 = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsparseSgpsvInterleavedBatch_bufferSizeExt"]                   = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsparseDgpsvInterleavedBatch_bufferSizeExt"]                   = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsparseCgpsvInterleavedBatch_bufferSizeExt"]                   = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsparseZgpsvInterleavedBatch_bufferSizeExt"]                   = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsparseSgpsvInterleavedBatch"]                                 = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsparseDgpsvInterleavedBatch"]                                 = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsparseCgpsvInterleavedBatch"]                                 = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsparseZgpsvInterleavedBatch"]                                 = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsparseSpGEMMreuse_workEstimation"]                            = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsparseSpGEMMreuse_nnz"]                                       = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsparseSpGEMMreuse_compute"]                                   = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsparseSpGEMMreuse_copy"]                                      = {HIP_5010, HIP_0,    HIP_0   };
+  m["hipsparseSpMatGetStridedBatch"]                                  = {HIP_5020, HIP_0,    HIP_0   };
+  m["hipsparseSpMatSetStridedBatch"]                                  = {HIP_5020, HIP_5020, HIP_0   };
+  m["hipsparseCooSetStridedBatch"]                                    = {HIP_5020, HIP_0,    HIP_0   };
+  m["hipsparseCsrSetStridedBatch"]                                    = {HIP_5020, HIP_0,    HIP_0   };
+  m["hipsparseDnMatGetStridedBatch"]                                  = {HIP_5020, HIP_0,    HIP_0   };
+  m["hipsparseDnMatSetStridedBatch"]                                  = {HIP_5020, HIP_0,    HIP_0   };
+  m["hipsparseCsr2cscEx2_bufferSize"]                                 = {HIP_5040, HIP_0,    HIP_0   };
+  m["hipsparseCsr2cscEx2"]                                            = {HIP_5040, HIP_0,    HIP_0   };
+  m["hipsparseCopyMatDescr"]                                          = {HIP_1092, HIP_0,    HIP_0   };
+  m["hipsparseGetErrorName"]                                          = {HIP_6000, HIP_0,    HIP_0   };
+  m["hipsparseGetErrorString"]                                        = {HIP_6000, HIP_0,    HIP_0   };
+  m["hipsparseCreateConstSpVec"]                                      = {HIP_6000, HIP_0,    HIP_0   };
+  m["hipsparseConstSpVecGet"]                                         = {HIP_6000, HIP_0,    HIP_0   };
+  m["hipsparseConstSpVecGetValues"]                                   = {HIP_6000, HIP_0,    HIP_0   };
+  m["hipsparseCreateConstCoo"]                                        = {HIP_6000, HIP_0,    HIP_0   };
+  m["hipsparseCreateConstCsr"]                                        = {HIP_6000, HIP_0,    HIP_0   };
+  m["hipsparseCreateConstCsc"]                                        = {HIP_6000, HIP_0,    HIP_0   };
+  m["hipsparseCreateConstBlockedEll"]                                 = {HIP_6000, HIP_0,    HIP_0   };
+  m["hipsparseConstCooGet"]                                           = {HIP_6000, HIP_0,    HIP_0   };
+  m["hipsparseConstCsrGet"]                                           = {HIP_6000, HIP_0,    HIP_0   };
+  m["hipsparseConstBlockedEllGet"]                                    = {HIP_6000, HIP_0,    HIP_0   };
+  m["hipsparseConstSpMatGetValues"]                                   = {HIP_6000, HIP_0,    HIP_0   };
+  m["hipsparseCreateConstDnVec"]                                      = {HIP_6000, HIP_0,    HIP_0   };
+  m["hipsparseConstDnVecGet"]                                         = {HIP_6000, HIP_0,    HIP_0   };
+  m["hipsparseConstDnVecGetValues"]                                   = {HIP_6000, HIP_0,    HIP_0   };
+  m["hipsparseCreateConstDnMat"]                                      = {HIP_6000, HIP_0,    HIP_0   };
+  m["hipsparseConstDnMatGet"]                                         = {HIP_6000, HIP_0,    HIP_0   };
+  m["hipsparseConstDnMatGetValues"]                                   = {HIP_6000, HIP_0,    HIP_0   };
+  m["hipsparseCscGet"]                                                = {HIP_6020, HIP_0,    HIP_0   };
+  m["hipsparseConstCscGet"]                                           = {HIP_6020, HIP_0,    HIP_0   };
+  m["hipsparseSpMV_preprocess"]                                       = {HIP_5020, HIP_0,    HIP_0   };
 
-const std::map<unsigned int, llvm::StringRef> CUDA_SPARSE_API_SECTION_MAP {
-  {4, "CUSPARSE Types References"},
-  {5, "CUSPARSE Management Function Reference"},
-  {6, "CUSPARSE Logging"},
-  {7, "CUSPARSE Helper Function Reference"},
-  {8, "CUSPARSE Level 1 Function Reference"},
-  {9, "CUSPARSE Level 2 Function Reference"},
-  {10, "CUSPARSE Level 3 Function Reference"},
-  {11, "CUSPARSE Extra Function Reference"},
-  {12, "CUSPARSE Preconditioners Reference"},
-  {13, "CUSPARSE Reorderings Reference"},
-  {14, "CUSPARSE Format Conversion Reference"},
-  {15, "CUSPARSE Generic API Reference"},
-};
+  m["rocsparse_create_handle"]                                        = {HIP_1090, HIP_0,    HIP_0   };
+  m["rocsparse_destroy_handle"]                                       = {HIP_1090, HIP_0,    HIP_0   };
+  m["rocsparse_set_stream"]                                           = {HIP_1090, HIP_0,    HIP_0   };
+  m["rocsparse_get_stream"]                                           = {HIP_1090, HIP_0,    HIP_0   };
+  m["rocsparse_set_pointer_mode"]                                     = {HIP_1090, HIP_0,    HIP_0   };
+  m["rocsparse_get_pointer_mode"]                                     = {HIP_1090, HIP_0,    HIP_0   };
+  m["rocsparse_get_version"]                                          = {HIP_1090, HIP_0,    HIP_0   };
+  m["rocsparse_create_mat_descr"]                                     = {HIP_1090, HIP_0,    HIP_0   };
+  m["rocsparse_copy_mat_descr"]                                       = {HIP_1090, HIP_0,    HIP_0   };
+  m["rocsparse_destroy_mat_descr"]                                    = {HIP_1090, HIP_0,    HIP_0   };
+  m["rocsparse_set_mat_index_base"]                                   = {HIP_1090, HIP_0,    HIP_0   };
+  m["rocsparse_get_mat_index_base"]                                   = {HIP_1090, HIP_0,    HIP_0   };
+  m["rocsparse_set_mat_type"]                                         = {HIP_1090, HIP_0,    HIP_0   };
+  m["rocsparse_get_mat_type"]                                         = {HIP_1090, HIP_0,    HIP_0   };
+  m["rocsparse_set_mat_fill_mode"]                                    = {HIP_1090, HIP_0,    HIP_0   };
+  m["rocsparse_get_mat_fill_mode"]                                    = {HIP_1090, HIP_0,    HIP_0   };
+  m["rocsparse_set_mat_diag_type"]                                    = {HIP_1090, HIP_0,    HIP_0   };
+  m["rocsparse_get_mat_diag_type"]                                    = {HIP_1090, HIP_0,    HIP_0   };
+  m["rocsparse_create_hyb_mat"]                                       = {HIP_1090, HIP_0,    HIP_0   };
+  m["rocsparse_destroy_hyb_mat"]                                      = {HIP_1090, HIP_0,    HIP_0   };
+  m["rocsparse_create_color_info"]                                    = {HIP_4050, HIP_0,    HIP_0   };
+  m["rocsparse_destroy_color_info"]                                   = {HIP_4050, HIP_0,    HIP_0   };
+  m["rocsparse_create_spvec_descr"]                                   = {HIP_4010, HIP_0,    HIP_0   };
+  m["rocsparse_destroy_spvec_descr"]                                  = {HIP_4010, HIP_0,    HIP_0   };
+  m["rocsparse_spvec_get"]                                            = {HIP_4010, HIP_0,    HIP_0   };
+  m["rocsparse_spvec_get_index_base"]                                 = {HIP_4010, HIP_0,    HIP_0   };
+  m["rocsparse_spvec_get_values"]                                     = {HIP_4010, HIP_0,    HIP_0   };
+  m["rocsparse_spvec_set_values"]                                     = {HIP_4010, HIP_0,    HIP_0   };
+  m["rocsparse_create_coo_descr"]                                     = {HIP_4010, HIP_0,    HIP_0   };
+  m["rocsparse_create_coo_aos_descr"]                                 = {HIP_4010, HIP_0,    HIP_0   };
+  m["rocsparse_create_csr_descr"]                                     = {HIP_4010, HIP_0,    HIP_0   };
+  m["rocsparse_create_csc_descr"]                                     = {HIP_4010, HIP_0,    HIP_0   };
+  m["rocsparse_create_bell_descr"]                                    = {HIP_4050, HIP_0,    HIP_0   };
+  m["rocsparse_destroy_spmat_descr"]                                  = {HIP_4010, HIP_0,    HIP_0   };
+  m["rocsparse_coo_get"]                                              = {HIP_4010, HIP_0,    HIP_0   };
+  m["rocsparse_coo_aos_get"]                                          = {HIP_4010, HIP_0,    HIP_0   };
+  m["rocsparse_csr_get"]                                              = {HIP_4010, HIP_0,    HIP_0   };
+  m["rocsparse_bell_get"]                                             = {HIP_4010, HIP_0,    HIP_0   };
+  m["rocsparse_coo_set_pointers"]                                     = {HIP_4010, HIP_0,    HIP_0   };
+  m["rocsparse_csr_set_pointers"]                                     = {HIP_4010, HIP_0,    HIP_0   };
+  m["rocsparse_csc_set_pointers"]                                     = {HIP_4010, HIP_0,    HIP_0   };
+  m["rocsparse_spmat_get_size"]                                       = {HIP_4010, HIP_0,    HIP_0   };
+  m["rocsparse_spmat_get_format"]                                     = {HIP_4010, HIP_0,    HIP_0   };
+  m["rocsparse_spmat_get_index_base"]                                 = {HIP_4010, HIP_0,    HIP_0   };
+  m["rocsparse_spmat_get_values"]                                     = {HIP_4010, HIP_0,    HIP_0   };
+  m["rocsparse_spmat_set_values"]                                     = {HIP_4010, HIP_0,    HIP_0   };
+  m["rocsparse_spmat_get_strided_batch"]                              = {HIP_5020, HIP_0,    HIP_0   };
+  m["rocsparse_spmat_set_strided_batch"]                              = {HIP_5020, HIP_0,    HIP_0   };
+  m["rocsparse_coo_set_strided_batch"]                                = {HIP_5020, HIP_0,    HIP_0   };
+  m["rocsparse_csr_set_strided_batch"]                                = {HIP_5020, HIP_0,    HIP_0   };
+  m["rocsparse_spmat_get_attribute"]                                  = {HIP_4050, HIP_0,    HIP_0   };
+  m["rocsparse_spmat_set_attribute"]                                  = {HIP_4050, HIP_0,    HIP_0   };
+  m["rocsparse_create_dnvec_descr"]                                   = {HIP_4010, HIP_0,    HIP_0   };
+  m["rocsparse_destroy_dnvec_descr"]                                  = {HIP_4010, HIP_0,    HIP_0   };
+  m["rocsparse_dnvec_get"]                                            = {HIP_4010, HIP_0,    HIP_0   };
+  m["rocsparse_dnvec_get_values"]                                     = {HIP_4010, HIP_0,    HIP_0   };
+  m["rocsparse_dnvec_set_values"]                                     = {HIP_4010, HIP_0,    HIP_0   };
+  m["rocsparse_create_dnmat_descr"]                                   = {HIP_4010, HIP_0,    HIP_0   };
+  m["rocsparse_destroy_dnmat_descr"]                                  = {HIP_4010, HIP_0,    HIP_0   };
+  m["rocsparse_dnmat_get"]                                            = {HIP_4010, HIP_0,    HIP_0   };
+  m["rocsparse_dnmat_get_values"]                                     = {HIP_4010, HIP_0,    HIP_0   };
+  m["rocsparse_dnmat_set_values"]                                     = {HIP_4010, HIP_0,    HIP_0   };
+  m["rocsparse_dnmat_get_strided_batch"]                              = {HIP_5020, HIP_0,    HIP_0   };
+  m["rocsparse_dnmat_set_strided_batch"]                              = {HIP_5020, HIP_0,    HIP_0   };
+  m["rocsparse_zcsrcolor"]                                            = {HIP_4050, HIP_0,    HIP_0   };
+  m["rocsparse_ccsrcolor"]                                            = {HIP_4050, HIP_0,    HIP_0   };
+  m["rocsparse_dcsrcolor"]                                            = {HIP_4050, HIP_0,    HIP_0   };
+  m["rocsparse_scsrcolor"]                                            = {HIP_4050, HIP_0,    HIP_0   };
+  m["rocsparse_sddmm_preprocess"]                                     = {HIP_4030, HIP_0,    HIP_0   };
+  m["rocsparse_sddmm_buffer_size"]                                    = {HIP_4030, HIP_0,    HIP_0   };
+  m["rocsparse_sddmm"]                                                = {HIP_4030, HIP_0,    HIP_0   };
+  m["rocsparse_spmv"]                                                 = {HIP_4010, HIP_0,    HIP_0   };
+  m["rocsparse_rot"]                                                  = {HIP_4010, HIP_0,    HIP_0   };
+  m["rocsparse_scatter"]                                              = {HIP_4010, HIP_0,    HIP_0   };
+  m["rocsparse_gather"]                                               = {HIP_4010, HIP_0,    HIP_0   };
+  m["rocsparse_axpby"]                                                = {HIP_4010, HIP_0,    HIP_0   };
+  m["rocsparse_zgebsr2gebsr"]                                         = {HIP_4010, HIP_0,    HIP_0   };
+  m["rocsparse_zgebsr2gebsr_buffer_size"]                             = {HIP_4010, HIP_0,    HIP_0   };
+  m["rocsparse_cgebsr2gebsr"]                                         = {HIP_4010, HIP_0,    HIP_0   };
+  m["rocsparse_cgebsr2gebsr_buffer_size"]                             = {HIP_4010, HIP_0,    HIP_0   };
+  m["rocsparse_dgebsr2gebsr"]                                         = {HIP_4010, HIP_0,    HIP_0   };
+  m["rocsparse_dgebsr2gebsr_buffer_size"]                             = {HIP_4010, HIP_0,    HIP_0   };
+  m["rocsparse_sgebsr2gebsr"]                                         = {HIP_4010, HIP_0,    HIP_0   };
+  m["rocsparse_sgebsr2gebsr_buffer_size"]                             = {HIP_4010, HIP_0,    HIP_0   };
+  m["rocsparse_gebsr2gebsr_nnz"]                                      = {HIP_4010, HIP_0,    HIP_0   };
+  m["rocsparse_zgebsr2csr"]                                           = {HIP_3100, HIP_0,    HIP_0   };
+  m["rocsparse_cgebsr2csr"]                                           = {HIP_3100, HIP_0,    HIP_0   };
+  m["rocsparse_dgebsr2csr"]                                           = {HIP_3100, HIP_0,    HIP_0   };
+  m["rocsparse_sgebsr2csr"]                                           = {HIP_3100, HIP_0,    HIP_0   };
+  m["rocsparse_zbsr2csr"]                                             = {HIP_3100, HIP_0,    HIP_0   };
+  m["rocsparse_cbsr2csr"]                                             = {HIP_3100, HIP_0,    HIP_0   };
+  m["rocsparse_dbsr2csr"]                                             = {HIP_3100, HIP_0,    HIP_0   };
+  m["rocsparse_sbsr2csr"]                                             = {HIP_3100, HIP_0,    HIP_0   };
+  m["rocsparse_coosort_by_column"]                                    = {HIP_1090, HIP_0,    HIP_0   };
+  m["rocsparse_coosort_by_row"]                                       = {HIP_1090, HIP_0,    HIP_0   };
+  m["rocsparse_coosort_buffer_size"]                                  = {HIP_1090, HIP_0,    HIP_0   };
+  m["rocsparse_cscsort"]                                              = {HIP_2100, HIP_0,    HIP_0   };
+  m["rocsparse_cscsort_buffer_size"]                                  = {HIP_2100, HIP_0,    HIP_0   };
+  m["rocsparse_csrsort"]                                              = {HIP_1090, HIP_0,    HIP_0   };
+  m["rocsparse_csrsort_buffer_size"]                                  = {HIP_1090, HIP_0,    HIP_0   };
+  m["rocsparse_create_identity_permutation"]                          = {HIP_1090, HIP_0,    HIP_0   };
+  m["rocsparse_coo2csr"]                                              = {HIP_1090, HIP_0,    HIP_0   };
+  m["rocsparse_dprune_csr2csr_by_percentage"]                         = {HIP_3090, HIP_0,    HIP_0   };
+  m["rocsparse_sprune_csr2csr_by_percentage"]                         = {HIP_3090, HIP_0,    HIP_0   };
+  m["rocsparse_dprune_csr2csr_nnz_by_percentage"]                     = {HIP_3090, HIP_0,    HIP_0   };
+  m["rocsparse_sprune_csr2csr_nnz_by_percentage"]                     = {HIP_3090, HIP_0,    HIP_0   };
+  m["rocsparse_dprune_csr2csr_by_percentage_buffer_size"]             = {HIP_3090, HIP_0,    HIP_0   };
+  m["rocsparse_sprune_csr2csr_by_percentage_buffer_size"]             = {HIP_3090, HIP_0,    HIP_0   };
+  m["rocsparse_dprune_csr2csr"]                                       = {HIP_3090, HIP_0,    HIP_0   };
+  m["rocsparse_sprune_csr2csr"]                                       = {HIP_3090, HIP_0,    HIP_0   };
+  m["rocsparse_dprune_csr2csr_nnz"]                                   = {HIP_3090, HIP_0,    HIP_0   };
+  m["rocsparse_sprune_csr2csr_nnz"]                                   = {HIP_3090, HIP_0,    HIP_0   };
+  m["rocsparse_dprune_csr2csr_buffer_size"]                           = {HIP_3090, HIP_0,    HIP_0   };
+  m["rocsparse_sprune_csr2csr_buffer_size"]                           = {HIP_3090, HIP_0,    HIP_0   };
+  m["rocsparse_zcsr2csr_compress"]                                    = {HIP_3050, HIP_0,    HIP_0   };
+  m["rocsparse_ccsr2csr_compress"]                                    = {HIP_3050, HIP_0,    HIP_0   };
+  m["rocsparse_dcsr2csr_compress"]                                    = {HIP_3050, HIP_0,    HIP_0   };
+  m["rocsparse_scsr2csr_compress"]                                    = {HIP_3050, HIP_0,    HIP_0   };
+  m["rocsparse_zcsr2gebsr"]                                           = {HIP_4010, HIP_0,    HIP_0   };
+  m["rocsparse_ccsr2gebsr"]                                           = {HIP_4010, HIP_0,    HIP_0   };
+  m["rocsparse_dcsr2gebsr"]                                           = {HIP_4010, HIP_0,    HIP_0   };
+  m["rocsparse_scsr2gebsr"]                                           = {HIP_4010, HIP_0,    HIP_0   };
+  m["rocsparse_csr2gebsr_nnz"]                                        = {HIP_4010, HIP_0,    HIP_0   };
+  m["rocsparse_zcsr2gebsr_buffer_size"]                               = {HIP_4010, HIP_0,    HIP_0   };
+  m["rocsparse_ccsr2gebsr_buffer_size"]                               = {HIP_4010, HIP_0,    HIP_0   };
+  m["rocsparse_dcsr2gebsr_buffer_size"]                               = {HIP_4010, HIP_0,    HIP_0   };
+  m["rocsparse_scsr2gebsr_buffer_size"]                               = {HIP_4010, HIP_0,    HIP_0   };
+  m["rocsparse_zcsr2bsr"]                                             = {HIP_3050, HIP_0,    HIP_0   };
+  m["rocsparse_ccsr2bsr"]                                             = {HIP_3050, HIP_0,    HIP_0   };
+  m["rocsparse_dcsr2bsr"]                                             = {HIP_3050, HIP_0,    HIP_0   };
+  m["rocsparse_scsr2bsr"]                                             = {HIP_3050, HIP_0,    HIP_0   };
+  m["rocsparse_csr2bsr_nnz"]                                          = {HIP_3050, HIP_0,    HIP_0   };
+  m["rocsparse_zcsr2hyb"]                                             = {HIP_2100, HIP_0,    HIP_0   };
+  m["rocsparse_ccsr2hyb"]                                             = {HIP_2100, HIP_0,    HIP_0   };
+  m["rocsparse_dcsr2hyb"]                                             = {HIP_1090, HIP_0,    HIP_0   };
+  m["rocsparse_scsr2hyb"]                                             = {HIP_1090, HIP_0,    HIP_0   };
+  m["rocsparse_zgebsr2gebsc"]                                         = {HIP_4010, HIP_0,    HIP_0   };
+  m["rocsparse_cgebsr2gebsc"]                                         = {HIP_4010, HIP_0,    HIP_0   };
+  m["rocsparse_dgebsr2gebsc"]                                         = {HIP_4010, HIP_0,    HIP_0   };
+  m["rocsparse_sgebsr2gebsc"]                                         = {HIP_4010, HIP_0,    HIP_0   };
+  m["rocsparse_zgebsr2gebsc_buffer_size"]                             = {HIP_4010, HIP_0,    HIP_0   };
+  m["rocsparse_cgebsr2gebsc_buffer_size"]                             = {HIP_4010, HIP_0,    HIP_0   };
+  m["rocsparse_dgebsr2gebsc_buffer_size"]                             = {HIP_4010, HIP_0,    HIP_0   };
+  m["rocsparse_sgebsr2gebsc_buffer_size"]                             = {HIP_4010, HIP_0,    HIP_0   };
+  m["rocsparse_csr2coo"]                                              = {HIP_1090, HIP_0,    HIP_0   };
+  m["rocsparse_znnz_compress"]                                        = {HIP_3050, HIP_0,    HIP_0   };
+  m["rocsparse_cnnz_compress"]                                        = {HIP_3050, HIP_0,    HIP_0   };
+  m["rocsparse_dnnz_compress"]                                        = {HIP_3050, HIP_0,    HIP_0   };
+  m["rocsparse_snnz_compress"]                                        = {HIP_3050, HIP_0,    HIP_0   };
+  m["rocsparse_zcsc2dense"]                                           = {HIP_3050, HIP_0,    HIP_0   };
+  m["rocsparse_ccsc2dense"]                                           = {HIP_3050, HIP_0,    HIP_0   };
+  m["rocsparse_dcsc2dense"]                                           = {HIP_3050, HIP_0,    HIP_0   };
+  m["rocsparse_scsc2dense"]                                           = {HIP_3050, HIP_0,    HIP_0   };
+  m["rocsparse_zcsr2dense"]                                           = {HIP_3050, HIP_0,    HIP_0   };
+  m["rocsparse_ccsr2dense"]                                           = {HIP_3050, HIP_0,    HIP_0   };
+  m["rocsparse_dcsr2dense"]                                           = {HIP_3050, HIP_0,    HIP_0   };
+  m["rocsparse_scsr2dense"]                                           = {HIP_3050, HIP_0,    HIP_0   };
+  m["rocsparse_zdense2csc"]                                           = {HIP_3020, HIP_0,    HIP_0   };
+  m["rocsparse_cdense2csc"]                                           = {HIP_3020, HIP_0,    HIP_0   };
+  m["rocsparse_ddense2csc"]                                           = {HIP_3020, HIP_0,    HIP_0   };
+  m["rocsparse_sdense2csc"]                                           = {HIP_3020, HIP_0,    HIP_0   };
+  m["rocsparse_dprune_dense2csr_by_percentage"]                       = {HIP_3090, HIP_0,    HIP_0   };
+  m["rocsparse_sprune_dense2csr_by_percentage"]                       = {HIP_3090, HIP_0,    HIP_0   };
+  m["rocsparse_dprune_dense2csr_nnz_by_percentage"]                   = {HIP_3090, HIP_0,    HIP_0   };
+  m["rocsparse_sprune_dense2csr_nnz_by_percentage"]                   = {HIP_3090, HIP_0,    HIP_0   };
+  m["rocsparse_dprune_dense2csr_by_percentage_buffer_size"]           = {HIP_3090, HIP_0,    HIP_0   };
+  m["rocsparse_sprune_dense2csr_by_percentage_buffer_size"]           = {HIP_3090, HIP_0,    HIP_0   };
+  m["rocsparse_dprune_dense2csr"]                                     = {HIP_3090, HIP_0,    HIP_0   };
+  m["rocsparse_sprune_dense2csr"]                                     = {HIP_3090, HIP_0,    HIP_0   };
+  m["rocsparse_dprune_dense2csr_nnz"]                                 = {HIP_3090, HIP_0,    HIP_0   };
+  m["rocsparse_sprune_dense2csr_nnz"]                                 = {HIP_3090, HIP_0,    HIP_0   };
+  m["rocsparse_dprune_dense2csr_buffer_size"]                         = {HIP_3090, HIP_0,    HIP_0   };
+  m["rocsparse_sprune_dense2csr_buffer_size"]                         = {HIP_3090, HIP_0,    HIP_0   };
+  m["rocsparse_zdense2csr"]                                           = {HIP_3020, HIP_0,    HIP_0   };
+  m["rocsparse_cdense2csr"]                                           = {HIP_3020, HIP_0,    HIP_0   };
+  m["rocsparse_ddense2csr"]                                           = {HIP_3020, HIP_0,    HIP_0   };
+  m["rocsparse_sdense2csr"]                                           = {HIP_3020, HIP_0,    HIP_0   };
+  m["rocsparse_znnz"]                                                 = {HIP_3020, HIP_0,    HIP_0   };
+  m["rocsparse_cnnz"]                                                 = {HIP_3020, HIP_0,    HIP_0   };
+  m["rocsparse_dnnz"]                                                 = {HIP_3020, HIP_0,    HIP_0   };
+  m["rocsparse_snnz"]                                                 = {HIP_3020, HIP_0,    HIP_0   };
+  m["rocsparse_zgpsv_interleaved_batch"]                              = {HIP_5010, HIP_0,    HIP_0   };
+  m["rocsparse_cgpsv_interleaved_batch"]                              = {HIP_5010, HIP_0,    HIP_0   };
+  m["rocsparse_dgpsv_interleaved_batch"]                              = {HIP_5010, HIP_0,    HIP_0   };
+  m["rocsparse_sgpsv_interleaved_batch"]                              = {HIP_5010, HIP_0,    HIP_0   };
+  m["rocsparse_zgpsv_interleaved_batch_buffer_size"]                  = {HIP_5010, HIP_0,    HIP_0   };
+  m["rocsparse_cgpsv_interleaved_batch_buffer_size"]                  = {HIP_5010, HIP_0,    HIP_0   };
+  m["rocsparse_dgpsv_interleaved_batch_buffer_size"]                  = {HIP_5010, HIP_0,    HIP_0   };
+  m["rocsparse_sgpsv_interleaved_batch_buffer_size"]                  = {HIP_5010, HIP_0,    HIP_0   };
+  m["rocsparse_zgtsv_interleaved_batch"]                              = {HIP_5010, HIP_0,    HIP_0   };
+  m["rocsparse_cgtsv_interleaved_batch"]                              = {HIP_5010, HIP_0,    HIP_0   };
+  m["rocsparse_dgtsv_interleaved_batch"]                              = {HIP_5010, HIP_0,    HIP_0   };
+  m["rocsparse_sgtsv_interleaved_batch"]                              = {HIP_5010, HIP_0,    HIP_0   };
+  m["rocsparse_zgtsv_interleaved_batch_buffer_size"]                  = {HIP_5010, HIP_0,    HIP_0   };
+  m["rocsparse_cgtsv_interleaved_batch_buffer_size"]                  = {HIP_5010, HIP_0,    HIP_0   };
+  m["rocsparse_dgtsv_interleaved_batch_buffer_size"]                  = {HIP_5010, HIP_0,    HIP_0   };
+  m["rocsparse_sgtsv_interleaved_batch_buffer_size"]                  = {HIP_5010, HIP_0,    HIP_0   };
+  m["rocsparse_zgtsv_no_pivot_strided_batch"]                         = {HIP_4030, HIP_0,    HIP_0   };
+  m["rocsparse_cgtsv_no_pivot_strided_batch"]                         = {HIP_4030, HIP_0,    HIP_0   };
+  m["rocsparse_dgtsv_no_pivot_strided_batch"]                         = {HIP_4030, HIP_0,    HIP_0   };
+  m["rocsparse_sgtsv_no_pivot_strided_batch"]                         = {HIP_4030, HIP_0,    HIP_0   };
+  m["rocsparse_zgtsv_no_pivot_strided_batch_buffer_size"]             = {HIP_4030, HIP_0,    HIP_0   };
+  m["rocsparse_cgtsv_no_pivot_strided_batch_buffer_size"]             = {HIP_4030, HIP_0,    HIP_0   };
+  m["rocsparse_dgtsv_no_pivot_strided_batch_buffer_size"]             = {HIP_4030, HIP_0,    HIP_0   };
+  m["rocsparse_sgtsv_no_pivot_strided_batch_buffer_size"]             = {HIP_4030, HIP_0,    HIP_0   };
+  m["rocsparse_zgtsv_no_pivot"]                                       = {HIP_4030, HIP_0,    HIP_0   };
+  m["rocsparse_cgtsv_no_pivot"]                                       = {HIP_4030, HIP_0,    HIP_0   };
+  m["rocsparse_dgtsv_no_pivot"]                                       = {HIP_4030, HIP_0,    HIP_0   };
+  m["rocsparse_sgtsv_no_pivot"]                                       = {HIP_4030, HIP_0,    HIP_0   };
+  m["rocsparse_zgtsv_no_pivot_buffer_size"]                           = {HIP_4030, HIP_0,    HIP_0   };
+  m["rocsparse_cgtsv_no_pivot_buffer_size"]                           = {HIP_4030, HIP_0,    HIP_0   };
+  m["rocsparse_dgtsv_no_pivot_buffer_size"]                           = {HIP_4030, HIP_0,    HIP_0   };
+  m["rocsparse_sgtsv_no_pivot_buffer_size"]                           = {HIP_4030, HIP_0,    HIP_0   };
+  m["rocsparse_zgtsv"]                                                = {HIP_4030, HIP_0,    HIP_0   };
+  m["rocsparse_cgtsv"]                                                = {HIP_4030, HIP_0,    HIP_0   };
+  m["rocsparse_dgtsv"]                                                = {HIP_4030, HIP_0,    HIP_0   };
+  m["rocsparse_sgtsv"]                                                = {HIP_4030, HIP_0,    HIP_0   };
+  m["rocsparse_zgtsv_buffer_size"]                                    = {HIP_4030, HIP_0,    HIP_0   };
+  m["rocsparse_cgtsv_buffer_size"]                                    = {HIP_4030, HIP_0,    HIP_0   };
+  m["rocsparse_dgtsv_buffer_size"]                                    = {HIP_4030, HIP_0,    HIP_0   };
+  m["rocsparse_sgtsv_buffer_size"]                                    = {HIP_4030, HIP_0,    HIP_0   };
+  m["rocsparse_zcsrilu0"]                                             = {HIP_2100, HIP_0,    HIP_0   };
+  m["rocsparse_ccsrilu0"]                                             = {HIP_2100, HIP_0,    HIP_0   };
+  m["rocsparse_dcsrilu0"]                                             = {HIP_1090, HIP_0,    HIP_0   };
+  m["rocsparse_scsrilu0"]                                             = {HIP_1090, HIP_0,    HIP_0   };
+  m["rocsparse_zcsrilu0_analysis"]                                    = {HIP_2100, HIP_0,    HIP_0   };
+  m["rocsparse_ccsrilu0_analysis"]                                    = {HIP_2100, HIP_0,    HIP_0   };
+  m["rocsparse_dcsrilu0_analysis"]                                    = {HIP_1090, HIP_0,    HIP_0   };
+  m["rocsparse_scsrilu0_analysis"]                                    = {HIP_1090, HIP_0,    HIP_0   };
+  m["rocsparse_zcsrilu0_buffer_size"]                                 = {HIP_2100, HIP_0,    HIP_0   };
+  m["rocsparse_ccsrilu0_buffer_size"]                                 = {HIP_2100, HIP_0,    HIP_0   };
+  m["rocsparse_dcsrilu0_buffer_size"]                                 = {HIP_1090, HIP_0,    HIP_0   };
+  m["rocsparse_scsrilu0_buffer_size"]                                 = {HIP_1090, HIP_0,    HIP_0   };
+  m["rocsparse_zcsrilu0_numeric_boost"]                               = {HIP_3090, HIP_0,    HIP_0   };
+  m["rocsparse_dccsrilu0_numeric_boost"]                              = {HIP_4050, HIP_0,    HIP_0   };
+  m["rocsparse_dcsrilu0_numeric_boost"]                               = {HIP_3090, HIP_0,    HIP_0   };
+  m["rocsparse_dscsrilu0_numeric_boost"]                              = {HIP_4050, HIP_0,    HIP_0   };
+  m["rocsparse_csrilu0_zero_pivot"]                                   = {HIP_1090, HIP_0,    HIP_0   };
+  m["rocsparse_zcsric0"]                                              = {HIP_3010, HIP_0,    HIP_0   };
+  m["rocsparse_ccsric0"]                                              = {HIP_3010, HIP_0,    HIP_0   };
+  m["rocsparse_dcsric0"]                                              = {HIP_3010, HIP_0,    HIP_0   };
+  m["rocsparse_scsric0"]                                              = {HIP_3010, HIP_0,    HIP_0   };
+  m["rocsparse_zcsric0_analysis"]                                     = {HIP_3010, HIP_0,    HIP_0   };
+  m["rocsparse_ccsric0_analysis"]                                     = {HIP_3010, HIP_0,    HIP_0   };
+  m["rocsparse_dcsric0_analysis"]                                     = {HIP_3010, HIP_0,    HIP_0   };
+  m["rocsparse_scsric0_analysis"]                                     = {HIP_3010, HIP_0,    HIP_0   };
+  m["rocsparse_zcsric0_buffer_size"]                                  = {HIP_3010, HIP_0,    HIP_0   };
+  m["rocsparse_ccsric0_buffer_size"]                                  = {HIP_3010, HIP_0,    HIP_0   };
+  m["rocsparse_dcsric0_buffer_size"]                                  = {HIP_3010, HIP_0,    HIP_0   };
+  m["rocsparse_scsric0_buffer_size"]                                  = {HIP_3010, HIP_0,    HIP_0   };
+  m["rocsparse_csric0_zero_pivot"]                                    = {HIP_3010, HIP_0,    HIP_0   };
+  m["rocsparse_zbsrilu0"]                                             = {HIP_3090, HIP_0,    HIP_0   };
+  m["rocsparse_cbsrilu0"]                                             = {HIP_3090, HIP_0,    HIP_0   };
+  m["rocsparse_dbsrilu0"]                                             = {HIP_3090, HIP_0,    HIP_0   };
+  m["rocsparse_sbsrilu0"]                                             = {HIP_3090, HIP_0,    HIP_0   };
+  m["rocsparse_bsrilu0_zero_pivot"]                                   = {HIP_3090, HIP_0,    HIP_0   };
+  m["rocsparse_zbsrilu0_analysis"]                                    = {HIP_3060, HIP_0,    HIP_0   };
+  m["rocsparse_cbsrilu0_analysis"]                                    = {HIP_3060, HIP_0,    HIP_0   };
+  m["rocsparse_dbsrilu0_analysis"]                                    = {HIP_3060, HIP_0,    HIP_0   };
+  m["rocsparse_sbsrilu0_analysis"]                                    = {HIP_3060, HIP_0,    HIP_0   };
+  m["rocsparse_dcbsrilu0_numeric_boost"]                              = {HIP_4050, HIP_0,    HIP_0   };
+  m["rocsparse_dsbsrilu0_numeric_boost"]                              = {HIP_4050, HIP_0,    HIP_0   };
+  m["rocsparse_zbsrilu0_numeric_boost"]                               = {HIP_3090, HIP_0,    HIP_0   };
+  m["rocsparse_dbsrilu0_numeric_boost"]                               = {HIP_3090, HIP_0,    HIP_0   };
+  m["rocsparse_zbsric0"]                                              = {HIP_3080, HIP_0,    HIP_0   };
+  m["rocsparse_cbsric0"]                                              = {HIP_3080, HIP_0,    HIP_0   };
+  m["rocsparse_dbsric0"]                                              = {HIP_3080, HIP_0,    HIP_0   };
+  m["rocsparse_sbsric0"]                                              = {HIP_3080, HIP_0,    HIP_0   };
+  m["rocsparse_zbsric0_analysis"]                                     = {HIP_3060, HIP_0,    HIP_0   };
+  m["rocsparse_cbsric0_analysis"]                                     = {HIP_3060, HIP_0,    HIP_0   };
+  m["rocsparse_dbsric0_analysis"]                                     = {HIP_3060, HIP_0,    HIP_0   };
+  m["rocsparse_sbsric0_analysis"]                                     = {HIP_3060, HIP_0,    HIP_0   };
+  m["rocsparse_zbsric0_buffer_size"]                                  = {HIP_3080, HIP_0,    HIP_0   };
+  m["rocsparse_cbsric0_buffer_size"]                                  = {HIP_3080, HIP_0,    HIP_0   };
+  m["rocsparse_dbsric0_buffer_size"]                                  = {HIP_3080, HIP_0,    HIP_0   };
+  m["rocsparse_sbsric0_buffer_size"]                                  = {HIP_3080, HIP_0,    HIP_0   };
+  m["rocsparse_bsric0_zero_pivot"]                                    = {HIP_3080, HIP_0,    HIP_0   };
+  m["rocsparse_csrgemm_nnz"]                                          = {HIP_2080, HIP_0,    HIP_0   };
+  m["rocsparse_zcsrgemm_buffer_size"]                                 = {HIP_2080, HIP_0,    HIP_0   };
+  m["rocsparse_ccsrgemm_buffer_size"]                                 = {HIP_2080, HIP_0,    HIP_0   };
+  m["rocsparse_dcsrgemm_buffer_size"]                                 = {HIP_2080, HIP_0,    HIP_0   };
+  m["rocsparse_scsrgemm_buffer_size"]                                 = {HIP_2080, HIP_0,    HIP_0   };
+  m["rocsparse_zcsrgeam"]                                             = {HIP_3050, HIP_0,    HIP_0   };
+  m["rocsparse_ccsrgeam"]                                             = {HIP_3050, HIP_0,    HIP_0   };
+  m["rocsparse_dcsrgeam"]                                             = {HIP_3050, HIP_0,    HIP_0   };
+  m["rocsparse_scsrgeam"]                                             = {HIP_3050, HIP_0,    HIP_0   };
+  m["rocsparse_csrgeam_nnz"]                                          = {HIP_3050, HIP_0,    HIP_0   };
+  m["rocsparse_zbsrsm_solve"]                                         = {HIP_4050, HIP_0,    HIP_0   };
+  m["rocsparse_cbsrsm_solve"]                                         = {HIP_4050, HIP_0,    HIP_0   };
+  m["rocsparse_dbsrsm_solve"]                                         = {HIP_4050, HIP_0,    HIP_0   };
+  m["rocsparse_sbsrsm_solve"]                                         = {HIP_4050, HIP_0,    HIP_0   };
+  m["rocsparse_zbsrsm_analysis"]                                      = {HIP_3060, HIP_0,    HIP_0   };
+  m["rocsparse_cbsrsm_analysis"]                                      = {HIP_3060, HIP_0,    HIP_0   };
+  m["rocsparse_dbsrsm_analysis"]                                      = {HIP_3060, HIP_0,    HIP_0   };
+  m["rocsparse_sbsrsm_analysis"]                                      = {HIP_3060, HIP_0,    HIP_0   };
+  m["rocsparse_zbsrsm_buffer_size"]                                   = {HIP_4050, HIP_0,    HIP_0   };
+  m["rocsparse_cbsrsm_buffer_size"]                                   = {HIP_4050, HIP_0,    HIP_0   };
+  m["rocsparse_dbsrsm_buffer_size"]                                   = {HIP_4050, HIP_0,    HIP_0   };
+  m["rocsparse_sbsrsm_buffer_size"]                                   = {HIP_4050, HIP_0,    HIP_0   };
+  m["rocsparse_bsrsm_zero_pivot"]                                     = {HIP_4050, HIP_0,    HIP_0   };
+  m["rocsparse_zcsrsm_solve"]                                         = {HIP_3010, HIP_0,    HIP_0   };
+  m["rocsparse_ccsrsm_solve"]                                         = {HIP_3010, HIP_0,    HIP_0   };
+  m["rocsparse_dcsrsm_solve"]                                         = {HIP_3010, HIP_0,    HIP_0   };
+  m["rocsparse_scsrsm_solve"]                                         = {HIP_3010, HIP_0,    HIP_0   };
+  m["rocsparse_scsrsm_analysis"]                                      = {HIP_3010, HIP_0,    HIP_0   };
+  m["rocsparse_dcsrsm_analysis"]                                      = {HIP_3010, HIP_0,    HIP_0   };
+  m["rocsparse_ccsrsm_analysis"]                                      = {HIP_3010, HIP_0,    HIP_0   };
+  m["rocsparse_zcsrsm_analysis"]                                      = {HIP_3010, HIP_0,    HIP_0   };
+  m["rocsparse_scsrsm_buffer_size"]                                   = {HIP_3010, HIP_0,    HIP_0   };
+  m["rocsparse_dcsrsm_buffer_size"]                                   = {HIP_3010, HIP_0,    HIP_0   };
+  m["rocsparse_ccsrsm_buffer_size"]                                   = {HIP_3010, HIP_0,    HIP_0   };
+  m["rocsparse_zcsrsm_buffer_size"]                                   = {HIP_3010, HIP_0,    HIP_0   };
+  m["rocsparse_csrsm_zero_pivot"]                                     = {HIP_3010, HIP_0,    HIP_0   };
+  m["rocsparse_zcsrmm"]                                               = {HIP_1090, HIP_0,    HIP_0   };
+  m["rocsparse_ccsrmm"]                                               = {HIP_1090, HIP_0,    HIP_0   };
+  m["rocsparse_dcsrmm"]                                               = {HIP_1090, HIP_0,    HIP_0   };
+  m["rocsparse_scsrmm"]                                               = {HIP_1090, HIP_0,    HIP_0   };
+  m["rocsparse_zbsrmm"]                                               = {HIP_3070, HIP_0,    HIP_0   };
+  m["rocsparse_cbsrmm"]                                               = {HIP_3070, HIP_0,    HIP_0   };
+  m["rocsparse_dbsrmm"]                                               = {HIP_3070, HIP_0,    HIP_0   };
+  m["rocsparse_sbsrmm"]                                               = {HIP_3070, HIP_0,    HIP_0   };
+  m["rocsparse_sgemvi"]                                               = {HIP_4030, HIP_0,    HIP_0   };
+  m["rocsparse_dgemvi"]                                               = {HIP_4030, HIP_0,    HIP_0   };
+  m["rocsparse_cgemvi"]                                               = {HIP_4030, HIP_0,    HIP_0   };
+  m["rocsparse_zgemvi"]                                               = {HIP_4030, HIP_0,    HIP_0   };
+  m["rocsparse_sgemvi_buffer_size"]                                   = {HIP_4030, HIP_0,    HIP_0   };
+  m["rocsparse_dgemvi_buffer_size"]                                   = {HIP_4030, HIP_0,    HIP_0   };
+  m["rocsparse_cgemvi_buffer_size"]                                   = {HIP_4030, HIP_0,    HIP_0   };
+  m["rocsparse_zgemvi_buffer_size"]                                   = {HIP_4030, HIP_0,    HIP_0   };
+  m["rocsparse_zhybmv"]                                               = {HIP_2100, HIP_0,    HIP_0   };
+  m["rocsparse_chybmv"]                                               = {HIP_2100, HIP_0,    HIP_0   };
+  m["rocsparse_dhybmv"]                                               = {HIP_1090, HIP_0,    HIP_0   };
+  m["rocsparse_shybmv"]                                               = {HIP_1090, HIP_0,    HIP_0   };
+  m["rocsparse_zcsrsv_solve"]                                         = {HIP_2100, HIP_0,    HIP_0   };
+  m["rocsparse_ccsrsv_solve"]                                         = {HIP_2100, HIP_0,    HIP_0   };
+  m["rocsparse_dcsrsv_solve"]                                         = {HIP_1090, HIP_0,    HIP_0   };
+  m["rocsparse_scsrsv_solve"]                                         = {HIP_1090, HIP_0,    HIP_0   };
+  m["rocsparse_zcsrsv_analysis"]                                      = {HIP_2100, HIP_0,    HIP_0   };
+  m["rocsparse_ccsrsv_analysis"]                                      = {HIP_2100, HIP_0,    HIP_0   };
+  m["rocsparse_dcsrsv_analysis"]                                      = {HIP_1090, HIP_0,    HIP_0   };
+  m["rocsparse_scsrsv_analysis"]                                      = {HIP_1090, HIP_0,    HIP_0   };
+  m["rocsparse_zcsrsv_buffer_size"]                                   = {HIP_2100, HIP_0,    HIP_0   };
+  m["rocsparse_ccsrsv_buffer_size"]                                   = {HIP_2100, HIP_0,    HIP_0   };
+  m["rocsparse_dcsrsv_buffer_size"]                                   = {HIP_1090, HIP_0,    HIP_0   };
+  m["rocsparse_scsrsv_buffer_size"]                                   = {HIP_1090, HIP_0,    HIP_0   };
+  m["rocsparse_csrsv_zero_pivot"]                                     = {HIP_1090, HIP_0,    HIP_0   };
+  m["rocsparse_zcsrmv"]                                               = {HIP_1090, HIP_0,    HIP_0   };
+  m["rocsparse_ccsrmv"]                                               = {HIP_1090, HIP_0,    HIP_0   };
+  m["rocsparse_dcsrmv"]                                               = {HIP_1090, HIP_0,    HIP_0   };
+  m["rocsparse_scsrmv"]                                               = {HIP_1090, HIP_0,    HIP_0   };
+  m["rocsparse_zbsrsv_solve"]                                         = {HIP_3060, HIP_0,    HIP_0   };
+  m["rocsparse_cbsrsv_solve"]                                         = {HIP_3060, HIP_0,    HIP_0   };
+  m["rocsparse_dbsrsv_solve"]                                         = {HIP_3060, HIP_0,    HIP_0   };
+  m["rocsparse_sbsrsv_solve"]                                         = {HIP_3060, HIP_0,    HIP_0   };
+  m["rocsparse_zbsrsv_analysis"]                                      = {HIP_3060, HIP_0,    HIP_0   };
+  m["rocsparse_cbsrsv_analysis"]                                      = {HIP_3060, HIP_0,    HIP_0   };
+  m["rocsparse_dbsrsv_analysis"]                                      = {HIP_3060, HIP_0,    HIP_0   };
+  m["rocsparse_sbsrsv_analysis"]                                      = {HIP_3060, HIP_0,    HIP_0   };
+  m["rocsparse_zbsrsv_buffer_size"]                                   = {HIP_3060, HIP_0,    HIP_0   };
+  m["rocsparse_cbsrsv_buffer_size"]                                   = {HIP_3060, HIP_0,    HIP_0   };
+  m["rocsparse_dbsrsv_buffer_size"]                                   = {HIP_3060, HIP_0,    HIP_0   };
+  m["rocsparse_sbsrsv_buffer_size"]                                   = {HIP_3060, HIP_0,    HIP_0   };
+  m["rocsparse_bsrsv_zero_pivot"]                                     = {HIP_3060, HIP_0,    HIP_0   };
+  m["rocsparse_zbsrxmv"]                                              = {HIP_4050, HIP_0,    HIP_0   };
+  m["rocsparse_cbsrxmv"]                                              = {HIP_4050, HIP_0,    HIP_0   };
+  m["rocsparse_dbsrxmv"]                                              = {HIP_4050, HIP_0,    HIP_0   };
+  m["rocsparse_sbsrxmv"]                                              = {HIP_4050, HIP_0,    HIP_0   };
+  m["rocsparse_zbsrmv"]                                               = {HIP_3050, HIP_5040, HIP_0   };
+  m["rocsparse_cbsrmv"]                                               = {HIP_3050, HIP_5040, HIP_0   };
+  m["rocsparse_dbsrmv"]                                               = {HIP_3050, HIP_5040, HIP_0   };
+  m["rocsparse_sbsrmv"]                                               = {HIP_3050, HIP_5040, HIP_0   };
+  m["rocsparse_zsctr"]                                                = {HIP_1090, HIP_0,    HIP_0   };
+  m["rocsparse_csctr"]                                                = {HIP_1090, HIP_0,    HIP_0   };
+  m["rocsparse_dsctr"]                                                = {HIP_1090, HIP_0,    HIP_0   };
+  m["rocsparse_ssctr"]                                                = {HIP_1090, HIP_0,    HIP_0   };
+  m["rocsparse_droti"]                                                = {HIP_1090, HIP_0,    HIP_0   };
+  m["rocsparse_sroti"]                                                = {HIP_1090, HIP_0,    HIP_0   };
+  m["rocsparse_zgthrz"]                                               = {HIP_1090, HIP_0,    HIP_0   };
+  m["rocsparse_cgthrz"]                                               = {HIP_1090, HIP_0,    HIP_0   };
+  m["rocsparse_dgthrz"]                                               = {HIP_1090, HIP_0,    HIP_0   };
+  m["rocsparse_sgthrz"]                                               = {HIP_1090, HIP_0,    HIP_0   };
+  m["rocsparse_sgthr"]                                                = {HIP_1090, HIP_0,    HIP_0   };
+  m["rocsparse_dgthr"]                                                = {HIP_1090, HIP_0,    HIP_0   };
+  m["rocsparse_cgthr"]                                                = {HIP_1090, HIP_0,    HIP_0   };
+  m["rocsparse_zgthr"]                                                = {HIP_1090, HIP_0,    HIP_0   };
+  m["rocsparse_cdotci"]                                               = {HIP_3000, HIP_0,    HIP_0   };
+  m["rocsparse_zdotci"]                                               = {HIP_3000, HIP_0,    HIP_0   };
+  m["rocsparse_sdoti"]                                                = {HIP_1090, HIP_0,    HIP_0   };
+  m["rocsparse_ddoti"]                                                = {HIP_1090, HIP_0,    HIP_0   };
+  m["rocsparse_cdoti"]                                                = {HIP_1090, HIP_0,    HIP_0   };
+  m["rocsparse_zdoti"]                                                = {HIP_1090, HIP_0,    HIP_0   };
+  m["rocsparse_saxpyi"]                                               = {HIP_1090, HIP_0,    HIP_0   };
+  m["rocsparse_daxpyi"]                                               = {HIP_1090, HIP_0,    HIP_0   };
+  m["rocsparse_caxpyi"]                                               = {HIP_1090, HIP_0,    HIP_0   };
+  m["rocsparse_zaxpyi"]                                               = {HIP_1090, HIP_0,    HIP_0   };
+  m["rocsparse_get_status_name"]                                      = {HIP_6000, HIP_0,    HIP_0   };
+  m["rocsparse_get_status_description"]                               = {HIP_6000, HIP_0,    HIP_0   };
+  m["rocsparse_create_const_spvec_descr"]                             = {HIP_6000, HIP_0,    HIP_0   };
+  m["rocsparse_const_spvec_get"]                                      = {HIP_6000, HIP_0,    HIP_0   };
+  m["rocsparse_const_spvec_get_values"]                               = {HIP_6000, HIP_0,    HIP_0   };
+  m["rocsparse_create_const_coo_descr"]                               = {HIP_6000, HIP_0,    HIP_0   };
+  m["rocsparse_create_const_csr_descr"]                               = {HIP_6000, HIP_0,    HIP_0   };
+  m["rocsparse_create_const_csc_descr"]                               = {HIP_6000, HIP_0,    HIP_0   };
+  m["rocsparse_create_const_bell_descr"]                              = {HIP_6000, HIP_0,    HIP_0   };
+  m["rocsparse_const_coo_get"]                                        = {HIP_6000, HIP_0,    HIP_0   };
+  m["rocsparse_const_csr_get"]                                        = {HIP_6000, HIP_0,    HIP_0   };
+  m["rocsparse_const_csc_get"]                                        = {HIP_6000, HIP_0,    HIP_0   };
+  m["rocsparse_const_bell_get"]                                       = {HIP_6000, HIP_0,    HIP_0   };
+  m["rocsparse_const_spmat_get_values"]                               = {HIP_6000, HIP_0,    HIP_0   };
+  m["rocsparse_create_const_dnvec_descr"]                             = {HIP_6000, HIP_0,    HIP_0   };
+  m["rocsparse_const_dnvec_get"]                                      = {HIP_6000, HIP_0,    HIP_0   };
+  m["rocsparse_const_dnvec_get_values"]                               = {HIP_6000, HIP_0,    HIP_0   };
+  m["rocsparse_create_const_dnmat_descr"]                             = {HIP_6000, HIP_0,    HIP_0   };
+  m["rocsparse_const_dnmat_get"]                                      = {HIP_6000, HIP_0,    HIP_0   };
+  m["rocsparse_const_dnmat_get_values"]                               = {HIP_6000, HIP_0,    HIP_0   };
+  m["rocsparse_create_mat_info"]                                      = {HIP_1090, HIP_0,    HIP_0   };
+  m["rocsparse_destroy_mat_info"]                                     = {HIP_1090, HIP_0,    HIP_0   };
+  m["rocsparse_scsrmm"]                                               = {HIP_1090, HIP_0,    HIP_0   };
+  m["rocsparse_dcsrmm"]                                               = {HIP_1090, HIP_0,    HIP_0   };
+  m["rocsparse_ccsrmm"]                                               = {HIP_1090, HIP_0,    HIP_0   };
+  m["rocsparse_zcsrmm"]                                               = {HIP_1090, HIP_0,    HIP_0   };
+  m["rocsparse_scsrgemm"]                                             = {HIP_2080, HIP_0,    HIP_0   };
+  m["rocsparse_dcsrgemm"]                                             = {HIP_2080, HIP_0,    HIP_0   };
+  m["rocsparse_ccsrgemm"]                                             = {HIP_2080, HIP_0,    HIP_0   };
+  m["rocsparse_zcsrgemm"]                                             = {HIP_2080, HIP_0,    HIP_0   };
+  m["rocsparse_sbsrilu0_buffer_size"]                                 = {HIP_3080, HIP_0,    HIP_0   };
+  m["rocsparse_dbsrilu0_buffer_size"]                                 = {HIP_3080, HIP_0,    HIP_0   };
+  m["rocsparse_cbsrilu0_buffer_size"]                                 = {HIP_3080, HIP_0,    HIP_0   };
+  m["rocsparse_zbsrilu0_buffer_size"]                                 = {HIP_3080, HIP_0,    HIP_0   };
+  m["rocsparse_csr2csc_buffer_size"]                                  = {HIP_1090, HIP_0,    HIP_0   };
+  m["rocsparse_sparse_to_dense"]                                      = {HIP_4010, HIP_0,    HIP_0   };
+  m["rocsparse_dense_to_sparse"]                                      = {HIP_4010, HIP_0,    HIP_0   };
+  m["rocsparse_spmm"]                                                 = {HIP_4020, HIP_0,    HIP_0   };
+  m["rocsparse_spsm"]                                                 = {HIP_4050, HIP_0,    HIP_0   };
+  m["rocsparse_spvv"]                                                 = {HIP_4010, HIP_0,    HIP_0   };
+  m["rocsparse_spsv"]                                                 = {HIP_4050, HIP_0,    HIP_0   };
+  m["rocsparse_csc_get"]                                              = {HIP_6010, HIP_0,    HIP_0   };
+  return m;
+}();
+
+const std::map<llvm::StringRef, cudaAPIChangedVersions> CUDA_SPARSE_FUNCTION_CHANGED_VER_MAP = [] {
+  std::map<llvm::StringRef, cudaAPIChangedVersions> m;
+  m["cusparseSpVecGetIndexBase"]                                      = {CUDA_120};
+  m["cusparseDestroySpVec"]                                           = {CUDA_120};
+  m["cusparseDestroyDnVec"]                                           = {CUDA_120};
+  m["cusparseSpMatGetAttribute"]                                      = {CUDA_120};
+  m["cusparseSpMatGetFormat"]                                         = {CUDA_120};
+  m["cusparseSpMatGetSize"]                                           = {CUDA_120};
+  m["cusparseSpMatGetIndexBase"]                                      = {CUDA_120};
+  m["cusparseSpMatGetStridedBatch"]                                   = {CUDA_120};
+  m["cusparseDestroySpMat"]                                           = {CUDA_120};
+  m["cusparseSpGEMM_compute"]                                         = {CUDA_120};
+  m["cusparseSpGEMM_copy"]                                            = {CUDA_120};
+  m["cusparseSpGEMM_workEstimation"]                                  = {CUDA_120};
+  m["cusparseSpGEMMreuse_compute"]                                    = {CUDA_120};
+  m["cusparseSpGEMMreuse_copy"]                                       = {CUDA_120};
+  m["cusparseSpGEMMreuse_nnz"]                                        = {CUDA_120};
+  m["cusparseSpGEMMreuse_workEstimation"]                             = {CUDA_120};
+  m["cusparseDnMatGetStridedBatch"]                                   = {CUDA_120};
+  m["cusparseDestroyDnMat"]                                           = {CUDA_120};
+  m["cusparseSpMM"]                                                   = {CUDA_120};
+  m["cusparseSpMM_bufferSize"]                                        = {CUDA_120};
+  m["cusparseSpMM_preprocess"]                                        = {CUDA_120};
+  m["cusparseSpMV"]                                                   = {CUDA_120};
+  m["cusparseSpMV_bufferSize"]                                        = {CUDA_120};
+  m["cusparseSpSM_analysis"]                                          = {CUDA_120};
+  m["cusparseSpSM_bufferSize"]                                        = {CUDA_120};
+  m["cusparseSpSM_solve"]                                             = {CUDA_120};
+  m["cusparseSpSV_analysis"]                                          = {CUDA_120};
+  m["cusparseSpSV_bufferSize"]                                        = {CUDA_120};
+  m["cusparseSpSV_solve"]                                             = {CUDA_120};
+  m["cusparseSpVV"]                                                   = {CUDA_120};
+  m["cusparseSpVV_bufferSize"]                                        = {CUDA_120};
+  m["cusparseSDDMM"]                                                  = {CUDA_120};
+  m["cusparseSDDMM_bufferSize"]                                       = {CUDA_120};
+  m["cusparseSDDMM_preprocess"]                                       = {CUDA_120};
+  m["cusparseAxpby"]                                                  = {CUDA_120};
+  m["cusparseGather"]                                                 = {CUDA_120};
+  m["cusparseScatter"]                                                = {CUDA_120};
+  m["cusparseSparseToDense"]                                          = {CUDA_120}; // C: CUSPARSE_VERSION 12000
+  m["cusparseSparseToDense_bufferSize"]                               = {CUDA_120};
+  m["cusparseDenseToSparse_analysis"]                                 = {CUDA_120};
+  m["cusparseDenseToSparse_bufferSize"]                               = {CUDA_120};
+  m["cusparseDenseToSparse_convert"]                                  = {CUDA_120};
+
+  return m;
+}();
+
+const std::map<llvm::StringRef, hipAPIChangedVersions> HIP_SPARSE_FUNCTION_CHANGED_VER_MAP = [] {
+  std::map<llvm::StringRef, hipAPIChangedVersions> m;
+
+  m["hipsparseSpVecGetIndexBase"]                                     = {HIP_6000};
+  m["hipsparseDestroySpVec"]                                          = {HIP_6000};
+  m["hipsparseDestroyDnVec"]                                          = {HIP_6000};
+  m["hipsparseSpMatGetAttribute"]                                     = {HIP_6000};
+  m["hipsparseSpMatGetFormat"]                                        = {HIP_6000};
+  m["hipsparseSpMatGetSize"]                                          = {HIP_6000};
+  m["hipsparseSpMatGetIndexBase"]                                     = {HIP_6000};
+  m["hipsparseSpMatGetStridedBatch"]                                  = {HIP_6000};
+  m["hipsparseDestroySpMat"]                                          = {HIP_6000};
+  m["hipsparseSpGEMM_compute"]                                        = {HIP_6000};
+  m["hipsparseSpGEMM_copy"]                                           = {HIP_6000};
+  m["hipsparseSpGEMM_workEstimation"]                                 = {HIP_6000};
+  m["hipsparseSpGEMMreuse_compute"]                                   = {HIP_6000};
+  m["hipsparseSpGEMMreuse_copy"]                                      = {HIP_6000};
+  m["hipsparseSpGEMMreuse_nnz"]                                       = {HIP_6000};
+  m["hipsparseSpGEMMreuse_workEstimation"]                            = {HIP_6000};
+  m["hipsparseDnMatGetStridedBatch"]                                  = {HIP_6000};
+  m["hipsparseDestroyDnMat"]                                          = {HIP_6000};
+  m["hipsparseSpMM"]                                                  = {HIP_6000};
+  m["hipsparseSpMM_bufferSize"]                                       = {HIP_6000};
+  m["hipsparseSpMM_preprocess"]                                       = {HIP_6000};
+  m["hipsparseSpMV"]                                                  = {HIP_6000};
+  m["hipsparseSpMV_bufferSize"]                                       = {HIP_6000};
+  m["hipsparseSpSM_analysis"]                                         = {HIP_6000};
+  m["hipsparseSpSM_bufferSize"]                                       = {HIP_6000};
+  m["hipsparseSpSM_solve"]                                            = {HIP_6000};
+  m["hipsparseSpSV_analysis"]                                         = {HIP_6000};
+  m["hipsparseSpSV_bufferSize"]                                       = {HIP_6000};
+  m["hipsparseSpSV_solve"]                                            = {HIP_6000};
+  m["hipsparseSpVV"]                                                  = {HIP_6000};
+  m["hipsparseSpVV_bufferSize"]                                       = {HIP_6000};
+  m["hipsparseSDDMM"]                                                 = {HIP_6000};
+  m["hipsparseSDDMM_bufferSize"]                                      = {HIP_6000};
+  m["hipsparseSDDMM_preprocess"]                                      = {HIP_6000};
+  m["hipsparseAxpby"]                                                 = {HIP_6000};
+  m["hipsparseGather"]                                                = {HIP_6000};
+  m["hipsparseScatter"]                                               = {HIP_6000};
+  m["hipsparseSparseToDense"]                                         = {HIP_6000};
+  m["hipsparseSparseToDense_bufferSize"]                              = {HIP_6000};
+  m["hipsparseDenseToSparse_analysis"]                                = {HIP_6000};
+  m["hipsparseDenseToSparse_bufferSize"]                              = {HIP_6000};
+  m["hipsparseDenseToSparse_convert"]                                 = {HIP_6000};
+  m["hipsparseSpMV_preprocess"]                                       = {HIP_6000};
+  m["rocsparse_destroy_spvec_descr"]                                  = {HIP_6000};
+  m["rocsparse_spvec_get_index_base"]                                 = {HIP_6000};
+  m["rocsparse_destroy_spmat_descr"]                                  = {HIP_6000};
+  m["rocsparse_spmat_get_size"]                                       = {HIP_6000};
+  m["rocsparse_spmat_get_format"]                                     = {HIP_6000};
+  m["rocsparse_spmat_get_index_base"]                                 = {HIP_6000};
+  m["rocsparse_spmat_get_strided_batch"]                              = {HIP_6000};
+  m["rocsparse_spmat_get_attribute"]                                  = {HIP_6000};
+  m["rocsparse_destroy_dnvec_descr"]                                  = {HIP_6000};
+  m["rocsparse_destroy_dnmat_descr"]                                  = {HIP_6000};
+  m["rocsparse_dnmat_get_strided_batch"]                              = {HIP_6000};
+  m["rocsparse_sparse_to_dense"]                                      = {HIP_6000};
+  m["rocsparse_dense_to_sparse"]                                      = {HIP_6000};
+  m["rocsparse_spmm"]                                                 = {HIP_6000};
+  m["rocsparse_spsm"]                                                 = {HIP_6000};
+  m["rocsparse_spvv"]                                                 = {HIP_6000};
+  m["rocsparse_spmv"]                                                 = {HIP_6000};
+  m["rocsparse_scatter"]                                              = {HIP_6000};
+  m["rocsparse_gather"]                                               = {HIP_6000};
+  m["rocsparse_axpby"]                                                = {HIP_6000};
+  m["rocsparse_sddmm"]                                                = {HIP_6000};
+  m["rocsparse_sddmm_buffer_size"]                                    = {HIP_6000};
+  m["rocsparse_sddmm_preprocess"]                                     = {HIP_6000};
+  m["rocsparse_spsv"]                                                 = {HIP_6000};
+
+  return m;
+}();
+
+const std::map<unsigned int, llvm::StringRef> CUDA_SPARSE_API_SECTION_MAP = [] {
+  std::map<unsigned int, llvm::StringRef> m;
+
+  m[4]                                                                = "CUSPARSE Types References";
+  m[5]                                                                = "CUSPARSE Management Function Reference";
+  m[6]                                                                = "CUSPARSE Logging";
+  m[7]                                                                = "CUSPARSE Helper Function Reference";
+  m[8]                                                                = "CUSPARSE Level 1 Function Reference";
+  m[9]                                                                = "CUSPARSE Level 2 Function Reference";
+  m[10]                                                               = "CUSPARSE Level 3 Function Reference";
+  m[11]                                                               = "CUSPARSE Extra Function Reference";
+  m[12]                                                               = "CUSPARSE Preconditioners Reference";
+  m[13]                                                               = "CUSPARSE Reorderings Reference";
+  m[14]                                                               = "CUSPARSE Format Conversion Reference";
+  m[15]                                                               = "CUSPARSE Generic API Reference";
+
+  return m;
+}();

--- a/src/CUDA2HIP_SPARSE_API_types.cpp
+++ b/src/CUDA2HIP_SPARSE_API_types.cpp
@@ -23,670 +23,680 @@ THE SOFTWARE.
 #include "CUDA2HIP.h"
 
 // Maps the names of CUDA SPARSE API types to the corresponding HIP types
-const std::map<llvm::StringRef, hipCounter> CUDA_SPARSE_TYPE_NAME_MAP {
+const std::map<llvm::StringRef, hipCounter> CUDA_SPARSE_TYPE_NAME_MAP = [] {
+  std::map<llvm::StringRef, hipCounter> m;
 
   // 1. Structs
-  {"cusparseContext",                            {"hipsparseContext",                           "_rocsparse_handle",                                  CONV_TYPE, API_SPARSE, 4, HIP_UNSUPPORTED}},
-  {"cusparseHandle_t",                           {"hipsparseHandle_t",                          "rocsparse_handle",                                   CONV_TYPE, API_SPARSE, 4}},
+  m["cusparseContext"]                                                = {"hipsparseContext",                           "_rocsparse_handle",                                  CONV_TYPE, API_SPARSE, 4, HIP_UNSUPPORTED};
+  m["cusparseHandle_t"]                                               = {"hipsparseHandle_t",                          "rocsparse_handle",                                   CONV_TYPE, API_SPARSE, 4};
 
-  {"cusparseHybMat",                             {"hipsparseHybMat",                            "_rocsparse_hyb_mat",                                 CONV_TYPE, API_SPARSE, 4, HIP_UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED}},
-  {"cusparseHybMat_t",                           {"hipsparseHybMat_t",                          "rocsparse_hyb_mat",                                  CONV_TYPE, API_SPARSE, 4, CUDA_DEPRECATED | CUDA_REMOVED}},
+  m["cusparseHybMat"]                                                 = {"hipsparseHybMat",                            "_rocsparse_hyb_mat",                                 CONV_TYPE, API_SPARSE, 4, HIP_UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED};
+  m["cusparseHybMat_t"]                                               = {"hipsparseHybMat_t",                          "rocsparse_hyb_mat",                                  CONV_TYPE, API_SPARSE, 4, CUDA_DEPRECATED | CUDA_REMOVED};
 
-  {"cusparseMatDescr",                           {"hipsparseMatDescr",                          "_rocsparse_mat_descr",                               CONV_TYPE, API_SPARSE, 4, HIP_UNSUPPORTED}},
-  {"cusparseMatDescr_t",                         {"hipsparseMatDescr_t",                        "rocsparse_mat_descr",                                CONV_TYPE, API_SPARSE, 4}},
+  m["cusparseMatDescr"]                                               = {"hipsparseMatDescr",                          "_rocsparse_mat_descr",                               CONV_TYPE, API_SPARSE, 4, HIP_UNSUPPORTED};
+  m["cusparseMatDescr_t"]                                             = {"hipsparseMatDescr_t",                        "rocsparse_mat_descr",                                CONV_TYPE, API_SPARSE, 4};
 
-  {"cusparseSolveAnalysisInfo",                  {"hipsparseSolveAnalysisInfo",                 "",                                                   CONV_TYPE, API_SPARSE, 4, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED}},
-  {"cusparseSolveAnalysisInfo_t",                {"hipsparseSolveAnalysisInfo_t",               "",                                                   CONV_TYPE, API_SPARSE, 4, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED}},
+  m["cusparseSolveAnalysisInfo"]                                      = {"hipsparseSolveAnalysisInfo",                 "",                                                   CONV_TYPE, API_SPARSE, 4, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED};
+  m["cusparseSolveAnalysisInfo_t"]                                    = {"hipsparseSolveAnalysisInfo_t",               "",                                                   CONV_TYPE, API_SPARSE, 4, UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED};
 
-  {"csrsv2Info",                                 {"csrsv2Info",                                 "_rocsparse_mat_descr",                               CONV_TYPE, API_SPARSE, 4, HIP_UNSUPPORTED | CUDA_REMOVED}},
-  {"csrsv2Info_t",                               {"csrsv2Info_t",                               "rocsparse_mat_descr",                                CONV_TYPE, API_SPARSE, 4, CUDA_REMOVED}},
+  m["csrsv2Info"]                                                     = {"csrsv2Info",                                 "_rocsparse_mat_descr",                               CONV_TYPE, API_SPARSE, 4, HIP_UNSUPPORTED | CUDA_REMOVED};
+  m["csrsv2Info_t"]                                                   = {"csrsv2Info_t",                               "rocsparse_mat_descr",                                CONV_TYPE, API_SPARSE, 4, CUDA_REMOVED};
 
-  {"csrsm2Info",                                 {"csrsm2Info",                                 "_rocsparse_mat_info",                                CONV_TYPE, API_SPARSE, 4, HIP_UNSUPPORTED | CUDA_REMOVED}},
-  {"csrsm2Info_t",                               {"csrsm2Info_t",                               "rocsparse_mat_info",                                 CONV_TYPE, API_SPARSE, 4, CUDA_REMOVED}},
+  m["csrsm2Info"]                                                     = {"csrsm2Info",                                 "_rocsparse_mat_info",                                CONV_TYPE, API_SPARSE, 4, HIP_UNSUPPORTED | CUDA_REMOVED};
+  m["csrsm2Info_t"]                                                   = {"csrsm2Info_t",                               "rocsparse_mat_info",                                 CONV_TYPE, API_SPARSE, 4, CUDA_REMOVED};
 
-  {"bsrsv2Info",                                 {"bsrsv2Info",                                 "_rocsparse_mat_info",                                CONV_TYPE, API_SPARSE, 4, CUDA_DEPRECATED}},
-  {"bsrsv2Info_t",                               {"bsrsv2Info_t",                               "rocsparse_mat_info",                                 CONV_TYPE, API_SPARSE, 4, CUDA_DEPRECATED}},
+  m["bsrsv2Info"]                                                     = {"bsrsv2Info",                                 "_rocsparse_mat_info",                                CONV_TYPE, API_SPARSE, 4, CUDA_DEPRECATED};
+  m["bsrsv2Info_t"]                                                   = {"bsrsv2Info_t",                               "rocsparse_mat_info",                                 CONV_TYPE, API_SPARSE, 4, CUDA_DEPRECATED};
 
-  {"bsrsm2Info",                                 {"bsrsm2Info",                                 "_rocsparse_mat_info",                                CONV_TYPE, API_SPARSE, 4, CUDA_DEPRECATED}},
-  {"bsrsm2Info_t",                               {"bsrsm2Info_t",                               "rocsparse_mat_info",                                 CONV_TYPE, API_SPARSE, 4, CUDA_DEPRECATED}},
+  m["bsrsm2Info"]                                                     = {"bsrsm2Info",                                 "_rocsparse_mat_info",                                CONV_TYPE, API_SPARSE, 4, CUDA_DEPRECATED};
+  m["bsrsm2Info_t"]                                                   = {"bsrsm2Info_t",                               "rocsparse_mat_info",                                 CONV_TYPE, API_SPARSE, 4, CUDA_DEPRECATED};
 
-  {"bsric02Info",                                {"bsric02Info",                                "_rocsparse_mat_info",                                CONV_TYPE, API_SPARSE, 4, CUDA_DEPRECATED}},
-  {"bsric02Info_t",                              {"bsric02Info_t",                              "rocsparse_mat_info",                                 CONV_TYPE, API_SPARSE, 4, CUDA_DEPRECATED}},
+  m["bsric02Info"]                                                    = {"bsric02Info",                                "_rocsparse_mat_info",                                CONV_TYPE, API_SPARSE, 4, CUDA_DEPRECATED};
+  m["bsric02Info_t"]                                                  = {"bsric02Info_t",                              "rocsparse_mat_info",                                 CONV_TYPE, API_SPARSE, 4, CUDA_DEPRECATED};
 
-  {"csrilu02Info",                               {"csrilu02Info",                               "_rocsparse_mat_info",                                CONV_TYPE, API_SPARSE, 4, CUDA_DEPRECATED}},
-  {"csrilu02Info_t",                             {"csrilu02Info_t",                             "rocsparse_mat_info",                                 CONV_TYPE, API_SPARSE, 4, CUDA_DEPRECATED}},
+  m["csrilu02Info"]                                                   = {"csrilu02Info",                               "_rocsparse_mat_info",                                CONV_TYPE, API_SPARSE, 4, CUDA_DEPRECATED};
+  m["csrilu02Info_t"]                                                 = {"csrilu02Info_t",                             "rocsparse_mat_info",                                 CONV_TYPE, API_SPARSE, 4, CUDA_DEPRECATED};
 
-  {"bsrilu02Info",                               {"bsrilu02Info",                               "_rocsparse_mat_info",                                CONV_TYPE, API_SPARSE, 4, CUDA_DEPRECATED}},
-  {"bsrilu02Info_t",                             {"bsrilu02Info_t",                             "rocsparse_mat_info",                                 CONV_TYPE, API_SPARSE, 4, CUDA_DEPRECATED}},
+  m["bsrilu02Info"]                                                   = {"bsrilu02Info",                               "_rocsparse_mat_info",                                CONV_TYPE, API_SPARSE, 4, CUDA_DEPRECATED};
+  m["bsrilu02Info_t"]                                                 = {"bsrilu02Info_t",                             "rocsparse_mat_info",                                 CONV_TYPE, API_SPARSE, 4, CUDA_DEPRECATED};
 
-  {"csru2csrInfo",                               {"csru2csrInfo",                               "",                                                   CONV_TYPE, API_SPARSE, 4, ROC_UNSUPPORTED | CUDA_DEPRECATED}},
-  {"csru2csrInfo_t",                             {"csru2csrInfo_t",                             "",                                                   CONV_TYPE, API_SPARSE, 4, ROC_UNSUPPORTED | CUDA_DEPRECATED}},
+  m["csru2csrInfo"]                                                   = {"csru2csrInfo",                               "",                                                   CONV_TYPE, API_SPARSE, 4, ROC_UNSUPPORTED | CUDA_DEPRECATED};
+  m["csru2csrInfo_t"]                                                 = {"csru2csrInfo_t",                             "",                                                   CONV_TYPE, API_SPARSE, 4, ROC_UNSUPPORTED | CUDA_DEPRECATED};
 
-  {"csric02Info",                                {"csric02Info",                                "_rocsparse_mat_info",                                CONV_TYPE, API_SPARSE, 4, CUDA_DEPRECATED}},
-  {"csric02Info_t",                              {"csric02Info_t",                              "rocsparse_mat_info",                                 CONV_TYPE, API_SPARSE, 4, CUDA_DEPRECATED}},
+  m["csric02Info"]                                                    = {"csric02Info",                                "_rocsparse_mat_info",                                CONV_TYPE, API_SPARSE, 4, CUDA_DEPRECATED};
+  m["csric02Info_t"]                                                  = {"csric02Info_t",                              "rocsparse_mat_info",                                 CONV_TYPE, API_SPARSE, 4, CUDA_DEPRECATED};
 
-  {"csrgemm2Info",                               {"csrgemm2Info",                               "_rocsparse_mat_info",                                CONV_TYPE, API_SPARSE, 4, CUDA_REMOVED}},
-  {"csrgemm2Info_t",                             {"csrgemm2Info_t",                             "rocsparse_mat_info",                                 CONV_TYPE, API_SPARSE, 4, CUDA_REMOVED}},
+  m["csrgemm2Info"]                                                   = {"csrgemm2Info",                               "_rocsparse_mat_info",                                CONV_TYPE, API_SPARSE, 4, CUDA_REMOVED};
+  m["csrgemm2Info_t"]                                                 = {"csrgemm2Info_t",                             "rocsparse_mat_info",                                 CONV_TYPE, API_SPARSE, 4, CUDA_REMOVED};
 
-  {"cusparseColorInfo",                          {"hipsparseColorInfo",                         "_rocsparse_color_info",                              CONV_TYPE, API_SPARSE, 4, HIP_UNSUPPORTED | CUDA_DEPRECATED}},
-  {"cusparseColorInfo_t",                        {"hipsparseColorInfo_t",                       "rocsparse_color_info",                               CONV_TYPE, API_SPARSE, 4, CUDA_DEPRECATED}},
+  m["cusparseColorInfo"]                                              = {"hipsparseColorInfo",                         "_rocsparse_color_info",                              CONV_TYPE, API_SPARSE, 4, HIP_UNSUPPORTED | CUDA_DEPRECATED};
+  m["cusparseColorInfo_t"]                                            = {"hipsparseColorInfo_t",                       "rocsparse_color_info",                               CONV_TYPE, API_SPARSE, 4, CUDA_DEPRECATED};
 
-  {"pruneInfo",                                  {"pruneInfo",                                  "_rocsparse_mat_info",                                CONV_TYPE, API_SPARSE, 4, CUDA_DEPRECATED}},
-  {"pruneInfo_t",                                {"pruneInfo_t",                                "rocsparse_mat_info",                                 CONV_TYPE, API_SPARSE, 4, CUDA_DEPRECATED}},
+  m["pruneInfo"]                                                      = {"pruneInfo",                                  "_rocsparse_mat_info",                                CONV_TYPE, API_SPARSE, 4, CUDA_DEPRECATED};
+  m["pruneInfo_t"]                                                    = {"pruneInfo_t",                                "rocsparse_mat_info",                                 CONV_TYPE, API_SPARSE, 4, CUDA_DEPRECATED};
 
-  {"cusparseSpMatDescr",                         {"hipsparseSpMatDescr",                        "_rocsparse_spmat_descr",                             CONV_TYPE, API_SPARSE, 4, HIP_UNSUPPORTED}},
-  {"cusparseSpMatDescr_t",                       {"hipsparseSpMatDescr_t",                      "rocsparse_spmat_descr",                              CONV_TYPE, API_SPARSE, 4}},
+  m["cusparseSpMatDescr"]                                             = {"hipsparseSpMatDescr",                        "_rocsparse_spmat_descr",                             CONV_TYPE, API_SPARSE, 4, HIP_UNSUPPORTED};
+  m["cusparseSpMatDescr_t"]                                           = {"hipsparseSpMatDescr_t",                      "rocsparse_spmat_descr",                              CONV_TYPE, API_SPARSE, 4};
 
-  {"cusparseDnMatDescr",                         {"hipsparseDnMatDescr",                        "_rocsparse_dnmat_descr",                             CONV_TYPE, API_SPARSE, 4, HIP_UNSUPPORTED}},
-  {"cusparseDnMatDescr_t",                       {"hipsparseDnMatDescr_t",                      "rocsparse_dnmat_descr",                              CONV_TYPE, API_SPARSE, 4}},
+  m["cusparseDnMatDescr"]                                             = {"hipsparseDnMatDescr",                        "_rocsparse_dnmat_descr",                             CONV_TYPE, API_SPARSE, 4, HIP_UNSUPPORTED};
+  m["cusparseDnMatDescr_t"]                                           = {"hipsparseDnMatDescr_t",                      "rocsparse_dnmat_descr",                              CONV_TYPE, API_SPARSE, 4};
 
-  {"cusparseSpVecDescr",                         {"hipsparseSpVecDescr",                        "_rocsparse_spvec_descr",                             CONV_TYPE, API_SPARSE, 4, HIP_UNSUPPORTED}},
-  {"cusparseSpVecDescr_t",                       {"hipsparseSpVecDescr_t",                      "rocsparse_spvec_descr",                              CONV_TYPE, API_SPARSE, 4}},
+  m["cusparseSpVecDescr"]                                             = {"hipsparseSpVecDescr",                        "_rocsparse_spvec_descr",                             CONV_TYPE, API_SPARSE, 4, HIP_UNSUPPORTED};
+  m["cusparseSpVecDescr_t"]                                           = {"hipsparseSpVecDescr_t",                      "rocsparse_spvec_descr",                              CONV_TYPE, API_SPARSE, 4};
 
-  {"cusparseDnVecDescr",                         {"hipsparseDnVecDescr",                        "_rocsparse_dnvec_descr",                             CONV_TYPE, API_SPARSE, 4, HIP_UNSUPPORTED}},
-  {"cusparseDnVecDescr_t",                       {"hipsparseDnVecDescr_t",                      "rocsparse_dnvec_descr",                              CONV_TYPE, API_SPARSE, 4}},
+  m["cusparseDnVecDescr"]                                             = {"hipsparseDnVecDescr",                        "_rocsparse_dnvec_descr",                             CONV_TYPE, API_SPARSE, 4, HIP_UNSUPPORTED};
+  m["cusparseDnVecDescr_t"]                                           = {"hipsparseDnVecDescr_t",                      "rocsparse_dnvec_descr",                              CONV_TYPE, API_SPARSE, 4};
 
-  {"cusparseSpGEMMDescr",                        {"hipsparseSpGEMMDescr",                       "",                                                   CONV_TYPE, API_SPARSE, 4, ROC_UNSUPPORTED}},
-  {"cusparseSpGEMMDescr_t",                      {"hipsparseSpGEMMDescr_t",                     "",                                                   CONV_TYPE, API_SPARSE, 4, ROC_UNSUPPORTED}},
+  m["cusparseSpGEMMDescr"]                                            = {"hipsparseSpGEMMDescr",                       "",                                                   CONV_TYPE, API_SPARSE, 4, ROC_UNSUPPORTED};
+  m["cusparseSpGEMMDescr_t"]                                          = {"hipsparseSpGEMMDescr_t",                     "",                                                   CONV_TYPE, API_SPARSE, 4, ROC_UNSUPPORTED};
 
-  {"cusparseSpSMDescr",                          {"hipsparseSpSMDescr",                         "",                                                   CONV_TYPE, API_SPARSE, 4, ROC_UNSUPPORTED}},
-  {"cusparseSpSMDescr_t",                        {"hipsparseSpSMDescr_t",                       "",                                                   CONV_TYPE, API_SPARSE, 4, ROC_UNSUPPORTED}},
+  m["cusparseSpSMDescr"]                                              = {"hipsparseSpSMDescr",                         "",                                                   CONV_TYPE, API_SPARSE, 4, ROC_UNSUPPORTED};
+  m["cusparseSpSMDescr_t"]                                            = {"hipsparseSpSMDescr_t",                       "",                                                   CONV_TYPE, API_SPARSE, 4, ROC_UNSUPPORTED};
 
-  {"cusparseSpSVDescr",                          {"hipsparseSpSVDescr",                         "",                                                   CONV_TYPE, API_SPARSE, 4, ROC_UNSUPPORTED}},
-  {"cusparseSpSVDescr_t",                        {"hipsparseSpSVDescr_t",                       "",                                                   CONV_TYPE, API_SPARSE, 4, ROC_UNSUPPORTED}},
+  m["cusparseSpSVDescr"]                                              = {"hipsparseSpSVDescr",                         "",                                                   CONV_TYPE, API_SPARSE, 4, ROC_UNSUPPORTED};
+  m["cusparseSpSVDescr_t"]                                            = {"hipsparseSpSVDescr_t",                       "",                                                   CONV_TYPE, API_SPARSE, 4, ROC_UNSUPPORTED};
 
-  {"cusparseSpMMOpPlan",                         {"hipsparseSpMMOpPlan",                        "",                                                   CONV_TYPE, API_SPARSE, 4, UNSUPPORTED}},
-  {"cusparseSpMMOpPlan_t",                       {"hipsparseSpMMOpPlan_t",                      "",                                                   CONV_TYPE, API_SPARSE, 4, UNSUPPORTED}},
+  m["cusparseSpMMOpPlan"]                                             = {"hipsparseSpMMOpPlan",                        "",                                                   CONV_TYPE, API_SPARSE, 4, UNSUPPORTED};
+  m["cusparseSpMMOpPlan_t"]                                           = {"hipsparseSpMMOpPlan_t",                      "",                                                   CONV_TYPE, API_SPARSE, 4, UNSUPPORTED};
 
   // 2. Enums
-  {"cusparseAction_t",                           {"hipsparseAction_t",                          "rocsparse_action",                                   CONV_TYPE, API_SPARSE, 4}},
-  {"CUSPARSE_ACTION_SYMBOLIC",                   {"HIPSPARSE_ACTION_SYMBOLIC",                  "rocsparse_action_symbolic",                          CONV_NUMERIC_LITERAL, API_SPARSE, 4}},
-  {"CUSPARSE_ACTION_NUMERIC",                    {"HIPSPARSE_ACTION_NUMERIC",                   "rocsparse_action_numeric",                           CONV_NUMERIC_LITERAL, API_SPARSE, 4}},
+  m["cusparseAction_t"]                                               = {"hipsparseAction_t",                          "rocsparse_action",                                   CONV_TYPE, API_SPARSE, 4};
+  m["CUSPARSE_ACTION_SYMBOLIC"]                                       = {"HIPSPARSE_ACTION_SYMBOLIC",                  "rocsparse_action_symbolic",                          CONV_NUMERIC_LITERAL, API_SPARSE, 4};
+  m["CUSPARSE_ACTION_NUMERIC"]                                        = {"HIPSPARSE_ACTION_NUMERIC",                   "rocsparse_action_numeric",                           CONV_NUMERIC_LITERAL, API_SPARSE, 4};
 
-  {"cusparseDirection_t",                        {"hipsparseDirection_t",                       "rocsparse_direction",                                CONV_TYPE, API_SPARSE, 4}},
-  {"CUSPARSE_DIRECTION_ROW",                     {"HIPSPARSE_DIRECTION_ROW",                    "rocsparse_direction_row",                            CONV_NUMERIC_LITERAL, API_SPARSE, 4}},
-  {"CUSPARSE_DIRECTION_COLUMN",                  {"HIPSPARSE_DIRECTION_COLUMN",                 "rocsparse_direction_column",                         CONV_NUMERIC_LITERAL, API_SPARSE, 4}},
+  m["cusparseDirection_t"]                                            = {"hipsparseDirection_t",                       "rocsparse_direction",                                CONV_TYPE, API_SPARSE, 4};
+  m["CUSPARSE_DIRECTION_ROW"]                                         = {"HIPSPARSE_DIRECTION_ROW",                    "rocsparse_direction_row",                            CONV_NUMERIC_LITERAL, API_SPARSE, 4};
+  m["CUSPARSE_DIRECTION_COLUMN"]                                      = {"HIPSPARSE_DIRECTION_COLUMN",                 "rocsparse_direction_column",                         CONV_NUMERIC_LITERAL, API_SPARSE, 4};
 
-  {"cusparseHybPartition_t",                     {"hipsparseHybPartition_t",                    "rocsparse_hyb_partition",                            CONV_TYPE, API_SPARSE, 4, CUDA_DEPRECATED | CUDA_REMOVED}},
-  {"CUSPARSE_HYB_PARTITION_AUTO",                {"HIPSPARSE_HYB_PARTITION_AUTO",               "rocsparse_hyb_partition_auto",                       CONV_NUMERIC_LITERAL, API_SPARSE, 4, CUDA_DEPRECATED | CUDA_REMOVED}},
-  {"CUSPARSE_HYB_PARTITION_USER",                {"HIPSPARSE_HYB_PARTITION_USER",               "rocsparse_hyb_partition_user",                       CONV_NUMERIC_LITERAL, API_SPARSE, 4, CUDA_DEPRECATED | CUDA_REMOVED}},
-  {"CUSPARSE_HYB_PARTITION_MAX",                 {"HIPSPARSE_HYB_PARTITION_MAX",                "rocsparse_hyb_partition_max",                        CONV_NUMERIC_LITERAL, API_SPARSE, 4, CUDA_DEPRECATED | CUDA_REMOVED}},
+  m["cusparseHybPartition_t"]                                         = {"hipsparseHybPartition_t",                    "rocsparse_hyb_partition",                            CONV_TYPE, API_SPARSE, 4, CUDA_DEPRECATED | CUDA_REMOVED};
+  m["CUSPARSE_HYB_PARTITION_AUTO"]                                    = {"HIPSPARSE_HYB_PARTITION_AUTO",               "rocsparse_hyb_partition_auto",                       CONV_NUMERIC_LITERAL, API_SPARSE, 4, CUDA_DEPRECATED | CUDA_REMOVED};
+  m["CUSPARSE_HYB_PARTITION_USER"]                                    = {"HIPSPARSE_HYB_PARTITION_USER",               "rocsparse_hyb_partition_user",                       CONV_NUMERIC_LITERAL, API_SPARSE, 4, CUDA_DEPRECATED | CUDA_REMOVED};
+  m["CUSPARSE_HYB_PARTITION_MAX"]                                     = {"HIPSPARSE_HYB_PARTITION_MAX",                "rocsparse_hyb_partition_max",                        CONV_NUMERIC_LITERAL, API_SPARSE, 4, CUDA_DEPRECATED | CUDA_REMOVED};
 
-  {"cusparseDiagType_t",                         {"hipsparseDiagType_t",                        "rocsparse_diag_type",                                CONV_TYPE, API_SPARSE, 4}},
-  {"CUSPARSE_DIAG_TYPE_NON_UNIT",                {"HIPSPARSE_DIAG_TYPE_NON_UNIT",               "rocsparse_diag_type_non_unit",                       CONV_NUMERIC_LITERAL, API_SPARSE, 4}},
-  {"CUSPARSE_DIAG_TYPE_UNIT",                    {"HIPSPARSE_DIAG_TYPE_UNIT",                   "rocsparse_diag_type_unit",                           CONV_NUMERIC_LITERAL, API_SPARSE, 4}},
+  m["cusparseDiagType_t"]                                             = {"hipsparseDiagType_t",                        "rocsparse_diag_type",                                CONV_TYPE, API_SPARSE, 4};
+  m["CUSPARSE_DIAG_TYPE_NON_UNIT"]                                    = {"HIPSPARSE_DIAG_TYPE_NON_UNIT",               "rocsparse_diag_type_non_unit",                       CONV_NUMERIC_LITERAL, API_SPARSE, 4};
+  m["CUSPARSE_DIAG_TYPE_UNIT"]                                        = {"HIPSPARSE_DIAG_TYPE_UNIT",                   "rocsparse_diag_type_unit",                           CONV_NUMERIC_LITERAL, API_SPARSE, 4};
 
-  {"cusparseFillMode_t",                         {"hipsparseFillMode_t",                        "rocsparse_fill_mode",                                CONV_TYPE, API_SPARSE, 4}},
-  {"CUSPARSE_FILL_MODE_LOWER",                   {"HIPSPARSE_FILL_MODE_LOWER",                  "rocsparse_fill_mode_lower",                          CONV_NUMERIC_LITERAL, API_SPARSE, 4}},
-  {"CUSPARSE_FILL_MODE_UPPER",                   {"HIPSPARSE_FILL_MODE_UPPER",                  "rocsparse_fill_mode_upper",                          CONV_NUMERIC_LITERAL, API_SPARSE, 4}},
+  m["cusparseFillMode_t"]                                             = {"hipsparseFillMode_t",                        "rocsparse_fill_mode",                                CONV_TYPE, API_SPARSE, 4};
+  m["CUSPARSE_FILL_MODE_LOWER"]                                       = {"HIPSPARSE_FILL_MODE_LOWER",                  "rocsparse_fill_mode_lower",                          CONV_NUMERIC_LITERAL, API_SPARSE, 4};
+  m["CUSPARSE_FILL_MODE_UPPER"]                                       = {"HIPSPARSE_FILL_MODE_UPPER",                  "rocsparse_fill_mode_upper",                          CONV_NUMERIC_LITERAL, API_SPARSE, 4};
 
-  {"cusparseIndexBase_t",                        {"hipsparseIndexBase_t",                       "rocsparse_index_base",                               CONV_TYPE, API_SPARSE, 4}},
-  {"CUSPARSE_INDEX_BASE_ZERO",                   {"HIPSPARSE_INDEX_BASE_ZERO",                  "rocsparse_index_base_zero",                          CONV_NUMERIC_LITERAL, API_SPARSE, 4}},
-  {"CUSPARSE_INDEX_BASE_ONE",                    {"HIPSPARSE_INDEX_BASE_ONE",                   "rocsparse_index_base_one",                           CONV_NUMERIC_LITERAL, API_SPARSE, 4}},
+  m["cusparseIndexBase_t"]                                            = {"hipsparseIndexBase_t",                       "rocsparse_index_base",                               CONV_TYPE, API_SPARSE, 4};
+  m["CUSPARSE_INDEX_BASE_ZERO"]                                       = {"HIPSPARSE_INDEX_BASE_ZERO",                  "rocsparse_index_base_zero",                          CONV_NUMERIC_LITERAL, API_SPARSE, 4};
+  m["CUSPARSE_INDEX_BASE_ONE"]                                        = {"HIPSPARSE_INDEX_BASE_ONE",                   "rocsparse_index_base_one",                           CONV_NUMERIC_LITERAL, API_SPARSE, 4};
 
-  {"cusparseMatrixType_t",                       {"hipsparseMatrixType_t",                      "rocsparse_matrix_type",                              CONV_TYPE, API_SPARSE, 4}},
-  {"CUSPARSE_MATRIX_TYPE_GENERAL",               {"HIPSPARSE_MATRIX_TYPE_GENERAL",              "rocsparse_matrix_type_general",                      CONV_NUMERIC_LITERAL, API_SPARSE, 4}},
-  {"CUSPARSE_MATRIX_TYPE_SYMMETRIC",             {"HIPSPARSE_MATRIX_TYPE_SYMMETRIC",            "rocsparse_matrix_type_symmetric",                    CONV_NUMERIC_LITERAL, API_SPARSE, 4}},
-  {"CUSPARSE_MATRIX_TYPE_HERMITIAN",             {"HIPSPARSE_MATRIX_TYPE_HERMITIAN",            "rocsparse_matrix_type_hermitian",                    CONV_NUMERIC_LITERAL, API_SPARSE, 4}},
-  {"CUSPARSE_MATRIX_TYPE_TRIANGULAR",            {"HIPSPARSE_MATRIX_TYPE_TRIANGULAR",           "rocsparse_matrix_type_triangular",                   CONV_NUMERIC_LITERAL, API_SPARSE, 4}},
+  m["cusparseMatrixType_t"]                                           = {"hipsparseMatrixType_t",                      "rocsparse_matrix_type",                              CONV_TYPE, API_SPARSE, 4};
+  m["CUSPARSE_MATRIX_TYPE_GENERAL"]                                   = {"HIPSPARSE_MATRIX_TYPE_GENERAL",              "rocsparse_matrix_type_general",                      CONV_NUMERIC_LITERAL, API_SPARSE, 4};
+  m["CUSPARSE_MATRIX_TYPE_SYMMETRIC"]                                 = {"HIPSPARSE_MATRIX_TYPE_SYMMETRIC",            "rocsparse_matrix_type_symmetric",                    CONV_NUMERIC_LITERAL, API_SPARSE, 4};
+  m["CUSPARSE_MATRIX_TYPE_HERMITIAN"]                                 = {"HIPSPARSE_MATRIX_TYPE_HERMITIAN",            "rocsparse_matrix_type_hermitian",                    CONV_NUMERIC_LITERAL, API_SPARSE, 4};
+  m["CUSPARSE_MATRIX_TYPE_TRIANGULAR"]                                = {"HIPSPARSE_MATRIX_TYPE_TRIANGULAR",           "rocsparse_matrix_type_triangular",                   CONV_NUMERIC_LITERAL, API_SPARSE, 4};
 
-  {"cusparseOperation_t",                        {"hipsparseOperation_t",                       "rocsparse_operation",                                CONV_TYPE, API_SPARSE, 4}},
-  {"CUSPARSE_OPERATION_NON_TRANSPOSE",           {"HIPSPARSE_OPERATION_NON_TRANSPOSE",          "rocsparse_operation_none",                           CONV_NUMERIC_LITERAL, API_SPARSE, 4}},
-  {"CUSPARSE_OPERATION_TRANSPOSE",               {"HIPSPARSE_OPERATION_TRANSPOSE",              "rocsparse_operation_transpose",                      CONV_NUMERIC_LITERAL, API_SPARSE, 4}},
-  {"CUSPARSE_OPERATION_CONJUGATE_TRANSPOSE",     {"HIPSPARSE_OPERATION_CONJUGATE_TRANSPOSE",    "rocsparse_operation_conjugate_transpose",            CONV_NUMERIC_LITERAL, API_SPARSE, 4}},
+  m["cusparseOperation_t"]                                            = {"hipsparseOperation_t",                       "rocsparse_operation",                                CONV_TYPE, API_SPARSE, 4};
+  m["CUSPARSE_OPERATION_NON_TRANSPOSE"]                               = {"HIPSPARSE_OPERATION_NON_TRANSPOSE",          "rocsparse_operation_none",                           CONV_NUMERIC_LITERAL, API_SPARSE, 4};
+  m["CUSPARSE_OPERATION_TRANSPOSE"]                                   = {"HIPSPARSE_OPERATION_TRANSPOSE",              "rocsparse_operation_transpose",                      CONV_NUMERIC_LITERAL, API_SPARSE, 4};
+  m["CUSPARSE_OPERATION_CONJUGATE_TRANSPOSE"]                         = {"HIPSPARSE_OPERATION_CONJUGATE_TRANSPOSE",    "rocsparse_operation_conjugate_transpose",            CONV_NUMERIC_LITERAL, API_SPARSE, 4};
 
-  {"cusparsePointerMode_t",                      {"hipsparsePointerMode_t",                     "rocsparse_pointer_mode",                             CONV_TYPE, API_SPARSE, 4}},
-  {"CUSPARSE_POINTER_MODE_HOST",                 {"HIPSPARSE_POINTER_MODE_HOST",                "rocsparse_pointer_mode_host",                        CONV_NUMERIC_LITERAL, API_SPARSE, 4}},
-  {"CUSPARSE_POINTER_MODE_DEVICE",               {"HIPSPARSE_POINTER_MODE_DEVICE",              "rocsparse_pointer_mode_device",                      CONV_NUMERIC_LITERAL, API_SPARSE, 4}},
+  m["cusparsePointerMode_t"]                                          = {"hipsparsePointerMode_t",                     "rocsparse_pointer_mode",                             CONV_TYPE, API_SPARSE, 4};
+  m["CUSPARSE_POINTER_MODE_HOST"]                                     = {"HIPSPARSE_POINTER_MODE_HOST",                "rocsparse_pointer_mode_host",                        CONV_NUMERIC_LITERAL, API_SPARSE, 4};
+  m["CUSPARSE_POINTER_MODE_DEVICE"]                                   = {"HIPSPARSE_POINTER_MODE_DEVICE",              "rocsparse_pointer_mode_device",                      CONV_NUMERIC_LITERAL, API_SPARSE, 4};
 
-  {"cusparseAlgMode_t",                          {"hipsparseAlgMode_t",                         "",                                                   CONV_TYPE, API_SPARSE, 4, UNSUPPORTED | CUDA_REMOVED}},
-  {"CUSPARSE_ALG0",                              {"CUSPARSE_ALG0",                              "",                                                   CONV_NUMERIC_LITERAL, API_SPARSE, 4, UNSUPPORTED | CUDA_REMOVED}},
-  {"CUSPARSE_ALG1",                              {"CUSPARSE_ALG1",                              "",                                                   CONV_NUMERIC_LITERAL, API_SPARSE, 4, UNSUPPORTED | CUDA_REMOVED}},
-  {"CUSPARSE_ALG_NAIVE",                         {"CUSPARSE_ALG_NAIVE",                         "",                                                   CONV_NUMERIC_LITERAL, API_SPARSE, 4, UNSUPPORTED | CUDA_REMOVED}},
-  {"CUSPARSE_ALG_MERGE_PATH",                    {"CUSPARSE_ALG_MERGE_PATH",                    "",                                                   CONV_NUMERIC_LITERAL, API_SPARSE, 4, UNSUPPORTED | CUDA_REMOVED}},
+  m["cusparseAlgMode_t"]                                              = {"hipsparseAlgMode_t",                         "",                                                   CONV_TYPE, API_SPARSE, 4, UNSUPPORTED | CUDA_REMOVED};
+  m["CUSPARSE_ALG0"]                                                  = {"CUSPARSE_ALG0",                              "",                                                   CONV_NUMERIC_LITERAL, API_SPARSE, 4, UNSUPPORTED | CUDA_REMOVED};
+  m["CUSPARSE_ALG1"]                                                  = {"CUSPARSE_ALG1",                              "",                                                   CONV_NUMERIC_LITERAL, API_SPARSE, 4, UNSUPPORTED | CUDA_REMOVED};
+  m["CUSPARSE_ALG_NAIVE"]                                             = {"CUSPARSE_ALG_NAIVE",                         "",                                                   CONV_NUMERIC_LITERAL, API_SPARSE, 4, UNSUPPORTED | CUDA_REMOVED};
+  m["CUSPARSE_ALG_MERGE_PATH"]                                        = {"CUSPARSE_ALG_MERGE_PATH",                    "",                                                   CONV_NUMERIC_LITERAL, API_SPARSE, 4, UNSUPPORTED | CUDA_REMOVED};
 
   // TODO [HIPIFY] Warn about hipification to rocsparse_solve_policy_auto (automatically decide on level information)
-  {"cusparseSolvePolicy_t",                      {"hipsparseSolvePolicy_t",                     "rocsparse_solve_policy",                             CONV_TYPE, API_SPARSE, 4, CUDA_DEPRECATED}},
-  {"CUSPARSE_SOLVE_POLICY_NO_LEVEL",             {"HIPSPARSE_SOLVE_POLICY_NO_LEVEL",            "rocsparse_solve_policy_auto",                        CONV_NUMERIC_LITERAL, API_SPARSE, 4, CUDA_DEPRECATED}},
-  {"CUSPARSE_SOLVE_POLICY_USE_LEVEL",            {"HIPSPARSE_SOLVE_POLICY_USE_LEVEL",           "rocsparse_solve_policy_auto",                        CONV_NUMERIC_LITERAL, API_SPARSE, 4, CUDA_DEPRECATED}},
+  m["cusparseSolvePolicy_t"]                                          = {"hipsparseSolvePolicy_t",                     "rocsparse_solve_policy",                             CONV_TYPE, API_SPARSE, 4, CUDA_DEPRECATED};
+  m["CUSPARSE_SOLVE_POLICY_NO_LEVEL"]                                 = {"HIPSPARSE_SOLVE_POLICY_NO_LEVEL",            "rocsparse_solve_policy_auto",                        CONV_NUMERIC_LITERAL, API_SPARSE, 4, CUDA_DEPRECATED};
+  m["CUSPARSE_SOLVE_POLICY_USE_LEVEL"]                                = {"HIPSPARSE_SOLVE_POLICY_USE_LEVEL",           "rocsparse_solve_policy_auto",                        CONV_NUMERIC_LITERAL, API_SPARSE, 4, CUDA_DEPRECATED};
 
-  {"cusparseStatus_t",                           {"hipsparseStatus_t",                          "rocsparse_status",                                   CONV_TYPE, API_SPARSE, 4}},
-  {"CUSPARSE_STATUS_SUCCESS",                    {"HIPSPARSE_STATUS_SUCCESS",                   "rocsparse_status_success",                           CONV_NUMERIC_LITERAL, API_SPARSE, 4}},
-  {"CUSPARSE_STATUS_NOT_INITIALIZED",            {"HIPSPARSE_STATUS_NOT_INITIALIZED",           "rocsparse_status_not_initialized",                   CONV_NUMERIC_LITERAL, API_SPARSE, 4}},
-  {"CUSPARSE_STATUS_ALLOC_FAILED",               {"HIPSPARSE_STATUS_ALLOC_FAILED",              "rocsparse_status_memory_error",                      CONV_NUMERIC_LITERAL, API_SPARSE, 4}},
-  {"CUSPARSE_STATUS_INVALID_VALUE",              {"HIPSPARSE_STATUS_INVALID_VALUE",             "rocsparse_status_invalid_value",                     CONV_NUMERIC_LITERAL, API_SPARSE, 4}},
-  {"CUSPARSE_STATUS_ARCH_MISMATCH",              {"HIPSPARSE_STATUS_ARCH_MISMATCH",             "rocsparse_status_arch_mismatch",                     CONV_NUMERIC_LITERAL, API_SPARSE, 4}},
-  {"CUSPARSE_STATUS_MAPPING_ERROR",              {"HIPSPARSE_STATUS_MAPPING_ERROR",             "",                                                   CONV_NUMERIC_LITERAL, API_SPARSE, 4, ROC_UNSUPPORTED}},
-  {"CUSPARSE_STATUS_EXECUTION_FAILED",           {"HIPSPARSE_STATUS_EXECUTION_FAILED",          "",                                                   CONV_NUMERIC_LITERAL, API_SPARSE, 4, ROC_UNSUPPORTED}},
-  {"CUSPARSE_STATUS_INTERNAL_ERROR",             {"HIPSPARSE_STATUS_INTERNAL_ERROR",            "rocsparse_status_internal_error",                    CONV_NUMERIC_LITERAL, API_SPARSE, 4}},
-  {"CUSPARSE_STATUS_MATRIX_TYPE_NOT_SUPPORTED",  {"HIPSPARSE_STATUS_MATRIX_TYPE_NOT_SUPPORTED", "",                                                   CONV_NUMERIC_LITERAL, API_SPARSE, 4, ROC_UNSUPPORTED}},
-  {"CUSPARSE_STATUS_ZERO_PIVOT",                 {"HIPSPARSE_STATUS_ZERO_PIVOT",                "rocsparse_status_zero_pivot",                        CONV_NUMERIC_LITERAL, API_SPARSE, 4}},
-  {"CUSPARSE_STATUS_NOT_SUPPORTED",              {"HIPSPARSE_STATUS_NOT_SUPPORTED",             "rocsparse_status_not_implemented",                   CONV_NUMERIC_LITERAL, API_SPARSE, 4}},
-  {"CUSPARSE_STATUS_INSUFFICIENT_RESOURCES",     {"HIPSPARSE_STATUS_INSUFFICIENT_RESOURCES",    "",                                                   CONV_NUMERIC_LITERAL, API_SPARSE, 4, ROC_UNSUPPORTED}},
+  m["cusparseStatus_t"]                                               = {"hipsparseStatus_t",                          "rocsparse_status",                                   CONV_TYPE, API_SPARSE, 4};
+  m["CUSPARSE_STATUS_SUCCESS"]                                        = {"HIPSPARSE_STATUS_SUCCESS",                   "rocsparse_status_success",                           CONV_NUMERIC_LITERAL, API_SPARSE, 4};
+  m["CUSPARSE_STATUS_NOT_INITIALIZED"]                                = {"HIPSPARSE_STATUS_NOT_INITIALIZED",           "rocsparse_status_not_initialized",                   CONV_NUMERIC_LITERAL, API_SPARSE, 4};
+  m["CUSPARSE_STATUS_ALLOC_FAILED"]                                   = {"HIPSPARSE_STATUS_ALLOC_FAILED",              "rocsparse_status_memory_error",                      CONV_NUMERIC_LITERAL, API_SPARSE, 4};
+  m["CUSPARSE_STATUS_INVALID_VALUE"]                                  = {"HIPSPARSE_STATUS_INVALID_VALUE",             "rocsparse_status_invalid_value",                     CONV_NUMERIC_LITERAL, API_SPARSE, 4};
+  m["CUSPARSE_STATUS_ARCH_MISMATCH"]                                  = {"HIPSPARSE_STATUS_ARCH_MISMATCH",             "rocsparse_status_arch_mismatch",                     CONV_NUMERIC_LITERAL, API_SPARSE, 4};
+  m["CUSPARSE_STATUS_MAPPING_ERROR"]                                  = {"HIPSPARSE_STATUS_MAPPING_ERROR",             "",                                                   CONV_NUMERIC_LITERAL, API_SPARSE, 4, ROC_UNSUPPORTED};
+  m["CUSPARSE_STATUS_EXECUTION_FAILED"]                               = {"HIPSPARSE_STATUS_EXECUTION_FAILED",          "",                                                   CONV_NUMERIC_LITERAL, API_SPARSE, 4, ROC_UNSUPPORTED};
+  m["CUSPARSE_STATUS_INTERNAL_ERROR"]                                 = {"HIPSPARSE_STATUS_INTERNAL_ERROR",            "rocsparse_status_internal_error",                    CONV_NUMERIC_LITERAL, API_SPARSE, 4};
+  m["CUSPARSE_STATUS_MATRIX_TYPE_NOT_SUPPORTED"]                      = {"HIPSPARSE_STATUS_MATRIX_TYPE_NOT_SUPPORTED", "",                                                   CONV_NUMERIC_LITERAL, API_SPARSE, 4, ROC_UNSUPPORTED};
+  m["CUSPARSE_STATUS_ZERO_PIVOT"]                                     = {"HIPSPARSE_STATUS_ZERO_PIVOT",                "rocsparse_status_zero_pivot",                        CONV_NUMERIC_LITERAL, API_SPARSE, 4};
+  m["CUSPARSE_STATUS_NOT_SUPPORTED"]                                  = {"HIPSPARSE_STATUS_NOT_SUPPORTED",             "rocsparse_status_not_implemented",                   CONV_NUMERIC_LITERAL, API_SPARSE, 4};
+  m["CUSPARSE_STATUS_INSUFFICIENT_RESOURCES"]                         = {"HIPSPARSE_STATUS_INSUFFICIENT_RESOURCES",    "",                                                   CONV_NUMERIC_LITERAL, API_SPARSE, 4, ROC_UNSUPPORTED};
 
-  {"cusparseCsr2CscAlg_t",                       {"hipsparseCsr2CscAlg_t",                      "",                                                   CONV_TYPE, API_SPARSE, 4, ROC_UNSUPPORTED}},
-  {"CUSPARSE_CSR2CSC_ALG1",                      {"HIPSPARSE_CSR2CSC_ALG1",                     "",                                                   CONV_NUMERIC_LITERAL, API_SPARSE, 4, ROC_UNSUPPORTED}},
-  {"CUSPARSE_CSR2CSC_ALG2",                      {"HIPSPARSE_CSR2CSC_ALG2",                     "",                                                   CONV_NUMERIC_LITERAL, API_SPARSE, 4, ROC_UNSUPPORTED}},
-  {"CUSPARSE_CSR2CSC_ALG_DEFAULT",               {"HIPSPARSE_CSR2CSC_ALG_DEFAULT",              "",                                                   CONV_NUMERIC_LITERAL, API_SPARSE, 4, ROC_UNSUPPORTED}},
+  m["cusparseCsr2CscAlg_t"]                                           = {"hipsparseCsr2CscAlg_t",                      "",                                                   CONV_TYPE, API_SPARSE, 4, ROC_UNSUPPORTED};
+  m["CUSPARSE_CSR2CSC_ALG1"]                                          = {"HIPSPARSE_CSR2CSC_ALG1",                     "",                                                   CONV_NUMERIC_LITERAL, API_SPARSE, 4, ROC_UNSUPPORTED};
+  m["CUSPARSE_CSR2CSC_ALG2"]                                          = {"HIPSPARSE_CSR2CSC_ALG2",                     "",                                                   CONV_NUMERIC_LITERAL, API_SPARSE, 4, ROC_UNSUPPORTED};
+  m["CUSPARSE_CSR2CSC_ALG_DEFAULT"]                                   = {"HIPSPARSE_CSR2CSC_ALG_DEFAULT",              "",                                                   CONV_NUMERIC_LITERAL, API_SPARSE, 4, ROC_UNSUPPORTED};
 
-  {"cusparseFormat_t",                           {"hipsparseFormat_t",                          "rocsparse_format",                                   CONV_TYPE, API_SPARSE, 4}},
-  {"CUSPARSE_FORMAT_CSR",                        {"HIPSPARSE_FORMAT_CSR",                       "rocsparse_format_csr",                               CONV_NUMERIC_LITERAL, API_SPARSE, 4}},
-  {"CUSPARSE_FORMAT_CSC",                        {"HIPSPARSE_FORMAT_CSC",                       "rocsparse_format_csc",                               CONV_NUMERIC_LITERAL, API_SPARSE, 4}},
-  {"CUSPARSE_FORMAT_COO",                        {"HIPSPARSE_FORMAT_COO",                       "rocsparse_format_coo",                               CONV_NUMERIC_LITERAL, API_SPARSE, 4}},
-  {"CUSPARSE_FORMAT_COO_AOS",                    {"HIPSPARSE_FORMAT_COO_AOS",                   "rocsparse_format_coo_aos",                           CONV_NUMERIC_LITERAL, API_SPARSE, 4, CUDA_REMOVED}},
-  {"CUSPARSE_FORMAT_BLOCKED_ELL",                {"HIPSPARSE_FORMAT_BLOCKED_ELL",               "rocsparse_format_bell",                              CONV_NUMERIC_LITERAL, API_SPARSE, 4}},
-  {"CUSPARSE_FORMAT_BSR",                        {"HIPSPARSE_FORMAT_BSR",                       "rocsparse_format_bsr",                               CONV_NUMERIC_LITERAL, API_SPARSE, 4, HIP_UNSUPPORTED}},
-  {"CUSPARSE_FORMAT_SLICED_ELLPACK",             {"HIPSPARSE_FORMAT_SLICED_ELLPACK",            "rocsparse_format_ell",                               CONV_NUMERIC_LITERAL, API_SPARSE, 4, HIP_UNSUPPORTED}},
+  m["cusparseFormat_t"]                                               = {"hipsparseFormat_t",                          "rocsparse_format",                                   CONV_TYPE, API_SPARSE, 4};
+  m["CUSPARSE_FORMAT_CSR"]                                            = {"HIPSPARSE_FORMAT_CSR",                       "rocsparse_format_csr",                               CONV_NUMERIC_LITERAL, API_SPARSE, 4};
+  m["CUSPARSE_FORMAT_CSC"]                                            = {"HIPSPARSE_FORMAT_CSC",                       "rocsparse_format_csc",                               CONV_NUMERIC_LITERAL, API_SPARSE, 4};
+  m["CUSPARSE_FORMAT_COO"]                                            = {"HIPSPARSE_FORMAT_COO",                       "rocsparse_format_coo",                               CONV_NUMERIC_LITERAL, API_SPARSE, 4};
+  m["CUSPARSE_FORMAT_COO_AOS"]                                        = {"HIPSPARSE_FORMAT_COO_AOS",                   "rocsparse_format_coo_aos",                           CONV_NUMERIC_LITERAL, API_SPARSE, 4, CUDA_REMOVED};
+  m["CUSPARSE_FORMAT_BLOCKED_ELL"]                                    = {"HIPSPARSE_FORMAT_BLOCKED_ELL",               "rocsparse_format_bell",                              CONV_NUMERIC_LITERAL, API_SPARSE, 4};
+  m["CUSPARSE_FORMAT_BSR"]                                            = {"HIPSPARSE_FORMAT_BSR",                       "rocsparse_format_bsr",                               CONV_NUMERIC_LITERAL, API_SPARSE, 4, HIP_UNSUPPORTED};
+  m["CUSPARSE_FORMAT_SLICED_ELLPACK"]                                 = {"HIPSPARSE_FORMAT_SLICED_ELLPACK",            "rocsparse_format_ell",                               CONV_NUMERIC_LITERAL, API_SPARSE, 4, HIP_UNSUPPORTED};
 
-  {"cusparseOrder_t",                            {"hipsparseOrder_t",                           "rocsparse_order",                                    CONV_TYPE, API_SPARSE, 4}},
-  {"CUSPARSE_ORDER_COL",                         {"HIPSPARSE_ORDER_COL",                        "rocsparse_order_row",                                CONV_NUMERIC_LITERAL, API_SPARSE, 4}},
-  {"CUSPARSE_ORDER_ROW",                         {"HIPSPARSE_ORDER_ROW",                        "rocsparse_order_column",                             CONV_NUMERIC_LITERAL, API_SPARSE, 4}},
+  m["cusparseOrder_t"]                                                = {"hipsparseOrder_t",                           "rocsparse_order",                                    CONV_TYPE, API_SPARSE, 4};
+  m["CUSPARSE_ORDER_COL"]                                             = {"HIPSPARSE_ORDER_COL",                        "rocsparse_order_row",                                CONV_NUMERIC_LITERAL, API_SPARSE, 4};
+  m["CUSPARSE_ORDER_ROW"]                                             = {"HIPSPARSE_ORDER_ROW",                        "rocsparse_order_column",                             CONV_NUMERIC_LITERAL, API_SPARSE, 4};
 
-  {"cusparseSpMVAlg_t",                          {"hipsparseSpMVAlg_t",                         "rocsparse_spmv_alg",                                 CONV_TYPE, API_SPARSE, 4}},
-  {"CUSPARSE_MV_ALG_DEFAULT",                    {"HIPSPARSE_MV_ALG_DEFAULT",                   "",                                                   CONV_NUMERIC_LITERAL, API_SPARSE, 4, ROC_UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED}},
-  {"CUSPARSE_SPMV_ALG_DEFAULT",                  {"HIPSPARSE_SPMV_ALG_DEFAULT",                 "rocsparse_spmv_alg_default",                         CONV_NUMERIC_LITERAL, API_SPARSE, 4}},
-  {"CUSPARSE_COOMV_ALG",                         {"HIPSPARSE_COOMV_ALG",                        "",                                                   CONV_NUMERIC_LITERAL, API_SPARSE, 4, ROC_UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED}},
-  {"CUSPARSE_SPMV_COO_ALG1",                     {"HIPSPARSE_SPMV_COO_ALG1",                    "rocsparse_spmv_alg_coo",                             CONV_NUMERIC_LITERAL, API_SPARSE, 4}},
-  {"CUSPARSE_SPMV_COO_ALG2",                     {"HIPSPARSE_SPMV_COO_ALG2",                    "rocsparse_spmv_alg_coo_atomic",                      CONV_NUMERIC_LITERAL, API_SPARSE, 4}},
-  {"CUSPARSE_CSRMV_ALG1",                        {"HIPSPARSE_CSRMV_ALG1",                       "",                                                   CONV_NUMERIC_LITERAL, API_SPARSE, 4, ROC_UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED}},
-  {"CUSPARSE_SPMV_CSR_ALG1",                     {"HIPSPARSE_SPMV_CSR_ALG1",                    "rocsparse_spmv_alg_csr_adaptive",                    CONV_NUMERIC_LITERAL, API_SPARSE, 4}},
-  {"CUSPARSE_CSRMV_ALG2",                        {"HIPSPARSE_CSRMV_ALG2",                       "",                                                   CONV_NUMERIC_LITERAL, API_SPARSE, 4, ROC_UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED}},
-  {"CUSPARSE_SPMV_CSR_ALG2",                     {"HIPSPARSE_SPMV_CSR_ALG2",                    "rocsparse_spmv_alg_csr_stream",                      CONV_NUMERIC_LITERAL, API_SPARSE, 4}},
-  {"CUSPARSE_SPMV_SELL_ALG1",                    {"HIPSPARSE_SPMV_SELL_ALG1",                   "rocsparse_spmv_alg_ell",                             CONV_NUMERIC_LITERAL, API_SPARSE, 4, HIP_UNSUPPORTED}},
-  {"CUSPARSE_SPMV_BSR_ALG1",                     {"HIPSPARSE_SPMV_BSR_ALG1",                    "",                                                   CONV_NUMERIC_LITERAL, API_SPARSE, 4, UNSUPPORTED}},
+  m["cusparseSpMVAlg_t"]                                              = {"hipsparseSpMVAlg_t",                         "rocsparse_spmv_alg",                                 CONV_TYPE, API_SPARSE, 4};
+  m["CUSPARSE_MV_ALG_DEFAULT"]                                        = {"HIPSPARSE_MV_ALG_DEFAULT",                   "",                                                   CONV_NUMERIC_LITERAL, API_SPARSE, 4, ROC_UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED};
+  m["CUSPARSE_SPMV_ALG_DEFAULT"]                                      = {"HIPSPARSE_SPMV_ALG_DEFAULT",                 "rocsparse_spmv_alg_default",                         CONV_NUMERIC_LITERAL, API_SPARSE, 4};
+  m["CUSPARSE_COOMV_ALG"]                                             = {"HIPSPARSE_COOMV_ALG",                        "",                                                   CONV_NUMERIC_LITERAL, API_SPARSE, 4, ROC_UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED};
+  m["CUSPARSE_SPMV_COO_ALG1"]                                         = {"HIPSPARSE_SPMV_COO_ALG1",                    "rocsparse_spmv_alg_coo",                             CONV_NUMERIC_LITERAL, API_SPARSE, 4};
+  m["CUSPARSE_SPMV_COO_ALG2"]                                         = {"HIPSPARSE_SPMV_COO_ALG2",                    "rocsparse_spmv_alg_coo_atomic",                      CONV_NUMERIC_LITERAL, API_SPARSE, 4};
+  m["CUSPARSE_CSRMV_ALG1"]                                            = {"HIPSPARSE_CSRMV_ALG1",                       "",                                                   CONV_NUMERIC_LITERAL, API_SPARSE, 4, ROC_UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED};
+  m["CUSPARSE_SPMV_CSR_ALG1"]                                         = {"HIPSPARSE_SPMV_CSR_ALG1",                    "rocsparse_spmv_alg_csr_adaptive",                    CONV_NUMERIC_LITERAL, API_SPARSE, 4};
+  m["CUSPARSE_CSRMV_ALG2"]                                            = {"HIPSPARSE_CSRMV_ALG2",                       "",                                                   CONV_NUMERIC_LITERAL, API_SPARSE, 4, ROC_UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED};
+  m["CUSPARSE_SPMV_CSR_ALG2"]                                         = {"HIPSPARSE_SPMV_CSR_ALG2",                    "rocsparse_spmv_alg_csr_stream",                      CONV_NUMERIC_LITERAL, API_SPARSE, 4};
+  m["CUSPARSE_SPMV_SELL_ALG1"]                                        = {"HIPSPARSE_SPMV_SELL_ALG1",                   "rocsparse_spmv_alg_ell",                             CONV_NUMERIC_LITERAL, API_SPARSE, 4, HIP_UNSUPPORTED};
+  m["CUSPARSE_SPMV_BSR_ALG1"]                                         = {"HIPSPARSE_SPMV_BSR_ALG1",                    "",                                                   CONV_NUMERIC_LITERAL, API_SPARSE, 4, UNSUPPORTED};
 
-  {"cusparseSpMMAlg_t",                          {"hipsparseSpMMAlg_t",                         "rocsparse_spmm_alg",                                 CONV_TYPE, API_SPARSE, 4}},
-  {"CUSPARSE_MM_ALG_DEFAULT",                    {"HIPSPARSE_MM_ALG_DEFAULT",                   "",                                                   CONV_NUMERIC_LITERAL, API_SPARSE, 4, ROC_UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED}},
-  {"CUSPARSE_SPMM_ALG_DEFAULT",                  {"HIPSPARSE_SPMM_ALG_DEFAULT",                 "rocsparse_spmm_alg_default",                         CONV_NUMERIC_LITERAL, API_SPARSE, 4}},
-  {"CUSPARSE_COOMM_ALG1",                        {"HIPSPARSE_COOMM_ALG1",                       "",                                                   CONV_NUMERIC_LITERAL, API_SPARSE, 4, ROC_UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED}},
-  {"CUSPARSE_SPMM_COO_ALG1",                     {"HIPSPARSE_SPMM_COO_ALG1",                    "rocsparse_spmm_alg_coo_segmented",                   CONV_NUMERIC_LITERAL, API_SPARSE, 4}},
-  {"CUSPARSE_COOMM_ALG2",                        {"HIPSPARSE_COOMM_ALG2",                       "",                                                   CONV_NUMERIC_LITERAL, API_SPARSE, 4, ROC_UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED}},
-  {"CUSPARSE_SPMM_COO_ALG2",                     {"HIPSPARSE_SPMM_COO_ALG2",                    "rocsparse_spmm_alg_coo_atomic",                      CONV_NUMERIC_LITERAL, API_SPARSE, 4}},
-  {"CUSPARSE_COOMM_ALG3",                        {"HIPSPARSE_COOMM_ALG3",                       "",                                                   CONV_NUMERIC_LITERAL, API_SPARSE, 4, ROC_UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED}},
-  {"CUSPARSE_SPMM_COO_ALG3",                     {"HIPSPARSE_SPMM_COO_ALG3",                    "rocsparse_spmm_alg_coo_segmented_atomic",            CONV_NUMERIC_LITERAL, API_SPARSE, 4}},
-  {"CUSPARSE_CSRMM_ALG1",                        {"HIPSPARSE_CSRMM_ALG1",                       "",                                                   CONV_NUMERIC_LITERAL, API_SPARSE, 4, ROC_UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED}},
-  {"CUSPARSE_SPMM_CSR_ALG1",                     {"HIPSPARSE_SPMM_CSR_ALG1",                    "rocsparse_spmm_alg_csr",                             CONV_NUMERIC_LITERAL, API_SPARSE, 4}},
-  {"CUSPARSE_SPMM_COO_ALG4",                     {"HIPSPARSE_SPMM_COO_ALG4",                    "",                                                   CONV_NUMERIC_LITERAL, API_SPARSE, 4, ROC_UNSUPPORTED}},
-  {"CUSPARSE_SPMM_CSR_ALG2",                     {"HIPSPARSE_SPMM_CSR_ALG2",                    "rocsparse_spmm_alg_csr_row_split",                   CONV_NUMERIC_LITERAL, API_SPARSE, 4}},
-  {"CUSPARSE_SPMM_CSR_ALG3",                     {"HIPSPARSE_SPMM_CSR_ALG3",                    "rocsparse_spmm_alg_csr_merge",                       CONV_NUMERIC_LITERAL, API_SPARSE, 4}},
-  {"CUSPARSE_SPMM_BLOCKED_ELL_ALG1",             {"HIPSPARSE_SPMM_BLOCKED_ELL_ALG1",            "rocsparse_spmm_alg_bell",                            CONV_NUMERIC_LITERAL, API_SPARSE, 4}},
-  {"CUSPARSE_SPMM_BSR_ALG1",                     {"HIPSPARSE_SPMM_BSR_ALG1",                    "rocsparse_spmm_alg_bell",                            CONV_NUMERIC_LITERAL, API_SPARSE, 4, UNSUPPORTED}},
-  {"CUSPARSE_SPMMA_PREPROCESS",                  {"HIPSPARSE_SPMMA_PREPROCESS",                 "",                                                   CONV_NUMERIC_LITERAL, API_SPARSE, 4, CUDA_REMOVED | UNSUPPORTED}},
-  {"CUSPARSE_SPMMA_ALG1",                        {"HIPSPARSE_SPMMA_ALG1",                       "",                                                   CONV_NUMERIC_LITERAL, API_SPARSE, 4, CUDA_REMOVED | UNSUPPORTED}},
-  {"CUSPARSE_SPMMA_ALG2",                        {"HIPSPARSE_SPMMA_ALG2",                       "",                                                   CONV_NUMERIC_LITERAL, API_SPARSE, 4, CUDA_REMOVED | UNSUPPORTED}},
-  {"CUSPARSE_SPMMA_ALG3",                        {"HIPSPARSE_SPMMA_ALG3",                       "",                                                   CONV_NUMERIC_LITERAL, API_SPARSE, 4, CUDA_REMOVED | UNSUPPORTED}},
-  {"CUSPARSE_SPMMA_ALG4",                        {"HIPSPARSE_SPMMA_ALG4",                       "",                                                   CONV_NUMERIC_LITERAL, API_SPARSE, 4, CUDA_REMOVED | UNSUPPORTED}},
+  m["cusparseSpMMAlg_t"]                                              = {"hipsparseSpMMAlg_t",                         "rocsparse_spmm_alg",                                 CONV_TYPE, API_SPARSE, 4};
+  m["CUSPARSE_MM_ALG_DEFAULT"]                                        = {"HIPSPARSE_MM_ALG_DEFAULT",                   "",                                                   CONV_NUMERIC_LITERAL, API_SPARSE, 4, ROC_UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED};
+  m["CUSPARSE_SPMM_ALG_DEFAULT"]                                      = {"HIPSPARSE_SPMM_ALG_DEFAULT",                 "rocsparse_spmm_alg_default",                         CONV_NUMERIC_LITERAL, API_SPARSE, 4};
+  m["CUSPARSE_COOMM_ALG1"]                                            = {"HIPSPARSE_COOMM_ALG1",                       "",                                                   CONV_NUMERIC_LITERAL, API_SPARSE, 4, ROC_UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED};
+  m["CUSPARSE_SPMM_COO_ALG1"]                                         = {"HIPSPARSE_SPMM_COO_ALG1",                    "rocsparse_spmm_alg_coo_segmented",                   CONV_NUMERIC_LITERAL, API_SPARSE, 4};
+  m["CUSPARSE_COOMM_ALG2"]                                            = {"HIPSPARSE_COOMM_ALG2",                       "",                                                   CONV_NUMERIC_LITERAL, API_SPARSE, 4, ROC_UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED};
+  m["CUSPARSE_SPMM_COO_ALG2"]                                         = {"HIPSPARSE_SPMM_COO_ALG2",                    "rocsparse_spmm_alg_coo_atomic",                      CONV_NUMERIC_LITERAL, API_SPARSE, 4};
+  m["CUSPARSE_COOMM_ALG3"]                                            = {"HIPSPARSE_COOMM_ALG3",                       "",                                                   CONV_NUMERIC_LITERAL, API_SPARSE, 4, ROC_UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED};
+  m["CUSPARSE_SPMM_COO_ALG3"]                                         = {"HIPSPARSE_SPMM_COO_ALG3",                    "rocsparse_spmm_alg_coo_segmented_atomic",            CONV_NUMERIC_LITERAL, API_SPARSE, 4};
+  m["CUSPARSE_CSRMM_ALG1"]                                            = {"HIPSPARSE_CSRMM_ALG1",                       "",                                                   CONV_NUMERIC_LITERAL, API_SPARSE, 4, ROC_UNSUPPORTED | CUDA_DEPRECATED | CUDA_REMOVED};
+  m["CUSPARSE_SPMM_CSR_ALG1"]                                         = {"HIPSPARSE_SPMM_CSR_ALG1",                    "rocsparse_spmm_alg_csr",                             CONV_NUMERIC_LITERAL, API_SPARSE, 4};
+  m["CUSPARSE_SPMM_COO_ALG4"]                                         = {"HIPSPARSE_SPMM_COO_ALG4",                    "",                                                   CONV_NUMERIC_LITERAL, API_SPARSE, 4, ROC_UNSUPPORTED};
+  m["CUSPARSE_SPMM_CSR_ALG2"]                                         = {"HIPSPARSE_SPMM_CSR_ALG2",                    "rocsparse_spmm_alg_csr_row_split",                   CONV_NUMERIC_LITERAL, API_SPARSE, 4};
+  m["CUSPARSE_SPMM_CSR_ALG3"]                                         = {"HIPSPARSE_SPMM_CSR_ALG3",                    "rocsparse_spmm_alg_csr_merge",                       CONV_NUMERIC_LITERAL, API_SPARSE, 4};
+  m["CUSPARSE_SPMM_BLOCKED_ELL_ALG1"]                                 = {"HIPSPARSE_SPMM_BLOCKED_ELL_ALG1",            "rocsparse_spmm_alg_bell",                            CONV_NUMERIC_LITERAL, API_SPARSE, 4};
+  m["CUSPARSE_SPMM_BSR_ALG1"]                                         = {"HIPSPARSE_SPMM_BSR_ALG1",                    "rocsparse_spmm_alg_bell",                            CONV_NUMERIC_LITERAL, API_SPARSE, 4, UNSUPPORTED};
+  m["CUSPARSE_SPMMA_PREPROCESS"]                                      = {"HIPSPARSE_SPMMA_PREPROCESS",                 "",                                                   CONV_NUMERIC_LITERAL, API_SPARSE, 4, CUDA_REMOVED | UNSUPPORTED};
+  m["CUSPARSE_SPMMA_ALG1"]                                            = {"HIPSPARSE_SPMMA_ALG1",                       "",                                                   CONV_NUMERIC_LITERAL, API_SPARSE, 4, CUDA_REMOVED | UNSUPPORTED};
+  m["CUSPARSE_SPMMA_ALG2"]                                            = {"HIPSPARSE_SPMMA_ALG2",                       "",                                                   CONV_NUMERIC_LITERAL, API_SPARSE, 4, CUDA_REMOVED | UNSUPPORTED};
+  m["CUSPARSE_SPMMA_ALG3"]                                            = {"HIPSPARSE_SPMMA_ALG3",                       "",                                                   CONV_NUMERIC_LITERAL, API_SPARSE, 4, CUDA_REMOVED | UNSUPPORTED};
+  m["CUSPARSE_SPMMA_ALG4"]                                            = {"HIPSPARSE_SPMMA_ALG4",                       "",                                                   CONV_NUMERIC_LITERAL, API_SPARSE, 4, CUDA_REMOVED | UNSUPPORTED};
 
-  {"cusparseIndexType_t",                        {"hipsparseIndexType_t",                       "rocsparse_indextype",                                CONV_TYPE, API_SPARSE, 4}},
-  {"CUSPARSE_INDEX_16U",                         {"HIPSPARSE_INDEX_16U",                        "rocsparse_indextype_u16",                            CONV_NUMERIC_LITERAL, API_SPARSE, 4}},
-  {"CUSPARSE_INDEX_32I",                         {"HIPSPARSE_INDEX_32I",                        "rocsparse_indextype_i32",                            CONV_NUMERIC_LITERAL, API_SPARSE, 4}},
-  {"CUSPARSE_INDEX_64I",                         {"HIPSPARSE_INDEX_64I",                        "rocsparse_indextype_i64",                            CONV_NUMERIC_LITERAL, API_SPARSE, 4}},
+  m["cusparseIndexType_t"]                                            = {"hipsparseIndexType_t",                       "rocsparse_indextype",                                CONV_TYPE, API_SPARSE, 4};
+  m["CUSPARSE_INDEX_16U"]                                             = {"HIPSPARSE_INDEX_16U",                        "rocsparse_indextype_u16",                            CONV_NUMERIC_LITERAL, API_SPARSE, 4};
+  m["CUSPARSE_INDEX_32I"]                                             = {"HIPSPARSE_INDEX_32I",                        "rocsparse_indextype_i32",                            CONV_NUMERIC_LITERAL, API_SPARSE, 4};
+  m["CUSPARSE_INDEX_64I"]                                             = {"HIPSPARSE_INDEX_64I",                        "rocsparse_indextype_i64",                            CONV_NUMERIC_LITERAL, API_SPARSE, 4};
 
-  {"cusparseSpGEMMAlg_t",                        {"hipsparseSpGEMMAlg_t",                       "rocsparse_spgemm_alg",                               CONV_TYPE, API_SPARSE, 4}},
-  {"CUSPARSE_SPGEMM_DEFAULT",                    {"HIPSPARSE_SPGEMM_DEFAULT",                   "rocsparse_spgemm_alg_default",                       CONV_NUMERIC_LITERAL, API_SPARSE, 4}},
-  {"CUSPARSE_SPGEMM_CSR_ALG_DETERMINITIC",       {"HIPSPARSE_SPGEMM_CSR_ALG_DETERMINISTIC",     "",                                                   CONV_NUMERIC_LITERAL, API_SPARSE, 4, ROC_UNSUPPORTED}},
-  {"CUSPARSE_SPGEMM_CSR_ALG_NONDETERMINITIC",    {"HIPSPARSE_SPGEMM_CSR_ALG_NONDETERMINISTIC",  "",                                                   CONV_NUMERIC_LITERAL, API_SPARSE, 4, ROC_UNSUPPORTED}},
-  {"CUSPARSE_SPGEMM_ALG1",                       {"HIPSPARSE_SPGEMM_ALG1",                      "",                                                   CONV_NUMERIC_LITERAL, API_SPARSE, 4, ROC_UNSUPPORTED}},
-  {"CUSPARSE_SPGEMM_ALG2",                       {"HIPSPARSE_SPGEMM_ALG2",                      "",                                                   CONV_NUMERIC_LITERAL, API_SPARSE, 4, ROC_UNSUPPORTED}},
-  {"CUSPARSE_SPGEMM_ALG3",                       {"HIPSPARSE_SPGEMM_ALG3",                      "",                                                   CONV_NUMERIC_LITERAL, API_SPARSE, 4, ROC_UNSUPPORTED}},
+  m["cusparseSpGEMMAlg_t"]                                            = {"hipsparseSpGEMMAlg_t",                       "rocsparse_spgemm_alg",                               CONV_TYPE, API_SPARSE, 4};
+  m["CUSPARSE_SPGEMM_DEFAULT"]                                        = {"HIPSPARSE_SPGEMM_DEFAULT",                   "rocsparse_spgemm_alg_default",                       CONV_NUMERIC_LITERAL, API_SPARSE, 4};
+  m["CUSPARSE_SPGEMM_CSR_ALG_DETERMINITIC"]                           = {"HIPSPARSE_SPGEMM_CSR_ALG_DETERMINISTIC",     "",                                                   CONV_NUMERIC_LITERAL, API_SPARSE, 4, ROC_UNSUPPORTED};
+  m["CUSPARSE_SPGEMM_CSR_ALG_NONDETERMINITIC"]                        = {"HIPSPARSE_SPGEMM_CSR_ALG_NONDETERMINISTIC",  "",                                                   CONV_NUMERIC_LITERAL, API_SPARSE, 4, ROC_UNSUPPORTED};
+  m["CUSPARSE_SPGEMM_ALG1"]                                           = {"HIPSPARSE_SPGEMM_ALG1",                      "",                                                   CONV_NUMERIC_LITERAL, API_SPARSE, 4, ROC_UNSUPPORTED};
+  m["CUSPARSE_SPGEMM_ALG2"]                                           = {"HIPSPARSE_SPGEMM_ALG2",                      "",                                                   CONV_NUMERIC_LITERAL, API_SPARSE, 4, ROC_UNSUPPORTED};
+  m["CUSPARSE_SPGEMM_ALG3"]                                           = {"HIPSPARSE_SPGEMM_ALG3",                      "",                                                   CONV_NUMERIC_LITERAL, API_SPARSE, 4, ROC_UNSUPPORTED};
 
-  {"cusparseDenseToSparseAlg_t",                 {"hipsparseDenseToSparseAlg_t",                "rocsparse_dense_to_sparse_alg",                      CONV_TYPE, API_SPARSE, 4}},
-  {"CUSPARSE_DENSETOSPARSE_ALG_DEFAULT",         {"HIPSPARSE_DENSETOSPARSE_ALG_DEFAULT",        "rocsparse_dense_to_sparse_alg_default",              CONV_NUMERIC_LITERAL, API_SPARSE, 4}},
+  m["cusparseDenseToSparseAlg_t"]                                     = {"hipsparseDenseToSparseAlg_t",                "rocsparse_dense_to_sparse_alg",                      CONV_TYPE, API_SPARSE, 4};
+  m["CUSPARSE_DENSETOSPARSE_ALG_DEFAULT"]                             = {"HIPSPARSE_DENSETOSPARSE_ALG_DEFAULT",        "rocsparse_dense_to_sparse_alg_default",              CONV_NUMERIC_LITERAL, API_SPARSE, 4};
 
-  {"cusparseSparseToDenseAlg_t",                 {"hipsparseSparseToDenseAlg_t",                "rocsparse_sparse_to_dense_alg",                      CONV_TYPE, API_SPARSE, 4}},
-  {"CUSPARSE_SPARSETODENSE_ALG_DEFAULT",         {"HIPSPARSE_SPARSETODENSE_ALG_DEFAULT",        "rocsparse_sparse_to_dense_alg_default",              CONV_NUMERIC_LITERAL, API_SPARSE, 4}},
+  m["cusparseSparseToDenseAlg_t"]                                     = {"hipsparseSparseToDenseAlg_t",                "rocsparse_sparse_to_dense_alg",                      CONV_TYPE, API_SPARSE, 4};
+  m["CUSPARSE_SPARSETODENSE_ALG_DEFAULT"]                             = {"HIPSPARSE_SPARSETODENSE_ALG_DEFAULT",        "rocsparse_sparse_to_dense_alg_default",              CONV_NUMERIC_LITERAL, API_SPARSE, 4};
 
-  {"cusparseSpMatAttribute_t",                   {"hipsparseSpMatAttribute_t",                  "rocsparse_spmat_attribute",                          CONV_TYPE, API_SPARSE, 4}},
-  {"CUSPARSE_SPMAT_FILL_MODE",                   {"HIPSPARSE_SPMAT_FILL_MODE",                  "rocsparse_spmat_fill_mode",                          CONV_NUMERIC_LITERAL, API_SPARSE, 4}},
-  {"CUSPARSE_SPMAT_DIAG_TYPE",                   {"HIPSPARSE_SPMAT_DIAG_TYPE",                  "rocsparse_spmat_diag_type",                          CONV_NUMERIC_LITERAL, API_SPARSE, 4}},
+  m["cusparseSpMatAttribute_t"]                                       = {"hipsparseSpMatAttribute_t",                  "rocsparse_spmat_attribute",                          CONV_TYPE, API_SPARSE, 4};
+  m["CUSPARSE_SPMAT_FILL_MODE"]                                       = {"HIPSPARSE_SPMAT_FILL_MODE",                  "rocsparse_spmat_fill_mode",                          CONV_NUMERIC_LITERAL, API_SPARSE, 4};
+  m["CUSPARSE_SPMAT_DIAG_TYPE"]                                       = {"HIPSPARSE_SPMAT_DIAG_TYPE",                  "rocsparse_spmat_diag_type",                          CONV_NUMERIC_LITERAL, API_SPARSE, 4};
 
-  {"cusparseSpSVAlg_t",                          {"hipsparseSpSVAlg_t",                         "rocsparse_spsv_alg",                                 CONV_TYPE, API_SPARSE, 4}},
-  {"CUSPARSE_SPSV_ALG_DEFAULT",                  {"HIPSPARSE_SPSV_ALG_DEFAULT",                 "rocsparse_spsv_alg_default",                         CONV_NUMERIC_LITERAL, API_SPARSE, 4}},
+  m["cusparseSpSVAlg_t"]                                              = {"hipsparseSpSVAlg_t",                         "rocsparse_spsv_alg",                                 CONV_TYPE, API_SPARSE, 4};
+  m["CUSPARSE_SPSV_ALG_DEFAULT"]                                      = {"HIPSPARSE_SPSV_ALG_DEFAULT",                 "rocsparse_spsv_alg_default",                         CONV_NUMERIC_LITERAL, API_SPARSE, 4};
 
-  {"cusparseSpSMAlg_t",                          {"hipsparseSpSMAlg_t",                         "rocsparse_spsm_alg",                                 CONV_TYPE, API_SPARSE, 4}},
-  {"CUSPARSE_SPSM_ALG_DEFAULT",                  {"HIPSPARSE_SPSM_ALG_DEFAULT",                 "rocsparse_spsm_alg_default",                         CONV_NUMERIC_LITERAL, API_SPARSE, 4}},
+  m["cusparseSpSMAlg_t"]                                              = {"hipsparseSpSMAlg_t",                         "rocsparse_spsm_alg",                                 CONV_TYPE, API_SPARSE, 4};
+  m["CUSPARSE_SPSM_ALG_DEFAULT"]                                      = {"HIPSPARSE_SPSM_ALG_DEFAULT",                 "rocsparse_spsm_alg_default",                         CONV_NUMERIC_LITERAL, API_SPARSE, 4};
 
-  {"cusparseSpSMUpdate_t",                       {"hipsparseSpSMUpdate_t",                      "",                                                   CONV_TYPE, API_SPARSE, 4, UNSUPPORTED}},
-  {"CUSPARSE_SPSM_UPDATE_GENERAL",               {"HIPSPARSE_SPSM_UPDATE_GENERAL",              "",                                                   CONV_NUMERIC_LITERAL, API_SPARSE, 4, UNSUPPORTED}},
-  {"CUSPARSE_SPSM_UPDATE_DIAGONAL",              {"HIPSPARSE_SPSM_UPDATE_DIAGONAL",             "",                                                   CONV_NUMERIC_LITERAL, API_SPARSE, 4, UNSUPPORTED}},
+  m["cusparseSpSMUpdate_t"]                                           = {"hipsparseSpSMUpdate_t",                      "",                                                   CONV_TYPE, API_SPARSE, 4, UNSUPPORTED};
+  m["CUSPARSE_SPSM_UPDATE_GENERAL"]                                   = {"HIPSPARSE_SPSM_UPDATE_GENERAL",              "",                                                   CONV_NUMERIC_LITERAL, API_SPARSE, 4, UNSUPPORTED};
+  m["CUSPARSE_SPSM_UPDATE_DIAGONAL"]                                  = {"HIPSPARSE_SPSM_UPDATE_DIAGONAL",             "",                                                   CONV_NUMERIC_LITERAL, API_SPARSE, 4, UNSUPPORTED};
 
-  {"cusparseSDDMMAlg_t",                         {"hipsparseSDDMMAlg_t",                        "rocsparse_sddmm_alg",                                CONV_TYPE, API_SPARSE, 4}},
-  {"CUSPARSE_SDDMM_ALG_DEFAULT",                 {"HIPSPARSE_SDDMM_ALG_DEFAULT",                "rocsparse_sddmm_alg_default",                        CONV_NUMERIC_LITERAL, API_SPARSE, 4}},
+  m["cusparseSDDMMAlg_t"]                                             = {"hipsparseSDDMMAlg_t",                        "rocsparse_sddmm_alg",                                CONV_TYPE, API_SPARSE, 4};
+  m["CUSPARSE_SDDMM_ALG_DEFAULT"]                                     = {"HIPSPARSE_SDDMM_ALG_DEFAULT",                "rocsparse_sddmm_alg_default",                        CONV_NUMERIC_LITERAL, API_SPARSE, 4};
 
-  {"cusparseSideMode_t",                         {"hipsparseSideMode_t",                        "",                                                   CONV_TYPE, API_SPARSE, 4, UNSUPPORTED | CUDA_REMOVED}},
-  {"CUSPARSE_SIDE_LEFT",                         {"HIPSPARSE_SIDE_LEFT",                        "",                                                   CONV_NUMERIC_LITERAL, API_SPARSE, 4, UNSUPPORTED | CUDA_REMOVED}},
-  {"CUSPARSE_SIDE_RIGHT",                        {"HIPSPARSE_SIDE_RIGHT",                       "",                                                   CONV_NUMERIC_LITERAL, API_SPARSE, 4, UNSUPPORTED | CUDA_REMOVED}},
+  m["cusparseSideMode_t"]                                             = {"hipsparseSideMode_t",                        "",                                                   CONV_TYPE, API_SPARSE, 4, UNSUPPORTED | CUDA_REMOVED};
+  m["CUSPARSE_SIDE_LEFT"]                                             = {"HIPSPARSE_SIDE_LEFT",                        "",                                                   CONV_NUMERIC_LITERAL, API_SPARSE, 4, UNSUPPORTED | CUDA_REMOVED};
+  m["CUSPARSE_SIDE_RIGHT"]                                            = {"HIPSPARSE_SIDE_RIGHT",                       "",                                                   CONV_NUMERIC_LITERAL, API_SPARSE, 4, UNSUPPORTED | CUDA_REMOVED};
 
-  {"cusparseSpMMOpAlg_t",                        {"hipsparseSpMMOpAlg_t",                       "",                                                   CONV_TYPE, API_SPARSE, 4, UNSUPPORTED}},
-  {"CUSPARSE_SPMM_OP_ALG_DEFAULT",               {"HIPSPARSE_SPMM_OP_ALG_DEFAULT",              "",                                                   CONV_NUMERIC_LITERAL, API_SPARSE, 4, UNSUPPORTED}},
+  m["cusparseSpMMOpAlg_t"]                                            = {"hipsparseSpMMOpAlg_t",                       "",                                                   CONV_TYPE, API_SPARSE, 4, UNSUPPORTED};
+  m["CUSPARSE_SPMM_OP_ALG_DEFAULT"]                                   = {"HIPSPARSE_SPMM_OP_ALG_DEFAULT",              "",                                                   CONV_NUMERIC_LITERAL, API_SPARSE, 4, UNSUPPORTED};
 
-  {"cusparseSpSVUpdate_t",                       {"hipsparseSpSVUpdate_t",                      "",                                                   CONV_TYPE, API_SPARSE, 4, UNSUPPORTED}},
-  {"CUSPARSE_SPSV_UPDATE_GENERAL",               {"HIPSPARSE_SPSV_UPDATE_GENERAL",              "",                                                   CONV_NUMERIC_LITERAL, API_SPARSE, 4, UNSUPPORTED}},
-  {"CUSPARSE_SPSV_UPDATE_DIAGONAL",              {"HIPSPARSE_SPSV_UPDATE_DIAGONAL",             "",                                                   CONV_NUMERIC_LITERAL, API_SPARSE, 4, UNSUPPORTED}},
+  m["cusparseSpSVUpdate_t"]                                           = {"hipsparseSpSVUpdate_t",                      "",                                                   CONV_TYPE, API_SPARSE, 4, UNSUPPORTED};
+  m["CUSPARSE_SPSV_UPDATE_GENERAL"]                                   = {"HIPSPARSE_SPSV_UPDATE_GENERAL",              "",                                                   CONV_NUMERIC_LITERAL, API_SPARSE, 4, UNSUPPORTED};
+  m["CUSPARSE_SPSV_UPDATE_DIAGONAL"]                                  = {"HIPSPARSE_SPSV_UPDATE_DIAGONAL",             "",                                                   CONV_NUMERIC_LITERAL, API_SPARSE, 4, UNSUPPORTED};
 
-  {"cusparseColorAlg_t",                         {"hipsparseColorAlg_t",                        "",                                                   CONV_TYPE, API_SPARSE, 4, UNSUPPORTED | CUDA_DEPRECATED}},
-  {"CUSPARSE_COLOR_ALG0",                        {"HIPSPARSE_COLOR_ALG0",                       "",                                                   CONV_NUMERIC_LITERAL, API_SPARSE, 4, UNSUPPORTED | CUDA_DEPRECATED}},
-  {"CUSPARSE_COLOR_ALG1",                        {"HIPSPARSE_COLOR_ALG1",                       "",                                                   CONV_NUMERIC_LITERAL, API_SPARSE, 4, UNSUPPORTED | CUDA_DEPRECATED}},
+  m["cusparseColorAlg_t"]                                             = {"hipsparseColorAlg_t",                        "",                                                   CONV_TYPE, API_SPARSE, 4, UNSUPPORTED | CUDA_DEPRECATED};
+  m["CUSPARSE_COLOR_ALG0"]                                            = {"HIPSPARSE_COLOR_ALG0",                       "",                                                   CONV_NUMERIC_LITERAL, API_SPARSE, 4, UNSUPPORTED | CUDA_DEPRECATED};
+  m["CUSPARSE_COLOR_ALG1"]                                            = {"HIPSPARSE_COLOR_ALG1",                       "",                                                   CONV_NUMERIC_LITERAL, API_SPARSE, 4, UNSUPPORTED | CUDA_DEPRECATED};
 
   // 3. Defines
 
   // 4. Typedefs
-  {"cusparseLoggerCallback_t",                   {"hipsparseLoggerCallback_t",                  "",                                                   CONV_TYPE, API_SPARSE, 4, UNSUPPORTED}},
-  {"cusparseConstSpVecDescr_t",                  {"hipsparseConstSpVecDescr_t",                 "rocsparse_const_spvec_descr",                        CONV_TYPE, API_SPARSE, 4}},
-  {"cusparseConstDnVecDescr_t",                  {"hipsparseConstDnVecDescr_t",                 "rocsparse_const_dnvec_descr",                        CONV_TYPE, API_SPARSE, 4}},
-  {"cusparseConstSpMatDescr_t",                  {"hipsparseConstSpMatDescr_t",                 "rocsparse_const_spmat_descr",                        CONV_TYPE, API_SPARSE, 4}},
-  {"cusparseConstDnMatDescr_t",                  {"hipsparseConstDnMatDescr_t",                 "rocsparse_const_dnmat_descr",                        CONV_TYPE, API_SPARSE, 4}},
-};
+  m["cusparseLoggerCallback_t"]                                       = {"hipsparseLoggerCallback_t",                  "",                                                   CONV_TYPE, API_SPARSE, 4, UNSUPPORTED};
+  m["cusparseConstSpVecDescr_t"]                                      = {"hipsparseConstSpVecDescr_t",                 "rocsparse_const_spvec_descr",                        CONV_TYPE, API_SPARSE, 4};
+  m["cusparseConstDnVecDescr_t"]                                      = {"hipsparseConstDnVecDescr_t",                 "rocsparse_const_dnvec_descr",                        CONV_TYPE, API_SPARSE, 4};
+  m["cusparseConstSpMatDescr_t"]                                      = {"hipsparseConstSpMatDescr_t",                 "rocsparse_const_spmat_descr",                        CONV_TYPE, API_SPARSE, 4};
+  m["cusparseConstDnMatDescr_t"]                                      = {"hipsparseConstDnMatDescr_t",                 "rocsparse_const_dnmat_descr",                        CONV_TYPE, API_SPARSE, 4};
 
-const std::map<llvm::StringRef, cudaAPIversions> CUDA_SPARSE_TYPE_NAME_VER_MAP {
-  {"cusparseHybMat",                             {CUDA_0,   CUDA_102, CUDA_110}},
-  {"cusparseHybMat_t",                           {CUDA_0,   CUDA_102, CUDA_110}},
-  {"cusparseSolveAnalysisInfo",                  {CUDA_0,   CUDA_102, CUDA_110}},
-  {"cusparseSolveAnalysisInfo_t",                {CUDA_0,   CUDA_102, CUDA_110}},
-  {"csrsm2Info",                                 {CUDA_92,  CUDA_0,   CUDA_120}},
-  {"csrsm2Info_t",                               {CUDA_92,  CUDA_0,   CUDA_120}},
-  {"pruneInfo",                                  {CUDA_90,  CUDA_122, CUDA_0  }},
-  {"pruneInfo_t",                                {CUDA_90,  CUDA_122, CUDA_0  }},
-  {"cusparseSpMatDescr",                         {CUDA_101, CUDA_0,   CUDA_0  }},
-  {"cusparseSpMatDescr_t",                       {CUDA_101, CUDA_0,   CUDA_0  }},
-  {"cusparseDnMatDescr",                         {CUDA_101, CUDA_0,   CUDA_0  }},
-  {"cusparseDnMatDescr_t",                       {CUDA_101, CUDA_0,   CUDA_0  }},
-  {"cusparseSpVecDescr",                         {CUDA_102, CUDA_0,   CUDA_0  }},
-  {"cusparseSpVecDescr_t",                       {CUDA_102, CUDA_0,   CUDA_0  }},
-  {"cusparseDnVecDescr",                         {CUDA_102, CUDA_0,   CUDA_0  }},
-  {"cusparseDnVecDescr_t",                       {CUDA_102, CUDA_0,   CUDA_0  }},
-  {"cusparseHybPartition_t",                     {CUDA_0,   CUDA_102, CUDA_110}},
-  {"CUSPARSE_HYB_PARTITION_AUTO",                {CUDA_0,   CUDA_102, CUDA_110}},
-  {"CUSPARSE_HYB_PARTITION_USER",                {CUDA_0,   CUDA_102, CUDA_110}},
-  {"CUSPARSE_HYB_PARTITION_MAX",                 {CUDA_0,   CUDA_102, CUDA_110}},
-  {"cusparseAlgMode_t",                          {CUDA_80,  CUDA_0,   CUDA_120}},
-  {"CUSPARSE_ALG0",                              {CUDA_80,  CUDA_0,   CUDA_110}},
-  {"CUSPARSE_ALG1",                              {CUDA_80,  CUDA_0,   CUDA_110}},
-  {"CUSPARSE_ALG_NAIVE",                         {CUDA_92,  CUDA_0,   CUDA_110}},
-  {"CUSPARSE_ALG_MERGE_PATH",                    {CUDA_92,  CUDA_0,   CUDA_120}},
-  {"CUSPARSE_STATUS_NOT_SUPPORTED",              {CUDA_102, CUDA_0,   CUDA_0  }},
-  {"CUSPARSE_STATUS_INSUFFICIENT_RESOURCES",     {CUDA_110, CUDA_0,   CUDA_0  }},
-  {"cusparseCsr2CscAlg_t",                       {CUDA_101, CUDA_0,   CUDA_0  }},
-  {"CUSPARSE_CSR2CSC_ALG1",                      {CUDA_101, CUDA_0,   CUDA_0  }},
-  {"CUSPARSE_CSR2CSC_ALG2",                      {CUDA_101, CUDA_0,   CUDA_120}},
-  {"CUSPARSE_CSR2CSC_ALG_DEFAULT",               {CUDA_120, CUDA_0,   CUDA_0  }},
-  {"cusparseFormat_t",                           {CUDA_101, CUDA_0,   CUDA_0  }},
-  {"CUSPARSE_FORMAT_CSR",                        {CUDA_101, CUDA_0,   CUDA_0  }},
-  {"CUSPARSE_FORMAT_CSC",                        {CUDA_101, CUDA_0,   CUDA_0  }},
-  {"CUSPARSE_FORMAT_COO",                        {CUDA_101, CUDA_0,   CUDA_0  }},
-  {"CUSPARSE_FORMAT_COO_AOS",                    {CUDA_102, CUDA_0,   CUDA_120}},
-  {"cusparseOrder_t",                            {CUDA_101, CUDA_0,   CUDA_0  }},
-  {"CUSPARSE_ORDER_COL",                         {CUDA_101, CUDA_0,   CUDA_0  }},
-  {"CUSPARSE_ORDER_ROW",                         {CUDA_101, CUDA_0,   CUDA_0  }},
-  {"cusparseSpMVAlg_t",                          {CUDA_102, CUDA_0,   CUDA_0  }},
-  {"CUSPARSE_MV_ALG_DEFAULT",                    {CUDA_102, CUDA_113, CUDA_120}},
-  {"CUSPARSE_SPMV_ALG_DEFAULT",                  {CUDA_112, CUDA_0,   CUDA_0  }},
-  {"CUSPARSE_COOMV_ALG",                         {CUDA_102, CUDA_112, CUDA_120}},
-  {"CUSPARSE_CSRMV_ALG1",                        {CUDA_102, CUDA_112, CUDA_120}},
-  {"CUSPARSE_CSRMV_ALG2",                        {CUDA_102, CUDA_112, CUDA_120}},
-  {"cusparseSpMMAlg_t",                          {CUDA_101, CUDA_0,   CUDA_0  }},
-  {"CUSPARSE_MM_ALG_DEFAULT",                    {CUDA_102, CUDA_110, CUDA_120}},
-  {"CUSPARSE_COOMM_ALG1",                        {CUDA_101, CUDA_110, CUDA_120}},
-  {"CUSPARSE_COOMM_ALG2",                        {CUDA_101, CUDA_110, CUDA_120}},
-  {"CUSPARSE_COOMM_ALG3",                        {CUDA_101, CUDA_110, CUDA_120}},
-  {"CUSPARSE_CSRMM_ALG1",                        {CUDA_102, CUDA_110, CUDA_120}},
-  {"CUSPARSE_SPMM_ALG_DEFAULT",                  {CUDA_110, CUDA_0,   CUDA_0  }},
-  {"CUSPARSE_SPMM_COO_ALG1",                     {CUDA_110, CUDA_0,   CUDA_0  }},
-  {"CUSPARSE_SPMM_COO_ALG2",                     {CUDA_110, CUDA_0,   CUDA_0  }},
-  {"CUSPARSE_SPMM_COO_ALG3",                     {CUDA_110, CUDA_0,   CUDA_0  }},
-  {"CUSPARSE_SPMM_COO_ALG4",                     {CUDA_110, CUDA_0,   CUDA_0  }},
-  {"CUSPARSE_SPMM_CSR_ALG1",                     {CUDA_110, CUDA_0,   CUDA_0  }},
-  {"CUSPARSE_SPMM_CSR_ALG2",                     {CUDA_110, CUDA_0,   CUDA_0  }},
-  {"CUSPARSE_SPMM_CSR_ALG3",                     {CUDA_112, CUDA_0,   CUDA_0  }},
-  {"CUSPARSE_SPMM_BLOCKED_ELL_ALG1",             {CUDA_112, CUDA_0,   CUDA_0  }},
-  {"cusparseIndexType_t",                        {CUDA_101, CUDA_0,   CUDA_0  }},
-  {"CUSPARSE_INDEX_16U",                         {CUDA_101, CUDA_0,   CUDA_0  }},
-  {"CUSPARSE_INDEX_32I",                         {CUDA_101, CUDA_0,   CUDA_0  }},
-  {"CUSPARSE_INDEX_64I",                         {CUDA_101, CUDA_0,   CUDA_0  }}, // CUSPARSE_VERSION 10200
-  {"cusparseSpGEMMAlg_t",                        {CUDA_110, CUDA_0,   CUDA_0  }},
-  {"CUSPARSE_SPGEMM_DEFAULT",                    {CUDA_110, CUDA_0,   CUDA_0  }},
-  {"cusparseSpGEMMDescr",                        {CUDA_110, CUDA_0,   CUDA_0  }},
-  {"cusparseSpGEMMDescr_t",                      {CUDA_110, CUDA_0,   CUDA_0  }},
-  {"cusparseDenseToSparseAlg_t",                 {CUDA_111, CUDA_0,   CUDA_0  }},
-  {"CUSPARSE_DENSETOSPARSE_ALG_DEFAULT",         {CUDA_111, CUDA_0,   CUDA_0  }},
-  {"cusparseSparseToDenseAlg_t",                 {CUDA_111, CUDA_0,   CUDA_0  }},
-  {"CUSPARSE_SPARSETODENSE_ALG_DEFAULT",         {CUDA_111, CUDA_0,   CUDA_0  }},
-  {"CUSPARSE_SPMMA_PREPROCESS",                  {CUDA_111, CUDA_0,   CUDA_112}},
-  {"CUSPARSE_SPMMA_ALG1",                        {CUDA_111, CUDA_0,   CUDA_112}},
-  {"CUSPARSE_SPMMA_ALG2",                        {CUDA_111, CUDA_0,   CUDA_112}},
-  {"CUSPARSE_SPMMA_ALG3",                        {CUDA_111, CUDA_0,   CUDA_112}},
-  {"CUSPARSE_SPMMA_ALG4",                        {CUDA_111, CUDA_0,   CUDA_112}},
-  {"cusparseSpMatAttribute_t",                   {CUDA_113, CUDA_0,   CUDA_0  }},
-  {"CUSPARSE_SPMAT_FILL_MODE",                   {CUDA_113, CUDA_0,   CUDA_0  }},
-  {"CUSPARSE_SPMAT_DIAG_TYPE",                   {CUDA_113, CUDA_0,   CUDA_0  }},
-  {"CUSPARSE_SPMV_COO_ALG1",                     {CUDA_112, CUDA_0,   CUDA_0  }},
-  {"CUSPARSE_SPMV_COO_ALG2",                     {CUDA_112, CUDA_0,   CUDA_0  }},
-  {"CUSPARSE_SPMV_CSR_ALG1",                     {CUDA_112, CUDA_0,   CUDA_0  }},
-  {"CUSPARSE_SPMV_CSR_ALG2",                     {CUDA_112, CUDA_0,   CUDA_0  }},
-  {"cusparseSpSVAlg_t",                          {CUDA_113, CUDA_0,   CUDA_0  }},
-  {"CUSPARSE_SPSV_ALG_DEFAULT",                  {CUDA_113, CUDA_0,   CUDA_0  }},
-  {"cusparseSpSMAlg_t",                          {CUDA_113, CUDA_0,   CUDA_0  }},
-  {"CUSPARSE_SPSM_ALG_DEFAULT",                  {CUDA_113, CUDA_0,   CUDA_0  }},
-  {"cusparseSpSMDescr",                          {CUDA_113, CUDA_0,   CUDA_0  }},
-  {"cusparseSpSMDescr_t",                        {CUDA_113, CUDA_0,   CUDA_0  }},
-  {"CUSPARSE_SPGEMM_CSR_ALG_DETERMINITIC",       {CUDA_113, CUDA_0,   CUDA_0  }},
-  {"CUSPARSE_SPGEMM_CSR_ALG_NONDETERMINITIC",    {CUDA_113, CUDA_0,   CUDA_0  }},
-  {"cusparseSDDMMAlg_t",                         {CUDA_112, CUDA_0,   CUDA_0  }},
-  {"CUSPARSE_SDDMM_ALG_DEFAULT",                 {CUDA_112, CUDA_0,   CUDA_0  }},
-  {"CUSPARSE_FORMAT_BLOCKED_ELL",                {CUDA_112, CUDA_0,   CUDA_0  }},
-  {"cusparseSpSVDescr",                          {CUDA_113, CUDA_0,   CUDA_0  }},
-  {"cusparseSpSVDescr_t",                        {CUDA_113, CUDA_0,   CUDA_0  }},
-  {"cusparseSideMode_t",                         {CUDA_0,   CUDA_0,   CUDA_115}},
-  {"CUSPARSE_SIDE_LEFT",                         {CUDA_0,   CUDA_0,   CUDA_115}},
-  {"CUSPARSE_SIDE_RIGHT",                        {CUDA_0,   CUDA_0,   CUDA_115}},
-  {"cusparseLoggerCallback_t",                   {CUDA_115, CUDA_0,   CUDA_0  }},
-  {"cusparseSpMMOpPlan",                         {CUDA_115, CUDA_0,   CUDA_0  }},
-  {"cusparseSpMMOpPlan_t",                       {CUDA_115, CUDA_0,   CUDA_0  }},
-  {"cusparseSpMMOpAlg_t",                        {CUDA_115, CUDA_0,   CUDA_0  }},
-  {"CUSPARSE_SPMM_OP_ALG_DEFAULT",               {CUDA_115, CUDA_0,   CUDA_0  }},
-  {"csrsv2Info",                                 {CUDA_0,   CUDA_0,   CUDA_120}},
-  {"csrsv2Info_t",                               {CUDA_0,   CUDA_0,   CUDA_120}},
-  {"csrgemm2Info",                               {CUDA_0,   CUDA_0,   CUDA_120}},
-  {"csrgemm2Info_t",                             {CUDA_0,   CUDA_0,   CUDA_120}},
-  {"cusparseConstSpVecDescr_t",                  {CUDA_120, CUDA_0,   CUDA_0  }},
-  {"cusparseConstDnVecDescr_t",                  {CUDA_120, CUDA_0,   CUDA_0  }},
-  {"cusparseConstSpMatDescr_t",                  {CUDA_120, CUDA_0,   CUDA_0  }},
-  {"cusparseConstDnMatDescr_t",                  {CUDA_120, CUDA_0,   CUDA_0  }},
-  {"CUSPARSE_SPGEMM_ALG1",                       {CUDA_120, CUDA_0,   CUDA_0  }},
-  {"CUSPARSE_SPGEMM_ALG2",                       {CUDA_120, CUDA_0,   CUDA_0  }},
-  {"CUSPARSE_SPGEMM_ALG3",                       {CUDA_120, CUDA_0,   CUDA_0  }},
-  {"CUSPARSE_FORMAT_BSR",                        {CUDA_121, CUDA_0,   CUDA_0  }}, // CUSPARSE_VERSION 12100
-  {"CUSPARSE_FORMAT_SLICED_ELLPACK",             {CUDA_121, CUDA_0,   CUDA_0  }}, // CUSPARSE_VERSION 12100
-  {"CUSPARSE_SPMV_SELL_ALG1",                    {CUDA_121, CUDA_0,   CUDA_0  }}, // CUSPARSE_VERSION 12100
-  {"cusparseSpSVUpdate_t",                       {CUDA_121, CUDA_0,   CUDA_0  }}, // CUSPARSE_VERSION 12100
-  {"CUSPARSE_SPSV_UPDATE_GENERAL",               {CUDA_121, CUDA_0,   CUDA_0  }}, // CUSPARSE_VERSION 12100
-  {"CUSPARSE_SPSV_UPDATE_DIAGONAL",              {CUDA_121, CUDA_0,   CUDA_0  }}, // CUSPARSE_VERSION 12100
-  {"bsrsv2Info",                                 {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"bsrsv2Info_t",                               {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"bsrsm2Info",                                 {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"bsrsm2Info_t",                               {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"csric02Info",                                {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"csric02Info_t",                              {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"csrilu02Info",                               {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"csrilu02Info_t",                             {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"bsrilu02Info",                               {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"bsrilu02Info_t",                             {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"csru2csrInfo",                               {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"csru2csrInfo_t",                             {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseColorInfo",                          {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseColorInfo_t",                        {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"pruneInfo",                                  {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"pruneInfo_t",                                {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseSolvePolicy_t",                      {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"CUSPARSE_SOLVE_POLICY_NO_LEVEL",             {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"CUSPARSE_SOLVE_POLICY_USE_LEVEL",            {CUDA_0,   CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseColorAlg_t",                         {CUDA_80,  CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"CUSPARSE_COLOR_ALG0",                        {CUDA_80,  CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"CUSPARSE_COLOR_ALG1",                        {CUDA_80,  CUDA_122, CUDA_0  }}, // CUSPARSE_VERSION 12120
-  {"cusparseSpSMUpdate_t",                       {CUDA_124, CUDA_0,   CUDA_0  }},
-  {"CUSPARSE_SPSM_UPDATE_GENERAL",               {CUDA_124, CUDA_0,   CUDA_0  }},
-  {"CUSPARSE_SPSM_UPDATE_DIAGONAL",              {CUDA_124, CUDA_0,   CUDA_0  }},
-  {"CUSPARSE_SPMM_BSR_ALG1",                     {CUDA_125, CUDA_0,   CUDA_0  }}, // CUSPARSE_VERSION 12501
-  {"CUSPARSE_SPMV_BSR_ALG1",                     {CUDA_130, CUDA_0,   CUDA_0  }}, // CUSPARSE_VERSION 12603 CUDA 13.0.1
-};
+  return m;
+}();
 
-const std::map<llvm::StringRef, hipAPIversions> HIP_SPARSE_TYPE_NAME_VER_MAP {
-  {"hipsparseHandle_t",                          {HIP_1092, HIP_0,    HIP_0   }},
-  {"hipsparseHybMat_t",                          {HIP_1092, HIP_0,    HIP_0   }},
-  {"hipsparseMatDescr_t",                        {HIP_1092, HIP_0,    HIP_0   }},
-  {"csrsv2Info_t",                               {HIP_1092, HIP_0,    HIP_0   }},
-  {"csrsm2Info_t",                               {HIP_3010, HIP_0,    HIP_0   }},
-  {"bsrsv2Info",                                 {HIP_3060, HIP_0,    HIP_0   }},
-  {"bsrsv2Info_t",                               {HIP_3060, HIP_0,    HIP_0   }},
-  {"bsric02Info",                                {HIP_3080, HIP_0,    HIP_0   }},
-  {"bsric02Info_t",                              {HIP_3080, HIP_0,    HIP_0   }},
-  {"csrilu02Info",                               {HIP_1092, HIP_0,    HIP_0   }},
-  {"csrilu02Info_t",                             {HIP_1092, HIP_0,    HIP_0   }},
-  {"bsrilu02Info",                               {HIP_3090, HIP_0,    HIP_0   }},
-  {"bsrilu02Info_t",                             {HIP_3090, HIP_0,    HIP_0   }},
-  {"csrgemm2Info",                               {HIP_2080, HIP_0,    HIP_0   }},
-  {"csrgemm2Info_t",                             {HIP_2080, HIP_0,    HIP_0   }},
-  {"pruneInfo",                                  {HIP_3090, HIP_0,    HIP_0   }},
-  {"pruneInfo_t",                                {HIP_3090, HIP_0,    HIP_0   }},
-  {"hipsparseAction_t",                          {HIP_1092, HIP_0,    HIP_0   }},
-  {"HIPSPARSE_ACTION_SYMBOLIC",                  {HIP_1092, HIP_0,    HIP_0   }},
-  {"HIPSPARSE_ACTION_NUMERIC",                   {HIP_1092, HIP_0,    HIP_0   }},
-  {"hipsparseDirection_t",                       {HIP_3020, HIP_0,    HIP_0   }},
-  {"HIPSPARSE_DIRECTION_ROW",                    {HIP_3020, HIP_0,    HIP_0   }},
-  {"HIPSPARSE_DIRECTION_COLUMN",                 {HIP_3020, HIP_0,    HIP_0   }},
-  {"hipsparseHybPartition_t",                    {HIP_1092, HIP_0,    HIP_0   }},
-  {"HIPSPARSE_HYB_PARTITION_AUTO",               {HIP_1092, HIP_0,    HIP_0   }},
-  {"HIPSPARSE_HYB_PARTITION_USER",               {HIP_1092, HIP_0,    HIP_0   }},
-  {"HIPSPARSE_HYB_PARTITION_MAX",                {HIP_1092, HIP_0,    HIP_0   }},
-  {"hipsparseDiagType_t",                        {HIP_1092, HIP_0,    HIP_0   }},
-  {"HIPSPARSE_DIAG_TYPE_NON_UNIT",               {HIP_1092, HIP_0,    HIP_0   }},
-  {"HIPSPARSE_DIAG_TYPE_UNIT",                   {HIP_1092, HIP_0,    HIP_0   }},
-  {"hipsparseFillMode_t",                        {HIP_1092, HIP_0,    HIP_0   }},
-  {"HIPSPARSE_FILL_MODE_LOWER",                  {HIP_1092, HIP_0,    HIP_0   }},
-  {"HIPSPARSE_FILL_MODE_UPPER",                  {HIP_1092, HIP_0,    HIP_0   }},
-  {"hipsparseIndexBase_t",                       {HIP_1092, HIP_0,    HIP_0   }},
-  {"HIPSPARSE_INDEX_BASE_ZERO",                  {HIP_1092, HIP_0,    HIP_0   }},
-  {"HIPSPARSE_INDEX_BASE_ONE",                   {HIP_1092, HIP_0,    HIP_0   }},
-  {"hipsparseMatrixType_t",                      {HIP_1092, HIP_0,    HIP_0   }},
-  {"HIPSPARSE_MATRIX_TYPE_GENERAL",              {HIP_1092, HIP_0,    HIP_0   }},
-  {"HIPSPARSE_MATRIX_TYPE_SYMMETRIC",            {HIP_1092, HIP_0,    HIP_0   }},
-  {"HIPSPARSE_MATRIX_TYPE_HERMITIAN",            {HIP_1092, HIP_0,    HIP_0   }},
-  {"HIPSPARSE_MATRIX_TYPE_TRIANGULAR",           {HIP_1092, HIP_0,    HIP_0   }},
-  {"hipsparseOperation_t",                       {HIP_1092, HIP_0,    HIP_0   }},
-  {"HIPSPARSE_OPERATION_NON_TRANSPOSE",          {HIP_1092, HIP_0,    HIP_0   }},
-  {"HIPSPARSE_OPERATION_TRANSPOSE",              {HIP_1092, HIP_0,    HIP_0   }},
-  {"HIPSPARSE_OPERATION_CONJUGATE_TRANSPOSE",    {HIP_1092, HIP_0,    HIP_0   }},
-  {"hipsparsePointerMode_t",                     {HIP_1092, HIP_0,    HIP_0   }},
-  {"HIPSPARSE_POINTER_MODE_HOST",                {HIP_1092, HIP_0,    HIP_0   }},
-  {"HIPSPARSE_POINTER_MODE_DEVICE",              {HIP_1092, HIP_0,    HIP_0   }},
-  {"hipsparseSolvePolicy_t",                     {HIP_1092, HIP_0,    HIP_0   }},
-  {"HIPSPARSE_SOLVE_POLICY_NO_LEVEL",            {HIP_1092, HIP_0,    HIP_0   }},
-  {"HIPSPARSE_SOLVE_POLICY_USE_LEVEL",           {HIP_1092, HIP_0,    HIP_0   }},
-  {"hipsparseStatus_t",                          {HIP_1092, HIP_0,    HIP_0   }},
-  {"HIPSPARSE_STATUS_SUCCESS",                   {HIP_1092, HIP_0,    HIP_0   }},
-  {"HIPSPARSE_STATUS_NOT_INITIALIZED",           {HIP_1092, HIP_0,    HIP_0   }},
-  {"HIPSPARSE_STATUS_ALLOC_FAILED",              {HIP_1092, HIP_0,    HIP_0   }},
-  {"HIPSPARSE_STATUS_INVALID_VALUE",             {HIP_1092, HIP_0,    HIP_0   }},
-  {"HIPSPARSE_STATUS_ARCH_MISMATCH",             {HIP_1092, HIP_0,    HIP_0   }},
-  {"HIPSPARSE_STATUS_MAPPING_ERROR",             {HIP_1092, HIP_0,    HIP_0   }},
-  {"HIPSPARSE_STATUS_EXECUTION_FAILED",          {HIP_1092, HIP_0,    HIP_0   }},
-  {"HIPSPARSE_STATUS_INTERNAL_ERROR",            {HIP_1092, HIP_0,    HIP_0   }},
-  {"HIPSPARSE_STATUS_MATRIX_TYPE_NOT_SUPPORTED", {HIP_1092, HIP_0,    HIP_0   }},
-  {"HIPSPARSE_STATUS_ZERO_PIVOT",                {HIP_1092, HIP_0,    HIP_0   }},
-  {"hipsparseSpMatDescr_t",                      {HIP_4010, HIP_0,    HIP_0   }},
-  {"hipsparseSpVecDescr_t",                      {HIP_4010, HIP_0,    HIP_0   }},
-  {"hipsparseDnVecDescr_t",                      {HIP_4010, HIP_0,    HIP_0   }},
-  {"hipsparseSpGEMMDescr",                       {HIP_4010, HIP_0,    HIP_0   }},
-  {"hipsparseSpGEMMDescr_t",                     {HIP_4010, HIP_0,    HIP_0   }},
-  {"HIPSPARSE_STATUS_NOT_SUPPORTED",             {HIP_4010, HIP_0,    HIP_0   }},
-  {"HIPSPARSE_STATUS_INSUFFICIENT_RESOURCES",    {HIP_4010, HIP_0,    HIP_0   }},
-  {"hipsparseFormat_t",                          {HIP_4010, HIP_0,    HIP_0   }},
-  {"HIPSPARSE_FORMAT_CSR",                       {HIP_4010, HIP_0,    HIP_0   }},
-  {"HIPSPARSE_FORMAT_CSC",                       {HIP_4010, HIP_0,    HIP_0   }},
-  {"HIPSPARSE_FORMAT_COO",                       {HIP_4010, HIP_0,    HIP_0   }},
-  {"HIPSPARSE_FORMAT_COO_AOS",                   {HIP_4010, HIP_0,    HIP_0   }},
-  {"hipsparseSpMVAlg_t",                         {HIP_4010, HIP_0,    HIP_0   }},
-  {"HIPSPARSE_MV_ALG_DEFAULT",                   {HIP_4010, HIP_0,    HIP_0   }},
-  {"HIPSPARSE_COOMV_ALG",                        {HIP_4010, HIP_0,    HIP_0   }},
-  {"HIPSPARSE_CSRMV_ALG1",                       {HIP_4010, HIP_0,    HIP_0   }},
-  {"HIPSPARSE_CSRMV_ALG2",                       {HIP_4010, HIP_0,    HIP_0   }},
-  {"hipsparseIndexType_t",                       {HIP_4010, HIP_0,    HIP_0   }},
-  {"HIPSPARSE_INDEX_16U",                        {HIP_4010, HIP_0,    HIP_0   }},
-  {"HIPSPARSE_INDEX_32I",                        {HIP_4010, HIP_0,    HIP_0   }},
-  {"HIPSPARSE_INDEX_64I",                        {HIP_4010, HIP_0,    HIP_0   }},
-  {"hipsparseSpGEMMAlg_t",                       {HIP_4010, HIP_0,    HIP_0   }},
-  {"HIPSPARSE_SPGEMM_DEFAULT",                   {HIP_4010, HIP_0,    HIP_0   }},
-  {"csru2csrInfo",                               {HIP_4020, HIP_0,    HIP_0   }},
-  {"csru2csrInfo_t",                             {HIP_4020, HIP_0,    HIP_0   }},
-  {"hipsparseDnMatDescr_t",                      {HIP_4020, HIP_0,    HIP_0   }},
-  {"hipsparseOrder_t",                           {HIP_4020, HIP_0,    HIP_0   }},
-  {"HIPSPARSE_ORDER_COL",                        {HIP_5040, HIP_0,    HIP_0   }},
-  {"HIPSPARSE_ORDER_ROW",                        {HIP_4020, HIP_0,    HIP_0   }},
-  {"hipsparseSpMMAlg_t",                         {HIP_4020, HIP_0,    HIP_0   }},
-  {"HIPSPARSE_MM_ALG_DEFAULT",                   {HIP_4020, HIP_0,    HIP_0   }},
-  {"HIPSPARSE_SPMM_ALG_DEFAULT",                 {HIP_4020, HIP_0,    HIP_0   }},
-  {"HIPSPARSE_COOMM_ALG1",                       {HIP_4020, HIP_0,    HIP_0   }},
-  {"HIPSPARSE_SPMM_COO_ALG1",                    {HIP_4020, HIP_0,    HIP_0   }},
-  {"HIPSPARSE_COOMM_ALG2",                       {HIP_4020, HIP_0,    HIP_0   }},
-  {"HIPSPARSE_SPMM_COO_ALG2",                    {HIP_4020, HIP_0,    HIP_0   }},
-  {"HIPSPARSE_COOMM_ALG3",                       {HIP_4020, HIP_0,    HIP_0   }},
-  {"HIPSPARSE_SPMM_COO_ALG3",                    {HIP_4020, HIP_0,    HIP_0   }},
-  {"HIPSPARSE_CSRMM_ALG1",                       {HIP_4020, HIP_0,    HIP_0   }},
-  {"HIPSPARSE_SPMM_CSR_ALG1",                    {HIP_4020, HIP_0,    HIP_0   }},
-  {"HIPSPARSE_SPMM_COO_ALG4",                    {HIP_4020, HIP_0,    HIP_0   }},
-  {"HIPSPARSE_SPMM_CSR_ALG2",                    {HIP_4020, HIP_0,    HIP_0   }},
-  {"hipsparseSparseToDenseAlg_t",                {HIP_4020, HIP_0,    HIP_0   }},
-  {"HIPSPARSE_SPARSETODENSE_ALG_DEFAULT",        {HIP_4020, HIP_0,    HIP_0   }},
-  {"hipsparseSDDMMAlg_t",                        {HIP_4030, HIP_0,    HIP_0   }},
-  {"HIPSPARSE_SDDMM_ALG_DEFAULT",                {HIP_4030, HIP_0,    HIP_0   }},
-  {"hipsparseColorInfo_t",                       {HIP_4050, HIP_0,    HIP_0   }},
-  {"bsrsm2Info_t",                               {HIP_4050, HIP_0,    HIP_0   }},
-  {"bsrsm2Info",                                 {HIP_4050, HIP_0,    HIP_0   }},
-  {"hipsparseSpSVDescr",                         {HIP_4050, HIP_0,    HIP_0   }},
-  {"hipsparseSpSVDescr_t",                       {HIP_4050, HIP_0,    HIP_0   }},
-  {"hipsparseSpSMDescr",                         {HIP_4050, HIP_0,    HIP_0   }},
-  {"hipsparseSpSMDescr_t",                       {HIP_4050, HIP_0,    HIP_0   }},
-  {"HIPSPARSE_FORMAT_BLOCKED_ELL",               {HIP_4050, HIP_0,    HIP_0   }},
-  {"HIPSPARSE_SPMV_ALG_DEFAULT",                 {HIP_4050, HIP_0,    HIP_0   }},
-  {"HIPSPARSE_SPMV_COO_ALG1",                    {HIP_4050, HIP_0,    HIP_0   }},
-  {"HIPSPARSE_SPMV_COO_ALG2",                    {HIP_4050, HIP_0,    HIP_0   }},
-  {"HIPSPARSE_SPMV_CSR_ALG1",                    {HIP_4050, HIP_0,    HIP_0   }},
-  {"HIPSPARSE_SPMV_CSR_ALG2",                    {HIP_4050, HIP_0,    HIP_0   }},
-  {"HIPSPARSE_SPMM_BLOCKED_ELL_ALG1",            {HIP_4050, HIP_0,    HIP_0   }},
-  {"HIPSPARSE_SPMM_CSR_ALG3",                    {HIP_4050, HIP_0,    HIP_0   }},
-  {"HIPSPARSE_SPSV_ALG_DEFAULT",                 {HIP_4050, HIP_0,    HIP_0   }},
-  {"HIPSPARSE_SPSM_ALG_DEFAULT",                 {HIP_4050, HIP_0,    HIP_0   }},
-  {"hipsparseSpSVAlg_t",                         {HIP_4050, HIP_0,    HIP_0   }},
-  {"hipsparseSpSMAlg_t",                         {HIP_4050, HIP_0,    HIP_0   }},
-  {"hipsparseSpMatAttribute_t",                  {HIP_4050, HIP_0,    HIP_0   }},
-  {"HIPSPARSE_SPMAT_FILL_MODE",                  {HIP_4050, HIP_0,    HIP_0   }},
-  {"HIPSPARSE_SPMAT_DIAG_TYPE",                  {HIP_4050, HIP_0,    HIP_0   }},
-  {"hipsparseCsr2CscAlg_t",                      {HIP_5040, HIP_0,    HIP_0   }},
-  {"HIPSPARSE_CSR2CSC_ALG1",                     {HIP_5040, HIP_0,    HIP_0   }},
-  {"HIPSPARSE_CSR2CSC_ALG2",                     {HIP_5040, HIP_0,    HIP_0   }},
-  {"HIPSPARSE_ORDER_COLUMN",                     {HIP_4020, HIP_5040, HIP_0   }},
-  {"hipsparseDenseToSparseAlg_t",                {HIP_4020, HIP_0,    HIP_0   }},
-  {"HIPSPARSE_DENSETOSPARSE_ALG_DEFAULT",        {HIP_4020, HIP_0,    HIP_0   }},
-  {"HIPSPARSE_CSR2CSC_ALG_DEFAULT",              {HIP_5060, HIP_0,    HIP_0   }},
-  {"HIPSPARSE_SPGEMM_CSR_ALG_DETERMINISTIC",     {HIP_5010, HIP_0,    HIP_0   }},
-  {"HIPSPARSE_SPGEMM_CSR_ALG_NONDETERMINISTIC",  {HIP_5010, HIP_0,    HIP_0   }},
-  {"HIPSPARSE_SPGEMM_ALG1",                      {HIP_5060, HIP_0,    HIP_0   }},
-  {"HIPSPARSE_SPGEMM_ALG2",                      {HIP_5060, HIP_0,    HIP_0   }},
-  {"HIPSPARSE_SPGEMM_ALG3",                      {HIP_5060, HIP_0,    HIP_0   }},
-  {"hipsparseConstSpVecDescr_t",                 {HIP_6000, HIP_0,    HIP_0   }},
-  {"hipsparseConstSpMatDescr_t",                 {HIP_6000, HIP_0,    HIP_0   }},
-  {"hipsparseConstDnVecDescr_t",                 {HIP_6000, HIP_0,    HIP_0   }},
-  {"hipsparseConstDnMatDescr_t",                 {HIP_6000, HIP_0,    HIP_0   }},
-  {"csric02Info_t",                              {HIP_3010, HIP_0,    HIP_0   }},
-  {"csric02Info",                                {HIP_3010, HIP_0,    HIP_0   }},
-  {"_rocsparse_handle",                          {HIP_1090, HIP_0,    HIP_0   }},
-  {"rocsparse_handle",                           {HIP_1090, HIP_0,    HIP_0   }},
-  {"_rocsparse_hyb_mat",                         {HIP_1090, HIP_0,    HIP_0   }},
-  {"rocsparse_hyb_mat",                          {HIP_1090, HIP_0,    HIP_0   }},
-  {"_rocsparse_mat_descr",                       {HIP_1090, HIP_0,    HIP_0   }},
-  {"rocsparse_mat_descr",                        {HIP_1090, HIP_0,    HIP_0   }},
-  {"_rocsparse_spvec_descr",                     {HIP_4010, HIP_0,    HIP_0   }},
-  {"rocsparse_spvec_descr",                      {HIP_4010, HIP_0,    HIP_0   }},
-  {"_rocsparse_spmat_descr",                     {HIP_4010, HIP_0,    HIP_0   }},
-  {"rocsparse_spmat_descr",                      {HIP_4010, HIP_0,    HIP_0   }},
-  {"_rocsparse_dnvec_descr",                     {HIP_4010, HIP_0,    HIP_0   }},
-  {"rocsparse_dnvec_descr",                      {HIP_4010, HIP_0,    HIP_0   }},
-  {"_rocsparse_dnmat_descr",                     {HIP_4010, HIP_0,    HIP_0   }},
-  {"rocsparse_dnmat_descr",                      {HIP_4010, HIP_0,    HIP_0   }},
-  {"_rocsparse_color_info",                      {HIP_4050, HIP_0,    HIP_0   }},
-  {"rocsparse_color_info",                       {HIP_4050, HIP_0,    HIP_0   }},
-  {"rocsparse_operation",                        {HIP_1090, HIP_0,    HIP_0   }},
-  {"rocsparse_operation_none",                   {HIP_1090, HIP_0,    HIP_0   }},
-  {"rocsparse_operation_transpose",              {HIP_1090, HIP_0,    HIP_0   }},
-  {"rocsparse_operation_conjugate_transpose",    {HIP_1090, HIP_0,    HIP_0   }},
-  {"rocsparse_index_base",                       {HIP_1090, HIP_0,    HIP_0   }},
-  {"rocsparse_index_base_zero",                  {HIP_1090, HIP_0,    HIP_0   }},
-  {"rocsparse_index_base_one",                   {HIP_1090, HIP_0,    HIP_0   }},
-  {"rocsparse_matrix_type",                      {HIP_1090, HIP_0,    HIP_0   }},
-  {"rocsparse_matrix_type_general",              {HIP_1090, HIP_0,    HIP_0   }},
-  {"rocsparse_matrix_type_symmetric",            {HIP_1090, HIP_0,    HIP_0   }},
-  {"rocsparse_matrix_type_hermitian",            {HIP_1090, HIP_0,    HIP_0   }},
-  {"rocsparse_matrix_type_triangular",           {HIP_1090, HIP_0,    HIP_0   }},
-  {"rocsparse_diag_type",                        {HIP_1090, HIP_0,    HIP_0   }},
-  {"rocsparse_diag_type_non_unit",               {HIP_1090, HIP_0,    HIP_0   }},
-  {"rocsparse_diag_type_unit",                   {HIP_1090, HIP_0,    HIP_0   }},
-  {"rocsparse_fill_mode",                        {HIP_1090, HIP_0,    HIP_0   }},
-  {"rocsparse_fill_mode_lower",                  {HIP_1090, HIP_0,    HIP_0   }},
-  {"rocsparse_fill_mode_upper",                  {HIP_1090, HIP_0,    HIP_0   }},
-  {"rocsparse_action",                           {HIP_1090, HIP_0,    HIP_0   }},
-  {"rocsparse_action_symbolic",                  {HIP_1090, HIP_0,    HIP_0   }},
-  {"rocsparse_action_numeric",                   {HIP_1090, HIP_0,    HIP_0   }},
-  {"rocsparse_direction",                        {HIP_3010, HIP_0,    HIP_0   }},
-  {"rocsparse_direction_row",                    {HIP_3010, HIP_0,    HIP_0   }},
-  {"rocsparse_direction_column",                 {HIP_3010, HIP_0,    HIP_0   }},
-  {"rocsparse_hyb_partition",                    {HIP_1090, HIP_0,    HIP_0   }},
-  {"rocsparse_hyb_partition_auto",               {HIP_1090, HIP_0,    HIP_0   }},
-  {"rocsparse_hyb_partition_user",               {HIP_1090, HIP_0,    HIP_0   }},
-  {"rocsparse_hyb_partition_max",                {HIP_1090, HIP_0,    HIP_0   }},
-  {"rocsparse_solve_policy",                     {HIP_1090, HIP_0,    HIP_0   }},
-  {"rocsparse_solve_policy_auto",                {HIP_1090, HIP_0,    HIP_0   }},
-  {"rocsparse_pointer_mode",                     {HIP_1090, HIP_0,    HIP_0   }},
-  {"rocsparse_pointer_mode_host",                {HIP_1090, HIP_0,    HIP_0   }},
-  {"rocsparse_pointer_mode_device",              {HIP_1090, HIP_0,    HIP_0   }},
-  {"rocsparse_status",                           {HIP_1090, HIP_0,    HIP_0   }},
-  {"rocsparse_status_success",                   {HIP_1090, HIP_0,    HIP_0   }},
-  {"rocsparse_status_not_initialized",           {HIP_4010, HIP_0,    HIP_0   }},
-  {"rocsparse_status_memory_error",              {HIP_1090, HIP_0,    HIP_0   }},
-  {"rocsparse_status_invalid_value",             {HIP_1090, HIP_0,    HIP_0   }},
-  {"rocsparse_status_arch_mismatch",             {HIP_1090, HIP_0,    HIP_0   }},
-  {"rocsparse_status_internal_error",            {HIP_1090, HIP_0,    HIP_0   }},
-  {"rocsparse_status_zero_pivot",                {HIP_1090, HIP_0,    HIP_0   }},
-  {"rocsparse_status_not_implemented",           {HIP_1090, HIP_0,    HIP_0   }},
-  {"rocsparse_indextype",                        {HIP_4010, HIP_0,    HIP_0   }},
-  {"rocsparse_indextype_u16",                    {HIP_4010, HIP_0,    HIP_0   }},
-  {"rocsparse_indextype_i32",                    {HIP_4010, HIP_0,    HIP_0   }},
-  {"rocsparse_indextype_i64",                    {HIP_4010, HIP_0,    HIP_0   }},
-  {"rocsparse_format",                           {HIP_4010, HIP_0,    HIP_0   }},
-  {"rocsparse_format_coo",                       {HIP_4010, HIP_0,    HIP_0   }},
-  {"rocsparse_format_coo_aos",                   {HIP_4010, HIP_0,    HIP_0   }},
-  {"rocsparse_format_csr",                       {HIP_4010, HIP_0,    HIP_0   }},
-  {"rocsparse_format_csc",                       {HIP_4010, HIP_0,    HIP_0   }},
-  {"rocsparse_format_ell",                       {HIP_4010, HIP_0,    HIP_0   }},
-  {"rocsparse_format_bell",                      {HIP_4050, HIP_0,    HIP_0   }},
-  {"rocsparse_format_bsr",                       {HIP_5030, HIP_0,    HIP_0   }},
-  {"rocsparse_order",                            {HIP_4010, HIP_0,    HIP_0   }},
-  {"rocsparse_order_row",                        {HIP_4010, HIP_0,    HIP_0   }},
-  {"rocsparse_order_column",                     {HIP_4010, HIP_0,    HIP_0   }},
-  {"rocsparse_spmat_attribute",                  {HIP_4050, HIP_0,    HIP_0   }},
-  {"rocsparse_spmat_fill_mode",                  {HIP_4050, HIP_0,    HIP_0   }},
-  {"rocsparse_spmat_diag_type",                  {HIP_4050, HIP_0,    HIP_0   }},
-  {"rocsparse_spmv_alg",                         {HIP_4010, HIP_0,    HIP_0   }},
-  {"rocsparse_spmv_alg_default",                 {HIP_4010, HIP_0,    HIP_0   }},
-  {"rocsparse_spmv_alg_coo",                     {HIP_4010, HIP_0,    HIP_0   }},
-  {"rocsparse_spmv_alg_coo_atomic",              {HIP_5030, HIP_0,    HIP_0   }},
-  {"rocsparse_spmv_alg_csr_adaptive",            {HIP_4010, HIP_0,    HIP_0   }},
-  {"rocsparse_spmv_alg_csr_stream",              {HIP_4010, HIP_0,    HIP_0   }},
-  {"rocsparse_spmv_alg_ell",                     {HIP_4010, HIP_0,    HIP_0   }},
-  {"rocsparse_spsv_alg",                         {HIP_4050, HIP_0,    HIP_0   }},
-  {"rocsparse_spsv_alg_default",                 {HIP_4050, HIP_0,    HIP_0   }},
-  {"rocsparse_spsm_alg",                         {HIP_4050, HIP_0,    HIP_0   }},
-  {"rocsparse_spsm_alg_default",                 {HIP_4050, HIP_0,    HIP_0   }},
-  {"rocsparse_spmm_alg",                         {HIP_4020, HIP_0,    HIP_0   }},
-  {"rocsparse_spmm_alg_default",                 {HIP_4020, HIP_0,    HIP_0   }},
-  {"rocsparse_spmm_alg_coo_segmented",           {HIP_4020, HIP_0,    HIP_0   }},
-  {"rocsparse_spmm_alg_coo_atomic",              {HIP_4020, HIP_0,    HIP_0   }},
-  {"rocsparse_spmm_alg_coo_segmented_atomic",    {HIP_4050, HIP_0,    HIP_0   }},
-  {"rocsparse_spmm_alg_csr",                     {HIP_4020, HIP_0,    HIP_0   }},
-  {"rocsparse_spmm_alg_csr_row_split",           {HIP_4050, HIP_0,    HIP_0   }},
-  {"rocsparse_spmm_alg_csr_merge",               {HIP_4050, HIP_0,    HIP_0   }},
-  {"rocsparse_spmm_alg_bell",                    {HIP_4050, HIP_0,    HIP_0   }},
-  {"rocsparse_sddmm_alg",                        {HIP_4030, HIP_0,    HIP_0   }},
-  {"rocsparse_sddmm_alg_default",                {HIP_4030, HIP_0,    HIP_0   }},
-  {"rocsparse_sparse_to_dense_alg",              {HIP_4010, HIP_0,    HIP_0   }},
-  {"rocsparse_sparse_to_dense_alg_default",      {HIP_4010, HIP_0,    HIP_0   }},
-  {"rocsparse_dense_to_sparse_alg",              {HIP_4010, HIP_0,    HIP_0   }},
-  {"rocsparse_dense_to_sparse_alg_default",      {HIP_4010, HIP_0,    HIP_0   }},
-  {"rocsparse_spgemm_alg",                       {HIP_4010, HIP_0,    HIP_0   }},
-  {"rocsparse_spgemm_alg_default",               {HIP_4010, HIP_0,    HIP_0   }},
-  {"_rocsparse_mat_info",                        {HIP_1090, HIP_0,    HIP_0   }},
-  {"rocsparse_mat_info",                         {HIP_1090, HIP_0,    HIP_0   }},
-  {"rocsparse_const_spvec_descr",                {HIP_6000, HIP_0,    HIP_0   }},
-  {"rocsparse_const_spmat_descr",                {HIP_6000, HIP_0,    HIP_0   }},
-  {"rocsparse_const_dnvec_descr",                {HIP_6000, HIP_0,    HIP_0   }},
-  {"rocsparse_const_dnmat_descr",                {HIP_6000, HIP_0,    HIP_0   }},
-};
+const std::map<llvm::StringRef, cudaAPIversions> CUDA_SPARSE_TYPE_NAME_VER_MAP = [] {
+  std::map<llvm::StringRef, cudaAPIversions> m;
+
+  m["cusparseHybMat"]                                                 = {CUDA_0,   CUDA_102, CUDA_110};
+  m["cusparseHybMat_t"]                                               = {CUDA_0,   CUDA_102, CUDA_110};
+  m["cusparseSolveAnalysisInfo"]                                      = {CUDA_0,   CUDA_102, CUDA_110};
+  m["cusparseSolveAnalysisInfo_t"]                                    = {CUDA_0,   CUDA_102, CUDA_110};
+  m["csrsm2Info"]                                                     = {CUDA_92,  CUDA_0,   CUDA_120};
+  m["csrsm2Info_t"]                                                   = {CUDA_92,  CUDA_0,   CUDA_120};
+  m["pruneInfo"]                                                      = {CUDA_90,  CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["pruneInfo_t"]                                                    = {CUDA_90,  CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseSpMatDescr"]                                             = {CUDA_101, CUDA_0,   CUDA_0  };
+  m["cusparseSpMatDescr_t"]                                           = {CUDA_101, CUDA_0,   CUDA_0  };
+  m["cusparseDnMatDescr"]                                             = {CUDA_101, CUDA_0,   CUDA_0  };
+  m["cusparseDnMatDescr_t"]                                           = {CUDA_101, CUDA_0,   CUDA_0  };
+  m["cusparseSpVecDescr"]                                             = {CUDA_102, CUDA_0,   CUDA_0  };
+  m["cusparseSpVecDescr_t"]                                           = {CUDA_102, CUDA_0,   CUDA_0  };
+  m["cusparseDnVecDescr"]                                             = {CUDA_102, CUDA_0,   CUDA_0  };
+  m["cusparseDnVecDescr_t"]                                           = {CUDA_102, CUDA_0,   CUDA_0  };
+  m["cusparseHybPartition_t"]                                         = {CUDA_0,   CUDA_102, CUDA_110};
+  m["CUSPARSE_HYB_PARTITION_AUTO"]                                    = {CUDA_0,   CUDA_102, CUDA_110};
+  m["CUSPARSE_HYB_PARTITION_USER"]                                    = {CUDA_0,   CUDA_102, CUDA_110};
+  m["CUSPARSE_HYB_PARTITION_MAX"]                                     = {CUDA_0,   CUDA_102, CUDA_110};
+  m["cusparseAlgMode_t"]                                              = {CUDA_80,  CUDA_0,   CUDA_120};
+  m["CUSPARSE_ALG0"]                                                  = {CUDA_80,  CUDA_0,   CUDA_110};
+  m["CUSPARSE_ALG1"]                                                  = {CUDA_80,  CUDA_0,   CUDA_110};
+  m["CUSPARSE_ALG_NAIVE"]                                             = {CUDA_92,  CUDA_0,   CUDA_110};
+  m["CUSPARSE_ALG_MERGE_PATH"]                                        = {CUDA_92,  CUDA_0,   CUDA_120};
+  m["CUSPARSE_STATUS_NOT_SUPPORTED"]                                  = {CUDA_102, CUDA_0,   CUDA_0  };
+  m["CUSPARSE_STATUS_INSUFFICIENT_RESOURCES"]                         = {CUDA_110, CUDA_0,   CUDA_0  };
+  m["cusparseCsr2CscAlg_t"]                                           = {CUDA_101, CUDA_0,   CUDA_0  };
+  m["CUSPARSE_CSR2CSC_ALG1"]                                          = {CUDA_101, CUDA_0,   CUDA_0  };
+  m["CUSPARSE_CSR2CSC_ALG2"]                                          = {CUDA_101, CUDA_0,   CUDA_120};
+  m["CUSPARSE_CSR2CSC_ALG_DEFAULT"]                                   = {CUDA_120, CUDA_0,   CUDA_0  };
+  m["cusparseFormat_t"]                                               = {CUDA_101, CUDA_0,   CUDA_0  };
+  m["CUSPARSE_FORMAT_CSR"]                                            = {CUDA_101, CUDA_0,   CUDA_0  };
+  m["CUSPARSE_FORMAT_CSC"]                                            = {CUDA_101, CUDA_0,   CUDA_0  };
+  m["CUSPARSE_FORMAT_COO"]                                            = {CUDA_101, CUDA_0,   CUDA_0  };
+  m["CUSPARSE_FORMAT_COO_AOS"]                                        = {CUDA_102, CUDA_0,   CUDA_120};
+  m["cusparseOrder_t"]                                                = {CUDA_101, CUDA_0,   CUDA_0  };
+  m["CUSPARSE_ORDER_COL"]                                             = {CUDA_101, CUDA_0,   CUDA_0  };
+  m["CUSPARSE_ORDER_ROW"]                                             = {CUDA_101, CUDA_0,   CUDA_0  };
+  m["cusparseSpMVAlg_t"]                                              = {CUDA_102, CUDA_0,   CUDA_0  };
+  m["CUSPARSE_MV_ALG_DEFAULT"]                                        = {CUDA_102, CUDA_113, CUDA_120};
+  m["CUSPARSE_SPMV_ALG_DEFAULT"]                                      = {CUDA_112, CUDA_0,   CUDA_0  };
+  m["CUSPARSE_COOMV_ALG"]                                             = {CUDA_102, CUDA_112, CUDA_120};
+  m["CUSPARSE_CSRMV_ALG1"]                                            = {CUDA_102, CUDA_112, CUDA_120};
+  m["CUSPARSE_CSRMV_ALG2"]                                            = {CUDA_102, CUDA_112, CUDA_120};
+  m["cusparseSpMMAlg_t"]                                              = {CUDA_101, CUDA_0,   CUDA_0  };
+  m["CUSPARSE_MM_ALG_DEFAULT"]                                        = {CUDA_102, CUDA_110, CUDA_120};
+  m["CUSPARSE_COOMM_ALG1"]                                            = {CUDA_101, CUDA_110, CUDA_120};
+  m["CUSPARSE_COOMM_ALG2"]                                            = {CUDA_101, CUDA_110, CUDA_120};
+  m["CUSPARSE_COOMM_ALG3"]                                            = {CUDA_101, CUDA_110, CUDA_120};
+  m["CUSPARSE_CSRMM_ALG1"]                                            = {CUDA_102, CUDA_110, CUDA_120};
+  m["CUSPARSE_SPMM_ALG_DEFAULT"]                                      = {CUDA_110, CUDA_0,   CUDA_0  };
+  m["CUSPARSE_SPMM_COO_ALG1"]                                         = {CUDA_110, CUDA_0,   CUDA_0  };
+  m["CUSPARSE_SPMM_COO_ALG2"]                                         = {CUDA_110, CUDA_0,   CUDA_0  };
+  m["CUSPARSE_SPMM_COO_ALG3"]                                         = {CUDA_110, CUDA_0,   CUDA_0  };
+  m["CUSPARSE_SPMM_COO_ALG4"]                                         = {CUDA_110, CUDA_0,   CUDA_0  };
+  m["CUSPARSE_SPMM_CSR_ALG1"]                                         = {CUDA_110, CUDA_0,   CUDA_0  };
+  m["CUSPARSE_SPMM_CSR_ALG2"]                                         = {CUDA_110, CUDA_0,   CUDA_0  };
+  m["CUSPARSE_SPMM_CSR_ALG3"]                                         = {CUDA_112, CUDA_0,   CUDA_0  };
+  m["CUSPARSE_SPMM_BLOCKED_ELL_ALG1"]                                 = {CUDA_112, CUDA_0,   CUDA_0  };
+  m["cusparseIndexType_t"]                                            = {CUDA_101, CUDA_0,   CUDA_0  };
+  m["CUSPARSE_INDEX_16U"]                                             = {CUDA_101, CUDA_0,   CUDA_0  };
+  m["CUSPARSE_INDEX_32I"]                                             = {CUDA_101, CUDA_0,   CUDA_0  };
+  m["CUSPARSE_INDEX_64I"]                                             = {CUDA_101, CUDA_0,   CUDA_0  }; // CUSPARSE_VERSION 10200
+  m["cusparseSpGEMMAlg_t"]                                            = {CUDA_110, CUDA_0,   CUDA_0  };
+  m["CUSPARSE_SPGEMM_DEFAULT"]                                        = {CUDA_110, CUDA_0,   CUDA_0  };
+  m["cusparseSpGEMMDescr"]                                            = {CUDA_110, CUDA_0,   CUDA_0  };
+  m["cusparseSpGEMMDescr_t"]                                          = {CUDA_110, CUDA_0,   CUDA_0  };
+  m["cusparseDenseToSparseAlg_t"]                                     = {CUDA_111, CUDA_0,   CUDA_0  };
+  m["CUSPARSE_DENSETOSPARSE_ALG_DEFAULT"]                             = {CUDA_111, CUDA_0,   CUDA_0  };
+  m["cusparseSparseToDenseAlg_t"]                                     = {CUDA_111, CUDA_0,   CUDA_0  };
+  m["CUSPARSE_SPARSETODENSE_ALG_DEFAULT"]                             = {CUDA_111, CUDA_0,   CUDA_0  };
+  m["CUSPARSE_SPMMA_PREPROCESS"]                                      = {CUDA_111, CUDA_0,   CUDA_112};
+  m["CUSPARSE_SPMMA_ALG1"]                                            = {CUDA_111, CUDA_0,   CUDA_112};
+  m["CUSPARSE_SPMMA_ALG2"]                                            = {CUDA_111, CUDA_0,   CUDA_112};
+  m["CUSPARSE_SPMMA_ALG3"]                                            = {CUDA_111, CUDA_0,   CUDA_112};
+  m["CUSPARSE_SPMMA_ALG4"]                                            = {CUDA_111, CUDA_0,   CUDA_112};
+  m["cusparseSpMatAttribute_t"]                                       = {CUDA_113, CUDA_0,   CUDA_0  };
+  m["CUSPARSE_SPMAT_FILL_MODE"]                                       = {CUDA_113, CUDA_0,   CUDA_0  };
+  m["CUSPARSE_SPMAT_DIAG_TYPE"]                                       = {CUDA_113, CUDA_0,   CUDA_0  };
+  m["CUSPARSE_SPMV_COO_ALG1"]                                         = {CUDA_112, CUDA_0,   CUDA_0  };
+  m["CUSPARSE_SPMV_COO_ALG2"]                                         = {CUDA_112, CUDA_0,   CUDA_0  };
+  m["CUSPARSE_SPMV_CSR_ALG1"]                                         = {CUDA_112, CUDA_0,   CUDA_0  };
+  m["CUSPARSE_SPMV_CSR_ALG2"]                                         = {CUDA_112, CUDA_0,   CUDA_0  };
+  m["cusparseSpSVAlg_t"]                                              = {CUDA_113, CUDA_0,   CUDA_0  };
+  m["CUSPARSE_SPSV_ALG_DEFAULT"]                                      = {CUDA_113, CUDA_0,   CUDA_0  };
+  m["cusparseSpSMAlg_t"]                                              = {CUDA_113, CUDA_0,   CUDA_0  };
+  m["CUSPARSE_SPSM_ALG_DEFAULT"]                                      = {CUDA_113, CUDA_0,   CUDA_0  };
+  m["cusparseSpSMDescr"]                                              = {CUDA_113, CUDA_0,   CUDA_0  };
+  m["cusparseSpSMDescr_t"]                                            = {CUDA_113, CUDA_0,   CUDA_0  };
+  m["CUSPARSE_SPGEMM_CSR_ALG_DETERMINITIC"]                           = {CUDA_113, CUDA_0,   CUDA_0  };
+  m["CUSPARSE_SPGEMM_CSR_ALG_NONDETERMINITIC"]                        = {CUDA_113, CUDA_0,   CUDA_0  };
+  m["cusparseSDDMMAlg_t"]                                             = {CUDA_112, CUDA_0,   CUDA_0  };
+  m["CUSPARSE_SDDMM_ALG_DEFAULT"]                                     = {CUDA_112, CUDA_0,   CUDA_0  };
+  m["CUSPARSE_FORMAT_BLOCKED_ELL"]                                    = {CUDA_112, CUDA_0,   CUDA_0  };
+  m["cusparseSpSVDescr"]                                              = {CUDA_113, CUDA_0,   CUDA_0  };
+  m["cusparseSpSVDescr_t"]                                            = {CUDA_113, CUDA_0,   CUDA_0  };
+  m["cusparseSideMode_t"]                                             = {CUDA_0,   CUDA_0,   CUDA_115};
+  m["CUSPARSE_SIDE_LEFT"]                                             = {CUDA_0,   CUDA_0,   CUDA_115};
+  m["CUSPARSE_SIDE_RIGHT"]                                            = {CUDA_0,   CUDA_0,   CUDA_115};
+  m["cusparseLoggerCallback_t"]                                       = {CUDA_115, CUDA_0,   CUDA_0  };
+  m["cusparseSpMMOpPlan"]                                             = {CUDA_115, CUDA_0,   CUDA_0  };
+  m["cusparseSpMMOpPlan_t"]                                           = {CUDA_115, CUDA_0,   CUDA_0  };
+  m["cusparseSpMMOpAlg_t"]                                            = {CUDA_115, CUDA_0,   CUDA_0  };
+  m["CUSPARSE_SPMM_OP_ALG_DEFAULT"]                                   = {CUDA_115, CUDA_0,   CUDA_0  };
+  m["csrsv2Info"]                                                     = {CUDA_0,   CUDA_0,   CUDA_120};
+  m["csrsv2Info_t"]                                                   = {CUDA_0,   CUDA_0,   CUDA_120};
+  m["csrgemm2Info"]                                                   = {CUDA_0,   CUDA_0,   CUDA_120};
+  m["csrgemm2Info_t"]                                                 = {CUDA_0,   CUDA_0,   CUDA_120};
+  m["cusparseConstSpVecDescr_t"]                                      = {CUDA_120, CUDA_0,   CUDA_0  };
+  m["cusparseConstDnVecDescr_t"]                                      = {CUDA_120, CUDA_0,   CUDA_0  };
+  m["cusparseConstSpMatDescr_t"]                                      = {CUDA_120, CUDA_0,   CUDA_0  };
+  m["cusparseConstDnMatDescr_t"]                                      = {CUDA_120, CUDA_0,   CUDA_0  };
+  m["CUSPARSE_SPGEMM_ALG1"]                                           = {CUDA_120, CUDA_0,   CUDA_0  };
+  m["CUSPARSE_SPGEMM_ALG2"]                                           = {CUDA_120, CUDA_0,   CUDA_0  };
+  m["CUSPARSE_SPGEMM_ALG3"]                                           = {CUDA_120, CUDA_0,   CUDA_0  };
+  m["CUSPARSE_FORMAT_BSR"]                                            = {CUDA_121, CUDA_0,   CUDA_0  }; // CUSPARSE_VERSION 12100
+  m["CUSPARSE_FORMAT_SLICED_ELLPACK"]                                 = {CUDA_121, CUDA_0,   CUDA_0  }; // CUSPARSE_VERSION 12100
+  m["CUSPARSE_SPMV_SELL_ALG1"]                                        = {CUDA_121, CUDA_0,   CUDA_0  }; // CUSPARSE_VERSION 12100
+  m["cusparseSpSVUpdate_t"]                                           = {CUDA_121, CUDA_0,   CUDA_0  }; // CUSPARSE_VERSION 12100
+  m["CUSPARSE_SPSV_UPDATE_GENERAL"]                                   = {CUDA_121, CUDA_0,   CUDA_0  }; // CUSPARSE_VERSION 12100
+  m["CUSPARSE_SPSV_UPDATE_DIAGONAL"]                                  = {CUDA_121, CUDA_0,   CUDA_0  }; // CUSPARSE_VERSION 12100
+  m["bsrsv2Info"]                                                     = {CUDA_0,   CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["bsrsv2Info_t"]                                                   = {CUDA_0,   CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["bsrsm2Info"]                                                     = {CUDA_0,   CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["bsrsm2Info_t"]                                                   = {CUDA_0,   CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["csric02Info"]                                                    = {CUDA_0,   CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["csric02Info_t"]                                                  = {CUDA_0,   CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["csrilu02Info"]                                                   = {CUDA_0,   CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["csrilu02Info_t"]                                                 = {CUDA_0,   CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["bsrilu02Info"]                                                   = {CUDA_0,   CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["bsrilu02Info_t"]                                                 = {CUDA_0,   CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["csru2csrInfo"]                                                   = {CUDA_0,   CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["csru2csrInfo_t"]                                                 = {CUDA_0,   CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseColorInfo"]                                              = {CUDA_0,   CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseColorInfo_t"]                                            = {CUDA_0,   CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseSolvePolicy_t"]                                          = {CUDA_0,   CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["CUSPARSE_SOLVE_POLICY_NO_LEVEL"]                                 = {CUDA_0,   CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["CUSPARSE_SOLVE_POLICY_USE_LEVEL"]                                = {CUDA_0,   CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseColorAlg_t"]                                             = {CUDA_80,  CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["CUSPARSE_COLOR_ALG0"]                                            = {CUDA_80,  CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["CUSPARSE_COLOR_ALG1"]                                            = {CUDA_80,  CUDA_122, CUDA_0  }; // CUSPARSE_VERSION 12120
+  m["cusparseSpSMUpdate_t"]                                           = {CUDA_124, CUDA_0,   CUDA_0  };
+  m["CUSPARSE_SPSM_UPDATE_GENERAL"]                                   = {CUDA_124, CUDA_0,   CUDA_0  };
+  m["CUSPARSE_SPSM_UPDATE_DIAGONAL"]                                  = {CUDA_124, CUDA_0,   CUDA_0  };
+  m["CUSPARSE_SPMM_BSR_ALG1"]                                         = {CUDA_125, CUDA_0,   CUDA_0  }; // CUSPARSE_VERSION 12501
+  m["CUSPARSE_SPMV_BSR_ALG1"]                                         = {CUDA_130, CUDA_0,   CUDA_0  }; // CUSPARSE_VERSION 12603 CUDA 13.0.1
+
+  return m;
+}();
+
+const std::map<llvm::StringRef, hipAPIversions> HIP_SPARSE_TYPE_NAME_VER_MAP = [] {
+  std::map<llvm::StringRef, hipAPIversions> m;
+
+  m["hipsparseHandle_t"]                                              = {HIP_1092, HIP_0,    HIP_0   };
+  m["hipsparseHybMat_t"]                                              = {HIP_1092, HIP_0,    HIP_0   };
+  m["hipsparseMatDescr_t"]                                            = {HIP_1092, HIP_0,    HIP_0   };
+  m["csrsv2Info_t"]                                                   = {HIP_1092, HIP_0,    HIP_0   };
+  m["csrsm2Info_t"]                                                   = {HIP_3010, HIP_0,    HIP_0   };
+  m["bsrsv2Info"]                                                     = {HIP_3060, HIP_0,    HIP_0   };
+  m["bsrsv2Info_t"]                                                   = {HIP_3060, HIP_0,    HIP_0   };
+  m["bsric02Info"]                                                    = {HIP_3080, HIP_0,    HIP_0   };
+  m["bsric02Info_t"]                                                  = {HIP_3080, HIP_0,    HIP_0   };
+  m["csrilu02Info"]                                                   = {HIP_1092, HIP_0,    HIP_0   };
+  m["csrilu02Info_t"]                                                 = {HIP_1092, HIP_0,    HIP_0   };
+  m["bsrilu02Info"]                                                   = {HIP_3090, HIP_0,    HIP_0   };
+  m["bsrilu02Info_t"]                                                 = {HIP_3090, HIP_0,    HIP_0   };
+  m["csrgemm2Info"]                                                   = {HIP_2080, HIP_0,    HIP_0   };
+  m["csrgemm2Info_t"]                                                 = {HIP_2080, HIP_0,    HIP_0   };
+  m["pruneInfo"]                                                      = {HIP_3090, HIP_0,    HIP_0   };
+  m["pruneInfo_t"]                                                    = {HIP_3090, HIP_0,    HIP_0   };
+  m["hipsparseAction_t"]                                              = {HIP_1092, HIP_0,    HIP_0   };
+  m["HIPSPARSE_ACTION_SYMBOLIC"]                                      = {HIP_1092, HIP_0,    HIP_0   };
+  m["HIPSPARSE_ACTION_NUMERIC"]                                       = {HIP_1092, HIP_0,    HIP_0   };
+  m["hipsparseDirection_t"]                                           = {HIP_3020, HIP_0,    HIP_0   };
+  m["HIPSPARSE_DIRECTION_ROW"]                                        = {HIP_3020, HIP_0,    HIP_0   };
+  m["HIPSPARSE_DIRECTION_COLUMN"]                                     = {HIP_3020, HIP_0,    HIP_0   };
+  m["hipsparseHybPartition_t"]                                        = {HIP_1092, HIP_0,    HIP_0   };
+  m["HIPSPARSE_HYB_PARTITION_AUTO"]                                   = {HIP_1092, HIP_0,    HIP_0   };
+  m["HIPSPARSE_HYB_PARTITION_USER"]                                   = {HIP_1092, HIP_0,    HIP_0   };
+  m["HIPSPARSE_HYB_PARTITION_MAX"]                                    = {HIP_1092, HIP_0,    HIP_0   };
+  m["hipsparseDiagType_t"]                                            = {HIP_1092, HIP_0,    HIP_0   };
+  m["HIPSPARSE_DIAG_TYPE_NON_UNIT"]                                   = {HIP_1092, HIP_0,    HIP_0   };
+  m["HIPSPARSE_DIAG_TYPE_UNIT"]                                       = {HIP_1092, HIP_0,    HIP_0   };
+  m["hipsparseFillMode_t"]                                            = {HIP_1092, HIP_0,    HIP_0   };
+  m["HIPSPARSE_FILL_MODE_LOWER"]                                      = {HIP_1092, HIP_0,    HIP_0   };
+  m["HIPSPARSE_FILL_MODE_UPPER"]                                      = {HIP_1092, HIP_0,    HIP_0   };
+  m["hipsparseIndexBase_t"]                                           = {HIP_1092, HIP_0,    HIP_0   };
+  m["HIPSPARSE_INDEX_BASE_ZERO"]                                      = {HIP_1092, HIP_0,    HIP_0   };
+  m["HIPSPARSE_INDEX_BASE_ONE"]                                       = {HIP_1092, HIP_0,    HIP_0   };
+  m["hipsparseMatrixType_t"]                                          = {HIP_1092, HIP_0,    HIP_0   };
+  m["HIPSPARSE_MATRIX_TYPE_GENERAL"]                                  = {HIP_1092, HIP_0,    HIP_0   };
+  m["HIPSPARSE_MATRIX_TYPE_SYMMETRIC"]                                = {HIP_1092, HIP_0,    HIP_0   };
+  m["HIPSPARSE_MATRIX_TYPE_HERMITIAN"]                                = {HIP_1092, HIP_0,    HIP_0   };
+  m["HIPSPARSE_MATRIX_TYPE_TRIANGULAR"]                               = {HIP_1092, HIP_0,    HIP_0   };
+  m["hipsparseOperation_t"]                                           = {HIP_1092, HIP_0,    HIP_0   };
+  m["HIPSPARSE_OPERATION_NON_TRANSPOSE"]                              = {HIP_1092, HIP_0,    HIP_0   };
+  m["HIPSPARSE_OPERATION_TRANSPOSE"]                                  = {HIP_1092, HIP_0,    HIP_0   };
+  m["HIPSPARSE_OPERATION_CONJUGATE_TRANSPOSE"]                        = {HIP_1092, HIP_0,    HIP_0   };
+  m["hipsparsePointerMode_t"]                                         = {HIP_1092, HIP_0,    HIP_0   };
+  m["HIPSPARSE_POINTER_MODE_HOST"]                                    = {HIP_1092, HIP_0,    HIP_0   };
+  m["HIPSPARSE_POINTER_MODE_DEVICE"]                                  = {HIP_1092, HIP_0,    HIP_0   };
+  m["hipsparseSolvePolicy_t"]                                         = {HIP_1092, HIP_0,    HIP_0   };
+  m["HIPSPARSE_SOLVE_POLICY_NO_LEVEL"]                                = {HIP_1092, HIP_0,    HIP_0   };
+  m["HIPSPARSE_SOLVE_POLICY_USE_LEVEL"]                               = {HIP_1092, HIP_0,    HIP_0   };
+  m["hipsparseStatus_t"]                                              = {HIP_1092, HIP_0,    HIP_0   };
+  m["HIPSPARSE_STATUS_SUCCESS"]                                       = {HIP_1092, HIP_0,    HIP_0   };
+  m["HIPSPARSE_STATUS_NOT_INITIALIZED"]                               = {HIP_1092, HIP_0,    HIP_0   };
+  m["HIPSPARSE_STATUS_ALLOC_FAILED"]                                  = {HIP_1092, HIP_0,    HIP_0   };
+  m["HIPSPARSE_STATUS_INVALID_VALUE"]                                 = {HIP_1092, HIP_0,    HIP_0   };
+  m["HIPSPARSE_STATUS_ARCH_MISMATCH"]                                 = {HIP_1092, HIP_0,    HIP_0   };
+  m["HIPSPARSE_STATUS_MAPPING_ERROR"]                                 = {HIP_1092, HIP_0,    HIP_0   };
+  m["HIPSPARSE_STATUS_EXECUTION_FAILED"]                              = {HIP_1092, HIP_0,    HIP_0   };
+  m["HIPSPARSE_STATUS_INTERNAL_ERROR"]                                = {HIP_1092, HIP_0,    HIP_0   };
+  m["HIPSPARSE_STATUS_MATRIX_TYPE_NOT_SUPPORTED"]                     = {HIP_1092, HIP_0,    HIP_0   };
+  m["HIPSPARSE_STATUS_ZERO_PIVOT"]                                    = {HIP_1092, HIP_0,    HIP_0   };
+  m["hipsparseSpMatDescr_t"]                                          = {HIP_4010, HIP_0,    HIP_0   };
+  m["hipsparseSpVecDescr_t"]                                          = {HIP_4010, HIP_0,    HIP_0   };
+  m["hipsparseDnVecDescr_t"]                                          = {HIP_4010, HIP_0,    HIP_0   };
+  m["hipsparseSpGEMMDescr"]                                           = {HIP_4010, HIP_0,    HIP_0   };
+  m["hipsparseSpGEMMDescr_t"]                                         = {HIP_4010, HIP_0,    HIP_0   };
+  m["HIPSPARSE_STATUS_NOT_SUPPORTED"]                                 = {HIP_4010, HIP_0,    HIP_0   };
+  m["HIPSPARSE_STATUS_INSUFFICIENT_RESOURCES"]                        = {HIP_4010, HIP_0,    HIP_0   };
+  m["hipsparseFormat_t"]                                              = {HIP_4010, HIP_0,    HIP_0   };
+  m["HIPSPARSE_FORMAT_CSR"]                                           = {HIP_4010, HIP_0,    HIP_0   };
+  m["HIPSPARSE_FORMAT_CSC"]                                           = {HIP_4010, HIP_0,    HIP_0   };
+  m["HIPSPARSE_FORMAT_COO"]                                           = {HIP_4010, HIP_0,    HIP_0   };
+  m["HIPSPARSE_FORMAT_COO_AOS"]                                       = {HIP_4010, HIP_0,    HIP_0   };
+  m["hipsparseSpMVAlg_t"]                                             = {HIP_4010, HIP_0,    HIP_0   };
+  m["HIPSPARSE_MV_ALG_DEFAULT"]                                       = {HIP_4010, HIP_0,    HIP_0   };
+  m["HIPSPARSE_COOMV_ALG"]                                            = {HIP_4010, HIP_0,    HIP_0   };
+  m["HIPSPARSE_CSRMV_ALG1"]                                           = {HIP_4010, HIP_0,    HIP_0   };
+  m["HIPSPARSE_CSRMV_ALG2"]                                           = {HIP_4010, HIP_0,    HIP_0   };
+  m["hipsparseIndexType_t"]                                           = {HIP_4010, HIP_0,    HIP_0   };
+  m["HIPSPARSE_INDEX_16U"]                                            = {HIP_4010, HIP_0,    HIP_0   };
+  m["HIPSPARSE_INDEX_32I"]                                            = {HIP_4010, HIP_0,    HIP_0   };
+  m["HIPSPARSE_INDEX_64I"]                                            = {HIP_4010, HIP_0,    HIP_0   };
+  m["hipsparseSpGEMMAlg_t"]                                           = {HIP_4010, HIP_0,    HIP_0   };
+  m["HIPSPARSE_SPGEMM_DEFAULT"]                                       = {HIP_4010, HIP_0,    HIP_0   };
+  m["csru2csrInfo"]                                                   = {HIP_4020, HIP_0,    HIP_0   };
+  m["csru2csrInfo_t"]                                                 = {HIP_4020, HIP_0,    HIP_0   };
+  m["hipsparseDnMatDescr_t"]                                          = {HIP_4020, HIP_0,    HIP_0   };
+  m["hipsparseOrder_t"]                                               = {HIP_4020, HIP_0,    HIP_0   };
+  m["HIPSPARSE_ORDER_COL"]                                            = {HIP_5040, HIP_0,    HIP_0   };
+  m["HIPSPARSE_ORDER_ROW"]                                            = {HIP_4020, HIP_0,    HIP_0   };
+  m["hipsparseSpMMAlg_t"]                                             = {HIP_4020, HIP_0,    HIP_0   };
+  m["HIPSPARSE_MM_ALG_DEFAULT"]                                       = {HIP_4020, HIP_0,    HIP_0   };
+  m["HIPSPARSE_SPMM_ALG_DEFAULT"]                                     = {HIP_4020, HIP_0,    HIP_0   };
+  m["HIPSPARSE_COOMM_ALG1"]                                           = {HIP_4020, HIP_0,    HIP_0   };
+  m["HIPSPARSE_SPMM_COO_ALG1"]                                        = {HIP_4020, HIP_0,    HIP_0   };
+  m["HIPSPARSE_COOMM_ALG2"]                                           = {HIP_4020, HIP_0,    HIP_0   };
+  m["HIPSPARSE_SPMM_COO_ALG2"]                                        = {HIP_4020, HIP_0,    HIP_0   };
+  m["HIPSPARSE_COOMM_ALG3"]                                           = {HIP_4020, HIP_0,    HIP_0   };
+  m["HIPSPARSE_SPMM_COO_ALG3"]                                        = {HIP_4020, HIP_0,    HIP_0   };
+  m["HIPSPARSE_CSRMM_ALG1"]                                           = {HIP_4020, HIP_0,    HIP_0   };
+  m["HIPSPARSE_SPMM_CSR_ALG1"]                                        = {HIP_4020, HIP_0,    HIP_0   };
+  m["HIPSPARSE_SPMM_COO_ALG4"]                                        = {HIP_4020, HIP_0,    HIP_0   };
+  m["HIPSPARSE_SPMM_CSR_ALG2"]                                        = {HIP_4020, HIP_0,    HIP_0   };
+  m["hipsparseSparseToDenseAlg_t"]                                    = {HIP_4020, HIP_0,    HIP_0   };
+  m["HIPSPARSE_SPARSETODENSE_ALG_DEFAULT"]                            = {HIP_4020, HIP_0,    HIP_0   };
+  m["hipsparseSDDMMAlg_t"]                                            = {HIP_4030, HIP_0,    HIP_0   };
+  m["HIPSPARSE_SDDMM_ALG_DEFAULT"]                                    = {HIP_4030, HIP_0,    HIP_0   };
+  m["hipsparseColorInfo_t"]                                           = {HIP_4050, HIP_0,    HIP_0   };
+  m["bsrsm2Info_t"]                                                   = {HIP_4050, HIP_0,    HIP_0   };
+  m["bsrsm2Info"]                                                     = {HIP_4050, HIP_0,    HIP_0   };
+  m["hipsparseSpSVDescr"]                                             = {HIP_4050, HIP_0,    HIP_0   };
+  m["hipsparseSpSVDescr_t"]                                           = {HIP_4050, HIP_0,    HIP_0   };
+  m["hipsparseSpSMDescr"]                                             = {HIP_4050, HIP_0,    HIP_0   };
+  m["hipsparseSpSMDescr_t"]                                           = {HIP_4050, HIP_0,    HIP_0   };
+  m["HIPSPARSE_FORMAT_BLOCKED_ELL"]                                   = {HIP_4050, HIP_0,    HIP_0   };
+  m["HIPSPARSE_SPMV_ALG_DEFAULT"]                                     = {HIP_4050, HIP_0,    HIP_0   };
+  m["HIPSPARSE_SPMV_COO_ALG1"]                                        = {HIP_4050, HIP_0,    HIP_0   };
+  m["HIPSPARSE_SPMV_COO_ALG2"]                                        = {HIP_4050, HIP_0,    HIP_0   };
+  m["HIPSPARSE_SPMV_CSR_ALG1"]                                        = {HIP_4050, HIP_0,    HIP_0   };
+  m["HIPSPARSE_SPMV_CSR_ALG2"]                                        = {HIP_4050, HIP_0,    HIP_0   };
+  m["HIPSPARSE_SPMM_BLOCKED_ELL_ALG1"]                                = {HIP_4050, HIP_0,    HIP_0   };
+  m["HIPSPARSE_SPMM_CSR_ALG3"]                                        = {HIP_4050, HIP_0,    HIP_0   };
+  m["HIPSPARSE_SPSV_ALG_DEFAULT"]                                     = {HIP_4050, HIP_0,    HIP_0   };
+  m["HIPSPARSE_SPSM_ALG_DEFAULT"]                                     = {HIP_4050, HIP_0,    HIP_0   };
+  m["hipsparseSpSVAlg_t"]                                             = {HIP_4050, HIP_0,    HIP_0   };
+  m["hipsparseSpSMAlg_t"]                                             = {HIP_4050, HIP_0,    HIP_0   };
+  m["hipsparseSpMatAttribute_t"]                                      = {HIP_4050, HIP_0,    HIP_0   };
+  m["HIPSPARSE_SPMAT_FILL_MODE"]                                      = {HIP_4050, HIP_0,    HIP_0   };
+  m["HIPSPARSE_SPMAT_DIAG_TYPE"]                                      = {HIP_4050, HIP_0,    HIP_0   };
+  m["hipsparseCsr2CscAlg_t"]                                          = {HIP_5040, HIP_0,    HIP_0   };
+  m["HIPSPARSE_CSR2CSC_ALG1"]                                         = {HIP_5040, HIP_0,    HIP_0   };
+  m["HIPSPARSE_CSR2CSC_ALG2"]                                         = {HIP_5040, HIP_0,    HIP_0   };
+  m["HIPSPARSE_ORDER_COLUMN"]                                         = {HIP_4020, HIP_5040, HIP_0   };
+  m["hipsparseDenseToSparseAlg_t"]                                    = {HIP_4020, HIP_0,    HIP_0   };
+  m["HIPSPARSE_DENSETOSPARSE_ALG_DEFAULT"]                            = {HIP_4020, HIP_0,    HIP_0   };
+  m["HIPSPARSE_CSR2CSC_ALG_DEFAULT"]                                  = {HIP_5060, HIP_0,    HIP_0   };
+  m["HIPSPARSE_SPGEMM_CSR_ALG_DETERMINISTIC"]                         = {HIP_5010, HIP_0,    HIP_0   };
+  m["HIPSPARSE_SPGEMM_CSR_ALG_NONDETERMINISTIC"]                      = {HIP_5010, HIP_0,    HIP_0   };
+  m["HIPSPARSE_SPGEMM_ALG1"]                                          = {HIP_5060, HIP_0,    HIP_0   };
+  m["HIPSPARSE_SPGEMM_ALG2"]                                          = {HIP_5060, HIP_0,    HIP_0   };
+  m["HIPSPARSE_SPGEMM_ALG3"]                                          = {HIP_5060, HIP_0,    HIP_0   };
+  m["hipsparseConstSpVecDescr_t"]                                     = {HIP_6000, HIP_0,    HIP_0   };
+  m["hipsparseConstSpMatDescr_t"]                                     = {HIP_6000, HIP_0,    HIP_0   };
+  m["hipsparseConstDnVecDescr_t"]                                     = {HIP_6000, HIP_0,    HIP_0   };
+  m["hipsparseConstDnMatDescr_t"]                                     = {HIP_6000, HIP_0,    HIP_0   };
+  m["csric02Info_t"]                                                  = {HIP_3010, HIP_0,    HIP_0   };
+  m["csric02Info"]                                                    = {HIP_3010, HIP_0,    HIP_0   };
+
+  m["_rocsparse_handle"]                                              = {HIP_1090, HIP_0,    HIP_0   };
+  m["rocsparse_handle"]                                               = {HIP_1090, HIP_0,    HIP_0   };
+  m["_rocsparse_hyb_mat"]                                             = {HIP_1090, HIP_0,    HIP_0   };
+  m["rocsparse_hyb_mat"]                                              = {HIP_1090, HIP_0,    HIP_0   };
+  m["_rocsparse_mat_descr"]                                           = {HIP_1090, HIP_0,    HIP_0   };
+  m["rocsparse_mat_descr"]                                            = {HIP_1090, HIP_0,    HIP_0   };
+  m["_rocsparse_spvec_descr"]                                         = {HIP_4010, HIP_0,    HIP_0   };
+  m["rocsparse_spvec_descr"]                                          = {HIP_4010, HIP_0,    HIP_0   };
+  m["_rocsparse_spmat_descr"]                                         = {HIP_4010, HIP_0,    HIP_0   };
+  m["rocsparse_spmat_descr"]                                          = {HIP_4010, HIP_0,    HIP_0   };
+  m["_rocsparse_dnvec_descr"]                                         = {HIP_4010, HIP_0,    HIP_0   };
+  m["rocsparse_dnvec_descr"]                                          = {HIP_4010, HIP_0,    HIP_0   };
+  m["_rocsparse_dnmat_descr"]                                         = {HIP_4010, HIP_0,    HIP_0   };
+  m["rocsparse_dnmat_descr"]                                          = {HIP_4010, HIP_0,    HIP_0   };
+  m["_rocsparse_color_info"]                                          = {HIP_4050, HIP_0,    HIP_0   };
+  m["rocsparse_color_info"]                                           = {HIP_4050, HIP_0,    HIP_0   };
+  m["rocsparse_operation"]                                            = {HIP_1090, HIP_0,    HIP_0   };
+  m["rocsparse_operation_none"]                                       = {HIP_1090, HIP_0,    HIP_0   };
+  m["rocsparse_operation_transpose"]                                  = {HIP_1090, HIP_0,    HIP_0   };
+  m["rocsparse_operation_conjugate_transpose"]                        = {HIP_1090, HIP_0,    HIP_0   };
+  m["rocsparse_index_base"]                                           = {HIP_1090, HIP_0,    HIP_0   };
+  m["rocsparse_index_base_zero"]                                      = {HIP_1090, HIP_0,    HIP_0   };
+  m["rocsparse_index_base_one"]                                       = {HIP_1090, HIP_0,    HIP_0   };
+  m["rocsparse_matrix_type"]                                          = {HIP_1090, HIP_0,    HIP_0   };
+  m["rocsparse_matrix_type_general"]                                  = {HIP_1090, HIP_0,    HIP_0   };
+  m["rocsparse_matrix_type_symmetric"]                                = {HIP_1090, HIP_0,    HIP_0   };
+  m["rocsparse_matrix_type_hermitian"]                                = {HIP_1090, HIP_0,    HIP_0   };
+  m["rocsparse_matrix_type_triangular"]                               = {HIP_1090, HIP_0,    HIP_0   };
+  m["rocsparse_diag_type"]                                            = {HIP_1090, HIP_0,    HIP_0   };
+  m["rocsparse_diag_type_non_unit"]                                   = {HIP_1090, HIP_0,    HIP_0   };
+  m["rocsparse_diag_type_unit"]                                       = {HIP_1090, HIP_0,    HIP_0   };
+  m["rocsparse_fill_mode"]                                            = {HIP_1090, HIP_0,    HIP_0   };
+  m["rocsparse_fill_mode_lower"]                                      = {HIP_1090, HIP_0,    HIP_0   };
+  m["rocsparse_fill_mode_upper"]                                      = {HIP_1090, HIP_0,    HIP_0   };
+  m["rocsparse_action"]                                               = {HIP_1090, HIP_0,    HIP_0   };
+  m["rocsparse_action_symbolic"]                                      = {HIP_1090, HIP_0,    HIP_0   };
+  m["rocsparse_action_numeric"]                                       = {HIP_1090, HIP_0,    HIP_0   };
+  m["rocsparse_direction"]                                            = {HIP_3010, HIP_0,    HIP_0   };
+  m["rocsparse_direction_row"]                                        = {HIP_3010, HIP_0,    HIP_0   };
+  m["rocsparse_direction_column"]                                     = {HIP_3010, HIP_0,    HIP_0   };
+  m["rocsparse_hyb_partition"]                                        = {HIP_1090, HIP_0,    HIP_0   };
+  m["rocsparse_hyb_partition_auto"]                                   = {HIP_1090, HIP_0,    HIP_0   };
+  m["rocsparse_hyb_partition_user"]                                   = {HIP_1090, HIP_0,    HIP_0   };
+  m["rocsparse_hyb_partition_max"]                                    = {HIP_1090, HIP_0,    HIP_0   };
+  m["rocsparse_solve_policy"]                                         = {HIP_1090, HIP_0,    HIP_0   };
+  m["rocsparse_solve_policy_auto"]                                    = {HIP_1090, HIP_0,    HIP_0   };
+  m["rocsparse_pointer_mode"]                                         = {HIP_1090, HIP_0,    HIP_0   };
+  m["rocsparse_pointer_mode_host"]                                    = {HIP_1090, HIP_0,    HIP_0   };
+  m["rocsparse_pointer_mode_device"]                                  = {HIP_1090, HIP_0,    HIP_0   };
+  m["rocsparse_status"]                                               = {HIP_1090, HIP_0,    HIP_0   };
+  m["rocsparse_status_success"]                                       = {HIP_1090, HIP_0,    HIP_0   };
+  m["rocsparse_status_not_initialized"]                               = {HIP_4010, HIP_0,    HIP_0   };
+  m["rocsparse_status_memory_error"]                                  = {HIP_1090, HIP_0,    HIP_0   };
+  m["rocsparse_status_invalid_value"]                                 = {HIP_1090, HIP_0,    HIP_0   };
+  m["rocsparse_status_arch_mismatch"]                                 = {HIP_1090, HIP_0,    HIP_0   };
+  m["rocsparse_status_internal_error"]                                = {HIP_1090, HIP_0,    HIP_0   };
+  m["rocsparse_status_zero_pivot"]                                    = {HIP_1090, HIP_0,    HIP_0   };
+  m["rocsparse_status_not_implemented"]                               = {HIP_1090, HIP_0,    HIP_0   };
+  m["rocsparse_indextype"]                                            = {HIP_4010, HIP_0,    HIP_0   };
+  m["rocsparse_indextype_u16"]                                        = {HIP_4010, HIP_0,    HIP_0   };
+  m["rocsparse_indextype_i32"]                                        = {HIP_4010, HIP_0,    HIP_0   };
+  m["rocsparse_indextype_i64"]                                        = {HIP_4010, HIP_0,    HIP_0   };
+  m["rocsparse_format"]                                               = {HIP_4010, HIP_0,    HIP_0   };
+  m["rocsparse_format_coo"]                                           = {HIP_4010, HIP_0,    HIP_0   };
+  m["rocsparse_format_coo_aos"]                                       = {HIP_4010, HIP_0,    HIP_0   };
+  m["rocsparse_format_csr"]                                           = {HIP_4010, HIP_0,    HIP_0   };
+  m["rocsparse_format_csc"]                                           = {HIP_4010, HIP_0,    HIP_0   };
+  m["rocsparse_format_ell"]                                           = {HIP_4010, HIP_0,    HIP_0   };
+  m["rocsparse_format_bell"]                                          = {HIP_4050, HIP_0,    HIP_0   };
+  m["rocsparse_format_bsr"]                                           = {HIP_5030, HIP_0,    HIP_0   };
+  m["rocsparse_order"]                                                = {HIP_4010, HIP_0,    HIP_0   };
+  m["rocsparse_order_row"]                                            = {HIP_4010, HIP_0,    HIP_0   };
+  m["rocsparse_order_column"]                                         = {HIP_4010, HIP_0,    HIP_0   };
+  m["rocsparse_spmat_attribute"]                                      = {HIP_4050, HIP_0,    HIP_0   };
+  m["rocsparse_spmat_fill_mode"]                                      = {HIP_4050, HIP_0,    HIP_0   };
+  m["rocsparse_spmat_diag_type"]                                      = {HIP_4050, HIP_0,    HIP_0   };
+  m["rocsparse_spmv_alg"]                                             = {HIP_4010, HIP_0,    HIP_0   };
+  m["rocsparse_spmv_alg_default"]                                     = {HIP_4010, HIP_0,    HIP_0   };
+  m["rocsparse_spmv_alg_coo"]                                         = {HIP_4010, HIP_0,    HIP_0   };
+  m["rocsparse_spmv_alg_coo_atomic"]                                  = {HIP_5030, HIP_0,    HIP_0   };
+  m["rocsparse_spmv_alg_csr_adaptive"]                                = {HIP_4010, HIP_0,    HIP_0   };
+  m["rocsparse_spmv_alg_csr_stream"]                                  = {HIP_4010, HIP_0,    HIP_0   };
+  m["rocsparse_spmv_alg_ell"]                                         = {HIP_4010, HIP_0,    HIP_0   };
+  m["rocsparse_spsv_alg"]                                             = {HIP_4050, HIP_0,    HIP_0   };
+  m["rocsparse_spsv_alg_default"]                                     = {HIP_4050, HIP_0,    HIP_0   };
+  m["rocsparse_spsm_alg"]                                             = {HIP_4050, HIP_0,    HIP_0   };
+  m["rocsparse_spsm_alg_default"]                                     = {HIP_4050, HIP_0,    HIP_0   };
+  m["rocsparse_spmm_alg"]                                             = {HIP_4020, HIP_0,    HIP_0   };
+  m["rocsparse_spmm_alg_default"]                                     = {HIP_4020, HIP_0,    HIP_0   };
+  m["rocsparse_spmm_alg_coo_segmented"]                               = {HIP_4020, HIP_0,    HIP_0   };
+  m["rocsparse_spmm_alg_coo_atomic"]                                  = {HIP_4020, HIP_0,    HIP_0   };
+  m["rocsparse_spmm_alg_coo_segmented_atomic"]                        = {HIP_4050, HIP_0,    HIP_0   };
+  m["rocsparse_spmm_alg_csr"]                                         = {HIP_4020, HIP_0,    HIP_0   };
+  m["rocsparse_spmm_alg_csr_row_split"]                               = {HIP_4050, HIP_0,    HIP_0   };
+  m["rocsparse_spmm_alg_csr_merge"]                                   = {HIP_4050, HIP_0,    HIP_0   };
+  m["rocsparse_spmm_alg_bell"]                                        = {HIP_4050, HIP_0,    HIP_0   };
+  m["rocsparse_sddmm_alg"]                                            = {HIP_4030, HIP_0,    HIP_0   };
+  m["rocsparse_sddmm_alg_default"]                                    = {HIP_4030, HIP_0,    HIP_0   };
+  m["rocsparse_sparse_to_dense_alg"]                                  = {HIP_4010, HIP_0,    HIP_0   };
+  m["rocsparse_sparse_to_dense_alg_default"]                          = {HIP_4010, HIP_0,    HIP_0   };
+  m["rocsparse_dense_to_sparse_alg"]                                  = {HIP_4010, HIP_0,    HIP_0   };
+  m["rocsparse_dense_to_sparse_alg_default"]                          = {HIP_4010, HIP_0,    HIP_0   };
+  m["rocsparse_spgemm_alg"]                                           = {HIP_4010, HIP_0,    HIP_0   };
+  m["rocsparse_spgemm_alg_default"]                                   = {HIP_4010, HIP_0,    HIP_0   };
+  m["_rocsparse_mat_info"]                                            = {HIP_1090, HIP_0,    HIP_0   };
+  m["rocsparse_mat_info"]                                             = {HIP_1090, HIP_0,    HIP_0   };
+  m["rocsparse_const_spvec_descr"]                                    = {HIP_6000, HIP_0,    HIP_0   };
+  m["rocsparse_const_spmat_descr"]                                    = {HIP_6000, HIP_0,    HIP_0   };
+  m["rocsparse_const_dnvec_descr"]                                    = {HIP_6000, HIP_0,    HIP_0   };
+  m["rocsparse_const_dnmat_descr"]                                    = {HIP_6000, HIP_0,    HIP_0   };
+
+  return m;
+}();


### PR DESCRIPTION
**[Synopsis]**
+ Transformation maps reside in Stack and occupy up to `64kB` each of stack memory now
+ That leads to multiple compiler warnings about possible Stack Overflow

**[Solution]**
+ Move maps' initialization logic into a lambda. This prevents the compiler from creating a massive temporary array on the stack, which was the root cause of the "excessive stack usage" warning.
