### PR TITLE
[HIPIFY][fix] `Stack Overflow` possible Issues - Part 9 - `FFT`

### DIFF
--- a/src/CUDA2HIP_FFT_API_functions.cpp
+++ b/src/CUDA2HIP_FFT_API_functions.cpp
@@ -23,264 +23,280 @@ THE SOFTWARE.
 #include "CUDA2HIP.h"
 
 // Map of all functions
-const std::map<llvm::StringRef, hipCounter> CUDA_FFT_FUNCTION_MAP {
-  {"cufftPlan1d",                                         {"hipfftPlan1d",                                         "", CONV_LIB_FUNC, API_FFT, 2}},
-  {"cufftPlan2d",                                         {"hipfftPlan2d",                                         "", CONV_LIB_FUNC, API_FFT, 2}},
-  {"cufftPlan3d",                                         {"hipfftPlan3d",                                         "", CONV_LIB_FUNC, API_FFT, 2}},
-  {"cufftPlanMany",                                       {"hipfftPlanMany",                                       "", CONV_LIB_FUNC, API_FFT, 2}},
-  {"cufftMakePlan1d",                                     {"hipfftMakePlan1d",                                     "", CONV_LIB_FUNC, API_FFT, 2}},
-  {"cufftMakePlan2d",                                     {"hipfftMakePlan2d",                                     "", CONV_LIB_FUNC, API_FFT, 2}},
-  {"cufftMakePlan3d",                                     {"hipfftMakePlan3d",                                     "", CONV_LIB_FUNC, API_FFT, 2}},
-  {"cufftMakePlanMany",                                   {"hipfftMakePlanMany",                                   "", CONV_LIB_FUNC, API_FFT, 2}},
-  {"cufftMakePlanMany64",                                 {"hipfftMakePlanMany64",                                 "", CONV_LIB_FUNC, API_FFT, 2}},
-  {"cufftGetSizeMany64",                                  {"hipfftGetSizeMany64",                                  "", CONV_LIB_FUNC, API_FFT, 2}},
-  {"cufftEstimate1d",                                     {"hipfftEstimate1d",                                     "", CONV_LIB_FUNC, API_FFT, 2}},
-  {"cufftEstimate2d",                                     {"hipfftEstimate2d",                                     "", CONV_LIB_FUNC, API_FFT, 2}},
-  {"cufftEstimate3d",                                     {"hipfftEstimate3d",                                     "", CONV_LIB_FUNC, API_FFT, 2}},
-  {"cufftEstimateMany",                                   {"hipfftEstimateMany",                                   "", CONV_LIB_FUNC, API_FFT, 2}},
-  {"cufftCreate",                                         {"hipfftCreate",                                         "", CONV_LIB_FUNC, API_FFT, 2}},
-  {"cufftGetSize1d",                                      {"hipfftGetSize1d",                                      "", CONV_LIB_FUNC, API_FFT, 2}},
-  {"cufftGetSize2d",                                      {"hipfftGetSize2d",                                      "", CONV_LIB_FUNC, API_FFT, 2}},
-  {"cufftGetSize3d",                                      {"hipfftGetSize3d",                                      "", CONV_LIB_FUNC, API_FFT, 2}},
-  {"cufftGetSizeMany",                                    {"hipfftGetSizeMany",                                    "", CONV_LIB_FUNC, API_FFT, 2}},
-  {"cufftGetSize",                                        {"hipfftGetSize",                                        "", CONV_LIB_FUNC, API_FFT, 2}},
-  {"cufftSetWorkArea",                                    {"hipfftSetWorkArea",                                    "", CONV_LIB_FUNC, API_FFT, 2}},
-  {"cufftSetAutoAllocation",                              {"hipfftSetAutoAllocation",                              "", CONV_LIB_FUNC, API_FFT, 2}},
-  {"cufftExecC2C",                                        {"hipfftExecC2C",                                        "", CONV_LIB_FUNC, API_FFT, 2}},
-  {"cufftExecR2C",                                        {"hipfftExecR2C",                                        "", CONV_LIB_FUNC, API_FFT, 2}},
-  {"cufftExecC2R",                                        {"hipfftExecC2R",                                        "", CONV_LIB_FUNC, API_FFT, 2}},
-  {"cufftExecZ2Z",                                        {"hipfftExecZ2Z",                                        "", CONV_LIB_FUNC, API_FFT, 2}},
-  {"cufftExecD2Z",                                        {"hipfftExecD2Z",                                        "", CONV_LIB_FUNC, API_FFT, 2}},
-  {"cufftExecZ2D",                                        {"hipfftExecZ2D",                                        "", CONV_LIB_FUNC, API_FFT, 2}},
-  {"cufftSetStream",                                      {"hipfftSetStream",                                      "", CONV_LIB_FUNC, API_FFT, 2}},
-  {"cufftDestroy",                                        {"hipfftDestroy",                                        "", CONV_LIB_FUNC, API_FFT, 2}},
-  {"cufftGetVersion",                                     {"hipfftGetVersion",                                     "", CONV_LIB_FUNC, API_FFT, 2}},
-  {"cufftGetProperty",                                    {"hipfftGetProperty",                                    "", CONV_LIB_FUNC, API_FFT, 2}},
-  {"cufftXtSetGPUs",                                      {"hipfftXtSetGPUs",                                      "", CONV_LIB_FUNC, API_FFT, 2}},
-  {"cufftXtMalloc",                                       {"hipfftXtMalloc",                                       "", CONV_LIB_FUNC, API_FFT, 2}},
-  {"cufftXtMemcpy",                                       {"hipfftXtMemcpy",                                       "", CONV_LIB_FUNC, API_FFT, 2}},
-  {"cufftXtFree",                                         {"hipfftXtFree",                                         "", CONV_LIB_FUNC, API_FFT, 2}},
-  {"cufftXtSetWorkArea",                                  {"hipfftXtSetWorkArea",                                  "", CONV_LIB_FUNC, API_FFT, 2, UNSUPPORTED}},
-  {"cufftXtExecDescriptorC2C",                            {"hipfftXtExecDescriptorC2C",                            "", CONV_LIB_FUNC, API_FFT, 2}},
-  {"cufftXtExecDescriptorR2C",                            {"hipfftXtExecDescriptorR2C",                            "", CONV_LIB_FUNC, API_FFT, 2}},
-  {"cufftXtExecDescriptorC2R",                            {"hipfftXtExecDescriptorC2R",                            "", CONV_LIB_FUNC, API_FFT, 2}},
-  {"cufftXtExecDescriptorZ2Z",                            {"hipfftXtExecDescriptorZ2Z",                            "", CONV_LIB_FUNC, API_FFT, 2}},
-  {"cufftXtExecDescriptorD2Z",                            {"hipfftXtExecDescriptorD2Z",                            "", CONV_LIB_FUNC, API_FFT, 2}},
-  {"cufftXtExecDescriptorZ2D",                            {"hipfftXtExecDescriptorZ2D",                            "", CONV_LIB_FUNC, API_FFT, 2}},
-  {"cufftXtQueryPlan",                                    {"hipfftXtQueryPlan",                                    "", CONV_LIB_FUNC, API_FFT, 2, UNSUPPORTED}},
-  {"cufftCallbackLoadC",                                  {"hipfftCallbackLoadC",                                  "", CONV_LIB_FUNC, API_FFT, 2}},
-  {"cufftCallbackLoadZ",                                  {"hipfftCallbackLoadZ",                                  "", CONV_LIB_FUNC, API_FFT, 2}},
-  {"cufftCallbackLoadR",                                  {"hipfftCallbackLoadR",                                  "", CONV_LIB_FUNC, API_FFT, 2}},
-  {"cufftCallbackLoadD",                                  {"hipfftCallbackLoadD",                                  "", CONV_LIB_FUNC, API_FFT, 2}},
-  {"cufftCallbackStoreC",                                 {"hipfftCallbackStoreC",                                 "", CONV_LIB_FUNC, API_FFT, 2}},
-  {"cufftCallbackStoreZ",                                 {"hipfftCallbackStoreZ",                                 "", CONV_LIB_FUNC, API_FFT, 2}},
-  {"cufftCallbackStoreR",                                 {"hipfftCallbackStoreR",                                 "", CONV_LIB_FUNC, API_FFT, 2}},
-  {"cufftCallbackStoreD",                                 {"hipfftCallbackStoreD",                                 "", CONV_LIB_FUNC, API_FFT, 2}},
-  {"cufftXtSetCallback",                                  {"hipfftXtSetCallback",                                  "", CONV_LIB_FUNC, API_FFT, 2}},
-  {"cufftXtClearCallback",                                {"hipfftXtClearCallback",                                "", CONV_LIB_FUNC, API_FFT, 2}},
-  {"cufftXtSetCallbackSharedSize",                        {"hipfftXtSetCallbackSharedSize",                        "", CONV_LIB_FUNC, API_FFT, 2}},
-  {"cufftXtMakePlanMany",                                 {"hipfftXtMakePlanMany",                                 "", CONV_LIB_FUNC, API_FFT, 2}},
-  {"cufftXtGetSizeMany",                                  {"hipfftXtGetSizeMany",                                  "", CONV_LIB_FUNC, API_FFT, 2}},
-  {"cufftXtExec",                                         {"hipfftXtExec",                                         "", CONV_LIB_FUNC, API_FFT, 2}},
-  {"cufftXtExecDescriptor",                               {"hipfftXtExecDescriptor",                               "", CONV_LIB_FUNC, API_FFT, 2}},
-  {"cufftXtSetWorkAreaPolicy",                            {"hipfftXtSetWorkAreaPolicy",                            "", CONV_LIB_FUNC, API_FFT, 2, UNSUPPORTED}},
-  {"cufftXtSetDistribution",                              {"hipfftXtSetDistribution",                              "", CONV_LIB_FUNC, API_FFT, 2, UNSUPPORTED}},
-  {"cufftSetPlanPropertyInt64",                           {"hipfftSetPlanPropertyInt64",                           "", CONV_LIB_FUNC, API_FFT, 2, UNSUPPORTED}},
-  {"cufftGetPlanPropertyInt64",                           {"hipfftGetPlanPropertyInt64",                           "", CONV_LIB_FUNC, API_FFT, 2, UNSUPPORTED}},
-  {"cufftResetPlanProperty",                              {"hipfftResetPlanProperty",                              "", CONV_LIB_FUNC, API_FFT, 2, UNSUPPORTED}},
-  {"fftw_plan_dft_1d",                                    {"fftw_plan_dft_1d",                                     "", CONV_LIB_FUNC, API_FFT, 2}},
-  {"fftw_plan_dft_2d",                                    {"fftw_plan_dft_2d",                                     "", CONV_LIB_FUNC, API_FFT, 2}},
-  {"fftw_plan_dft_3d",                                    {"fftw_plan_dft_3d",                                     "", CONV_LIB_FUNC, API_FFT, 2}},
-  {"fftw_plan_dft",                                       {"fftw_plan_dft",                                        "", CONV_LIB_FUNC, API_FFT, 2}},
-  {"fftw_plan_dft_r2c_1d",                                {"fftw_plan_dft_r2c_1d",                                 "", CONV_LIB_FUNC, API_FFT, 2}},
-  {"fftw_plan_dft_r2c_2d",                                {"fftw_plan_dft_r2c_2d",                                 "", CONV_LIB_FUNC, API_FFT, 2}},
-  {"fftw_plan_dft_r2c_3d",                                {"fftw_plan_dft_r2c_3d",                                 "", CONV_LIB_FUNC, API_FFT, 2}},
-  {"fftw_plan_dft_r2c",                                   {"fftw_plan_dft_r2c",                                    "", CONV_LIB_FUNC, API_FFT, 2}},
-  {"fftw_plan_dft_c2r_1d",                                {"fftw_plan_dft_c2r_1d",                                 "", CONV_LIB_FUNC, API_FFT, 2}},
-  {"fftw_plan_dft_c2r_2d",                                {"fftw_plan_dft_c2r_2d",                                 "", CONV_LIB_FUNC, API_FFT, 2}},
-  {"fftw_plan_dft_c2r_3d",                                {"fftw_plan_dft_c2r_3d",                                 "", CONV_LIB_FUNC, API_FFT, 2}},
-  {"fftw_plan_dft_c2r",                                   {"fftw_plan_dft_c2r",                                    "", CONV_LIB_FUNC, API_FFT, 2}},
-  {"fftw_execute",                                        {"fftw_execute",                                         "", CONV_LIB_FUNC, API_FFT, 2}},
-  {"fftwf_plan_dft_1d",                                   {"fftwf_plan_dft_1d",                                    "", CONV_LIB_FUNC, API_FFT, 2}},
-  {"fftwf_plan_dft_2d",                                   {"fftwf_plan_dft_2d",                                    "", CONV_LIB_FUNC, API_FFT, 2}},
-  {"fftwf_plan_dft_3d",                                   {"fftwf_plan_dft_3d",                                    "", CONV_LIB_FUNC, API_FFT, 2}},
-  {"fftwf_plan_dft",                                      {"fftwf_plan_dft",                                       "", CONV_LIB_FUNC, API_FFT, 2}},
-  {"fftwf_plan_dft_r2c_1d",                               {"fftwf_plan_dft_r2c_1d",                                "", CONV_LIB_FUNC, API_FFT, 2}},
-  {"fftwf_plan_dft_r2c_2d",                               {"fftwf_plan_dft_r2c_2d",                                "", CONV_LIB_FUNC, API_FFT, 2}},
-  {"fftwf_plan_dft_r2c_3d",                               {"fftwf_plan_dft_r2c_3d",                                "", CONV_LIB_FUNC, API_FFT, 2}},
-  {"fftwf_plan_dft_r2c",                                  {"fftwf_plan_dft_r2c",                                   "", CONV_LIB_FUNC, API_FFT, 2}},
-  {"fftwf_plan_dft_c2r_1d",                               {"fftwf_plan_dft_c2r_1d",                                "", CONV_LIB_FUNC, API_FFT, 2}},
-  {"fftwf_plan_dft_c2r_2d",                               {"fftwf_plan_dft_c2r_2d",                                "", CONV_LIB_FUNC, API_FFT, 2}},
-  {"fftwf_plan_dft_c2r_3d",                               {"fftwf_plan_dft_c2r_3d",                                "", CONV_LIB_FUNC, API_FFT, 2}},
-  {"fftwf_plan_dft_c2r",                                  {"fftwf_plan_dft_c2r",                                   "", CONV_LIB_FUNC, API_FFT, 2}},
-  {"fftwf_execute",                                       {"fftwf_execute",                                        "", CONV_LIB_FUNC, API_FFT, 2}},
-  {"fftw_print_plan",                                     {"fftw_print_plan",                                      "", CONV_LIB_FUNC, API_FFT, 2}},
-  {"fftwf_print_plan",                                    {"fftwf_print_plan",                                     "", CONV_LIB_FUNC, API_FFT, 2}},
-  {"fftw_set_timelimit",                                  {"fftw_set_timelimit",                                   "", CONV_LIB_FUNC, API_FFT, 2}},
-  {"fftwf_set_timelimit",                                 {"fftwf_set_timelimit",                                  "", CONV_LIB_FUNC, API_FFT, 2}},
-  {"fftw_cost",                                           {"fftw_cost",                                            "", CONV_LIB_FUNC, API_FFT, 2}},
-  {"fftwf_cost",                                          {"fftwf_cost",                                           "", CONV_LIB_FUNC, API_FFT, 2}},
-  {"fftw_flops",                                          {"fftw_flops",                                           "", CONV_LIB_FUNC, API_FFT, 2}},
-  {"fftwf_flops",                                         {"fftwf_flops",                                          "", CONV_LIB_FUNC, API_FFT, 2}},
-  {"fftw_destroy_plan",                                   {"fftw_destroy_plan",                                    "", CONV_LIB_FUNC, API_FFT, 2}},
-  {"fftwf_destroy_plan",                                  {"fftwf_destroy_plan",                                   "", CONV_LIB_FUNC, API_FFT, 2}},
-  {"fftw_cleanup",                                        {"fftw_cleanup",                                         "", CONV_LIB_FUNC, API_FFT, 2}},
-  {"fftwf_cleanup",                                       {"fftwf_cleanup",                                        "", CONV_LIB_FUNC, API_FFT, 2}},
-  {"fftw_plan_many_dft",                                  {"fftw_plan_many_dft",                                   "", CONV_LIB_FUNC, API_FFT, 2, UNSUPPORTED}},
-  {"fftw_plan_many_dft_r2c",                              {"fftw_plan_many_dft_r2c",                               "", CONV_LIB_FUNC, API_FFT, 2, UNSUPPORTED}},
-  {"fftw_plan_many_dft_c2r",                              {"fftw_plan_many_dft_c2r",                               "", CONV_LIB_FUNC, API_FFT, 2, UNSUPPORTED}},
-  {"fftw_plan_guru_dft",                                  {"fftw_plan_guru_dft",                                   "", CONV_LIB_FUNC, API_FFT, 2, UNSUPPORTED}},
-  {"fftw_plan_guru_dft_r2c",                              {"fftw_plan_guru_dft_r2c",                               "", CONV_LIB_FUNC, API_FFT, 2, UNSUPPORTED}},
-  {"fftw_plan_guru_dft_c2r",                              {"fftw_plan_guru_dft_c2r",                               "", CONV_LIB_FUNC, API_FFT, 2, UNSUPPORTED}},
-  {"fftw_plan_guru64_dft",                                {"fftw_plan_guru64_dft",                                 "", CONV_LIB_FUNC, API_FFT, 2, UNSUPPORTED}},
-  {"fftw_plan_guru64_dft_r2c",                            {"fftw_plan_guru64_dft_r2c",                             "", CONV_LIB_FUNC, API_FFT, 2, UNSUPPORTED}},
-  {"fftw_plan_guru64_dft_c2r",                            {"fftw_plan_guru64_dft_c2r",                             "", CONV_LIB_FUNC, API_FFT, 2, UNSUPPORTED}},
-  {"fftw_execute_dft",                                    {"fftw_execute_dft",                                     "", CONV_LIB_FUNC, API_FFT, 2}},
-  {"fftw_execute_dft_r2c",                                {"fftw_execute_dft_r2c",                                 "", CONV_LIB_FUNC, API_FFT, 2}},
-  {"fftw_execute_dft_c2r",                                {"fftw_execute_dft_c2r",                                 "", CONV_LIB_FUNC, API_FFT, 2}},
-  {"fftwf_plan_many_dft",                                 {"fftwf_plan_many_dft",                                  "", CONV_LIB_FUNC, API_FFT, 2, UNSUPPORTED}},
-  {"fftwf_plan_many_dft_r2c",                             {"fftwf_plan_many_dft_r2c",                              "", CONV_LIB_FUNC, API_FFT, 2, UNSUPPORTED}},
-  {"fftwf_plan_many_dft_c2r",                             {"fftwf_plan_many_dft_c2r",                              "", CONV_LIB_FUNC, API_FFT, 2, UNSUPPORTED}},
-  {"fftwf_plan_guru_dft",                                 {"fftwf_plan_guru_dft",                                  "", CONV_LIB_FUNC, API_FFT, 2, UNSUPPORTED}},
-  {"fftwf_plan_guru_dft_r2c",                             {"fftwf_plan_guru_dft_r2c",                              "", CONV_LIB_FUNC, API_FFT, 2, UNSUPPORTED}},
-  {"fftwf_plan_guru_dft_c2r",                             {"fftwf_plan_guru_dft_c2r",                              "", CONV_LIB_FUNC, API_FFT, 2, UNSUPPORTED}},
-  {"fftwf_plan_guru64_dft",                               {"fftwf_plan_guru64_dft",                                "", CONV_LIB_FUNC, API_FFT, 2, UNSUPPORTED}},
-  {"fftwf_plan_guru64_dft_r2c",                           {"fftwf_plan_guru64_dft_r2c",                            "", CONV_LIB_FUNC, API_FFT, 2, UNSUPPORTED}},
-  {"fftwf_plan_guru64_dft_c2r",                           {"fftwf_plan_guru64_dft_c2r",                            "", CONV_LIB_FUNC, API_FFT, 2, UNSUPPORTED}},
-  {"fftwf_execute_dft",                                   {"fftwf_execute_dft",                                    "", CONV_LIB_FUNC, API_FFT, 2}},
-  {"fftwf_execute_dft_r2c",                               {"fftwf_execute_dft_r2c",                                "", CONV_LIB_FUNC, API_FFT, 2}},
-  {"fftwf_execute_dft_c2r",                               {"fftwf_execute_dft_c2r",                                "", CONV_LIB_FUNC, API_FFT, 2}},
-  {"fftw_export_wisdom_to_file",                          {"fftw_export_wisdom_to_file",                           "", CONV_LIB_FUNC, API_FFT, 2, UNSUPPORTED}},
-  {"fftwf_export_wisdom_to_file",                         {"fftwf_export_wisdom_to_file",                          "", CONV_LIB_FUNC, API_FFT, 2, UNSUPPORTED}},
-  {"fftw_import_wisdom_from_file",                        {"fftw_import_wisdom_from_file",                         "", CONV_LIB_FUNC, API_FFT, 2, UNSUPPORTED}},
-  {"fftwf_import_wisdom_from_file",                       {"fftwf_import_wisdom_from_file",                        "", CONV_LIB_FUNC, API_FFT, 2, UNSUPPORTED}},
-};
+const std::map<llvm::StringRef, hipCounter> CUDA_FFT_FUNCTION_MAP = []() {
+  std::map<llvm::StringRef, hipCounter> m;
 
-const std::map<llvm::StringRef, cudaAPIversions> CUDA_FFT_FUNCTION_VER_MAP {
-  {"cufftMakePlanMany64",                                 {CUDA_75,  CUDA_0,   CUDA_0  }},
-  {"cufftGetSizeMany64",                                  {CUDA_75,  CUDA_0,   CUDA_0  }},
-  {"cufftGetProperty",                                    {CUDA_80,  CUDA_0,   CUDA_0  }},
-  {"cufftXtMakePlanMany",                                 {CUDA_80,  CUDA_0,   CUDA_0  }},
-  {"cufftXtGetSizeMany",                                  {CUDA_80,  CUDA_0,   CUDA_0  }},
-  {"cufftXtExec",                                         {CUDA_80,  CUDA_0,   CUDA_0  }},
-  {"cufftXtExecDescriptor",                               {CUDA_80,  CUDA_0,   CUDA_0  }},
-  {"cufftXtSetWorkAreaPolicy",                            {CUDA_92,  CUDA_0,   CUDA_0  }},
-  {"cufftXtSetDistribution",                              {CUDA_118, CUDA_0,   CUDA_0  }},
-  {"cufftSetPlanPropertyInt64",                           {CUDA_124, CUDA_0,   CUDA_0  }},
-  {"cufftGetPlanPropertyInt64",                           {CUDA_124, CUDA_0,   CUDA_0  }},
-  {"cufftResetPlanProperty",                              {CUDA_124, CUDA_0,   CUDA_0  }},
-  {"fftw_plan_guru64_dft",                                {CUDA_100, CUDA_0,   CUDA_0  }},
-  {"fftw_plan_guru64_dft_r2c",                            {CUDA_100, CUDA_0,   CUDA_0  }},
-  {"fftw_plan_guru64_dft_c2r",                            {CUDA_100, CUDA_0,   CUDA_0  }},
-  {"fftwf_plan_guru64_dft",                               {CUDA_100, CUDA_0,   CUDA_0  }},
-  {"fftwf_plan_guru64_dft_r2c",                           {CUDA_100, CUDA_0,   CUDA_0  }},
-  {"fftwf_plan_guru64_dft_c2r",                           {CUDA_100, CUDA_0,   CUDA_0  }},
-};
+  m["cufftPlan1d"]                                      = {"hipfftPlan1d",                                         "", CONV_LIB_FUNC, API_FFT, 2};
+  m["cufftPlan2d"]                                      = {"hipfftPlan2d",                                         "", CONV_LIB_FUNC, API_FFT, 2};
+  m["cufftPlan3d"]                                      = {"hipfftPlan3d",                                         "", CONV_LIB_FUNC, API_FFT, 2};
+  m["cufftPlanMany"]                                    = {"hipfftPlanMany",                                       "", CONV_LIB_FUNC, API_FFT, 2};
+  m["cufftMakePlan1d"]                                  = {"hipfftMakePlan1d",                                     "", CONV_LIB_FUNC, API_FFT, 2};
+  m["cufftMakePlan2d"]                                  = {"hipfftMakePlan2d",                                     "", CONV_LIB_FUNC, API_FFT, 2};
+  m["cufftMakePlan3d"]                                  = {"hipfftMakePlan3d",                                     "", CONV_LIB_FUNC, API_FFT, 2};
+  m["cufftMakePlanMany"]                                = {"hipfftMakePlanMany",                                   "", CONV_LIB_FUNC, API_FFT, 2};
+  m["cufftMakePlanMany64"]                              = {"hipfftMakePlanMany64",                                 "", CONV_LIB_FUNC, API_FFT, 2};
+  m["cufftGetSizeMany64"]                               = {"hipfftGetSizeMany64",                                  "", CONV_LIB_FUNC, API_FFT, 2};
+  m["cufftEstimate1d"]                                  = {"hipfftEstimate1d",                                     "", CONV_LIB_FUNC, API_FFT, 2};
+  m["cufftEstimate2d"]                                  = {"hipfftEstimate2d",                                     "", CONV_LIB_FUNC, API_FFT, 2};
+  m["cufftEstimate3d"]                                  = {"hipfftEstimate3d",                                     "", CONV_LIB_FUNC, API_FFT, 2};
+  m["cufftEstimateMany"]                                = {"hipfftEstimateMany",                                   "", CONV_LIB_FUNC, API_FFT, 2};
+  m["cufftCreate"]                                      = {"hipfftCreate",                                         "", CONV_LIB_FUNC, API_FFT, 2};
+  m["cufftGetSize1d"]                                   = {"hipfftGetSize1d",                                      "", CONV_LIB_FUNC, API_FFT, 2};
+  m["cufftGetSize2d"]                                   = {"hipfftGetSize2d",                                      "", CONV_LIB_FUNC, API_FFT, 2};
+  m["cufftGetSize3d"]                                   = {"hipfftGetSize3d",                                      "", CONV_LIB_FUNC, API_FFT, 2};
+  m["cufftGetSizeMany"]                                 = {"hipfftGetSizeMany",                                    "", CONV_LIB_FUNC, API_FFT, 2};
+  m["cufftGetSize"]                                     = {"hipfftGetSize",                                        "", CONV_LIB_FUNC, API_FFT, 2};
+  m["cufftSetWorkArea"]                                 = {"hipfftSetWorkArea",                                    "", CONV_LIB_FUNC, API_FFT, 2};
+  m["cufftSetAutoAllocation"]                           = {"hipfftSetAutoAllocation",                              "", CONV_LIB_FUNC, API_FFT, 2};
+  m["cufftExecC2C"]                                     = {"hipfftExecC2C",                                        "", CONV_LIB_FUNC, API_FFT, 2};
+  m["cufftExecR2C"]                                     = {"hipfftExecR2C",                                        "", CONV_LIB_FUNC, API_FFT, 2};
+  m["cufftExecC2R"]                                     = {"hipfftExecC2R",                                        "", CONV_LIB_FUNC, API_FFT, 2};
+  m["cufftExecZ2Z"]                                     = {"hipfftExecZ2Z",                                        "", CONV_LIB_FUNC, API_FFT, 2};
+  m["cufftExecD2Z"]                                     = {"hipfftExecD2Z",                                        "", CONV_LIB_FUNC, API_FFT, 2};
+  m["cufftExecZ2D"]                                     = {"hipfftExecZ2D",                                        "", CONV_LIB_FUNC, API_FFT, 2};
+  m["cufftSetStream"]                                   = {"hipfftSetStream",                                      "", CONV_LIB_FUNC, API_FFT, 2};
+  m["cufftDestroy"]                                     = {"hipfftDestroy",                                        "", CONV_LIB_FUNC, API_FFT, 2};
+  m["cufftGetVersion"]                                  = {"hipfftGetVersion",                                     "", CONV_LIB_FUNC, API_FFT, 2};
+  m["cufftGetProperty"]                                 = {"hipfftGetProperty",                                    "", CONV_LIB_FUNC, API_FFT, 2};
+  m["cufftXtSetGPUs"]                                   = {"hipfftXtSetGPUs",                                      "", CONV_LIB_FUNC, API_FFT, 2};
+  m["cufftXtMalloc"]                                    = {"hipfftXtMalloc",                                       "", CONV_LIB_FUNC, API_FFT, 2};
+  m["cufftXtMemcpy"]                                    = {"hipfftXtMemcpy",                                       "", CONV_LIB_FUNC, API_FFT, 2};
+  m["cufftXtFree"]                                      = {"hipfftXtFree",                                         "", CONV_LIB_FUNC, API_FFT, 2};
+  m["cufftXtSetWorkArea"]                               = {"hipfftXtSetWorkArea",                                  "", CONV_LIB_FUNC, API_FFT, 2, UNSUPPORTED};
+  m["cufftXtExecDescriptorC2C"]                         = {"hipfftXtExecDescriptorC2C",                            "", CONV_LIB_FUNC, API_FFT, 2};
+  m["cufftXtExecDescriptorR2C"]                         = {"hipfftXtExecDescriptorR2C",                            "", CONV_LIB_FUNC, API_FFT, 2};
+  m["cufftXtExecDescriptorC2R"]                         = {"hipfftXtExecDescriptorC2R",                            "", CONV_LIB_FUNC, API_FFT, 2};
+  m["cufftXtExecDescriptorZ2Z"]                         = {"hipfftXtExecDescriptorZ2Z",                            "", CONV_LIB_FUNC, API_FFT, 2};
+  m["cufftXtExecDescriptorD2Z"]                         = {"hipfftXtExecDescriptorD2Z",                            "", CONV_LIB_FUNC, API_FFT, 2};
+  m["cufftXtExecDescriptorZ2D"]                         = {"hipfftXtExecDescriptorZ2D",                            "", CONV_LIB_FUNC, API_FFT, 2};
+  m["cufftXtQueryPlan"]                                 = {"hipfftXtQueryPlan",                                    "", CONV_LIB_FUNC, API_FFT, 2, UNSUPPORTED};
+  m["cufftCallbackLoadC"]                               = {"hipfftCallbackLoadC",                                  "", CONV_LIB_FUNC, API_FFT, 2};
+  m["cufftCallbackLoadZ"]                               = {"hipfftCallbackLoadZ",                                  "", CONV_LIB_FUNC, API_FFT, 2};
+  m["cufftCallbackLoadR"]                               = {"hipfftCallbackLoadR",                                  "", CONV_LIB_FUNC, API_FFT, 2};
+  m["cufftCallbackLoadD"]                               = {"hipfftCallbackLoadD",                                  "", CONV_LIB_FUNC, API_FFT, 2};
+  m["cufftCallbackStoreC"]                              = {"hipfftCallbackStoreC",                                 "", CONV_LIB_FUNC, API_FFT, 2};
+  m["cufftCallbackStoreZ"]                              = {"hipfftCallbackStoreZ",                                 "", CONV_LIB_FUNC, API_FFT, 2};
+  m["cufftCallbackStoreR"]                              = {"hipfftCallbackStoreR",                                 "", CONV_LIB_FUNC, API_FFT, 2};
+  m["cufftCallbackStoreD"]                              = {"hipfftCallbackStoreD",                                 "", CONV_LIB_FUNC, API_FFT, 2};
+  m["cufftXtSetCallback"]                               = {"hipfftXtSetCallback",                                  "", CONV_LIB_FUNC, API_FFT, 2};
+  m["cufftXtClearCallback"]                             = {"hipfftXtClearCallback",                                "", CONV_LIB_FUNC, API_FFT, 2};
+  m["cufftXtSetCallbackSharedSize"]                     = {"hipfftXtSetCallbackSharedSize",                        "", CONV_LIB_FUNC, API_FFT, 2};
+  m["cufftXtMakePlanMany"]                              = {"hipfftXtMakePlanMany",                                 "", CONV_LIB_FUNC, API_FFT, 2};
+  m["cufftXtGetSizeMany"]                               = {"hipfftXtGetSizeMany",                                  "", CONV_LIB_FUNC, API_FFT, 2};
+  m["cufftXtExec"]                                      = {"hipfftXtExec",                                         "", CONV_LIB_FUNC, API_FFT, 2};
+  m["cufftXtExecDescriptor"]                            = {"hipfftXtExecDescriptor",                               "", CONV_LIB_FUNC, API_FFT, 2};
+  m["cufftXtSetWorkAreaPolicy"]                         = {"hipfftXtSetWorkAreaPolicy",                            "", CONV_LIB_FUNC, API_FFT, 2, UNSUPPORTED};
+  m["cufftXtSetDistribution"]                           = {"hipfftXtSetDistribution",                              "", CONV_LIB_FUNC, API_FFT, 2, UNSUPPORTED};
+  m["cufftSetPlanPropertyInt64"]                        = {"hipfftSetPlanPropertyInt64",                           "", CONV_LIB_FUNC, API_FFT, 2, UNSUPPORTED};
+  m["cufftGetPlanPropertyInt64"]                        = {"hipfftGetPlanPropertyInt64",                           "", CONV_LIB_FUNC, API_FFT, 2, UNSUPPORTED};
+  m["cufftResetPlanProperty"]                           = {"hipfftResetPlanProperty",                              "", CONV_LIB_FUNC, API_FFT, 2, UNSUPPORTED};
+  m["fftw_plan_dft_1d"]                                 = {"fftw_plan_dft_1d",                                     "", CONV_LIB_FUNC, API_FFT, 2};
+  m["fftw_plan_dft_2d"]                                 = {"fftw_plan_dft_2d",                                     "", CONV_LIB_FUNC, API_FFT, 2};
+  m["fftw_plan_dft_3d"]                                 = {"fftw_plan_dft_3d",                                     "", CONV_LIB_FUNC, API_FFT, 2};
+  m["fftw_plan_dft"]                                    = {"fftw_plan_dft",                                        "", CONV_LIB_FUNC, API_FFT, 2};
+  m["fftw_plan_dft_r2c_1d"]                             = {"fftw_plan_dft_r2c_1d",                                 "", CONV_LIB_FUNC, API_FFT, 2};
+  m["fftw_plan_dft_r2c_2d"]                             = {"fftw_plan_dft_r2c_2d",                                 "", CONV_LIB_FUNC, API_FFT, 2};
+  m["fftw_plan_dft_r2c_3d"]                             = {"fftw_plan_dft_r2c_3d",                                 "", CONV_LIB_FUNC, API_FFT, 2};
+  m["fftw_plan_dft_r2c"]                                = {"fftw_plan_dft_r2c",                                    "", CONV_LIB_FUNC, API_FFT, 2};
+  m["fftw_plan_dft_c2r_1d"]                             = {"fftw_plan_dft_c2r_1d",                                 "", CONV_LIB_FUNC, API_FFT, 2};
+  m["fftw_plan_dft_c2r_2d"]                             = {"fftw_plan_dft_c2r_2d",                                 "", CONV_LIB_FUNC, API_FFT, 2};
+  m["fftw_plan_dft_c2r_3d"]                             = {"fftw_plan_dft_c2r_3d",                                 "", CONV_LIB_FUNC, API_FFT, 2};
+  m["fftw_plan_dft_c2r"]                                = {"fftw_plan_dft_c2r",                                    "", CONV_LIB_FUNC, API_FFT, 2};
+  m["fftw_execute"]                                     = {"fftw_execute",                                         "", CONV_LIB_FUNC, API_FFT, 2};
+  m["fftwf_plan_dft_1d"]                                = {"fftwf_plan_dft_1d",                                    "", CONV_LIB_FUNC, API_FFT, 2};
+  m["fftwf_plan_dft_2d"]                                = {"fftwf_plan_dft_2d",                                    "", CONV_LIB_FUNC, API_FFT, 2};
+  m["fftwf_plan_dft_3d"]                                = {"fftwf_plan_dft_3d",                                    "", CONV_LIB_FUNC, API_FFT, 2};
+  m["fftwf_plan_dft"]                                   = {"fftwf_plan_dft",                                       "", CONV_LIB_FUNC, API_FFT, 2};
+  m["fftwf_plan_dft_r2c_1d"]                            = {"fftwf_plan_dft_r2c_1d",                                "", CONV_LIB_FUNC, API_FFT, 2};
+  m["fftwf_plan_dft_r2c_2d"]                            = {"fftwf_plan_dft_r2c_2d",                                "", CONV_LIB_FUNC, API_FFT, 2};
+  m["fftwf_plan_dft_r2c_3d"]                            = {"fftwf_plan_dft_r2c_3d",                                "", CONV_LIB_FUNC, API_FFT, 2};
+  m["fftwf_plan_dft_r2c"]                               = {"fftwf_plan_dft_r2c",                                   "", CONV_LIB_FUNC, API_FFT, 2};
+  m["fftwf_plan_dft_c2r_1d"]                            = {"fftwf_plan_dft_c2r_1d",                                "", CONV_LIB_FUNC, API_FFT, 2};
+  m["fftwf_plan_dft_c2r_2d"]                            = {"fftwf_plan_dft_c2r_2d",                                "", CONV_LIB_FUNC, API_FFT, 2};
+  m["fftwf_plan_dft_c2r_3d"]                            = {"fftwf_plan_dft_c2r_3d",                                "", CONV_LIB_FUNC, API_FFT, 2};
+  m["fftwf_plan_dft_c2r"]                               = {"fftwf_plan_dft_c2r",                                   "", CONV_LIB_FUNC, API_FFT, 2};
+  m["fftwf_execute"]                                    = {"fftwf_execute",                                        "", CONV_LIB_FUNC, API_FFT, 2};
+  m["fftw_print_plan"]                                  = {"fftw_print_plan",                                      "", CONV_LIB_FUNC, API_FFT, 2};
+  m["fftwf_print_plan"]                                 = {"fftwf_print_plan",                                     "", CONV_LIB_FUNC, API_FFT, 2};
+  m["fftw_set_timelimit"]                               = {"fftw_set_timelimit",                                   "", CONV_LIB_FUNC, API_FFT, 2};
+  m["fftwf_set_timelimit"]                              = {"fftwf_set_timelimit",                                  "", CONV_LIB_FUNC, API_FFT, 2};
+  m["fftw_cost"]                                        = {"fftw_cost",                                            "", CONV_LIB_FUNC, API_FFT, 2};
+  m["fftwf_cost"]                                       = {"fftwf_cost",                                           "", CONV_LIB_FUNC, API_FFT, 2};
+  m["fftw_flops"]                                       = {"fftw_flops",                                           "", CONV_LIB_FUNC, API_FFT, 2};
+  m["fftwf_flops"]                                      = {"fftwf_flops",                                          "", CONV_LIB_FUNC, API_FFT, 2};
+  m["fftw_destroy_plan"]                                = {"fftw_destroy_plan",                                    "", CONV_LIB_FUNC, API_FFT, 2};
+  m["fftwf_destroy_plan"]                               = {"fftwf_destroy_plan",                                   "", CONV_LIB_FUNC, API_FFT, 2};
+  m["fftw_cleanup"]                                     = {"fftw_cleanup",                                         "", CONV_LIB_FUNC, API_FFT, 2};
+  m["fftwf_cleanup"]                                    = {"fftwf_cleanup",                                        "", CONV_LIB_FUNC, API_FFT, 2};
+  m["fftw_plan_many_dft"]                               = {"fftw_plan_many_dft",                                   "", CONV_LIB_FUNC, API_FFT, 2, UNSUPPORTED};
+  m["fftw_plan_many_dft_r2c"]                           = {"fftw_plan_many_dft_r2c",                               "", CONV_LIB_FUNC, API_FFT, 2, UNSUPPORTED};
+  m["fftw_plan_many_dft_c2r"]                           = {"fftw_plan_many_dft_c2r",                               "", CONV_LIB_FUNC, API_FFT, 2, UNSUPPORTED};
+  m["fftw_plan_guru_dft"]                               = {"fftw_plan_guru_dft",                                   "", CONV_LIB_FUNC, API_FFT, 2, UNSUPPORTED};
+  m["fftw_plan_guru_dft_r2c"]                           = {"fftw_plan_guru_dft_r2c",                               "", CONV_LIB_FUNC, API_FFT, 2, UNSUPPORTED};
+  m["fftw_plan_guru_dft_c2r"]                           = {"fftw_plan_guru_dft_c2r",                               "", CONV_LIB_FUNC, API_FFT, 2, UNSUPPORTED};
+  m["fftw_plan_guru64_dft"]                             = {"fftw_plan_guru64_dft",                                 "", CONV_LIB_FUNC, API_FFT, 2, UNSUPPORTED};
+  m["fftw_plan_guru64_dft_r2c"]                         = {"fftw_plan_guru64_dft_r2c",                             "", CONV_LIB_FUNC, API_FFT, 2, UNSUPPORTED};
+  m["fftw_plan_guru64_dft_c2r"]                         = {"fftw_plan_guru64_dft_c2r",                             "", CONV_LIB_FUNC, API_FFT, 2, UNSUPPORTED};
+  m["fftw_execute_dft"]                                 = {"fftw_execute_dft",                                     "", CONV_LIB_FUNC, API_FFT, 2};
+  m["fftw_execute_dft_r2c"]                             = {"fftw_execute_dft_r2c",                                 "", CONV_LIB_FUNC, API_FFT, 2};
+  m["fftw_execute_dft_c2r"]                             = {"fftw_execute_dft_c2r",                                 "", CONV_LIB_FUNC, API_FFT, 2};
+  m["fftwf_plan_many_dft"]                              = {"fftwf_plan_many_dft",                                  "", CONV_LIB_FUNC, API_FFT, 2, UNSUPPORTED};
+  m["fftwf_plan_many_dft_r2c"]                          = {"fftwf_plan_many_dft_r2c",                              "", CONV_LIB_FUNC, API_FFT, 2, UNSUPPORTED};
+  m["fftwf_plan_many_dft_c2r"]                          = {"fftwf_plan_many_dft_c2r",                              "", CONV_LIB_FUNC, API_FFT, 2, UNSUPPORTED};
+  m["fftwf_plan_guru_dft"]                              = {"fftwf_plan_guru_dft",                                  "", CONV_LIB_FUNC, API_FFT, 2, UNSUPPORTED};
+  m["fftwf_plan_guru_dft_r2c"]                          = {"fftwf_plan_guru_dft_r2c",                              "", CONV_LIB_FUNC, API_FFT, 2, UNSUPPORTED};
+  m["fftwf_plan_guru_dft_c2r"]                          = {"fftwf_plan_guru_dft_c2r",                              "", CONV_LIB_FUNC, API_FFT, 2, UNSUPPORTED};
+  m["fftwf_plan_guru64_dft"]                            = {"fftwf_plan_guru64_dft",                                "", CONV_LIB_FUNC, API_FFT, 2, UNSUPPORTED};
+  m["fftwf_plan_guru64_dft_r2c"]                        = {"fftwf_plan_guru64_dft_r2c",                            "", CONV_LIB_FUNC, API_FFT, 2, UNSUPPORTED};
+  m["fftwf_plan_guru64_dft_c2r"]                        = {"fftwf_plan_guru64_dft_c2r",                            "", CONV_LIB_FUNC, API_FFT, 2, UNSUPPORTED};
+  m["fftwf_execute_dft"]                                = {"fftwf_execute_dft",                                    "", CONV_LIB_FUNC, API_FFT, 2};
+  m["fftwf_execute_dft_r2c"]                            = {"fftwf_execute_dft_r2c",                                "", CONV_LIB_FUNC, API_FFT, 2};
+  m["fftwf_execute_dft_c2r"]                            = {"fftwf_execute_dft_c2r",                                "", CONV_LIB_FUNC, API_FFT, 2};
+  m["fftw_export_wisdom_to_file"]                       = {"fftw_export_wisdom_to_file",                           "", CONV_LIB_FUNC, API_FFT, 2, UNSUPPORTED};
+  m["fftwf_export_wisdom_to_file"]                      = {"fftwf_export_wisdom_to_file",                          "", CONV_LIB_FUNC, API_FFT, 2, UNSUPPORTED};
+  m["fftw_import_wisdom_from_file"]                     = {"fftw_import_wisdom_from_file",                         "", CONV_LIB_FUNC, API_FFT, 2, UNSUPPORTED};
+  m["fftwf_import_wisdom_from_file"]                    = {"fftwf_import_wisdom_from_file",                        "", CONV_LIB_FUNC, API_FFT, 2, UNSUPPORTED};
 
-const std::map<llvm::StringRef, hipAPIversions> HIP_FFT_FUNCTION_VER_MAP {
-  {"hipfftPlan1d",                                        {HIP_1070, HIP_0,    HIP_0   }},
-  {"hipfftPlan2d",                                        {HIP_1070, HIP_0,    HIP_0   }},
-  {"hipfftPlan3d",                                        {HIP_1070, HIP_0,    HIP_0   }},
-  {"hipfftPlanMany",                                      {HIP_1070, HIP_0,    HIP_0   }},
-  {"hipfftMakePlan1d",                                    {HIP_1070, HIP_0,    HIP_0   }},
-  {"hipfftMakePlan2d",                                    {HIP_1070, HIP_0,    HIP_0   }},
-  {"hipfftMakePlan3d",                                    {HIP_1070, HIP_0,    HIP_0   }},
-  {"hipfftMakePlanMany",                                  {HIP_1070, HIP_0,    HIP_0   }},
-  {"hipfftMakePlanMany64",                                {HIP_1070, HIP_0,    HIP_0   }},
-  {"hipfftGetSizeMany64",                                 {HIP_1070, HIP_0,    HIP_0   }},
-  {"hipfftEstimate1d",                                    {HIP_1070, HIP_0,    HIP_0   }},
-  {"hipfftEstimate2d",                                    {HIP_1070, HIP_0,    HIP_0   }},
-  {"hipfftEstimate3d",                                    {HIP_1070, HIP_0,    HIP_0   }},
-  {"hipfftEstimateMany",                                  {HIP_1070, HIP_0,    HIP_0   }},
-  {"hipfftCreate",                                        {HIP_1070, HIP_0,    HIP_0   }},
-  {"hipfftGetSize1d",                                     {HIP_1070, HIP_0,    HIP_0   }},
-  {"hipfftGetSize2d",                                     {HIP_1070, HIP_0,    HIP_0   }},
-  {"hipfftGetSize3d",                                     {HIP_1070, HIP_0,    HIP_0   }},
-  {"hipfftGetSizeMany",                                   {HIP_1070, HIP_0,    HIP_0   }},
-  {"hipfftGetSize",                                       {HIP_1070, HIP_0,    HIP_0   }},
-  {"hipfftSetWorkArea",                                   {HIP_1070, HIP_0,    HIP_0   }},
-  {"hipfftSetAutoAllocation",                             {HIP_1070, HIP_0,    HIP_0   }},
-  {"hipfftExecC2C",                                       {HIP_1070, HIP_0,    HIP_0   }},
-  {"hipfftExecR2C",                                       {HIP_1070, HIP_0,    HIP_0   }},
-  {"hipfftExecC2R",                                       {HIP_1070, HIP_0,    HIP_0   }},
-  {"hipfftExecZ2Z",                                       {HIP_1070, HIP_0,    HIP_0   }},
-  {"hipfftExecD2Z",                                       {HIP_1070, HIP_0,    HIP_0   }},
-  {"hipfftExecZ2D",                                       {HIP_1070, HIP_0,    HIP_0   }},
-  {"hipfftSetStream",                                     {HIP_1070, HIP_0,    HIP_0   }},
-  {"hipfftDestroy",                                       {HIP_1070, HIP_0,    HIP_0   }},
-  {"hipfftGetVersion",                                    {HIP_1070, HIP_0,    HIP_0   }},
-  {"hipfftGetProperty",                                   {HIP_2060, HIP_0,    HIP_0   }},
-  {"hipfftCallbackLoadC",                                 {HIP_4030, HIP_0,    HIP_0   }},
-  {"hipfftCallbackLoadZ",                                 {HIP_4030, HIP_0,    HIP_0   }},
-  {"hipfftCallbackLoadR",                                 {HIP_4030, HIP_0,    HIP_0   }},
-  {"hipfftCallbackLoadD",                                 {HIP_4030, HIP_0,    HIP_0   }},
-  {"hipfftCallbackStoreC",                                {HIP_4030, HIP_0,    HIP_0   }},
-  {"hipfftCallbackStoreZ",                                {HIP_4030, HIP_0,    HIP_0   }},
-  {"hipfftCallbackStoreR",                                {HIP_4030, HIP_0,    HIP_0   }},
-  {"hipfftCallbackStoreD",                                {HIP_4030, HIP_0,    HIP_0   }},
-  {"hipfftXtSetCallback",                                 {HIP_4030, HIP_0,    HIP_0   }},
-  {"hipfftXtClearCallback",                               {HIP_4030, HIP_0,    HIP_0   }},
-  {"hipfftXtSetCallbackSharedSize",                       {HIP_4030, HIP_0,    HIP_0   }},
-  {"hipfftXtSetGPUs",                                     {HIP_6000, HIP_0,    HIP_0   }},
-  {"hipfftXtMalloc",                                      {HIP_6000, HIP_0,    HIP_0   }},
-  {"hipfftXtMemcpy",                                      {HIP_6000, HIP_0,    HIP_0   }},
-  {"hipfftXtFree",                                        {HIP_6000, HIP_0,    HIP_0   }},
-  {"hipfftXtExecDescriptorC2C",                           {HIP_6000, HIP_0,    HIP_0   }},
-  {"hipfftXtExecDescriptorR2C",                           {HIP_6000, HIP_0,    HIP_0   }},
-  {"hipfftXtExecDescriptorC2R",                           {HIP_6000, HIP_0,    HIP_0   }},
-  {"hipfftXtExecDescriptorZ2Z",                           {HIP_6000, HIP_0,    HIP_0   }},
-  {"hipfftXtExecDescriptorD2Z",                           {HIP_6000, HIP_0,    HIP_0   }},
-  {"hipfftXtExecDescriptorZ2D",                           {HIP_6000, HIP_0,    HIP_0   }},
-  {"hipfftXtMakePlanMany",                                {HIP_5060, HIP_0,    HIP_0   }},
-  {"hipfftXtGetSizeMany",                                 {HIP_5060, HIP_0,    HIP_0   }},
-  {"hipfftXtExec",                                        {HIP_5060, HIP_0,    HIP_0   }},
-  {"hipfftXtExecDescriptor",                              {HIP_6000, HIP_0,    HIP_0   }},
-  {"fftw_plan_dft_1d",                                    {HIP_7010, HIP_0,    HIP_0   }},
-  {"fftw_plan_dft_2d",                                    {HIP_7010, HIP_0,    HIP_0   }},
-  {"fftw_plan_dft_3d",                                    {HIP_7010, HIP_0,    HIP_0   }},
-  {"fftw_plan_dft",                                       {HIP_7010, HIP_0,    HIP_0   }},
-  {"fftw_plan_dft_r2c_1d",                                {HIP_7010, HIP_0,    HIP_0   }},
-  {"fftw_plan_dft_r2c_2d",                                {HIP_7010, HIP_0,    HIP_0   }},
-  {"fftw_plan_dft_r2c_3d",                                {HIP_7010, HIP_0,    HIP_0   }},
-  {"fftw_plan_dft_r2c",                                   {HIP_7010, HIP_0,    HIP_0   }},
-  {"fftw_plan_dft_c2r_2d",                                {HIP_7010, HIP_0,    HIP_0   }},
-  {"fftw_plan_dft_c2r_3d",                                {HIP_7010, HIP_0,    HIP_0   }},
-  {"fftw_plan_dft_c2r",                                   {HIP_7010, HIP_0,    HIP_0   }},
-  {"fftw_execute",                                        {HIP_7010, HIP_0,    HIP_0   }},
-  {"fftwf_plan_dft_1d",                                   {HIP_7010, HIP_0,    HIP_0   }},
-  {"fftwf_plan_dft_2d",                                   {HIP_7010, HIP_0,    HIP_0   }},
-  {"fftwf_plan_dft_3d",                                   {HIP_7010, HIP_0,    HIP_0   }},
-  {"fftwf_plan_dft",                                      {HIP_7010, HIP_0,    HIP_0   }},
-  {"fftwf_plan_dft_r2c_1d",                               {HIP_7010, HIP_0,    HIP_0   }},
-  {"fftwf_plan_dft_r2c_2d",                               {HIP_7010, HIP_0,    HIP_0   }},
-  {"fftwf_plan_dft_r2c_3d",                               {HIP_7010, HIP_0,    HIP_0   }},
-  {"fftwf_plan_dft_r2c",                                  {HIP_7010, HIP_0,    HIP_0   }},
-  {"fftwf_plan_dft_c2r_1d",                               {HIP_7010, HIP_0,    HIP_0   }},
-  {"fftwf_plan_dft_c2r_2d",                               {HIP_7010, HIP_0,    HIP_0   }},
-  {"fftwf_plan_dft_c2r_3d",                               {HIP_7010, HIP_0,    HIP_0   }},
-  {"fftwf_plan_dft_c2r",                                  {HIP_7010, HIP_0,    HIP_0   }},
-  {"fftwf_execute",                                       {HIP_7010, HIP_0,    HIP_0   }},
-  {"fftw_print_plan",                                     {HIP_7010, HIP_0,    HIP_0   }},
-  {"fftwf_print_plan",                                    {HIP_7010, HIP_0,    HIP_0   }},
-  {"fftw_set_timelimit",                                  {HIP_7010, HIP_0,    HIP_0   }},
-  {"fftwf_set_timelimit",                                 {HIP_7010, HIP_0,    HIP_0   }},
-  {"fftw_cost",                                           {HIP_7010, HIP_0,    HIP_0   }},
-  {"fftwf_cost",                                          {HIP_7010, HIP_0,    HIP_0   }},
-  {"fftw_flops",                                          {HIP_7010, HIP_0,    HIP_0   }},
-  {"fftwf_flops",                                         {HIP_7010, HIP_0,    HIP_0   }},
-  {"fftw_destroy_plan",                                   {HIP_7010, HIP_0,    HIP_0   }},
-  {"fftwf_destroy_plan",                                  {HIP_7010, HIP_0,    HIP_0   }},
-  {"fftw_cleanup",                                        {HIP_7010, HIP_0,    HIP_0   }},
-  {"fftwf_cleanup",                                       {HIP_7010, HIP_0,    HIP_0   }},
-  {"fftw_execute_dft",                                    {HIP_7020, HIP_0,    HIP_0   }},
-  {"fftw_execute_dft_r2c",                                {HIP_7020, HIP_0,    HIP_0   }},
-  {"fftw_execute_dft_c2r",                                {HIP_7020, HIP_0,    HIP_0   }},
-  {"fftwf_execute_dft",                                   {HIP_7020, HIP_0,    HIP_0   }},
-  {"fftwf_execute_dft_r2c",                               {HIP_7020, HIP_0,    HIP_0   }},
-  {"fftwf_execute_dft_c2r",                               {HIP_7020, HIP_0,    HIP_0   }},
-};
+  return m;
+}();
 
