### PR TITLE
[HIPIFY][Perl][#1776][optimization] Remove redundant loops in Perl hash generator function `generateExperimentalSubstitutions` - Part 3

### DIFF
--- a/src/CUDA2HIP_Perl.cpp
+++ b/src/CUDA2HIP_Perl.cpp
@@ -341,30 +341,22 @@ namespace perl {
 
   void generateExperimentalSubstitutions(ostream &out) {
     out << endl << sub << sExperimentalMappings << " {" << endl;
-    for (int i = 0; i < NUM_CONV_TYPES; ++i) {
-      if (i != CONV_INCLUDE_CUDA_MAIN_H && i != CONV_INCLUDE_CUDA_MAIN_V2_H && i != CONV_INCLUDE) {
-        for (auto &ma : CUDA_RENAMES_MAP()) {
-          if (!Statistics::isHipExperimental(ma.second)) continue;
-          if (i == ma.second.type) {
-            out << tab << "$mappings{\"" << ma.first.str() << "\"} = { rep => \"" << ma.second.hipName.str() << "\", type => \"" << counterNames[ma.second.type] << "\" };" << endl;
-          }
-        }
+    for (auto &ma : CUDA_RENAMES_MAP()) {
+      if (!Statistics::isHipExperimental(ma.second)) continue;
+      if (ma.second.type != CONV_INCLUDE_CUDA_MAIN_H && ma.second.type != CONV_INCLUDE_CUDA_MAIN_V2_H && ma.second.type != CONV_INCLUDE) {
+        out << tab << "$mappings{\"" << ma.first.str() << "\"} = { rep => \"" << ma.second.hipName.str() << "\", type => \"" << counterNames[ma.second.type] << "\" };" << endl;
       }
     }
     out << "}" << endl;
     out << endl << sub << sExperimentalIncludes << " {" << endl;
-    for (int i = 0; i < NUM_CONV_TYPES; ++i) {
-      if (i == CONV_INCLUDE_CUDA_MAIN_H || i == CONV_INCLUDE_CUDA_MAIN_V2_H || i == CONV_INCLUDE) {
-        for (auto &ma : CUDA_INCLUDE_MAP) {
-          if (!Statistics::isHipExperimental(ma.second)) continue;
-          if (i == ma.second.type) {
-            string sCUDA = ma.first.str();
-            string sHIP = ma.second.hipName.str();
-            sCUDA = regex_replace(sCUDA, regex("/"), "\\/");
-            sHIP = regex_replace(sHIP, regex("/"), "\\/");
-            out << tab << "subst(\"" << sCUDA << "\", \"" << sHIP << "\", \"" << counterNames[ma.second.type] << "\");" << endl;
-          }
-        }
+    for (auto &ma : CUDA_INCLUDE_MAP) {
+      if (!Statistics::isHipExperimental(ma.second)) continue;
+      if (ma.second.type == CONV_INCLUDE_CUDA_MAIN_H || ma.second.type == CONV_INCLUDE_CUDA_MAIN_V2_H || ma.second.type == CONV_INCLUDE) {
+        string sCUDA = ma.first.str();
+        string sHIP = ma.second.hipName.str();
+        sCUDA = regex_replace(sCUDA, regex("/"), "\\/");
+        sHIP = regex_replace(sHIP, regex("/"), "\\/");
+        out << tab << "subst(\"" << sCUDA << "\", \"" << sHIP << "\", \"" << counterNames[ma.second.type] << "\");" << endl;
       }
     }
     out << "}" << endl;


### PR DESCRIPTION
**[Optimization]**
+ Unnecessary nested `O(N x M)` loops in `generateExperimentalSubstitutions` have been removed

**[Reason]**
+ Since Perl hashes are unordered, grouping dictionary insertions by conversion type is redundant

**[Targets]**
+ Optimize, simplify, and clean up the C++ generator logic
+ This is a preliminary step for the primary target:
  - Drastically minimizing the footprint, size, and complexity of the generated `hipify-perl` in the subsequent steps

**[Justification]**
+ `perl -c hipify-perl`
+ The generated `hipify-perl` predictably left unchanged
