### PR TITLE
[HIPIFY][FILE][#2174][#2362][fix] Fix typo: `CUDA_DRV_ERR` -> `CU_FILE_CUDA_ERR`

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -9857,12 +9857,12 @@ sub simpleSubstitutions {
     subst("CUDA_ARRAY3D_TEXTURE_GATHER", "hipArrayTextureGather", "define");
     subst("CUDA_COOPERATIVE_LAUNCH_MULTI_DEVICE_NO_POST_LAUNCH_SYNC", "hipCooperativeLaunchMultiDeviceNoPostSync", "define");
     subst("CUDA_COOPERATIVE_LAUNCH_MULTI_DEVICE_NO_PRE_LAUNCH_SYNC", "hipCooperativeLaunchMultiDeviceNoPreSync", "define");
-    subst("CUDA_DRV_ERR", "HIP_DRV_ERR", "define");
     subst("CUDA_EXTERNAL_MEMORY_DEDICATED", "hipExternalMemoryDedicated", "define");
     subst("CUDA_IPC_HANDLE_SIZE", "HIP_IPC_HANDLE_SIZE", "define");
     subst("CUFILE_ERRSTR", "HIPFILE_ERRSTR", "define");
     subst("CU_DEVICE_CPU", "hipCpuDeviceId", "define");
     subst("CU_DEVICE_INVALID", "hipInvalidDeviceId", "define");
+    subst("CU_FILE_CUDA_ERR", "HIP_DRV_ERR", "define");
     subst("CU_GRAPH_KERNEL_NODE_PORT_DEFAULT", "hipGraphKernelNodePortDefault", "define");
     subst("CU_GRAPH_KERNEL_NODE_PORT_LAUNCH_ORDER", "hipGraphKernelNodePortLaunchCompletion", "define");
     subst("CU_GRAPH_KERNEL_NODE_PORT_PROGRAMMATIC", "hipGraphKernelNodePortProgrammatic", "define");

--- a/docs/reference/tables/cuFile_API_supported_by_HIP.md
+++ b/docs/reference/tables/cuFile_API_supported_by_HIP.md
@@ -14,7 +14,6 @@
 
 |**CUDA**|**A**|**D**|**C**|**R**|**HIP**|**A**|**D**|**C**|**R**|**U**|**E**|
 |:--|:-:|:-:|:-:|:-:|:--|:-:|:-:|:-:|:-:|:-:|:-:|
-|`CUDA_DRV_ERR`|12.9| | | |`HIP_DRV_ERR`|7.2.0| | | | | |
 |`CUFILE_BATCH`|1.2.0| | | |`hipFileBatch`|7.2.0| | | | | |
 |`CUFILE_CANCELED`|1.2.0| | | |`hipFileCanceled`|7.2.0| | | | | |
 |`CUFILE_COMPLETE`|1.2.0| | | |`hipFileComplete`|7.2.0| | | | | |
@@ -64,6 +63,7 @@
 |`CU_FILE_BEEGFS_SUPPORTED`|1.1.1| | | |`hipFileBEEGFSSupported`|7.2.0| | | | | |
 |`CU_FILE_CUDA_CONTEXT_MISMATCH`|1.0.0| | | |`hipFileHipContextMismatch`|7.2.0| | | | | |
 |`CU_FILE_CUDA_DRIVER_ERROR`|1.0.0| | | |`hipFileHipDriverError`|7.2.0| | | | | |
+|`CU_FILE_CUDA_ERR`|1.0.0| | | |`HIP_DRV_ERR`|7.2.0| | | | | |
 |`CU_FILE_CUDA_MEMORY_TYPE_INVALID`|1.0.0| | | |`hipFileHipMemoryTypeInvalid`|7.2.0| | | | | |
 |`CU_FILE_CUDA_POINTER_INVALID`|1.0.0| | | |`hipFileHipPointerInvalid`|7.2.0| | | | | |
 |`CU_FILE_CUDA_POINTER_RANGE_ERROR`|1.0.0| | | |`hipFileHipPointerRangeError`|7.2.0| | | | | |

--- a/src/CUDA2HIP_FILE_API_types.cpp
+++ b/src/CUDA2HIP_FILE_API_types.cpp
@@ -146,8 +146,7 @@ const std::map<llvm::StringRef, hipCounter> CUDA_FILE_TYPE_NAME_MAP {
   {"CUFILE_PARAM_LOG_DIR",                                  {"hipFileParamLogDir",                             "", CONV_NUMERIC_LITERAL, API_FILE, 1}},
   {"IS_CUFILE_ERR", {"IS_HIPFILE_ERR", "", CONV_DEFINE, API_FILE, 1}},
   {"CUFILE_ERRSTR", {"HIPFILE_ERRSTR", "", CONV_DEFINE, API_FILE, 1}},
-  // TODO: Check CUDA_DRV_ERR for existence in cuFile
-  {"CUDA_DRV_ERR",  {"HIP_DRV_ERR",    "", CONV_DEFINE, API_FILE, 1}},
+  {"CU_FILE_CUDA_ERR",  {"HIP_DRV_ERR", "", CONV_DEFINE, API_FILE, 1}},
   {"IS_CUDA_ERR",   {"IS_HIP_DRV_ERR", "", CONV_DEFINE, API_FILE, 1}},
 };
 
@@ -275,7 +274,7 @@ const std::map<llvm::StringRef, cudaAPIversions> CUDA_FILE_TYPE_NAME_VER_MAP {
   {"CUFILE_PARAM_LOG_DIR",                                  {CUFILE_1140, CUDA_0, CUDA_0}},
   {"IS_CUFILE_ERR",                     {CUFILE_1000, CUDA_0, CUDA_0}},
   {"CUFILE_ERRSTR",                     {CUFILE_1000, CUDA_0, CUDA_0}},
-  {"CUDA_DRV_ERR",                      {CUDA_129, CUDA_0, CUDA_0}},
+  {"CU_FILE_CUDA_ERR",                  {CUFILE_1000, CUDA_0, CUDA_0}},
   {"IS_CUDA_ERR",                       {CUFILE_1000, CUDA_0, CUDA_0}},
 };
 


### PR DESCRIPTION
+ Updated the regenerated `hipify-perl` and `File` `CUDA2HIP` docs accordingly
