### PR TITLE
[HIPIFY][HIP][7.12][Meta][ROCM-20351][Sync] CU_DEVICE_ATTRIBUTE_DMA_BUF_SUPPORTED support

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -8801,6 +8801,7 @@ sub simpleMappings {
     $mappings{"CU_DEVICE_ATTRIBUTE_COOPERATIVE_LAUNCH"} = { rep => "hipDeviceAttributeCooperativeLaunch", type => "numeric_literal" };
     $mappings{"CU_DEVICE_ATTRIBUTE_COOPERATIVE_MULTI_DEVICE_LAUNCH"} = { rep => "hipDeviceAttributeCooperativeMultiDeviceLaunch", type => "numeric_literal" };
     $mappings{"CU_DEVICE_ATTRIBUTE_DIRECT_MANAGED_MEM_ACCESS_FROM_HOST"} = { rep => "hipDeviceAttributeDirectManagedMemAccessFromHost", type => "numeric_literal" };
+    $mappings{"CU_DEVICE_ATTRIBUTE_DMA_BUF_SUPPORTED"} = { rep => "hipDeviceAttributeDmaBufSupported", type => "numeric_literal" };
     $mappings{"CU_DEVICE_ATTRIBUTE_ECC_ENABLED"} = { rep => "hipDeviceAttributeEccEnabled", type => "numeric_literal" };
     $mappings{"CU_DEVICE_ATTRIBUTE_GLOBAL_L1_CACHE_SUPPORTED"} = { rep => "hipDeviceAttributeGlobalL1CacheSupported", type => "numeric_literal" };
     $mappings{"CU_DEVICE_ATTRIBUTE_GLOBAL_MEMORY_BUS_WIDTH"} = { rep => "hipDeviceAttributeMemoryBusWidth", type => "numeric_literal" };
@@ -12503,7 +12504,6 @@ my %hash_HipOnlyUnsupportedFunctions = (
     'CU_DEVICE_ATTRIBUTE_CLUSTER_LAUNCH' => 1,
     'CU_DEVICE_ATTRIBUTE_D3D12_CIG_SUPPORTED' => 1,
     'CU_DEVICE_ATTRIBUTE_DEFERRED_MAPPING_CUDA_ARRAY_SUPPORTED' => 1,
-    'CU_DEVICE_ATTRIBUTE_DMA_BUF_SUPPORTED' => 1,
     'CU_DEVICE_ATTRIBUTE_GENERIC_COMPRESSION_SUPPORTED' => 1,
     'CU_DEVICE_ATTRIBUTE_GPU_DIRECT_RDMA_FLUSH_WRITES_OPTIONS' => 1,
     'CU_DEVICE_ATTRIBUTE_GPU_DIRECT_RDMA_SUPPORTED' => 1,

--- a/docs/reference/tables/CUDA_Driver_API_functions_supported_by_HIP.md
+++ b/docs/reference/tables/CUDA_Driver_API_functions_supported_by_HIP.md
@@ -454,7 +454,7 @@
 |`CU_DEVICE_ATTRIBUTE_D3D12_CIG_SUPPORTED`|12.5| | | | | | | | | | |
 |`CU_DEVICE_ATTRIBUTE_DEFERRED_MAPPING_CUDA_ARRAY_SUPPORTED`|11.6| | | | | | | | | | |
 |`CU_DEVICE_ATTRIBUTE_DIRECT_MANAGED_MEM_ACCESS_FROM_HOST`|9.2| | | |`hipDeviceAttributeDirectManagedMemAccessFromHost`|3.10.0| | | | | |
-|`CU_DEVICE_ATTRIBUTE_DMA_BUF_SUPPORTED`|11.7| | | | | | | | | | |
+|`CU_DEVICE_ATTRIBUTE_DMA_BUF_SUPPORTED`|11.7| | | |`hipDeviceAttributeDmaBufSupported`|7.12.0| | | | | |
 |`CU_DEVICE_ATTRIBUTE_ECC_ENABLED`| | | | |`hipDeviceAttributeEccEnabled`|2.10.0| | | | | |
 |`CU_DEVICE_ATTRIBUTE_GENERIC_COMPRESSION_SUPPORTED`|11.0| | | | | | | | | | |
 |`CU_DEVICE_ATTRIBUTE_GLOBAL_L1_CACHE_SUPPORTED`| | | | |`hipDeviceAttributeGlobalL1CacheSupported`|4.3.0| | | | | |

--- a/src/CUDA2HIP_Driver_API_types.cpp
+++ b/src/CUDA2HIP_Driver_API_types.cpp
@@ -1040,7 +1040,7 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_TYPE_NAME_MAP = [] {
   // cudaDevAttrReserved123
   m["CU_DEVICE_ATTRIBUTE_CAN_USE_STREAM_WAIT_VALUE_NOR_V2"]              = {"hipDeviceAttributeCanUseStreamWaitValueNorV2",               "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED | CUDA_REMOVED}; // 123
   // cudaDevAttrReserved124
-  m["CU_DEVICE_ATTRIBUTE_DMA_BUF_SUPPORTED"]                             = {"hipDeviceAttributeDmaBufSupported",                          "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED}; // 124
+  m["CU_DEVICE_ATTRIBUTE_DMA_BUF_SUPPORTED"]                             = {"hipDeviceAttributeDmaBufSupported",                          "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES}; // 124
   // cudaDevAttrIpcEventSupport
   m["CU_DEVICE_ATTRIBUTE_IPC_EVENT_SUPPORTED"]                           = {"hipDeviceAttributeIpcEventSupported",                        "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED}; // 125
   // cudaDevAttrMemSyncDomainCount
@@ -5004,6 +5004,7 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_DRIVER_TYPE_NAME_VER_MAP = [
   m["hipKernel_t"]                                                       = {HIP_7010, HIP_0,    HIP_0   };
   m["hipLibraryOption_e"]                                                = {HIP_7010, HIP_0,    HIP_0   };
   m["hipDeviceAttributeHostNumaId"]                                      = {HIP_7020, HIP_0,    HIP_0   };
+  m["hipDeviceAttributeDmaBufSupported"]                                 = {HIP_7120, HIP_0,    HIP_0   };
   m["hipDeviceAttributeHandleTypeFabricSupported"]                       = {HIP_8000, HIP_0,    HIP_0,  HIP_LATEST};
   m["hipMemHandleTypeFabric"]                                            = {HIP_8000, HIP_0,    HIP_0,  HIP_LATEST};
 

--- a/src/Statistics.cpp
+++ b/src/Statistics.cpp
@@ -835,6 +835,7 @@ std::string Statistics::getHipVersion(const hipVersions &ver) {
     case HIP_7000: return "7.0.0";
     case HIP_7010: return "7.1.0";
     case HIP_7020: return "7.2.0";
+    case HIP_7120: return "7.12.0";
     case HIP_8000: return "8.0.0";
   }
   return "";

--- a/src/Statistics.h
+++ b/src/Statistics.h
@@ -463,6 +463,7 @@ enum hipVersions {
   HIP_7000 = 7000,
   HIP_7010 = 7010,
   HIP_7020 = 7020,
+  HIP_7120 = 7120,
   HIP_8000 = 8000,
   HIP_LATEST = HIP_8000,
 };

--- a/tests/unit_tests/synthetic/driver_enums.cu
+++ b/tests/unit_tests/synthetic/driver_enums.cu
@@ -1230,6 +1230,9 @@ int main() {
   CUmemRangeHandleType_enum MemRangeHandleType_enum;
   CUmemRangeHandleType MEM_RANGE_HANDLE_TYPE_DMA_BUF_FD = CU_MEM_RANGE_HANDLE_TYPE_DMA_BUF_FD;
   CUmemRangeHandleType MEM_RANGE_HANDLE_TYPE_MAX = CU_MEM_RANGE_HANDLE_TYPE_MAX;
+
+  // CHECK: hipDeviceAttribute_t DEVICE_ATTRIBUTE_DMA_BUF_SUPPORTED = hipDeviceAttributeDmaBufSupported;
+  CUdevice_attribute DEVICE_ATTRIBUTE_DMA_BUF_SUPPORTED = CU_DEVICE_ATTRIBUTE_DMA_BUF_SUPPORTED;
 #endif
 
 #if CUDA_VERSION >= 11080


### PR DESCRIPTION
+ Updated the corresponding tests, regenerated `hipify-perl`, and `Driver` `CUDA2HIP` docs accordingly
