### PR TITLE
[HIPIFY][#2340][feature] Add implicit CUDA header inclusion to mimic nvcc behavior

### DIFF
--- a/src/ImplicitCudaHeaders.cpp
+++ b/src/ImplicitCudaHeaders.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2015 - present Advanced Micro Devices, Inc. All rights reserved.
+Copyright (c) 2026 - present Advanced Micro Devices, Inc. All rights reserved.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -25,24 +25,13 @@ THE SOFTWARE.
 
 namespace hipify {
 
-std::vector<std::string> getImplicitCudaHeaders() {
-  return {
-    "cuda_runtime.h"
-  };
-}
+static const char *const ImplicitCudaHeader = "cuda_runtime.h";
 
 void addImplicitCudaHeaders(ct::RefactoringTool &Tool) {
-  
-  std::vector<std::string> headers = getImplicitCudaHeaders();
-  
-  for (const auto &header : headers) {
-    Tool.appendArgumentsAdjuster(
-        ct::getInsertArgumentAdjuster(header.c_str(), 
-                                       ct::ArgumentInsertPosition::BEGIN));
-    Tool.appendArgumentsAdjuster(
-        ct::getInsertArgumentAdjuster("-include", 
-                                       ct::ArgumentInsertPosition::BEGIN));
-  }
+  Tool.appendArgumentsAdjuster(ct::getInsertArgumentAdjuster(
+      ImplicitCudaHeader, ct::ArgumentInsertPosition::BEGIN));
+  Tool.appendArgumentsAdjuster(ct::getInsertArgumentAdjuster(
+      "-include", ct::ArgumentInsertPosition::BEGIN));
 }
 
 } // namespace hipify

--- a/src/ImplicitCudaHeaders.cpp
+++ b/src/ImplicitCudaHeaders.cpp
@@ -1,0 +1,48 @@
+/*
+Copyright (c) 2015 - present Advanced Micro Devices, Inc. All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+#include "ImplicitCudaHeaders.h"
+#include "clang/Tooling/ArgumentsAdjusters.h"
+
+namespace hipify {
+
+std::vector<std::string> getImplicitCudaHeaders() {
+  return {
+    "cuda_runtime.h"
+  };
+}
+
+void addImplicitCudaHeaders(ct::RefactoringTool &Tool) {
+  
+  std::vector<std::string> headers = getImplicitCudaHeaders();
+  
+  for (const auto &header : headers) {
+    Tool.appendArgumentsAdjuster(
+        ct::getInsertArgumentAdjuster(header.c_str(), 
+                                       ct::ArgumentInsertPosition::BEGIN));
+    Tool.appendArgumentsAdjuster(
+        ct::getInsertArgumentAdjuster("-include", 
+                                       ct::ArgumentInsertPosition::BEGIN));
+  }
+}
+
+} // namespace hipify

--- a/src/ImplicitCudaHeaders.h
+++ b/src/ImplicitCudaHeaders.h
@@ -1,0 +1,46 @@
+/*
+Copyright (c) 2015 - present Advanced Micro Devices, Inc. All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+#pragma once
+
+#include "clang/Tooling/Refactoring.h"
+
+namespace ct = clang::tooling;
+
+namespace hipify {
+
+/// nvcc automatically pre-includes certain CUDA headers at the beginning of
+/// any compilation unit.
+///
+/// The primary header is cuda_runtime.h, which transitively includes:
+///   - host_config.h      (System configuration)
+///   - builtin_types.h    (Basic CUDA types)
+///   - device_types.h     (Device enums and structs)
+///   - host_defines.h     (Macro definitions)
+///   - driver_types.h     (Driver types)
+///   - vector_types.h     (float3, int2, etc.)
+
+void addImplicitCudaHeaders(ct::RefactoringTool &Tool);
+
+std::vector<std::string> getImplicitCudaHeaders();
+
+} // namespace hipify

--- a/src/ImplicitCudaHeaders.h
+++ b/src/ImplicitCudaHeaders.h
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2015 - present Advanced Micro Devices, Inc. All rights reserved.
+Copyright (c) 2026 - present Advanced Micro Devices, Inc. All rights reserved.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -40,7 +40,5 @@ namespace hipify {
 ///   - vector_types.h     (float3, int2, etc.)
 
 void addImplicitCudaHeaders(ct::RefactoringTool &Tool);
-
-std::vector<std::string> getImplicitCudaHeaders();
 
 } // namespace hipify

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -44,6 +44,7 @@ THE SOFTWARE.
 #endif
 
 #include "LocalHeader.h"
+#include "ImplicitCudaHeaders.h"
 
 #if LLVM_VERSION_MAJOR < 8
 #include "llvm/Support/Path.h"
@@ -221,6 +222,9 @@ bool appendArgumentsAdjusters(ct::RefactoringTool &Tool, const std::string &sSou
     std::string sCudaPath = "--cuda-path=" + CudaPath;
     Tool.appendArgumentsAdjuster(ct::getInsertArgumentAdjuster(sCudaPath.c_str(), ct::ArgumentInsertPosition::BEGIN));
   }
+
+  // Implicit CUDA headers to mimic nvcc behavior
+  hipify::addImplicitCudaHeaders(Tool);
   llcompat::addTargetIfNeeded(Tool);
   Tool.appendArgumentsAdjuster(ct::getInsertArgumentAdjuster("cuda", ct::ArgumentInsertPosition::BEGIN));
   Tool.appendArgumentsAdjuster(ct::getInsertArgumentAdjuster("-x", ct::ArgumentInsertPosition::BEGIN));


### PR DESCRIPTION
## Purpose

Add implicit CUDA header pre-inclusion to hipify-clang to mimic nvcc's automatic header inclusion behavior.

## Problem Statement

nvcc automatically pre-includes `cuda_runtime.h` at the beginning of any CUDA compilation unit. This allows CUDA code to compile without explicit `#include` directives.

hipify-clang uses clang for parsing, which does not perform this implicit inclusion. This causes hipification to fail for some of the source files that rely on nvcc's implicit behavior.

## Solution

Introduce implicit CUDA header inclusion by adding `-include cuda_runtime.h` to clang's argument list during hipification. `cuda_runtime.h` is nvcc's single implicit entry point which transitively includes all necessary headers such as 

- crt/host_config.h (System check)
- builtin_types.h (Basic types)
- device_types.h (enums and structs)
- host_defines.h (Macro definitions)

Fixes #2340