### PR TITLE
[HIPIFY][Infra] Enable `Windows` CI and update `Linux` CI for `amd-staging`

### DIFF
--- a/.github/workflows/build_portable_linux_artifacts.yml
+++ b/.github/workflows/build_portable_linux_artifacts.yml
@@ -78,13 +78,11 @@ jobs:
       IS_PR_FROM_FORK: ${{ github.event.pull_request.head.repo.fork }}
     steps:
       - name: Checkout TheRock repository
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           repository: "ROCm/TheRock"
-          ref: compiler/amd-staging
-          #ref: ${{ secrets.THEROCK_MAINLINE_REF }}
-          fetch-depth: 10
-
+          ref: 'compiler/amd-staging'
+          
       - name: Update Submodule Pointer to the PR
         run: |
           git config --global --add safe.directory $PWD
@@ -94,10 +92,11 @@ jobs:
           git update-index --cacheinfo 160000,$PR_SHA,compiler/hipify
           git config --global user.email "z1-cciauto@amd.com"
           git config --global user.name "Z1 cciauto"
-          git commit -m "Update submodule reference for compiler/hipify"          
+          git commit -m "Update submodule reference for compiler/hipify"
           # Verify the pointer update
           git submodule status
           git submodule
+    
 
       - name: Install python deps
         run: |
@@ -126,6 +125,10 @@ jobs:
         run: |
           python -m pytest build_tools/tests build_tools/github_actions/tests
 
+      - name: Remove ununsed existing patchces
+        run: |
+          rm -fv patches/amd-mainline/llvm-project/0001-Ensure-to-use-libamdhip64-with-major-version.patch
+
       - name: Fetch sources
         timeout-minutes: 30
         run: |
@@ -138,10 +141,10 @@ jobs:
           path: compiler/amd-llvm
           ref: amd-staging
 
-      - name: "Checking out repository for spriv-llvm-translator"
+      - name: "Checking out repository for spirv-llvm-translator"
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
-          repository: "ROCm/SPIRV-LLVM-Translator"
+          repository: "ROCm/spirv-llvm-translator"
           path: compiler/spirv-llvm-translator
           ref: amd-staging
 
@@ -163,10 +166,10 @@ jobs:
              ls -l compiler/amd-llvm
              cd compiler/amd-llvm/llvm  
              ls -l
-             git log --oneline -3             
+             git log --oneline -3
              cd -
 
-      - name: Configure Projects
+      - name: Configure PR Projects
         env:
           cmake_preset: ${{ inputs.build_variant_cmake_preset }}
           amdgpu_families: ${{ inputs.amdgpu_families }}

--- a/.github/workflows/build_portable_linux_python_packages.yml
+++ b/.github/workflows/build_portable_linux_python_packages.yml
@@ -39,7 +39,7 @@ jobs:
     # Note: GitHub-hosted runners run out of disk space for some gpu families
     runs-on: ${{ github.repository_owner == 'ROCm' && 'azure-linux-scale-rocm' || 'ubuntu-24.04' }}
     env:
-      BUILD_IMAGE: ghcr.io/rocm/therock_build_manylinux_x86_64@sha256:583d473f263a289222c48d4b493e2956b2354a45796f09dee6f2c8ecd4504ab6
+      BUILD_IMAGE: ghcr.io/rocm/therock_build_manylinux_x86_64@sha256:6e8242d347af7e0c43c82d5031a3ac67b669f24898ea8dc2f1d5b7e4798b66bd
       ARTIFACT_RUN_ID: "${{ inputs.artifact_run_id != '' && inputs.artifact_run_id || github.run_id }}"
       ARTIFACTS_DIR: "${{ github.workspace }}/artifacts"
       PACKAGES_DIR: "${{ github.workspace }}/packages"
@@ -49,7 +49,7 @@ jobs:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           repository: "ROCm/TheRock"
-          ref: ${{ secrets.THEROCK_MAINLINE_REF }}
+          ref: 'compiler/amd-staging'
       - uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6.1.0
         with:
           python-version: '3.12'

