### PR TITLE
[HIPIFY][ROCM-1254] Add cooperative_groups reduce and scans support

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -9920,6 +9920,8 @@ sub simpleMappings {
 sub simpleIncludes {
     subst("channel_descriptor.h", "hip\/channel_descriptor.h", "include");
     subst("cooperative_groups.h", "hip\/hip_cooperative_groups.h", "include");
+    subst("cooperative_groups\/reduce.h", "hip\/cooperative_groups\/hip_reduce.h", "include");
+    subst("cooperative_groups\/scan.h", "hip\/cooperative_groups\/hip_scan.h", "include");
     subst("cuComplex.h", "hip\/hip_complex.h", "include_cuda_main_header");
     subst("cub\/cub.cuh", "hipcub\/hipcub.hpp", "include_cuda_main_header");
     subst("cublas.h", "hipblas.h", "include_cuda_main_header");

--- a/src/CUDA2HIP.cpp
+++ b/src/CUDA2HIP.cpp
@@ -42,6 +42,7 @@ const std::map <llvm::StringRef, hipCounter> CUDA_INCLUDE_MAP {
   {"cuda_profiler_api.h",                                   {"hip/hip_runtime_api.h",                                 "",                                                               CONV_INCLUDE,                API_RUNTIME, 0}},
   {"cooperative_groups.h",                                  {"hip/hip_cooperative_groups.h",                          "",                                                               CONV_INCLUDE,                API_RUNTIME, 0}},
   {"cooperative_groups/reduce.h",                           {"hip/cooperative_groups/hip_reduce.h",                   "",                                                               CONV_INCLUDE,                API_RUNTIME, 0}},
+  {"cooperative_groups/scan.h",                             {"hip/cooperative_groups/hip_scah",                       "",                                                               CONV_INCLUDE,                API_RUNTIME, 0}},
   {"library_types.h",                                       {"hip/library_types.h",                                   "",                                                               CONV_INCLUDE,                API_RUNTIME, 0}},
   {"math_constants.h",                                      {"hip/hip_math_constants.h",                              "",                                                               CONV_INCLUDE,                API_RUNTIME, 0}},
   // cuda-samples helper includes

--- a/src/CUDA2HIP.cpp
+++ b/src/CUDA2HIP.cpp
@@ -42,7 +42,7 @@ const std::map <llvm::StringRef, hipCounter> CUDA_INCLUDE_MAP {
   {"cuda_profiler_api.h",                                   {"hip/hip_runtime_api.h",                                 "",                                                               CONV_INCLUDE,                API_RUNTIME, 0}},
   {"cooperative_groups.h",                                  {"hip/hip_cooperative_groups.h",                          "",                                                               CONV_INCLUDE,                API_RUNTIME, 0}},
   {"cooperative_groups/reduce.h",                           {"hip/cooperative_groups/hip_reduce.h",                   "",                                                               CONV_INCLUDE,                API_RUNTIME, 0}},
-  {"cooperative_groups/scan.h",                             {"hip/cooperative_groups/hip_scah",                       "",                                                               CONV_INCLUDE,                API_RUNTIME, 0}},
+  {"cooperative_groups/scan.h",                             {"hip/cooperative_groups/hip_scan.h",                     "",                                                               CONV_INCLUDE,                API_RUNTIME, 0}},
   {"library_types.h",                                       {"hip/library_types.h",                                   "",                                                               CONV_INCLUDE,                API_RUNTIME, 0}},
   {"math_constants.h",                                      {"hip/hip_math_constants.h",                              "",                                                               CONV_INCLUDE,                API_RUNTIME, 0}},
   // cuda-samples helper includes

--- a/src/CUDA2HIP.cpp
+++ b/src/CUDA2HIP.cpp
@@ -41,6 +41,7 @@ const std::map <llvm::StringRef, hipCounter> CUDA_INCLUDE_MAP {
   {"vector_types.h",                                        {"hip/hip_vector_types.h",                                "",                                                               CONV_INCLUDE,                API_RUNTIME, 0}},
   {"cuda_profiler_api.h",                                   {"hip/hip_runtime_api.h",                                 "",                                                               CONV_INCLUDE,                API_RUNTIME, 0}},
   {"cooperative_groups.h",                                  {"hip/hip_cooperative_groups.h",                          "",                                                               CONV_INCLUDE,                API_RUNTIME, 0}},
+  {"cooperative_groups/reduce.h",                           {"hip/cooperative_groups/hip_reduce.h",                   "",                                                               CONV_INCLUDE,                API_RUNTIME, 0}},
   {"library_types.h",                                       {"hip/library_types.h",                                   "",                                                               CONV_INCLUDE,                API_RUNTIME, 0}},
   {"math_constants.h",                                      {"hip/hip_math_constants.h",                              "",                                                               CONV_INCLUDE,                API_RUNTIME, 0}},
   // cuda-samples helper includes

--- a/src/CUDA2HIP_Device_functions.cpp
+++ b/src/CUDA2HIP_Device_functions.cpp
@@ -22,7 +22,7 @@ THE SOFTWARE.
 
 #include "CUDA2HIP.h"
 
-// Maps CUDA header names to HIP header names
+// Maps CUDA device function names to HIP device function names
 const std::map<llvm::StringRef, hipCounter> CUDA_DEVICE_FUNCTION_MAP = [] {
   std::map<llvm::StringRef, hipCounter> m;
 

--- a/tests/lit.cfg
+++ b/tests/lit.cfg
@@ -149,6 +149,7 @@ if config.cuda_version_major > 10:
 
 if config.cuda_version_major < 11:
     config.excludes.append('headers_test_09_bf16_11000.cu')
+    config.excludes.append('header_tests_14_cooperative_groups.cu')
 
 if config.cuda_version_major < 11 or (config.cuda_version_major == 11 and config.cuda_version_minor < 1):
     config.excludes.append('runtime_functions_11010.cu')

--- a/tests/lit.cfg
+++ b/tests/lit.cfg
@@ -149,7 +149,7 @@ if config.cuda_version_major > 10:
 
 if config.cuda_version_major < 11:
     config.excludes.append('headers_test_09_bf16_11000.cu')
-    config.excludes.append('header_tests_14_cooperative_groups.cu')
+    config.excludes.append('headers_test_14_cooperative_groups.cu')
 
 if config.cuda_version_major < 11 or (config.cuda_version_major == 11 and config.cuda_version_minor < 1):
     config.excludes.append('runtime_functions_11010.cu')

--- a/tests/unit_tests/headers/headers_test_14_cooperative_groups.cu
+++ b/tests/unit_tests/headers/headers_test_14_cooperative_groups.cu
@@ -1,8 +1,8 @@
 // RUN: %run_test hipify "%s" "%t" %hipify_args %clang_args
 
 // CHECK: #include <hip/hip_cooperative_groups.h>
-// CHECK: #include <hip/cooperative_groups/hip_reduce.h>
-// CHECK: #include <hip/cooperative_groups/hip_scan.h>
+// CHECK-NEXT: #include <hip/cooperative_groups/hip_reduce.h>
+// CHECK-NEXT: #include <hip/cooperative_groups/hip_scan.h>
 #include <cooperative_groups.h>
 #include <cooperative_groups/reduce.h>
 #include <cooperative_groups/scan.h>

--- a/tests/unit_tests/headers/headers_test_14_cooperative_groups.cu
+++ b/tests/unit_tests/headers/headers_test_14_cooperative_groups.cu
@@ -1,0 +1,8 @@
+// RUN: %run_test hipify "%s" "%t" %hipify_args %clang_args
+
+// CHECK: #include <hip/hip_cooperative_groups.h>
+// CHECK: #include <hip/cooperative_groups/hip_reduce.h>
+// CHECK: #include <hip/cooperative_groups/hip_scan.h>
+#include <cooperative_groups.h>
+#include <cooperative_groups/reduce.h>
+#include <cooperative_groups/scan.h>


### PR DESCRIPTION
## Motivation

`cooperative_groups::reduce()` was recently added in HIP.

`cg::inclusive_scan` and `exclusive_scan` were added in 7.14: https://github.com/ROCm/rocm-systems/pull/5914

## Technical Details

This PR enables automatic translation of header paths accordingly:

`cooperative_groups/reduce.h` to `cooperative_groups/hip_reduce.h`
`cooperative_groups/scan.h` to `cooperative_groups/hip_scan.h`

## Test Plan

To be tested locally

## Test Result

TBD

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
