### PR TITLE
[HIPIFY][ROCM-1367][fix] Use host target in Init() to avoid CUDA 12.x ptxas/nvlink errors

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -37,6 +37,11 @@ THE SOFTWARE.
 #endif
 #include "clang/Driver/Tool.h"
 #include "clang/Frontend/TextDiagnosticPrinter.h"
+#if LLVM_VERSION_MAJOR >= 16
+#include "llvm/TargetParser/Host.h"
+#else
+#include "llvm/Support/Host.h"
+#endif
 
 #include "LocalHeader.h"
 
@@ -99,7 +104,7 @@ void Init(int argc, const char **argv, std::vector<std::string> &files) {
   clang::TextDiagnosticPrinter diagClient(llvm::errs(), &*diagOpts);
   clang::DiagnosticsEngine Diagnostics(IntrusiveRefCntPtr<clang::DiagnosticIDs>(new clang::DiagnosticIDs()), &*diagOpts, &diagClient, false);
 #endif
-  std::unique_ptr<clang::driver::Driver> driver(new clang::driver::Driver("", "nvptx64-nvidia-cuda", Diagnostics));
+  std::unique_ptr<clang::driver::Driver> driver(new clang::driver::Driver("", llvm::sys::getDefaultTargetTriple(), Diagnostics));
   std::vector<const char*> Args(argv, argv + argc);
   cleanupHipifyOptions(Args);
   std::unique_ptr<clang::driver::Compilation> C(driver->BuildCompilation(Args));


### PR DESCRIPTION
## Problem Statement
When running `hipify-clang` with CUDA 12.x, users encounter the following errors:
```
error: must pass in an explicit nvptx64 gpu architecture to 'ptxas'
error: must pass in an explicit nvptx64 gpu architecture to 'nvlink'
```
## Root Cause
The Init() function creates a Clang Driver for CUDA version detection and file sorting. Using nvptx64-nvidia-cuda target unnecessarily invokes ptxas/nvlink which require explicit --cuda-gpu-arch in CUDA 12.x. Since this compilation is only for detection/sorting (not actual device compilation), use the host target instead. 

## Solution
Change the Driver target from `nvptx64-nvidia-cuda` to the host target (`llvm::sys::getDefaultTargetTriple()`).