-const std::map<unsigned int, llvm::StringRef> CUDA_FFT_API_SECTION_MAP {
-  {1, "CUFFT Data types"},
-  {2, "CUFFT API functions"},
-};
+const std::map<llvm::StringRef, cudaAPIversions> CUDA_FFT_FUNCTION_VER_MAP = []() {
+  std::map<llvm::StringRef, cudaAPIversions> m;
+
+  m["cufftMakePlanMany64"]                                = {CUDA_75,  CUDA_0,   CUDA_0  };
+  m["cufftGetSizeMany64"]                                 = {CUDA_75,  CUDA_0,   CUDA_0  };
+  m["cufftGetProperty"]                                   = {CUDA_80,  CUDA_0,   CUDA_0  };
+  m["cufftXtMakePlanMany"]                                = {CUDA_80,  CUDA_0,   CUDA_0  };
+  m["cufftXtGetSizeMany"]                                 = {CUDA_80,  CUDA_0,   CUDA_0  };
+  m["cufftXtExec"]                                        = {CUDA_80,  CUDA_0,   CUDA_0  };
+  m["cufftXtExecDescriptor"]                              = {CUDA_80,  CUDA_0,   CUDA_0  };
+  m["cufftXtSetWorkAreaPolicy"]                           = {CUDA_92,  CUDA_0,   CUDA_0  };
+  m["cufftXtSetDistribution"]                             = {CUDA_118, CUDA_0,   CUDA_0  };
+  m["cufftSetPlanPropertyInt64"]                          = {CUDA_124, CUDA_0,   CUDA_0  };
+  m["cufftGetPlanPropertyInt64"]                          = {CUDA_124, CUDA_0,   CUDA_0  };
+  m["cufftResetPlanProperty"]                             = {CUDA_124, CUDA_0,   CUDA_0  };
+  m["fftw_plan_guru64_dft"]                               = {CUDA_100, CUDA_0,   CUDA_0  };
+  m["fftw_plan_guru64_dft_r2c"]                           = {CUDA_100, CUDA_0,   CUDA_0  };
+  m["fftw_plan_guru64_dft_c2r"]                           = {CUDA_100, CUDA_0,   CUDA_0  };
+  m["fftwf_plan_guru64_dft"]                              = {CUDA_100, CUDA_0,   CUDA_0  };
+  m["fftwf_plan_guru64_dft_r2c"]                          = {CUDA_100, CUDA_0,   CUDA_0  };
+  m["fftwf_plan_guru64_dft_c2r"]                          = {CUDA_100, CUDA_0,   CUDA_0  };
+
+  return m;
+}();
+
+const std::map<llvm::StringRef, hipAPIversions> HIP_FFT_FUNCTION_VER_MAP = []() {
+  std::map<llvm::StringRef, hipAPIversions> m;
+
+  m["hipfftPlan1d"]                                       = {HIP_1070, HIP_0,    HIP_0   };
+  m["hipfftPlan2d"]                                       = {HIP_1070, HIP_0,    HIP_0   };
+  m["hipfftPlan3d"]                                       = {HIP_1070, HIP_0,    HIP_0   };
+  m["hipfftPlanMany"]                                     = {HIP_1070, HIP_0,    HIP_0   };
+  m["hipfftMakePlan1d"]                                   = {HIP_1070, HIP_0,    HIP_0   };
+  m["hipfftMakePlan2d"]                                   = {HIP_1070, HIP_0,    HIP_0   };
+  m["hipfftMakePlan3d"]                                   = {HIP_1070, HIP_0,    HIP_0   };
+  m["hipfftMakePlanMany"]                                 = {HIP_1070, HIP_0,    HIP_0   };
+  m["hipfftMakePlanMany64"]                               = {HIP_1070, HIP_0,    HIP_0   };
+  m["hipfftGetSizeMany64"]                                = {HIP_1070, HIP_0,    HIP_0   };
+  m["hipfftEstimate1d"]                                   = {HIP_1070, HIP_0,    HIP_0   };
+  m["hipfftEstimate2d"]                                   = {HIP_1070, HIP_0,    HIP_0   };
+  m["hipfftEstimate3d"]                                   = {HIP_1070, HIP_0,    HIP_0   };
+  m["hipfftEstimateMany"]                                 = {HIP_1070, HIP_0,    HIP_0   };
+  m["hipfftCreate"]                                       = {HIP_1070, HIP_0,    HIP_0   };
+  m["hipfftGetSize1d"]                                    = {HIP_1070, HIP_0,    HIP_0   };
+  m["hipfftGetSize2d"]                                    = {HIP_1070, HIP_0,    HIP_0   };
+  m["hipfftGetSize3d"]                                    = {HIP_1070, HIP_0,    HIP_0   };
+  m["hipfftGetSizeMany"]                                  = {HIP_1070, HIP_0,    HIP_0   };
+  m["hipfftGetSize"]                                      = {HIP_1070, HIP_0,    HIP_0   };
+  m["hipfftSetWorkArea"]                                  = {HIP_1070, HIP_0,    HIP_0   };
+  m["hipfftSetAutoAllocation"]                            = {HIP_1070, HIP_0,    HIP_0   };
+  m["hipfftExecC2C"]                                      = {HIP_1070, HIP_0,    HIP_0   };
+  m["hipfftExecR2C"]                                      = {HIP_1070, HIP_0,    HIP_0   };
+  m["hipfftExecC2R"]                                      = {HIP_1070, HIP_0,    HIP_0   };
+  m["hipfftExecZ2Z"]                                      = {HIP_1070, HIP_0,    HIP_0   };
+  m["hipfftExecD2Z"]                                      = {HIP_1070, HIP_0,    HIP_0   };
+  m["hipfftExecZ2D"]                                      = {HIP_1070, HIP_0,    HIP_0   };
+  m["hipfftSetStream"]                                    = {HIP_1070, HIP_0,    HIP_0   };
+  m["hipfftDestroy"]                                      = {HIP_1070, HIP_0,    HIP_0   };
+  m["hipfftGetVersion"]                                   = {HIP_1070, HIP_0,    HIP_0   };
+  m["hipfftGetProperty"]                                  = {HIP_2060, HIP_0,    HIP_0   };
+  m["hipfftCallbackLoadC"]                                = {HIP_4030, HIP_0,    HIP_0   };
+  m["hipfftCallbackLoadZ"]                                = {HIP_4030, HIP_0,    HIP_0   };
+  m["hipfftCallbackLoadR"]                                = {HIP_4030, HIP_0,    HIP_0   };
+  m["hipfftCallbackLoadD"]                                = {HIP_4030, HIP_0,    HIP_0   };
+  m["hipfftCallbackStoreC"]                               = {HIP_4030, HIP_0,    HIP_0   };
+  m["hipfftCallbackStoreZ"]                               = {HIP_4030, HIP_0,    HIP_0   };
+  m["hipfftCallbackStoreR"]                               = {HIP_4030, HIP_0,    HIP_0   };
+  m["hipfftCallbackStoreD"]                               = {HIP_4030, HIP_0,    HIP_0   };
+  m["hipfftXtSetCallback"]                                = {HIP_4030, HIP_0,    HIP_0   };
+  m["hipfftXtClearCallback"]                              = {HIP_4030, HIP_0,    HIP_0   };
+  m["hipfftXtSetCallbackSharedSize"]                      = {HIP_4030, HIP_0,    HIP_0   };
+  m["hipfftXtSetGPUs"]                                    = {HIP_6000, HIP_0,    HIP_0   };
+  m["hipfftXtMalloc"]                                     = {HIP_6000, HIP_0,    HIP_0   };
+  m["hipfftXtMemcpy"]                                     = {HIP_6000, HIP_0,    HIP_0   };
+  m["hipfftXtFree"]                                       = {HIP_6000, HIP_0,    HIP_0   };
+  m["hipfftXtExecDescriptorC2C"]                          = {HIP_6000, HIP_0,    HIP_0   };
+  m["hipfftXtExecDescriptorR2C"]                          = {HIP_6000, HIP_0,    HIP_0   };
+  m["hipfftXtExecDescriptorC2R"]                          = {HIP_6000, HIP_0,    HIP_0   };
+  m["hipfftXtExecDescriptorZ2Z"]                          = {HIP_6000, HIP_0,    HIP_0   };
+  m["hipfftXtExecDescriptorD2Z"]                          = {HIP_6000, HIP_0,    HIP_0   };
+  m["hipfftXtExecDescriptorZ2D"]                          = {HIP_6000, HIP_0,    HIP_0   };
+  m["hipfftXtMakePlanMany"]                               = {HIP_5060, HIP_0,    HIP_0   };
+  m["hipfftXtGetSizeMany"]                                = {HIP_5060, HIP_0,    HIP_0   };
+  m["hipfftXtExec"]                                       = {HIP_5060, HIP_0,    HIP_0   };
+  m["hipfftXtExecDescriptor"]                             = {HIP_6000, HIP_0,    HIP_0   };
+  m["fftw_plan_dft_1d"]                                   = {HIP_7010, HIP_0,    HIP_0   };
+  m["fftw_plan_dft_2d"]                                   = {HIP_7010, HIP_0,    HIP_0   };
+  m["fftw_plan_dft_3d"]                                   = {HIP_7010, HIP_0,    HIP_0   };
+  m["fftw_plan_dft"]                                      = {HIP_7010, HIP_0,    HIP_0   };
+  m["fftw_plan_dft_r2c_1d"]                               = {HIP_7010, HIP_0,    HIP_0   };
+  m["fftw_plan_dft_r2c_2d"]                               = {HIP_7010, HIP_0,    HIP_0   };
+  m["fftw_plan_dft_r2c_3d"]                               = {HIP_7010, HIP_0,    HIP_0   };
+  m["fftw_plan_dft_r2c"]                                  = {HIP_7010, HIP_0,    HIP_0   };
+  m["fftw_plan_dft_c2r_2d"]                               = {HIP_7010, HIP_0,    HIP_0   };
+  m["fftw_plan_dft_c2r_3d"]                               = {HIP_7010, HIP_0,    HIP_0   };
+  m["fftw_plan_dft_c2r"]                                  = {HIP_7010, HIP_0,    HIP_0   };
+  m["fftw_execute"]                                       = {HIP_7010, HIP_0,    HIP_0   };
+  m["fftwf_plan_dft_1d"]                                  = {HIP_7010, HIP_0,    HIP_0   };
+  m["fftwf_plan_dft_2d"]                                  = {HIP_7010, HIP_0,    HIP_0   };
+  m["fftwf_plan_dft_3d"]                                  = {HIP_7010, HIP_0,    HIP_0   };
+  m["fftwf_plan_dft"]                                     = {HIP_7010, HIP_0,    HIP_0   };
+  m["fftwf_plan_dft_r2c_1d"]                              = {HIP_7010, HIP_0,    HIP_0   };
+  m["fftwf_plan_dft_r2c_2d"]                              = {HIP_7010, HIP_0,    HIP_0   };
+  m["fftwf_plan_dft_r2c_3d"]                              = {HIP_7010, HIP_0,    HIP_0   };
+  m["fftwf_plan_dft_r2c"]                                 = {HIP_7010, HIP_0,    HIP_0   };
+  m["fftwf_plan_dft_c2r_1d"]                              = {HIP_7010, HIP_0,    HIP_0   };
+  m["fftwf_plan_dft_c2r_2d"]                              = {HIP_7010, HIP_0,    HIP_0   };
+  m["fftwf_plan_dft_c2r_3d"]                              = {HIP_7010, HIP_0,    HIP_0   };
+  m["fftwf_plan_dft_c2r"]                                 = {HIP_7010, HIP_0,    HIP_0   };
+  m["fftwf_execute"]                                      = {HIP_7010, HIP_0,    HIP_0   };
+  m["fftw_print_plan"]                                    = {HIP_7010, HIP_0,    HIP_0   };
+  m["fftwf_print_plan"]                                   = {HIP_7010, HIP_0,    HIP_0   };
+  m["fftw_set_timelimit"]                                 = {HIP_7010, HIP_0,    HIP_0   };
+  m["fftwf_set_timelimit"]                                = {HIP_7010, HIP_0,    HIP_0   };
+  m["fftw_cost"]                                          = {HIP_7010, HIP_0,    HIP_0   };
+  m["fftwf_cost"]                                         = {HIP_7010, HIP_0,    HIP_0   };
+  m["fftw_flops"]                                         = {HIP_7010, HIP_0,    HIP_0   };
+  m["fftwf_flops"]                                        = {HIP_7010, HIP_0,    HIP_0   };
+  m["fftw_destroy_plan"]                                  = {HIP_7010, HIP_0,    HIP_0   };
+  m["fftwf_destroy_plan"]                                 = {HIP_7010, HIP_0,    HIP_0   };
+  m["fftw_cleanup"]                                       = {HIP_7010, HIP_0,    HIP_0   };
+  m["fftwf_cleanup"]                                      = {HIP_7010, HIP_0,    HIP_0   };
+  m["fftw_execute_dft"]                                   = {HIP_7020, HIP_0,    HIP_0   };
+  m["fftw_execute_dft_r2c"]                               = {HIP_7020, HIP_0,    HIP_0   };
+  m["fftw_execute_dft_c2r"]                               = {HIP_7020, HIP_0,    HIP_0   };
+  m["fftwf_execute_dft"]                                  = {HIP_7020, HIP_0,    HIP_0   };
+  m["fftwf_execute_dft_r2c"]                              = {HIP_7020, HIP_0,    HIP_0   };
+  m["fftwf_execute_dft_c2r"]                              = {HIP_7020, HIP_0,    HIP_0   };
+
+  return m;
+}();
+
+const std::map<unsigned int, llvm::StringRef> CUDA_FFT_API_SECTION_MAP = []() {
+  std::map<unsigned int, llvm::StringRef> m;
+
+  m[1] = "CUFFT Data types";
+  m[2] = "CUFFT API functions";
+
+  return m;
+}();

