### PR TITLE
[HIPIFY][fix] `Stack Overflow` possible Issues - Part 8 - `RAND`

### DIFF
--- a/src/CUDA2HIP_RAND_API_functions.cpp
+++ b/src/CUDA2HIP_RAND_API_functions.cpp
@@ -23,182 +23,198 @@ THE SOFTWARE.
 #include "CUDA2HIP.h"
 
 // Map of all functions
-const std::map<llvm::StringRef, hipCounter> CUDA_RAND_FUNCTION_MAP {
+const std::map<llvm::StringRef, hipCounter> CUDA_RAND_FUNCTION_MAP = []() {
+  std::map<llvm::StringRef, hipCounter> m;
+
   // RAND Host functions
-  {"curandCreateGenerator",                         {"hiprandCreateGenerator",                         "rocrand_create_generator",                                   CONV_LIB_FUNC, API_RAND, 2}},
-  {"curandCreateGeneratorHost",                     {"hiprandCreateGeneratorHost",                     "rocrand_create_generator_host_blocking",                     CONV_LIB_FUNC, API_RAND, 2}},
-  {"curandCreatePoissonDistribution",               {"hiprandCreatePoissonDistribution",               "rocrand_create_poisson_distribution",                        CONV_LIB_FUNC, API_RAND, 2}},
-  {"curandDestroyDistribution",                     {"hiprandDestroyDistribution",                     "rocrand_destroy_discrete_distribution",                      CONV_LIB_FUNC, API_RAND, 2}},
-  {"curandDestroyGenerator",                        {"hiprandDestroyGenerator",                        "rocrand_destroy_generator",                                  CONV_LIB_FUNC, API_RAND, 2}},
-  {"curandGenerate",                                {"hiprandGenerate",                                "rocrand_generate",                                           CONV_LIB_FUNC, API_RAND, 2}},
-  {"curandGenerateLogNormal",                       {"hiprandGenerateLogNormal",                       "rocrand_generate_log_normal",                                CONV_LIB_FUNC, API_RAND, 2}},
-  {"curandGenerateLogNormalDouble",                 {"hiprandGenerateLogNormalDouble",                 "rocrand_generate_log_normal_double",                         CONV_LIB_FUNC, API_RAND, 2}},
-  {"curandGenerateLongLong",                        {"hiprandGenerateLongLong",                        "rocrand_generate_long_long",                                 CONV_LIB_FUNC, API_RAND, 2}},
-  {"curandGenerateNormal",                          {"hiprandGenerateNormal",                          "rocrand_generate_normal",                                    CONV_LIB_FUNC, API_RAND, 2}},
-  {"curandGenerateNormalDouble",                    {"hiprandGenerateNormalDouble",                    "rocrand_generate_normal_double",                             CONV_LIB_FUNC, API_RAND, 2}},
-  {"curandGeneratePoisson",                         {"hiprandGeneratePoisson",                         "rocrand_generate_poisson",                                   CONV_LIB_FUNC, API_RAND, 2}},
-  {"curandGenerateSeeds",                           {"hiprandGenerateSeeds",                           "rocrand_initialize_generator",                               CONV_LIB_FUNC, API_RAND, 2}},
-  {"curandGenerateUniform",                         {"hiprandGenerateUniform",                         "rocrand_generate_uniform",                                   CONV_LIB_FUNC, API_RAND, 2}},
-  {"curandGenerateUniformDouble",                   {"hiprandGenerateUniformDouble",                   "rocrand_generate_uniform_double",                            CONV_LIB_FUNC, API_RAND, 2}},
-  {"curandGetDirectionVectors32",                   {"hiprandGetDirectionVectors32",                   "rocrand_get_direction_vectors32",                            CONV_LIB_FUNC, API_RAND, 2}},
-  {"curandGetDirectionVectors64",                   {"hiprandGetDirectionVectors64",                   "rocrand_get_direction_vectors64",                            CONV_LIB_FUNC, API_RAND, 2}},
-  {"curandGetProperty",                             {"hiprandGetProperty",                             "",                                                           CONV_LIB_FUNC, API_RAND, 2, UNSUPPORTED}},
-  {"curandGetScrambleConstants32",                  {"hiprandGetScrambleConstants32",                  "rocrand_get_scramble_constants32",                           CONV_LIB_FUNC, API_RAND, 2}},
-  {"curandGetScrambleConstants64",                  {"hiprandGetScrambleConstants64",                  "rocrand_get_scramble_constants64",                           CONV_LIB_FUNC, API_RAND, 2}},
-  {"curandGetVersion",                              {"hiprandGetVersion",                              "rocrand_get_version",                                        CONV_LIB_FUNC, API_RAND, 2}},
-  {"curandSetGeneratorOffset",                      {"hiprandSetGeneratorOffset",                      "rocrand_set_offset",                                         CONV_LIB_FUNC, API_RAND, 2}},
-  {"curandSetGeneratorOrdering",                    {"hiprandSetGeneratorOrdering",                    "rocrand_set_ordering",                                       CONV_LIB_FUNC, API_RAND, 2}},
-  {"curandSetPseudoRandomGeneratorSeed",            {"hiprandSetPseudoRandomGeneratorSeed",            "rocrand_set_seed",                                           CONV_LIB_FUNC, API_RAND, 2}},
-  {"curandSetQuasiRandomGeneratorDimensions",       {"hiprandSetQuasiRandomGeneratorDimensions",       "rocrand_set_quasi_random_generator_dimensions",              CONV_LIB_FUNC, API_RAND, 2}},
-  {"curandSetStream",                               {"hiprandSetStream",                               "rocrand_set_stream",                                         CONV_LIB_FUNC, API_RAND, 2}},
-  {"curandMakeMTGP32Constants",                     {"hiprandMakeMTGP32Constants",                     "rocrand_make_constant",                                      CONV_LIB_FUNC, API_RAND, 2}},
-  {"curandMakeMTGP32KernelState",                   {"hiprandMakeMTGP32KernelState",                   "rocrand_make_state_mtgp32",                                  CONV_LIB_FUNC, API_RAND, 2}},
+  m["curandCreateGenerator"]                         = {"hiprandCreateGenerator",                         "rocrand_create_generator",                                   CONV_LIB_FUNC, API_RAND, 2};
+  m["curandCreateGeneratorHost"]                     = {"hiprandCreateGeneratorHost",                     "rocrand_create_generator_host_blocking",                     CONV_LIB_FUNC, API_RAND, 2};
+  m["curandCreatePoissonDistribution"]               = {"hiprandCreatePoissonDistribution",               "rocrand_create_poisson_distribution",                        CONV_LIB_FUNC, API_RAND, 2};
+  m["curandDestroyDistribution"]                     = {"hiprandDestroyDistribution",                     "rocrand_destroy_discrete_distribution",                      CONV_LIB_FUNC, API_RAND, 2};
+  m["curandDestroyGenerator"]                        = {"hiprandDestroyGenerator",                        "rocrand_destroy_generator",                                  CONV_LIB_FUNC, API_RAND, 2};
+  m["curandGenerate"]                                = {"hiprandGenerate",                                "rocrand_generate",                                           CONV_LIB_FUNC, API_RAND, 2};
+  m["curandGenerateLogNormal"]                       = {"hiprandGenerateLogNormal",                       "rocrand_generate_log_normal",                                CONV_LIB_FUNC, API_RAND, 2};
+  m["curandGenerateLogNormalDouble"]                 = {"hiprandGenerateLogNormalDouble",                 "rocrand_generate_log_normal_double",                         CONV_LIB_FUNC, API_RAND, 2};
+  m["curandGenerateLongLong"]                        = {"hiprandGenerateLongLong",                        "rocrand_generate_long_long",                                 CONV_LIB_FUNC, API_RAND, 2};
+  m["curandGenerateNormal"]                          = {"hiprandGenerateNormal",                          "rocrand_generate_normal",                                    CONV_LIB_FUNC, API_RAND, 2};
+  m["curandGenerateNormalDouble"]                    = {"hiprandGenerateNormalDouble",                    "rocrand_generate_normal_double",                             CONV_LIB_FUNC, API_RAND, 2};
+  m["curandGeneratePoisson"]                         = {"hiprandGeneratePoisson",                         "rocrand_generate_poisson",                                   CONV_LIB_FUNC, API_RAND, 2};
+  m["curandGenerateSeeds"]                           = {"hiprandGenerateSeeds",                           "rocrand_initialize_generator",                               CONV_LIB_FUNC, API_RAND, 2};
+  m["curandGenerateUniform"]                         = {"hiprandGenerateUniform",                         "rocrand_generate_uniform",                                   CONV_LIB_FUNC, API_RAND, 2};
+  m["curandGenerateUniformDouble"]                   = {"hiprandGenerateUniformDouble",                   "rocrand_generate_uniform_double",                            CONV_LIB_FUNC, API_RAND, 2};
+  m["curandGetDirectionVectors32"]                   = {"hiprandGetDirectionVectors32",                   "rocrand_get_direction_vectors32",                            CONV_LIB_FUNC, API_RAND, 2};
+  m["curandGetDirectionVectors64"]                   = {"hiprandGetDirectionVectors64",                   "rocrand_get_direction_vectors64",                            CONV_LIB_FUNC, API_RAND, 2};
+  m["curandGetProperty"]                             = {"hiprandGetProperty",                             "",                                                           CONV_LIB_FUNC, API_RAND, 2, UNSUPPORTED};
+  m["curandGetScrambleConstants32"]                  = {"hiprandGetScrambleConstants32",                  "rocrand_get_scramble_constants32",                           CONV_LIB_FUNC, API_RAND, 2};
+  m["curandGetScrambleConstants64"]                  = {"hiprandGetScrambleConstants64",                  "rocrand_get_scramble_constants64",                           CONV_LIB_FUNC, API_RAND, 2};
+  m["curandGetVersion"]                              = {"hiprandGetVersion",                              "rocrand_get_version",                                        CONV_LIB_FUNC, API_RAND, 2};
+  m["curandSetGeneratorOffset"]                      = {"hiprandSetGeneratorOffset",                      "rocrand_set_offset",                                         CONV_LIB_FUNC, API_RAND, 2};
+  m["curandSetGeneratorOrdering"]                    = {"hiprandSetGeneratorOrdering",                    "rocrand_set_ordering",                                       CONV_LIB_FUNC, API_RAND, 2};
+  m["curandSetPseudoRandomGeneratorSeed"]            = {"hiprandSetPseudoRandomGeneratorSeed",            "rocrand_set_seed",                                           CONV_LIB_FUNC, API_RAND, 2};
+  m["curandSetQuasiRandomGeneratorDimensions"]       = {"hiprandSetQuasiRandomGeneratorDimensions",       "rocrand_set_quasi_random_generator_dimensions",              CONV_LIB_FUNC, API_RAND, 2};
+  m["curandSetStream"]                               = {"hiprandSetStream",                               "rocrand_set_stream",                                         CONV_LIB_FUNC, API_RAND, 2};
+  m["curandMakeMTGP32Constants"]                     = {"hiprandMakeMTGP32Constants",                     "rocrand_make_constant",                                      CONV_LIB_FUNC, API_RAND, 2};
+  m["curandMakeMTGP32KernelState"]                   = {"hiprandMakeMTGP32KernelState",                   "rocrand_make_state_mtgp32",                                  CONV_LIB_FUNC, API_RAND, 2};
 
   // RAND Device functions
-  {"curand",                                        {"hiprand",                                        "rocrand",                                                    CONV_LIB_DEVICE_FUNC, API_RAND, 3}},
-  {"curand_init",                                   {"hiprand_init",                                   "rocrand_init",                                               CONV_LIB_DEVICE_FUNC, API_RAND, 3}},
-  {"curand_log_normal",                             {"hiprand_log_normal",                             "rocrand_log_normal",                                         CONV_LIB_DEVICE_FUNC, API_RAND, 3}},
-  {"curand_log_normal_double",                      {"hiprand_log_normal_double",                      "rocrand_log_normal_double",                                  CONV_LIB_DEVICE_FUNC, API_RAND, 3}},
-  {"curand_log_normal2",                            {"hiprand_log_normal2",                            "rocrand_log_normal2",                                        CONV_LIB_DEVICE_FUNC, API_RAND, 3}},
-  {"curand_log_normal2_double",                     {"hiprand_log_normal2_double",                     "rocrand_log_normal_double2",                                 CONV_LIB_DEVICE_FUNC, API_RAND, 3}},
-  {"curand_log_normal4",                            {"hiprand_log_normal4",                            "rocrand_log_normal4",                                        CONV_LIB_DEVICE_FUNC, API_RAND, 3}},
-  {"curand_log_normal4_double",                     {"hiprand_log_normal4_double",                     "rocrand_log_normal_double4",                                 CONV_LIB_DEVICE_FUNC, API_RAND, 3, CUDA_DEPRECATED}},
-  {"curand_mtgp32_single",                          {"hiprand_mtgp32_single",                          "",                                                           CONV_LIB_DEVICE_FUNC, API_RAND, 3, UNSUPPORTED}},
-  {"curand_mtgp32_single_specific",                 {"hiprand_mtgp32_single_specific",                 "",                                                           CONV_LIB_DEVICE_FUNC, API_RAND, 3, UNSUPPORTED}},
-  {"curand_mtgp32_specific",                        {"hiprand_mtgp32_specific",                        "",                                                           CONV_LIB_DEVICE_FUNC, API_RAND, 3, UNSUPPORTED}},
-  {"curand_normal",                                 {"hiprand_normal",                                 "rocrand_normal",                                             CONV_LIB_DEVICE_FUNC, API_RAND, 3}},
-  {"curand_normal_double",                          {"hiprand_normal_double",                          "rocrand_normal_double",                                      CONV_LIB_DEVICE_FUNC, API_RAND, 3}},
-  {"curand_normal2",                                {"hiprand_normal2",                                "rocrand_normal2",                                            CONV_LIB_DEVICE_FUNC, API_RAND, 3}},
-  {"curand_normal2_double",                         {"hiprand_normal2_double",                         "rocrand_normal_double2",                                     CONV_LIB_DEVICE_FUNC, API_RAND, 3}},
-  {"curand_normal4",                                {"hiprand_normal4",                                "rocrand_normal4",                                            CONV_LIB_DEVICE_FUNC, API_RAND, 3}},
-  {"curand_normal4_double",                         {"hiprand_normal4_double",                         "rocrand_normal_double4",                                     CONV_LIB_DEVICE_FUNC, API_RAND, 3}},
-  {"curand_uniform",                                {"hiprand_uniform",                                "rocrand_uniform",                                            CONV_LIB_DEVICE_FUNC, API_RAND, 3}},
-  {"curand_uniform_double",                         {"hiprand_uniform_double",                         "rocrand_uniform_double",                                     CONV_LIB_DEVICE_FUNC, API_RAND, 3}},
-  {"curand_uniform2_double",                        {"hiprand_uniform2_double",                        "rocrand_uniform_double2",                                    CONV_LIB_DEVICE_FUNC, API_RAND, 3}},
-  {"curand_uniform4",                               {"hiprand_uniform4",                               "rocrand_uniform4",                                           CONV_LIB_DEVICE_FUNC, API_RAND, 3}},
-  {"curand_uniform4_double",                        {"hiprand_uniform4_double",                        "rocrand_uniform_double4",                                    CONV_LIB_DEVICE_FUNC, API_RAND, 3, CUDA_DEPRECATED}},
-  {"curand_discrete",                               {"hiprand_discrete",                               "rocrand_discrete",                                           CONV_LIB_DEVICE_FUNC, API_RAND, 3}},
-  {"curand_discrete4",                              {"hiprand_discrete4",                              "rocrand_discrete4",                                          CONV_LIB_DEVICE_FUNC, API_RAND, 3}},
-  {"curand_poisson",                                {"hiprand_poisson",                                "rocrand_poisson",                                            CONV_LIB_DEVICE_FUNC, API_RAND, 3}},
-  {"curand_poisson4",                               {"hiprand_poisson4",                               "rocrand_poisson4",                                           CONV_LIB_DEVICE_FUNC, API_RAND, 3}},
-  {"curand_Philox4x32_10",                          {"hiprand_Philox4x32_10",                          "",                                                           CONV_LIB_DEVICE_FUNC, API_RAND, 3, UNSUPPORTED}},
-  {"__curand_umul",                                 {"__hiprand_umul",                                 "",                                                           CONV_LIB_DEVICE_FUNC, API_RAND, 3, UNSUPPORTED}},
+  m["curand"]                                        = {"hiprand",                                        "rocrand",                                                    CONV_LIB_DEVICE_FUNC, API_RAND, 3};
+  m["curand_init"]                                   = {"hiprand_init",                                   "rocrand_init",                                               CONV_LIB_DEVICE_FUNC, API_RAND, 3};
+  m["curand_log_normal"]                             = {"hiprand_log_normal",                             "rocrand_log_normal",                                         CONV_LIB_DEVICE_FUNC, API_RAND, 3};
+  m["curand_log_normal_double"]                      = {"hiprand_log_normal_double",                      "rocrand_log_normal_double",                                  CONV_LIB_DEVICE_FUNC, API_RAND, 3};
+  m["curand_log_normal2"]                            = {"hiprand_log_normal2",                            "rocrand_log_normal2",                                        CONV_LIB_DEVICE_FUNC, API_RAND, 3};
+  m["curand_log_normal2_double"]                     = {"hiprand_log_normal2_double",                     "rocrand_log_normal_double2",                                 CONV_LIB_DEVICE_FUNC, API_RAND, 3};
+  m["curand_log_normal4"]                            = {"hiprand_log_normal4",                            "rocrand_log_normal4",                                        CONV_LIB_DEVICE_FUNC, API_RAND, 3};
+  m["curand_log_normal4_double"]                     = {"hiprand_log_normal4_double",                     "rocrand_log_normal_double4",                                 CONV_LIB_DEVICE_FUNC, API_RAND, 3, CUDA_DEPRECATED};
+  m["curand_mtgp32_single"]                          = {"hiprand_mtgp32_single",                          "",                                                           CONV_LIB_DEVICE_FUNC, API_RAND, 3, UNSUPPORTED};
+  m["curand_mtgp32_single_specific"]                 = {"hiprand_mtgp32_single_specific",                 "",                                                           CONV_LIB_DEVICE_FUNC, API_RAND, 3, UNSUPPORTED};
+  m["curand_mtgp32_specific"]                        = {"hiprand_mtgp32_specific",                        "",                                                           CONV_LIB_DEVICE_FUNC, API_RAND, 3, UNSUPPORTED};
+  m["curand_normal"]                                 = {"hiprand_normal",                                 "rocrand_normal",                                             CONV_LIB_DEVICE_FUNC, API_RAND, 3};
+  m["curand_normal_double"]                          = {"hiprand_normal_double",                          "rocrand_normal_double",                                      CONV_LIB_DEVICE_FUNC, API_RAND, 3};
+  m["curand_normal2"]                                = {"hiprand_normal2",                                "rocrand_normal2",                                            CONV_LIB_DEVICE_FUNC, API_RAND, 3};
+  m["curand_normal2_double"]                         = {"hiprand_normal2_double",                         "rocrand_normal_double2",                                     CONV_LIB_DEVICE_FUNC, API_RAND, 3};
+  m["curand_normal4"]                                = {"hiprand_normal4",                                "rocrand_normal4",                                            CONV_LIB_DEVICE_FUNC, API_RAND, 3};
+  m["curand_normal4_double"]                         = {"hiprand_normal4_double",                         "rocrand_normal_double4",                                     CONV_LIB_DEVICE_FUNC, API_RAND, 3};
+  m["curand_uniform"]                                = {"hiprand_uniform",                                "rocrand_uniform",                                            CONV_LIB_DEVICE_FUNC, API_RAND, 3};
+  m["curand_uniform_double"]                         = {"hiprand_uniform_double",                         "rocrand_uniform_double",                                     CONV_LIB_DEVICE_FUNC, API_RAND, 3};
+  m["curand_uniform2_double"]                        = {"hiprand_uniform2_double",                        "rocrand_uniform_double2",                                    CONV_LIB_DEVICE_FUNC, API_RAND, 3};
+  m["curand_uniform4"]                               = {"hiprand_uniform4",                               "rocrand_uniform4",                                           CONV_LIB_DEVICE_FUNC, API_RAND, 3};
+  m["curand_uniform4_double"]                        = {"hiprand_uniform4_double",                        "rocrand_uniform_double4",                                    CONV_LIB_DEVICE_FUNC, API_RAND, 3, CUDA_DEPRECATED};
+  m["curand_discrete"]                               = {"hiprand_discrete",                               "rocrand_discrete",                                           CONV_LIB_DEVICE_FUNC, API_RAND, 3};
+  m["curand_discrete4"]                              = {"hiprand_discrete4",                              "rocrand_discrete4",                                          CONV_LIB_DEVICE_FUNC, API_RAND, 3};
+  m["curand_poisson"]                                = {"hiprand_poisson",                                "rocrand_poisson",                                            CONV_LIB_DEVICE_FUNC, API_RAND, 3};
+  m["curand_poisson4"]                               = {"hiprand_poisson4",                               "rocrand_poisson4",                                           CONV_LIB_DEVICE_FUNC, API_RAND, 3};
+  m["curand_Philox4x32_10"]                          = {"hiprand_Philox4x32_10",                          "",                                                           CONV_LIB_DEVICE_FUNC, API_RAND, 3, UNSUPPORTED};
+  m["__curand_umul"]                                 = {"__hiprand_umul",                                 "",                                                           CONV_LIB_DEVICE_FUNC, API_RAND, 3, UNSUPPORTED};
   // unchanged function names: skipahead, skipahead_sequence, skipahead_subsequence
-};
 
-const std::map<llvm::StringRef, cudaAPIversions> CUDA_RAND_FUNCTION_VER_MAP {
-  {"curandGetProperty",                             {CUDA_80,  CUDA_0,   CUDA_0   }},
-  {"__curand_umul",                                 {CUDA_115, CUDA_0,   CUDA_0   }},
-  {"curand_log_normal4_double",                     {CUDA_0,   CUDA_130, CUDA_0   }},
-  {"curand_uniform4_double",                        {CUDA_0,   CUDA_130, CUDA_0   }},
-};
+  return m;
+}();
 
