### PR TITLE
[HIPIFY][#2402] Warn users for non-self-contained header hipification in isolation - Part 2

### DIFF
--- a/src/LLVMCompat.cpp
+++ b/src/LLVMCompat.cpp
@@ -28,7 +28,8 @@ THE SOFTWARE.
 #include "clang/Lex/PreprocessorOptions.h"
 #include "clang/Frontend/CompilerInstance.h"
 
-const std::string sHipify = "[HIPIFY] ", sConflict = "conflict: ", sError = "error: ", sWarning = "warning: ";
+const std::string sHipify = "[HIPIFY] ", sConflict = "conflict: ",
+                  sError = "error: ", sWarning = "warning: ", sNote = "note: ";
 
 namespace llcompat {
 

--- a/src/LLVMCompat.h
+++ b/src/LLVMCompat.h
@@ -30,7 +30,7 @@ THE SOFTWARE.
 
 namespace ct = clang::tooling;
 
-extern const std::string sHipify, sConflict, sError, sWarning;
+extern const std::string sHipify, sConflict, sError, sWarning, sNote;
 
 // Things for papering over the differences between different LLVM versions.
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -57,6 +57,16 @@ constexpr auto DEBUG_TYPE = "cuda2hip";
 
 namespace ct = clang::tooling;
 
+static bool isHeaderFile(llvm::StringRef filePath) {
+  llvm::StringRef extension = llvm::sys::path::extension(filePath);
+  return extension.equals_insensitive(".h") ||
+         extension.equals_insensitive(".hpp") ||
+         extension.equals_insensitive(".hxx") ||
+         extension.equals_insensitive(".cuh") ||
+         extension.equals_insensitive(".inl") ||
+         extension.equals_insensitive(".inc");
+}
+
 void cleanupHipifyOptions(std::vector<const char*> &args) {
   for (const auto &a : hipifyOptions) {
     args.erase(std::remove(args.begin(), args.end(), "--" + a), args.end());
@@ -539,6 +549,20 @@ int main(int argc, const char **argv) {
       Statistics::current().hasErrors = true;
       Result = 1;
       LLVM_DEBUG(llvm::dbgs() << "Hipification failed for: " << src << "\n");
+      if (isHeaderFile(src)) {
+        llvm::errs()
+            << "\n"
+            << sHipify << sWarning << "Header file '"
+            << sys::path::filename(sSourceAbsPath)
+            << "' failed to hipify. This header may not be self-contained.\n";
+        llvm::errs() << sHipify << sNote
+                     << "Headers that depend on symbols from other files "
+                     << "cannot be hipified in isolation.\n";
+        llvm::errs() << sHipify << sNote
+                     << "Consider hipifying the parent source file (.cu/.cpp) "
+                     << "that includes this header to ensure all dependencies "
+                        "are resolved.\n";
+      }
     }
 
     Statistics::current().markCompletion();


### PR DESCRIPTION
## Context

Follow-up PR to #2402 for implicit local header hipification by default. `hipify-clang sample.cu` automatically detects and hipifies all local headers recursively, no flags needed. 

## Purpose

#2402 
> Warn (besides compiler’s error messaging) the user about imposibility to hipify a header file, which is not self-contained.

Added clear, actionable warning when a header file fails hipification, explaining the likely cause and suggesting the correct approach. 
 