--- a/src/CUDA2HIP_FFT_API_types.cpp
+++ b/src/CUDA2HIP_FFT_API_types.cpp
@@ -23,229 +23,240 @@ THE SOFTWARE.
 #include "CUDA2HIP.h"
 
 // Map of all functions
-const std::map<llvm::StringRef, hipCounter> CUDA_FFT_TYPE_NAME_MAP {
+const std::map<llvm::StringRef, hipCounter> CUDA_FFT_TYPE_NAME_MAP = []() {
+  std::map<llvm::StringRef, hipCounter> m;
+
   // cuFFT defines
-  {"CUFFT_FORWARD",                                   {"HIPFFT_FORWARD",                                   "", CONV_NUMERIC_LITERAL, API_FFT, 1}},  // -1
-  {"CUFFT_INVERSE",                                   {"HIPFFT_BACKWARD",                                  "", CONV_NUMERIC_LITERAL, API_FFT, 1}}, //  1
-  {"CUFFT_COMPATIBILITY_DEFAULT",                     {"HIPFFT_COMPATIBILITY_DEFAULT",                     "", CONV_NUMERIC_LITERAL, API_FFT, 1, UNSUPPORTED}},  //  CUFFT_COMPATIBILITY_FFTW_PADDING
-  {"MAX_CUFFT_ERROR",                                 {"HIPFFT_MAX_ERROR",                                 "", CONV_NUMERIC_LITERAL, API_FFT, 1, UNSUPPORTED}},  //  0x11
+  m["CUFFT_FORWARD"]                                    = {"HIPFFT_FORWARD",                                   "", CONV_NUMERIC_LITERAL, API_FFT, 1};  // -1
+  m["CUFFT_INVERSE"]                                    = {"HIPFFT_BACKWARD",                                  "", CONV_NUMERIC_LITERAL, API_FFT, 1};  //  1
+  m["CUFFT_COMPATIBILITY_DEFAULT"]                      = {"HIPFFT_COMPATIBILITY_DEFAULT",                     "", CONV_NUMERIC_LITERAL, API_FFT, 1, UNSUPPORTED};  //  CUFFT_COMPATIBILITY_FFTW_PADDING
+  m["MAX_CUFFT_ERROR"]                                  = {"HIPFFT_MAX_ERROR",                                 "", CONV_NUMERIC_LITERAL, API_FFT, 1, UNSUPPORTED};  //  0x11
 
   // cuFFT enums
-  {"cufftResult_t",                                   {"hipfftResult_t",                                   "", CONV_TYPE, API_FFT, 1}},
-  {"cufftResult",                                     {"hipfftResult",                                     "", CONV_TYPE, API_FFT, 1}},
-  {"CUFFT_SUCCESS",                                   {"HIPFFT_SUCCESS",                                   "", CONV_NUMERIC_LITERAL, API_FFT, 1}},  //  0x0  0
-  {"CUFFT_INVALID_PLAN",                              {"HIPFFT_INVALID_PLAN",                              "", CONV_NUMERIC_LITERAL, API_FFT, 1}},  //  0x1  1
-  {"CUFFT_ALLOC_FAILED",                              {"HIPFFT_ALLOC_FAILED",                              "", CONV_NUMERIC_LITERAL, API_FFT, 1}},  //  0x2  2
-  {"CUFFT_INVALID_TYPE",                              {"HIPFFT_INVALID_TYPE",                              "", CONV_NUMERIC_LITERAL, API_FFT, 1}},  //  0x3  3
-  {"CUFFT_INVALID_VALUE",                             {"HIPFFT_INVALID_VALUE",                             "", CONV_NUMERIC_LITERAL, API_FFT, 1}},  //  0x4  4
-  {"CUFFT_INTERNAL_ERROR",                            {"HIPFFT_INTERNAL_ERROR",                            "", CONV_NUMERIC_LITERAL, API_FFT, 1}},  //  0x5  5
-  {"CUFFT_EXEC_FAILED",                               {"HIPFFT_EXEC_FAILED",                               "", CONV_NUMERIC_LITERAL, API_FFT, 1}},  //  0x6  6
-  {"CUFFT_SETUP_FAILED",                              {"HIPFFT_SETUP_FAILED",                              "", CONV_NUMERIC_LITERAL, API_FFT, 1}},  //  0x7  7
-  {"CUFFT_INVALID_SIZE",                              {"HIPFFT_INVALID_SIZE",                              "", CONV_NUMERIC_LITERAL, API_FFT, 1}},  //  0x8  8
-  {"CUFFT_UNALIGNED_DATA",                            {"HIPFFT_UNALIGNED_DATA",                            "", CONV_NUMERIC_LITERAL, API_FFT, 1}},  //  0x9  9
-  {"CUFFT_INCOMPLETE_PARAMETER_LIST",                 {"HIPFFT_INCOMPLETE_PARAMETER_LIST",                 "", CONV_NUMERIC_LITERAL, API_FFT, 1, CUDA_REMOVED}},  //  0xA  10
-  {"CUFFT_INVALID_DEVICE",                            {"HIPFFT_INVALID_DEVICE",                            "", CONV_NUMERIC_LITERAL, API_FFT, 1}},  //  0xB  11
-  {"CUFFT_PARSE_ERROR",                               {"HIPFFT_PARSE_ERROR",                               "", CONV_NUMERIC_LITERAL, API_FFT, 1, CUDA_REMOVED}},  //  0xC  12
-  {"CUFFT_NO_WORKSPACE",                              {"HIPFFT_NO_WORKSPACE",                              "", CONV_NUMERIC_LITERAL, API_FFT, 1}},  //  0xD  13
-  {"CUFFT_NOT_IMPLEMENTED",                           {"HIPFFT_NOT_IMPLEMENTED",                           "", CONV_NUMERIC_LITERAL, API_FFT, 1}},  //  0xE  14
-  {"CUFFT_LICENSE_ERROR",                             {"HIPFFT_LICENSE_ERROR",                             "", CONV_NUMERIC_LITERAL, API_FFT, 1, UNSUPPORTED | CUDA_REMOVED}},
-  {"CUFFT_NOT_SUPPORTED",                             {"HIPFFT_NOT_SUPPORTED",                             "", CONV_NUMERIC_LITERAL, API_FFT, 1}},  //  0x10 16
-  {"CUFFT_MISSING_DEPENDENCY",                        {"HIPFFT_MISSING_DEPENDENCY",                        "", CONV_NUMERIC_LITERAL, API_FFT, 1, UNSUPPORTED}},  //  0x11 17
-  {"CUFFT_NVRTC_FAILURE",                             {"HIPFFT_NVRTC_FAILURE",                             "", CONV_NUMERIC_LITERAL, API_FFT, 1, UNSUPPORTED}},  //  0x12 18
-  {"CUFFT_NVJITLINK_FAILURE",                         {"HIPFFT_NVJITLINK_FAILURE",                         "", CONV_NUMERIC_LITERAL, API_FFT, 1, UNSUPPORTED}},  //  0x13 19
-  {"CUFFT_NVSHMEM_FAILURE",                           {"HIPFFT_NVSHMEM_FAILURE",                           "", CONV_NUMERIC_LITERAL, API_FFT, 1, UNSUPPORTED}},  //  0x14 20
+  m["cufftResult_t"]                                    = {"hipfftResult_t",                                   "", CONV_TYPE, API_FFT, 1};
+  m["cufftResult"]                                      = {"hipfftResult",                                     "", CONV_TYPE, API_FFT, 1};
+  m["CUFFT_SUCCESS"]                                    = {"HIPFFT_SUCCESS",                                   "", CONV_NUMERIC_LITERAL, API_FFT, 1};  //  0x0  0
+  m["CUFFT_INVALID_PLAN"]                               = {"HIPFFT_INVALID_PLAN",                              "", CONV_NUMERIC_LITERAL, API_FFT, 1};  //  0x1  1
+  m["CUFFT_ALLOC_FAILED"]                               = {"HIPFFT_ALLOC_FAILED",                              "", CONV_NUMERIC_LITERAL, API_FFT, 1};  //  0x2  2
+  m["CUFFT_INVALID_TYPE"]                               = {"HIPFFT_INVALID_TYPE",                              "", CONV_NUMERIC_LITERAL, API_FFT, 1};  //  0x3  3
+  m["CUFFT_INVALID_VALUE"]                              = {"HIPFFT_INVALID_VALUE",                             "", CONV_NUMERIC_LITERAL, API_FFT, 1};  //  0x4  4
+  m["CUFFT_INTERNAL_ERROR"]                             = {"HIPFFT_INTERNAL_ERROR",                            "", CONV_NUMERIC_LITERAL, API_FFT, 1};  //  0x5  5
+  m["CUFFT_EXEC_FAILED"]                                = {"HIPFFT_EXEC_FAILED",                               "", CONV_NUMERIC_LITERAL, API_FFT, 1};  //  0x6  6
+  m["CUFFT_SETUP_FAILED"]                               = {"HIPFFT_SETUP_FAILED",                              "", CONV_NUMERIC_LITERAL, API_FFT, 1};  //  0x7  7
+  m["CUFFT_INVALID_SIZE"]                               = {"HIPFFT_INVALID_SIZE",                              "", CONV_NUMERIC_LITERAL, API_FFT, 1};  //  0x8  8
+  m["CUFFT_UNALIGNED_DATA"]                             = {"HIPFFT_UNALIGNED_DATA",                            "", CONV_NUMERIC_LITERAL, API_FFT, 1};  //  0x9  9
+  m["CUFFT_INCOMPLETE_PARAMETER_LIST"]                  = {"HIPFFT_INCOMPLETE_PARAMETER_LIST",                 "", CONV_NUMERIC_LITERAL, API_FFT, 1, CUDA_REMOVED};  //  0xA  10
+  m["CUFFT_INVALID_DEVICE"]                             = {"HIPFFT_INVALID_DEVICE",                            "", CONV_NUMERIC_LITERAL, API_FFT, 1};  //  0xB  11
+  m["CUFFT_PARSE_ERROR"]                                = {"HIPFFT_PARSE_ERROR",                               "", CONV_NUMERIC_LITERAL, API_FFT, 1, CUDA_REMOVED};  //  0xC  12
+  m["CUFFT_NO_WORKSPACE"]                               = {"HIPFFT_NO_WORKSPACE",                              "", CONV_NUMERIC_LITERAL, API_FFT, 1};  //  0xD  13
+  m["CUFFT_NOT_IMPLEMENTED"]                            = {"HIPFFT_NOT_IMPLEMENTED",                           "", CONV_NUMERIC_LITERAL, API_FFT, 1};  //  0xE  14
+  m["CUFFT_LICENSE_ERROR"]                              = {"HIPFFT_LICENSE_ERROR",                             "", CONV_NUMERIC_LITERAL, API_FFT, 1, UNSUPPORTED | CUDA_REMOVED};
+  m["CUFFT_NOT_SUPPORTED"]                              = {"HIPFFT_NOT_SUPPORTED",                             "", CONV_NUMERIC_LITERAL, API_FFT, 1};  //  0x10 16
+  m["CUFFT_MISSING_DEPENDENCY"]                         = {"HIPFFT_MISSING_DEPENDENCY",                        "", CONV_NUMERIC_LITERAL, API_FFT, 1, UNSUPPORTED};  //  0x11 17
+  m["CUFFT_NVRTC_FAILURE"]                              = {"HIPFFT_NVRTC_FAILURE",                             "", CONV_NUMERIC_LITERAL, API_FFT, 1, UNSUPPORTED};  //  0x12 18
+  m["CUFFT_NVJITLINK_FAILURE"]                          = {"HIPFFT_NVJITLINK_FAILURE",                         "", CONV_NUMERIC_LITERAL, API_FFT, 1, UNSUPPORTED};  //  0x13 19
+  m["CUFFT_NVSHMEM_FAILURE"]                            = {"HIPFFT_NVSHMEM_FAILURE",                           "", CONV_NUMERIC_LITERAL, API_FFT, 1, UNSUPPORTED};  //  0x14 20
 
-  {"cufftType_t",                                     {"hipfftType_t",                                     "", CONV_TYPE, API_FFT, 1}},
-  {"cufftType",                                       {"hipfftType",                                       "", CONV_TYPE, API_FFT, 1}},
-  {"CUFFT_R2C",                                       {"HIPFFT_R2C",                                       "", CONV_NUMERIC_LITERAL, API_FFT, 1}},  //  0x2a
-  {"CUFFT_C2R",                                       {"HIPFFT_C2R",                                       "", CONV_NUMERIC_LITERAL, API_FFT, 1}},  //  0x2c
-  {"CUFFT_C2C",                                       {"HIPFFT_C2C",                                       "", CONV_NUMERIC_LITERAL, API_FFT, 1}},  //  0x29
-  {"CUFFT_D2Z",                                       {"HIPFFT_D2Z",                                       "", CONV_NUMERIC_LITERAL, API_FFT, 1}},  //  0x6a
-  {"CUFFT_Z2D",                                       {"HIPFFT_Z2D",                                       "", CONV_NUMERIC_LITERAL, API_FFT, 1}},  //  0x6c
-  {"CUFFT_Z2Z",                                       {"HIPFFT_Z2Z",                                       "", CONV_NUMERIC_LITERAL, API_FFT, 1}},  //  0x69
+  m["cufftType_t"]                                      = {"hipfftType_t",                                     "", CONV_TYPE, API_FFT, 1};
+  m["cufftType"]                                        = {"hipfftType",                                       "", CONV_TYPE, API_FFT, 1};
+  m["CUFFT_R2C"]                                        = {"HIPFFT_R2C",                                       "", CONV_NUMERIC_LITERAL, API_FFT, 1};  //  0x2a
+  m["CUFFT_C2R"]                                        = {"HIPFFT_C2R",                                       "", CONV_NUMERIC_LITERAL, API_FFT, 1};  //  0x2c
+  m["CUFFT_C2C"]                                        = {"HIPFFT_C2C",                                       "", CONV_NUMERIC_LITERAL, API_FFT, 1};  //  0x29
+  m["CUFFT_D2Z"]                                        = {"HIPFFT_D2Z",                                       "", CONV_NUMERIC_LITERAL, API_FFT, 1};  //  0x6a
+  m["CUFFT_Z2D"]                                        = {"HIPFFT_Z2D",                                       "", CONV_NUMERIC_LITERAL, API_FFT, 1};  //  0x6c
+  m["CUFFT_Z2Z"]                                        = {"HIPFFT_Z2Z",                                       "", CONV_NUMERIC_LITERAL, API_FFT, 1};  //  0x69
 
-  {"cufftCompatibility_t",                            {"hipfftCompatibility_t",                            "", CONV_TYPE, API_FFT, 1, UNSUPPORTED}},
-  {"cufftCompatibility",                              {"hipfftCompatibility",                              "", CONV_TYPE, API_FFT, 1, UNSUPPORTED}},
-  {"CUFFT_COMPATIBILITY_FFTW_PADDING",                {"HIPFFT_COMPATIBILITY_FFTW_PADDING",                "", CONV_NUMERIC_LITERAL, API_FFT, 1, UNSUPPORTED}},  //  0x01
+  m["cufftCompatibility_t"]                             = {"hipfftCompatibility_t",                            "", CONV_TYPE, API_FFT, 1, UNSUPPORTED};
+  m["cufftCompatibility"]                               = {"hipfftCompatibility",                              "", CONV_TYPE, API_FFT, 1, UNSUPPORTED};
+  m["CUFFT_COMPATIBILITY_FFTW_PADDING"]                 = {"HIPFFT_COMPATIBILITY_FFTW_PADDING",                "", CONV_NUMERIC_LITERAL, API_FFT, 1, UNSUPPORTED};  //  0x01
 
   // cufftXt enums
-  {"cufftXtSubFormat_t",                              {"hipfftXtSubFormat_t",                              "", CONV_TYPE, API_FFT, 1}},
-  {"cufftXtSubFormat",                                {"hipfftXtSubFormat",                                "", CONV_TYPE, API_FFT, 1}},
-  {"CUFFT_XT_FORMAT_INPUT",                           {"HIPFFT_XT_FORMAT_INPUT",                           "", CONV_NUMERIC_LITERAL, API_FFT, 1}},  //  0x00
-  {"CUFFT_XT_FORMAT_OUTPUT",                          {"HIPFFT_XT_FORMAT_OUTPUT",                          "", CONV_NUMERIC_LITERAL, API_FFT, 1}},  //  0x01
-  {"CUFFT_XT_FORMAT_INPLACE",                         {"HIPFFT_XT_FORMAT_INPLACE",                         "", CONV_NUMERIC_LITERAL, API_FFT, 1}},  //  0x02
-  {"CUFFT_XT_FORMAT_INPLACE_SHUFFLED",                {"HIPFFT_XT_FORMAT_INPLACE_SHUFFLED",                "", CONV_NUMERIC_LITERAL, API_FFT, 1}},  //  0x03
-  {"CUFFT_XT_FORMAT_1D_INPUT_SHUFFLED",               {"HIPFFT_XT_FORMAT_1D_INPUT_SHUFFLED",               "", CONV_NUMERIC_LITERAL, API_FFT, 1}},  //  0x04
-  {"CUFFT_XT_FORMAT_DISTRIBUTED_INPUT",               {"HIPFFT_XT_FORMAT_DISTRIBUTED_INPUT",               "", CONV_NUMERIC_LITERAL, API_FFT, 1, UNSUPPORTED}},  //  0x05
-  {"CUFFT_XT_FORMAT_DISTRIBUTED_OUTPUT",              {"HIPFFT_XT_FORMAT_DISTRIBUTED_OUTPUT",              "", CONV_NUMERIC_LITERAL, API_FFT, 1, UNSUPPORTED}},  //  0x06
-  {"CUFFT_FORMAT_UNDEFINED",                          {"HIPFFT_FORMAT_UNDEFINED",                          "", CONV_NUMERIC_LITERAL, API_FFT, 1}},  //  0x07
+  m["cufftXtSubFormat_t"]                               = {"hipfftXtSubFormat_t",                              "", CONV_TYPE, API_FFT, 1};
+  m["cufftXtSubFormat"]                                 = {"hipfftXtSubFormat",                                "", CONV_TYPE, API_FFT, 1};
+  m["CUFFT_XT_FORMAT_INPUT"]                            = {"HIPFFT_XT_FORMAT_INPUT",                           "", CONV_NUMERIC_LITERAL, API_FFT, 1};  //  0x00
+  m["CUFFT_XT_FORMAT_OUTPUT"]                           = {"HIPFFT_XT_FORMAT_OUTPUT",                          "", CONV_NUMERIC_LITERAL, API_FFT, 1};  //  0x01
+  m["CUFFT_XT_FORMAT_INPLACE"]                          = {"HIPFFT_XT_FORMAT_INPLACE",                         "", CONV_NUMERIC_LITERAL, API_FFT, 1};  //  0x02
+  m["CUFFT_XT_FORMAT_INPLACE_SHUFFLED"]                 = {"HIPFFT_XT_FORMAT_INPLACE_SHUFFLED",                "", CONV_NUMERIC_LITERAL, API_FFT, 1};  //  0x03
+  m["CUFFT_XT_FORMAT_1D_INPUT_SHUFFLED"]                = {"HIPFFT_XT_FORMAT_1D_INPUT_SHUFFLED",               "", CONV_NUMERIC_LITERAL, API_FFT, 1};  //  0x04
+  m["CUFFT_XT_FORMAT_DISTRIBUTED_INPUT"]                = {"HIPFFT_XT_FORMAT_DISTRIBUTED_INPUT",               "", CONV_NUMERIC_LITERAL, API_FFT, 1, UNSUPPORTED};  //  0x05
+  m["CUFFT_XT_FORMAT_DISTRIBUTED_OUTPUT"]               = {"HIPFFT_XT_FORMAT_DISTRIBUTED_OUTPUT",              "", CONV_NUMERIC_LITERAL, API_FFT, 1, UNSUPPORTED};  //  0x06
+  m["CUFFT_FORMAT_UNDEFINED"]                           = {"HIPFFT_FORMAT_UNDEFINED",                          "", CONV_NUMERIC_LITERAL, API_FFT, 1};  //  0x07
 
-  {"cufftXtCopyType_t",                               {"hipfftXtCopyType_t",                               "", CONV_TYPE, API_FFT, 1}},
-  {"cufftXtCopyType",                                 {"hipfftXtCopyType",                                 "", CONV_TYPE, API_FFT, 1}},
-  {"CUFFT_COPY_HOST_TO_DEVICE",                       {"HIPFFT_COPY_HOST_TO_DEVICE",                       "", CONV_NUMERIC_LITERAL, API_FFT, 1}},  //  0x00
-  {"CUFFT_COPY_DEVICE_TO_HOST",                       {"HIPFFT_COPY_DEVICE_TO_HOST",                       "", CONV_NUMERIC_LITERAL, API_FFT, 1}},  //  0x01
-  {"CUFFT_COPY_DEVICE_TO_DEVICE",                     {"HIPFFT_COPY_DEVICE_TO_DEVICE",                     "", CONV_NUMERIC_LITERAL, API_FFT, 1}},  //  0x02
-  {"CUFFT_COPY_UNDEFINED",                            {"HIPFFT_COPY_UNDEFINED",                            "", CONV_NUMERIC_LITERAL, API_FFT, 1}},  //  0x03
+  m["cufftXtCopyType_t"]                                = {"hipfftXtCopyType_t",                               "", CONV_TYPE, API_FFT, 1};
+  m["cufftXtCopyType"]                                  = {"hipfftXtCopyType",                                 "", CONV_TYPE, API_FFT, 1};
+  m["CUFFT_COPY_HOST_TO_DEVICE"]                        = {"HIPFFT_COPY_HOST_TO_DEVICE",                       "", CONV_NUMERIC_LITERAL, API_FFT, 1};  //  0x00
+  m["CUFFT_COPY_DEVICE_TO_HOST"]                        = {"HIPFFT_COPY_DEVICE_TO_HOST",                       "", CONV_NUMERIC_LITERAL, API_FFT, 1};  //  0x01
+  m["CUFFT_COPY_DEVICE_TO_DEVICE"]                      = {"HIPFFT_COPY_DEVICE_TO_DEVICE",                     "", CONV_NUMERIC_LITERAL, API_FFT, 1};  //  0x02
+  m["CUFFT_COPY_UNDEFINED"]                             = {"HIPFFT_COPY_UNDEFINED",                            "", CONV_NUMERIC_LITERAL, API_FFT, 1};  //  0x03
 
-  {"cufftXtQueryType_t",                              {"hipfftXtQueryType_t",                              "", CONV_TYPE, API_FFT, 1, UNSUPPORTED}},
-  {"cufftXtQueryType",                                {"hipfftXtQueryType",                                "", CONV_TYPE, API_FFT, 1, UNSUPPORTED}},
-  {"CUFFT_QUERY_1D_FACTORS",                          {"HIPFFT_QUERY_1D_FACTORS",                          "", CONV_NUMERIC_LITERAL, API_FFT, 1, UNSUPPORTED}},  //  0x00
-  {"CUFFT_QUERY_UNDEFINED",                           {"HIPFFT_QUERY_UNDEFINED",                           "", CONV_NUMERIC_LITERAL, API_FFT, 1, UNSUPPORTED}},  //  0x01
+  m["cufftXtQueryType_t"]                               = {"hipfftXtQueryType_t",                              "", CONV_TYPE, API_FFT, 1, UNSUPPORTED};
+  m["cufftXtQueryType"]                                 = {"hipfftXtQueryType",                                "", CONV_TYPE, API_FFT, 1, UNSUPPORTED};
+  m["CUFFT_QUERY_1D_FACTORS"]                           = {"HIPFFT_QUERY_1D_FACTORS",                          "", CONV_NUMERIC_LITERAL, API_FFT, 1, UNSUPPORTED};  //  0x00
+  m["CUFFT_QUERY_UNDEFINED"]                            = {"HIPFFT_QUERY_UNDEFINED",                           "", CONV_NUMERIC_LITERAL, API_FFT, 1, UNSUPPORTED};  //  0x01
 
-  {"cufftXtWorkAreaPolicy_t",                         {"hipfftXtWorkAreaPolicy_t",                         "", CONV_TYPE, API_FFT, 1, UNSUPPORTED}},
-  {"cufftXtWorkAreaPolicy",                           {"hipfftXtWorkAreaPolicy",                           "", CONV_TYPE, API_FFT, 1, UNSUPPORTED}},
-  {"CUFFT_WORKAREA_MINIMAL",                          {"HIPFFT_WORKAREA_MINIMAL",                          "", CONV_NUMERIC_LITERAL, API_FFT, 1, UNSUPPORTED}},  //  0
-  {"CUFFT_WORKAREA_USER",                             {"HIPFFT_WORKAREA_USER",                             "", CONV_NUMERIC_LITERAL, API_FFT, 1, UNSUPPORTED}},  //  1
-  {"CUFFT_WORKAREA_PERFORMANCE",                      {"HIPFFT_WORKAREA_PERFORMANCE",                      "", CONV_NUMERIC_LITERAL, API_FFT, 1, UNSUPPORTED}},  //  2
+  m["cufftXtWorkAreaPolicy_t"]                          = {"hipfftXtWorkAreaPolicy_t",                         "", CONV_TYPE, API_FFT, 1, UNSUPPORTED};
+  m["cufftXtWorkAreaPolicy"]                            = {"hipfftXtWorkAreaPolicy",                           "", CONV_TYPE, API_FFT, 1, UNSUPPORTED};
+  m["CUFFT_WORKAREA_MINIMAL"]                           = {"HIPFFT_WORKAREA_MINIMAL",                          "", CONV_NUMERIC_LITERAL, API_FFT, 1, UNSUPPORTED};  //  0
+  m["CUFFT_WORKAREA_USER"]                              = {"HIPFFT_WORKAREA_USER",                             "", CONV_NUMERIC_LITERAL, API_FFT, 1, UNSUPPORTED};  //  1
+  m["CUFFT_WORKAREA_PERFORMANCE"]                       = {"HIPFFT_WORKAREA_PERFORMANCE",                      "", CONV_NUMERIC_LITERAL, API_FFT, 1, UNSUPPORTED};  //  2
 
-  {"cufftXtCallbackType_t",                           {"hipfftXtCallbackType_t",                           "", CONV_TYPE, API_FFT, 1}},
-  {"cufftXtCallbackType",                             {"hipfftXtCallbackType",                             "", CONV_TYPE, API_FFT, 1}},
-  {"CUFFT_CB_LD_COMPLEX",                             {"HIPFFT_CB_LD_COMPLEX",                             "", CONV_NUMERIC_LITERAL, API_FFT, 1}},  //  0x0
-  {"CUFFT_CB_LD_COMPLEX_DOUBLE",                      {"HIPFFT_CB_LD_COMPLEX_DOUBLE",                      "", CONV_NUMERIC_LITERAL, API_FFT, 1}},  //  0x1
-  {"CUFFT_CB_LD_REAL",                                {"HIPFFT_CB_LD_REAL",                                "", CONV_NUMERIC_LITERAL, API_FFT, 1}},  //  0x2
-  {"CUFFT_CB_LD_REAL_DOUBLE",                         {"HIPFFT_CB_LD_REAL_DOUBLE",                         "", CONV_NUMERIC_LITERAL, API_FFT, 1}},  //  0x3
-  {"CUFFT_CB_ST_COMPLEX",                             {"HIPFFT_CB_ST_COMPLEX",                             "", CONV_NUMERIC_LITERAL, API_FFT, 1}},  //  0x4
-  {"CUFFT_CB_ST_COMPLEX_DOUBLE",                      {"HIPFFT_CB_ST_COMPLEX_DOUBLE",                      "", CONV_NUMERIC_LITERAL, API_FFT, 1}},  //  0x5
-  {"CUFFT_CB_ST_REAL",                                {"HIPFFT_CB_ST_REAL",                                "", CONV_NUMERIC_LITERAL, API_FFT, 1}},  //  0x6
-  {"CUFFT_CB_ST_REAL_DOUBLE",                         {"HIPFFT_CB_ST_REAL_DOUBLE",                         "", CONV_NUMERIC_LITERAL, API_FFT, 1}},  //  0x7
-  {"CUFFT_CB_UNDEFINED",                              {"HIPFFT_CB_UNDEFINED",                              "", CONV_NUMERIC_LITERAL, API_FFT, 1}},  //  0x7
+  m["cufftXtCallbackType_t"]                            = {"hipfftXtCallbackType_t",                           "", CONV_TYPE, API_FFT, 1};
+  m["cufftXtCallbackType"]                              = {"hipfftXtCallbackType",                             "", CONV_TYPE, API_FFT, 1};
+  m["CUFFT_CB_LD_COMPLEX"]                              = {"HIPFFT_CB_LD_COMPLEX",                             "", CONV_NUMERIC_LITERAL, API_FFT, 1};  //  0x0
+  m["CUFFT_CB_LD_COMPLEX_DOUBLE"]                       = {"HIPFFT_CB_LD_COMPLEX_DOUBLE",                      "", CONV_NUMERIC_LITERAL, API_FFT, 1};  //  0x1
+  m["CUFFT_CB_LD_REAL"]                                 = {"HIPFFT_CB_LD_REAL",                                "", CONV_NUMERIC_LITERAL, API_FFT, 1};  //  0x2
+  m["CUFFT_CB_LD_REAL_DOUBLE"]                          = {"HIPFFT_CB_LD_REAL_DOUBLE",                         "", CONV_NUMERIC_LITERAL, API_FFT, 1};  //  0x3
+  m["CUFFT_CB_ST_COMPLEX"]                              = {"HIPFFT_CB_ST_COMPLEX",                             "", CONV_NUMERIC_LITERAL, API_FFT, 1};  //  0x4
+  m["CUFFT_CB_ST_COMPLEX_DOUBLE"]                       = {"HIPFFT_CB_ST_COMPLEX_DOUBLE",                      "", CONV_NUMERIC_LITERAL, API_FFT, 1};  //  0x5
+  m["CUFFT_CB_ST_REAL"]                                 = {"HIPFFT_CB_ST_REAL",                                "", CONV_NUMERIC_LITERAL, API_FFT, 1};  //  0x6
+  m["CUFFT_CB_ST_REAL_DOUBLE"]                          = {"HIPFFT_CB_ST_REAL_DOUBLE",                         "", CONV_NUMERIC_LITERAL, API_FFT, 1};  //  0x7
+  m["CUFFT_CB_UNDEFINED"]                               = {"HIPFFT_CB_UNDEFINED",                              "", CONV_NUMERIC_LITERAL, API_FFT, 1};  //  0x7
 
-  {"cufftProperty_t",                                 {"hipfftProperty",                                   "", CONV_TYPE, API_FFT, 1, UNSUPPORTED}},
-  {"cufftProperty",                                   {"hipfftProperty",                                   "", CONV_TYPE, API_FFT, 1, UNSUPPORTED}},
-  {"NVFFT_PLAN_PROPERTY_INT64_PATIENT_JIT",           {"HIPFFT_PLAN_PROPERTY_INT64_PATIENT_JIT",           "", CONV_NUMERIC_LITERAL, API_FFT, 1, UNSUPPORTED}},  //  0x1
-  {"NVFFT_PLAN_PROPERTY_INT64_MAX_NUM_HOST_THREADS",  {"HIPFFT_PLAN_PROPERTY_INT64_MAX_NUM_HOST_THREADS",  "", CONV_NUMERIC_LITERAL, API_FFT, 1, UNSUPPORTED}},  //  0x2
+  m["cufftProperty_t"]                                  = {"hipfftProperty",                                   "", CONV_TYPE, API_FFT, 1, UNSUPPORTED};
+  m["cufftProperty"]                                    = {"hipfftProperty",                                   "", CONV_TYPE, API_FFT, 1, UNSUPPORTED};
+  m["NVFFT_PLAN_PROPERTY_INT64_PATIENT_JIT"]            = {"HIPFFT_PLAN_PROPERTY_INT64_PATIENT_JIT",           "", CONV_NUMERIC_LITERAL, API_FFT, 1, UNSUPPORTED};  //  0x1
+  m["NVFFT_PLAN_PROPERTY_INT64_MAX_NUM_HOST_THREADS"]   = {"HIPFFT_PLAN_PROPERTY_INT64_MAX_NUM_HOST_THREADS",  "", CONV_NUMERIC_LITERAL, API_FFT, 1, UNSUPPORTED};  //  0x2
 
   // cuFFT types
-  {"cufftReal",                                       {"hipfftReal",                                       "", CONV_TYPE, API_FFT, 1}},
-  {"cufftDoubleReal",                                 {"hipfftDoubleReal",                                 "", CONV_TYPE, API_FFT, 1}},
-  {"cufftComplex",                                    {"hipfftComplex",                                    "", CONV_TYPE, API_FFT, 1}},
-  {"cufftDoubleComplex",                              {"hipfftDoubleComplex",                              "", CONV_TYPE, API_FFT, 1}},
-  {"cufftHandle",                                     {"hipfftHandle",                                     "", CONV_TYPE, API_FFT, 1}},
-  {"cufftXt1dFactors_t",                              {"hipfftXt1dFactors_t",                              "", CONV_TYPE, API_FFT, 1, UNSUPPORTED}},
-  {"cufftXt1dFactors",                                {"hipfftXt1dFactors",                                "", CONV_TYPE, API_FFT, 1, UNSUPPORTED}},
-  {"cufftBox3d_t",                                    {"hipfftBox3d_t",                                    "", CONV_TYPE, API_FFT, 1, UNSUPPORTED}},
-  {"cufftBox3d",                                      {"hipfftBox3d",                                      "", CONV_TYPE, API_FFT, 1, UNSUPPORTED}},
-  {"cudaLibXtDesc_t",                                 {"hipLibXtDesc_t",                                   "", CONV_TYPE, API_FFT, 1}},
-  {"cudaLibXtDesc",                                   {"hipLibXtDesc",                                     "", CONV_TYPE, API_FFT, 1}},
+  m["cufftReal"]                                        = {"hipfftReal",                                       "", CONV_TYPE, API_FFT, 1};
+  m["cufftDoubleReal"]                                  = {"hipfftDoubleReal",                                 "", CONV_TYPE, API_FFT, 1};
+  m["cufftComplex"]                                     = {"hipfftComplex",                                    "", CONV_TYPE, API_FFT, 1};
+  m["cufftDoubleComplex"]                               = {"hipfftDoubleComplex",                              "", CONV_TYPE, API_FFT, 1};
+  m["cufftHandle"]                                      = {"hipfftHandle",                                     "", CONV_TYPE, API_FFT, 1};
+  m["cufftXt1dFactors_t"]                               = {"hipfftXt1dFactors_t",                              "", CONV_TYPE, API_FFT, 1, UNSUPPORTED};
+  m["cufftXt1dFactors"]                                 = {"hipfftXt1dFactors",                                "", CONV_TYPE, API_FFT, 1, UNSUPPORTED};
+  m["cufftBox3d_t"]                                     = {"hipfftBox3d_t",                                    "", CONV_TYPE, API_FFT, 1, UNSUPPORTED};
+  m["cufftBox3d"]                                       = {"hipfftBox3d",                                      "", CONV_TYPE, API_FFT, 1, UNSUPPORTED};
+  m["cudaLibXtDesc_t"]                                  = {"hipLibXtDesc_t",                                   "", CONV_TYPE, API_FFT, 1};
+  m["cudaLibXtDesc"]                                    = {"hipLibXtDesc",                                     "", CONV_TYPE, API_FFT, 1};
 
   // cuFFTw types
-  {"FFTW_FORWARD",                                    {"FFTW_FORWARD",                                     "", CONV_DEFINE, API_FFT, 1}},
-  {"FFTW_BACKWARD",                                   {"FFTW_BACKWARD",                                    "", CONV_DEFINE, API_FFT, 1}},
-  {"FFTW_INVERSE",                                    {"FFTW_INVERSE",                                     "", CONV_DEFINE, API_FFT, 1, UNSUPPORTED}},
-  {"FFTW_ESTIMATE",                                   {"FFTW_ESTIMATE",                                    "", CONV_DEFINE, API_FFT, 1}},
-  {"FFTW_MEASURE",                                    {"FFTW_MEASURE",                                     "", CONV_DEFINE, API_FFT, 1}},
-  {"FFTW_PATIENT",                                    {"FFTW_PATIENT",                                     "", CONV_DEFINE, API_FFT, 1}},
-  {"FFTW_EXHAUSTIVE",                                 {"FFTW_EXHAUSTIVE",                                  "", CONV_DEFINE, API_FFT, 1}},
-  {"FFTW_WISDOM_ONLY",                                {"FFTW_WISDOM_ONLY",                                 "", CONV_DEFINE, API_FFT, 1}},
-  {"FFTW_DESTROY_INPUT",                              {"FFTW_DESTROY_INPUT",                               "", CONV_DEFINE, API_FFT, 1}},
-  {"FFTW_PRESERVE_INPUT",                             {"FFTW_PRESERVE_INPUT",                              "", CONV_DEFINE, API_FFT, 1}},
-  {"FFTW_UNALIGNED",                                  {"FFTW_UNALIGNED",                                   "", CONV_DEFINE, API_FFT, 1}},
-  {"fftw_complex",                                    {"fftw_complex",                                     "", CONV_TYPE, API_FFT, 1}},
-  {"fftwf_complex",                                   {"fftwf_complex",                                    "", CONV_TYPE, API_FFT, 1}},
-  {"fftw_iodim",                                      {"fftw_iodim",                                       "", CONV_TYPE, API_FFT, 1, UNSUPPORTED}},
-  {"fftwf_iodim",                                     {"fftwf_iodim",                                      "", CONV_TYPE, API_FFT, 1, UNSUPPORTED}},
-  {"fftw_iodim64",                                    {"fftw_iodim64",                                     "", CONV_TYPE, API_FFT, 1, UNSUPPORTED}},
-  {"fftwf_iodim64",                                   {"fftwf_iodim64",                                    "", CONV_TYPE, API_FFT, 1, UNSUPPORTED}},
-  {"fftw_plan",                                       {"fftw_plan",                                        "", CONV_TYPE, API_FFT, 1}},
-  {"fftwf_plan",                                      {"fftwf_plan",                                       "", CONV_TYPE, API_FFT, 1}},
-};
+  m["FFTW_FORWARD"]                                     = {"FFTW_FORWARD",                                     "", CONV_DEFINE, API_FFT, 1};
+  m["FFTW_BACKWARD"]                                    = {"FFTW_BACKWARD",                                    "", CONV_DEFINE, API_FFT, 1};
+  m["FFTW_INVERSE"]                                     = {"FFTW_INVERSE",                                     "", CONV_DEFINE, API_FFT, 1, UNSUPPORTED};
+  m["FFTW_ESTIMATE"]                                    = {"FFTW_ESTIMATE",                                    "", CONV_DEFINE, API_FFT, 1};
+  m["FFTW_MEASURE"]                                     = {"FFTW_MEASURE",                                     "", CONV_DEFINE, API_FFT, 1};
+  m["FFTW_PATIENT"]                                     = {"FFTW_PATIENT",                                     "", CONV_DEFINE, API_FFT, 1};
+  m["FFTW_EXHAUSTIVE"]                                  = {"FFTW_EXHAUSTIVE",                                  "", CONV_DEFINE, API_FFT, 1};
+  m["FFTW_WISDOM_ONLY"]                                 = {"FFTW_WISDOM_ONLY",                                 "", CONV_DEFINE, API_FFT, 1};
+  m["FFTW_DESTROY_INPUT"]                               = {"FFTW_DESTROY_INPUT",                               "", CONV_DEFINE, API_FFT, 1};
+  m["FFTW_PRESERVE_INPUT"]                              = {"FFTW_PRESERVE_INPUT",                              "", CONV_DEFINE, API_FFT, 1};
+  m["FFTW_UNALIGNED"]                                   = {"FFTW_UNALIGNED",                                   "", CONV_DEFINE, API_FFT, 1};
+  m["fftw_complex"]                                     = {"fftw_complex",                                     "", CONV_TYPE, API_FFT, 1};
+  m["fftwf_complex"]                                    = {"fftwf_complex",                                    "", CONV_TYPE, API_FFT, 1};
+  m["fftw_iodim"]                                       = {"fftw_iodim",                                       "", CONV_TYPE, API_FFT, 1, UNSUPPORTED};
+  m["fftwf_iodim"]                                      = {"fftwf_iodim",                                      "", CONV_TYPE, API_FFT, 1, UNSUPPORTED};
+  m["fftw_iodim64"]                                     = {"fftw_iodim64",                                     "", CONV_TYPE, API_FFT, 1, UNSUPPORTED};
+  m["fftwf_iodim64"]                                    = {"fftwf_iodim64",                                    "", CONV_TYPE, API_FFT, 1, UNSUPPORTED};
+  m["fftw_plan"]                                        = {"fftw_plan",                                        "", CONV_TYPE, API_FFT, 1};
+  m["fftwf_plan"]                                       = {"fftwf_plan",                                       "", CONV_TYPE, API_FFT, 1};
+  
+  return m;
+}();
 