-const std::map<llvm::StringRef, hipAPIversions> HIP_RAND_FUNCTION_VER_MAP {
-  {"hiprandCreateGenerator",                        {HIP_1050, HIP_0,    HIP_0    }},
-  {"hiprandCreateGeneratorHost",                    {HIP_1050, HIP_0,    HIP_0    }},
-  {"hiprandCreatePoissonDistribution",              {HIP_1050, HIP_0,    HIP_0    }},
-  {"hiprandDestroyDistribution",                    {HIP_1050, HIP_0,    HIP_0    }},
-  {"hiprandDestroyGenerator",                       {HIP_1050, HIP_0,    HIP_0    }},
-  {"hiprandGenerate",                               {HIP_1050, HIP_0,    HIP_0    }},
-  {"hiprandGenerateLogNormal",                      {HIP_1050, HIP_0,    HIP_0    }},
-  {"hiprandGenerateLogNormalDouble",                {HIP_1050, HIP_0,    HIP_0    }},
-  {"hiprandGenerateNormal",                         {HIP_1050, HIP_0,    HIP_0    }},
-  {"hiprandGenerateNormalDouble",                   {HIP_1050, HIP_0,    HIP_0    }},
-  {"hiprandGeneratePoisson",                        {HIP_1050, HIP_0,    HIP_0    }},
-  {"hiprandGenerateSeeds",                          {HIP_1050, HIP_0,    HIP_0    }},
-  {"hiprandGenerateUniform",                        {HIP_1050, HIP_0,    HIP_0    }},
-  {"hiprandGenerateUniformDouble",                  {HIP_1050, HIP_0,    HIP_0    }},
-  {"hiprandGetVersion",                             {HIP_1050, HIP_0,    HIP_0    }},
-  {"hiprandSetGeneratorOffset",                     {HIP_1050, HIP_0,    HIP_0    }},
-  {"hiprandSetPseudoRandomGeneratorSeed",           {HIP_1050, HIP_0,    HIP_0    }},
-  {"hiprandSetQuasiRandomGeneratorDimensions",      {HIP_1050, HIP_0,    HIP_0    }},
-  {"hiprandSetStream",                              {HIP_1050, HIP_0,    HIP_0    }},
-  {"hiprandMakeMTGP32Constants",                    {HIP_1050, HIP_0,    HIP_0    }},
-  {"hiprandMakeMTGP32KernelState",                  {HIP_1050, HIP_0,    HIP_0    }},
-  {"hiprand",                                       {HIP_1050, HIP_0,    HIP_0    }},
-  {"hiprand_init",                                  {HIP_1050, HIP_0,    HIP_0    }},
-  {"hiprand_log_normal",                            {HIP_1050, HIP_0,    HIP_0    }},
-  {"hiprand_log_normal_double",                     {HIP_1050, HIP_0,    HIP_0    }},
-  {"hiprand_log_normal2",                           {HIP_1050, HIP_0,    HIP_0    }},
-  {"hiprand_log_normal2_double",                    {HIP_1050, HIP_0,    HIP_0    }},
-  {"hiprand_log_normal4",                           {HIP_1050, HIP_0,    HIP_0    }},
-  {"hiprand_log_normal4_double",                    {HIP_1050, HIP_0,    HIP_0    }},
-  {"hiprand_normal",                                {HIP_1050, HIP_0,    HIP_0    }},
-  {"hiprand_normal_double",                         {HIP_1050, HIP_0,    HIP_0    }},
-  {"hiprand_normal2",                               {HIP_1050, HIP_0,    HIP_0    }},
-  {"hiprand_normal2_double",                        {HIP_1050, HIP_0,    HIP_0    }},
-  {"hiprand_normal4",                               {HIP_1050, HIP_0,    HIP_0    }},
-  {"hiprand_normal4_double",                        {HIP_1050, HIP_0,    HIP_0    }},
-  {"hiprand_uniform",                               {HIP_1050, HIP_0,    HIP_0    }},
-  {"hiprand_uniform_double",                        {HIP_1050, HIP_0,    HIP_0    }},
-  {"hiprand_uniform2_double",                       {HIP_1050, HIP_0,    HIP_0    }},
-  {"hiprand_uniform4",                              {HIP_1050, HIP_0,    HIP_0    }},
-  {"hiprand_uniform4_double",                       {HIP_1050, HIP_0,    HIP_0    }},
-  {"hiprand_discrete",                              {HIP_1050, HIP_0,    HIP_0    }},
-  {"hiprand_discrete4",                             {HIP_1050, HIP_0,    HIP_0    }},
-  {"hiprand_poisson",                               {HIP_1050, HIP_0,    HIP_0    }},
-  {"hiprand_poisson4",                              {HIP_1050, HIP_0,    HIP_0    }},
-  {"hiprandGetDirectionVectors32",                  {HIP_6000, HIP_0,    HIP_0    }},
-  {"hiprandGetDirectionVectors64",                  {HIP_6000, HIP_0,    HIP_0    }},
-  {"hiprandGetScrambleConstants32",                 {HIP_6000, HIP_0,    HIP_0    }},
-  {"hiprandGetScrambleConstants64",                 {HIP_6000, HIP_0,    HIP_0    }},
-  {"hiprandSetGeneratorOrdering",                   {HIP_6020, HIP_0,    HIP_0    }},
-  {"hiprandGenerateLongLong",                       {HIP_5050, HIP_0,    HIP_0    }},
+const std::map<llvm::StringRef, cudaAPIversions> CUDA_RAND_FUNCTION_VER_MAP = []() {
+  std::map<llvm::StringRef, cudaAPIversions> m;
 
-  {"rocrand_create_generator",                      {HIP_1050, HIP_0,    HIP_0    }},
-  {"rocrand_create_generator_host_blocking",        {HIP_6020, HIP_0,    HIP_0    }},
-  {"rocrand_destroy_generator",                     {HIP_1050, HIP_0,    HIP_0    }},
-  {"rocrand_generate",                              {HIP_1050, HIP_0,    HIP_0    }},
-  {"rocrand_generate_long_long",                    {HIP_5040, HIP_0,    HIP_0    }},
-  {"rocrand_generate_uniform",                      {HIP_1050, HIP_0,    HIP_0    }},
-  {"rocrand_generate_uniform_double",               {HIP_1050, HIP_0,    HIP_0    }},
-  {"rocrand_generate_normal",                       {HIP_1050, HIP_0,    HIP_0    }},
-  {"rocrand_generate_normal_double",                {HIP_1050, HIP_0,    HIP_0    }},
-  {"rocrand_generate_log_normal",                   {HIP_1050, HIP_0,    HIP_0    }},
-  {"rocrand_generate_log_normal_double",            {HIP_1050, HIP_0,    HIP_0    }},
-  {"rocrand_generate_poisson",                      {HIP_1050, HIP_0,    HIP_0    }},
-  {"rocrand_initialize_generator",                  {HIP_1050, HIP_0,    HIP_0    }},
-  {"rocrand_set_stream",                            {HIP_1050, HIP_0,    HIP_0    }},
-  {"rocrand_set_seed",                              {HIP_1050, HIP_0,    HIP_0    }},
-  {"rocrand_set_offset",                            {HIP_1050, HIP_0,    HIP_0    }},
-  {"rocrand_set_ordering",                          {HIP_5050, HIP_0,    HIP_0    }},
-  {"rocrand_set_quasi_random_generator_dimensions", {HIP_1050, HIP_0,    HIP_0    }},
-  {"rocrand_get_version",                           {HIP_1050, HIP_0,    HIP_0    }},
-  {"rocrand_create_poisson_distribution",           {HIP_1050, HIP_0,    HIP_0    }},
-  {"rocrand_get_direction_vectors32",               {HIP_6000, HIP_0,    HIP_0    }},
-  {"rocrand_get_direction_vectors64",               {HIP_6000, HIP_0,    HIP_0    }},
-  {"rocrand_get_scramble_constants32",              {HIP_6000, HIP_0,    HIP_0    }},
-  {"rocrand_get_scramble_constants64",              {HIP_6000, HIP_0,    HIP_0    }},
-  {"rocrand_destroy_discrete_distribution",         {HIP_1050, HIP_0,    HIP_0    }},
-  {"rocrand_make_constant",                         {HIP_1050, HIP_0,    HIP_0    }},
-  {"rocrand_make_state_mtgp32",                     {HIP_1050, HIP_0,    HIP_0    }},
-  {"rocrand",                                       {HIP_1050, HIP_0,    HIP_0    }},
-  {"rocrand_init",                                  {HIP_1050, HIP_0,    HIP_0    }},
-  {"rocrand_log_normal",                            {HIP_1050, HIP_0,    HIP_0    }},
-  {"rocrand_log_normal_double",                     {HIP_1050, HIP_0,    HIP_0    }},
-  {"rocrand_log_normal2",                           {HIP_1050, HIP_0,    HIP_0    }},
-  {"rocrand_log_normal_double2",                    {HIP_1050, HIP_0,    HIP_0    }},
-  {"rocrand_log_normal4",                           {HIP_1050, HIP_0,    HIP_0    }},
-  {"rocrand_log_normal_double4",                    {HIP_1050, HIP_0,    HIP_0    }},
-  {"rocrand_normal",                                {HIP_1050, HIP_0,    HIP_0    }},
-  {"rocrand_normal_double",                         {HIP_1050, HIP_0,    HIP_0    }},
-  {"rocrand_normal2",                               {HIP_1050, HIP_0,    HIP_0    }},
-  {"rocrand_normal_double2",                        {HIP_1050, HIP_0,    HIP_0    }},
-  {"rocrand_normal4",                               {HIP_1050, HIP_0,    HIP_0    }},
-  {"rocrand_normal_double4",                        {HIP_1050, HIP_0,    HIP_0    }},
-  {"rocrand_uniform",                               {HIP_1050, HIP_0,    HIP_0    }},
-  {"rocrand_uniform_double",                        {HIP_1050, HIP_0,    HIP_0    }},
-  {"rocrand_uniform_double2",                       {HIP_1050, HIP_0,    HIP_0    }},
-  {"rocrand_uniform4",                              {HIP_1050, HIP_0,    HIP_0    }},
-  {"rocrand_uniform_double4",                       {HIP_1050, HIP_0,    HIP_0    }},
-  {"rocrand_discrete",                              {HIP_1050, HIP_0,    HIP_0    }},
-  {"rocrand_discrete4",                             {HIP_1050, HIP_0,    HIP_0    }},
-  {"rocrand_poisson",                               {HIP_1050, HIP_0,    HIP_0    }},
-  {"rocrand_poisson4",                              {HIP_1050, HIP_0,    HIP_0    }},
-};
+  m["curandGetProperty"]                             = {CUDA_80,  CUDA_0,   CUDA_0   };
+  m["__curand_umul"]                                 = {CUDA_115, CUDA_0,   CUDA_0   };
+  m["curand_log_normal4_double"]                     = {CUDA_0,   CUDA_130, CUDA_0   };
+  m["curand_uniform4_double"]                        = {CUDA_0,   CUDA_130, CUDA_0   };
 
-const std::map<unsigned int, llvm::StringRef> CUDA_RAND_API_SECTION_MAP {
-  {1, "CURAND Data types"},
-  {2, "Host API Functions"},
-  {3, "Device API Functions"},
-};
+  return m;
+}();
+
+const std::map<llvm::StringRef, hipAPIversions> HIP_RAND_FUNCTION_VER_MAP = []() {
+  std::map<llvm::StringRef, hipAPIversions> m;
+
+  m["hiprandCreateGenerator"]                        = {HIP_1050, HIP_0,    HIP_0    };
+  m["hiprandCreateGeneratorHost"]                    = {HIP_1050, HIP_0,    HIP_0    };
+  m["hiprandCreatePoissonDistribution"]              = {HIP_1050, HIP_0,    HIP_0    };
+  m["hiprandDestroyDistribution"]                    = {HIP_1050, HIP_0,    HIP_0    };
+  m["hiprandDestroyGenerator"]                       = {HIP_1050, HIP_0,    HIP_0    };
+  m["hiprandGenerate"]                               = {HIP_1050, HIP_0,    HIP_0    };
+  m["hiprandGenerateLogNormal"]                      = {HIP_1050, HIP_0,    HIP_0    };
+  m["hiprandGenerateLogNormalDouble"]                = {HIP_1050, HIP_0,    HIP_0    };
+  m["hiprandGenerateNormal"]                         = {HIP_1050, HIP_0,    HIP_0    };
+  m["hiprandGenerateNormalDouble"]                   = {HIP_1050, HIP_0,    HIP_0    };
+  m["hiprandGeneratePoisson"]                        = {HIP_1050, HIP_0,    HIP_0    };
+  m["hiprandGenerateSeeds"]                          = {HIP_1050, HIP_0,    HIP_0    };
+  m["hiprandGenerateUniform"]                        = {HIP_1050, HIP_0,    HIP_0    };
+  m["hiprandGenerateUniformDouble"]                  = {HIP_1050, HIP_0,    HIP_0    };
+  m["hiprandGetVersion"]                             = {HIP_1050, HIP_0,    HIP_0    };
+  m["hiprandSetGeneratorOffset"]                     = {HIP_1050, HIP_0,    HIP_0    };
+  m["hiprandSetPseudoRandomGeneratorSeed"]           = {HIP_1050, HIP_0,    HIP_0    };
+  m["hiprandSetQuasiRandomGeneratorDimensions"]      = {HIP_1050, HIP_0,    HIP_0    };
+  m["hiprandSetStream"]                              = {HIP_1050, HIP_0,    HIP_0    };
+  m["hiprandMakeMTGP32Constants"]                    = {HIP_1050, HIP_0,    HIP_0    };
+  m["hiprandMakeMTGP32KernelState"]                  = {HIP_1050, HIP_0,    HIP_0    };
+  m["hiprand"]                                       = {HIP_1050, HIP_0,    HIP_0    };
+  m["hiprand_init"]                                  = {HIP_1050, HIP_0,    HIP_0    };
+  m["hiprand_log_normal"]                            = {HIP_1050, HIP_0,    HIP_0    };
+  m["hiprand_log_normal_double"]                     = {HIP_1050, HIP_0,    HIP_0    };
+  m["hiprand_log_normal2"]                           = {HIP_1050, HIP_0,    HIP_0    };
+  m["hiprand_log_normal2_double"]                    = {HIP_1050, HIP_0,    HIP_0    };
+  m["hiprand_log_normal4"]                           = {HIP_1050, HIP_0,    HIP_0    };
+  m["hiprand_log_normal4_double"]                    = {HIP_1050, HIP_0,    HIP_0    };
+  m["hiprand_normal"]                                = {HIP_1050, HIP_0,    HIP_0    };
+  m["hiprand_normal_double"]                         = {HIP_1050, HIP_0,    HIP_0    };
+  m["hiprand_normal2"]                               = {HIP_1050, HIP_0,    HIP_0    };
+  m["hiprand_normal2_double"]                        = {HIP_1050, HIP_0,    HIP_0    };
+  m["hiprand_normal4"]                               = {HIP_1050, HIP_0,    HIP_0    };
+  m["hiprand_normal4_double"]                        = {HIP_1050, HIP_0,    HIP_0    };
+  m["hiprand_uniform"]                               = {HIP_1050, HIP_0,    HIP_0    };
+  m["hiprand_uniform_double"]                        = {HIP_1050, HIP_0,    HIP_0    };
+  m["hiprand_uniform2_double"]                       = {HIP_1050, HIP_0,    HIP_0    };
+  m["hiprand_uniform4"]                              = {HIP_1050, HIP_0,    HIP_0    };
+  m["hiprand_uniform4_double"]                       = {HIP_1050, HIP_0,    HIP_0    };
+  m["hiprand_discrete"]                              = {HIP_1050, HIP_0,    HIP_0    };
+  m["hiprand_discrete4"]                             = {HIP_1050, HIP_0,    HIP_0    };
+  m["hiprand_poisson"]                               = {HIP_1050, HIP_0,    HIP_0    };
+  m["hiprand_poisson4"]                              = {HIP_1050, HIP_0,    HIP_0    };
+  m["hiprandGetDirectionVectors32"]                  = {HIP_6000, HIP_0,    HIP_0    };
+  m["hiprandGetDirectionVectors64"]                  = {HIP_6000, HIP_0,    HIP_0    };
+  m["hiprandGetScrambleConstants32"]                 = {HIP_6000, HIP_0,    HIP_0    };
+  m["hiprandGetScrambleConstants64"]                 = {HIP_6000, HIP_0,    HIP_0    };
+  m["hiprandSetGeneratorOrdering"]                   = {HIP_6020, HIP_0,    HIP_0    };
+  m["hiprandGenerateLongLong"]                       = {HIP_5050, HIP_0,    HIP_0    };
+
+  m["rocrand_create_generator"]                      = {HIP_1050, HIP_0,    HIP_0    };
+  m["rocrand_create_generator_host_blocking"]        = {HIP_6020, HIP_0,    HIP_0    };
+  m["rocrand_destroy_generator"]                     = {HIP_1050, HIP_0,    HIP_0    };
+  m["rocrand_generate"]                              = {HIP_1050, HIP_0,    HIP_0    };
+  m["rocrand_generate_long_long"]                    = {HIP_5040, HIP_0,    HIP_0    };
+  m["rocrand_generate_uniform"]                      = {HIP_1050, HIP_0,    HIP_0    };
+  m["rocrand_generate_uniform_double"]               = {HIP_1050, HIP_0,    HIP_0    };
+  m["rocrand_generate_normal"]                       = {HIP_1050, HIP_0,    HIP_0    };
+  m["rocrand_generate_normal_double"]                = {HIP_1050, HIP_0,    HIP_0    };
+  m["rocrand_generate_log_normal"]                   = {HIP_1050, HIP_0,    HIP_0    };
+  m["rocrand_generate_log_normal_double"]            = {HIP_1050, HIP_0,    HIP_0    };
+  m["rocrand_generate_poisson"]                      = {HIP_1050, HIP_0,    HIP_0    };
+  m["rocrand_initialize_generator"]                  = {HIP_1050, HIP_0,    HIP_0    };
+  m["rocrand_set_stream"]                            = {HIP_1050, HIP_0,    HIP_0    };
+  m["rocrand_set_seed"]                              = {HIP_1050, HIP_0,    HIP_0    };
+  m["rocrand_set_offset"]                            = {HIP_1050, HIP_0,    HIP_0    };
+  m["rocrand_set_ordering"]                          = {HIP_5050, HIP_0,    HIP_0    };
+  m["rocrand_set_quasi_random_generator_dimensions"] = {HIP_1050, HIP_0,    HIP_0    };
+  m["rocrand_get_version"]                           = {HIP_1050, HIP_0,    HIP_0    };
+  m["rocrand_create_poisson_distribution"]           = {HIP_1050, HIP_0,    HIP_0    };
+  m["rocrand_get_direction_vectors32"]               = {HIP_6000, HIP_0,    HIP_0    };
+  m["rocrand_get_direction_vectors64"]               = {HIP_6000, HIP_0,    HIP_0    };
+  m["rocrand_get_scramble_constants32"]              = {HIP_6000, HIP_0,    HIP_0    };
+  m["rocrand_get_scramble_constants64"]              = {HIP_6000, HIP_0,    HIP_0    };
+  m["rocrand_destroy_discrete_distribution"]         = {HIP_1050, HIP_0,    HIP_0    };
+  m["rocrand_make_constant"]                         = {HIP_1050, HIP_0,    HIP_0    };
+  m["rocrand_make_state_mtgp32"]                     = {HIP_1050, HIP_0,    HIP_0    };
+  m["rocrand"]                                       = {HIP_1050, HIP_0,    HIP_0    };
+  m["rocrand_init"]                                  = {HIP_1050, HIP_0,    HIP_0    };
+  m["rocrand_log_normal"]                            = {HIP_1050, HIP_0,    HIP_0    };
+  m["rocrand_log_normal_double"]                     = {HIP_1050, HIP_0,    HIP_0    };
+  m["rocrand_log_normal2"]                           = {HIP_1050, HIP_0,    HIP_0    };
+  m["rocrand_log_normal_double2"]                    = {HIP_1050, HIP_0,    HIP_0    };
+  m["rocrand_log_normal4"]                           = {HIP_1050, HIP_0,    HIP_0    };
+  m["rocrand_log_normal_double4"]                    = {HIP_1050, HIP_0,    HIP_0    };
+  m["rocrand_normal"]                                = {HIP_1050, HIP_0,    HIP_0    };
+  m["rocrand_normal_double"]                         = {HIP_1050, HIP_0,    HIP_0    };
+  m["rocrand_normal2"]                               = {HIP_1050, HIP_0,    HIP_0    };
+  m["rocrand_normal_double2"]                        = {HIP_1050, HIP_0,    HIP_0    };
+  m["rocrand_normal4"]                               = {HIP_1050, HIP_0,    HIP_0    };
+  m["rocrand_normal_double4"]                        = {HIP_1050, HIP_0,    HIP_0    };
+  m["rocrand_uniform"]                               = {HIP_1050, HIP_0,    HIP_0    };
+  m["rocrand_uniform_double"]                        = {HIP_1050, HIP_0,    HIP_0    };
+  m["rocrand_uniform_double2"]                       = {HIP_1050, HIP_0,    HIP_0    };
+  m["rocrand_uniform4"]                              = {HIP_1050, HIP_0,    HIP_0    };
+  m["rocrand_uniform_double4"]                       = {HIP_1050, HIP_0,    HIP_0    };
+  m["rocrand_discrete"]                              = {HIP_1050, HIP_0,    HIP_0    };
+  m["rocrand_discrete4"]                             = {HIP_1050, HIP_0,    HIP_0    };
+  m["rocrand_poisson"]                               = {HIP_1050, HIP_0,    HIP_0    };
+  m["rocrand_poisson4"]                              = {HIP_1050, HIP_0,    HIP_0    };
+
+  return m;
+}();
+
+const std::map<unsigned int, llvm::StringRef> CUDA_RAND_API_SECTION_MAP = []() {
+  std::map<unsigned int, llvm::StringRef> m;
+
+  m[1]                                               = "CURAND Data types";
+  m[2]                                               = "Host API Functions";
+  m[3]                                               = "Device API Functions";
+
+  return m;
+}();

