### PR TITLE
[HIPIFY][FILE][tests][Windows][fix] Fix the `cufile2hipfile.cu` test failed on `Windows` only

### DIFF
--- a/tests/unit_tests/synthetic/libraries/cufile2hipfile.cu
+++ b/tests/unit_tests/synthetic/libraries/cufile2hipfile.cu
@@ -247,18 +247,18 @@ int main() {
   CUfileOpcode_t FILE_OPCODE_WRITE = CUFILE_WRITE;
 
   // CHECK: hipFileStatus_t STATUS_WAITING = hipFileWaiting;
-  // CHECK-NEXT: hipFileStatus_t STATUS_PENDING = hipFilePending;
+  // CHECK-NEXT: hipFileStatus_t STATUS_PENDING_ = hipFilePending;
   // CHECK-NEXT: hipFileStatus_t STATUS_INVALID = hipFileInvalid;
   // CHECK-NEXT: hipFileStatus_t STATUS_CANCELED = hipFileCanceled;
   // CHECK-NEXT: hipFileStatus_t STATUS_COMPLETE = hipFileComplete;
-  // CHECK-NEXT: hipFileStatus_t STATUS_TIMEOUT = hipFileTimeout;
+  // CHECK-NEXT: hipFileStatus_t STATUS_TIMEOUT_ = hipFileTimeout;
   // CHECK-NEXT: hipFileStatus_t STATUS_FAILED = hipFileFailed;
   CUfileStatus_t STATUS_WAITING = CUFILE_WAITING;
-  CUfileStatus_t STATUS_PENDING = CUFILE_PENDING;
+  CUfileStatus_t STATUS_PENDING_ = CUFILE_PENDING;
   CUfileStatus_t STATUS_INVALID = CUFILE_INVALID;
   CUfileStatus_t STATUS_CANCELED = CUFILE_CANCELED;
   CUfileStatus_t STATUS_COMPLETE = CUFILE_COMPLETE;
-  CUfileStatus_t STATUS_TIMEOUT = CUFILE_TIMEOUT;
+  CUfileStatus_t STATUS_TIMEOUT_ = CUFILE_TIMEOUT;
   CUfileStatus_t STATUS_FAILED = CUFILE_FAILED;
 
   // CHECK: hipFileBatchMode_t BATCH_MODE = hipFileBatch;


### PR DESCRIPTION
**[Synopsis]**
+ Compilation error: `error : expression is not assignable`:
  - CUfileStatus_t STATUS_PENDING = CUFILE_PENDING;
  - CUfileStatus_t STATUS_TIMEOUT = CUFILE_TIMEOUT;

**[Root Cause]**
+ `STATUS_PENDING` and `STATUS_TIMEOUT` are defined in `winnt.h` as:
   - #define STATUS_TIMEOUT                   ((DWORD   )0x00000102L)
   - #define STATUS_PENDING                   ((DWORD   )0x00000103L)
+ Thus assignment error

**[Solution]**
+ Renaming the conflicting variables of the `CUfileStatus_t` type in the test itself
+ [ToDo] Rename all the rest `STATUS_*` variables