-const std::map<llvm::StringRef, cudaAPIversions> CUDA_FFT_TYPE_NAME_VER_MAP {
-  {"CUFFT_NOT_SUPPORTED",                             {CUDA_80,  CUDA_0,   CUDA_0  }},
-  {"cufftXtWorkAreaPolicy_t",                         {CUDA_92,  CUDA_0,   CUDA_0  }},
-  {"cufftXtWorkAreaPolicy",                           {CUDA_92,  CUDA_0,   CUDA_0  }},
-  {"CUFFT_WORKAREA_MINIMAL",                          {CUDA_92,  CUDA_0,   CUDA_0  }},
-  {"CUFFT_WORKAREA_USER",                             {CUDA_92,  CUDA_0,   CUDA_0  }},
-  {"CUFFT_XT_FORMAT_DISTRIBUTED_INPUT",               {CUDA_118, CUDA_0,   CUDA_0  }},
-  {"CUFFT_XT_FORMAT_DISTRIBUTED_OUTPUT",              {CUDA_118, CUDA_0,   CUDA_0  }},
-  {"cufftBox3d_t",                                    {CUDA_118, CUDA_0,   CUDA_0  }},
-  {"cufftBox3d",                                      {CUDA_118, CUDA_0,   CUDA_0  }},
-  {"cufftProperty_t",                                 {CUDA_124, CUDA_0,   CUDA_0  }},
-  {"cufftProperty",                                   {CUDA_124, CUDA_0,   CUDA_0  }},
-  {"NVFFT_PLAN_PROPERTY_INT64_PATIENT_JIT",           {CUDA_124, CUDA_0,   CUDA_0  }},
-  {"NVFFT_PLAN_PROPERTY_INT64_MAX_NUM_HOST_THREADS",  {CUDA_125, CUDA_0,   CUDA_0  }},
-  {"CUFFT_INCOMPLETE_PARAMETER_LIST",                 {CUDA_0,   CUDA_0,   CUDA_130}},
-  {"CUFFT_PARSE_ERROR",                               {CUDA_0,   CUDA_0,   CUDA_130}},
-  {"CUFFT_LICENSE_ERROR",                             {CUDA_0,   CUDA_0,   CUDA_130}},
-  {"CUFFT_MISSING_DEPENDENCY",                        {CUDA_130, CUDA_0,   CUDA_0  }},
-  {"CUFFT_NVRTC_FAILURE",                             {CUDA_130, CUDA_0,   CUDA_0  }},
-  {"CUFFT_NVJITLINK_FAILURE",                         {CUDA_130, CUDA_0,   CUDA_0  }},
-  {"CUFFT_NVSHMEM_FAILURE",                           {CUDA_130, CUDA_0,   CUDA_0  }},
-};
+const std::map<llvm::StringRef, cudaAPIversions> CUDA_FFT_TYPE_NAME_VER_MAP = []() {
+  std::map<llvm::StringRef, cudaAPIversions> m;
+  m["CUFFT_NOT_SUPPORTED"]                              = {CUDA_80,  CUDA_0,   CUDA_0  };
+  m["cufftXtWorkAreaPolicy_t"]                          = {CUDA_92,  CUDA_0,   CUDA_0  };
+  m["cufftXtWorkAreaPolicy"]                            = {CUDA_92,  CUDA_0,   CUDA_0  };
+  m["CUFFT_WORKAREA_MINIMAL"]                           = {CUDA_92,  CUDA_0,   CUDA_0  };
+  m["CUFFT_WORKAREA_USER"]                              = {CUDA_92,  CUDA_0,   CUDA_0  };
+  m["CUFFT_XT_FORMAT_DISTRIBUTED_INPUT"]                = {CUDA_118, CUDA_0,   CUDA_0  };
+  m["CUFFT_XT_FORMAT_DISTRIBUTED_OUTPUT"]               = {CUDA_118, CUDA_0,   CUDA_0  };
+  m["cufftBox3d_t"]                                     = {CUDA_118, CUDA_0,   CUDA_0  };
+  m["cufftBox3d"]                                       = {CUDA_118, CUDA_0,   CUDA_0  };
+  m["cufftProperty_t"]                                  = {CUDA_124, CUDA_0,   CUDA_0  };
+  m["cufftProperty"]                                    = {CUDA_124, CUDA_0,   CUDA_0  };
+  m["NVFFT_PLAN_PROPERTY_INT64_PATIENT_JIT"]            = {CUDA_124, CUDA_0,   CUDA_0  };
+  m["NVFFT_PLAN_PROPERTY_INT64_MAX_NUM_HOST_THREADS"]   = {CUDA_125, CUDA_0,   CUDA_0  };
+  m["CUFFT_INCOMPLETE_PARAMETER_LIST"]                  = {CUDA_0,   CUDA_0,   CUDA_130};
+  m["CUFFT_PARSE_ERROR"]                                = {CUDA_0,   CUDA_0,   CUDA_130};
+  m["CUFFT_LICENSE_ERROR"]                              = {CUDA_0,   CUDA_0,   CUDA_130};
+  m["CUFFT_MISSING_DEPENDENCY"]                         = {CUDA_130, CUDA_0,   CUDA_0  };
+  m["CUFFT_NVRTC_FAILURE"]                              = {CUDA_130, CUDA_0,   CUDA_0  };
+  m["CUFFT_NVJITLINK_FAILURE"]                          = {CUDA_130, CUDA_0,   CUDA_0  };
+  m["CUFFT_NVSHMEM_FAILURE"]                            = {CUDA_130, CUDA_0,   CUDA_0  };
 
-const std::map<llvm::StringRef, hipAPIversions> HIP_FFT_TYPE_NAME_VER_MAP {
-  {"HIPFFT_FORWARD",                                  {HIP_1070, HIP_0,    HIP_0   }},
-  {"HIPFFT_BACKWARD",                                 {HIP_1070, HIP_0,    HIP_0   }},
-  {"hipfftResult_t",                                  {HIP_1070, HIP_0,    HIP_0   }},
-  {"hipfftResult",                                    {HIP_1070, HIP_0,    HIP_0   }},
-  {"HIPFFT_SUCCESS",                                  {HIP_1070, HIP_0,    HIP_0   }},
-  {"HIPFFT_INVALID_PLAN",                             {HIP_1070, HIP_0,    HIP_0   }},
-  {"HIPFFT_ALLOC_FAILED",                             {HIP_1070, HIP_0,    HIP_0   }},
-  {"HIPFFT_INVALID_TYPE",                             {HIP_1070, HIP_0,    HIP_0   }},
-  {"HIPFFT_INVALID_VALUE",                            {HIP_1070, HIP_0,    HIP_0   }},
-  {"HIPFFT_INTERNAL_ERROR",                           {HIP_1070, HIP_0,    HIP_0   }},
-  {"HIPFFT_EXEC_FAILED",                              {HIP_1070, HIP_0,    HIP_0   }},
-  {"HIPFFT_SETUP_FAILED",                             {HIP_1070, HIP_0,    HIP_0   }},
-  {"HIPFFT_INVALID_SIZE",                             {HIP_1070, HIP_0,    HIP_0   }},
-  {"HIPFFT_UNALIGNED_DATA",                           {HIP_1070, HIP_0,    HIP_0   }},
-  {"HIPFFT_INCOMPLETE_PARAMETER_LIST",                {HIP_1070, HIP_0,    HIP_0   }},
-  {"HIPFFT_INVALID_DEVICE",                           {HIP_1070, HIP_0,    HIP_0   }},
-  {"HIPFFT_PARSE_ERROR",                              {HIP_1070, HIP_0,    HIP_0   }},
-  {"HIPFFT_NO_WORKSPACE",                             {HIP_1070, HIP_0,    HIP_0   }},
-  {"HIPFFT_NOT_IMPLEMENTED",                          {HIP_1070, HIP_0,    HIP_0   }},
-  {"HIPFFT_NOT_SUPPORTED",                            {HIP_1070, HIP_0,    HIP_0   }},
-  {"hipfftType_t",                                    {HIP_1070, HIP_0,    HIP_0   }},
-  {"hipfftType",                                      {HIP_1070, HIP_0,    HIP_0   }},
-  {"HIPFFT_R2C",                                      {HIP_1070, HIP_0,    HIP_0   }},
-  {"HIPFFT_C2R",                                      {HIP_1070, HIP_0,    HIP_0   }},
-  {"HIPFFT_C2C",                                      {HIP_1070, HIP_0,    HIP_0   }},
-  {"HIPFFT_D2Z",                                      {HIP_1070, HIP_0,    HIP_0   }},
-  {"HIPFFT_Z2D",                                      {HIP_1070, HIP_0,    HIP_0   }},
-  {"HIPFFT_Z2Z",                                      {HIP_1070, HIP_0,    HIP_0   }},
-  {"hipfftReal",                                      {HIP_1070, HIP_0,    HIP_0   }},
-  {"hipfftDoubleReal",                                {HIP_1070, HIP_0,    HIP_0   }},
-  {"hipfftComplex",                                   {HIP_1070, HIP_0,    HIP_0   }},
-  {"hipfftDoubleComplex",                             {HIP_1070, HIP_0,    HIP_0   }},
-  {"hipfftHandle",                                    {HIP_1070, HIP_0,    HIP_0   }},
-  {"hipfftXtSubFormat_t",                             {HIP_6000, HIP_0,    HIP_0   }},
-  {"hipfftXtSubFormat",                               {HIP_6000, HIP_0,    HIP_0   }},
-  {"HIPFFT_XT_FORMAT_INPUT",                          {HIP_6000, HIP_0,    HIP_0   }},
-  {"HIPFFT_XT_FORMAT_OUTPUT",                         {HIP_6000, HIP_0,    HIP_0   }},
-  {"HIPFFT_XT_FORMAT_INPLACE",                        {HIP_6000, HIP_0,    HIP_0   }},
-  {"HIPFFT_XT_FORMAT_INPLACE_SHUFFLED",               {HIP_6000, HIP_0,    HIP_0   }},
-  {"HIPFFT_XT_FORMAT_1D_INPUT_SHUFFLED",              {HIP_6000, HIP_0,    HIP_0   }},
-  {"HIPFFT_FORMAT_UNDEFINED",                         {HIP_6000, HIP_0,    HIP_0   }},
-  {"hipfftXtCopyType_t",                              {HIP_6000, HIP_0,    HIP_0   }},
-  {"hipfftXtCopyType",                                {HIP_6000, HIP_0,    HIP_0   }},
-  {"HIPFFT_COPY_HOST_TO_DEVICE",                      {HIP_6000, HIP_0,    HIP_0   }},
-  {"HIPFFT_COPY_DEVICE_TO_HOST",                      {HIP_6000, HIP_0,    HIP_0   }},
-  {"HIPFFT_COPY_DEVICE_TO_DEVICE",                    {HIP_6000, HIP_0,    HIP_0   }},
-  {"HIPFFT_COPY_UNDEFINED",                           {HIP_6000, HIP_0,    HIP_0   }},
-  {"hipfftXtCallbackType_t",                          {HIP_4030, HIP_0,    HIP_0   }},
-  {"hipfftXtCallbackType",                            {HIP_4030, HIP_0,    HIP_0   }},
-  {"HIPFFT_CB_LD_COMPLEX",                            {HIP_4030, HIP_0,    HIP_0   }},
-  {"HIPFFT_CB_LD_COMPLEX_DOUBLE",                     {HIP_4030, HIP_0,    HIP_0   }},
-  {"HIPFFT_CB_LD_REAL",                               {HIP_4030, HIP_0,    HIP_0   }},
-  {"HIPFFT_CB_LD_REAL_DOUBLE",                        {HIP_4030, HIP_0,    HIP_0   }},
-  {"HIPFFT_CB_ST_COMPLEX",                            {HIP_4030, HIP_0,    HIP_0   }},
-  {"HIPFFT_CB_ST_COMPLEX_DOUBLE",                     {HIP_4030, HIP_0,    HIP_0   }},
-  {"HIPFFT_CB_ST_REAL",                               {HIP_4030, HIP_0,    HIP_0   }},
-  {"HIPFFT_CB_ST_REAL_DOUBLE",                        {HIP_4030, HIP_0,    HIP_0   }},
-  {"HIPFFT_CB_UNDEFINED",                             {HIP_4030, HIP_0,    HIP_0   }},
-  {"hipLibXtDesc_t",                                  {HIP_6000, HIP_0,    HIP_0   }},
-  {"hipLibXtDesc",                                    {HIP_6000, HIP_0,    HIP_0   }},
-  {"FFTW_FORWARD",                                    {HIP_7010, HIP_0,    HIP_0   }},
-  {"FFTW_BACKWARD",                                   {HIP_7010, HIP_0,    HIP_0   }},
-  {"FFTW_ESTIMATE",                                   {HIP_7010, HIP_0,    HIP_0   }},
-  {"FFTW_MEASURE",                                    {HIP_7010, HIP_0,    HIP_0   }},
-  {"FFTW_PATIENT",                                    {HIP_7010, HIP_0,    HIP_0   }},
-  {"FFTW_EXHAUSTIVE",                                 {HIP_7010, HIP_0,    HIP_0   }},
-  {"FFTW_WISDOM_ONLY",                                {HIP_7010, HIP_0,    HIP_0   }},
-  {"FFTW_DESTROY_INPUT",                              {HIP_7010, HIP_0,    HIP_0   }},
-  {"FFTW_PRESERVE_INPUT",                             {HIP_7010, HIP_0,    HIP_0   }},
-  {"FFTW_UNALIGNED",                                  {HIP_7010, HIP_0,    HIP_0   }},
-  {"fftw_complex",                                    {HIP_7010, HIP_0,    HIP_0   }},
-  {"fftwf_complex",                                   {HIP_7010, HIP_0,    HIP_0   }},
-  {"fftw_plan",                                       {HIP_7010, HIP_0,    HIP_0   }},
-  {"fftwf_plan",                                      {HIP_7010, HIP_0,    HIP_0   }},
-};
+  return m;
+}();
+
+const std::map<llvm::StringRef, hipAPIversions> HIP_FFT_TYPE_NAME_VER_MAP = []() {
+  std::map<llvm::StringRef, hipAPIversions> m;
+
+  m["HIPFFT_FORWARD"]                                   = {HIP_1070, HIP_0,    HIP_0   };
+  m["HIPFFT_BACKWARD"]                                  = {HIP_1070, HIP_0,    HIP_0   };
+  m["hipfftResult_t"]                                   = {HIP_1070, HIP_0,    HIP_0   };
+  m["hipfftResult"]                                     = {HIP_1070, HIP_0,    HIP_0   };
+  m["HIPFFT_SUCCESS"]                                   = {HIP_1070, HIP_0,    HIP_0   };
+  m["HIPFFT_INVALID_PLAN"]                              = {HIP_1070, HIP_0,    HIP_0   };
+  m["HIPFFT_ALLOC_FAILED"]                              = {HIP_1070, HIP_0,    HIP_0   };
+  m["HIPFFT_INVALID_TYPE"]                              = {HIP_1070, HIP_0,    HIP_0   };
+  m["HIPFFT_INVALID_VALUE"]                             = {HIP_1070, HIP_0,    HIP_0   };
+  m["HIPFFT_INTERNAL_ERROR"]                            = {HIP_1070, HIP_0,    HIP_0   };
+  m["HIPFFT_EXEC_FAILED"]                               = {HIP_1070, HIP_0,    HIP_0   };
+  m["HIPFFT_SETUP_FAILED"]                              = {HIP_1070, HIP_0,    HIP_0   };
+  m["HIPFFT_INVALID_SIZE"]                              = {HIP_1070, HIP_0,    HIP_0   };
+  m["HIPFFT_UNALIGNED_DATA"]                            = {HIP_1070, HIP_0,    HIP_0   };
+  m["HIPFFT_INCOMPLETE_PARAMETER_LIST"]                 = {HIP_1070, HIP_0,    HIP_0   };
+  m["HIPFFT_INVALID_DEVICE"]                            = {HIP_1070, HIP_0,    HIP_0   };
+  m["HIPFFT_PARSE_ERROR"]                               = {HIP_1070, HIP_0,    HIP_0   };
+  m["HIPFFT_NO_WORKSPACE"]                              = {HIP_1070, HIP_0,    HIP_0   };
+  m["HIPFFT_NOT_IMPLEMENTED"]                           = {HIP_1070, HIP_0,    HIP_0   };
+  m["HIPFFT_NOT_SUPPORTED"]                             = {HIP_1070, HIP_0,    HIP_0   };
+  m["hipfftType_t"]                                     = {HIP_1070, HIP_0,    HIP_0   };
+  m["hipfftType"]                                       = {HIP_1070, HIP_0,    HIP_0   };
+  m["HIPFFT_R2C"]                                       = {HIP_1070, HIP_0,    HIP_0   };
+  m["HIPFFT_C2R"]                                       = {HIP_1070, HIP_0,    HIP_0   };
+  m["HIPFFT_C2C"]                                       = {HIP_1070, HIP_0,    HIP_0   };
+  m["HIPFFT_D2Z"]                                       = {HIP_1070, HIP_0,    HIP_0   };
+  m["HIPFFT_Z2D"]                                       = {HIP_1070, HIP_0,    HIP_0   };
+  m["HIPFFT_Z2Z"]                                       = {HIP_1070, HIP_0,    HIP_0   };
+  m["hipfftReal"]                                       = {HIP_1070, HIP_0,    HIP_0   };
+  m["hipfftDoubleReal"]                                 = {HIP_1070, HIP_0,    HIP_0   };
+  m["hipfftComplex"]                                    = {HIP_1070, HIP_0,    HIP_0   };
+  m["hipfftDoubleComplex"]                              = {HIP_1070, HIP_0,    HIP_0   };
+  m["hipfftHandle"]                                     = {HIP_1070, HIP_0,    HIP_0   };
+  m["hipfftXtSubFormat_t"]                              = {HIP_6000, HIP_0,    HIP_0   };
+  m["hipfftXtSubFormat"]                                = {HIP_6000, HIP_0,    HIP_0   };
+  m["HIPFFT_XT_FORMAT_INPUT"]                           = {HIP_6000, HIP_0,    HIP_0   };
+  m["HIPFFT_XT_FORMAT_OUTPUT"]                          = {HIP_6000, HIP_0,    HIP_0   };
+  m["HIPFFT_XT_FORMAT_INPLACE"]                         = {HIP_6000, HIP_0,    HIP_0   };
+  m["HIPFFT_XT_FORMAT_INPLACE_SHUFFLED"]                = {HIP_6000, HIP_0,    HIP_0   };
+  m["HIPFFT_XT_FORMAT_1D_INPUT_SHUFFLED"]               = {HIP_6000, HIP_0,    HIP_0   };
+  m["HIPFFT_FORMAT_UNDEFINED"]                          = {HIP_6000, HIP_0,    HIP_0   };
+  m["hipfftXtCopyType_t"]                               = {HIP_6000, HIP_0,    HIP_0   };
+  m["hipfftXtCopyType"]                                 = {HIP_6000, HIP_0,    HIP_0   };
+  m["HIPFFT_COPY_HOST_TO_DEVICE"]                       = {HIP_6000, HIP_0,    HIP_0   };
+  m["HIPFFT_COPY_DEVICE_TO_HOST"]                       = {HIP_6000, HIP_0,    HIP_0   };
+  m["HIPFFT_COPY_DEVICE_TO_DEVICE"]                     = {HIP_6000, HIP_0,    HIP_0   };
+  m["HIPFFT_COPY_UNDEFINED"]                            = {HIP_6000, HIP_0,    HIP_0   };
+  m["hipfftXtCallbackType_t"]                           = {HIP_4030, HIP_0,    HIP_0   };
+  m["hipfftXtCallbackType"]                             = {HIP_4030, HIP_0,    HIP_0   };
+  m["HIPFFT_CB_LD_COMPLEX"]                             = {HIP_4030, HIP_0,    HIP_0   };
+  m["HIPFFT_CB_LD_COMPLEX_DOUBLE"]                      = {HIP_4030, HIP_0,    HIP_0   };
+  m["HIPFFT_CB_LD_REAL"]                                = {HIP_4030, HIP_0,    HIP_0   };
+  m["HIPFFT_CB_LD_REAL_DOUBLE"]                         = {HIP_4030, HIP_0,    HIP_0   };
+  m["HIPFFT_CB_ST_COMPLEX"]                             = {HIP_4030, HIP_0,    HIP_0   };
+  m["HIPFFT_CB_ST_COMPLEX_DOUBLE"]                      = {HIP_4030, HIP_0,    HIP_0   };
+  m["HIPFFT_CB_ST_REAL"]                                = {HIP_4030, HIP_0,    HIP_0   };
+  m["HIPFFT_CB_ST_REAL_DOUBLE"]                         = {HIP_4030, HIP_0,    HIP_0   };
+  m["HIPFFT_CB_UNDEFINED"]                              = {HIP_4030, HIP_0,    HIP_0   };
+  m["hipLibXtDesc_t"]                                   = {HIP_6000, HIP_0,    HIP_0   };
+  m["hipLibXtDesc"]                                     = {HIP_6000, HIP_0,    HIP_0   };
+  m["FFTW_FORWARD"]                                     = {HIP_7010, HIP_0,    HIP_0   };
+  m["FFTW_BACKWARD"]                                    = {HIP_7010, HIP_0,    HIP_0   };
+  m["FFTW_ESTIMATE"]                                    = {HIP_7010, HIP_0,    HIP_0   };
+  m["FFTW_MEASURE"]                                     = {HIP_7010, HIP_0,    HIP_0   };
+  m["FFTW_PATIENT"]                                     = {HIP_7010, HIP_0,    HIP_0   };
+  m["FFTW_EXHAUSTIVE"]                                  = {HIP_7010, HIP_0,    HIP_0   };
+  m["FFTW_WISDOM_ONLY"]                                 = {HIP_7010, HIP_0,    HIP_0   };
+  m["FFTW_DESTROY_INPUT"]                               = {HIP_7010, HIP_0,    HIP_0   };
+  m["FFTW_PRESERVE_INPUT"]                              = {HIP_7010, HIP_0,    HIP_0   };
+  m["FFTW_UNALIGNED"]                                   = {HIP_7010, HIP_0,    HIP_0   };
+  m["fftw_complex"]                                     = {HIP_7010, HIP_0,    HIP_0   };
+  m["fftwf_complex"]                                    = {HIP_7010, HIP_0,    HIP_0   };
+  m["fftw_plan"]                                        = {HIP_7010, HIP_0,    HIP_0   };
+  m["fftwf_plan"]                                       = {HIP_7010, HIP_0,    HIP_0   };
+
+  return m;
+}();


### PR DESCRIPTION
**[Synopsis]**
+ Transformation maps reside in Stack and occupy up to `64kB` each of stack memory now
+ That leads to multiple compiler warnings about possible Stack Overflow

**[Solution]**
+ Move maps' initialization logic into a lambda. This prevents the compiler from creating a massive temporary array on the stack, which was the root cause of the "excessive stack usage" warning.
