### PR TITLE
[HIPIFY][CUDA 13.2][FFT] `CUDA 13.2.0` support - Step 3 - `cuFFT Device`

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -6164,6 +6164,7 @@ my %hash_HipOnlyUnsupportedFunctions = (
     'cufftDeviceGetLTOIRs' => 1,
     'cufftDeviceGetNumDeviceFunctions' => 1,
     'cufftDeviceGetNumLTOIRs' => 1,
+    'cufftDeviceGetSemanticVersion' => 1,
     'cufftDeviceGetVersion' => 1,
     'cufftDeviceHandle' => 1,
     'cufftDeviceIsSupported' => 1,

--- a/docs/reference/tables/CUFFT_API_supported_by_HIP.md
+++ b/docs/reference/tables/CUFFT_API_supported_by_HIP.md
@@ -187,6 +187,7 @@
 |`cufftDeviceGetLTOIRs`|13.1| | | | | | | | | | |
 |`cufftDeviceGetNumDeviceFunctions`|13.1| | | | | | | | | | |
 |`cufftDeviceGetNumLTOIRs`|13.1| | | | | | | | | | |
+|`cufftDeviceGetSemanticVersion`|13.2| | | | | | | | | | |
 |`cufftDeviceGetVersion`|13.1| | | | | | | | | | |
 |`cufftDeviceIsSupported`|13.1| | | | | | | | | | |
 |`cufftEstimate1d`| | | | |`hipfftEstimate1d`|1.7.0| | | | | |

--- a/src/CUDA2HIP_FFT_API_functions.cpp
+++ b/src/CUDA2HIP_FFT_API_functions.cpp
@@ -158,6 +158,7 @@ const std::map<llvm::StringRef, hipCounter> CUDA_FFT_FUNCTION_MAP = [] {
   m["fftwf_import_wisdom_from_file"]                    = {"fftwf_import_wisdom_from_file",                        "", CONV_LIB_FUNC, API_FFT, 2, UNSUPPORTED};
 
   m["cufftDeviceGetVersion"]                            = {"hipfftDeviceGetVersion",                               "", CONV_LIB_FUNC, API_FFT, 2, UNSUPPORTED};
+  m["cufftDeviceGetSemanticVersion"]                    = {"hipfftDeviceGetSemanticVersion",                       "", CONV_LIB_FUNC, API_FFT, 2, UNSUPPORTED};
   m["cufftDescriptionCreate"]                           = {"hipfftDescriptionCreate",                              "", CONV_LIB_FUNC, API_FFT, 2, UNSUPPORTED};
   m["cufftDescriptionSetTraitInt64"]                    = {"hipfftDescriptionSetTraitInt64",                       "", CONV_LIB_FUNC, API_FFT, 2, UNSUPPORTED};
   m["cufftDescriptionGetTraitInt64"]                    = {"hipfftDescriptionGetTraitInt64",                       "", CONV_LIB_FUNC, API_FFT, 2, UNSUPPORTED};
@@ -212,6 +213,7 @@ const std::map<llvm::StringRef, cudaAPIversions> CUDA_FFT_FUNCTION_VER_MAP = [] 
   m["cufftDeviceGetLTOIRSizes"]                           = {CUDA_131, CUDA_0,   CUDA_0  };
   m["cufftDeviceGetLTOIRs"]                               = {CUDA_131, CUDA_0,   CUDA_0  };
   m["cufftDeviceDestroy"]                                 = {CUDA_131, CUDA_0,   CUDA_0  };
+  m["cufftDeviceGetSemanticVersion"]                      = {CUDA_132, CUDA_0,   CUDA_0  };
 
   return m;
 }();


### PR DESCRIPTION
+ Updated the regenerated `hipify-perl` and `FFT` `CUDA2HIP` docs accordingly
