### PR TITLE
[HIPIFY][ROCM-1367][merge][#2322][fix] Use host target in Init() to avoid CUDA 12.x ptxas/nvlink errors

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -44,6 +44,11 @@ THE SOFTWARE.
 #endif
 #include "clang/Driver/Tool.h"
 #include "clang/Frontend/TextDiagnosticPrinter.h"
+#if LLVM_VERSION_MAJOR >= 16
+#include "llvm/TargetParser/Host.h"
+#else
+#include "llvm/Support/Host.h"
+#endif
 
 #include "LocalHeader.h"
 
@@ -106,7 +111,7 @@ void Init(int argc, const char **argv, std::vector<std::string> &files) {
   clang::TextDiagnosticPrinter diagClient(llvm::errs(), &*diagOpts);
   clang::DiagnosticsEngine Diagnostics(IntrusiveRefCntPtr<clang::DiagnosticIDs>(new clang::DiagnosticIDs()), &*diagOpts, &diagClient, false);
 #endif
-  std::unique_ptr<clang::driver::Driver> driver(new clang::driver::Driver("", "nvptx64-nvidia-cuda", Diagnostics));
+  std::unique_ptr<clang::driver::Driver> driver(new clang::driver::Driver("", llvm::sys::getDefaultTargetTriple(), Diagnostics));
   std::vector<const char*> Args(argv, argv + argc);
   cleanupHipifyOptions(Args);
   std::unique_ptr<clang::driver::Compilation> C(driver->BuildCompilation(Args));


### PR DESCRIPTION
CP [929cc3a02a7](https://github.com/ROCm/HIPIFY/commit/929cc3a02a79a87a9ed5d644308a3d7e7563aef0) into amd-mainline. Fixes ROCM-1367.