### PR TITLE
[HIPIFY][fix] `Stack Overflow` possible Issues - Final clean up and formatting

### DIFF
--- a/src/CUDA2HIP_BLAS_API_functions.cpp
+++ b/src/CUDA2HIP_BLAS_API_functions.cpp
@@ -27,6 +27,7 @@ using SEC = blas::BLAS_API_SECTIONS;
 // Map of all functions
 const std::map<llvm::StringRef, hipCounter> CUDA_BLAS_FUNCTION_MAP = [] {
   std::map<llvm::StringRef, hipCounter> m;
+
   // Blas management functions
   m["cublasInit"]                                                   = {"hipblasInit",                                               "rocblas_initialize",                                 CONV_LIB_FUNC, API_BLAS, SEC::BLAS_HELPER, HIP_UNSUPPORTED};
   m["cublasShutdown"]                                               = {"hipblasShutdown",                                           "",                                                   CONV_LIB_FUNC, API_BLAS, SEC::BLAS_HELPER, UNSUPPORTED};
@@ -1160,6 +1161,7 @@ const std::map<llvm::StringRef, hipCounter> CUDA_BLAS_FUNCTION_MAP = [] {
 
 const std::map<llvm::StringRef, cudaAPIversions> CUDA_BLAS_FUNCTION_VER_MAP = [] {
   std::map<llvm::StringRef, cudaAPIversions> m;
+
   m["cublasGetMathMode"]                                            = {CUDA_90,  CUDA_0,   CUDA_0   };
   m["cublasSetMathMode"]                                            = {CUDA_90,  CUDA_0,   CUDA_0   };
   m["cublasMigrateComputeType"]                                     = {CUDA_110, CUDA_0,   CUDA_0   };
@@ -1672,11 +1674,13 @@ const std::map<llvm::StringRef, cudaAPIversions> CUDA_BLAS_FUNCTION_VER_MAP = []
   m["cublasSetFixedPointEmulationMantissaBitOffset"]                = {CUDA_130, CUDA_0,   CUDA_0   }; // A: CUDA 13.0.2, CUBLAS_VERSION 130100
   m["cublasGetFixedPointEmulationMantissaBitCountPointer"]          = {CUDA_130, CUDA_0,   CUDA_0   }; // A: CUDA 13.0.2, CUBLAS_VERSION 130100
   m["cublasSetFixedPointEmulationMantissaBitCountPointer"]          = {CUDA_130, CUDA_0,   CUDA_0   }; // A: CUDA 13.0.2, CUBLAS_VERSION 130100
+
   return m;
 }();
 
 const std::map<llvm::StringRef, hipAPIversions> HIP_BLAS_FUNCTION_VER_MAP = [] {
   std::map<llvm::StringRef, hipAPIversions> m;
+
   m["hipblasGetAtomicsMode"]                                        = {HIP_3100, HIP_0,    HIP_0   };
   m["hipblasSetAtomicsMode"]                                        = {HIP_3100, HIP_0,    HIP_0   };
   m["hipblasCreate"]                                                = {HIP_1082, HIP_0,    HIP_0   };
@@ -2581,6 +2585,7 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_BLAS_FUNCTION_VER_MAP = [] {
 
 const std::map<llvm::StringRef, hipAPIChangedVersions> HIP_BLAS_FUNCTION_CHANGED_VER_MAP = [] {
   std::map<llvm::StringRef, hipAPIChangedVersions> m;
+
   m["hipblasStrmm"]                                                 = {HIP_6000};
   m["hipblasDtrmm"]                                                 = {HIP_6000};
   m["hipblasGemmEx"]                                                = {HIP_7000};
@@ -2828,6 +2833,7 @@ const std::map<llvm::StringRef, hipAPIChangedVersions> HIP_BLAS_FUNCTION_CHANGED
 
 const std::map<llvm::StringRef, cudaAPIChangedVersions> CUDA_BLAS_FUNCTION_CHANGED_VER_MAP = [] {
   std::map<llvm::StringRef, cudaAPIChangedVersions> m;
+
   m["cublasLtMatmulDescCreate"]                                     = {CUDA_110};
   m["cublasGemmEx"]                                                 = {CUDA_110};
   m["cublasGemmBatchedEx"]                                          = {CUDA_110};
@@ -2838,6 +2844,7 @@ const std::map<llvm::StringRef, cudaAPIChangedVersions> CUDA_BLAS_FUNCTION_CHANG
 
 const std::map<unsigned int, llvm::StringRef> CUDA_BLAS_API_SECTION_MAP = [] {
   std::map<unsigned int, llvm::StringRef> m;
+
   m[SEC::BLAS_DATA_TYPES]                                           = "CUBLAS Data types";
   m[SEC::CUDA_DATA_TYPES]                                           = "CUDA Library Data types";
   m[SEC::BLAS_LT_DATA_TYPES]                                        = "CUBLASLt Data types";

--- a/src/CUDA2HIP_BLAS_API_types.cpp
+++ b/src/CUDA2HIP_BLAS_API_types.cpp
@@ -27,6 +27,7 @@ using SEC = blas::BLAS_API_SECTIONS;
 // Map of all functions
 const std::map<llvm::StringRef, hipCounter> CUDA_BLAS_TYPE_NAME_MAP = [] {
   std::map<llvm::StringRef, hipCounter> m;
+
   // Blas operations
   m["cublasOperation_t"]                                              = {"hipblasOperation_t",                                                "rocblas_operation",                                        CONV_TYPE, API_BLAS, SEC::BLAS_DATA_TYPES};
   m["CUBLAS_OP_N"]                                                    = {"HIPBLAS_OP_N",                                                      "rocblas_operation_none",                                   CONV_NUMERIC_LITERAL, API_BLAS, SEC::BLAS_DATA_TYPES};
@@ -1145,11 +1146,13 @@ const std::map<llvm::StringRef, hipCounter> CUDA_BLAS_TYPE_NAME_MAP = [] {
   m["CUBLASLT_EMULATION_DESC_FIXEDPOINT_MAX_MANTISSA_BIT_COUNT"]      = {"HIPBLASLT_EMULATION_DESC_FIXEDPOINT_MAX_MANTISSA_BIT_COUNT",        "",                                                         CONV_NUMERIC_LITERAL, API_BLAS, SEC::BLAS_LT_DATA_TYPES, UNSUPPORTED};
   m["CUBLASLT_EMULATION_DESC_FIXEDPOINT_MANTISSA_BIT_OFFSET"]         = {"HIPBLASLT_EMULATION_DESC_FIXEDPOINT_MANTISSA_BIT_OFFSET",           "",                                                         CONV_NUMERIC_LITERAL, API_BLAS, SEC::BLAS_LT_DATA_TYPES, UNSUPPORTED};
   m["CUBLASLT_EMULATION_DESC_FIXEDPOINT_MANTISSA_BIT_COUNT_POINTER"]  = {"HIPBLASLT_EMULATION_DESC_FIXEDPOINT_MANTISSA_BIT_COUNT_POINTER",    "",                                                         CONV_NUMERIC_LITERAL, API_BLAS, SEC::BLAS_LT_DATA_TYPES, UNSUPPORTED};
+
   return m;
 }();
 
 const std::map<llvm::StringRef, cudaAPIversions> CUDA_BLAS_TYPE_NAME_VER_MAP = [] {
   std::map<llvm::StringRef, cudaAPIversions> m;
+
   m["CUBLAS_OP_CONJG"]                                                = {CUDA_101, CUDA_0,   CUDA_0  };
   m["CUBLAS_OP_HERMITAN"]                                             = {CUDA_101, CUDA_0,   CUDA_0  };
   m["CUBLAS_FILL_MODE_FULL"]                                          = {CUDA_101, CUDA_0,   CUDA_0  };
@@ -2199,11 +2202,13 @@ const std::map<llvm::StringRef, cudaAPIversions> CUDA_BLAS_TYPE_NAME_VER_MAP = [
   m["CUBLASLT_EMULATION_DESC_FIXEDPOINT_MANTISSA_BIT_COUNT_POINTER"]  = {CUDA_130, CUDA_0,   CUDA_0  }; // CUBLAS_VERSION 130100 CUDA 13.0.2
   m["CUBLAS_FP64_EMULATED_FIXEDPOINT_MATH"]                           = {CUDA_130, CUDA_0,   CUDA_0  }; // CUBLAS_VERSION 130100 CUDA 13.0.2
   m["CUBLAS_COMPUTE_64F_EMULATED_FIXEDPOINT"]                         = {CUDA_130, CUDA_0,   CUDA_0  }; // CUBLAS_VERSION 130100 CUDA 13.0.2
+
   return m;
 }();
 
 const std::map<llvm::StringRef, hipAPIversions> HIP_BLAS_TYPE_NAME_VER_MAP = [] {
   std::map<llvm::StringRef, hipAPIversions> m;
+
   m["hipblasOperation_t"]                                             = {HIP_1082, HIP_0,    HIP_0   };
   m["HIPBLAS_OP_N"]                                                   = {HIP_1082, HIP_0,    HIP_0   };
   m["HIPBLAS_OP_T"]                                                   = {HIP_1082, HIP_0,    HIP_0   };

--- a/src/CUDA2HIP_CUB_API_functions.cpp
+++ b/src/CUDA2HIP_CUB_API_functions.cpp
@@ -23,17 +23,17 @@ THE SOFTWARE.
 #include "CUDA2HIP.h"
 
 // Maps the names of CUDA CUB API functions to the corresponding HIP functions
-const std::map<llvm::StringRef, hipCounter> CUDA_CUB_FUNCTION_MAP = [] () {
+const std::map<llvm::StringRef, hipCounter> CUDA_CUB_FUNCTION_MAP = [] {
   std::map<llvm::StringRef, hipCounter> m;
   return m;
 }();
 
-const std::map<llvm::StringRef, cudaAPIversions> CUDA_CUB_FUNCTION_VER_MAP = []() {
+const std::map<llvm::StringRef, cudaAPIversions> CUDA_CUB_FUNCTION_VER_MAP = [] {
   std::map<llvm::StringRef, cudaAPIversions> m;
   return m;
 }();
 
-const std::map<llvm::StringRef, hipAPIversions> HIP_CUB_FUNCTION_VER_MAP = []() {
+const std::map<llvm::StringRef, hipAPIversions> HIP_CUB_FUNCTION_VER_MAP = [] {
   std::map<llvm::StringRef, hipAPIversions> m;
   return m;
 }();

--- a/src/CUDA2HIP_CUB_API_types.cpp
+++ b/src/CUDA2HIP_CUB_API_types.cpp
@@ -25,7 +25,7 @@ THE SOFTWARE.
 using SEC = cub::CUB_API_SECTIONS;
 
 // Maps the names of CUDA CUB API types to the corresponding HIP types
-const std::map<llvm::StringRef, hipCounter> CUDA_CUB_NAMESPACE_MAP = []() {
+const std::map<llvm::StringRef, hipCounter> CUDA_CUB_NAMESPACE_MAP = [] {
   std::map<llvm::StringRef, hipCounter> m;
 
   m["cub"]                                      = {"hipcub",                                    "", CONV_TYPE, API_CUB, SEC::DATA_TYPES};
@@ -34,7 +34,7 @@ const std::map<llvm::StringRef, hipCounter> CUDA_CUB_NAMESPACE_MAP = []() {
 }();
 
 // Maps the names of CUDA CUB API types to the corresponding HIP types
-const std::map<llvm::StringRef, hipCounter> CUDA_CUB_TYPE_NAME_MAP = []() {
+const std::map<llvm::StringRef, hipCounter> CUDA_CUB_TYPE_NAME_MAP = [] {
   std::map<llvm::StringRef, hipCounter> m;
 
   // 1. Structs
@@ -114,12 +114,12 @@ const std::map<llvm::StringRef, hipCounter> CUDA_CUB_TYPE_NAME_MAP = []() {
   return m;
 }();
 
-const std::map<llvm::StringRef, cudaAPIversions> CUDA_CUB_TYPE_NAME_VER_MAP = []() {
+const std::map<llvm::StringRef, cudaAPIversions> CUDA_CUB_TYPE_NAME_VER_MAP = [] {
   std::map<llvm::StringRef, cudaAPIversions> m;
   return m;
 }();
 
-const std::map<llvm::StringRef, hipAPIversions> HIP_CUB_TYPE_NAME_VER_MAP = []() {
+const std::map<llvm::StringRef, hipAPIversions> HIP_CUB_TYPE_NAME_VER_MAP = [] {
   std::map<llvm::StringRef, hipAPIversions> m;
 
   m["HIPCUB_STDERR"]                            = {HIP_2050, HIP_0,    HIP_0   };
@@ -137,7 +137,7 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_CUB_TYPE_NAME_VER_MAP = []()
   return m;
 }();
 
-const std::map<unsigned int, llvm::StringRef> CUDA_CUB_API_SECTION_MAP = []() {
+const std::map<unsigned int, llvm::StringRef> CUDA_CUB_API_SECTION_MAP = [] {
   std::map<unsigned int, llvm::StringRef> m;
 
   m[SEC::DATA_TYPES]                            = "CUB Data types";

--- a/src/CUDA2HIP_Complex_API_functions.cpp
+++ b/src/CUDA2HIP_Complex_API_functions.cpp
@@ -23,7 +23,7 @@ THE SOFTWARE.
 #include "CUDA2HIP.h"
 
 // Maps the names of CUDA Complex API functions to the corresponding HIP functions
-const std::map<llvm::StringRef, hipCounter> CUDA_COMPLEX_FUNCTION_MAP = []() {
+const std::map<llvm::StringRef, hipCounter> CUDA_COMPLEX_FUNCTION_MAP = [] {
   std::map<llvm::StringRef, hipCounter> m;
 
   m["cuCrealf"]                = {"hipCrealf",               "", CONV_COMPLEX, API_COMPLEX, 2};
@@ -53,12 +53,12 @@ const std::map<llvm::StringRef, hipCounter> CUDA_COMPLEX_FUNCTION_MAP = []() {
   return m;
 }();
 
-const std::map<llvm::StringRef, cudaAPIversions> CUDA_COMPLEX_FUNCTION_VER_MAP = []() {
+const std::map<llvm::StringRef, cudaAPIversions> CUDA_COMPLEX_FUNCTION_VER_MAP = [] {
   std::map<llvm::StringRef, cudaAPIversions> m;
   return m;
 }();
 
-const std::map<llvm::StringRef, hipAPIversions> HIP_COMPLEX_FUNCTION_VER_MAP = []() {
+const std::map<llvm::StringRef, hipAPIversions> HIP_COMPLEX_FUNCTION_VER_MAP = [] {
   std::map<llvm::StringRef, hipAPIversions> m;
 
   m["hipCrealf"]               = {HIP_1060, HIP_0,    HIP_0   };
@@ -88,7 +88,7 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_COMPLEX_FUNCTION_VER_MAP = [
   return m;
 }();
 
-const std::map<unsigned int, llvm::StringRef> CUDA_COMPLEX_API_SECTION_MAP = []() {
+const std::map<unsigned int, llvm::StringRef> CUDA_COMPLEX_API_SECTION_MAP = [] {
   std::map<unsigned int, llvm::StringRef> m;
 
   m[1]                         = "cuComplex Data types";

--- a/src/CUDA2HIP_Complex_API_types.cpp
+++ b/src/CUDA2HIP_Complex_API_types.cpp
@@ -23,22 +23,22 @@ THE SOFTWARE.
 #include "CUDA2HIP.h"
 
 // Maps the names of CUDA Complex API types to the corresponding HIP types
-const std::map<llvm::StringRef, hipCounter> CUDA_COMPLEX_TYPE_NAME_MAP = []() {
+const std::map<llvm::StringRef, hipCounter> CUDA_COMPLEX_TYPE_NAME_MAP = [] {
   std::map<llvm::StringRef, hipCounter> m;
 
   m["cuFloatComplex"]  = {"hipFloatComplex",  "rocblas_float_complex",  CONV_TYPE, API_COMPLEX, 1};
   m["cuDoubleComplex"] = {"hipDoubleComplex", "rocblas_double_complex", CONV_TYPE, API_COMPLEX, 1};
-  m["cuComplex"]       = {"hipComplex",       "rocblas_float_complex",  CONV_TYPE, API_COMPLEX, 1};\
+  m["cuComplex"]       = {"hipComplex",       "rocblas_float_complex",  CONV_TYPE, API_COMPLEX, 1};
 
   return m;
 }();
 
-const std::map<llvm::StringRef, cudaAPIversions> CUDA_COMPLEX_TYPE_NAME_VER_MAP = []() {
+const std::map<llvm::StringRef, cudaAPIversions> CUDA_COMPLEX_TYPE_NAME_VER_MAP = [] {
   std::map<llvm::StringRef, cudaAPIversions> m;
   return m;
 }();
 
-const std::map<llvm::StringRef, hipAPIversions> HIP_COMPLEX_TYPE_NAME_VER_MAP = []() {
+const std::map<llvm::StringRef, hipAPIversions> HIP_COMPLEX_TYPE_NAME_VER_MAP = [] {
   std::map<llvm::StringRef, hipAPIversions> m;
 
   m["hipFloatComplex"]  = {HIP_1060, HIP_0,    HIP_0   };

--- a/src/CUDA2HIP_Device_functions.cpp
+++ b/src/CUDA2HIP_Device_functions.cpp
@@ -23,7 +23,7 @@ THE SOFTWARE.
 #include "CUDA2HIP.h"
 
 // Maps CUDA header names to HIP header names
-const std::map<llvm::StringRef, hipCounter> CUDA_DEVICE_FUNCTION_MAP = []() {
+const std::map<llvm::StringRef, hipCounter> CUDA_DEVICE_FUNCTION_MAP = [] {
   std::map<llvm::StringRef, hipCounter> m;
 
   // math functions
@@ -990,7 +990,7 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DEVICE_FUNCTION_MAP = []() {
   return m;
 }();
 
-const std::map<llvm::StringRef, cudaAPIversions> CUDA_DEVICE_FUNCTION_VER_MAP = []() {
+const std::map<llvm::StringRef, cudaAPIversions> CUDA_DEVICE_FUNCTION_VER_MAP = [] {
   std::map<llvm::StringRef, cudaAPIversions> m;
 
   m["__shfl"]                           = {CUDA_75,  CUDA_90,  CUDA_0  };
@@ -1233,7 +1233,7 @@ const std::map<llvm::StringRef, cudaAPIversions> CUDA_DEVICE_FUNCTION_VER_MAP = 
   return m;
 }();
 
-const std::map<llvm::StringRef, hipAPIversions> HIP_DEVICE_FUNCTION_VER_MAP = []() {
+const std::map<llvm::StringRef, hipAPIversions> HIP_DEVICE_FUNCTION_VER_MAP = [] {
   std::map<llvm::StringRef, hipAPIversions> m;
 
   m["abs"]                              = {HIP_1060, HIP_0,    HIP_0   };
@@ -1866,7 +1866,7 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_DEVICE_FUNCTION_VER_MAP = []
   return m;
 }();
 
-const std::map<llvm::StringRef, cudaAPIChangedVersions> CUDA_DEVICE_FUNCTION_CHANGED_VER_MAP = []() {
+const std::map<llvm::StringRef, cudaAPIChangedVersions> CUDA_DEVICE_FUNCTION_CHANGED_VER_MAP = [] {
   std::map<llvm::StringRef, cudaAPIChangedVersions> m;
 
   m["__hmax2"]                          = {CUDA_122};
@@ -1887,7 +1887,7 @@ const std::map<llvm::StringRef, cudaAPIChangedVersions> CUDA_DEVICE_FUNCTION_CHA
   return m;
 }();
 
-const std::map<unsigned int, llvm::StringRef> CUDA_DEVICE_FUNCTION_API_SECTION_MAP = []() {
+const std::map<unsigned int, llvm::StringRef> CUDA_DEVICE_FUNCTION_API_SECTION_MAP = [] {
   std::map<unsigned int, llvm::StringRef> m;
 
   m[1]                                  = "Device Functions";

--- a/src/CUDA2HIP_Device_types.cpp
+++ b/src/CUDA2HIP_Device_types.cpp
@@ -23,7 +23,7 @@ THE SOFTWARE.
 #include "CUDA2HIP.h"
 
 // Maps the names of CUDA Device/Host types to the corresponding HIP types
-const std::map<llvm::StringRef, hipCounter> CUDA_DEVICE_TYPE_NAME_MAP = []() {
+const std::map<llvm::StringRef, hipCounter> CUDA_DEVICE_TYPE_NAME_MAP = [] {
   std::map<llvm::StringRef, hipCounter> m;
 
   // float16 Precision Device types
@@ -156,7 +156,7 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DEVICE_TYPE_NAME_MAP = []() {
   return m;
 }();
 
-const std::map<llvm::StringRef, cudaAPIversions> CUDA_DEVICE_TYPE_NAME_VER_MAP = []() {
+const std::map<llvm::StringRef, cudaAPIversions> CUDA_DEVICE_TYPE_NAME_VER_MAP = [] {
   std::map<llvm::StringRef, cudaAPIversions> m;
 
   m["__nv_bfloat16"]                       = {CUDA_110, CUDA_0,   CUDA_0  };
@@ -229,7 +229,7 @@ const std::map<llvm::StringRef, cudaAPIversions> CUDA_DEVICE_TYPE_NAME_VER_MAP =
   return m;
 }();
 
-const std::map<llvm::StringRef, hipAPIversions> HIP_DEVICE_TYPE_NAME_VER_MAP = []() {
+const std::map<llvm::StringRef, hipAPIversions> HIP_DEVICE_TYPE_NAME_VER_MAP = [] {
   std::map<llvm::StringRef, hipAPIversions> m;
 
   m["__half"]                              = {HIP_1060, HIP_0,    HIP_0   };

--- a/src/CUDA2HIP_Driver_API_functions.cpp
+++ b/src/CUDA2HIP_Driver_API_functions.cpp
@@ -25,7 +25,7 @@ THE SOFTWARE.
 using SEC = driver::CUDA_DRIVER_API_SECTIONS;
 
 // Map of all CUDA Driver API functions
-const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_FUNCTION_MAP = []() {
+const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_FUNCTION_MAP = [] {
   std::map<llvm::StringRef, hipCounter> m;
 
   // 2. Error Handling
@@ -1234,7 +1234,7 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_FUNCTION_MAP = []() {
   return m;
 }();
 
-const std::map<llvm::StringRef, cudaAPIversions> CUDA_DRIVER_FUNCTION_VER_MAP = []() {
+const std::map<llvm::StringRef, cudaAPIversions> CUDA_DRIVER_FUNCTION_VER_MAP = [] {
   std::map<llvm::StringRef, cudaAPIversions> m;
 
   m["cuDeviceGetLuid"]                                                   = {CUDA_100, CUDA_0,   CUDA_0  };
@@ -1612,7 +1612,7 @@ const std::map<llvm::StringRef, cudaAPIversions> CUDA_DRIVER_FUNCTION_VER_MAP = 
   return m;
 }();
 
-const std::map<llvm::StringRef, hipAPIversions> HIP_DRIVER_FUNCTION_VER_MAP = []() {
+const std::map<llvm::StringRef, hipAPIversions> HIP_DRIVER_FUNCTION_VER_MAP = [] {
   std::map<llvm::StringRef, hipAPIversions> m;
 
   m["hipInit"]                                                           = {HIP_1060, HIP_0,    HIP_0   };
@@ -1795,7 +1795,7 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_DRIVER_FUNCTION_VER_MAP = []
   return m;
 }();
 
-const std::map<llvm::StringRef, cudaAPIChangedVersions> CUDA_DRIVER_FUNCTION_CHANGED_VER_MAP = []() {
+const std::map<llvm::StringRef, cudaAPIChangedVersions> CUDA_DRIVER_FUNCTION_CHANGED_VER_MAP = [] {
   std::map<llvm::StringRef, cudaAPIChangedVersions> m;
 
   m["cuGetProcAddress"]                                                  = {CUDA_120};
@@ -1816,7 +1816,7 @@ const std::map<llvm::StringRef, cudaAPIChangedVersions> CUDA_DRIVER_FUNCTION_CHA
   return m;
 }();
 
-const std::map<llvm::StringRef, hipAPIChangedVersions> HIP_DRIVER_FUNCTION_CHANGED_VER_MAP = []() {
+const std::map<llvm::StringRef, hipAPIChangedVersions> HIP_DRIVER_FUNCTION_CHANGED_VER_MAP = [] {
   std::map<llvm::StringRef, hipAPIChangedVersions> m;
 
   m["hipCtxGetApiVersion"]                                               = {HIP_7000};
@@ -1828,7 +1828,7 @@ const std::map<llvm::StringRef, hipAPIChangedVersions> HIP_DRIVER_FUNCTION_CHANG
   return m;
 }();
 
-const std::map<llvm::StringRef, cudaAPIUnsupportedVersions> CUDA_DRIVER_FUNCTION_UNSUPPORTED_VER_MAP = []() {
+const std::map<llvm::StringRef, cudaAPIUnsupportedVersions> CUDA_DRIVER_FUNCTION_UNSUPPORTED_VER_MAP = [] {
   std::map<llvm::StringRef, cudaAPIUnsupportedVersions> m;
 
   m["cuCtxCreate"]                                                       = {CUDA_130};
@@ -1850,7 +1850,7 @@ const std::map<llvm::StringRef, cudaAPIUnsupportedVersions> CUDA_DRIVER_FUNCTION
   return m;
 }();
 
-const std::map<unsigned int, llvm::StringRef> CUDA_DRIVER_API_SECTION_MAP = []() {
+const std::map<unsigned int, llvm::StringRef> CUDA_DRIVER_API_SECTION_MAP = [] {
   std::map<unsigned int, llvm::StringRef> m;
 
   m[SEC::DATA_TYPES]                                                     = "CUDA Driver Data Types";

--- a/src/CUDA2HIP_Driver_API_types.cpp
+++ b/src/CUDA2HIP_Driver_API_types.cpp
@@ -25,7 +25,7 @@ THE SOFTWARE.
 using SEC = driver::CUDA_DRIVER_API_SECTIONS;
 
 // Maps the names of CUDA DRIVER API types to the corresponding HIP types
-const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_TYPE_NAME_MAP = []() {
+const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_TYPE_NAME_MAP = [] {
   std::map<llvm::StringRef, hipCounter> m;
 
   // 1. Structs
@@ -3352,7 +3352,7 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_TYPE_NAME_MAP = []() {
   return m;
 }();
 
-const std::map<llvm::StringRef, cudaAPIversions> CUDA_DRIVER_TYPE_NAME_VER_MAP = []() {
+const std::map<llvm::StringRef, cudaAPIversions> CUDA_DRIVER_TYPE_NAME_VER_MAP = [] {
   std::map<llvm::StringRef, cudaAPIversions> m;
 
   m["CU_CTX_BLOCKING_SYNC"]                                              = {CUDA_0,   CUDA_40,  CUDA_0  };
@@ -4519,7 +4519,7 @@ const std::map<llvm::StringRef, cudaAPIversions> CUDA_DRIVER_TYPE_NAME_VER_MAP =
   return m;
 }();
 
-const std::map<llvm::StringRef, hipAPIversions> HIP_DRIVER_TYPE_NAME_VER_MAP = []() {
+const std::map<llvm::StringRef, hipAPIversions> HIP_DRIVER_TYPE_NAME_VER_MAP = [] {
   std::map<llvm::StringRef, hipAPIversions> m;
 
   m["HIP_LAUNCH_PARAM_BUFFER_POINTER"]                                   = {HIP_1060, HIP_0,    HIP_0   };
@@ -5010,7 +5010,7 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_DRIVER_TYPE_NAME_VER_MAP = [
   return m;
 }();
 
-const std::map<llvm::StringRef, cudaAPIChangedVersions> CUDA_DRIVER_TYPE_CHANGED_VER_MAP = []() {
+const std::map<llvm::StringRef, cudaAPIChangedVersions> CUDA_DRIVER_TYPE_CHANGED_VER_MAP = [] {
   std::map<llvm::StringRef, cudaAPIChangedVersions> m;
 
   m["CUdevSmResource_st"]                                                = {CUDA_131};
@@ -5020,7 +5020,7 @@ const std::map<llvm::StringRef, cudaAPIChangedVersions> CUDA_DRIVER_TYPE_CHANGED
   return m;
   }();
 
-const std::map<llvm::StringRef, hipAPIChangedVersions> HIP_DRIVER_TYPE_CHANGED_VER_MAP = []() {
+const std::map<llvm::StringRef, hipAPIChangedVersions> HIP_DRIVER_TYPE_CHANGED_VER_MAP = [] {
   std::map<llvm::StringRef, hipAPIChangedVersions> m;
 
   m["hipLaunchAttributeValue"]                                           = {HIP_7010};

--- a/src/CUDA2HIP_FFT_API_functions.cpp
+++ b/src/CUDA2HIP_FFT_API_functions.cpp
@@ -23,7 +23,7 @@ THE SOFTWARE.
 #include "CUDA2HIP.h"
 
 // Map of all functions
-const std::map<llvm::StringRef, hipCounter> CUDA_FFT_FUNCTION_MAP = []() {
+const std::map<llvm::StringRef, hipCounter> CUDA_FFT_FUNCTION_MAP = [] {
   std::map<llvm::StringRef, hipCounter> m;
 
   m["cufftPlan1d"]                                      = {"hipfftPlan1d",                                         "", CONV_LIB_FUNC, API_FFT, 2};
@@ -160,7 +160,7 @@ const std::map<llvm::StringRef, hipCounter> CUDA_FFT_FUNCTION_MAP = []() {
   return m;
 }();
 
-const std::map<llvm::StringRef, cudaAPIversions> CUDA_FFT_FUNCTION_VER_MAP = []() {
+const std::map<llvm::StringRef, cudaAPIversions> CUDA_FFT_FUNCTION_VER_MAP = [] {
   std::map<llvm::StringRef, cudaAPIversions> m;
 
   m["cufftMakePlanMany64"]                                = {CUDA_75,  CUDA_0,   CUDA_0  };
@@ -185,7 +185,7 @@ const std::map<llvm::StringRef, cudaAPIversions> CUDA_FFT_FUNCTION_VER_MAP = [](
   return m;
 }();
 
-const std::map<llvm::StringRef, hipAPIversions> HIP_FFT_FUNCTION_VER_MAP = []() {
+const std::map<llvm::StringRef, hipAPIversions> HIP_FFT_FUNCTION_VER_MAP = [] {
   std::map<llvm::StringRef, hipAPIversions> m;
 
   m["hipfftPlan1d"]                                       = {HIP_1070, HIP_0,    HIP_0   };
@@ -292,7 +292,7 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_FFT_FUNCTION_VER_MAP = []() 
   return m;
 }();
 
-const std::map<unsigned int, llvm::StringRef> CUDA_FFT_API_SECTION_MAP = []() {
+const std::map<unsigned int, llvm::StringRef> CUDA_FFT_API_SECTION_MAP = [] {
   std::map<unsigned int, llvm::StringRef> m;
 
   m[1] = "CUFFT Data types";

--- a/src/CUDA2HIP_FFT_API_types.cpp
+++ b/src/CUDA2HIP_FFT_API_types.cpp
@@ -23,7 +23,7 @@ THE SOFTWARE.
 #include "CUDA2HIP.h"
 
 // Map of all functions
-const std::map<llvm::StringRef, hipCounter> CUDA_FFT_TYPE_NAME_MAP = []() {
+const std::map<llvm::StringRef, hipCounter> CUDA_FFT_TYPE_NAME_MAP = [] {
   std::map<llvm::StringRef, hipCounter> m;
 
   // cuFFT defines
@@ -154,8 +154,9 @@ const std::map<llvm::StringRef, hipCounter> CUDA_FFT_TYPE_NAME_MAP = []() {
   return m;
 }();
 
-const std::map<llvm::StringRef, cudaAPIversions> CUDA_FFT_TYPE_NAME_VER_MAP = []() {
+const std::map<llvm::StringRef, cudaAPIversions> CUDA_FFT_TYPE_NAME_VER_MAP = [] {
   std::map<llvm::StringRef, cudaAPIversions> m;
+
   m["CUFFT_NOT_SUPPORTED"]                              = {CUDA_80,  CUDA_0,   CUDA_0  };
   m["cufftXtWorkAreaPolicy_t"]                          = {CUDA_92,  CUDA_0,   CUDA_0  };
   m["cufftXtWorkAreaPolicy"]                            = {CUDA_92,  CUDA_0,   CUDA_0  };
@@ -180,7 +181,7 @@ const std::map<llvm::StringRef, cudaAPIversions> CUDA_FFT_TYPE_NAME_VER_MAP = []
   return m;
 }();
 
-const std::map<llvm::StringRef, hipAPIversions> HIP_FFT_TYPE_NAME_VER_MAP = []() {
+const std::map<llvm::StringRef, hipAPIversions> HIP_FFT_TYPE_NAME_VER_MAP = [] {
   std::map<llvm::StringRef, hipAPIversions> m;
 
   m["HIPFFT_FORWARD"]                                   = {HIP_1070, HIP_0,    HIP_0   };

--- a/src/CUDA2HIP_FILE_API_functions.cpp
+++ b/src/CUDA2HIP_FILE_API_functions.cpp
@@ -22,7 +22,7 @@ THE SOFTWARE.
 
 #include "CUDA2HIP.h"
 
-const std::map<llvm::StringRef, hipCounter> CUDA_FILE_FUNCTION_MAP = []() {
+const std::map<llvm::StringRef, hipCounter> CUDA_FILE_FUNCTION_MAP = [] {
   std::map<llvm::StringRef, hipCounter> m;
 
   m["cufileop_status_error"]                                = {"hipFileOpStatusError",                         "", CONV_LIB_FUNC, API_FILE, 2};
@@ -75,7 +75,7 @@ const std::map<llvm::StringRef, hipCounter> CUDA_FILE_FUNCTION_MAP = []() {
   return m;
 }();
 
-const std::map<llvm::StringRef, cudaAPIversions> CUDA_FILE_FUNCTION_VER_MAP = []() {
+const std::map<llvm::StringRef, cudaAPIversions> CUDA_FILE_FUNCTION_VER_MAP = [] {
   std::map<llvm::StringRef, cudaAPIversions> m;
 
   m["cufileop_status_error"]                                = {CUFILE_1000, CUDA_0, CUDA_0};
@@ -128,7 +128,7 @@ const std::map<llvm::StringRef, cudaAPIversions> CUDA_FILE_FUNCTION_VER_MAP = []
   return m;
 }();
 
-const std::map<llvm::StringRef, hipAPIversions> HIP_FILE_FUNCTION_VER_MAP = []() {
+const std::map<llvm::StringRef, hipAPIversions> HIP_FILE_FUNCTION_VER_MAP = [] {
   std::map<llvm::StringRef, hipAPIversions> m;
 
   m["hipFileOpStatusError"]                                 = {HIP_7020, HIP_0, HIP_0};
@@ -165,7 +165,7 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_FILE_FUNCTION_VER_MAP = []()
   return m;
 }();
 
-const std::map<unsigned int, llvm::StringRef> CUDA_FILE_API_SECTION_MAP = []() {
+const std::map<unsigned int, llvm::StringRef> CUDA_FILE_API_SECTION_MAP = [] {
   std::map<unsigned int, llvm::StringRef> m;
 
   m[1]                                                      = "cuFile Types";

--- a/src/CUDA2HIP_FILE_API_types.cpp
+++ b/src/CUDA2HIP_FILE_API_types.cpp
@@ -22,7 +22,7 @@ THE SOFTWARE.
 
 #include "CUDA2HIP.h"
 
-const std::map<llvm::StringRef, hipCounter> CUDA_FILE_TYPE_NAME_MAP = []() {
+const std::map<llvm::StringRef, hipCounter> CUDA_FILE_TYPE_NAME_MAP = [] {
   std::map<llvm::StringRef, hipCounter> m;
 
   m["CUfileOpError"]                                         = {"hipFileOpError_t",                               "", CONV_TYPE, API_FILE, 1};
@@ -194,7 +194,7 @@ const std::map<llvm::StringRef, hipCounter> CUDA_FILE_TYPE_NAME_MAP = []() {
   return m;
 }();
 
-const std::map<llvm::StringRef, cudaAPIversions> CUDA_FILE_TYPE_NAME_VER_MAP = []() {
+const std::map<llvm::StringRef, cudaAPIversions> CUDA_FILE_TYPE_NAME_VER_MAP = [] {
   std::map<llvm::StringRef, cudaAPIversions> m;
 
   m["CUfileOpError"]                                         = {CUFILE_1000, CUDA_0, CUDA_0};
@@ -366,7 +366,7 @@ const std::map<llvm::StringRef, cudaAPIversions> CUDA_FILE_TYPE_NAME_VER_MAP = [
   return m;
 }();
 
-const std::map<llvm::StringRef, hipAPIversions> HIP_FILE_TYPE_NAME_VER_MAP = []() {
+const std::map<llvm::StringRef, hipAPIversions> HIP_FILE_TYPE_NAME_VER_MAP = [] {
   std::map<llvm::StringRef, hipAPIversions> m;
 
   m["hipFileOpError_t"]                                      = {HIP_7020, HIP_0, HIP_0};

--- a/src/CUDA2HIP_RAND_API_functions.cpp
+++ b/src/CUDA2HIP_RAND_API_functions.cpp
@@ -23,7 +23,7 @@ THE SOFTWARE.
 #include "CUDA2HIP.h"
 
 // Map of all functions
-const std::map<llvm::StringRef, hipCounter> CUDA_RAND_FUNCTION_MAP = []() {
+const std::map<llvm::StringRef, hipCounter> CUDA_RAND_FUNCTION_MAP = [] {
   std::map<llvm::StringRef, hipCounter> m;
 
   // RAND Host functions
@@ -90,7 +90,7 @@ const std::map<llvm::StringRef, hipCounter> CUDA_RAND_FUNCTION_MAP = []() {
   return m;
 }();
 
-const std::map<llvm::StringRef, cudaAPIversions> CUDA_RAND_FUNCTION_VER_MAP = []() {
+const std::map<llvm::StringRef, cudaAPIversions> CUDA_RAND_FUNCTION_VER_MAP = [] {
   std::map<llvm::StringRef, cudaAPIversions> m;
 
   m["curandGetProperty"]                             = {CUDA_80,  CUDA_0,   CUDA_0   };
@@ -101,7 +101,7 @@ const std::map<llvm::StringRef, cudaAPIversions> CUDA_RAND_FUNCTION_VER_MAP = []
   return m;
 }();
 
-const std::map<llvm::StringRef, hipAPIversions> HIP_RAND_FUNCTION_VER_MAP = []() {
+const std::map<llvm::StringRef, hipAPIversions> HIP_RAND_FUNCTION_VER_MAP = [] {
   std::map<llvm::StringRef, hipAPIversions> m;
 
   m["hiprandCreateGenerator"]                        = {HIP_1050, HIP_0,    HIP_0    };
@@ -209,7 +209,7 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_RAND_FUNCTION_VER_MAP = []()
   return m;
 }();
 
-const std::map<unsigned int, llvm::StringRef> CUDA_RAND_API_SECTION_MAP = []() {
+const std::map<unsigned int, llvm::StringRef> CUDA_RAND_API_SECTION_MAP = [] {
   std::map<unsigned int, llvm::StringRef> m;
 
   m[1]                                               = "CURAND Data types";

--- a/src/CUDA2HIP_RAND_API_types.cpp
+++ b/src/CUDA2HIP_RAND_API_types.cpp
@@ -23,7 +23,7 @@ THE SOFTWARE.
 #include "CUDA2HIP.h"
 
 // Map of all functions
-const std::map<llvm::StringRef, hipCounter> CUDA_RAND_TYPE_NAME_MAP = []() {
+const std::map<llvm::StringRef, hipCounter> CUDA_RAND_TYPE_NAME_MAP = [] {
   std::map<llvm::StringRef, hipCounter> m;
 
   // RAND Host types
@@ -142,7 +142,7 @@ const std::map<llvm::StringRef, hipCounter> CUDA_RAND_TYPE_NAME_MAP = []() {
   return m;
 }();
 
-const std::map<llvm::StringRef, cudaAPIversions> CUDA_RAND_TYPE_NAME_VER_MAP = []() {
+const std::map<llvm::StringRef, cudaAPIversions> CUDA_RAND_TYPE_NAME_VER_MAP = [] {
   std::map<llvm::StringRef, cudaAPIversions> m;
 
   m["CURAND_ORDERING_PSEUDO_LEGACY"]                   = {CUDA_110, CUDA_0,   CUDA_0  };
@@ -151,7 +151,7 @@ const std::map<llvm::StringRef, cudaAPIversions> CUDA_RAND_TYPE_NAME_VER_MAP = [
   return m;
 }();
 
-const std::map<llvm::StringRef, hipAPIversions> HIP_RAND_TYPE_NAME_VER_MAP = []() {
+const std::map<llvm::StringRef, hipAPIversions> HIP_RAND_TYPE_NAME_VER_MAP = [] {
   std::map<llvm::StringRef, hipAPIversions> m;
 
   m["hiprandStatus"]                                   = {HIP_1050, HIP_0,    HIP_0   };

--- a/src/CUDA2HIP_RTC_API_functions.cpp
+++ b/src/CUDA2HIP_RTC_API_functions.cpp
@@ -23,7 +23,7 @@ THE SOFTWARE.
 #include "CUDA2HIP.h"
 
 // Maps the names of CUDA RTC API functions to the corresponding HIP functions
-const std::map<llvm::StringRef, hipCounter> CUDA_RTC_FUNCTION_MAP = []() {
+const std::map<llvm::StringRef, hipCounter> CUDA_RTC_FUNCTION_MAP = [] {
   std::map<llvm::StringRef, hipCounter> m;
 
   m["nvrtcGetErrorString"]                        = {"hiprtcGetErrorString",                         "", CONV_LIB_FUNC, API_RTC, 2};
@@ -56,7 +56,7 @@ const std::map<llvm::StringRef, hipCounter> CUDA_RTC_FUNCTION_MAP = []() {
   return m;
 }();
 
-const std::map<llvm::StringRef, cudaAPIversions> CUDA_RTC_FUNCTION_VER_MAP = []() {
+const std::map<llvm::StringRef, cudaAPIversions> CUDA_RTC_FUNCTION_VER_MAP = [] {
   std::map<llvm::StringRef, cudaAPIversions> m;
 
   m["nvrtcGetNumSupportedArchs"]                  = {CUDA_112, CUDA_0,   CUDA_0  };
@@ -80,7 +80,7 @@ const std::map<llvm::StringRef, cudaAPIversions> CUDA_RTC_FUNCTION_VER_MAP = [](
   return m;
 }();
 
-const std::map<llvm::StringRef, hipAPIversions> HIP_RTC_FUNCTION_VER_MAP = []() {
+const std::map<llvm::StringRef, hipAPIversions> HIP_RTC_FUNCTION_VER_MAP = [] {
   std::map<llvm::StringRef, hipAPIversions> m;
 
   m["hiprtcGetErrorString"]                       = {HIP_2060, HIP_0,    HIP_0   };
@@ -100,7 +100,7 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_RTC_FUNCTION_VER_MAP = []() 
   return m;
 }();
 
-const std::map<llvm::StringRef, cudaAPIChangedVersions> CUDA_RTC_FUNCTION_CHANGED_VER_MAP = []() {
+const std::map<llvm::StringRef, cudaAPIChangedVersions> CUDA_RTC_FUNCTION_CHANGED_VER_MAP = [] {
   std::map<llvm::StringRef, cudaAPIChangedVersions> m;
 
   m["nvrtcCreateProgram"]                         = {CUDA_80};
@@ -109,7 +109,7 @@ const std::map<llvm::StringRef, cudaAPIChangedVersions> CUDA_RTC_FUNCTION_CHANGE
   return m;
 }();
 
-const std::map<llvm::StringRef, hipAPIChangedVersions> HIP_RTC_FUNCTION_CHANGED_VER_MAP = []() {
+const std::map<llvm::StringRef, hipAPIChangedVersions> HIP_RTC_FUNCTION_CHANGED_VER_MAP = [] {
   std::map<llvm::StringRef, hipAPIChangedVersions> m;
 
   m["hiprtcCreateProgram"]                        = {HIP_7000};
@@ -118,7 +118,7 @@ const std::map<llvm::StringRef, hipAPIChangedVersions> HIP_RTC_FUNCTION_CHANGED_
   return m;
 }();
 
-const std::map<unsigned int, llvm::StringRef> CUDA_RTC_API_SECTION_MAP = []() {
+const std::map<unsigned int, llvm::StringRef> CUDA_RTC_API_SECTION_MAP = [] {
   std::map<unsigned int, llvm::StringRef> m;
 
   m[1]                                            = "RTC Data types";

--- a/src/CUDA2HIP_RTC_API_types.cpp
+++ b/src/CUDA2HIP_RTC_API_types.cpp
@@ -23,7 +23,7 @@ THE SOFTWARE.
 #include "CUDA2HIP.h"
 
 // Maps the names of CUDA RTC API types to the corresponding HIP types
-const std::map<llvm::StringRef, hipCounter> CUDA_RTC_TYPE_NAME_MAP = []() {
+const std::map<llvm::StringRef, hipCounter> CUDA_RTC_TYPE_NAME_MAP = [] {
   std::map<llvm::StringRef, hipCounter> m;
 
   m["nvrtcResult"]                                               = {"hiprtcResult",                                        "", CONV_TYPE, API_RTC, 1};
@@ -52,7 +52,7 @@ const std::map<llvm::StringRef, hipCounter> CUDA_RTC_TYPE_NAME_MAP = []() {
   return m;
 }();
 
-const std::map<llvm::StringRef, cudaAPIversions> CUDA_RTC_TYPE_NAME_VER_MAP = []() {
+const std::map<llvm::StringRef, cudaAPIversions> CUDA_RTC_TYPE_NAME_VER_MAP = [] {
   std::map<llvm::StringRef, cudaAPIversions> m;
 
   m["NVRTC_ERROR_NO_NAME_EXPRESSIONS_AFTER_COMPILATION"]         = {CUDA_80,  CUDA_0,   CUDA_0  };
@@ -69,7 +69,7 @@ const std::map<llvm::StringRef, cudaAPIversions> CUDA_RTC_TYPE_NAME_VER_MAP = []
   return m;
 }();
 
-const std::map<llvm::StringRef, hipAPIversions> HIP_RTC_TYPE_NAME_VER_MAP = []() {
+const std::map<llvm::StringRef, hipAPIversions> HIP_RTC_TYPE_NAME_VER_MAP = [] {
   std::map<llvm::StringRef, hipAPIversions> m;
 
   m["hiprtcResult"]                                              = {HIP_2060, HIP_0,    HIP_0   };

--- a/src/CUDA2HIP_Runtime_API_functions.cpp
+++ b/src/CUDA2HIP_Runtime_API_functions.cpp
@@ -25,7 +25,7 @@ THE SOFTWARE.
 using SEC = runtime::CUDA_RUNTIME_API_SECTIONS;
 
 // Map of all CUDA Runtime API functions
-const std::map<llvm::StringRef, hipCounter> CUDA_RUNTIME_FUNCTION_MAP = []() {
+const std::map<llvm::StringRef, hipCounter> CUDA_RUNTIME_FUNCTION_MAP = [] {
   std::map<llvm::StringRef,  hipCounter> m;
 
   // 1. Device Management
@@ -997,7 +997,7 @@ const std::map<llvm::StringRef, hipCounter> CUDA_RUNTIME_FUNCTION_MAP = []() {
   return m;
 }();
 
-const std::map<llvm::StringRef, cudaAPIversions> CUDA_RUNTIME_FUNCTION_VER_MAP = []() {
+const std::map<llvm::StringRef, cudaAPIversions> CUDA_RUNTIME_FUNCTION_VER_MAP = [] {
   std::map<llvm::StringRef,  cudaAPIversions> m;
 
   m["cudaDeviceGetNvSciSyncAttributes"]                        = {CUDA_102, CUDA_0,   CUDA_0  };
@@ -1269,7 +1269,7 @@ const std::map<llvm::StringRef, cudaAPIversions> CUDA_RUNTIME_FUNCTION_VER_MAP =
   return m;
 }();
 
-const std::map<llvm::StringRef, hipAPIversions> HIP_RUNTIME_FUNCTION_VER_MAP = []() {
+const std::map<llvm::StringRef, hipAPIversions> HIP_RUNTIME_FUNCTION_VER_MAP = [] {
   std::map<llvm::StringRef,  hipAPIversions> m;
 
   m["hipHostAlloc"]                                            = {HIP_1060, HIP_0,    HIP_0   };
@@ -1552,7 +1552,7 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_RUNTIME_FUNCTION_VER_MAP = [
   return m;
 }();
 
-const std::map<llvm::StringRef, cudaAPIChangedVersions> CUDA_RUNTIME_FUNCTION_CHANGED_VER_MAP = []() {
+const std::map<llvm::StringRef, cudaAPIChangedVersions> CUDA_RUNTIME_FUNCTION_CHANGED_VER_MAP = [] {
   std::map<llvm::StringRef,  cudaAPIChangedVersions> m;
 
   m["cudaGetDriverEntryPoint"]                                 = {CUDA_120};
@@ -1574,7 +1574,7 @@ const std::map<llvm::StringRef, cudaAPIChangedVersions> CUDA_RUNTIME_FUNCTION_CH
   return m;
 }();
 
-const std::map<llvm::StringRef, hipAPIChangedVersions> HIP_RUNTIME_FUNCTION_CHANGED_VER_MAP = []() {
+const std::map<llvm::StringRef, hipAPIChangedVersions> HIP_RUNTIME_FUNCTION_CHANGED_VER_MAP = [] {
   std::map<llvm::StringRef,  hipAPIChangedVersions> m;
 
   m["hipDeviceGetTexture1DLinearMaxWidth"]                     = {HIP_7000};
@@ -1582,7 +1582,7 @@ const std::map<llvm::StringRef, hipAPIChangedVersions> HIP_RUNTIME_FUNCTION_CHAN
   return m;
 }();
 
-const std::map<llvm::StringRef, cudaAPIUnsupportedVersions> CUDA_RUNTIME_FUNCTION_UNSUPPORTED_VER_MAP = []() {
+const std::map<llvm::StringRef, cudaAPIUnsupportedVersions> CUDA_RUNTIME_FUNCTION_UNSUPPORTED_VER_MAP = [] {
   std::map<llvm::StringRef,  cudaAPIUnsupportedVersions> m;
 
   m["cudaStreamGetCaptureInfo"]                                = {CUDA_130};
@@ -1602,7 +1602,7 @@ const std::map<llvm::StringRef, cudaAPIUnsupportedVersions> CUDA_RUNTIME_FUNCTIO
   return m;
 }();
 
-const std::map<unsigned int, llvm::StringRef> CUDA_RUNTIME_API_SECTION_MAP = []() {
+const std::map<unsigned int, llvm::StringRef> CUDA_RUNTIME_API_SECTION_MAP = [] {
   std::map<unsigned int,  llvm::StringRef> m;
 
   m[SEC::DEVICE]                                               = "Device Management";

--- a/src/CUDA2HIP_Runtime_API_types.cpp
+++ b/src/CUDA2HIP_Runtime_API_types.cpp
@@ -25,7 +25,7 @@ THE SOFTWARE.
 using SEC = runtime::CUDA_RUNTIME_API_SECTIONS;
 
 // Maps the names of CUDA RUNTIME API types to the corresponding HIP types
-const std::map<llvm::StringRef, hipCounter> CUDA_RUNTIME_TYPE_NAME_MAP = []() {
+const std::map<llvm::StringRef, hipCounter> CUDA_RUNTIME_TYPE_NAME_MAP = [] {
 
   std::map<llvm::StringRef, hipCounter> m;
 
@@ -2606,7 +2606,7 @@ const std::map<llvm::StringRef, hipCounter> CUDA_RUNTIME_TYPE_NAME_MAP = []() {
   return m;
 }();
 
-const std::map<llvm::StringRef, cudaAPIversions> CUDA_RUNTIME_TYPE_NAME_VER_MAP = []() {
+const std::map<llvm::StringRef, cudaAPIversions> CUDA_RUNTIME_TYPE_NAME_VER_MAP = [] {
   std::map<llvm::StringRef, cudaAPIversions> m;
 
   m["cudaEglFrame"]                                             = {CUDA_91,  CUDA_0,   CUDA_0  };
@@ -3351,7 +3351,7 @@ const std::map<llvm::StringRef, cudaAPIversions> CUDA_RUNTIME_TYPE_NAME_VER_MAP 
   return m;
 }();
 
-const std::map<llvm::StringRef, cudaAPIChangedVersions> CUDA_RUNTIME_TYPE_CHANGED_VER_MAP = []() {
+const std::map<llvm::StringRef, cudaAPIChangedVersions> CUDA_RUNTIME_TYPE_CHANGED_VER_MAP = [] {
   std::map<llvm::StringRef, cudaAPIChangedVersions> m;
 
   m["cudaExternalSemaphoreSignalParams"]                        = {CUDA_130};
@@ -3361,7 +3361,7 @@ const std::map<llvm::StringRef, cudaAPIChangedVersions> CUDA_RUNTIME_TYPE_CHANGE
   return m;
 }();
 
-const std::map<llvm::StringRef, hipAPIChangedVersions> HIP_RUNTIME_TYPE_CHANGED_VER_MAP = []() {
+const std::map<llvm::StringRef, hipAPIChangedVersions> HIP_RUNTIME_TYPE_CHANGED_VER_MAP = [] {
   std::map<llvm::StringRef, hipAPIChangedVersions> m;
 
   m["hipLaunchAttributeValue"]                                  = {HIP_7010};
@@ -3369,7 +3369,7 @@ const std::map<llvm::StringRef, hipAPIChangedVersions> HIP_RUNTIME_TYPE_CHANGED_
   return m;
 }();
 
-const std::map<llvm::StringRef, hipAPIversions> HIP_RUNTIME_TYPE_NAME_VER_MAP = []() {
+const std::map<llvm::StringRef, hipAPIversions> HIP_RUNTIME_TYPE_NAME_VER_MAP = [] {
   std::map<llvm::StringRef, hipAPIversions> m;
 
   m["hipHostRegisterDefault"]                                   = {HIP_1060, HIP_0,    HIP_0   };

--- a/src/CUDA2HIP_SPARSE_API_functions.cpp
+++ b/src/CUDA2HIP_SPARSE_API_functions.cpp
@@ -2475,11 +2475,13 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_SPARSE_FUNCTION_VER_MAP = []
   m["rocsparse_spvv"]                                                 = {HIP_4010, HIP_0,    HIP_0   };
   m["rocsparse_spsv"]                                                 = {HIP_4050, HIP_0,    HIP_0   };
   m["rocsparse_csc_get"]                                              = {HIP_6010, HIP_0,    HIP_0   };
+
   return m;
 }();
 
 const std::map<llvm::StringRef, cudaAPIChangedVersions> CUDA_SPARSE_FUNCTION_CHANGED_VER_MAP = [] {
   std::map<llvm::StringRef, cudaAPIChangedVersions> m;
+
   m["cusparseSpVecGetIndexBase"]                                      = {CUDA_120};
   m["cusparseDestroySpVec"]                                           = {CUDA_120};
   m["cusparseDestroyDnVec"]                                           = {CUDA_120};


### PR DESCRIPTION
+ Removed redundant `()` from the lambda initializations
+ [Reason]
  - Omitting the redundant parentheses reduces visual noise and makes it much clearer that this is an Immediately Invoked Function Expression (`IIFE`), allowing the trailing `()` execution call at the end of the block to stand out
+ Formatting
