### PR TITLE
[HIPIFY][FILE][test][Windows] Added support for testing `cuFile` on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -404,6 +404,8 @@ if(HIPIFY_CLANG_TESTS OR HIPIFY_CLANG_TESTS_ONLY)
 
   if(CUDA_FILE_ROOT_DIR STREQUAL "")
     set(CUDA_FILE_ROOT_DIR OFF)
+  else()
+    set(CUDA_FILE_ROOT_DIR "${CUDA_FILE_ROOT_DIR}/include")
   endif()
 
   message(STATUS "Found CUDA config:")

--- a/tests/lit.cfg
+++ b/tests/lit.cfg
@@ -16,6 +16,9 @@ config.excludes = ['cmdparser.hpp']
 config.excludes.append('spatial_batch_norm_op.h')
 config.excludes.append('common_cudnn.h')
 config.excludes.append('inc.h')
+config.excludes.append('inet.h')
+config.excludes.append('types.h')
+config.excludes.append('socket.h')
 
 delimiter = "===============================================================";
 print(delimiter)

--- a/tests/unit_tests/synthetic/libraries/arpa/inet.h
+++ b/tests/unit_tests/synthetic/libraries/arpa/inet.h
@@ -1,0 +1,13 @@
+// Fake arpa/inet.h to appease cuFile testing on Windows
+#pragma once
+
+#ifdef _WIN32
+    #ifndef WIN32_LEAN_AND_MEAN
+    #define WIN32_LEAN_AND_MEAN
+    #endif
+    #include <winsock2.h>
+    #include <ws2tcpip.h>
+#else
+    // On Linux, bypass this shim and load the real system header
+    #include_next <arpa/inet.h>
+#endif

--- a/tests/unit_tests/synthetic/libraries/sys/socket.h
+++ b/tests/unit_tests/synthetic/libraries/sys/socket.h
@@ -1,0 +1,16 @@
+// Fake sys/socket.h to appease cuFile testing on Windows
+#pragma once
+
+#ifdef _WIN32
+    #ifndef WIN32_LEAN_AND_MEAN
+    #define WIN32_LEAN_AND_MEAN
+    #endif
+    #include <winsock2.h>
+    
+    // Sometimes Windows needs this for types like ssize_t
+    #include <BaseTsd.h> 
+    typedef SSIZE_T ssize_t;
+#else
+    // On Linux, bypass this shim and load the real system header
+    #include_next <sys/socket.h>
+#endif

--- a/tests/unit_tests/synthetic/libraries/sys/types.h
+++ b/tests/unit_tests/synthetic/libraries/sys/types.h
@@ -1,0 +1,17 @@
+// Fake sys/types.h to appease cuFile testing on Windows
+#pragma once
+
+// ALWAYS load the real system header first (works for Windows SDK and Linux glibc)
+#include_next <sys/types.h>
+
+// 2. Add our Linux missing types
+#ifdef _WIN32
+    #include <stdint.h>
+    
+    // Define the Linux 64-bit file offset type for Windows
+    typedef int64_t loff_t;
+    typedef int64_t off64_t; 
+    
+    // (Optional) Include corecrt just in case standard sys/types.h misses it
+    #include <corecrt.h> 
+#endif


### PR DESCRIPTION
+ [IMP] Provide `shim headers` for OS-specific system header files
+ [IMP][Linux] Force test hipification through the fallback path in those shim header files
+ [IMP] `CUDA_FILE_ROOT_DIR` must be specified only on `Windows`, as `cuFile.h` is shipped with the `CUDA Toolkit` for `Linux` and is found as a regular CUDA file
+ [Tests] The `Header Shim` approach was tested on both `Windows` and `Linux`
