### PR TITLE
[HIPIFY][Perl][#1776][fix] Fixed `CONVERTED refs count` calculation under the `-print-stats`

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -18126,14 +18126,6 @@ while (@ARGV) {
                                 $warnings++;
                             }
                         }
-                        if (exists $hash_SupportedDeviceDataTypes{$func}) {
-                            my $c = () = $_ =~ m/\b$func\b/g;
-                            $ft{'device_type'} += $c;
-                        }
-                        if (exists $hash_SupportedDeviceFunctions{$func}) {
-                            my $c = () = $_ =~ m/\b$func\b\s*\((?!\s*void)/g;
-                            $ft{'device_function'} += $c;
-                        }
                     }
                 }
             }
@@ -18170,6 +18162,14 @@ while (@ARGV) {
             }
             transformCubNamespace();
             my $hasDeviceCode = $countKeywords + $ft{'device_function'} + $ft{'device_type'};
+            foreach my $func (keys %hash_SupportedDeviceDataTypes) {
+                my $c = () = $_ =~ m/\b$func\b/g;
+                if ($c) { $ft{'device_type'} += $c; }
+            }
+            foreach my $func (keys %hash_SupportedDeviceFunctions) {
+                my $c = () = $_ =~ m/\b$func\b\s*\((?!\s*void)/g;
+                if ($c) { $ft{'device_function'} += $c; }
+            }
             unless ($quiet_warnings) {
                 # Copy into array of lines, process line-by-line to show warnings
                 if ($hasDeviceCode or (/\bcu|CU/) or (/<<<.*>>>/)) {

--- a/src/CUDA2HIP_Perl.cpp
+++ b/src/CUDA2HIP_Perl.cpp
@@ -838,16 +838,6 @@ namespace perl {
     out << tab_8 << "$warnings++;" << endl;
     out << tab_7 << "}" << endl;
     out << tab_6 << "}" << endl;
-
-    out << tab_6 << "if (exists $hash_SupportedDeviceDataTypes{$func}) {" << endl;
-    out << tab_7 << "my $c = () = $_ =~ m/\\b$func\\b/g;" << endl;
-    out << tab_7 << "$ft{'" << counterNames[CONV_DEVICE_TYPE] << "'} += $c;" << endl;
-    out << tab_6 << "}" << endl;
-
-    out << tab_6 << "if (exists $hash_SupportedDeviceFunctions{$func}) {" << endl;
-    out << tab_7 << "my $c = () = $_ =~ m/\\b$func\\b\\s*\\((?!\\s*void)/g;" << endl;
-    out << tab_7 << "$ft{'" << counterNames[CONV_DEVICE_FUNC] << "'} += $c;" << endl;
-    out << tab_6 << "}" << endl;
     out << tab_5 << "}" << endl;
     out << tab_4 << "}" << endl;
     out << tab_3 << "}" << endl;
@@ -888,7 +878,19 @@ namespace perl {
     out << tab_3 << "}" << endl;
     out << tab_3 << sTransformCubNamespace << "();" << endl;
     out << tab_3 << my << "$hasDeviceCode = $countKeywords + $ft{'" << counterNames[CONV_DEVICE_FUNC] << "'} + $ft{'" << counterNames[CONV_DEVICE_TYPE] << "'};" << endl;
+
+    out << tab_3 << "foreach my $func (keys %hash_SupportedDeviceDataTypes) {" << endl;
+    out << tab_4 << "my $c = () = $_ =~ m/\\b$func\\b/g;" << endl;
+    out << tab_4 << "if ($c) { $ft{'" << counterNames[CONV_DEVICE_TYPE] << "'} += $c; }" << endl;
+    out << tab_3 << "}" << endl;
+
+    out << tab_3 << "foreach my $func (keys %hash_SupportedDeviceFunctions) {" << endl;
+    out << tab_4 << "my $c = () = $_ =~ m/\\b$func\\b\\s*\\((?!\\s*void)/g;" << endl;
+    out << tab_4 << "if ($c) { $ft{'" << counterNames[CONV_DEVICE_FUNC] << "'} += $c; }" << endl;
+    out << tab_3 << "}" << endl;
+
     out << tab_3 << unless_ << "($quiet_warnings) {" << endl;
+
     out << tab_4 << "# Copy into array of lines, process line-by-line to show warnings" << endl;
     out << tab_4 << "if ($hasDeviceCode or (/\\bcu|CU/) or (/<<<.*>>>/)) {" << endl;
     out << tab_5 << my << "@lines = split /\\n/, $_;" << endl;


### PR DESCRIPTION
**[Bug]**
+ In `CUDA2HIP_Perl.cpp`, the variable `$hasDeviceCode` is assigned before the line-scanning loops for device functions and types

**[Solution]**
+ Move the `$hasDeviceCode` assignment to strictly after the `foreach` scanning loops

**[Side Effect]**
+ Minor `hipify-perl` performance improvement in the amount of statistical error
