### PR TITLE
[HIPIFY][fix] `Stack Overflow` possible Issues - Part 7 - `RTC`

### DIFF
--- a/src/CUDA2HIP_RTC_API_functions.cpp
+++ b/src/CUDA2HIP_RTC_API_functions.cpp
@@ -23,82 +23,106 @@ THE SOFTWARE.
 #include "CUDA2HIP.h"
 
 // Maps the names of CUDA RTC API functions to the corresponding HIP functions
-const std::map<llvm::StringRef, hipCounter> CUDA_RTC_FUNCTION_MAP {
-  {"nvrtcGetErrorString",                         {"hiprtcGetErrorString",                         "", CONV_LIB_FUNC, API_RTC, 2}},
-  {"nvrtcVersion",                                {"hiprtcVersion",                                "", CONV_LIB_FUNC, API_RTC, 2}},
-  {"nvrtcGetNumSupportedArchs",                   {"hiprtcGetNumSupportedArchs",                   "", CONV_LIB_FUNC, API_RTC, 2, UNSUPPORTED}},
-  {"nvrtcGetSupportedArchs",                      {"hiprtcGetSupportedArchs",                      "", CONV_LIB_FUNC, API_RTC, 2, UNSUPPORTED}},
-  {"nvrtcCreateProgram",                          {"hiprtcCreateProgram",                          "", CONV_LIB_FUNC, API_RTC, 2}},
-  {"nvrtcDestroyProgram",                         {"hiprtcDestroyProgram",                         "", CONV_LIB_FUNC, API_RTC, 2}},
-  {"nvrtcCompileProgram",                         {"hiprtcCompileProgram",                         "", CONV_LIB_FUNC, API_RTC, 2}},
-  {"nvrtcGetPTXSize",                             {"hiprtcGetCodeSize",                            "", CONV_LIB_FUNC, API_RTC, 2}},
-  {"nvrtcGetPTX",                                 {"hiprtcGetCode",                                "", CONV_LIB_FUNC, API_RTC, 2}},
-  {"nvrtcGetCUBINSize",                           {"hiprtcGetBitcodeSize",                         "", CONV_LIB_FUNC, API_RTC, 2}},
-  {"nvrtcGetCUBIN",                               {"hiprtcGetBitcode",                             "", CONV_LIB_FUNC, API_RTC, 2}},
-  {"nvrtcGetNVVMSize",                            {"hiprtcGetNVVMSize",                            "", CONV_LIB_FUNC, API_RTC, 2, CUDA_DEPRECATED | CUDA_REMOVED | UNSUPPORTED}},
-  {"nvrtcGetNVVM",                                {"hiprtcGetNVVM",                                "", CONV_LIB_FUNC, API_RTC, 2, CUDA_DEPRECATED | CUDA_REMOVED | UNSUPPORTED}},
-  {"nvrtcGetProgramLogSize",                      {"hiprtcGetProgramLogSize",                      "", CONV_LIB_FUNC, API_RTC, 2}},
-  {"nvrtcGetProgramLog",                          {"hiprtcGetProgramLog",                          "", CONV_LIB_FUNC, API_RTC, 2}},
-  {"nvrtcAddNameExpression",                      {"hiprtcAddNameExpression",                      "", CONV_LIB_FUNC, API_RTC, 2}},
-  {"nvrtcGetLoweredName",                         {"hiprtcGetLoweredName",                         "", CONV_LIB_FUNC, API_RTC, 2}},
-  {"nvrtcGetLTOIRSize",                           {"hiprtcGetLTOIRSize",                           "", CONV_LIB_FUNC, API_RTC, 2, UNSUPPORTED}},
-  {"nvrtcGetLTOIR",                               {"hiprtcGetLTOIR",                               "", CONV_LIB_FUNC, API_RTC, 2, UNSUPPORTED}},
-  {"nvrtcGetOptiXIRSize",                         {"hiprtcGetOptiXIRSize",                         "", CONV_LIB_FUNC, API_RTC, 2, UNSUPPORTED}},
-  {"nvrtcGetOptiXIR",                             {"hiprtcGetOptiXIR",                             "", CONV_LIB_FUNC, API_RTC, 2, UNSUPPORTED}},
-  {"nvrtcGetPCHHeapSize",                         {"hiprtcGetPCHHeapSize",                         "", CONV_LIB_FUNC, API_RTC, 2, UNSUPPORTED}},
-  {"nvrtcSetPCHHeapSize",                         {"hiprtcSetPCHHeapSize",                         "", CONV_LIB_FUNC, API_RTC, 2, UNSUPPORTED}},
-  {"nvrtcGetPCHCreateStatus",                     {"hiprtcGetPCHCreateStatus",                     "", CONV_LIB_FUNC, API_RTC, 2, UNSUPPORTED}},
-  {"nvrtcGetPCHHeapSizeRequired",                 {"hiprtcGetPCHHeapSizeRequired",                 "", CONV_LIB_FUNC, API_RTC, 2, UNSUPPORTED}},
-  {"nvrtcSetFlowCallback",                        {"hiprtcSetFlowCallback",                        "", CONV_LIB_FUNC, API_RTC, 2, UNSUPPORTED}},
-};
+const std::map<llvm::StringRef, hipCounter> CUDA_RTC_FUNCTION_MAP = []() {
+  std::map<llvm::StringRef, hipCounter> m;
 
-const std::map<llvm::StringRef, cudaAPIversions> CUDA_RTC_FUNCTION_VER_MAP {
-  {"nvrtcGetNumSupportedArchs",                   {CUDA_112, CUDA_0,   CUDA_0  }},
-  {"nvrtcGetSupportedArchs",                      {CUDA_112, CUDA_0,   CUDA_0  }},
-  {"nvrtcGetCUBINSize",                           {CUDA_111, CUDA_0,   CUDA_0  }},
-  {"nvrtcGetCUBIN",                               {CUDA_111, CUDA_0,   CUDA_0  }},
-  {"nvrtcGetNVVMSize",                            {CUDA_114, CUDA_120, CUDA_130}},
-  {"nvrtcGetNVVM",                                {CUDA_114, CUDA_120, CUDA_130}},
-  {"nvrtcAddNameExpression",                      {CUDA_80,  CUDA_0,   CUDA_0  }},
-  {"nvrtcGetLoweredName",                         {CUDA_80,  CUDA_0,   CUDA_0  }},
-  {"nvrtcGetLTOIRSize",                           {CUDA_120, CUDA_0,   CUDA_0  }},
-  {"nvrtcGetLTOIR",                               {CUDA_120, CUDA_0,   CUDA_0  }},
-  {"nvrtcGetOptiXIRSize",                         {CUDA_120, CUDA_0,   CUDA_0  }},
-  {"nvrtcGetOptiXIR",                             {CUDA_120, CUDA_0,   CUDA_0  }},
-  {"nvrtcGetPCHHeapSize",                         {CUDA_128, CUDA_0,   CUDA_0  }},
-  {"nvrtcSetPCHHeapSize",                         {CUDA_128, CUDA_0,   CUDA_0  }},
-  {"nvrtcGetPCHCreateStatus",                     {CUDA_128, CUDA_0,   CUDA_0  }},
-  {"nvrtcGetPCHHeapSizeRequired",                 {CUDA_128, CUDA_0,   CUDA_0  }},
-  {"nvrtcSetFlowCallback",                        {CUDA_128, CUDA_0,   CUDA_0  }},
-};
+  m["nvrtcGetErrorString"]                        = {"hiprtcGetErrorString",                         "", CONV_LIB_FUNC, API_RTC, 2};
+  m["nvrtcVersion"]                               = {"hiprtcVersion",                                "", CONV_LIB_FUNC, API_RTC, 2};
+  m["nvrtcGetNumSupportedArchs"]                  = {"hiprtcGetNumSupportedArchs",                   "", CONV_LIB_FUNC, API_RTC, 2, UNSUPPORTED};
+  m["nvrtcGetSupportedArchs"]                     = {"hiprtcGetSupportedArchs",                      "", CONV_LIB_FUNC, API_RTC, 2, UNSUPPORTED};
+  m["nvrtcCreateProgram"]                         = {"hiprtcCreateProgram",                          "", CONV_LIB_FUNC, API_RTC, 2};
+  m["nvrtcDestroyProgram"]                        = {"hiprtcDestroyProgram",                         "", CONV_LIB_FUNC, API_RTC, 2};
+  m["nvrtcCompileProgram"]                        = {"hiprtcCompileProgram",                         "", CONV_LIB_FUNC, API_RTC, 2};
+  m["nvrtcGetPTXSize"]                            = {"hiprtcGetCodeSize",                            "", CONV_LIB_FUNC, API_RTC, 2};
+  m["nvrtcGetPTX"]                                = {"hiprtcGetCode",                                "", CONV_LIB_FUNC, API_RTC, 2};
+  m["nvrtcGetCUBINSize"]                          = {"hiprtcGetBitcodeSize",                         "", CONV_LIB_FUNC, API_RTC, 2};
+  m["nvrtcGetCUBIN"]                              = {"hiprtcGetBitcode",                             "", CONV_LIB_FUNC, API_RTC, 2};
+  m["nvrtcGetNVVMSize"]                           = {"hiprtcGetNVVMSize",                            "", CONV_LIB_FUNC, API_RTC, 2, CUDA_DEPRECATED | CUDA_REMOVED | UNSUPPORTED};
+  m["nvrtcGetNVVM"]                               = {"hiprtcGetNVVM",                                "", CONV_LIB_FUNC, API_RTC, 2, CUDA_DEPRECATED | CUDA_REMOVED | UNSUPPORTED};
+  m["nvrtcGetProgramLogSize"]                     = {"hiprtcGetProgramLogSize",                      "", CONV_LIB_FUNC, API_RTC, 2};
+  m["nvrtcGetProgramLog"]                         = {"hiprtcGetProgramLog",                          "", CONV_LIB_FUNC, API_RTC, 2};
+  m["nvrtcAddNameExpression"]                     = {"hiprtcAddNameExpression",                      "", CONV_LIB_FUNC, API_RTC, 2};
+  m["nvrtcGetLoweredName"]                        = {"hiprtcGetLoweredName",                         "", CONV_LIB_FUNC, API_RTC, 2};
+  m["nvrtcGetLTOIRSize"]                          = {"hiprtcGetLTOIRSize",                           "", CONV_LIB_FUNC, API_RTC, 2, UNSUPPORTED};
+  m["nvrtcGetLTOIR"]                              = {"hiprtcGetLTOIR",                               "", CONV_LIB_FUNC, API_RTC, 2, UNSUPPORTED};
+  m["nvrtcGetOptiXIRSize"]                        = {"hiprtcGetOptiXIRSize",                         "", CONV_LIB_FUNC, API_RTC, 2, UNSUPPORTED};
+  m["nvrtcGetOptiXIR"]                            = {"hiprtcGetOptiXIR",                             "", CONV_LIB_FUNC, API_RTC, 2, UNSUPPORTED};
+  m["nvrtcGetPCHHeapSize"]                        = {"hiprtcGetPCHHeapSize",                         "", CONV_LIB_FUNC, API_RTC, 2, UNSUPPORTED};
+  m["nvrtcSetPCHHeapSize"]                        = {"hiprtcSetPCHHeapSize",                         "", CONV_LIB_FUNC, API_RTC, 2, UNSUPPORTED};
+  m["nvrtcGetPCHCreateStatus"]                    = {"hiprtcGetPCHCreateStatus",                     "", CONV_LIB_FUNC, API_RTC, 2, UNSUPPORTED};
+  m["nvrtcGetPCHHeapSizeRequired"]                = {"hiprtcGetPCHHeapSizeRequired",                 "", CONV_LIB_FUNC, API_RTC, 2, UNSUPPORTED};
+  m["nvrtcSetFlowCallback"]                       = {"hiprtcSetFlowCallback",                        "", CONV_LIB_FUNC, API_RTC, 2, UNSUPPORTED};
 
-const std::map<llvm::StringRef, hipAPIversions> HIP_RTC_FUNCTION_VER_MAP {
-  {"hiprtcGetErrorString",                        {HIP_2060, HIP_0,    HIP_0   }},
-  {"hiprtcVersion",                               {HIP_2060, HIP_0,    HIP_0   }},
-  {"hiprtcCreateProgram",                         {HIP_2060, HIP_0,    HIP_0   }},
-  {"hiprtcDestroyProgram",                        {HIP_2060, HIP_0,    HIP_0   }},
-  {"hiprtcCompileProgram",                        {HIP_2060, HIP_0,    HIP_0   }},
-  {"hiprtcGetCodeSize",                           {HIP_2060, HIP_0,    HIP_0   }},
-  {"hiprtcGetCode",                               {HIP_2060, HIP_0,    HIP_0   }},
-  {"hiprtcGetProgramLogSize",                     {HIP_2060, HIP_0,    HIP_0   }},
-  {"hiprtcGetProgramLog",                         {HIP_2060, HIP_0,    HIP_0   }},
-  {"hiprtcAddNameExpression",                     {HIP_2060, HIP_0,    HIP_0   }},
-  {"hiprtcGetLoweredName",                        {HIP_2060, HIP_0,    HIP_0   }},
-  {"hiprtcGetBitcode",                            {HIP_5030, HIP_0,    HIP_0   }},
-  {"hiprtcGetBitcodeSize",                        {HIP_5030, HIP_0,    HIP_0   }},
-};
+  return m;
+}();
 
