### PR TITLE
[HIPIFY][HIP][7.12][Meta][7.0.2.2][#2429][ROCM-20351][backport] `CU_DEVICE_ATTRIBUTE_DMA_BUF_SUPPORTED` support

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -8506,6 +8506,7 @@ sub simpleSubstitutions {
     subst("CU_DEVICE_ATTRIBUTE_COOPERATIVE_LAUNCH", "hipDeviceAttributeCooperativeLaunch", "numeric_literal");
     subst("CU_DEVICE_ATTRIBUTE_COOPERATIVE_MULTI_DEVICE_LAUNCH", "hipDeviceAttributeCooperativeMultiDeviceLaunch", "numeric_literal");
     subst("CU_DEVICE_ATTRIBUTE_DIRECT_MANAGED_MEM_ACCESS_FROM_HOST", "hipDeviceAttributeDirectManagedMemAccessFromHost", "numeric_literal");
+    subst("CU_DEVICE_ATTRIBUTE_DMA_BUF_SUPPORTED", "hipDeviceAttributeDmaBufSupported", "numeric_literal");
     subst("CU_DEVICE_ATTRIBUTE_ECC_ENABLED", "hipDeviceAttributeEccEnabled", "numeric_literal");
     subst("CU_DEVICE_ATTRIBUTE_GLOBAL_L1_CACHE_SUPPORTED", "hipDeviceAttributeGlobalL1CacheSupported", "numeric_literal");
     subst("CU_DEVICE_ATTRIBUTE_GLOBAL_MEMORY_BUS_WIDTH", "hipDeviceAttributeMemoryBusWidth", "numeric_literal");
@@ -12792,7 +12793,6 @@ sub warnRemovedFunctions {
     "CU_DEVICE_ATTRIBUTE_GPU_DIRECT_RDMA_SUPPORTED",
     "CU_DEVICE_ATTRIBUTE_GPU_DIRECT_RDMA_FLUSH_WRITES_OPTIONS",
     "CU_DEVICE_ATTRIBUTE_GENERIC_COMPRESSION_SUPPORTED",
-    "CU_DEVICE_ATTRIBUTE_DMA_BUF_SUPPORTED",
     "CU_DEVICE_ATTRIBUTE_DEFERRED_MAPPING_CUDA_ARRAY_SUPPORTED",
     "CU_DEVICE_ATTRIBUTE_D3D12_CIG_SUPPORTED",
     "CU_DEVICE_ATTRIBUTE_CLUSTER_LAUNCH",

--- a/docs/reference/tables/CUDA_Driver_API_functions_supported_by_HIP.md
+++ b/docs/reference/tables/CUDA_Driver_API_functions_supported_by_HIP.md
@@ -415,7 +415,7 @@
 |`CU_DEVICE_ATTRIBUTE_D3D12_CIG_SUPPORTED`|12.5| | | | | | | | | |
 |`CU_DEVICE_ATTRIBUTE_DEFERRED_MAPPING_CUDA_ARRAY_SUPPORTED`|11.6| | | | | | | | | |
 |`CU_DEVICE_ATTRIBUTE_DIRECT_MANAGED_MEM_ACCESS_FROM_HOST`|9.2| | | |`hipDeviceAttributeDirectManagedMemAccessFromHost`|3.10.0| | | | |
-|`CU_DEVICE_ATTRIBUTE_DMA_BUF_SUPPORTED`|11.7| | | | | | | | | |
+|`CU_DEVICE_ATTRIBUTE_DMA_BUF_SUPPORTED`|11.7| | | |`hipDeviceAttributeDmaBufSupported`|7.12.0| | | | | |
 |`CU_DEVICE_ATTRIBUTE_ECC_ENABLED`| | | | |`hipDeviceAttributeEccEnabled`|2.10.0| | | | |
 |`CU_DEVICE_ATTRIBUTE_GENERIC_COMPRESSION_SUPPORTED`|11.0| | | | | | | | | |
 |`CU_DEVICE_ATTRIBUTE_GLOBAL_L1_CACHE_SUPPORTED`| | | | |`hipDeviceAttributeGlobalL1CacheSupported`|4.3.0| | | | |

--- a/src/CUDA2HIP_Driver_API_types.cpp
+++ b/src/CUDA2HIP_Driver_API_types.cpp
@@ -994,7 +994,7 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_TYPE_NAME_MAP {
   // cudaDevAttrReserved123
   {"CU_DEVICE_ATTRIBUTE_CAN_USE_STREAM_WAIT_VALUE_NOR_V2",             {"hipDeviceAttributeCanUseStreamWaitValueNorV2",             "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED | CUDA_REMOVED}}, // 123
   // cudaDevAttrReserved124
-  {"CU_DEVICE_ATTRIBUTE_DMA_BUF_SUPPORTED",                            {"hipDeviceAttributeDmaBufSupported",                        "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED}}, // 124
+  {"CU_DEVICE_ATTRIBUTE_DMA_BUF_SUPPORTED",                            {"hipDeviceAttributeDmaBufSupported",                        "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES}}, // 124
   // cudaDevAttrIpcEventSupport
   {"CU_DEVICE_ATTRIBUTE_IPC_EVENT_SUPPORTED",                          {"hipDeviceAttributeIpcEventSupported",                      "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED}}, // 125
   // cudaDevAttrMemSyncDomainCount
@@ -4746,4 +4746,5 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_DRIVER_TYPE_NAME_VER_MAP {
   {"hipMemRangeHandleTypeMax",                                         {HIP_7000, HIP_0,    HIP_0,  HIP_LATEST}},
   {"hipMemRangeFlags",                                                 {HIP_7000, HIP_0,    HIP_0,  HIP_LATEST}},
   {"hipMemRangeFlagDmaBufMappingTypePcie",                             {HIP_7000, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipDeviceAttributeDmaBufSupported",                                {HIP_7120, HIP_0,    HIP_0   }},
 };

--- a/src/Statistics.cpp
+++ b/src/Statistics.cpp
@@ -656,6 +656,7 @@ std::string Statistics::getHipVersion(const hipVersions &ver) {
     case HIP_6030: return "6.3.0";
     case HIP_6040: return "6.4.0";
     case HIP_7000: return "7.0.0";
+    case HIP_7120: return "7.12.0";
   }
   return "";
 }

--- a/src/Statistics.h
+++ b/src/Statistics.h
@@ -406,6 +406,7 @@ enum hipVersions {
   HIP_6030 = 6030,
   HIP_6040 = 6040,
   HIP_7000 = 7000,
+  HIP_7120 = 7120,
   HIP_LATEST = HIP_7000,
 };
 

--- a/tests/unit_tests/synthetic/driver_enums.cu
+++ b/tests/unit_tests/synthetic/driver_enums.cu
@@ -1198,6 +1198,9 @@ int main() {
   CUmemRangeHandleType_enum MemRangeHandleType_enum;
   CUmemRangeHandleType MEM_RANGE_HANDLE_TYPE_DMA_BUF_FD = CU_MEM_RANGE_HANDLE_TYPE_DMA_BUF_FD;
   CUmemRangeHandleType MEM_RANGE_HANDLE_TYPE_MAX = CU_MEM_RANGE_HANDLE_TYPE_MAX;
+
+  // CHECK: hipDeviceAttribute_t DEVICE_ATTRIBUTE_DMA_BUF_SUPPORTED = hipDeviceAttributeDmaBufSupported;
+  CUdevice_attribute DEVICE_ATTRIBUTE_DMA_BUF_SUPPORTED = CU_DEVICE_ATTRIBUTE_DMA_BUF_SUPPORTED;
 #endif
 
 #if CUDA_VERSION >= 11080


### PR DESCRIPTION
+ Backport of #2429 (`theROC 7.12.0`) to `ROCm 7.0.2.2` Release intended only for `Meta`
+ Updated the corresponding tests, regenerated `hipify-perl`, and `Driver` `CUDA2HIP` docs accordingly for `ROCm 7.0.2.2`
+ Tested against `LLVM 20.1.8`
