### PR TITLE
[HIPIFY][#837][#2062][#2415] Add multi-declaration gaurd check for `e_insert_new_argument` - Part 2

### DIFF
--- a/src/HipifyAction.cpp
+++ b/src/HipifyAction.cpp
@@ -2732,8 +2732,7 @@ bool HipifyAction::cudaHostFuncCall(const mat::MatchFinder::MatchResult &Result)
       std::string combinedDeclText;
       std::string combinedArgText;
       bool hasInsertions = false;
-      std::vector<hipify::CastInfo> insertionWarnings;
-      std::vector<std::string> insertionVarNames;
+      std::vector<std::pair<hipify::CastInfo, std::string>> insertions;
       clang::SourceLocation callBeginLoc = call->getBeginLoc();
       unsigned callCol = SM.getSpellingColumnNumber(callBeginLoc);
       clang::SourceLocation stmtInsertLoc = callBeginLoc.getLocWithOffset(-static_cast<int>(callCol - 1));
@@ -2744,7 +2743,8 @@ bool HipifyAction::cudaHostFuncCall(const mat::MatchFinder::MatchResult &Result)
       for (auto c : cc.castMap) {
         if (c.second.castType == e_insert_new_argument) {
           const std::string &baseName = c.second.constValToAddOrReplace;
-          unsigned counter = InsertedVarCounter[baseName]++;
+          clang::FileID fileID = SM.getFileID(call->getBeginLoc());
+          unsigned counter = InsertedVarCounter[{fileID, baseName}]++;
           std::string uniqueName = (counter == 0) ? baseName : baseName + "_" + std::to_string(counter);
           hasInsertions = true;
           std::string initExpr = c.second.defaultInitValue.empty() ? "{}" : c.second.defaultInitValue;
@@ -2764,8 +2764,7 @@ bool HipifyAction::cudaHostFuncCall(const mat::MatchFinder::MatchResult &Result)
               combinedArgText += ", ";
             combinedArgText += argText;
           }
-          insertionWarnings.push_back(c.second);
-          insertionVarNames.push_back(uniqueName);
+          insertions.push_back({c.second, uniqueName});
         }
       }
       if (hasInsertions) {
@@ -2779,15 +2778,15 @@ bool HipifyAction::cudaHostFuncCall(const mat::MatchFinder::MatchResult &Result)
           clang::FullSourceLoc argFullSL(insertLoc, SM);
           insertReplacement(argRep, argFullSL);
         }