--- a/src/CUDA2HIP_RAND_API_types.cpp
+++ b/src/CUDA2HIP_RAND_API_types.cpp
@@ -23,246 +23,258 @@ THE SOFTWARE.
 #include "CUDA2HIP.h"
 
 // Map of all functions
-const std::map<llvm::StringRef, hipCounter> CUDA_RAND_TYPE_NAME_MAP {
+const std::map<llvm::StringRef, hipCounter> CUDA_RAND_TYPE_NAME_MAP = []() {
+  std::map<llvm::StringRef, hipCounter> m;
+
   // RAND Host types
-  {"curandStatus",                                     {"hiprandStatus",                                  "rocrand_status",                                                 CONV_TYPE, API_RAND, 1}},
-  {"curandStatus_t",                                   {"hiprandStatus_t",                                "rocrand_status",                                                 CONV_TYPE, API_RAND, 1}},
+  m["curandStatus"]                                    = {"hiprandStatus",                                  "rocrand_status",                                                 CONV_TYPE, API_RAND, 1};
+  m["curandStatus_t"]                                  = {"hiprandStatus_t",                                "rocrand_status",                                                 CONV_TYPE, API_RAND, 1};
   // RAND function call status types (enum curandStatus)
-  {"CURAND_STATUS_SUCCESS",                            {"HIPRAND_STATUS_SUCCESS",                         "ROCRAND_STATUS_SUCCESS",                                         CONV_NUMERIC_LITERAL, API_RAND, 1}},
-  {"CURAND_STATUS_VERSION_MISMATCH",                   {"HIPRAND_STATUS_VERSION_MISMATCH",                "ROCRAND_STATUS_VERSION_MISMATCH",                                CONV_NUMERIC_LITERAL, API_RAND, 1}},
-  {"CURAND_STATUS_NOT_INITIALIZED",                    {"HIPRAND_STATUS_NOT_INITIALIZED",                 "ROCRAND_STATUS_NOT_CREATED",                                     CONV_NUMERIC_LITERAL, API_RAND, 1}},
-  {"CURAND_STATUS_ALLOCATION_FAILED",                  {"HIPRAND_STATUS_ALLOCATION_FAILED",               "ROCRAND_STATUS_ALLOCATION_FAILED",                               CONV_NUMERIC_LITERAL, API_RAND, 1}},
-  {"CURAND_STATUS_TYPE_ERROR",                         {"HIPRAND_STATUS_TYPE_ERROR",                      "ROCRAND_STATUS_TYPE_ERROR",                                      CONV_NUMERIC_LITERAL, API_RAND, 1}},
-  {"CURAND_STATUS_OUT_OF_RANGE",                       {"HIPRAND_STATUS_OUT_OF_RANGE",                    "ROCRAND_STATUS_OUT_OF_RANGE",                                    CONV_NUMERIC_LITERAL, API_RAND, 1}},
-  {"CURAND_STATUS_LENGTH_NOT_MULTIPLE",                {"HIPRAND_STATUS_LENGTH_NOT_MULTIPLE",             "ROCRAND_STATUS_LENGTH_NOT_MULTIPLE",                             CONV_NUMERIC_LITERAL, API_RAND, 1}},
-  {"CURAND_STATUS_DOUBLE_PRECISION_REQUIRED",          {"HIPRAND_STATUS_DOUBLE_PRECISION_REQUIRED",       "ROCRAND_STATUS_DOUBLE_PRECISION_REQUIRED",                       CONV_NUMERIC_LITERAL, API_RAND, 1}},
-  {"CURAND_STATUS_LAUNCH_FAILURE",                     {"HIPRAND_STATUS_LAUNCH_FAILURE",                  "ROCRAND_STATUS_LAUNCH_FAILURE",                                  CONV_NUMERIC_LITERAL, API_RAND, 1}},
-  {"CURAND_STATUS_PREEXISTING_FAILURE",                {"HIPRAND_STATUS_PREEXISTING_FAILURE",             "",                                                               CONV_NUMERIC_LITERAL, API_RAND, 1, ROC_UNSUPPORTED}},
-  {"CURAND_STATUS_INITIALIZATION_FAILED",              {"HIPRAND_STATUS_INITIALIZATION_FAILED",           "",                                                               CONV_NUMERIC_LITERAL, API_RAND, 1, ROC_UNSUPPORTED}},
-  {"CURAND_STATUS_ARCH_MISMATCH",                      {"HIPRAND_STATUS_ARCH_MISMATCH",                   "",                                                               CONV_NUMERIC_LITERAL, API_RAND, 1, ROC_UNSUPPORTED}},
-  {"CURAND_STATUS_INTERNAL_ERROR",                     {"HIPRAND_STATUS_INTERNAL_ERROR",                  "ROCRAND_STATUS_INTERNAL_ERROR",                                  CONV_NUMERIC_LITERAL, API_RAND, 1}},
+  m["CURAND_STATUS_SUCCESS"]                           = {"HIPRAND_STATUS_SUCCESS",                         "ROCRAND_STATUS_SUCCESS",                                         CONV_NUMERIC_LITERAL, API_RAND, 1};
+  m["CURAND_STATUS_VERSION_MISMATCH"]                  = {"HIPRAND_STATUS_VERSION_MISMATCH",                "ROCRAND_STATUS_VERSION_MISMATCH",                                CONV_NUMERIC_LITERAL, API_RAND, 1};
+  m["CURAND_STATUS_NOT_INITIALIZED"]                   = {"HIPRAND_STATUS_NOT_INITIALIZED",                 "ROCRAND_STATUS_NOT_CREATED",                                     CONV_NUMERIC_LITERAL, API_RAND, 1};
+  m["CURAND_STATUS_ALLOCATION_FAILED"]                 = {"HIPRAND_STATUS_ALLOCATION_FAILED",               "ROCRAND_STATUS_ALLOCATION_FAILED",                               CONV_NUMERIC_LITERAL, API_RAND, 1};
+  m["CURAND_STATUS_TYPE_ERROR"]                        = {"HIPRAND_STATUS_TYPE_ERROR",                      "ROCRAND_STATUS_TYPE_ERROR",                                      CONV_NUMERIC_LITERAL, API_RAND, 1};
+  m["CURAND_STATUS_OUT_OF_RANGE"]                      = {"HIPRAND_STATUS_OUT_OF_RANGE",                    "ROCRAND_STATUS_OUT_OF_RANGE",                                    CONV_NUMERIC_LITERAL, API_RAND, 1};
+  m["CURAND_STATUS_LENGTH_NOT_MULTIPLE"]               = {"HIPRAND_STATUS_LENGTH_NOT_MULTIPLE",             "ROCRAND_STATUS_LENGTH_NOT_MULTIPLE",                             CONV_NUMERIC_LITERAL, API_RAND, 1};
+  m["CURAND_STATUS_DOUBLE_PRECISION_REQUIRED"]         = {"HIPRAND_STATUS_DOUBLE_PRECISION_REQUIRED",       "ROCRAND_STATUS_DOUBLE_PRECISION_REQUIRED",                       CONV_NUMERIC_LITERAL, API_RAND, 1};
+  m["CURAND_STATUS_LAUNCH_FAILURE"]                    = {"HIPRAND_STATUS_LAUNCH_FAILURE",                  "ROCRAND_STATUS_LAUNCH_FAILURE",                                  CONV_NUMERIC_LITERAL, API_RAND, 1};
+  m["CURAND_STATUS_PREEXISTING_FAILURE"]               = {"HIPRAND_STATUS_PREEXISTING_FAILURE",             "",                                                               CONV_NUMERIC_LITERAL, API_RAND, 1, ROC_UNSUPPORTED};
+  m["CURAND_STATUS_INITIALIZATION_FAILED"]             = {"HIPRAND_STATUS_INITIALIZATION_FAILED",           "",                                                               CONV_NUMERIC_LITERAL, API_RAND, 1, ROC_UNSUPPORTED};
+  m["CURAND_STATUS_ARCH_MISMATCH"]                     = {"HIPRAND_STATUS_ARCH_MISMATCH",                   "",                                                               CONV_NUMERIC_LITERAL, API_RAND, 1, ROC_UNSUPPORTED};
+  m["CURAND_STATUS_INTERNAL_ERROR"]                    = {"HIPRAND_STATUS_INTERNAL_ERROR",                  "ROCRAND_STATUS_INTERNAL_ERROR",                                  CONV_NUMERIC_LITERAL, API_RAND, 1};
 
-  {"curandRngType",                                    {"hiprandRngType_t",                               "rocrand_rng_type",                                               CONV_TYPE, API_RAND, 1}},
-  {"curandRngType_t",                                  {"hiprandRngType_t",                               "rocrand_rng_type",                                               CONV_TYPE, API_RAND, 1}},
+  m["curandRngType"]                                   = {"hiprandRngType_t",                               "rocrand_rng_type",                                               CONV_TYPE, API_RAND, 1};
+  m["curandRngType_t"]                                 = {"hiprandRngType_t",                               "rocrand_rng_type",                                               CONV_TYPE, API_RAND, 1};
   // RAND generator types (enum curandRngType)
-  {"CURAND_RNG_TEST",                                  {"HIPRAND_RNG_TEST",                               "",                                                               CONV_NUMERIC_LITERAL, API_RAND, 1, ROC_UNSUPPORTED}},
-  {"CURAND_RNG_PSEUDO_DEFAULT",                        {"HIPRAND_RNG_PSEUDO_DEFAULT",                     "ROCRAND_RNG_PSEUDO_DEFAULT",                                     CONV_NUMERIC_LITERAL, API_RAND, 1}},
-  {"CURAND_RNG_PSEUDO_XORWOW",                         {"HIPRAND_RNG_PSEUDO_XORWOW",                      "ROCRAND_RNG_PSEUDO_XORWOW",                                      CONV_NUMERIC_LITERAL, API_RAND, 1}},
-  {"CURAND_RNG_PSEUDO_MRG32K3A",                       {"HIPRAND_RNG_PSEUDO_MRG32K3A",                    "ROCRAND_RNG_PSEUDO_MRG32K3A",                                    CONV_NUMERIC_LITERAL, API_RAND, 1}},
-  {"CURAND_RNG_PSEUDO_MTGP32",                         {"HIPRAND_RNG_PSEUDO_MTGP32",                      "ROCRAND_RNG_PSEUDO_MTGP32",                                      CONV_NUMERIC_LITERAL, API_RAND, 1}},
-  {"CURAND_RNG_PSEUDO_MT19937",                        {"HIPRAND_RNG_PSEUDO_MT19937",                     "ROCRAND_RNG_PSEUDO_MT19937",                                     CONV_NUMERIC_LITERAL, API_RAND, 1}},
-  {"CURAND_RNG_PSEUDO_PHILOX4_32_10",                  {"HIPRAND_RNG_PSEUDO_PHILOX4_32_10",               "ROCRAND_RNG_PSEUDO_PHILOX4_32_10",                               CONV_NUMERIC_LITERAL, API_RAND, 1}},
-  {"CURAND_RNG_QUASI_DEFAULT",                         {"HIPRAND_RNG_QUASI_DEFAULT",                      "ROCRAND_RNG_QUASI_DEFAULT",                                      CONV_NUMERIC_LITERAL, API_RAND, 1}},
-  {"CURAND_RNG_QUASI_SOBOL32",                         {"HIPRAND_RNG_QUASI_SOBOL32",                      "ROCRAND_RNG_QUASI_SOBOL32",                                      CONV_NUMERIC_LITERAL, API_RAND, 1}},
-  {"CURAND_RNG_QUASI_SCRAMBLED_SOBOL32",               {"HIPRAND_RNG_QUASI_SCRAMBLED_SOBOL32",            "ROCRAND_RNG_QUASI_SCRAMBLED_SOBOL32",                            CONV_NUMERIC_LITERAL, API_RAND, 1}},
-  {"CURAND_RNG_QUASI_SOBOL64",                         {"HIPRAND_RNG_QUASI_SOBOL64",                      "ROCRAND_RNG_QUASI_SOBOL64",                                      CONV_NUMERIC_LITERAL, API_RAND, 1}},
-  {"CURAND_RNG_QUASI_SCRAMBLED_SOBOL64",               {"HIPRAND_RNG_QUASI_SCRAMBLED_SOBOL64",            "ROCRAND_RNG_QUASI_SCRAMBLED_SOBOL64",                            CONV_NUMERIC_LITERAL, API_RAND, 1}},
+  m["CURAND_RNG_TEST"]                                 = {"HIPRAND_RNG_TEST",                               "",                                                               CONV_NUMERIC_LITERAL, API_RAND, 1, ROC_UNSUPPORTED};
+  m["CURAND_RNG_PSEUDO_DEFAULT"]                       = {"HIPRAND_RNG_PSEUDO_DEFAULT",                     "ROCRAND_RNG_PSEUDO_DEFAULT",                                     CONV_NUMERIC_LITERAL, API_RAND, 1};
+  m["CURAND_RNG_PSEUDO_XORWOW"]                        = {"HIPRAND_RNG_PSEUDO_XORWOW",                      "ROCRAND_RNG_PSEUDO_XORWOW",                                      CONV_NUMERIC_LITERAL, API_RAND, 1};
+  m["CURAND_RNG_PSEUDO_MRG32K3A"]                      = {"HIPRAND_RNG_PSEUDO_MRG32K3A",                    "ROCRAND_RNG_PSEUDO_MRG32K3A",                                    CONV_NUMERIC_LITERAL, API_RAND, 1};
+  m["CURAND_RNG_PSEUDO_MTGP32"]                        = {"HIPRAND_RNG_PSEUDO_MTGP32",                      "ROCRAND_RNG_PSEUDO_MTGP32",                                      CONV_NUMERIC_LITERAL, API_RAND, 1};
+  m["CURAND_RNG_PSEUDO_MT19937"]                       = {"HIPRAND_RNG_PSEUDO_MT19937",                     "ROCRAND_RNG_PSEUDO_MT19937",                                     CONV_NUMERIC_LITERAL, API_RAND, 1};
+  m["CURAND_RNG_PSEUDO_PHILOX4_32_10"]                 = {"HIPRAND_RNG_PSEUDO_PHILOX4_32_10",               "ROCRAND_RNG_PSEUDO_PHILOX4_32_10",                               CONV_NUMERIC_LITERAL, API_RAND, 1};
+  m["CURAND_RNG_QUASI_DEFAULT"]                        = {"HIPRAND_RNG_QUASI_DEFAULT",                      "ROCRAND_RNG_QUASI_DEFAULT",                                      CONV_NUMERIC_LITERAL, API_RAND, 1};
+  m["CURAND_RNG_QUASI_SOBOL32"]                        = {"HIPRAND_RNG_QUASI_SOBOL32",                      "ROCRAND_RNG_QUASI_SOBOL32",                                      CONV_NUMERIC_LITERAL, API_RAND, 1};
+  m["CURAND_RNG_QUASI_SCRAMBLED_SOBOL32"]              = {"HIPRAND_RNG_QUASI_SCRAMBLED_SOBOL32",            "ROCRAND_RNG_QUASI_SCRAMBLED_SOBOL32",                            CONV_NUMERIC_LITERAL, API_RAND, 1};
+  m["CURAND_RNG_QUASI_SOBOL64"]                        = {"HIPRAND_RNG_QUASI_SOBOL64",                      "ROCRAND_RNG_QUASI_SOBOL64",                                      CONV_NUMERIC_LITERAL, API_RAND, 1};
+  m["CURAND_RNG_QUASI_SCRAMBLED_SOBOL64"]              = {"HIPRAND_RNG_QUASI_SCRAMBLED_SOBOL64",            "ROCRAND_RNG_QUASI_SCRAMBLED_SOBOL64",                            CONV_NUMERIC_LITERAL, API_RAND, 1};
 
-  {"curandOrdering",                                   {"hiprandOrdering",                                "rocrand_ordering",                                               CONV_TYPE, API_RAND, 1}},
-  {"curandOrdering_t",                                 {"hiprandOrdering_t",                              "rocrand_ordering",                                               CONV_TYPE, API_RAND, 1}},
+  m["curandOrdering"]                                  = {"hiprandOrdering",                                "rocrand_ordering",                                               CONV_TYPE, API_RAND, 1};
+  m["curandOrdering_t"]                                = {"hiprandOrdering_t",                              "rocrand_ordering",                                               CONV_TYPE, API_RAND, 1};
   // RAND ordering of results in memory (enum curandOrdering)
-  {"CURAND_ORDERING_PSEUDO_BEST",                      {"HIPRAND_ORDERING_PSEUDO_BEST",                   "ROCRAND_ORDERING_PSEUDO_BEST",                                   CONV_NUMERIC_LITERAL, API_RAND, 1}},
-  {"CURAND_ORDERING_PSEUDO_DEFAULT",                   {"HIPRAND_ORDERING_PSEUDO_DEFAULT",                "ROCRAND_ORDERING_PSEUDO_DEFAULT",                                CONV_NUMERIC_LITERAL, API_RAND, 1}},
-  {"CURAND_ORDERING_PSEUDO_SEEDED",                    {"HIPRAND_ORDERING_PSEUDO_SEEDED",                 "ROCRAND_ORDERING_PSEUDO_SEEDED",                                 CONV_NUMERIC_LITERAL, API_RAND, 1}},
-  {"CURAND_ORDERING_PSEUDO_LEGACY",                    {"HIPRAND_ORDERING_PSEUDO_LEGACY",                 "ROCRAND_ORDERING_PSEUDO_LEGACY",                                 CONV_NUMERIC_LITERAL, API_RAND, 1}},
-  {"CURAND_ORDERING_PSEUDO_DYNAMIC",                   {"HIPRAND_ORDERING_PSEUDO_DYNAMIC",                "ROCRAND_ORDERING_PSEUDO_DYNAMIC",                                CONV_NUMERIC_LITERAL, API_RAND, 1}},
-  {"CURAND_ORDERING_QUASI_DEFAULT",                    {"HIPRAND_ORDERING_QUASI_DEFAULT",                 "ROCRAND_ORDERING_QUASI_DEFAULT",                                 CONV_NUMERIC_LITERAL, API_RAND, 1}},
+  m["CURAND_ORDERING_PSEUDO_BEST"]                     = {"HIPRAND_ORDERING_PSEUDO_BEST",                   "ROCRAND_ORDERING_PSEUDO_BEST",                                   CONV_NUMERIC_LITERAL, API_RAND, 1};
+  m["CURAND_ORDERING_PSEUDO_DEFAULT"]                  = {"HIPRAND_ORDERING_PSEUDO_DEFAULT",                "ROCRAND_ORDERING_PSEUDO_DEFAULT",                                CONV_NUMERIC_LITERAL, API_RAND, 1};
+  m["CURAND_ORDERING_PSEUDO_SEEDED"]                   = {"HIPRAND_ORDERING_PSEUDO_SEEDED",                 "ROCRAND_ORDERING_PSEUDO_SEEDED",                                 CONV_NUMERIC_LITERAL, API_RAND, 1};
+  m["CURAND_ORDERING_PSEUDO_LEGACY"]                   = {"HIPRAND_ORDERING_PSEUDO_LEGACY",                 "ROCRAND_ORDERING_PSEUDO_LEGACY",                                 CONV_NUMERIC_LITERAL, API_RAND, 1};
+  m["CURAND_ORDERING_PSEUDO_DYNAMIC"]                  = {"HIPRAND_ORDERING_PSEUDO_DYNAMIC",                "ROCRAND_ORDERING_PSEUDO_DYNAMIC",                                CONV_NUMERIC_LITERAL, API_RAND, 1};
+  m["CURAND_ORDERING_QUASI_DEFAULT"]                   = {"HIPRAND_ORDERING_QUASI_DEFAULT",                 "ROCRAND_ORDERING_QUASI_DEFAULT",                                 CONV_NUMERIC_LITERAL, API_RAND, 1};
 
-  {"curandDirectionVectorSet",                         {"hiprandDirectionVectorSet_t",                    "rocrand_direction_vector_set",                                   CONV_TYPE, API_RAND, 1}},
-  {"curandDirectionVectorSet_t",                       {"hiprandDirectionVectorSet_t",                    "rocrand_direction_vector_set",                                   CONV_TYPE, API_RAND, 1}},
+  m["curandDirectionVectorSet"]                        = {"hiprandDirectionVectorSet_t",                    "rocrand_direction_vector_set",                                   CONV_TYPE, API_RAND, 1};
+  m["curandDirectionVectorSet_t"]                      = {"hiprandDirectionVectorSet_t",                    "rocrand_direction_vector_set",                                   CONV_TYPE, API_RAND, 1};
   // RAND choice of direction vector set (enum curandDirectionVectorSet)
-  {"CURAND_DIRECTION_VECTORS_32_JOEKUO6",              {"HIPRAND_DIRECTION_VECTORS_32_JOEKUO6",           "ROCRAND_DIRECTION_VECTORS_32_JOEKUO6",                           CONV_NUMERIC_LITERAL, API_RAND, 1}},
-  {"CURAND_SCRAMBLED_DIRECTION_VECTORS_32_JOEKUO6",    {"HIPRAND_SCRAMBLED_DIRECTION_VECTORS_32_JOEKUO6", "ROCRAND_SCRAMBLED_DIRECTION_VECTORS_32_JOEKUO6",                 CONV_NUMERIC_LITERAL, API_RAND, 1}},
-  {"CURAND_DIRECTION_VECTORS_64_JOEKUO6",              {"HIPRAND_DIRECTION_VECTORS_64_JOEKUO6",           "ROCRAND_DIRECTION_VECTORS_64_JOEKUO6",                           CONV_NUMERIC_LITERAL, API_RAND, 1}},
-  {"CURAND_SCRAMBLED_DIRECTION_VECTORS_64_JOEKUO6",    {"HIPRAND_SCRAMBLED_DIRECTION_VECTORS_64_JOEKUO6", "ROCRAND_SCRAMBLED_DIRECTION_VECTORS_64_JOEKUO6",                 CONV_NUMERIC_LITERAL, API_RAND, 1}},
+  m["CURAND_DIRECTION_VECTORS_32_JOEKUO6"]             = {"HIPRAND_DIRECTION_VECTORS_32_JOEKUO6",           "ROCRAND_DIRECTION_VECTORS_32_JOEKUO6",                           CONV_NUMERIC_LITERAL, API_RAND, 1};
+  m["CURAND_SCRAMBLED_DIRECTION_VECTORS_32_JOEKUO6"]   = {"HIPRAND_SCRAMBLED_DIRECTION_VECTORS_32_JOEKUO6", "ROCRAND_SCRAMBLED_DIRECTION_VECTORS_32_JOEKUO6",                 CONV_NUMERIC_LITERAL, API_RAND, 1};
+  m["CURAND_DIRECTION_VECTORS_64_JOEKUO6"]             = {"HIPRAND_DIRECTION_VECTORS_64_JOEKUO6",           "ROCRAND_DIRECTION_VECTORS_64_JOEKUO6",                           CONV_NUMERIC_LITERAL, API_RAND, 1};
+  m["CURAND_SCRAMBLED_DIRECTION_VECTORS_64_JOEKUO6"]   = {"HIPRAND_SCRAMBLED_DIRECTION_VECTORS_64_JOEKUO6", "ROCRAND_SCRAMBLED_DIRECTION_VECTORS_64_JOEKUO6",                 CONV_NUMERIC_LITERAL, API_RAND, 1};
 
-  {"curandGenerator_st",                               {"hiprandGenerator_st",                            "rocrand_generator_base_type",                                    CONV_TYPE, API_RAND, 1}},
-  {"curandGenerator_t",                                {"hiprandGenerator_t",                             "rocrand_generator",                                              CONV_TYPE, API_RAND, 1}},
+  m["curandGenerator_st"]                              = {"hiprandGenerator_st",                            "rocrand_generator_base_type",                                    CONV_TYPE, API_RAND, 1};
+  m["curandGenerator_t"]                               = {"hiprandGenerator_t",                             "rocrand_generator",                                              CONV_TYPE, API_RAND, 1};
 
-  {"curandDistribution_st",                            {"hiprandDistribution_st",                         "",                                                               CONV_TYPE, API_RAND, 1, UNSUPPORTED}},
-  {"curandDistribution_t",                             {"hiprandDistribution_t",                          "",                                                               CONV_TYPE, API_RAND, 1, UNSUPPORTED}},
+  m["curandDistribution_st"]                           = {"hiprandDistribution_st",                         "",                                                               CONV_TYPE, API_RAND, 1, UNSUPPORTED};
+  m["curandDistribution_t"]                            = {"hiprandDistribution_t",                          "",                                                               CONV_TYPE, API_RAND, 1, UNSUPPORTED};
 
-  {"curandHistogramM2V_st",                            {"hiprandHistogramM2V_st",                         "",                                                               CONV_TYPE, API_RAND, 1, UNSUPPORTED}},
-  {"curandHistogramM2V_t",                             {"hiprandHistogramM2V_t",                          "",                                                               CONV_TYPE, API_RAND, 1, UNSUPPORTED}},
+  m["curandHistogramM2V_st"]                           = {"hiprandHistogramM2V_st",                         "",                                                               CONV_TYPE, API_RAND, 1, UNSUPPORTED};
+  m["curandHistogramM2V_t"]                            = {"hiprandHistogramM2V_t",                          "",                                                               CONV_TYPE, API_RAND, 1, UNSUPPORTED};
 
-  {"curandDistributionShift_st",                       {"hiprandDistributionShift_st",                    "",                                                               CONV_TYPE, API_RAND, 1, UNSUPPORTED}},
-  {"curandDistributionShift_t",                        {"hiprandDistributionShift_t",                     "",                                                               CONV_TYPE, API_RAND, 1, UNSUPPORTED}},
+  m["curandDistributionShift_st"]                      = {"hiprandDistributionShift_st",                    "",                                                               CONV_TYPE, API_RAND, 1, UNSUPPORTED};
+  m["curandDistributionShift_t"]                       = {"hiprandDistributionShift_t",                     "",                                                               CONV_TYPE, API_RAND, 1, UNSUPPORTED};
 
-  {"curandDistributionM2Shift_st",                     {"hiprandDistributionM2Shift_st",                  "",                                                               CONV_TYPE, API_RAND, 1, UNSUPPORTED}},
-  {"curandDistributionM2Shift_t",                      {"hiprandDistributionM2Shift_t",                   "",                                                               CONV_TYPE, API_RAND, 1, UNSUPPORTED}},
-  {"curandHistogramM2_st",                             {"hiprandHistogramM2_st",                          "",                                                               CONV_TYPE, API_RAND, 1, UNSUPPORTED}},
-  {"curandHistogramM2_t",                              {"hiprandHistogramM2_t",                           "",                                                               CONV_TYPE, API_RAND, 1, UNSUPPORTED}},
-  {"curandHistogramM2K_st",                            {"hiprandHistogramM2K_st",                         "",                                                               CONV_TYPE, API_RAND, 1, UNSUPPORTED}},
-  {"curandHistogramM2K_t",                             {"hiprandHistogramM2K_t",                          "",                                                               CONV_TYPE, API_RAND, 1, UNSUPPORTED}},
-  {"curandDiscreteDistribution_st",                    {"hiprandDiscreteDistribution_st",                 "rocrand_discrete_distribution_st",                               CONV_TYPE, API_RAND, 1}},
-  {"curandDiscreteDistribution_t",                     {"hiprandDiscreteDistribution_t",                  "rocrand_discrete_distribution",                                  CONV_TYPE, API_RAND, 1}},
-  {"curandMethod",                                     {"hiprandMethod_t",                                "",                                                               CONV_TYPE, API_RAND, 1, UNSUPPORTED}},
-  {"curandMethod_t",                                   {"hiprandMethod_t",                                "",                                                               CONV_TYPE, API_RAND, 1, UNSUPPORTED}},
-  {"curandDirectionVectors32_t",                       {"hiprandDirectionVectors32_t",                    "",                                                               CONV_TYPE, API_RAND, 1, ROC_UNSUPPORTED}},
-  {"curandDirectionVectors64_t",                       {"hiprandDirectionVectors64_t",                    "",                                                               CONV_TYPE, API_RAND, 1, ROC_UNSUPPORTED}},
+  m["curandDistributionM2Shift_st"]                    = {"hiprandDistributionM2Shift_st",                  "",                                                               CONV_TYPE, API_RAND, 1, UNSUPPORTED};
+  m["curandDistributionM2Shift_t"]                     = {"hiprandDistributionM2Shift_t",                   "",                                                               CONV_TYPE, API_RAND, 1, UNSUPPORTED};
+  m["curandHistogramM2_st"]                            = {"hiprandHistogramM2_st",                          "",                                                               CONV_TYPE, API_RAND, 1, UNSUPPORTED};
+  m["curandHistogramM2_t"]                             = {"hiprandHistogramM2_t",                           "",                                                               CONV_TYPE, API_RAND, 1, UNSUPPORTED};
+  m["curandHistogramM2K_st"]                           = {"hiprandHistogramM2K_st",                         "",                                                               CONV_TYPE, API_RAND, 1, UNSUPPORTED};
+  m["curandHistogramM2K_t"]                            = {"hiprandHistogramM2K_t",                          "",                                                               CONV_TYPE, API_RAND, 1, UNSUPPORTED};
+  m["curandDiscreteDistribution_st"]                   = {"hiprandDiscreteDistribution_st",                 "rocrand_discrete_distribution_st",                               CONV_TYPE, API_RAND, 1};
+  m["curandDiscreteDistribution_t"]                    = {"hiprandDiscreteDistribution_t",                  "rocrand_discrete_distribution",                                  CONV_TYPE, API_RAND, 1};
+  m["curandMethod"]                                    = {"hiprandMethod_t",                                "",                                                               CONV_TYPE, API_RAND, 1, UNSUPPORTED};
+  m["curandMethod_t"]                                  = {"hiprandMethod_t",                                "",                                                               CONV_TYPE, API_RAND, 1, UNSUPPORTED};
+  m["curandDirectionVectors32_t"]                      = {"hiprandDirectionVectors32_t",                    "",                                                               CONV_TYPE, API_RAND, 1, ROC_UNSUPPORTED};
+  m["curandDirectionVectors64_t"]                      = {"hiprandDirectionVectors64_t",                    "",                                                               CONV_TYPE, API_RAND, 1, ROC_UNSUPPORTED};
 
   // RAND types for Device functions
-  {"curandStateMtgp32",                                {"hiprandStateMtgp32",                             "rocrand_device::mtgp32_engine",                                  CONV_TYPE, API_RAND, 1}},
-  {"curandStateMtgp32_t",                              {"hiprandStateMtgp32_t",                           "rocrand_state_mtgp32",                                           CONV_TYPE, API_RAND, 1}},
-  {"curandStateScrambledSobol64",                      {"hiprandStateScrambledSobol64",                   "rocrand_device::scrambled_sobol64_engine<false>",                CONV_TYPE, API_RAND, 1}},
-  {"curandStateScrambledSobol64_t",                    {"hiprandStateScrambledSobol64_t",                 "rocrand_state_scrambled_sobol64",                                CONV_TYPE, API_RAND, 1}},
-  {"curandStateSobol64",                               {"hiprandStateSobol64",                            "rocrand_device::sobol64_engine<false>",                          CONV_TYPE, API_RAND, 1}},
-  {"curandStateSobol64_t",                             {"hiprandStateSobol64_t",                          "rocrand_state_sobol64",                                          CONV_TYPE, API_RAND, 1}},
-  {"curandStateScrambledSobol32",                      {"hiprandStateScrambledSobol32",                   "rocrand_device::scrambled_sobol32_engine<false>",                CONV_TYPE, API_RAND, 1}},
-  {"curandStateScrambledSobol32_t",                    {"hiprandStateScrambledSobol32_t",                 "rocrand_state_scrambled_sobol32",                                CONV_TYPE, API_RAND, 1}},
-  {"curandStateSobol32",                               {"hiprandStateSobol32",                            "rocrand_device::sobol32_engine<false>",                          CONV_TYPE, API_RAND, 1}},
-  {"curandStateSobol32_t",                             {"hiprandStateSobol32_t",                          "rocrand_state_sobol32",                                          CONV_TYPE, API_RAND, 1}},
-  {"curandStateMRG32k3a",                              {"hiprandStateMRG32k3a",                           "rocrand_device::mrg32k3a_engine",                                CONV_TYPE, API_RAND, 1}},
-  {"curandStateMRG32k3a_t",                            {"hiprandStateMRG32k3a_t",                         "rocrand_state_mrg32k3a",                                         CONV_TYPE, API_RAND, 1}},
-  {"curandStatePhilox4_32_10",                         {"hiprandStatePhilox4_32_10",                      "rocrand_device::philox4x32_10_engine",                           CONV_TYPE, API_RAND, 1}},
-  {"curandStatePhilox4_32_10_t",                       {"hiprandStatePhilox4_32_10_t",                    "rocrand_state_philox4x32_10",                                    CONV_TYPE, API_RAND, 1}},
-  {"curandStateXORWOW",                                {"hiprandStateXORWOW",                             "rocrand_device::xorwow_engine",                                  CONV_TYPE, API_RAND, 1}},
-  {"curandStateXORWOW_t",                              {"hiprandStateXORWOW_t",                           "rocrand_state_xorwow",                                           CONV_TYPE, API_RAND, 1}},
-  {"curandState",                                      {"hiprandState",                                   "",                                                               CONV_TYPE, API_RAND, 1, ROC_UNSUPPORTED}},
-  {"curandState_t",                                    {"hiprandState_t",                                 "",                                                               CONV_TYPE, API_RAND, 1, ROC_UNSUPPORTED}},
+  m["curandStateMtgp32"]                               = {"hiprandStateMtgp32",                             "rocrand_device::mtgp32_engine",                                  CONV_TYPE, API_RAND, 1};
+  m["curandStateMtgp32_t"]                             = {"hiprandStateMtgp32_t",                           "rocrand_state_mtgp32",                                           CONV_TYPE, API_RAND, 1};
+  m["curandStateScrambledSobol64"]                     = {"hiprandStateScrambledSobol64",                   "rocrand_device::scrambled_sobol64_engine<false>",                CONV_TYPE, API_RAND, 1};
+  m["curandStateScrambledSobol64_t"]                   = {"hiprandStateScrambledSobol64_t",                 "rocrand_state_scrambled_sobol64",                                CONV_TYPE, API_RAND, 1};
+  m["curandStateSobol64"]                              = {"hiprandStateSobol64",                            "rocrand_device::sobol64_engine<false>",                          CONV_TYPE, API_RAND, 1};
+  m["curandStateSobol64_t"]                            = {"hiprandStateSobol64_t",                          "rocrand_state_sobol64",                                          CONV_TYPE, API_RAND, 1};
+  m["curandStateScrambledSobol32"]                     = {"hiprandStateScrambledSobol32",                   "rocrand_device::scrambled_sobol32_engine<false>",                CONV_TYPE, API_RAND, 1};
+  m["curandStateScrambledSobol32_t"]                   = {"hiprandStateScrambledSobol32_t",                 "rocrand_state_scrambled_sobol32",                                CONV_TYPE, API_RAND, 1};
+  m["curandStateSobol32"]                              = {"hiprandStateSobol32",                            "rocrand_device::sobol32_engine<false>",                          CONV_TYPE, API_RAND, 1};
+  m["curandStateSobol32_t"]                            = {"hiprandStateSobol32_t",                          "rocrand_state_sobol32",                                          CONV_TYPE, API_RAND, 1};
+  m["curandStateMRG32k3a"]                             = {"hiprandStateMRG32k3a",                           "rocrand_device::mrg32k3a_engine",                                CONV_TYPE, API_RAND, 1};
+  m["curandStateMRG32k3a_t"]                           = {"hiprandStateMRG32k3a_t",                         "rocrand_state_mrg32k3a",                                         CONV_TYPE, API_RAND, 1};
+  m["curandStatePhilox4_32_10"]                        = {"hiprandStatePhilox4_32_10",                      "rocrand_device::philox4x32_10_engine",                           CONV_TYPE, API_RAND, 1};
+  m["curandStatePhilox4_32_10_t"]                      = {"hiprandStatePhilox4_32_10_t",                    "rocrand_state_philox4x32_10",                                    CONV_TYPE, API_RAND, 1};
+  m["curandStateXORWOW"]                               = {"hiprandStateXORWOW",                             "rocrand_device::xorwow_engine",                                  CONV_TYPE, API_RAND, 1};
+  m["curandStateXORWOW_t"]                             = {"hiprandStateXORWOW_t",                           "rocrand_state_xorwow",                                           CONV_TYPE, API_RAND, 1};
+  m["curandState"]                                     = {"hiprandState",                                   "",                                                               CONV_TYPE, API_RAND, 1, ROC_UNSUPPORTED};
+  m["curandState_t"]                                   = {"hiprandState_t",                                 "",                                                               CONV_TYPE, API_RAND, 1, ROC_UNSUPPORTED};
 
   // RAND method (enum curandMethod)
-  {"CURAND_CHOOSE_BEST",                               {"HIPRAND_CHOOSE_BEST",                            "",                                                                CONV_NUMERIC_LITERAL, API_RAND, 1, UNSUPPORTED}},
-  {"CURAND_ITR",                                       {"HIPRAND_ITR",                                    "",                                                                CONV_NUMERIC_LITERAL, API_RAND, 1, UNSUPPORTED}},
-  {"CURAND_KNUTH",                                     {"HIPRAND_KNUTH",                                  "",                                                                CONV_NUMERIC_LITERAL, API_RAND, 1, UNSUPPORTED}},
-  {"CURAND_HITR",                                      {"HIPRAND_HITR",                                   "",                                                                CONV_NUMERIC_LITERAL, API_RAND, 1, UNSUPPORTED}},
-  {"CURAND_M1",                                        {"HIPRAND_M1",                                     "",                                                                CONV_NUMERIC_LITERAL, API_RAND, 1, UNSUPPORTED}},
-  {"CURAND_M2",                                        {"HIPRAND_M2",                                     "",                                                                CONV_NUMERIC_LITERAL, API_RAND, 1, UNSUPPORTED}},
-  {"CURAND_BINARY_SEARCH",                             {"HIPRAND_BINARY_SEARCH",                          "",                                                                CONV_NUMERIC_LITERAL, API_RAND, 1, UNSUPPORTED}},
-  {"CURAND_DISCRETE_GAUSS",                            {"HIPRAND_DISCRETE_GAUSS",                         "",                                                                CONV_NUMERIC_LITERAL, API_RAND, 1, UNSUPPORTED}},
-  {"CURAND_REJECTION",                                 {"HIPRAND_REJECTION",                              "",                                                                CONV_NUMERIC_LITERAL, API_RAND, 1, UNSUPPORTED}},
-  {"CURAND_DEVICE_API",                                {"HIPRAND_DEVICE_API",                             "",                                                                CONV_NUMERIC_LITERAL, API_RAND, 1, UNSUPPORTED}},
-  {"CURAND_FAST_REJECTION",                            {"HIPRAND_FAST_REJECTION",                         "",                                                                CONV_NUMERIC_LITERAL, API_RAND, 1, UNSUPPORTED}},
-  {"CURAND_3RD",                                       {"HIPRAND_3RD",                                    "",                                                                CONV_NUMERIC_LITERAL, API_RAND, 1, UNSUPPORTED}},
-  {"CURAND_DEFINITION",                                {"HIPRAND_DEFINITION",                             "",                                                                CONV_NUMERIC_LITERAL, API_RAND, 1, UNSUPPORTED}},
-  {"CURAND_POISSON",                                   {"HIPRAND_POISSON",                                "",                                                                CONV_NUMERIC_LITERAL, API_RAND, 1, UNSUPPORTED}},
-};
+  m["CURAND_CHOOSE_BEST"]                              = {"HIPRAND_CHOOSE_BEST",                            "",                                                                CONV_NUMERIC_LITERAL, API_RAND, 1, UNSUPPORTED};
+  m["CURAND_ITR"]                                      = {"HIPRAND_ITR",                                    "",                                                                CONV_NUMERIC_LITERAL, API_RAND, 1, UNSUPPORTED};
+  m["CURAND_KNUTH"]                                    = {"HIPRAND_KNUTH",                                  "",                                                                CONV_NUMERIC_LITERAL, API_RAND, 1, UNSUPPORTED};
+  m["CURAND_HITR"]                                     = {"HIPRAND_HITR",                                   "",                                                                CONV_NUMERIC_LITERAL, API_RAND, 1, UNSUPPORTED};
+  m["CURAND_M1"]                                       = {"HIPRAND_M1",                                     "",                                                                CONV_NUMERIC_LITERAL, API_RAND, 1, UNSUPPORTED};
+  m["CURAND_M2"]                                       = {"HIPRAND_M2",                                     "",                                                                CONV_NUMERIC_LITERAL, API_RAND, 1, UNSUPPORTED};
+  m["CURAND_BINARY_SEARCH"]                            = {"HIPRAND_BINARY_SEARCH",                          "",                                                                CONV_NUMERIC_LITERAL, API_RAND, 1, UNSUPPORTED};
+  m["CURAND_DISCRETE_GAUSS"]                           = {"HIPRAND_DISCRETE_GAUSS",                         "",                                                                CONV_NUMERIC_LITERAL, API_RAND, 1, UNSUPPORTED};
+  m["CURAND_REJECTION"]                                = {"HIPRAND_REJECTION",                              "",                                                                CONV_NUMERIC_LITERAL, API_RAND, 1, UNSUPPORTED};
+  m["CURAND_DEVICE_API"]                               = {"HIPRAND_DEVICE_API",                             "",                                                                CONV_NUMERIC_LITERAL, API_RAND, 1, UNSUPPORTED};
+  m["CURAND_FAST_REJECTION"]                           = {"HIPRAND_FAST_REJECTION",                         "",                                                                CONV_NUMERIC_LITERAL, API_RAND, 1, UNSUPPORTED};
+  m["CURAND_3RD"]                                      = {"HIPRAND_3RD",                                    "",                                                                CONV_NUMERIC_LITERAL, API_RAND, 1, UNSUPPORTED};
+  m["CURAND_DEFINITION"]                               = {"HIPRAND_DEFINITION",                             "",                                                                CONV_NUMERIC_LITERAL, API_RAND, 1, UNSUPPORTED};
+  m["CURAND_POISSON"]                                  = {"HIPRAND_POISSON",                                "",                                                                CONV_NUMERIC_LITERAL, API_RAND, 1, UNSUPPORTED};
 
-const std::map<llvm::StringRef, cudaAPIversions> CUDA_RAND_TYPE_NAME_VER_MAP {
-  {"CURAND_ORDERING_PSEUDO_LEGACY",                    {CUDA_110, CUDA_0,   CUDA_0  }}, // A: CUDA_VERSION 11001, CURAND_VERSION 10200, CURAND_VER_MAJOR 10 CURAND_VER_MINOR 2 CURAND_VER_PATCH 0
-  {"CURAND_ORDERING_PSEUDO_DYNAMIC",                   {CUDA_115, CUDA_0,   CUDA_0  }}, // A: CUDA_VERSION 11052, CURAND_VERSION 10207, CURAND_VER_MAJOR 10 CURAND_VER_MINOR 2 CURAND_VER_PATCH 7
-};
+  return m;
+}();
 