-const std::map<llvm::StringRef, cudaAPIChangedVersions> CUDA_RTC_FUNCTION_CHANGED_VER_MAP {
-  {"nvrtcCreateProgram",                          {CUDA_80}},
-  {"nvrtcCompileProgram",                         {CUDA_80}},
-};
+const std::map<llvm::StringRef, cudaAPIversions> CUDA_RTC_FUNCTION_VER_MAP = []() {
+  std::map<llvm::StringRef, cudaAPIversions> m;
 
-const std::map<llvm::StringRef, hipAPIChangedVersions> HIP_RTC_FUNCTION_CHANGED_VER_MAP {
-  {"hiprtcCreateProgram",                         {HIP_7000}},
-  {"hiprtcCompileProgram",                        {HIP_7000}},
-};
+  m["nvrtcGetNumSupportedArchs"]                  = {CUDA_112, CUDA_0,   CUDA_0  };
+  m["nvrtcGetSupportedArchs"]                     = {CUDA_112, CUDA_0,   CUDA_0  };
+  m["nvrtcGetCUBINSize"]                          = {CUDA_111, CUDA_0,   CUDA_0  };
+  m["nvrtcGetCUBIN"]                              = {CUDA_111, CUDA_0,   CUDA_0  };
+  m["nvrtcGetNVVMSize"]                           = {CUDA_114, CUDA_120, CUDA_130};
+  m["nvrtcGetNVVM"]                               = {CUDA_114, CUDA_120, CUDA_130};
+  m["nvrtcAddNameExpression"]                     = {CUDA_80,  CUDA_0,   CUDA_0  };
+  m["nvrtcGetLoweredName"]                        = {CUDA_80,  CUDA_0,   CUDA_0  };
+  m["nvrtcGetLTOIRSize"]                          = {CUDA_120, CUDA_0,   CUDA_0  };
+  m["nvrtcGetLTOIR"]                              = {CUDA_120, CUDA_0,   CUDA_0  };
+  m["nvrtcGetOptiXIRSize"]                        = {CUDA_120, CUDA_0,   CUDA_0  };
+  m["nvrtcGetOptiXIR"]                            = {CUDA_120, CUDA_0,   CUDA_0  };
+  m["nvrtcGetPCHHeapSize"]                        = {CUDA_128, CUDA_0,   CUDA_0  };
+  m["nvrtcSetPCHHeapSize"]                        = {CUDA_128, CUDA_0,   CUDA_0  };
+  m["nvrtcGetPCHCreateStatus"]                    = {CUDA_128, CUDA_0,   CUDA_0  };
+  m["nvrtcGetPCHHeapSizeRequired"]                = {CUDA_128, CUDA_0,   CUDA_0  };
+  m["nvrtcSetFlowCallback"]                       = {CUDA_128, CUDA_0,   CUDA_0  };
 
-const std::map<unsigned int, llvm::StringRef> CUDA_RTC_API_SECTION_MAP {
-  {1, "RTC Data types"},
-  {2, "RTC API functions"},
-};
+  return m;
+}();
+
+const std::map<llvm::StringRef, hipAPIversions> HIP_RTC_FUNCTION_VER_MAP = []() {
+  std::map<llvm::StringRef, hipAPIversions> m;
+
+  m["hiprtcGetErrorString"]                       = {HIP_2060, HIP_0,    HIP_0   };
+  m["hiprtcVersion"]                              = {HIP_2060, HIP_0,    HIP_0   };
+  m["hiprtcCreateProgram"]                        = {HIP_2060, HIP_0,    HIP_0   };
+  m["hiprtcDestroyProgram"]                       = {HIP_2060, HIP_0,    HIP_0   };
+  m["hiprtcCompileProgram"]                       = {HIP_2060, HIP_0,    HIP_0   };
+  m["hiprtcGetCodeSize"]                          = {HIP_2060, HIP_0,    HIP_0   };
+  m["hiprtcGetCode"]                              = {HIP_2060, HIP_0,    HIP_0   };
+  m["hiprtcGetProgramLogSize"]                    = {HIP_2060, HIP_0,    HIP_0   };
+  m["hiprtcGetProgramLog"]                        = {HIP_2060, HIP_0,    HIP_0   };
+  m["hiprtcAddNameExpression"]                    = {HIP_2060, HIP_0,    HIP_0   };
+  m["hiprtcGetLoweredName"]                       = {HIP_2060, HIP_0,    HIP_0   };
+  m["hiprtcGetBitcode"]                           = {HIP_5030, HIP_0,    HIP_0   };
+  m["hiprtcGetBitcodeSize"]                       = {HIP_5030, HIP_0,    HIP_0   };
+
+  return m;
+}();
+
+const std::map<llvm::StringRef, cudaAPIChangedVersions> CUDA_RTC_FUNCTION_CHANGED_VER_MAP = []() {
+  std::map<llvm::StringRef, cudaAPIChangedVersions> m;
+
+  m["nvrtcCreateProgram"]                         = {CUDA_80};
+  m["nvrtcCompileProgram"]                        = {CUDA_80};
+
+  return m;
+}();
+
+const std::map<llvm::StringRef, hipAPIChangedVersions> HIP_RTC_FUNCTION_CHANGED_VER_MAP = []() {
+  std::map<llvm::StringRef, hipAPIChangedVersions> m;
+
+  m["hiprtcCreateProgram"]                        = {HIP_7000};
+  m["hiprtcCompileProgram"]                       = {HIP_7000};
+
+  return m;
+}();
+
+const std::map<unsigned int, llvm::StringRef> CUDA_RTC_API_SECTION_MAP = []() {
+  std::map<unsigned int, llvm::StringRef> m;
+
+  m[1]                                            = "RTC Data types";
+  m[2]                                            = "RTC API functions";
+
+  return m;
+}();

