### PR TITLE
[HIPIFY][cuFile][Windows][doc][tests] Update `Windows` testing documentation

### DIFF
--- a/docs/building/build-hipify-clang-windows.rst
+++ b/docs/building/build-hipify-clang-windows.rst
@@ -110,6 +110,22 @@ We recommend that you build ``LLVM+Clang`` from sources, as prebuilt binaries ar
 
    -DCUDA_CUB_ROOT_DIR=D:/CUDA/CUB
 
+- [Optional] Download `cuFile <https://developer.download.nvidia.com/compute/cuda/redist/libcufile/linux-x86_64/libcufile-linux-x86_64-1.17.0.44-archive.tar.xz>`_ for ``CUDA >= 11.4`` only.
+
+  Then, extract the downloaded archive, extract it with ``tar``:
+
+  .. code-block:: bash
+
+   tar -xf libcufile-linux-x86_64-1.17.0.44-archive.tar.xz
+
+  Copy the extracted folder to a desired location, for example, ``D:/CUDA/cuFile/1.17.0``.
+
+  To specify the path to cuFile, use the ``CUDA_FILE_ROOT_DIR`` option:
+
+  .. code-block:: bash
+
+   -DCUDA_FILE_ROOT_DIR=D:/CUDA/cuFile/1.17.0
+
 - Install `Python <https://www.python.org/downloads>`_ version 3.0 or greater.
 
 - Install ``lit`` and ``FileCheck``; these are distributed with LLVM.

--- a/docs/sphinx/_toc.yml.in
+++ b/docs/sphinx/_toc.yml.in
@@ -47,6 +47,8 @@ subtrees:
         title: cuTENSOR API
       - file: reference/tables/CUB_API_supported_by_HIP
         title: CUB API
+      - file: reference/tables/cuFile_API_supported_by_HIP
+        title: cuFile API
   - file: reference/roc_supported_apis
     subtrees:
     - entries:


### PR DESCRIPTION
**[IMP]**
  - `cuFile` testing is optional on `Windows`, as `NVIDIA`:
    + doesn't support `cuFile` on `Windows`
    + doesn't ship `cuFile` with `CUDA Toolkit` for `Windows`
  - Whereas, `cuFile` -> `hipFile` hipification is absolutely possible on `Windows`

**[Misc]**
  - Populated the documentation TOC with `cuFile`