-const std::map<llvm::StringRef, hipAPIversions> HIP_RAND_TYPE_NAME_VER_MAP {
-  {"hiprandStatus",                                    {HIP_1050, HIP_0,    HIP_0   }},
-  {"hiprandStatus_t",                                  {HIP_1050, HIP_0,    HIP_0   }},
-  {"hiprandRngType_t",                                 {HIP_1050, HIP_0,    HIP_0   }},
-  {"hiprandGenerator_st",                              {HIP_1050, HIP_0,    HIP_0   }},
-  {"hiprandGenerator_t",                               {HIP_1050, HIP_0,    HIP_0   }},
-  {"hiprandDiscreteDistribution_st",                   {HIP_1050, HIP_0,    HIP_0   }},
-  {"hiprandDiscreteDistribution_t",                    {HIP_1050, HIP_0,    HIP_0   }},
-  {"hiprandDirectionVectors32_t",                      {HIP_1050, HIP_0,    HIP_0   }},
-  {"hiprandStateMtgp32",                               {HIP_1080, HIP_0,    HIP_0   }},
-  {"hiprandStateMtgp32_t",                             {HIP_1050, HIP_0,    HIP_0   }},
-  {"hiprandStateSobol32",                              {HIP_1080, HIP_0,    HIP_0   }},
-  {"hiprandStateSobol32_t",                            {HIP_1050, HIP_0,    HIP_0   }},
-  {"hiprandStateMRG32k3a",                             {HIP_1080, HIP_0,    HIP_0   }},
-  {"hiprandStateMRG32k3a_t",                           {HIP_1050, HIP_0,    HIP_0   }},
-  {"hiprandStatePhilox4_32_10",                        {HIP_1080, HIP_0,    HIP_0   }},
-  {"hiprandStatePhilox4_32_10_t",                      {HIP_1080, HIP_0,    HIP_0   }},
-  {"hiprandStateXORWOW",                               {HIP_1080, HIP_0,    HIP_0   }},
-  {"hiprandStateXORWOW_t",                             {HIP_1050, HIP_0,    HIP_0   }},
-  {"hiprandState",                                     {HIP_1080, HIP_0,    HIP_0   }},
-  {"hiprandState_t",                                   {HIP_1050, HIP_0,    HIP_0   }},
-  {"HIPRAND_STATUS_SUCCESS",                           {HIP_1050, HIP_0,    HIP_0   }},
-  {"HIPRAND_STATUS_VERSION_MISMATCH",                  {HIP_1050, HIP_0,    HIP_0   }},
-  {"HIPRAND_STATUS_NOT_INITIALIZED",                   {HIP_1050, HIP_0,    HIP_0   }},
-  {"HIPRAND_STATUS_ALLOCATION_FAILED",                 {HIP_1050, HIP_0,    HIP_0   }},
-  {"HIPRAND_STATUS_TYPE_ERROR",                        {HIP_1050, HIP_0,    HIP_0   }},
-  {"HIPRAND_STATUS_OUT_OF_RANGE",                      {HIP_1050, HIP_0,    HIP_0   }},
-  {"HIPRAND_STATUS_LENGTH_NOT_MULTIPLE",               {HIP_1050, HIP_0,    HIP_0   }},
-  {"HIPRAND_STATUS_DOUBLE_PRECISION_REQUIRED",         {HIP_1050, HIP_0,    HIP_0   }},
-  {"HIPRAND_STATUS_LAUNCH_FAILURE",                    {HIP_1050, HIP_0,    HIP_0   }},
-  {"HIPRAND_STATUS_PREEXISTING_FAILURE",               {HIP_1050, HIP_0,    HIP_0   }},
-  {"HIPRAND_STATUS_INITIALIZATION_FAILED",             {HIP_1050, HIP_0,    HIP_0   }},
-  {"HIPRAND_STATUS_ARCH_MISMATCH",                     {HIP_1050, HIP_0,    HIP_0   }},
-  {"HIPRAND_STATUS_INTERNAL_ERROR",                    {HIP_1050, HIP_0,    HIP_0   }},
-  {"HIPRAND_RNG_TEST",                                 {HIP_1050, HIP_0,    HIP_0   }},
-  {"HIPRAND_RNG_PSEUDO_DEFAULT",                       {HIP_1050, HIP_0,    HIP_0   }},
-  {"HIPRAND_RNG_PSEUDO_XORWOW",                        {HIP_1050, HIP_0,    HIP_0   }},
-  {"HIPRAND_RNG_PSEUDO_MRG32K3A",                      {HIP_1050, HIP_0,    HIP_0   }},
-  {"HIPRAND_RNG_PSEUDO_MTGP32",                        {HIP_1050, HIP_0,    HIP_0   }},
-  {"HIPRAND_RNG_PSEUDO_MT19937",                       {HIP_1050, HIP_0,    HIP_0   }},
-  {"HIPRAND_RNG_PSEUDO_PHILOX4_32_10",                 {HIP_1050, HIP_0,    HIP_0   }},
-  {"HIPRAND_RNG_QUASI_DEFAULT",                        {HIP_1050, HIP_0,    HIP_0   }},
-  {"HIPRAND_RNG_QUASI_SOBOL32",                        {HIP_1050, HIP_0,    HIP_0   }},
-  {"HIPRAND_RNG_QUASI_SCRAMBLED_SOBOL32",              {HIP_1050, HIP_0,    HIP_0   }},
-  {"HIPRAND_RNG_QUASI_SOBOL64",                        {HIP_1050, HIP_0,    HIP_0   }},
-  {"HIPRAND_RNG_QUASI_SCRAMBLED_SOBOL64",              {HIP_1050, HIP_0,    HIP_0   }},
-  {"hiprandDirectionVectorSet_t",                      {HIP_6000, HIP_0,    HIP_0   }},
-  {"HIPRAND_DIRECTION_VECTORS_32_JOEKUO6",             {HIP_6000, HIP_0,    HIP_0   }},
-  {"HIPRAND_SCRAMBLED_DIRECTION_VECTORS_32_JOEKUO6",   {HIP_6000, HIP_0,    HIP_0   }},
-  {"HIPRAND_DIRECTION_VECTORS_64_JOEKUO6",             {HIP_6000, HIP_0,    HIP_0   }},
-  {"HIPRAND_SCRAMBLED_DIRECTION_VECTORS_64_JOEKUO6",   {HIP_6000, HIP_0,    HIP_0   }},
-  {"hiprandDirectionVectors64_t",                      {HIP_6000, HIP_0,    HIP_0   }},
-  {"hiprandOrdering",                                  {HIP_6020, HIP_0,    HIP_0   }},
-  {"hiprandOrdering_t",                                {HIP_6020, HIP_0,    HIP_0   }},
-  {"HIPRAND_ORDERING_PSEUDO_BEST",                     {HIP_6020, HIP_0,    HIP_0   }},
-  {"HIPRAND_ORDERING_PSEUDO_DEFAULT",                  {HIP_6020, HIP_0,    HIP_0   }},
-  {"HIPRAND_ORDERING_PSEUDO_SEEDED",                   {HIP_6020, HIP_0,    HIP_0   }},
-  {"HIPRAND_ORDERING_PSEUDO_LEGACY",                   {HIP_6020, HIP_0,    HIP_0   }},
-  {"HIPRAND_ORDERING_PSEUDO_DYNAMIC",                  {HIP_6020, HIP_0,    HIP_0   }},
-  {"HIPRAND_ORDERING_QUASI_DEFAULT",                   {HIP_6020, HIP_0,    HIP_0   }},
-  {"hiprandStateScrambledSobol32",                     {HIP_6020, HIP_0,    HIP_0   }},
-  {"hiprandStateScrambledSobol32_t",                   {HIP_6020, HIP_0,    HIP_0   }},
-  {"hiprandStateScrambledSobol64",                     {HIP_6020, HIP_0,    HIP_0   }},
-  {"hiprandStateScrambledSobol64_t",                   {HIP_6020, HIP_0,    HIP_0   }},
-  {"hiprandStateSobol64",                              {HIP_6020, HIP_0,    HIP_0   }},
-  {"hiprandStateSobol64_t",                            {HIP_6020, HIP_0,    HIP_0   }},
+const std::map<llvm::StringRef, cudaAPIversions> CUDA_RAND_TYPE_NAME_VER_MAP = []() {
+  std::map<llvm::StringRef, cudaAPIversions> m;
 
-  {"rocrand_status",                                   {HIP_1050, HIP_0,    HIP_0   }},
-  {"ROCRAND_STATUS_SUCCESS",                           {HIP_1050, HIP_0,    HIP_0   }},
-  {"ROCRAND_STATUS_VERSION_MISMATCH",                  {HIP_1050, HIP_0,    HIP_0   }},
-  {"ROCRAND_STATUS_NOT_CREATED",                       {HIP_1050, HIP_0,    HIP_0   }},
-  {"ROCRAND_STATUS_ALLOCATION_FAILED",                 {HIP_1050, HIP_0,    HIP_0   }},
-  {"ROCRAND_STATUS_TYPE_ERROR",                        {HIP_1050, HIP_0,    HIP_0   }},
-  {"ROCRAND_STATUS_OUT_OF_RANGE",                      {HIP_1050, HIP_0,    HIP_0   }},
-  {"ROCRAND_STATUS_LENGTH_NOT_MULTIPLE",               {HIP_1050, HIP_0,    HIP_0   }},
-  {"ROCRAND_STATUS_DOUBLE_PRECISION_REQUIRED",         {HIP_1050, HIP_0,    HIP_0   }},
-  {"ROCRAND_STATUS_LAUNCH_FAILURE",                    {HIP_1050, HIP_0,    HIP_0   }},
-  {"ROCRAND_STATUS_INTERNAL_ERROR",                    {HIP_1050, HIP_0,    HIP_0   }},
-  {"rocrand_rng_type",                                 {HIP_1050, HIP_0,    HIP_0   }},
-  {"ROCRAND_RNG_PSEUDO_DEFAULT",                       {HIP_1050, HIP_0,    HIP_0   }},
-  {"ROCRAND_RNG_PSEUDO_XORWOW",                        {HIP_1050, HIP_0,    HIP_0   }},
-  {"ROCRAND_RNG_PSEUDO_MRG32K3A",                      {HIP_1050, HIP_0,    HIP_0   }},
-  {"ROCRAND_RNG_PSEUDO_MTGP32",                        {HIP_1050, HIP_0,    HIP_0   }},
-  {"ROCRAND_RNG_PSEUDO_MT19937",                       {HIP_5050, HIP_0,    HIP_0   }},
-  {"ROCRAND_RNG_PSEUDO_PHILOX4_32_10",                 {HIP_1050, HIP_0,    HIP_0   }},
-  {"ROCRAND_RNG_QUASI_DEFAULT",                        {HIP_1050, HIP_0,    HIP_0   }},
-  {"ROCRAND_RNG_QUASI_SOBOL32",                        {HIP_1050, HIP_0,    HIP_0   }},
-  {"ROCRAND_RNG_QUASI_SCRAMBLED_SOBOL32",              {HIP_5040, HIP_0,    HIP_0   }},
-  {"ROCRAND_RNG_QUASI_SOBOL64",                        {HIP_4050, HIP_0,    HIP_0   }},
-  {"ROCRAND_RNG_QUASI_SCRAMBLED_SOBOL64",              {HIP_5040, HIP_0,    HIP_0   }},
-  {"rocrand_ordering",                                 {HIP_5050, HIP_0,    HIP_0   }},
-  {"ROCRAND_ORDERING_PSEUDO_BEST",                     {HIP_5050, HIP_0,    HIP_0   }},
-  {"ROCRAND_ORDERING_PSEUDO_DEFAULT",                  {HIP_5050, HIP_0,    HIP_0   }},
-  {"ROCRAND_ORDERING_PSEUDO_SEEDED",                   {HIP_5050, HIP_0,    HIP_0   }},
-  {"ROCRAND_ORDERING_PSEUDO_LEGACY",                   {HIP_5050, HIP_0,    HIP_0   }},
-  {"ROCRAND_ORDERING_PSEUDO_DYNAMIC",                  {HIP_5050, HIP_0,    HIP_0   }},
-  {"ROCRAND_ORDERING_QUASI_DEFAULT",                   {HIP_5050, HIP_0,    HIP_0   }},
-  {"rocrand_direction_vector_set",                     {HIP_6000, HIP_0,    HIP_0   }},
-  {"ROCRAND_DIRECTION_VECTORS_32_JOEKUO6",             {HIP_6000, HIP_0,    HIP_0   }},
-  {"ROCRAND_SCRAMBLED_DIRECTION_VECTORS_32_JOEKUO6",   {HIP_6000, HIP_0,    HIP_0   }},
-  {"ROCRAND_DIRECTION_VECTORS_64_JOEKUO6",             {HIP_6000, HIP_0,    HIP_0   }},
-  {"ROCRAND_SCRAMBLED_DIRECTION_VECTORS_64_JOEKUO6",   {HIP_6000, HIP_0,    HIP_0   }},
-  {"rocrand_generator_base_type",                      {HIP_1050, HIP_0,    HIP_0   }},
-  {"rocrand_generator",                                {HIP_1050, HIP_0,    HIP_0   }},
-  {"rocrand_discrete_distribution_st",                 {HIP_1050, HIP_0,    HIP_0   }},
-  {"rocrand_discrete_distribution",                    {HIP_1050, HIP_0,    HIP_0   }},
-  {"rocrand_device::philox4x32_10_engine",             {HIP_1050, HIP_0,    HIP_0   }},
-  {"rocrand_state_philox4x32_10",                      {HIP_1050, HIP_0,    HIP_0   }},
-  {"rocrand_device::mtgp32_engine",                    {HIP_1050, HIP_0,    HIP_0   }},
-  {"rocrand_state_mtgp32",                             {HIP_1050, HIP_0,    HIP_0   }},
-  {"rocrand_device::scrambled_sobol32_engine<false>",  {HIP_5040, HIP_0,    HIP_0   }},
-  {"rocrand_state_scrambled_sobol32",                  {HIP_5040, HIP_0,    HIP_0   }},
-  {"rocrand_device::scrambled_sobol64_engine<false>",  {HIP_5040, HIP_0,    HIP_0   }},
-  {"rocrand_state_scrambled_sobol64",                  {HIP_5040, HIP_0,    HIP_0   }},
-  {"rocrand_device::sobol32_engine<false>",            {HIP_1050, HIP_0,    HIP_0   }},
-  {"rocrand_state_sobol32",                            {HIP_1050, HIP_0,    HIP_0   }},
-  {"rocrand_device::sobol64_engine<false>",            {HIP_4050, HIP_0,    HIP_0   }},
-  {"rocrand_state_sobol64",                            {HIP_4050, HIP_0,    HIP_0   }},
-  {"rocrand_device::mrg32k3a_engine",                  {HIP_1050, HIP_0,    HIP_0   }},
-  {"rocrand_state_mrg32k3a",                           {HIP_1050, HIP_0,    HIP_0   }},
-  {"rocrand_device::xorwow_engine",                    {HIP_1050, HIP_0,    HIP_0   }},
-  {"rocrand_state_xorwow",                             {HIP_1050, HIP_0,    HIP_0   }},
-};
+  m["CURAND_ORDERING_PSEUDO_LEGACY"]                   = {CUDA_110, CUDA_0,   CUDA_0  };
+  m["CURAND_ORDERING_PSEUDO_DYNAMIC"]                  = {CUDA_115, CUDA_0,   CUDA_0  };
+
+  return m;
+}();
+
+const std::map<llvm::StringRef, hipAPIversions> HIP_RAND_TYPE_NAME_VER_MAP = []() {
+  std::map<llvm::StringRef, hipAPIversions> m;
+
+  m["hiprandStatus"]                                   = {HIP_1050, HIP_0,    HIP_0   };
+  m["hiprandStatus_t"]                                 = {HIP_1050, HIP_0,    HIP_0   };
+  m["hiprandRngType_t"]                                = {HIP_1050, HIP_0,    HIP_0   };
+  m["hiprandGenerator_st"]                             = {HIP_1050, HIP_0,    HIP_0   };
+  m["hiprandGenerator_t"]                              = {HIP_1050, HIP_0,    HIP_0   };
+  m["hiprandDiscreteDistribution_st"]                  = {HIP_1050, HIP_0,    HIP_0   };
+  m["hiprandDiscreteDistribution_t"]                   = {HIP_1050, HIP_0,    HIP_0   };
+  m["hiprandDirectionVectors32_t"]                     = {HIP_1050, HIP_0,    HIP_0   };
+  m["hiprandStateMtgp32"]                              = {HIP_1080, HIP_0,    HIP_0   };
+  m["hiprandStateMtgp32_t"]                            = {HIP_1050, HIP_0,    HIP_0   };
+  m["hiprandStateSobol32"]                             = {HIP_1080, HIP_0,    HIP_0   };
+  m["hiprandStateSobol32_t"]                           = {HIP_1050, HIP_0,    HIP_0   };
+  m["hiprandStateMRG32k3a"]                            = {HIP_1080, HIP_0,    HIP_0   };
+  m["hiprandStateMRG32k3a_t"]                          = {HIP_1050, HIP_0,    HIP_0   };
+  m["hiprandStatePhilox4_32_10"]                       = {HIP_1080, HIP_0,    HIP_0   };
+  m["hiprandStatePhilox4_32_10_t"]                     = {HIP_1080, HIP_0,    HIP_0   };
+  m["hiprandStateXORWOW"]                              = {HIP_1080, HIP_0,    HIP_0   };
+  m["hiprandStateXORWOW_t"]                            = {HIP_1050, HIP_0,    HIP_0   };
+  m["hiprandState"]                                    = {HIP_1080, HIP_0,    HIP_0   };
+  m["hiprandState_t"]                                  = {HIP_1050, HIP_0,    HIP_0   };
+  m["HIPRAND_STATUS_SUCCESS"]                          = {HIP_1050, HIP_0,    HIP_0   };
+  m["HIPRAND_STATUS_VERSION_MISMATCH"]                 = {HIP_1050, HIP_0,    HIP_0   };
+  m["HIPRAND_STATUS_NOT_INITIALIZED"]                  = {HIP_1050, HIP_0,    HIP_0   };
+  m["HIPRAND_STATUS_ALLOCATION_FAILED"]                = {HIP_1050, HIP_0,    HIP_0   };
+  m["HIPRAND_STATUS_TYPE_ERROR"]                       = {HIP_1050, HIP_0,    HIP_0   };
+  m["HIPRAND_STATUS_OUT_OF_RANGE"]                     = {HIP_1050, HIP_0,    HIP_0   };
+  m["HIPRAND_STATUS_LENGTH_NOT_MULTIPLE"]              = {HIP_1050, HIP_0,    HIP_0   };
+  m["HIPRAND_STATUS_DOUBLE_PRECISION_REQUIRED"]        = {HIP_1050, HIP_0,    HIP_0   };
+  m["HIPRAND_STATUS_LAUNCH_FAILURE"]                   = {HIP_1050, HIP_0,    HIP_0   };
+  m["HIPRAND_STATUS_PREEXISTING_FAILURE"]              = {HIP_1050, HIP_0,    HIP_0   };
+  m["HIPRAND_STATUS_INITIALIZATION_FAILED"]            = {HIP_1050, HIP_0,    HIP_0   };
+  m["HIPRAND_STATUS_ARCH_MISMATCH"]                    = {HIP_1050, HIP_0,    HIP_0   };
+  m["HIPRAND_STATUS_INTERNAL_ERROR"]                   = {HIP_1050, HIP_0,    HIP_0   };
+  m["HIPRAND_RNG_TEST"]                                = {HIP_1050, HIP_0,    HIP_0   };
+  m["HIPRAND_RNG_PSEUDO_DEFAULT"]                      = {HIP_1050, HIP_0,    HIP_0   };
+  m["HIPRAND_RNG_PSEUDO_XORWOW"]                       = {HIP_1050, HIP_0,    HIP_0   };
+  m["HIPRAND_RNG_PSEUDO_MRG32K3A"]                     = {HIP_1050, HIP_0,    HIP_0   };
+  m["HIPRAND_RNG_PSEUDO_MTGP32"]                       = {HIP_1050, HIP_0,    HIP_0   };
+  m["HIPRAND_RNG_PSEUDO_MT19937"]                      = {HIP_1050, HIP_0,    HIP_0   };
+  m["HIPRAND_RNG_PSEUDO_PHILOX4_32_10"]                = {HIP_1050, HIP_0,    HIP_0   };
+  m["HIPRAND_RNG_QUASI_DEFAULT"]                       = {HIP_1050, HIP_0,    HIP_0   };
+  m["HIPRAND_RNG_QUASI_SOBOL32"]                       = {HIP_1050, HIP_0,    HIP_0   };
+  m["HIPRAND_RNG_QUASI_SCRAMBLED_SOBOL32"]             = {HIP_1050, HIP_0,    HIP_0   };
+  m["HIPRAND_RNG_QUASI_SOBOL64"]                       = {HIP_1050, HIP_0,    HIP_0   };
+  m["HIPRAND_RNG_QUASI_SCRAMBLED_SOBOL64"]             = {HIP_1050, HIP_0,    HIP_0   };
+  m["hiprandDirectionVectorSet_t"]                     = {HIP_6000, HIP_0,    HIP_0   };
+  m["HIPRAND_DIRECTION_VECTORS_32_JOEKUO6"]            = {HIP_6000, HIP_0,    HIP_0   };
+  m["HIPRAND_SCRAMBLED_DIRECTION_VECTORS_32_JOEKUO6"]  = {HIP_6000, HIP_0,    HIP_0   };
+  m["HIPRAND_DIRECTION_VECTORS_64_JOEKUO6"]            = {HIP_6000, HIP_0,    HIP_0   };
+  m["HIPRAND_SCRAMBLED_DIRECTION_VECTORS_64_JOEKUO6"]  = {HIP_6000, HIP_0,    HIP_0   };
+  m["hiprandDirectionVectors64_t"]                     = {HIP_6000, HIP_0,    HIP_0   };
+  m["hiprandOrdering"]                                 = {HIP_6020, HIP_0,    HIP_0   };
+  m["hiprandOrdering_t"]                               = {HIP_6020, HIP_0,    HIP_0   };
+  m["HIPRAND_ORDERING_PSEUDO_BEST"]                    = {HIP_6020, HIP_0,    HIP_0   };
+  m["HIPRAND_ORDERING_PSEUDO_DEFAULT"]                 = {HIP_6020, HIP_0,    HIP_0   };
+  m["HIPRAND_ORDERING_PSEUDO_SEEDED"]                  = {HIP_6020, HIP_0,    HIP_0   };
+  m["HIPRAND_ORDERING_PSEUDO_LEGACY"]                  = {HIP_6020, HIP_0,    HIP_0   };
+  m["HIPRAND_ORDERING_PSEUDO_DYNAMIC"]                 = {HIP_6020, HIP_0,    HIP_0   };
+  m["HIPRAND_ORDERING_QUASI_DEFAULT"]                  = {HIP_6020, HIP_0,    HIP_0   };
+  m["hiprandStateScrambledSobol32"]                    = {HIP_6020, HIP_0,    HIP_0   };
+  m["hiprandStateScrambledSobol32_t"]                  = {HIP_6020, HIP_0,    HIP_0   };
+  m["hiprandStateScrambledSobol64"]                    = {HIP_6020, HIP_0,    HIP_0   };
+  m["hiprandStateScrambledSobol64_t"]                  = {HIP_6020, HIP_0,    HIP_0   };
+  m["hiprandStateSobol64"]                             = {HIP_6020, HIP_0,    HIP_0   };
+  m["hiprandStateSobol64_t"]                           = {HIP_6020, HIP_0,    HIP_0   };
+
+  m["rocrand_status"]                                  = {HIP_1050, HIP_0,    HIP_0   };
+  m["ROCRAND_STATUS_SUCCESS"]                          = {HIP_1050, HIP_0,    HIP_0   };
+  m["ROCRAND_STATUS_VERSION_MISMATCH"]                 = {HIP_1050, HIP_0,    HIP_0   };
+  m["ROCRAND_STATUS_NOT_CREATED"]                      = {HIP_1050, HIP_0,    HIP_0   };
+  m["ROCRAND_STATUS_ALLOCATION_FAILED"]                = {HIP_1050, HIP_0,    HIP_0   };
+  m["ROCRAND_STATUS_TYPE_ERROR"]                       = {HIP_1050, HIP_0,    HIP_0   };
+  m["ROCRAND_STATUS_OUT_OF_RANGE"]                     = {HIP_1050, HIP_0,    HIP_0   };
+  m["ROCRAND_STATUS_LENGTH_NOT_MULTIPLE"]              = {HIP_1050, HIP_0,    HIP_0   };
+  m["ROCRAND_STATUS_DOUBLE_PRECISION_REQUIRED"]        = {HIP_1050, HIP_0,    HIP_0   };
+  m["ROCRAND_STATUS_LAUNCH_FAILURE"]                   = {HIP_1050, HIP_0,    HIP_0   };
+  m["ROCRAND_STATUS_INTERNAL_ERROR"]                   = {HIP_1050, HIP_0,    HIP_0   };
+  m["rocrand_rng_type"]                                = {HIP_1050, HIP_0,    HIP_0   };
+  m["ROCRAND_RNG_PSEUDO_DEFAULT"]                      = {HIP_1050, HIP_0,    HIP_0   };
+  m["ROCRAND_RNG_PSEUDO_XORWOW"]                       = {HIP_1050, HIP_0,    HIP_0   };
+  m["ROCRAND_RNG_PSEUDO_MRG32K3A"]                     = {HIP_1050, HIP_0,    HIP_0   };
+  m["ROCRAND_RNG_PSEUDO_MTGP32"]                       = {HIP_1050, HIP_0,    HIP_0   };
+  m["ROCRAND_RNG_PSEUDO_MT19937"]                      = {HIP_5050, HIP_0,    HIP_0   };
+  m["ROCRAND_RNG_PSEUDO_PHILOX4_32_10"]                = {HIP_1050, HIP_0,    HIP_0   };
+  m["ROCRAND_RNG_QUASI_DEFAULT"]                       = {HIP_1050, HIP_0,    HIP_0   };
+  m["ROCRAND_RNG_QUASI_SOBOL32"]                       = {HIP_1050, HIP_0,    HIP_0   };
+  m["ROCRAND_RNG_QUASI_SCRAMBLED_SOBOL32"]             = {HIP_5040, HIP_0,    HIP_0   };
+  m["ROCRAND_RNG_QUASI_SOBOL64"]                       = {HIP_4050, HIP_0,    HIP_0   };
+  m["ROCRAND_RNG_QUASI_SCRAMBLED_SOBOL64"]             = {HIP_5040, HIP_0,    HIP_0   };
+  m["rocrand_ordering"]                                = {HIP_5050, HIP_0,    HIP_0   };
+  m["ROCRAND_ORDERING_PSEUDO_BEST"]                    = {HIP_5050, HIP_0,    HIP_0   };
+  m["ROCRAND_ORDERING_PSEUDO_DEFAULT"]                 = {HIP_5050, HIP_0,    HIP_0   };
+  m["ROCRAND_ORDERING_PSEUDO_SEEDED"]                  = {HIP_5050, HIP_0,    HIP_0   };
+  m["ROCRAND_ORDERING_PSEUDO_LEGACY"]                  = {HIP_5050, HIP_0,    HIP_0   };
+  m["ROCRAND_ORDERING_PSEUDO_DYNAMIC"]                 = {HIP_5050, HIP_0,    HIP_0   };
+  m["ROCRAND_ORDERING_QUASI_DEFAULT"]                  = {HIP_5050, HIP_0,    HIP_0   };
+  m["rocrand_direction_vector_set"]                    = {HIP_6000, HIP_0,    HIP_0   };
+  m["ROCRAND_DIRECTION_VECTORS_32_JOEKUO6"]            = {HIP_6000, HIP_0,    HIP_0   };
+  m["ROCRAND_SCRAMBLED_DIRECTION_VECTORS_32_JOEKUO6"]  = {HIP_6000, HIP_0,    HIP_0   };
+  m["ROCRAND_DIRECTION_VECTORS_64_JOEKUO6"]            = {HIP_6000, HIP_0,    HIP_0   };
+  m["ROCRAND_SCRAMBLED_DIRECTION_VECTORS_64_JOEKUO6"]  = {HIP_6000, HIP_0,    HIP_0   };
+  m["rocrand_generator_base_type"]                     = {HIP_1050, HIP_0,    HIP_0   };
+  m["rocrand_generator"]                               = {HIP_1050, HIP_0,    HIP_0   };
+  m["rocrand_discrete_distribution_st"]                = {HIP_1050, HIP_0,    HIP_0   };
+  m["rocrand_discrete_distribution"]                   = {HIP_1050, HIP_0,    HIP_0   };
+  m["rocrand_device::philox4x32_10_engine"]            = {HIP_1050, HIP_0,    HIP_0   };
+  m["rocrand_state_philox4x32_10"]                     = {HIP_1050, HIP_0,    HIP_0   };
+  m["rocrand_device::mtgp32_engine"]                   = {HIP_1050, HIP_0,    HIP_0   };
+  m["rocrand_state_mtgp32"]                            = {HIP_1050, HIP_0,    HIP_0   };
+  m["rocrand_device::scrambled_sobol32_engine<false>"] = {HIP_5040, HIP_0,    HIP_0   };
+  m["rocrand_state_scrambled_sobol32"]                 = {HIP_5040, HIP_0,    HIP_0   };
+  m["rocrand_device::scrambled_sobol64_engine<false>"] = {HIP_5040, HIP_0,    HIP_0   };
+  m["rocrand_state_scrambled_sobol64"]                 = {HIP_5040, HIP_0,    HIP_0   };
+  m["rocrand_device::sobol32_engine<false>"]           = {HIP_1050, HIP_0,    HIP_0   };
+  m["rocrand_state_sobol32"]                           = {HIP_1050, HIP_0,    HIP_0   };
+  m["rocrand_device::sobol64_engine<false>"]           = {HIP_4050, HIP_0,    HIP_0   };
+  m["rocrand_state_sobol64"]                           = {HIP_4050, HIP_0,    HIP_0   };
+  m["rocrand_device::mrg32k3a_engine"]                 = {HIP_1050, HIP_0,    HIP_0   };
+  m["rocrand_state_mrg32k3a"]                          = {HIP_1050, HIP_0,    HIP_0   };
+  m["rocrand_device::xorwow_engine"]                   = {HIP_1050, HIP_0,    HIP_0   };
+  m["rocrand_state_xorwow"]                            = {HIP_1050, HIP_0,    HIP_0   };
+
+  return m;
+}();


### PR DESCRIPTION
**[Synopsis]**
+ Transformation maps reside in Stack and occupy up to `64kB` each of stack memory now
+ That leads to multiple compiler warnings about possible Stack Overflow

**[Solution]**
+ Move maps' initialization logic into a lambda. This prevents the compiler from creating a massive temporary array on the stack, which was the root cause of the "excessive stack usage" warning.