-
-        for (size_t i = 0; i < insertionWarnings.size(); ++i) {
+        for (auto &ins : insertions) {
           clang::DiagnosticsEngine &DE = getCompilerInstance().getDiagnostics();
           const auto ID = DE.getCustomDiagID(clang::DiagnosticsEngine::Warning,
             "HIP API '%0' requires additional argument '%1' of type '%2'. "
             "A variable declaration has been inserted before the call. "
             "Please initialize it appropriately.");
           clang::FullSourceLoc warnFullSL(call->getBeginLoc(), SM);
-          DE.Report(warnFullSL, ID) << sName << insertionVarNames[i] << insertionWarnings[i].newArgTypeName;
+          DE.Report(warnFullSL, ID)
+              << sName << ins.second << ins.first.newArgTypeName;
         }
       }
       for (auto c : cc.castMap) {

--- a/src/HipifyAction.cpp
+++ b/src/HipifyAction.cpp
@@ -2733,6 +2733,7 @@ bool HipifyAction::cudaHostFuncCall(const mat::MatchFinder::MatchResult &Result)
       std::string combinedArgText;
       bool hasInsertions = false;
       std::vector<hipify::CastInfo> insertionWarnings;
+      std::vector<std::string> insertionVarNames;
       clang::SourceLocation callBeginLoc = call->getBeginLoc();
       unsigned callCol = SM.getSpellingColumnNumber(callBeginLoc);
       clang::SourceLocation stmtInsertLoc = callBeginLoc.getLocWithOffset(-static_cast<int>(callCol - 1));
@@ -2742,14 +2743,17 @@ bool HipifyAction::cudaHostFuncCall(const mat::MatchFinder::MatchResult &Result)
         indent += *indentPtr++;
       for (auto c : cc.castMap) {
         if (c.second.castType == e_insert_new_argument) {
+          const std::string &baseName = c.second.constValToAddOrReplace;
+          unsigned counter = InsertedVarCounter[baseName]++;
+          std::string uniqueName = (counter == 0) ? baseName : baseName + "_" + std::to_string(counter);
           hasInsertions = true;
           std::string initExpr = c.second.defaultInitValue.empty() ? "{}" : c.second.defaultInitValue;
-          combinedDeclText += indent + c.second.newArgTypeName + " " + c.second.constValToAddOrReplace + " = " + initExpr + ";\n";
+          combinedDeclText += indent + c.second.newArgTypeName + " " + uniqueName + " = " + initExpr + ";\n";
           std::string argText;
           if (c.second.isPointerArg)
-            argText = "&" + c.second.constValToAddOrReplace;
+            argText = "&" + uniqueName;
           else
-            argText = c.second.constValToAddOrReplace;
+            argText = uniqueName;
           if (c.first < call->getNumArgs()) {
             clang::SourceLocation argLoc = call->getArg(c.first)->getBeginLoc();
             ct::Replacement middleRep(SM, argLoc, 0, argText + ", ");
@@ -2761,6 +2765,7 @@ bool HipifyAction::cudaHostFuncCall(const mat::MatchFinder::MatchResult &Result)
             combinedArgText += argText;
           }
           insertionWarnings.push_back(c.second);
+          insertionVarNames.push_back(uniqueName);
         }
       }
       if (hasInsertions) {
@@ -2775,14 +2780,14 @@ bool HipifyAction::cudaHostFuncCall(const mat::MatchFinder::MatchResult &Result)
           insertReplacement(argRep, argFullSL);
         }
 
-        for (auto &info : insertionWarnings) {
+        for (size_t i = 0; i < insertionWarnings.size(); ++i) {
           clang::DiagnosticsEngine &DE = getCompilerInstance().getDiagnostics();
           const auto ID = DE.getCustomDiagID(clang::DiagnosticsEngine::Warning,
             "HIP API '%0' requires additional argument '%1' of type '%2'. "
             "A variable declaration has been inserted before the call. "
             "Please initialize it appropriately.");
           clang::FullSourceLoc warnFullSL(call->getBeginLoc(), SM);
-          DE.Report(warnFullSL, ID) << sName << info.constValToAddOrReplace << info.newArgTypeName;
+          DE.Report(warnFullSL, ID) << sName << insertionVarNames[i] << insertionWarnings[i].newArgTypeName;
         }
       }
       for (auto c : cc.castMap) {

--- a/src/HipifyAction.cpp
+++ b/src/HipifyAction.cpp
@@ -2743,8 +2743,16 @@ bool HipifyAction::cudaHostFuncCall(const mat::MatchFinder::MatchResult &Result)
       for (auto c : cc.castMap) {
         if (c.second.castType == e_insert_new_argument) {
           const std::string &baseName = c.second.constValToAddOrReplace;
-          clang::FileID fileID = SM.getFileID(call->getBeginLoc());
-          unsigned counter = InsertedVarCounter[{fileID, baseName}]++;
+          unsigned scopeKey = 0;
+          auto parents = Result.Context->getParents(*call);
+          while (!parents.empty()) {
+            if (const auto *cs = parents[0].get<clang::CompoundStmt>()) {
+              scopeKey = cs->getLBracLoc().getRawEncoding();
+              break;
+            }
+            parents = Result.Context->getParents(parents[0]);
+          }
+          unsigned counter = InsertedVarCounter[{scopeKey, baseName}]++;
           std::string uniqueName = (counter == 0) ? baseName : baseName + "_" + std::to_string(counter);
           hasInsertions = true;
           std::string initExpr = c.second.defaultInitValue.empty() ? "{}" : c.second.defaultInitValue;

--- a/src/HipifyAction.cpp
+++ b/src/HipifyAction.cpp
@@ -2740,19 +2740,28 @@ bool HipifyAction::cudaHostFuncCall(const mat::MatchFinder::MatchResult &Result)
       const char *indentPtr = SM.getCharacterData(stmtInsertLoc);
       while (*indentPtr == ' ' || *indentPtr == '\t')
         indent += *indentPtr++;
+      unsigned scopeKey = 0;
+      clang::FileID fileId;
+      {
+        bool foundScope = false;
+        auto parents = Result.Context->getParents(*call);
+        while (!parents.empty() && !foundScope) {
+          for (const auto &parent : parents) {
+            if (const auto *cs = parent.get<clang::CompoundStmt>()) {
+              fileId = SM.getFileID(cs->getLBracLoc());
+              scopeKey = cs->getLBracLoc().getRawEncoding();
+              foundScope = true;
+              break;
+            }
+          }
+          if (!foundScope)
+            parents = Result.Context->getParents(parents[0]);
+        }
+      }
       for (auto c : cc.castMap) {
         if (c.second.castType == e_insert_new_argument) {
           const std::string &baseName = c.second.constValToAddOrReplace;
-          unsigned scopeKey = 0;
-          auto parents = Result.Context->getParents(*call);
-          while (!parents.empty()) {
-            if (const auto *cs = parents[0].get<clang::CompoundStmt>()) {
-              scopeKey = cs->getLBracLoc().getRawEncoding();
-              break;
-            }
-            parents = Result.Context->getParents(parents[0]);
-          }
-          unsigned counter = InsertedVarCounter[{scopeKey, baseName}]++;
+          unsigned counter = InsertedVarCounter[{fileId, scopeKey, baseName}]++;
           std::string uniqueName = (counter == 0) ? baseName : baseName + "_" + std::to_string(counter);
           hasInsertions = true;
           std::string initExpr = c.second.defaultInitValue.empty() ? "{}" : c.second.defaultInitValue;
@@ -2776,6 +2785,8 @@ bool HipifyAction::cudaHostFuncCall(const mat::MatchFinder::MatchResult &Result)
         }
       }
       if (hasInsertions) {
+        // TODO: Braceless control flow is not yet handled. Detect non-CompoundStmt
+        // enclosing parent and wrap with { }.
         ct::Replacement declRep(SM, stmtInsertLoc, 0, combinedDeclText);
         clang::FullSourceLoc declFullSL(stmtInsertLoc, SM);
         insertReplacement(declRep, declFullSL);

--- a/src/HipifyAction.h
+++ b/src/HipifyAction.h
@@ -42,12 +42,11 @@ class HipifyAction : public clang::ASTFrontendAction,
 private:
   ct::Replacements *replacements = nullptr;
   std::map<std::string, clang::SourceLocation> Ifndefs;
-  // Tracks how many times each inserted variable name (e.g., hipify_var)
-  // has been used in the current file, to avoid redefinition when the same
-  // API is called multiple times. The key is a pair of FileID and name, so
-  // the headers in the same translation unit would otherwise pollute the
-  // counter for the main file.
-  std::map<std::pair<clang::FileID, std::string>, unsigned> InsertedVarCounter;
+  // Tracks how many times each inserted variable name (e.g., hipify_use_mask)
+  // has been used per C++ block scope, to avoid redefinition when the same
+  // API is called multiple times in the same scope. getRawEncoding() is
+  // globally unique per block across the entire translation unit.
+  std::map<std::pair<unsigned, std::string>, unsigned> InsertedVarCounter;
   std::vector<clang::SourceRange> SkippedSourceRanges;
   std::unique_ptr<mat::MatchFinder> Finder;
   // CUDA implicitly adds its runtime header. We rewrite explicitly-provided CUDA includes with equivalent

--- a/src/HipifyAction.h
+++ b/src/HipifyAction.h
@@ -42,7 +42,12 @@ class HipifyAction : public clang::ASTFrontendAction,
 private:
   ct::Replacements *replacements = nullptr;
   std::map<std::string, clang::SourceLocation> Ifndefs;
-  std::map<std::string, unsigned> InsertedVarCounter;
+  // Tracks how many times each inserted variable name (e.g., hipify_var)
+  // has been used in the current file, to avoid redefinition when the same
+  // API is called multiple times. The key is a pair of FileID and name, so
+  // the headers in the same translation unit would otherwise pollute the
+  // counter for the main file.
+  std::map<std::pair<clang::FileID, std::string>, unsigned> InsertedVarCounter;
   std::vector<clang::SourceRange> SkippedSourceRanges;
   std::unique_ptr<mat::MatchFinder> Finder;
   // CUDA implicitly adds its runtime header. We rewrite explicitly-provided CUDA includes with equivalent

--- a/src/HipifyAction.h
+++ b/src/HipifyAction.h
@@ -42,6 +42,7 @@ class HipifyAction : public clang::ASTFrontendAction,
 private:
   ct::Replacements *replacements = nullptr;
   std::map<std::string, clang::SourceLocation> Ifndefs;
+  std::map<std::string, unsigned> InsertedVarCounter;
   std::vector<clang::SourceRange> SkippedSourceRanges;
   std::unique_ptr<mat::MatchFinder> Finder;
   // CUDA implicitly adds its runtime header. We rewrite explicitly-provided CUDA includes with equivalent

--- a/src/HipifyAction.h
+++ b/src/HipifyAction.h
@@ -46,7 +46,7 @@ private:
   // has been used per C++ block scope, to avoid redefinition when the same
   // API is called multiple times in the same scope. getRawEncoding() is
   // globally unique per block across the entire translation unit.
-  std::map<std::pair<unsigned, std::string>, unsigned> InsertedVarCounter;
+  std::map<std::tuple<clang::FileID,unsigned, std::string>, unsigned> InsertedVarCounter;
   std::vector<clang::SourceRange> SkippedSourceRanges;
   std::unique_ptr<mat::MatchFinder> Finder;
   // CUDA implicitly adds its runtime header. We rewrite explicitly-provided CUDA includes with equivalent

--- a/tests/lit.cfg
+++ b/tests/lit.cfg
@@ -37,6 +37,8 @@ if not config.cuda_dnn_root or config.cuda_dnn_root == "OFF":
     config.excludes.append('cudnn_softmax.cu')
     config.excludes.append('cudnn2miopen.cu')
     config.excludes.append('cudnn2miopen_before_9000.cu')
+    config.excludes.append('cudnn_insert_new_arg.cu')
+    config.excludes.append('dummy_cudnn_call_header.h')
     print("WARN: cuDNN tests are excluded because CUDA_DNN_ROOT_DIR is not specified")
     warns = True
 else:

--- a/tests/unit_tests/synthetic/libraries/cudnn_insert_new_arg.cu
+++ b/tests/unit_tests/synthetic/libraries/cudnn_insert_new_arg.cu
@@ -1,0 +1,52 @@
+// RUN: %run_test hipify "%s" "%t" %hipify_args 4 --skip-excluded-preprocessor-conditional-blocks --experimental --roc --miopen %clang_args -D__CUDA_API_VERSION_INTERNAL
+
+// CHECK: #include <hip/hip_runtime.h>
+#include <cuda_runtime.h>
+#include <stdio.h>
+// CHECK: #include "miopen/miopen.h"
+#include "cudnn.h"
+
+int main() {
+  printf("e_insert_new_argument: duplicate variable name guard test\n");
+
+  // CHECK: miopenStatus_t status;
+  cudnnStatus_t status;
+
+  // CHECK: miopenHandle_t handle;
+  cudnnHandle_t handle;
+
+  // CHECK: miopenDropoutDescriptor_t DropoutDescriptor;
+  cudnnDropoutDescriptor_t DropoutDescriptor;
+
+  float dropout = 0.5f;
+  void* states = nullptr;
+  size_t reserveSpaceNumBytes = 0;
+  unsigned long long seed = 42;
+
+  // CUDA: cudnnStatus_t CUDNNWINAPI cudnnSetDropoutDescriptor(cudnnDropoutDescriptor_t dropoutDesc, cudnnHandle_t handle, float dropout, void* states, size_t stateSizeInBytes, unsigned long long seed);
+  // MIOPEN: MIOPEN_EXPORT miopenStatus_t miopenSetDropoutDescriptor(miopenDropoutDescriptor_t dropoutDesc, miopenHandle_t handle, float dropout, void* states, size_t stateSizeInBytes, unsigned long long seed, bool use_mask, bool state_evo, miopenRNGType_t rng_mode);
+
+  // First call: base names, no suffix.
+  // CHECK: bool hipify_use_mask = {};
+  // CHECK-NEXT: bool hipify_state_evo = {};
+  // CHECK-NEXT: miopenRNGType_t hipify_rng_mode = {};
+  // CHECK-NEXT: status = miopenSetDropoutDescriptor(DropoutDescriptor, handle, dropout, states, reserveSpaceNumBytes, seed, hipify_use_mask, hipify_state_evo, hipify_rng_mode);
+  status = cudnnSetDropoutDescriptor(DropoutDescriptor, handle, dropout, states, reserveSpaceNumBytes, seed);
+
+  // Second call in same scope: _1 suffix to avoid redefinition.
+  // CHECK: bool hipify_use_mask_1 = {};
+  // CHECK-NEXT: bool hipify_state_evo_1 = {};
+  // CHECK-NEXT: miopenRNGType_t hipify_rng_mode_1 = {};
+  // CHECK-NEXT: status = miopenSetDropoutDescriptor(DropoutDescriptor, handle, dropout, states, reserveSpaceNumBytes, seed, hipify_use_mask_1, hipify_state_evo_1, hipify_rng_mode_1);
+  status = cudnnSetDropoutDescriptor(DropoutDescriptor, handle, dropout, states, reserveSpaceNumBytes, seed);
+
+  // Third call in same scope: _2 suffix.
+  // CHECK: bool hipify_use_mask_2 = {};
+  // CHECK-NEXT: bool hipify_state_evo_2 = {};
+  // CHECK-NEXT: miopenRNGType_t hipify_rng_mode_2 = {};
+  // CHECK-NEXT: status = miopenSetDropoutDescriptor(DropoutDescriptor, handle, dropout, states, reserveSpaceNumBytes, seed, hipify_use_mask_2, hipify_state_evo_2, hipify_rng_mode_2);
+  status = cudnnSetDropoutDescriptor(DropoutDescriptor, handle, dropout, states, reserveSpaceNumBytes, seed);
+
+  // CHECK: return 0;
+  return 0;
+}

--- a/tests/unit_tests/synthetic/libraries/cudnn_insert_new_arg.cu
+++ b/tests/unit_tests/synthetic/libraries/cudnn_insert_new_arg.cu
@@ -5,6 +5,7 @@
 #include <stdio.h>
 // CHECK: #include "miopen/miopen.h"
 #include "cudnn.h"
+#include "dummy_cudnn_call_header.h"
 
 int main() {
   printf("e_insert_new_argument: duplicate variable name guard test\n");
@@ -49,4 +50,15 @@ int main() {
 
   // CHECK: return 0;
   return 0;
+}
+
+// CHECK: bool hipify_use_mask = {};
+// CHECK-NEXT: bool hipify_state_evo = {};
+// CHECK-NEXT: miopenRNGType_t hipify_rng_mode = {};
+// CHECK-NEXT: miopenSetDropoutDescriptor(DropoutDescriptor, handle, dropout, states, reserveSpaceNumBytes, seed, hipify_use_mask, hipify_state_evo, hipify_rng_mode);
+void secondSetup(cudnnDropoutDescriptor_t DropoutDescriptor, cudnnHandle_t handle,
+                 float dropout, void* states, size_t reserveSpaceNumBytes,
+                 unsigned long long seed) {
+  cudnnStatus_t status;
+  status = cudnnSetDropoutDescriptor(DropoutDescriptor, handle, dropout, states, reserveSpaceNumBytes, seed);
 }

--- a/tests/unit_tests/synthetic/libraries/cudnn_insert_new_arg.cu
+++ b/tests/unit_tests/synthetic/libraries/cudnn_insert_new_arg.cu
@@ -48,9 +48,11 @@ int main() {
   // CHECK-NEXT: status = miopenSetDropoutDescriptor(DropoutDescriptor, handle, dropout, states, reserveSpaceNumBytes, seed, hipify_use_mask_2, hipify_state_evo_2, hipify_rng_mode_2);
   status = cudnnSetDropoutDescriptor(DropoutDescriptor, handle, dropout, states, reserveSpaceNumBytes, seed);
 
-  // CHECK: return 0;
   return 0;
 }
+
+// TODO: Braceless control flow is not yet handled. Detect non-CompoundStmt
+// enclosing parent and wrap with { }.
 
 // CHECK: bool hipify_use_mask = {};
 // CHECK-NEXT: bool hipify_state_evo = {};

--- a/tests/unit_tests/synthetic/libraries/dummy_cudnn_call_header.h
+++ b/tests/unit_tests/synthetic/libraries/dummy_cudnn_call_header.h
@@ -1,0 +1,18 @@
+// RUN: %run_test hipify "%s" "%t" %hipify_args 4 --skip-excluded-preprocessor-conditional-blocks --experimental --roc --miopen %clang_args -D__CUDA_API_VERSION_INTERNAL
+
+#pragma once
+// CHECK: #include "miopen/miopen.h"
+#include "cudnn.h"
+
+inline void headerSetup(cudnnDropoutDescriptor_t DropoutDescriptor,
+                        cudnnHandle_t handle, float dropout,
+                        void* states, size_t reserveSpaceNumBytes,
+                        unsigned long long seed) {
+  // CHECK: miopenStatus_t status;
+  cudnnStatus_t status;
+  // CHECK: bool hipify_use_mask = {};
+  // CHECK-NEXT: bool hipify_state_evo = {};
+  // CHECK-NEXT: miopenRNGType_t hipify_rng_mode = {};
+  // CHECK-NEXT: status = miopenSetDropoutDescriptor(DropoutDescriptor, handle, dropout, states, reserveSpaceNumBytes, seed, hipify_use_mask, hipify_state_evo, hipify_rng_mode);
+  status = cudnnSetDropoutDescriptor(DropoutDescriptor, handle, dropout, states, reserveSpaceNumBytes, seed);
+}


### PR DESCRIPTION
## Context

Follow-up PR to #2415 for `e_insert_new_argument` cast type that generates variable declarations above a function call when hipifying APIs where MIOpen requires additional arguments not present in CUDA.

One known limitation in #2415 was:

> **Multiple-declaration guard**: If the same API is called twice in the same scope,
> the `hipify_` variables would be declared twice, causing a compile-time redefinition
> error.

With this PR, we are fixing it.

## Problem

Given a CUDA code with the same API called multiple times in the same scope:

```cpp
status = cudnnSetDropoutDescriptor(desc, handle, dropout, states, size, seed);
status = cudnnSetDropoutDescriptor(desc, handle, dropout, states, size, seed);
```
#2415 would generate 
```cpp
bool hipify_use_mask = {};       // works
bool hipify_use_mask = {};       // fails — REDEFINITION ERROR
```
## Solution

Added `InsertedVarCounter` that tracks the count for each base variable name that has been generated.

Also fixed warning emission loop with `insertionVarNames` vector so the compiler warning message correctly reports the unique name `hipify_use_mask_1` instead of the base name `hipify_use_mask`.

With this change code would generate like:
```cpp
bool hipify_use_mask = {};         // works
bool hipify_use_mask_1 = {};       // works - unique name
bool hipify_use_mask_2 = {};       // works - unique name
```