--- a/src/CUDA2HIP_RTC_API_types.cpp
+++ b/src/CUDA2HIP_RTC_API_types.cpp
@@ -23,58 +23,70 @@ THE SOFTWARE.
 #include "CUDA2HIP.h"
 
 // Maps the names of CUDA RTC API types to the corresponding HIP types
-const std::map<llvm::StringRef, hipCounter> CUDA_RTC_TYPE_NAME_MAP {
-  {"nvrtcResult",                                                {"hiprtcResult",                                        "", CONV_TYPE, API_RTC, 1}},
-  {"NVRTC_SUCCESS",                                              {"HIPRTC_SUCCESS",                                      "", CONV_NUMERIC_LITERAL, API_RTC, 1}}, // 0
-  {"NVRTC_ERROR_OUT_OF_MEMORY",                                  {"HIPRTC_ERROR_OUT_OF_MEMORY",                          "", CONV_NUMERIC_LITERAL, API_RTC, 1}}, // 1
-  {"NVRTC_ERROR_PROGRAM_CREATION_FAILURE",                       {"HIPRTC_ERROR_PROGRAM_CREATION_FAILURE",               "", CONV_NUMERIC_LITERAL, API_RTC, 1}}, // 2
-  {"NVRTC_ERROR_INVALID_INPUT",                                  {"HIPRTC_ERROR_INVALID_INPUT",                          "", CONV_NUMERIC_LITERAL, API_RTC, 1}}, // 3
-  {"NVRTC_ERROR_INVALID_PROGRAM",                                {"HIPRTC_ERROR_INVALID_PROGRAM",                        "", CONV_NUMERIC_LITERAL, API_RTC, 1}}, // 4
-  {"NVRTC_ERROR_INVALID_OPTION",                                 {"HIPRTC_ERROR_INVALID_OPTION",                         "", CONV_NUMERIC_LITERAL, API_RTC, 1}}, // 5
-  {"NVRTC_ERROR_COMPILATION",                                    {"HIPRTC_ERROR_COMPILATION",                            "", CONV_NUMERIC_LITERAL, API_RTC, 1}}, // 6
-  {"NVRTC_ERROR_BUILTIN_OPERATION_FAILURE",                      {"HIPRTC_ERROR_BUILTIN_OPERATION_FAILURE",              "", CONV_NUMERIC_LITERAL, API_RTC, 1}}, // 7
-  {"NVRTC_ERROR_NO_NAME_EXPRESSIONS_AFTER_COMPILATION",          {"HIPRTC_ERROR_NO_NAME_EXPRESSIONS_AFTER_COMPILATION",  "", CONV_NUMERIC_LITERAL, API_RTC, 1}}, // 8
-  {"NVRTC_ERROR_NO_LOWERED_NAMES_BEFORE_COMPILATION",            {"HIPRTC_ERROR_NO_LOWERED_NAMES_BEFORE_COMPILATION",    "", CONV_NUMERIC_LITERAL, API_RTC, 1}}, // 9
-  {"NVRTC_ERROR_NAME_EXPRESSION_NOT_VALID",                      {"HIPRTC_ERROR_NAME_EXPRESSION_NOT_VALID",              "", CONV_NUMERIC_LITERAL, API_RTC, 1}}, // 10
-  {"NVRTC_ERROR_INTERNAL_ERROR",                                 {"HIPRTC_ERROR_INTERNAL_ERROR",                         "", CONV_NUMERIC_LITERAL, API_RTC, 1}}, // 11
-  {"NVRTC_ERROR_TIME_FILE_WRITE_FAILED",                         {"HIPRTC_ERROR_TIME_FILE_WRITE_FAILED",                 "", CONV_NUMERIC_LITERAL, API_RTC, 1, UNSUPPORTED}}, // 12
-  {"NVRTC_ERROR_NO_PCH_CREATE_ATTEMPTED",                        {"HIPRTC_ERROR_NO_PCH_CREATE_ATTEMPTED",                "", CONV_NUMERIC_LITERAL, API_RTC, 1, UNSUPPORTED}}, // 13
-  {"NVRTC_ERROR_PCH_CREATE_HEAP_EXHAUSTED",                      {"HIPRTC_ERROR_PCH_CREATE_HEAP_EXHAUSTED",              "", CONV_NUMERIC_LITERAL, API_RTC, 1, UNSUPPORTED}}, // 14
-  {"NVRTC_ERROR_PCH_CREATE",                                     {"HIPRTC_ERROR_PCH_CREATE",                             "", CONV_NUMERIC_LITERAL, API_RTC, 1, UNSUPPORTED}}, // 15
-  {"NVRTC_ERROR_CANCELLED",                                      {"HIPRTC_ERROR_CANCELLED",                              "", CONV_NUMERIC_LITERAL, API_RTC, 1, UNSUPPORTED}}, // 16
-  {"NVRTC_ERROR_TIME_TRACE_FILE_WRITE_FAILED",                   {"HIPRTC_ERROR_TIME_TRACE_FILE_WRITE_FAILED",           "", CONV_NUMERIC_LITERAL, API_RTC, 1, UNSUPPORTED}}, // 17
+const std::map<llvm::StringRef, hipCounter> CUDA_RTC_TYPE_NAME_MAP = []() {
+  std::map<llvm::StringRef, hipCounter> m;
 
-  {"nvrtcProgram",                                               {"hiprtcProgram",                                       "", CONV_TYPE, API_RTC, 1}},
-  {"_nvrtcProgram",                                              {"_hiprtcProgram",                                      "", CONV_TYPE, API_RTC, 1}},
-};
+  m["nvrtcResult"]                                               = {"hiprtcResult",                                        "", CONV_TYPE, API_RTC, 1};
+  m["NVRTC_SUCCESS"]                                             = {"HIPRTC_SUCCESS",                                      "", CONV_NUMERIC_LITERAL, API_RTC, 1}; // 0
+  m["NVRTC_ERROR_OUT_OF_MEMORY"]                                 = {"HIPRTC_ERROR_OUT_OF_MEMORY",                          "", CONV_NUMERIC_LITERAL, API_RTC, 1}; // 1
+  m["NVRTC_ERROR_PROGRAM_CREATION_FAILURE"]                      = {"HIPRTC_ERROR_PROGRAM_CREATION_FAILURE",               "", CONV_NUMERIC_LITERAL, API_RTC, 1}; // 2
+  m["NVRTC_ERROR_INVALID_INPUT"]                                 = {"HIPRTC_ERROR_INVALID_INPUT",                          "", CONV_NUMERIC_LITERAL, API_RTC, 1}; // 3
+  m["NVRTC_ERROR_INVALID_PROGRAM"]                               = {"HIPRTC_ERROR_INVALID_PROGRAM",                        "", CONV_NUMERIC_LITERAL, API_RTC, 1}; // 4
+  m["NVRTC_ERROR_INVALID_OPTION"]                                = {"HIPRTC_ERROR_INVALID_OPTION",                         "", CONV_NUMERIC_LITERAL, API_RTC, 1}; // 5
+  m["NVRTC_ERROR_COMPILATION"]                                   = {"HIPRTC_ERROR_COMPILATION",                            "", CONV_NUMERIC_LITERAL, API_RTC, 1}; // 6
+  m["NVRTC_ERROR_BUILTIN_OPERATION_FAILURE"]                     = {"HIPRTC_ERROR_BUILTIN_OPERATION_FAILURE",              "", CONV_NUMERIC_LITERAL, API_RTC, 1}; // 7
+  m["NVRTC_ERROR_NO_NAME_EXPRESSIONS_AFTER_COMPILATION"]         = {"HIPRTC_ERROR_NO_NAME_EXPRESSIONS_AFTER_COMPILATION",  "", CONV_NUMERIC_LITERAL, API_RTC, 1}; // 8
+  m["NVRTC_ERROR_NO_LOWERED_NAMES_BEFORE_COMPILATION"]           = {"HIPRTC_ERROR_NO_LOWERED_NAMES_BEFORE_COMPILATION",    "", CONV_NUMERIC_LITERAL, API_RTC, 1}; // 9
+  m["NVRTC_ERROR_NAME_EXPRESSION_NOT_VALID"]                     = {"HIPRTC_ERROR_NAME_EXPRESSION_NOT_VALID",              "", CONV_NUMERIC_LITERAL, API_RTC, 1}; // 10
+  m["NVRTC_ERROR_INTERNAL_ERROR"]                                = {"HIPRTC_ERROR_INTERNAL_ERROR",                         "", CONV_NUMERIC_LITERAL, API_RTC, 1}; // 11
+  m["NVRTC_ERROR_TIME_FILE_WRITE_FAILED"]                        = {"HIPRTC_ERROR_TIME_FILE_WRITE_FAILED",                 "", CONV_NUMERIC_LITERAL, API_RTC, 1, UNSUPPORTED}; // 12
+  m["NVRTC_ERROR_NO_PCH_CREATE_ATTEMPTED"]                       = {"HIPRTC_ERROR_NO_PCH_CREATE_ATTEMPTED",                "", CONV_NUMERIC_LITERAL, API_RTC, 1, UNSUPPORTED}; // 13
+  m["NVRTC_ERROR_PCH_CREATE_HEAP_EXHAUSTED"]                     = {"HIPRTC_ERROR_PCH_CREATE_HEAP_EXHAUSTED",              "", CONV_NUMERIC_LITERAL, API_RTC, 1, UNSUPPORTED}; // 14
+  m["NVRTC_ERROR_PCH_CREATE"]                                    = {"HIPRTC_ERROR_PCH_CREATE",                             "", CONV_NUMERIC_LITERAL, API_RTC, 1, UNSUPPORTED}; // 15
+  m["NVRTC_ERROR_CANCELLED"]                                     = {"HIPRTC_ERROR_CANCELLED",                              "", CONV_NUMERIC_LITERAL, API_RTC, 1, UNSUPPORTED}; // 16
+  m["NVRTC_ERROR_TIME_TRACE_FILE_WRITE_FAILED"]                  = {"HIPRTC_ERROR_TIME_TRACE_FILE_WRITE_FAILED",           "", CONV_NUMERIC_LITERAL, API_RTC, 1, UNSUPPORTED}; // 17
 
-const std::map<llvm::StringRef, cudaAPIversions> CUDA_RTC_TYPE_NAME_VER_MAP {
-  {"NVRTC_ERROR_NO_NAME_EXPRESSIONS_AFTER_COMPILATION",          {CUDA_80,  CUDA_0,   CUDA_0  }},
-  {"NVRTC_ERROR_NO_LOWERED_NAMES_BEFORE_COMPILATION",            {CUDA_80,  CUDA_0,   CUDA_0  }},
-  {"NVRTC_ERROR_NAME_EXPRESSION_NOT_VALID",                      {CUDA_80,  CUDA_0,   CUDA_0  }},
-  {"NVRTC_ERROR_INTERNAL_ERROR",                                 {CUDA_80,  CUDA_0,   CUDA_0  }},
-  {"NVRTC_ERROR_TIME_FILE_WRITE_FAILED",                         {CUDA_121, CUDA_0,   CUDA_0  }},
-  {"NVRTC_ERROR_NO_PCH_CREATE_ATTEMPTED",                        {CUDA_128, CUDA_0,   CUDA_0  }},
-  {"NVRTC_ERROR_PCH_CREATE_HEAP_EXHAUSTED",                      {CUDA_128, CUDA_0,   CUDA_0  }},
-  {"NVRTC_ERROR_PCH_CREATE",                                     {CUDA_128, CUDA_0,   CUDA_0  }},
-  {"NVRTC_ERROR_CANCELLED",                                      {CUDA_128, CUDA_0,   CUDA_0  }},
-  {"NVRTC_ERROR_TIME_TRACE_FILE_WRITE_FAILED",                   {CUDA_130, CUDA_0,   CUDA_0  }},
-};
+  m["nvrtcProgram"]                                              = {"hiprtcProgram",                                       "", CONV_TYPE, API_RTC, 1};
+  m["_nvrtcProgram"]                                             = {"_hiprtcProgram",                                      "", CONV_TYPE, API_RTC, 1};
 
-const std::map<llvm::StringRef, hipAPIversions> HIP_RTC_TYPE_NAME_VER_MAP {
-  {"hiprtcResult",                                               {HIP_2060, HIP_0,    HIP_0   }},
-  {"HIPRTC_SUCCESS",                                             {HIP_2060, HIP_0,    HIP_0   }},
-  {"HIPRTC_ERROR_OUT_OF_MEMORY",                                 {HIP_2060, HIP_0,    HIP_0   }},
-  {"HIPRTC_ERROR_PROGRAM_CREATION_FAILURE",                      {HIP_2060, HIP_0,    HIP_0   }},
-  {"HIPRTC_ERROR_INVALID_INPUT",                                 {HIP_2060, HIP_0,    HIP_0   }},
-  {"HIPRTC_ERROR_INVALID_PROGRAM",                               {HIP_2060, HIP_0,    HIP_0   }},
-  {"HIPRTC_ERROR_INVALID_OPTION",                                {HIP_2060, HIP_0,    HIP_0   }},
-  {"HIPRTC_ERROR_COMPILATION",                                   {HIP_2060, HIP_0,    HIP_0   }},
-  {"HIPRTC_ERROR_BUILTIN_OPERATION_FAILURE",                     {HIP_2060, HIP_0,    HIP_0   }},
-  {"HIPRTC_ERROR_NO_NAME_EXPRESSIONS_AFTER_COMPILATION",         {HIP_2060, HIP_0,    HIP_0   }},
-  {"HIPRTC_ERROR_NO_LOWERED_NAMES_BEFORE_COMPILATION",           {HIP_2060, HIP_0,    HIP_0   }},
-  {"HIPRTC_ERROR_NAME_EXPRESSION_NOT_VALID",                     {HIP_2060, HIP_0,    HIP_0   }},
-  {"HIPRTC_ERROR_INTERNAL_ERROR",                                {HIP_2060, HIP_0,    HIP_0   }},
-  {"hiprtcProgram",                                              {HIP_2060, HIP_0,    HIP_0   }},
-  {"_hiprtcProgram",                                             {HIP_2060, HIP_0,    HIP_0   }},
-};
+  return m;
+}();
+
+const std::map<llvm::StringRef, cudaAPIversions> CUDA_RTC_TYPE_NAME_VER_MAP = []() {
+  std::map<llvm::StringRef, cudaAPIversions> m;
+
+  m["NVRTC_ERROR_NO_NAME_EXPRESSIONS_AFTER_COMPILATION"]         = {CUDA_80,  CUDA_0,   CUDA_0  };
+  m["NVRTC_ERROR_NO_LOWERED_NAMES_BEFORE_COMPILATION"]           = {CUDA_80,  CUDA_0,   CUDA_0  };
+  m["NVRTC_ERROR_NAME_EXPRESSION_NOT_VALID"]                     = {CUDA_80,  CUDA_0,   CUDA_0  };
+  m["NVRTC_ERROR_INTERNAL_ERROR"]                                = {CUDA_80,  CUDA_0,   CUDA_0  };
+  m["NVRTC_ERROR_TIME_FILE_WRITE_FAILED"]                        = {CUDA_121, CUDA_0,   CUDA_0  };
+  m["NVRTC_ERROR_NO_PCH_CREATE_ATTEMPTED"]                       = {CUDA_128, CUDA_0,   CUDA_0  };
+  m["NVRTC_ERROR_PCH_CREATE_HEAP_EXHAUSTED"]                     = {CUDA_128, CUDA_0,   CUDA_0  };
+  m["NVRTC_ERROR_PCH_CREATE"]                                    = {CUDA_128, CUDA_0,   CUDA_0  };
+  m["NVRTC_ERROR_CANCELLED"]                                     = {CUDA_128, CUDA_0,   CUDA_0  };
+  m["NVRTC_ERROR_TIME_TRACE_FILE_WRITE_FAILED"]                  = {CUDA_130, CUDA_0,   CUDA_0  };
+
+  return m;
+}();
+
+const std::map<llvm::StringRef, hipAPIversions> HIP_RTC_TYPE_NAME_VER_MAP = []() {
+  std::map<llvm::StringRef, hipAPIversions> m;
+
+  m["hiprtcResult"]                                              = {HIP_2060, HIP_0,    HIP_0   };
+  m["HIPRTC_SUCCESS"]                                            = {HIP_2060, HIP_0,    HIP_0   };
+  m["HIPRTC_ERROR_OUT_OF_MEMORY"]                                = {HIP_2060, HIP_0,    HIP_0   };
+  m["HIPRTC_ERROR_PROGRAM_CREATION_FAILURE"]                     = {HIP_2060, HIP_0,    HIP_0   };
+  m["HIPRTC_ERROR_INVALID_INPUT"]                                = {HIP_2060, HIP_0,    HIP_0   };
+  m["HIPRTC_ERROR_INVALID_PROGRAM"]                              = {HIP_2060, HIP_0,    HIP_0   };
+  m["HIPRTC_ERROR_INVALID_OPTION"]                               = {HIP_2060, HIP_0,    HIP_0   };
+  m["HIPRTC_ERROR_COMPILATION"]                                  = {HIP_2060, HIP_0,    HIP_0   };
+  m["HIPRTC_ERROR_BUILTIN_OPERATION_FAILURE"]                    = {HIP_2060, HIP_0,    HIP_0   };
+  m["HIPRTC_ERROR_NO_NAME_EXPRESSIONS_AFTER_COMPILATION"]        = {HIP_2060, HIP_0,    HIP_0   };
+  m["HIPRTC_ERROR_NO_LOWERED_NAMES_BEFORE_COMPILATION"]          = {HIP_2060, HIP_0,    HIP_0   };
+  m["HIPRTC_ERROR_NAME_EXPRESSION_NOT_VALID"]                    = {HIP_2060, HIP_0,    HIP_0   };
+  m["HIPRTC_ERROR_INTERNAL_ERROR"]                               = {HIP_2060, HIP_0,    HIP_0   };
+  m["hiprtcProgram"]                                             = {HIP_2060, HIP_0,    HIP_0   };
+  m["_hiprtcProgram"]                                            = {HIP_2060, HIP_0,    HIP_0   };
+
+  return m;
+}();


### PR DESCRIPTION
**[Synopsis]**
+ Transformation maps reside in Stack and occupy up to `64kB` each of stack memory now
+ That leads to multiple compiler warnings about possible Stack Overflow

**[Solution]**
+ Move maps' initialization logic into a lambda. This prevents the compiler from creating a massive temporary array on the stack, which was the root cause of the "excessive stack usage" warning.