--- a/.github/workflows/build_windows_artifacts.yml
+++ b/.github/workflows/build_windows_artifacts.yml
@@ -75,16 +75,26 @@ jobs:
       IS_PR_FROM_FORK: ${{ github.event.pull_request.head.repo.fork }}
     steps:
       - name: Checkout TheRock repository
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           repository: "ROCm/TheRock"
-          ref: ${{ secrets.THEROCK_MAINLINE_REF }}
-          fetch-depth: 10
+          ref: 'compiler/amd-staging'
 
-      - name: SHA of TheRock
+
+      - name: Update Submodule Pointer to the PR
         run: |
-             git rev-parse HEAD
-             git log -1
+          git config --global --add safe.directory $PWD
+          # Fetch the latest commit SHA from the PR branch
+          PR_SHA=${{ github.event.pull_request.head.sha }}
+          # Update the submodule pointer using cacheinfo
+          git update-index --cacheinfo 160000,$PR_SHA,compiler/hipify
+          git config --global user.email "z1-cciauto@amd.com"
+          git config --global user.name "Z1 cciauto"
+          git commit -m "Update submodule reference for compiler/hipify"
+          # Verify the pointer update
+          git submodule status
+          git submodule
+
 
       - uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6.1.0
         with:
@@ -126,15 +136,11 @@ jobs:
         run: |
           python -m pytest build_tools/tests build_tools/github_actions/tests
 
-      # TODO: We shouldn't be using a cache on actual release branches, but it
-      # really helps for iteration time.
-      - name: Enable cache
-        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
-        with:
-          path: ${{ env.CACHE_DIR }}
-          key: windows-build-packages-v4-${{ inputs.amdgpu_families }}-${{ github.sha }}
-          restore-keys: |
-            windows-build-packages-v4-${{ inputs.amdgpu_families }}-
+      - name: Remove ununsed existing patchces
+        run: |
+          rm -fv patches/amd-mainline/llvm-project/0003-HACK-Handle-ROCM-installation-layout-of-lib-llvm-bin.patch
+          rm -fv patches/amd-mainline/llvm-project/0009-Add-gcc-toolset-13-prefix-detection.patch
+          rm -fv patches/amd-mainline/llvm-project/0001-Ensure-to-use-libamdhip64-with-major-version.patch
 
       - name: Fetch sources
         timeout-minutes: 30
