### PR TITLE
[HIPIFY][#837][#2062][RFC][feature] Implement `e_insert_new_argument` for APIs need variable declarations - Part 1

### DIFF
--- a/src/CUDA2HIP_Scripting.h
+++ b/src/CUDA2HIP_Scripting.h
@@ -41,6 +41,7 @@ namespace hipify {
     e_add_var_argument,
     e_move_argument,
     e_replace_argument_with_const,
+    e_insert_new_argument,
   };
 
   enum OverloadTypes {
@@ -50,6 +51,7 @@ namespace hipify {
   enum CastWarning {
     cw_None,
     cw_DataLoss,
+    cw_NeedsNewArgDecl,
   };
 
   enum OverloadWarning {
@@ -62,6 +64,8 @@ namespace hipify {
     std::string constValToAddOrReplace = "";
     unsigned moveOrCopyTo = 0;
     unsigned numberToMoveOrCopy = 1;
+    std::string newArgTypeName = "";
+    bool isPointerArg = false;
   };
 
   typedef std::map<unsigned, CastInfo> ArgCastMap;

--- a/src/CUDA2HIP_Scripting.h
+++ b/src/CUDA2HIP_Scripting.h
@@ -61,11 +61,14 @@ namespace hipify {
   struct CastInfo {
     CastTypes castType = e_HIP_SYMBOL;
     CastWarning castWarn = cw_None;
+    // For e_add_const_argument / e_replace_argument_with_const: the literal value to insert or replace.
+    // For e_insert_new_argument: the variable name to declare and pass as an argument.
     std::string constValToAddOrReplace = "";
     unsigned moveOrCopyTo = 0;
     unsigned numberToMoveOrCopy = 1;
     std::string newArgTypeName = "";
     bool isPointerArg = false;
+    std::string defaultInitValue = "";
   };
 
   typedef std::map<unsigned, CastInfo> ArgCastMap;

--- a/src/HipifyAction.cpp
+++ b/src/HipifyAction.cpp
@@ -599,7 +599,7 @@ std::map<std::string, std::vector<ArgCastStruct>> FuncArgCasts {
       {
         {
           {0, {e_remove_argument, cw_None}},
-          {7, {e_insert_new_argument, cw_NeedsNewArgDecl, "biasMode", 7, 1, "miopenRNNBiasMode_t", true}}
+          {8, {e_insert_new_argument, cw_NeedsNewArgDecl, "biasMode", 0, 1, "miopenRNNBiasMode_t", true}}
         },
         true,
         true
@@ -611,7 +611,7 @@ std::map<std::string, std::vector<ArgCastStruct>> FuncArgCasts {
       {
         {
           {0, {e_remove_argument, cw_None}},
-          {7, {e_insert_new_argument, cw_NeedsNewArgDecl, "biasMode", 7, 1, "miopenRNNBiasMode_t", false}}
+          {8, {e_insert_new_argument, cw_NeedsNewArgDecl, "biasMode", 0, 1, "miopenRNNBiasMode_t", false}}
         },
         true,
         true
@@ -2733,43 +2733,47 @@ bool HipifyAction::cudaHostFuncCall(const mat::MatchFinder::MatchResult &Result)
       std::string combinedArgText;
       bool hasInsertions = false;
       std::vector<hipify::CastInfo> insertionWarnings;
+      clang::SourceLocation callBeginLoc = call->getBeginLoc();
+      unsigned callCol = SM.getSpellingColumnNumber(callBeginLoc);
+      clang::SourceLocation stmtInsertLoc = callBeginLoc.getLocWithOffset(-static_cast<int>(callCol - 1));
       std::string indent;
-      {
-        clang::SourceLocation loc = call->getBeginLoc();
-        unsigned col = SM.getSpellingColumnNumber(loc);
-        clang::SourceLocation lineStart = loc.getLocWithOffset(-static_cast<int>(col - 1));
-        const char *p = SM.getCharacterData(lineStart);
-        while (*p == ' ' || *p == '\t')
-          indent += *p++;
-      }
+      const char *indentPtr = SM.getCharacterData(stmtInsertLoc);
+      while (*indentPtr == ' ' || *indentPtr == '\t')
+        indent += *indentPtr++;
       for (auto c : cc.castMap) {
         if (c.second.castType == e_insert_new_argument) {
           hasInsertions = true;
-          combinedDeclText += indent + c.second.newArgTypeName + " " + c.second.constValToAddOrReplace + ";\n";
+          std::string initExpr = c.second.defaultInitValue.empty() ? "{}" : c.second.defaultInitValue;
+          combinedDeclText += indent + c.second.newArgTypeName + " " + c.second.constValToAddOrReplace + " = " + initExpr + ";\n";
           std::string argText;
           if (c.second.isPointerArg)
             argText = "&" + c.second.constValToAddOrReplace;
           else
             argText = c.second.constValToAddOrReplace;
-          if (!combinedArgText.empty())
-            combinedArgText += ", ";
-          combinedArgText += argText;
+          if (c.first < call->getNumArgs()) {
+            clang::SourceLocation argLoc = call->getArg(c.first)->getBeginLoc();
+            ct::Replacement middleRep(SM, argLoc, 0, argText + ", ");
+            clang::FullSourceLoc middleFullSL(argLoc, SM);
+            insertReplacement(middleRep, middleFullSL);
+          } else {
+            if (!combinedArgText.empty())
+              combinedArgText += ", ";
+            combinedArgText += argText;
+          }
           insertionWarnings.push_back(c.second);
         }
       }
       if (hasInsertions) {
-        clang::SourceLocation callBeginLoc = call->getBeginLoc();
-        unsigned col = SM.getSpellingColumnNumber(callBeginLoc);
-        clang::SourceLocation stmtInsertLoc = callBeginLoc.getLocWithOffset(-static_cast<int>(col - 1));
         ct::Replacement declRep(SM, stmtInsertLoc, 0, combinedDeclText);
         clang::FullSourceLoc declFullSL(stmtInsertLoc, SM);
         insertReplacement(declRep, declFullSL);
-
-        clang::SourceLocation insertLoc = call->getEndLoc();
-        std::string fullArgText = ", " + combinedArgText;
-        ct::Replacement argRep(SM, insertLoc, 0, fullArgText);
-        clang::FullSourceLoc argFullSL(insertLoc, SM);
-        insertReplacement(argRep, argFullSL);
+        if (!combinedArgText.empty()) {
+          clang::SourceLocation insertLoc = call->getEndLoc();
+          std::string fullArgText = ", " + combinedArgText;
+          ct::Replacement argRep(SM, insertLoc, 0, fullArgText);
+          clang::FullSourceLoc argFullSL(insertLoc, SM);
+          insertReplacement(argRep, argFullSL);
+        }
 
         for (auto &info : insertionWarnings) {
           clang::DiagnosticsEngine &DE = getCompilerInstance().getDiagnostics();

--- a/src/HipifyAction.cpp
+++ b/src/HipifyAction.cpp
@@ -91,6 +91,7 @@ const std::string sCudnnGetPoolingNdDescriptor = "cudnnGetPoolingNdDescriptor";
 const std::string sCudnnSetLRNDescriptor = "cudnnSetLRNDescriptor";
 const std::string sCudnnGetRNNDescriptor_v6 = "cudnnGetRNNDescriptor_v6";
 const std::string sCudnnSetRNNDescriptor_v6 = "cudnnSetRNNDescriptor_v6";
+const std::string sCudnnSetDropoutDescriptor = "cudnnSetDropoutDescriptor";
 const std::string sCudnnSoftmaxForward = "cudnnSoftmaxForward";
 const std::string sCudnnSoftmaxBackward = "cudnnSoftmaxBackward";
 const std::string sCudnnConvolutionForward = "cudnnConvolutionForward";
@@ -263,6 +264,7 @@ std::string getCastType(hipify::CastTypes c) {
     case e_add_var_argument: return "";
     case e_move_argument: return "";
     case e_replace_argument_with_const: return "";
+    case e_insert_new_argument: return "";
     default: return "";
   }
 }
@@ -596,7 +598,8 @@ std::map<std::string, std::vector<ArgCastStruct>> FuncArgCasts {
     {
       {
         {
-          {0, {e_remove_argument, cw_None}}
+          {0, {e_remove_argument, cw_None}},
+          {7, {e_insert_new_argument, cw_NeedsNewArgDecl, "biasMode", 7, 1, "miopenRNNBiasMode_t", true}}
         },
         true,
         true
@@ -607,7 +610,21 @@ std::map<std::string, std::vector<ArgCastStruct>> FuncArgCasts {
     {
       {
         {
-          {0, {e_remove_argument, cw_None}}
+          {0, {e_remove_argument, cw_None}},
+          {7, {e_insert_new_argument, cw_NeedsNewArgDecl, "biasMode", 7, 1, "miopenRNNBiasMode_t", false}}
+        },
+        true,
+        true
+      }
+    }
+  },
+  {sCudnnSetDropoutDescriptor,
+    {
+      {
+        {
+          {6, {e_insert_new_argument, cw_NeedsNewArgDecl, "use_mask", 6, 1, "bool", false}},
+          {7, {e_insert_new_argument, cw_NeedsNewArgDecl, "state_evo", 7, 1, "bool", false}},
+          {8, {e_insert_new_argument, cw_NeedsNewArgDecl, "rng_mode", 8, 1, "miopenRNGType_t", false}}
         },
         true,
         true
@@ -2712,7 +2729,61 @@ bool HipifyAction::cudaHostFuncCall(const mat::MatchFinder::MatchResult &Result)
       if (TranslateToRoc == true && cc.isToRoc == false) continue;
       if (TranslateToRoc == false && cc.isToRoc == true && TranslateToMIOpen == false) continue;
       clang::LangOptions DefaultLangOptions;
+      std::string combinedDeclText;
+      std::string combinedArgText;
+      bool hasInsertions = false;
+      std::vector<hipify::CastInfo> insertionWarnings;
+      std::string indent;
+      {
+        clang::SourceLocation loc = call->getBeginLoc();
+        unsigned col = SM.getSpellingColumnNumber(loc);
+        clang::SourceLocation lineStart = loc.getLocWithOffset(-static_cast<int>(col - 1));
+        const char *p = SM.getCharacterData(lineStart);
+        while (*p == ' ' || *p == '\t')
+          indent += *p++;
+      }
       for (auto c : cc.castMap) {
+        if (c.second.castType == e_insert_new_argument) {
+          hasInsertions = true;
+          combinedDeclText += indent + c.second.newArgTypeName + " " + c.second.constValToAddOrReplace + ";\n";
+          std::string argText;
+          if (c.second.isPointerArg)
+            argText = "&" + c.second.constValToAddOrReplace;
+          else
+            argText = c.second.constValToAddOrReplace;
+          if (!combinedArgText.empty())
+            combinedArgText += ", ";
+          combinedArgText += argText;
+          insertionWarnings.push_back(c.second);
+        }
+      }
+      if (hasInsertions) {
+        clang::SourceLocation callBeginLoc = call->getBeginLoc();
+        unsigned col = SM.getSpellingColumnNumber(callBeginLoc);
+        clang::SourceLocation stmtInsertLoc = callBeginLoc.getLocWithOffset(-static_cast<int>(col - 1));
+        ct::Replacement declRep(SM, stmtInsertLoc, 0, combinedDeclText);
+        clang::FullSourceLoc declFullSL(stmtInsertLoc, SM);
+        insertReplacement(declRep, declFullSL);
+
+        clang::SourceLocation insertLoc = call->getEndLoc();
+        std::string fullArgText = ", " + combinedArgText;
+        ct::Replacement argRep(SM, insertLoc, 0, fullArgText);
+        clang::FullSourceLoc argFullSL(insertLoc, SM);
+        insertReplacement(argRep, argFullSL);
+
+        for (auto &info : insertionWarnings) {
+          clang::DiagnosticsEngine &DE = getCompilerInstance().getDiagnostics();
+          const auto ID = DE.getCustomDiagID(clang::DiagnosticsEngine::Warning,
+            "HIP API '%0' requires additional argument '%1' of type '%2'. "
+            "A variable declaration has been inserted before the call. "
+            "Please initialize it appropriately.");
+          clang::FullSourceLoc warnFullSL(call->getBeginLoc(), SM);
+          DE.Report(warnFullSL, ID) << sName << info.constValToAddOrReplace << info.newArgTypeName;
+        }
+      }
+      for (auto c : cc.castMap) {
+        if (c.second.castType == e_insert_new_argument)
+          continue;
         size_t length = 0;
         unsigned int argNum = c.first;
         clang::SmallString<40> XStr;
@@ -2991,6 +3062,7 @@ std::unique_ptr<clang::ASTConsumer> HipifyAction::CreateASTConsumer(clang::Compi
             sCudnnSetLRNDescriptor,
             sCudnnGetRNNDescriptor_v6,
             sCudnnSetRNNDescriptor_v6,
+            sCudnnSetDropoutDescriptor,
             sCudnnSoftmaxForward,
             sCudnnSoftmaxBackward,
             sCudnnConvolutionForward,

--- a/src/HipifyAction.cpp
+++ b/src/HipifyAction.cpp
@@ -599,7 +599,7 @@ std::map<std::string, std::vector<ArgCastStruct>> FuncArgCasts {
       {
         {
           {0, {e_remove_argument, cw_None}},
-          {8, {e_insert_new_argument, cw_NeedsNewArgDecl, "biasMode", 0, 1, "miopenRNNBiasMode_t", true}}
+          {8, {e_insert_new_argument, cw_NeedsNewArgDecl, "hipify_biasMode", 0, 1, "miopenRNNBiasMode_t", true}}
         },
         true,
         true
@@ -611,7 +611,7 @@ std::map<std::string, std::vector<ArgCastStruct>> FuncArgCasts {
       {
         {
           {0, {e_remove_argument, cw_None}},
-          {8, {e_insert_new_argument, cw_NeedsNewArgDecl, "biasMode", 0, 1, "miopenRNNBiasMode_t", false}}
+          {8, {e_insert_new_argument, cw_NeedsNewArgDecl, "hipify_biasMode", 0, 1, "miopenRNNBiasMode_t", false}}
         },
         true,
         true
@@ -622,9 +622,9 @@ std::map<std::string, std::vector<ArgCastStruct>> FuncArgCasts {
     {
       {
         {
-          {6, {e_insert_new_argument, cw_NeedsNewArgDecl, "use_mask", 6, 1, "bool", false}},
-          {7, {e_insert_new_argument, cw_NeedsNewArgDecl, "state_evo", 7, 1, "bool", false}},
-          {8, {e_insert_new_argument, cw_NeedsNewArgDecl, "rng_mode", 8, 1, "miopenRNGType_t", false}}
+          {6, {e_insert_new_argument, cw_NeedsNewArgDecl, "hipify_use_mask", 6, 1, "bool", false}},
+          {7, {e_insert_new_argument, cw_NeedsNewArgDecl, "hipify_state_evo", 7, 1, "bool", false}},
+          {8, {e_insert_new_argument, cw_NeedsNewArgDecl, "hipify_rng_mode", 8, 1, "miopenRNGType_t", false}}
         },
         true,
         true

--- a/tests/unit_tests/synthetic/libraries/cudnn2miopen.cu
+++ b/tests/unit_tests/synthetic/libraries/cudnn2miopen.cu
@@ -747,9 +747,9 @@ int main() {
 
   // CUDA: cudnnStatus_t CUDNNWINAPI cudnnSetDropoutDescriptor(cudnnDropoutDescriptor_t dropoutDesc, cudnnHandle_t handle, float dropout, void* states, size_t stateSizeInBytes, unsigned long long seed);
   // MIOPEN: MIOPEN_EXPORT miopenStatus_t miopenSetDropoutDescriptor(miopenDropoutDescriptor_t dropoutDesc, miopenHandle_t handle, float dropout, void* states, size_t stateSizeInBytes, unsigned long long seed, bool use_mask, bool state_evo, miopenRNGType_t rng_mode);
-  // CHECK: bool use_mask;
-  // CHECK-NEXT: bool state_evo;
-  // CHECK-NEXT: miopenRNGType_t rng_mode;
+  // CHECK: bool use_mask = {};
+  // CHECK-NEXT: bool state_evo = {};
+  // CHECK-NEXT: miopenRNGType_t rng_mode = {};
   // CHECK-NEXT: status = miopenSetDropoutDescriptor(DropoutDescriptor, handle, dropout, states, reserveSpaceNumBytes, seed, use_mask, state_evo, rng_mode);
   status = cudnnSetDropoutDescriptor(DropoutDescriptor, handle, dropout, states, reserveSpaceNumBytes, seed);
 

--- a/tests/unit_tests/synthetic/libraries/cudnn2miopen.cu
+++ b/tests/unit_tests/synthetic/libraries/cudnn2miopen.cu
@@ -745,10 +745,12 @@ int main() {
   // CHECK: status = miopenGetDropoutDescriptor(DropoutDescriptor, handle, &dropout, &states, &seed);
   status = cudnnGetDropoutDescriptor(DropoutDescriptor, handle, &dropout, &states, &seed);
 
-  // TODO [#837]: Insert bool use_mask, bool state_evo, miopenRNGType_t rng_mode in the hipified miopenGetDropoutDescriptor: will need variable declaration
   // CUDA: cudnnStatus_t CUDNNWINAPI cudnnSetDropoutDescriptor(cudnnDropoutDescriptor_t dropoutDesc, cudnnHandle_t handle, float dropout, void* states, size_t stateSizeInBytes, unsigned long long seed);
   // MIOPEN: MIOPEN_EXPORT miopenStatus_t miopenSetDropoutDescriptor(miopenDropoutDescriptor_t dropoutDesc, miopenHandle_t handle, float dropout, void* states, size_t stateSizeInBytes, unsigned long long seed, bool use_mask, bool state_evo, miopenRNGType_t rng_mode);
-  // CHECK: status = miopenSetDropoutDescriptor(DropoutDescriptor, handle, dropout, states, reserveSpaceNumBytes, seed);
+  // CHECK: bool use_mask;
+  // CHECK-NEXT: bool state_evo;
+  // CHECK-NEXT: miopenRNGType_t rng_mode;
+  // CHECK-NEXT: status = miopenSetDropoutDescriptor(DropoutDescriptor, handle, dropout, states, reserveSpaceNumBytes, seed, use_mask, state_evo, rng_mode);
   status = cudnnSetDropoutDescriptor(DropoutDescriptor, handle, dropout, states, reserveSpaceNumBytes, seed);
 
   // TODO [#837]: Insert bool use_mask, bool state_evo, miopenRNGType_t rng_mode in the hipified miopenRestoreDropoutDescriptor: will need variable declaration

--- a/tests/unit_tests/synthetic/libraries/cudnn2miopen.cu
+++ b/tests/unit_tests/synthetic/libraries/cudnn2miopen.cu
@@ -747,10 +747,10 @@ int main() {
 
   // CUDA: cudnnStatus_t CUDNNWINAPI cudnnSetDropoutDescriptor(cudnnDropoutDescriptor_t dropoutDesc, cudnnHandle_t handle, float dropout, void* states, size_t stateSizeInBytes, unsigned long long seed);
   // MIOPEN: MIOPEN_EXPORT miopenStatus_t miopenSetDropoutDescriptor(miopenDropoutDescriptor_t dropoutDesc, miopenHandle_t handle, float dropout, void* states, size_t stateSizeInBytes, unsigned long long seed, bool use_mask, bool state_evo, miopenRNGType_t rng_mode);
-  // CHECK: bool use_mask = {};
-  // CHECK-NEXT: bool state_evo = {};
-  // CHECK-NEXT: miopenRNGType_t rng_mode = {};
-  // CHECK-NEXT: status = miopenSetDropoutDescriptor(DropoutDescriptor, handle, dropout, states, reserveSpaceNumBytes, seed, use_mask, state_evo, rng_mode);
+  // CHECK: bool hipify_use_mask = {};
+  // CHECK-NEXT: bool hipify_state_evo = {};
+  // CHECK-NEXT: miopenRNGType_t hipify_rng_mode = {};
+  // CHECK-NEXT: status = miopenSetDropoutDescriptor(DropoutDescriptor, handle, dropout, states, reserveSpaceNumBytes, seed, hipify_use_mask, hipify_state_evo, hipify_rng_mode);
   status = cudnnSetDropoutDescriptor(DropoutDescriptor, handle, dropout, states, reserveSpaceNumBytes, seed);
 
   // TODO [#837]: Insert bool use_mask, bool state_evo, miopenRNGType_t rng_mode in the hipified miopenRestoreDropoutDescriptor: will need variable declaration

--- a/tests/unit_tests/synthetic/libraries/cudnn2miopen_before_9000.cu
+++ b/tests/unit_tests/synthetic/libraries/cudnn2miopen_before_9000.cu
@@ -61,16 +61,16 @@ int main() {
   size_t reserveSpaceNumBytes = 0;
 
 #if CUDNN_MAJOR < 9
-  // TODO [#837]: Insert miopenRNNBiasMode_t biasMode in the hipified miopenSetRNNDescriptor_V2 after miopenRNNMode_t rnnMode: will need variable declaration
   // CUDA: CUDNN_DEPRECATED cudnnStatus_t CUDNNWINAPI cudnnSetRNNDescriptor_v6(cudnnHandle_t handle, cudnnRNNDescriptor_t rnnDesc, const int hiddenSize, const int numLayers, cudnnDropoutDescriptor_t dropoutDesc, cudnnRNNInputMode_t inputMode, cudnnDirectionMode_t direction, cudnnRNNMode_t cellMode, cudnnRNNAlgo_t algo, cudnnDataType_t mathPrec);
   // MIOPEN: MIOPEN_EXPORT miopenStatus_t miopenSetRNNDescriptor_V2(miopenRNNDescriptor_t rnnDesc, const int hsize, const int nlayers, miopenDropoutDescriptor_t dropoutDesc, miopenRNNInputMode_t inMode, miopenRNNDirectionMode_t direction, miopenRNNMode_t rnnMode, miopenRNNBiasMode_t biasMode, miopenRNNAlgo_t algo, miopenDataType_t dataType);
-  // CHECK: status = miopenSetRNNDescriptor_V2(RNNDescriptor, hiddenSize, layer, DropoutDescriptor, RNNInputMode, DirectionMode, RNNMode, RNNAlgo, dataType);
+  // CHECK: miopenRNNBiasMode_t biasMode;
+  // CHECK-NEXT: status = miopenSetRNNDescriptor_V2(RNNDescriptor, hiddenSize, layer, DropoutDescriptor, RNNInputMode, DirectionMode, RNNMode, RNNAlgo, dataType, biasMode);
   status = cudnnSetRNNDescriptor_v6(handle, RNNDescriptor, hiddenSize, layer, DropoutDescriptor, RNNInputMode, DirectionMode, RNNMode, RNNAlgo, dataType);
 
-  // TODO [#837]: Insert miopenRNNBiasMode_t* biasMode in the hipified miopenGetRNNDescriptor_V2 after miopenRNNMode_t* rnnMode: will need variable declaration
   // CUDA: CUDNN_DEPRECATED cudnnStatus_t CUDNNWINAPI cudnnGetRNNDescriptor_v6(cudnnHandle_t handle, cudnnRNNDescriptor_t rnnDesc, int* hiddenSize, int* numLayers, cudnnDropoutDescriptor_t* dropoutDesc, cudnnRNNInputMode_t* inputMode, cudnnDirectionMode_t* direction, cudnnRNNMode_t* cellMode, cudnnRNNAlgo_t* algo, cudnnDataType_t* mathPrec);
   // MIOPEN: MIOPEN_EXPORT miopenStatus_t miopenGetRNNDescriptor_V2(miopenRNNDescriptor_t rnnDesc, int* hiddenSize, int* layer, miopenDropoutDescriptor_t* dropoutDesc, miopenRNNInputMode_t* inputMode, miopenRNNDirectionMode_t* dirMode, miopenRNNMode_t* rnnMode, miopenRNNBiasMode_t* biasMode, miopenRNNAlgo_t* algoMode, miopenDataType_t* dataType);
-  // CHECK: status = miopenGetRNNDescriptor_V2(RNNDescriptor, &hiddenSize, &layer, &DropoutDescriptor, &RNNInputMode, &DirectionMode, &RNNMode, &RNNAlgo, &dataType);
+  // CHECK: miopenRNNBiasMode_t biasMode;
+  // CHECK-NEXT: status = miopenGetRNNDescriptor_V2(RNNDescriptor, &hiddenSize, &layer, &DropoutDescriptor, &RNNInputMode, &DirectionMode, &RNNMode, &RNNAlgo, &dataType, &biasMode);
   status = cudnnGetRNNDescriptor_v6(handle, RNNDescriptor, &hiddenSize, &layer, &DropoutDescriptor, &RNNInputMode, &DirectionMode, &RNNMode, &RNNAlgo, &dataType);
 
   // CUDA: CUDNN_DEPRECATED cudnnStatus_t CUDNNWINAPI cudnnRNNBackwardWeights(cudnnHandle_t handle, const cudnnRNNDescriptor_t rnnDesc, const int seqLength, const cudnnTensorDescriptor_t* xDesc, const void* x, const cudnnTensorDescriptor_t hxDesc, const void* hx, const cudnnTensorDescriptor_t* yDesc, const void* y, const void* workSpace, size_t workSpaceSizeInBytes, const cudnnFilterDescriptor_t dwDesc, void* dw, const void* reserveSpace, size_t reserveSpaceSizeInBytes);

--- a/tests/unit_tests/synthetic/libraries/cudnn2miopen_before_9000.cu
+++ b/tests/unit_tests/synthetic/libraries/cudnn2miopen_before_9000.cu
@@ -63,14 +63,14 @@ int main() {
 #if CUDNN_MAJOR < 9
   // CUDA: CUDNN_DEPRECATED cudnnStatus_t CUDNNWINAPI cudnnSetRNNDescriptor_v6(cudnnHandle_t handle, cudnnRNNDescriptor_t rnnDesc, const int hiddenSize, const int numLayers, cudnnDropoutDescriptor_t dropoutDesc, cudnnRNNInputMode_t inputMode, cudnnDirectionMode_t direction, cudnnRNNMode_t cellMode, cudnnRNNAlgo_t algo, cudnnDataType_t mathPrec);
   // MIOPEN: MIOPEN_EXPORT miopenStatus_t miopenSetRNNDescriptor_V2(miopenRNNDescriptor_t rnnDesc, const int hsize, const int nlayers, miopenDropoutDescriptor_t dropoutDesc, miopenRNNInputMode_t inMode, miopenRNNDirectionMode_t direction, miopenRNNMode_t rnnMode, miopenRNNBiasMode_t biasMode, miopenRNNAlgo_t algo, miopenDataType_t dataType);
-  // CHECK: miopenRNNBiasMode_t biasMode = {};
-  // CHECK-NEXT: status = miopenSetRNNDescriptor_V2(RNNDescriptor, hiddenSize, layer, DropoutDescriptor, RNNInputMode, DirectionMode, RNNMode, biasMode, RNNAlgo, dataType);
+  // CHECK: miopenRNNBiasMode_t hipify_biasMode = {};
+  // CHECK-NEXT: status = miopenSetRNNDescriptor_V2(RNNDescriptor, hiddenSize, layer, DropoutDescriptor, RNNInputMode, DirectionMode, RNNMode, hipify_biasMode, RNNAlgo, dataType);
   status = cudnnSetRNNDescriptor_v6(handle, RNNDescriptor, hiddenSize, layer, DropoutDescriptor, RNNInputMode, DirectionMode, RNNMode, RNNAlgo, dataType);
 
   // CUDA: CUDNN_DEPRECATED cudnnStatus_t CUDNNWINAPI cudnnGetRNNDescriptor_v6(cudnnHandle_t handle, cudnnRNNDescriptor_t rnnDesc, int* hiddenSize, int* numLayers, cudnnDropoutDescriptor_t* dropoutDesc, cudnnRNNInputMode_t* inputMode, cudnnDirectionMode_t* direction, cudnnRNNMode_t* cellMode, cudnnRNNAlgo_t* algo, cudnnDataType_t* mathPrec);
   // MIOPEN: MIOPEN_EXPORT miopenStatus_t miopenGetRNNDescriptor_V2(miopenRNNDescriptor_t rnnDesc, int* hiddenSize, int* layer, miopenDropoutDescriptor_t* dropoutDesc, miopenRNNInputMode_t* inputMode, miopenRNNDirectionMode_t* dirMode, miopenRNNMode_t* rnnMode, miopenRNNBiasMode_t* biasMode, miopenRNNAlgo_t* algoMode, miopenDataType_t* dataType);
-  // CHECK: miopenRNNBiasMode_t biasMode = {};
-  // CHECK-NEXT: status = miopenGetRNNDescriptor_V2(RNNDescriptor, &hiddenSize, &layer, &DropoutDescriptor, &RNNInputMode, &DirectionMode, &RNNMode, &biasMode, &RNNAlgo, &dataType);
+  // CHECK: miopenRNNBiasMode_t hipify_biasMode = {};
+  // CHECK-NEXT: status = miopenGetRNNDescriptor_V2(RNNDescriptor, &hiddenSize, &layer, &DropoutDescriptor, &RNNInputMode, &DirectionMode, &RNNMode, &hipify_biasMode, &RNNAlgo, &dataType);
   status = cudnnGetRNNDescriptor_v6(handle, RNNDescriptor, &hiddenSize, &layer, &DropoutDescriptor, &RNNInputMode, &DirectionMode, &RNNMode, &RNNAlgo, &dataType);
 
   // CUDA: CUDNN_DEPRECATED cudnnStatus_t CUDNNWINAPI cudnnRNNBackwardWeights(cudnnHandle_t handle, const cudnnRNNDescriptor_t rnnDesc, const int seqLength, const cudnnTensorDescriptor_t* xDesc, const void* x, const cudnnTensorDescriptor_t hxDesc, const void* hx, const cudnnTensorDescriptor_t* yDesc, const void* y, const void* workSpace, size_t workSpaceSizeInBytes, const cudnnFilterDescriptor_t dwDesc, void* dw, const void* reserveSpace, size_t reserveSpaceSizeInBytes);

--- a/tests/unit_tests/synthetic/libraries/cudnn2miopen_before_9000.cu
+++ b/tests/unit_tests/synthetic/libraries/cudnn2miopen_before_9000.cu
@@ -63,14 +63,14 @@ int main() {
 #if CUDNN_MAJOR < 9
   // CUDA: CUDNN_DEPRECATED cudnnStatus_t CUDNNWINAPI cudnnSetRNNDescriptor_v6(cudnnHandle_t handle, cudnnRNNDescriptor_t rnnDesc, const int hiddenSize, const int numLayers, cudnnDropoutDescriptor_t dropoutDesc, cudnnRNNInputMode_t inputMode, cudnnDirectionMode_t direction, cudnnRNNMode_t cellMode, cudnnRNNAlgo_t algo, cudnnDataType_t mathPrec);
   // MIOPEN: MIOPEN_EXPORT miopenStatus_t miopenSetRNNDescriptor_V2(miopenRNNDescriptor_t rnnDesc, const int hsize, const int nlayers, miopenDropoutDescriptor_t dropoutDesc, miopenRNNInputMode_t inMode, miopenRNNDirectionMode_t direction, miopenRNNMode_t rnnMode, miopenRNNBiasMode_t biasMode, miopenRNNAlgo_t algo, miopenDataType_t dataType);
-  // CHECK: miopenRNNBiasMode_t biasMode;
-  // CHECK-NEXT: status = miopenSetRNNDescriptor_V2(RNNDescriptor, hiddenSize, layer, DropoutDescriptor, RNNInputMode, DirectionMode, RNNMode, RNNAlgo, dataType, biasMode);
+  // CHECK: miopenRNNBiasMode_t biasMode = {};
+  // CHECK-NEXT: status = miopenSetRNNDescriptor_V2(RNNDescriptor, hiddenSize, layer, DropoutDescriptor, RNNInputMode, DirectionMode, RNNMode, biasMode, RNNAlgo, dataType);
   status = cudnnSetRNNDescriptor_v6(handle, RNNDescriptor, hiddenSize, layer, DropoutDescriptor, RNNInputMode, DirectionMode, RNNMode, RNNAlgo, dataType);
 
   // CUDA: CUDNN_DEPRECATED cudnnStatus_t CUDNNWINAPI cudnnGetRNNDescriptor_v6(cudnnHandle_t handle, cudnnRNNDescriptor_t rnnDesc, int* hiddenSize, int* numLayers, cudnnDropoutDescriptor_t* dropoutDesc, cudnnRNNInputMode_t* inputMode, cudnnDirectionMode_t* direction, cudnnRNNMode_t* cellMode, cudnnRNNAlgo_t* algo, cudnnDataType_t* mathPrec);
   // MIOPEN: MIOPEN_EXPORT miopenStatus_t miopenGetRNNDescriptor_V2(miopenRNNDescriptor_t rnnDesc, int* hiddenSize, int* layer, miopenDropoutDescriptor_t* dropoutDesc, miopenRNNInputMode_t* inputMode, miopenRNNDirectionMode_t* dirMode, miopenRNNMode_t* rnnMode, miopenRNNBiasMode_t* biasMode, miopenRNNAlgo_t* algoMode, miopenDataType_t* dataType);
-  // CHECK: miopenRNNBiasMode_t biasMode;
-  // CHECK-NEXT: status = miopenGetRNNDescriptor_V2(RNNDescriptor, &hiddenSize, &layer, &DropoutDescriptor, &RNNInputMode, &DirectionMode, &RNNMode, &RNNAlgo, &dataType, &biasMode);
+  // CHECK: miopenRNNBiasMode_t biasMode = {};
+  // CHECK-NEXT: status = miopenGetRNNDescriptor_V2(RNNDescriptor, &hiddenSize, &layer, &DropoutDescriptor, &RNNInputMode, &DirectionMode, &RNNMode, &biasMode, &RNNAlgo, &dataType);
   status = cudnnGetRNNDescriptor_v6(handle, RNNDescriptor, &hiddenSize, &layer, &DropoutDescriptor, &RNNInputMode, &DirectionMode, &RNNMode, &RNNAlgo, &dataType);
 
   // CUDA: CUDNN_DEPRECATED cudnnStatus_t CUDNNWINAPI cudnnRNNBackwardWeights(cudnnHandle_t handle, const cudnnRNNDescriptor_t rnnDesc, const int seqLength, const cudnnTensorDescriptor_t* xDesc, const void* x, const cudnnTensorDescriptor_t hxDesc, const void* hx, const cudnnTensorDescriptor_t* yDesc, const void* y, const void* workSpace, size_t workSpaceSizeInBytes, const cudnnFilterDescriptor_t dwDesc, void* dw, const void* reserveSpace, size_t reserveSpaceSizeInBytes);


### PR DESCRIPTION
## Motivation

Issue #837, additional arguments must be declared before the function call. This is necessary because several cuDNN to MIOpen mappings require parameters such as `use_mask, state_evo, and rng_mode` for `miopenSetDropoutDescriptor` which lack CUDA equivalents and cannot be inferred from the current context. 

## Problem Statement

When hipify-clang encounters a CUDA API whose HIP/MIOpen equivalent has additional arguments that are not present in the original call, it currently has no mechanism to
1. Declare new variables before the function call
2. Append new variables as arguments after hipified call
3. Warn user that new variables need initialization before usage

## Solution

Introduces `e_insert_new_argument`:
1. Declares a new variable before the function call 
2. Appends the variable as an argument
3. Emits a warning to user for each inserted variable about intialization

## Summary of changes in this PR:

- `e_insert_new_argument` type for APIs where MIOpen requires additional arguments not present in CUDA #837
- Variable declarations generated with value-initialization (`= {}`) and `hipify_` prefix
- Middle insertions at correct positions, end-appends batched to work for same-offset constraint
- Compiler warning emitted for each generated variable instructing user to initialize appropriately

**ToDo work (follow-up PRs):**

- [ ] **Braceless control flow scope**: When API call is inside a single-statement `if/for/while` without braces, the inserted declarations break control flow. **Fix**: query AST parents to detect `CompoundStmt` and wrap with `{ }`.
- [ ] **Multiple-declaration guard**: If the same API is called twice in same scope, the `hipify_` variables would be declared twice. **Fix**: append a number (e.g., `hipify_use_mask_1`).