### PR TITLE
[HIPIFY][fix] `LLVM upstream preparations` - Part 1 - Header files usage revision

### DIFF
--- a/src/CUDA2HIP.h
+++ b/src/CUDA2HIP.h
@@ -22,9 +22,6 @@ THE SOFTWARE.
 
 #pragma once
 
-#include "llvm/ADT/StringRef.h"
-#include <set>
-#include <map>
 #include "Statistics.h"
 
 const std::string sHIP_version = Statistics::getHipVersion(HIP_LATEST);

--- a/src/CUDA2HIP_Doc.cpp
+++ b/src/CUDA2HIP_Doc.cpp
@@ -22,11 +22,8 @@ THE SOFTWARE.
 
 #include <sstream>
 #include <vector>
-#include <map>
 #include "CUDA2HIP.h"
-#include "CUDA2HIP_Scripting.h"
 #include "ArgParse.h"
-#include "StringUtils.h"
 #include "LLVMCompat.h"
 
 namespace doc {

--- a/src/CUDA2HIP_Perl.cpp
+++ b/src/CUDA2HIP_Perl.cpp
@@ -22,15 +22,11 @@ THE SOFTWARE.
 
 #include <sstream>
 #include <regex>
-#include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/SmallString.h"
-#include "llvm/Support/Path.h"
 #include "CUDA2HIP.h"
 #include "CUDA2HIP_Scripting.h"
 #include "ArgParse.h"
-#include "StringUtils.h"
 #include "LLVMCompat.h"
-#include "Statistics.h"
 
 namespace perl {
 

--- a/src/CUDA2HIP_Python.cpp
+++ b/src/CUDA2HIP_Python.cpp
@@ -20,16 +20,11 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-#include <sstream>
-#include "llvm/ADT/StringRef.h"
+#include <fstream>
 #include "llvm/ADT/SmallString.h"
-#include "llvm/Support/Path.h"
 #include "CUDA2HIP.h"
-#include "CUDA2HIP_Scripting.h"
 #include "ArgParse.h"
-#include "StringUtils.h"
 #include "LLVMCompat.h"
-#include "Statistics.h"
 
 using namespace llvm;
 

--- a/src/HipifyAction.cpp
+++ b/src/HipifyAction.cpp
@@ -21,7 +21,6 @@ THE SOFTWARE.
 */
 
 #include <algorithm>
-#include <set>
 #include <string>
 #include "HipifyAction.h"
 #include "CUDA2HIP_Scripting.h"
@@ -29,13 +28,11 @@ THE SOFTWARE.
 #include "clang/Frontend/CompilerInstance.h"
 #include "clang/ASTMatchers/ASTMatchFinder.h"
 #include "clang/ASTMatchers/ASTMatchers.h"
-#include "clang/Lex/HeaderSearch.h"
 #if LLVM_VERSION_MAJOR < 17
 #include "clang/Basic/TargetInfo.h"
 #endif
 #include "LLVMCompat.h"
 #include "CUDA2HIP.h"
-#include "StringUtils.h"
 #include "ArgParse.h"
 
 using namespace hipify;

--- a/src/LLVMCompat.cpp
+++ b/src/LLVMCompat.cpp
@@ -22,7 +22,6 @@ THE SOFTWARE.
 
 #include "ArgParse.h"
 #include "LLVMCompat.h"
-#include "llvm/Support/Path.h"
 #if LLVM_VERSION_MAJOR < 13
 #include "clang/Lex/HeaderSearch.h"
 #endif

--- a/src/LocalHeader.cpp
+++ b/src/LocalHeader.cpp
@@ -11,12 +11,7 @@
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/raw_ostream.h"
 
-#include "clang/Tooling/Refactoring.h"
-#include "clang/Tooling/Tooling.h"
-
-#include "CUDA2HIP.h"       
-#include "LLVMCompat.h"     
-#include "HipifyAction.h"   
+#include "LLVMCompat.h"
 
 using namespace clang;
 using namespace clang::tooling;

--- a/src/Statistics.cpp
+++ b/src/Statistics.cpp
@@ -24,7 +24,6 @@ THE SOFTWARE.
 #include <assert.h>
 #include <sstream>
 #include <iomanip>
-#include <cmath>
 
 #if defined(__has_include) && __has_include(<optional>)
 #include <optional>

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -20,19 +20,12 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-#include <cstdio>
 #include <fstream>
-#include <set>
-#include <cmath>
-#include <chrono>
-#include <iomanip>
-#include <sstream>
 #include "CUDA2HIP.h"
 #include "CUDA2HIP_Scripting.h"
 #include "LLVMCompat.h"
 #include "HipifyAction.h"
 #include "ArgParse.h"
-#include "StringUtils.h"
 #include "llvm/Support/Debug.h"
 #include "clang/Basic/Diagnostic.h"
 #include "clang/Basic/DiagnosticIDs.h"


### PR DESCRIPTION
+ Removed excessive includes
+ Substituted includes with more concrete header files