@@ -147,31 +153,52 @@ jobs:
       - name: "Checking out repository for llvm-project"
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
-           path: compiler/amd-llvm
+          repository: "ROCm/llvm-project"
+          path: compiler/amd-llvm
+          ref: amd-staging
+
+      - name: "Checking out repository for spirv-llvm-translator"
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          repository: "ROCm/spirv-llvm-translator"
+          path: compiler/spirv-llvm-translator
+          ref: amd-staging
 
       - name: Apply patches
         run: |
              cp -v patches/amd-mainline/llvm-project/*.patch compiler/amd-llvm
              cd compiler/amd-llvm
-             git config --global --add safe.directory /__w/llvm-project/llvm-project
+             git log -10
+             git config --global --add safe.directory $PWD
              find . -type f -name '*.patch' -exec git apply --check {} \;
              find . -type f -name '*.patch' -exec git apply {} \;
              git log -15
              cd -
 
-      - name: Configure Projects
+      - name: TheRock and llvm SHA
+        run: |
+             git config --global --add safe.directory $PWD
+             git log --oneline -1
+             ls -l compiler/amd-llvm
+             cd compiler/amd-llvm/llvm
+             ls -l
+             git log --oneline -3
+             cd -
+
+      - name: Configure PR Projects
         env:
           cmake_preset: ${{ inputs.build_variant_cmake_preset }}
           amdgpu_families: ${{ inputs.amdgpu_families }}
           package_version: ${{ inputs.package_version }}
-          extra_cmake_options: ${{ inputs.extra_cmake_options }}
+          #extra_cmake_options: ${{ inputs.extra_cmake_options }}
+          extra_cmake_options: "-DTHEROCK_ENABLE_ALL=OFF -DTHEROCK_ENABLE_COMPILER=ON -DTHEROCK_ENABLE_HIP_RUNTIME=ON -DTHEROCK_ENABLE_PRIM=ON -DTHEROCK_ENABLE_BLAS=ON -DTHEROCK_ENABLE_RAND=ON -DTHEROCK_ENABLE_SOLVER=ON -DTHEROCK_ENABLE_SPARSE=ON -DTHEROCK_ENABLE_SYSDEPS=OFF  -DTHEROCK_ENABLE_COMPOSABLE_KERNEL=OFF -DTHEROCK_ENABLE_OCL_RUNTIME=ON  -DTHEROCK_ENABLE_MATH_LIBS=ON -DLLVM_SMREV_REPO='' -DLLVM_SMREV_REVISION=''"
         run: |
           # clear cache before build and after download
           ccache -z
           python3 build_tools/github_actions/build_configure.py
 
       - name: Build therock-archives and therock-dist
-        run: cmake --build "${{ env.BUILD_DIR }}" --target therock-archives therock-dist -- -k 0
+        run: cmake --build "${{ env.BUILD_DIR }}" --target therock-archives therock-dist -- -j32
 
       - name: Report
         if: ${{ !cancelled() }}
@@ -210,7 +237,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # v5.1.1
         with:
           aws-region: us-east-2
-          role-to-assume: arn:aws:iam::692859939525:role/therock-ci
+          role-to-assume: arn:aws:iam::692859939525:role/therock-ci-external
           special-characters-workaround: true
 
       - name: Post Build Upload
@@ -222,9 +249,3 @@ jobs:
             --build-dir ${{ env.BUILD_DIR }} \
             --upload
 
-      - name: Save cache
-        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
-        if: ${{ !cancelled() }}
-        with:
-          path: ${{ env.CACHE_DIR }}
-          key: windows-build-packages-v4-${{ inputs.amdgpu_families }}-${{ github.sha }}

--- a/.github/workflows/build_windows_python_packages.yml
+++ b/.github/workflows/build_windows_python_packages.yml
@@ -46,7 +46,7 @@ jobs:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           repository: "ROCm/TheRock"
-          ref: ${{ secrets.THEROCK_MAINLINE_REF }}
+          ref: 'compiler/amd-staging'
       - uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6.1.0
         with:
           python-version: '3.12'
@@ -76,12 +76,5 @@ jobs:
       - name: Inspect Python packages
         run: |
           ls -la "${{ env.PACKAGES_DIR }}"
-
-      - name: Sanity check Python packages
-        run: |
-          piprepo build "${{ env.PACKAGES_DIR }}/dist"
-          pip install rocm[libraries,devel]==${{ inputs.package_version }} \
-            --extra-index-url "${{ env.PACKAGES_DIR }}/dist/simple/"
-          rocm-sdk test
 
       # TODO(#1559): upload packages to artifacts S3 bucket and/or a dedicated Python packages bucket

--- a/.github/workflows/ci_linux.yml
+++ b/.github/workflows/ci_linux.yml
@@ -19,6 +19,9 @@ on:
         type: string
       test_runs_on:
         type: string
+      benchmark_runs_on:
+        type: string
+        default: ""
       expect_failure:
         type: boolean
       use_prebuilt_artifacts:
@@ -84,6 +87,7 @@ jobs:
       test_type: ${{ inputs.test_type }}
       test_labels: ${{ inputs.test_labels }}
       sanity_check_only_for_family: ${{ inputs.sanity_check_only_for_family == true }}
+
 
   build_portable_linux_python_packages:
     needs: [build_portable_linux_artifacts]

--- a/.github/workflows/ci_windows.yml
+++ b/.github/workflows/ci_windows.yml
@@ -19,6 +19,9 @@ on:
         type: string
       test_runs_on:
         type: string
+      benchmark_runs_on:
+        type: string
+        default: ""
       expect_failure:
         type: boolean
       use_prebuilt_artifacts:
@@ -51,20 +54,13 @@ jobs:
       contents: read
       id-token: write
 
-  # TODO: rework "artifact_run_id" and "use_prebuilt_artifacts" here?
-  #   I don't want to copy/paste this condition and special case plumbing
-  #   through multiple workflows. All the packaging and testing workflows need
-  #   to know is what artifact run id to use. That could be the current
-  #   (implicit) run id, or it could be an explicit run id.
-  #   How about having the "build artifacts" job run as a passthrough?
-
-  test_windows_artifacts:
+  test_windows_benchmarks:
     needs: [build_windows_artifacts]
-    name: Test Artifacts
-    # If the dependent job failed/cancelled, this job will not be run
-    # The use_prebuilt_artifacts "or" statement ensures that tests will run if
-    # previous build step is run or skipped.concurrency.
-    # If we are expecting a build failure, do not run tests to save machine capacity
+    name: Test Windows Benchmarks
+    # Run benchmarks if:
+    # - Build succeeded (or using prebuilt artifacts)
+    # - Not expecting failure
+    # - Benchmark runner is available (benchmark_runs_on is set)
     if: >-
       ${{
         !failure() &&
@@ -73,17 +69,17 @@ jobs:
           inputs.use_prebuilt_artifacts == 'false' ||
           inputs.use_prebuilt_artifacts == 'true'
         ) &&
-        inputs.expect_failure == false
+        inputs.expect_failure == false &&
+        inputs.benchmark_runs_on != ''
       }}
-    uses: ./.github/workflows/test_artifacts.yml
+    uses: ./.github/workflows/test_benchmarks.yml
+    secrets: inherit
     with:
       artifact_group: ${{ inputs.artifact_group }}
       amdgpu_families: ${{ inputs.amdgpu_families }}
-      test_runs_on: ${{ inputs.test_runs_on }}
+      test_runs_on: ${{ inputs.benchmark_runs_on }}
       artifact_run_id: ${{ inputs.artifact_run_id }}
-      test_type: ${{ inputs.test_type }}
-      test_labels: ${{ inputs.test_labels }}
-      sanity_check_only_for_family: ${{ inputs.sanity_check_only_for_family == true }}
+
 
   build_windows_python_packages:
     needs: [build_windows_artifacts]

--- a/.github/workflows/rockci-hipify-amd-staging.yml
+++ b/.github/workflows/rockci-hipify-amd-staging.yml
@@ -12,7 +12,7 @@
 #
 # Note: If a test machine is not available for a specific AMD GPU family in `amdgpu_family_matrix.py`, tests will be skipped.
 
-name: CI
+name: CI HIPIFY amd-staging
 
 on:
   push:
@@ -47,6 +47,7 @@ on:
         description: "If provided, the tests will run on this artifact ID"
         default: ""
   pull_request:
+    branches: [amd-staging]
     types:
       - labeled
       - opened
@@ -93,6 +94,36 @@ jobs:
       artifact_run_id: ${{ inputs.artifact_run_id }}
       expect_failure: ${{ matrix.variant.expect_failure == true }}
       use_prebuilt_artifacts: ${{ inputs.linux_use_prebuilt_artifacts == true && 'true' || 'false' }}
+      rocm_package_version: ${{ needs.setup.outputs.rocm_package_version }}
+      test_type: ${{ needs.setup.outputs.test_type }}
+      sanity_check_only_for_family: ${{ matrix.variant.sanity_check_only_for_family == true }}
+    permissions:
+      contents: read
+      id-token: write
+
+  windows_build_and_test:
+    name: Windows::${{ matrix.variant.family }}::${{ matrix.variant.build_variant_label }}
+    needs: setup
+    if: >-
+      ${{
+        needs.setup.outputs.windows_variants != '[]'
+      }}
+    strategy:
+      fail-fast: false
+      matrix:
+        variant: ${{ fromJSON(needs.setup.outputs.windows_variants) }}
+    uses: ./.github/workflows/ci_windows.yml
+    with:
+      amdgpu_families: ${{ matrix.variant.family }}
+      artifact_group: ${{ matrix.variant.artifact_group }}
+      test_runs_on: ${{ matrix.variant.test-runs-on }}
+      build_variant_label: ${{ matrix.variant.build_variant_label }}
+      build_variant_suffix: ${{ matrix.variant.build_variant_suffix }}
+      build_variant_cmake_preset: ${{ matrix.variant.build_variant_cmake_preset }}
+      test_labels: ${{ needs.setup.outputs.windows_test_labels }}
+      artifact_run_id: ${{ inputs.artifact_run_id }}
+      expect_failure: ${{ matrix.variant.expect_failure == true }}
+      use_prebuilt_artifacts: ${{ inputs.windows_use_prebuilt_artifacts == true && 'true' || 'false' }}
       rocm_package_version: ${{ needs.setup.outputs.rocm_package_version }}
       test_type: 'smoke'
       sanity_check_only_for_family: ${{ matrix.variant.sanity_check_only_for_family == true }}

--- a/.github/workflows/setup.yml
+++ b/.github/workflows/setup.yml
@@ -16,7 +16,7 @@ on:
         value: true
       linux_variants:
         description: Matrix variants to run on Linux
-        value: ${{ jobs.setup.outputs.linux_variants }}
+        value:  ${{ jobs.setup.outputs.linux_variants }}
       linux_test_labels:
         description: ROCm projects to run Linux tests on. Optional filter.
         value: ${{ jobs.setup.outputs.linux_test_labels }}
@@ -40,24 +40,23 @@ jobs:
   setup:
     runs-on: ubuntu-24.04
     env:
-      # The commit being checked out is the merge commit for a PR. Its first
-      # parent will be the tip of the base branch.
-      BASE_REF: HEAD^
+      BASE_REF: '5a23b542e1d03fbb515e014a7d9635c8884b12e6'
     outputs:
       enable_build_jobs: true
-      linux_variants: ${{ steps.configure.outputs.linux_variants }}
+      linux_variants: >
+        [ {"test-runs-on": "", "family": "gfx110X-all", "bypass_tests_for_releases": true, "sanity_check_only_for_family": true, "build_variant_label": "release", "build_variant_suffix": "", "build_variant_cmake_preset": "", "artifact_group": "gfx110X-all"}, {"test-runs-on": "linux-mi325-1gpu-ossci-rocm", "test-runs-on-multi-gpu": "linux-mi325-4gpu-ossci-rocm", "benchmark-runs-on": "linux-mi325-1gpu-ossci-rocm", "family": "gfx94X-dcgpu", "build_variant_label": "release", "build_variant_suffix": "", "build_variant_cmake_preset": "", "artifact_group": "gfx94X-dcgpu"}]
       linux_test_labels: ${{ steps.configure.outputs.linux_test_labels }}
-      windows_variants: ${{ steps.configure.outputs.windows_variants }}
+      windows_variants: >
+            [{"test-runs-on": "windows-gfx1151-gpu-rocm", "benchmark-runs-on": "windows-gfx1151-gpu-rocm", "family": "gfx1151", "build_variant_label": "release", "build_variant_suffix": "", "build_variant_cmake_preset": "windows-release", "artifact_group": "gfx1151"}]
       test_type: 'smoke'
       windows_test_labels: ${{ steps.configure.outputs.windows_test_labels }}
       rocm_package_version: ${{ steps.rocm_package_version.outputs.rocm_package_version }}
     steps:
       - name: Checkout TheRock repository
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           repository: "ROCm/TheRock"
-          ref: ${{ secrets.THEROCK_MAINLINE_REF }}
-          fetch-depth: 10
+          ref: '5a23b542e1d03fbb515e014a7d9635c8884b12e6'
       - name: SHA of TheRock
         run: |
              git rev-parse HEAD
@@ -74,7 +73,7 @@ jobs:
         id: configure
         env:
           #INPUT_LINUX_AMDGPU_FAMILIES: ${{ github.event.inputs.linux_amdgpu_families }}
-          INPUT_LINUX_AMDGPU_FAMILIES: "gfx94X"
+          INPUT_LINUX_AMDGPU_FAMILIES: 'gfx94X-dcgpu,gfx110X-all,gfx1151'
           LINUX_TEST_LABELS: ${{ github.event.inputs.linux_test_labels }}
           LINUX_USE_PREBUILT_ARTIFACTS: ${{ github.event.inputs.linux_use_prebuilt_artifacts }}
           #INPUT_WINDOWS_AMDGPU_FAMILIES: ${{ github.event.inputs.windows_amdgpu_families }}

--- a/.github/workflows/test_benchmarks.yml
+++ b/.github/workflows/test_benchmarks.yml
@@ -1,4 +1,4 @@
-name: Test Artifacts
+name: Test Benchmarks
 
 on:
   workflow_dispatch:
@@ -12,13 +12,6 @@ on:
         type: string
       test_runs_on:
         type: string
-      sanity_check_only_for_family:
-        type: boolean
-        default: false
-      test_type:
-        type: string
-      test_labels:
-        type: string
   workflow_call:
     inputs:
       artifact_group:
@@ -30,37 +23,24 @@ on:
         type: string
       test_runs_on:
         type: string
-      sanity_check_only_for_family:
-        type: boolean
-        default: false
-      test_type:
-        type: string
-      test_labels:
-        type: string
-  push:
-    branches:
-      - ADHOCBUILD
 
 permissions:
   contents: read
 
 jobs:
-  configure_test_matrix:
-    name: "Configure test matrix"
+  configure_benchmark_matrix:
+    name: "Configure benchmark matrix"
     # if there is a test machine available
     if: ${{ inputs.test_runs_on != '' }}
     runs-on: ${{ inputs.test_runs_on }}
     outputs:
       components: ${{ steps.configure.outputs.components }}
       platform: ${{ steps.configure.outputs.platform }}
-      shard_arr: ${{ steps.configure.outputs.shard_arr }}
     steps:
       - name: "Fetch 'build_tools' from repository"
         if: ${{ runner.os == 'Windows' }}
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
-          repository: "ROCm/TheRock"
-          ref: '5a23b542e1d03fbb515e014a7d9635c8884b12e6'
           sparse-checkout: build_tools
           path: "prejob"
 
@@ -73,57 +53,35 @@ jobs:
 
       - name: "Checking out repository"
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
-        with:
-          repository: "ROCm/TheRock"
-          ref: '5a23b542e1d03fbb515e014a7d9635c8884b12e6'
 
       - name: Setting up Python
         uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6.1.0
         with:
           python-version: 3.12
 
-      - name: "Configuring CI options"
+      - name: "Configuring benchmark options"
         id: configure
         env:
           ARTIFACT_GROUP: ${{ inputs.artifact_group }}
           AMDGPU_FAMILIES: ${{ inputs.amdgpu_families }}
-          TEST_TYPE: ${{ inputs.test_type }}
-          TEST_LABELS: ${{ inputs.test_labels }}
-          project_to_test: 'rocblas,rocroller,hipblas,hipblaslt,hipsolver,rocsolver,rocprim,hipcub,rocthrust,hipsparse,rocsparse,rocrand,hiprand,rocfft,hipfft,rocwmma'
+          IS_BENCHMARK_WORKFLOW: "true"
         run: python ./build_tools/github_actions/fetch_test_configurations.py
 
-  test_sanity_check:
-    name: 'Test Sanity Check'
-    needs: configure_test_matrix
-    uses: './.github/workflows/test_sanity_check.yml'
-    with:
-      artifact_group: ${{ inputs.artifact_group }}
-      artifact_run_id: ${{ inputs.artifact_run_id }}
-      amdgpu_families: ${{ inputs.amdgpu_families }}
-      test_runs_on: ${{ inputs.test_runs_on }}
-      platform: ${{ needs.configure_test_matrix.outputs.platform }}
-
-  test_components:
-    name: 'Test ${{ matrix.components.job_name }}'
-    needs: [test_sanity_check, configure_test_matrix]
-    # skip tests if no test matrix to run and sanity check only requested
-    if: ${{ needs.configure_test_matrix.outputs.components != '[]' && !inputs.sanity_check_only_for_family }}
+  run_benchmarks:
+    name: 'Benchmark ${{ matrix.components.job_name }}'
+    needs: [configure_benchmark_matrix]
+    # skip benchmarks if no benchmark matrix to run
+    if: ${{ needs.configure_benchmark_matrix.outputs.components != '[]' }}
     strategy:
       fail-fast: false
       matrix:
-        components: ${{ fromJSON(needs.configure_test_matrix.outputs.components) }}
+        components: ${{ fromJSON(needs.configure_benchmark_matrix.outputs.components) }}
     uses: './.github/workflows/test_component.yml'
+    secrets: inherit
     with:
       artifact_run_id: ${{ inputs.artifact_run_id }}
       artifact_group: ${{ inputs.artifact_group }}
       amdgpu_families: ${{ inputs.amdgpu_families }}
-      # If the test requires a multi GPU, use the multi GPU test runner
-      # Otherwise, use the standard test runner
-      test_runs_on: >-
-        ${{
-          matrix.components.multi_gpu_runner != '' &&
-            matrix.components.multi_gpu_runner ||
-            inputs.test_runs_on
-        }}
-      platform: ${{ needs.configure_test_matrix.outputs.platform }}
+      test_runs_on: ${{ inputs.test_runs_on }}
+      platform: ${{ needs.configure_benchmark_matrix.outputs.platform }}
       component: ${{ toJSON(matrix.components) }}

--- a/.github/workflows/test_component.yml
+++ b/.github/workflows/test_component.yml
@@ -22,18 +22,28 @@ permissions:
 
 jobs:
   test_component:
-    name: 'Test ${{ fromJSON(inputs.component).job_name }} (shard ${{ matrix.shard }} of ${{ fromJSON(inputs.component).total_shards }})'
+    name: >-
+      Test ${{ fromJSON(inputs.component).job_name }}
+      (shard ${{ matrix.shard }} of ${{ fromJSON(inputs.component).total_shards }})
+      ${{ fromJSON(inputs.component).expect_failure == true && '(xfail)' || '' }}
     runs-on: ${{ inputs.test_runs_on }}
+    continue-on-error: ${{ fromJSON(inputs.component).expect_failure == true }}
     timeout-minutes: 210
     container:
       image: ${{ inputs.platform == 'linux' && 'ghcr.io/rocm/no_rocm_image_ubuntu24_04@sha256:4150afe4759d14822f0e3f8930e1124f26e11f68b5c7b91ec9a02b20b1ebbb98' || null }}
+      # --ulimit memlock=-1:-1 - Prevents memory allocation issues with ROCm inside container
+      # --security-opt seccomp=unconfined - enables memory mapping, and is recommended for containers running in HPC environments
+      # --env-file /etc/podinfo/gha-gpu-isolation-settings - Required for GPU isolation on OSSCI MIXXX runners
+      # --user 0:0 - Running as root, by recommendation of GitHub: https://docs.github.com/en/actions/reference/workflows-and-actions/dockerfile-support#user
       options: --ipc host
         --group-add video
         --device /dev/kfd
         --device /dev/dri
         --group-add 110
+        --ulimit memlock=-1:-1
+        --security-opt seccomp=unconfined
         --env-file /etc/podinfo/gha-gpu-isolation-settings
-        --user 0:0 # Running as root, by recommendation of GitHub: https://docs.github.com/en/actions/reference/workflows-and-actions/dockerfile-support#user
+        --user 0:0
     strategy:
       fail-fast: false
       matrix:
@@ -49,12 +59,17 @@ jobs:
       OUTPUT_ARTIFACTS_DIR: "./build"
       THEROCK_BIN_DIR: "./build/bin"
       AMDGPU_FAMILIES: ${{ inputs.amdgpu_families }}
+      # Benchmark results database API endpoints for performance metrics collection
+      # NOTE: These secrets are only required for benchmark results submission in nightly CI runs.
+      # For PR/push workflows, secret retrieval will fail gracefully and benchmarks will skip API submission.
+      BENCHMARK_DB_URL: ${{ secrets.BENCHMARK_DB_URL }}
+      BENCHMARK_DB_FALLBACK_URL: ${{ secrets.BENCHMARK_DB_FALLBACK_URL }}
     steps:
       - name: "Fetch 'build_tools' from repository"
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           repository: "ROCm/TheRock"
-          ref: ${{ secrets.THEROCK_MAINLINE_REF }}
+          ref: '5a23b542e1d03fbb515e014a7d9635c8884b12e6'
           sparse-checkout: build_tools
           path: "prejob"
 
@@ -67,7 +82,7 @@ jobs:
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           repository: "ROCm/TheRock"
-          ref: ${{ secrets.THEROCK_MAINLINE_REF }}
+          ref: '5a23b542e1d03fbb515e014a7d9635c8884b12e6'
 
       - name: Run setup test environment workflow
         uses: './.github/actions/setup_test_environment'

--- a/.github/workflows/test_sanity_check.yml
+++ b/.github/workflows/test_sanity_check.yml
@@ -40,15 +40,24 @@ jobs:
   test_sanity_check:
     name: "Sanity ROCM Test"
     runs-on: ${{ inputs.test_runs_on }}
+    # Running docker with cap-add and -v /lib/modiles, by recommendation of Github: https://rocm.docs.amd.com/projects/amdsmi/en/amd-staging/how-to/setup-docker-container.html
     container:
-      image: ${{ inputs.platform == 'linux' && 'ghcr.io/rocm/no_rocm_image_ubuntu24_04@sha256:405945a40deaff9db90b9839c0f41d4cba4a383c1a7459b28627047bf6302a26' || null }}
+      image: ${{ inputs.platform == 'linux' && 'ghcr.io/rocm/no_rocm_image_ubuntu24_04@sha256:4150afe4759d14822f0e3f8930e1124f26e11f68b5c7b91ec9a02b20b1ebbb98' || null }}
+      # --ulimit memlock=-1:-1 - Prevents memory allocation issues with ROCm inside container
+      # --security-opt seccomp=unconfined - enables memory mapping, and is recommended for containers running in HPC environments
+      # --env-file /etc/podinfo/gha-gpu-isolation-settings - Required for GPU isolation on OSSCI MIXXX runners
+      # --user 0:0 - Running as root, by recommendation of GitHub: https://docs.github.com/en/actions/reference/workflows-and-actions/dockerfile-support#user
       options: --ipc host
         --group-add video
         --device /dev/kfd
         --device /dev/dri
         --group-add 110
+        --cap-add SYS_MODULE
+        -v /lib/modules:/lib/modules
+        --ulimit memlock=-1:-1
+        --security-opt seccomp=unconfined
         --env-file /etc/podinfo/gha-gpu-isolation-settings
-        --user 0:0 # Running as root, by recommendation of GitHub: https://docs.github.com/en/actions/reference/workflows-and-actions/dockerfile-support#user
+        --user 0:0
     defaults:
       run:
         shell: bash
@@ -57,6 +66,7 @@ jobs:
       ARTIFACT_RUN_ID: "${{ inputs.artifact_run_id != '' && inputs.artifact_run_id || github.run_id }}"
       OUTPUT_ARTIFACTS_DIR: ${{ github.workspace }}/build
       THEROCK_BIN_DIR: ${{ github.workspace }}/build/bin
+      AMDGPU_FAMILIES: ${{ inputs.amdgpu_families }}
     steps:
       - name: "Fetch 'build_tools' from repository"
         if: ${{ runner.os == 'Windows' }}
@@ -74,7 +84,7 @@ jobs:
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           repository: "ROCm/TheRock"
-          ref: ${{ secrets.THEROCK_MAINLINE_REF }}
+          ref: '5a23b542e1d03fbb515e014a7d9635c8884b12e6'
 
       - name: Pre-job cleanup Docker containers on Linux
         if: ${{ runner.os == 'Linux' }}
@@ -100,6 +110,7 @@ jobs:
         run: echo "HIP_CLANG_PATH=${OUTPUT_ARTIFACTS_DIR}\lib\llvm\bin" >> $GITHUB_ENV
 
       - name: Driver / GPU sanity check
+        timeout-minutes: 3
         run: |
           python ./build_tools/print_driver_gpu_info.py
 
@@ -110,7 +121,7 @@ jobs:
           # https://rocm.docs.amd.com/projects/HIP/en/latest/how-to/debugging.html
           AMD_LOG_LEVEL: 4
         run: |
-          pytest tests/ --log-cli-level=info --timeout=60
+          pytest tests/ --log-cli-level=info --timeout=300
 
       - name: Post-job cleanup processes on Windows
         if: ${{ always() && runner.os == 'Windows' }}


### PR DESCRIPTION
Linux: builds for gfx1151 and gfx94X-dcgpu targets
Linux: runs tests on gfx94X-dcgpu family
Linux: updated the test runner label to linux-mi325-1gpu-ossci-rocm
Windows: builds for gfx1151 target
Windows: no tests enabled on psdb