### PR TITLE
[HIPIFY][7.2][roSPARSE][fix] Sync with `rocSPARSE 7.2.0`

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -3333,7 +3333,7 @@ sub rocMappings {
     $mappings{"CUSPARSE_FORMAT_COO_AOS"} = { rep => "rocsparse_format_coo_aos", type => "numeric_literal" };
     $mappings{"CUSPARSE_FORMAT_CSC"} = { rep => "rocsparse_format_csc", type => "numeric_literal" };
     $mappings{"CUSPARSE_FORMAT_CSR"} = { rep => "rocsparse_format_csr", type => "numeric_literal" };
-    $mappings{"CUSPARSE_FORMAT_SLICED_ELLPACK"} = { rep => "rocsparse_format_ell", type => "numeric_literal" };
+    $mappings{"CUSPARSE_FORMAT_SLICED_ELLPACK"} = { rep => "rocsparse_format_sell", type => "numeric_literal" };
     $mappings{"CUSPARSE_HYB_PARTITION_AUTO"} = { rep => "rocsparse_hyb_partition_auto", type => "numeric_literal" };
     $mappings{"CUSPARSE_HYB_PARTITION_MAX"} = { rep => "rocsparse_hyb_partition_max", type => "numeric_literal" };
     $mappings{"CUSPARSE_HYB_PARTITION_USER"} = { rep => "rocsparse_hyb_partition_user", type => "numeric_literal" };

--- a/docs/reference/tables/CUSPARSE_API_supported_by_HIP_and_ROC.md
+++ b/docs/reference/tables/CUSPARSE_API_supported_by_HIP_and_ROC.md
@@ -45,7 +45,7 @@
 |`CUSPARSE_FORMAT_COO_AOS`|10.2| | |12.0|`HIPSPARSE_FORMAT_COO_AOS`|4.1.0| | | | | |`rocsparse_format_coo_aos`|4.1.0| | | | |
 |`CUSPARSE_FORMAT_CSC`|10.1| | | |`HIPSPARSE_FORMAT_CSC`|4.1.0| | | | | |`rocsparse_format_csc`|4.1.0| | | | |
 |`CUSPARSE_FORMAT_CSR`|10.1| | | |`HIPSPARSE_FORMAT_CSR`|4.1.0| | | | | |`rocsparse_format_csr`|4.1.0| | | | |
-|`CUSPARSE_FORMAT_SLICED_ELLPACK`|12.1| | | | | | | | | | |`rocsparse_format_ell`|4.1.0| | | | |
+|`CUSPARSE_FORMAT_SLICED_ELLPACK`|12.1| | | | | | | | | | |`rocsparse_format_sell`|7.2.0| | | | |
 |`CUSPARSE_HYB_PARTITION_AUTO`| |10.2| |11.0|`HIPSPARSE_HYB_PARTITION_AUTO`|1.9.2| | | | | |`rocsparse_hyb_partition_auto`|1.9.0| | | | |
 |`CUSPARSE_HYB_PARTITION_MAX`| |10.2| |11.0|`HIPSPARSE_HYB_PARTITION_MAX`|1.9.2| | | | | |`rocsparse_hyb_partition_max`|1.9.0| | | | |
 |`CUSPARSE_HYB_PARTITION_USER`| |10.2| |11.0|`HIPSPARSE_HYB_PARTITION_USER`|1.9.2| | | | | |`rocsparse_hyb_partition_user`|1.9.0| | | | |

--- a/docs/reference/tables/CUSPARSE_API_supported_by_ROC.md
+++ b/docs/reference/tables/CUSPARSE_API_supported_by_ROC.md
@@ -45,7 +45,7 @@
 |`CUSPARSE_FORMAT_COO_AOS`|10.2| | |12.0|`rocsparse_format_coo_aos`|4.1.0| | | | | |
 |`CUSPARSE_FORMAT_CSC`|10.1| | | |`rocsparse_format_csc`|4.1.0| | | | | |
 |`CUSPARSE_FORMAT_CSR`|10.1| | | |`rocsparse_format_csr`|4.1.0| | | | | |
-|`CUSPARSE_FORMAT_SLICED_ELLPACK`|12.1| | | |`rocsparse_format_ell`|4.1.0| | | | | |
+|`CUSPARSE_FORMAT_SLICED_ELLPACK`|12.1| | | |`rocsparse_format_sell`|7.2.0| | | | | |
 |`CUSPARSE_HYB_PARTITION_AUTO`| |10.2| |11.0|`rocsparse_hyb_partition_auto`|1.9.0| | | | | |
 |`CUSPARSE_HYB_PARTITION_MAX`| |10.2| |11.0|`rocsparse_hyb_partition_max`|1.9.0| | | | | |
 |`CUSPARSE_HYB_PARTITION_USER`| |10.2| |11.0|`rocsparse_hyb_partition_user`|1.9.0| | | | | |

--- a/src/CUDA2HIP_SPARSE_API_types.cpp
+++ b/src/CUDA2HIP_SPARSE_API_types.cpp
@@ -177,7 +177,7 @@ const std::map<llvm::StringRef, hipCounter> CUDA_SPARSE_TYPE_NAME_MAP = [] {
   m["CUSPARSE_FORMAT_COO_AOS"]                                        = {"HIPSPARSE_FORMAT_COO_AOS",                   "rocsparse_format_coo_aos",                           CONV_NUMERIC_LITERAL, API_SPARSE, 4, CUDA_REMOVED};
   m["CUSPARSE_FORMAT_BLOCKED_ELL"]                                    = {"HIPSPARSE_FORMAT_BLOCKED_ELL",               "rocsparse_format_bell",                              CONV_NUMERIC_LITERAL, API_SPARSE, 4};
   m["CUSPARSE_FORMAT_BSR"]                                            = {"HIPSPARSE_FORMAT_BSR",                       "rocsparse_format_bsr",                               CONV_NUMERIC_LITERAL, API_SPARSE, 4, HIP_UNSUPPORTED};
-  m["CUSPARSE_FORMAT_SLICED_ELLPACK"]                                 = {"HIPSPARSE_FORMAT_SLICED_ELLPACK",            "rocsparse_format_ell",                               CONV_NUMERIC_LITERAL, API_SPARSE, 4, HIP_UNSUPPORTED};
+  m["CUSPARSE_FORMAT_SLICED_ELLPACK"]                                 = {"HIPSPARSE_FORMAT_SLICED_ELLPACK",            "rocsparse_format_sell",                              CONV_NUMERIC_LITERAL, API_SPARSE, 4, HIP_UNSUPPORTED};
 
   m["cusparseOrder_t"]                                                = {"hipsparseOrder_t",                           "rocsparse_order",                                    CONV_TYPE, API_SPARSE, 4};
   m["CUSPARSE_ORDER_COL"]                                             = {"HIPSPARSE_ORDER_COL",                        "rocsparse_order_row",                                CONV_NUMERIC_LITERAL, API_SPARSE, 4};
@@ -697,6 +697,7 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_SPARSE_TYPE_NAME_VER_MAP = [
   m["rocsparse_const_spmat_descr"]                                    = {HIP_6000, HIP_0,    HIP_0   };
   m["rocsparse_const_dnvec_descr"]                                    = {HIP_6000, HIP_0,    HIP_0   };
   m["rocsparse_const_dnmat_descr"]                                    = {HIP_6000, HIP_0,    HIP_0   };
+  m["rocsparse_format_sell"]                                          = {HIP_7020, HIP_0,    HIP_0   };
 
   return m;
 }();

--- a/tests/unit_tests/synthetic/libraries/cusparse2rocsparse.cu
+++ b/tests/unit_tests/synthetic/libraries/cusparse2rocsparse.cu
@@ -2570,7 +2570,7 @@ int main() {
   cusparseSpMVAlg_t SPMV_SELL_ALG1 = CUSPARSE_SPMV_SELL_ALG1;
 
   // CHECK: rocsparse_format FORMAT_BSR = rocsparse_format_bsr;
-  // CHECK-NEXT: rocsparse_format FORMAT_SLICED_ELLPACK = rocsparse_format_ell;
+  // CHECK-NEXT: rocsparse_format FORMAT_SLICED_ELLPACK = rocsparse_format_sell;
   cusparseFormat_t FORMAT_BSR = CUSPARSE_FORMAT_BSR;
   cusparseFormat_t FORMAT_SLICED_ELLPACK = CUSPARSE_FORMAT_SLICED_ELLPACK;
 #endif


### PR DESCRIPTION
+ `rocsparse_format::rocsparse_format_sell` introduced, and `CUSPARSE_FORMAT_SLICED_ELLPACK` should be hipified to `rocsparse_format_sell` instead of `rocsparse_format_ell`
+ There is no `CUSPARSE_FORMAT_ELLPACK` in `cuSPARSE`, so  `rocsparse_format_ell` has no correspondence in `cuSPARSE`
+ Updated synthetic tests, the regenerated `hipify-perl`, and `SPARSE` `CUDA2HIP` docs accordingly
