### PR TITLE
[HIPIFY][test][fix] Fix the test `complex_kernel_launches.cu` failed on `CUDA < 9.2`

### DIFF
--- a/tests/unit_tests/kernel_launch/complex_kernel_launches.cu
+++ b/tests/unit_tests/kernel_launch/complex_kernel_launches.cu
@@ -27,8 +27,8 @@ void test_launches() {
     my_kernel<<<config.x == 1 ? 2 : 1, 256>>>(0);
 
     // 4. Address-of operator
-    // CHECK: hipLaunchKernelGGL(my_kernel, dim3(1), dim3(256), shared_mem, &stream, 0);
-    my_kernel<<<1, 256, shared_mem, &stream>>>(0);
+    // CHECK: hipLaunchKernelGGL(my_kernel, dim3(1), dim3(256), shared_mem, stream, 0);
+    my_kernel<<<1, 256, shared_mem, stream>>>(0);
 
     // 5. Std calls
     // CHECK: hipLaunchKernelGGL(my_kernel, dim3(1), dim3(std::max(config.x, config.y)), shared_mem, 0, std::min(config.x, config.y));


### PR DESCRIPTION
**[Synopsis]**
+ Previously, the memory address of the stream variable (`&stream` of type `cudaStream_t*`) was being passed instead of the stream handle itself (`stream` of type `cudaStream_t`).
+ While this code successfully compiles by `Clang` for `CUDA >= 9.2` due to relaxed type checking (implicit conversion of any pointer to `void*` in Clang’s `__cudaPushCallConfiguration` wrapper), it causes the driver to receive an invalid local memory address rather than a valid stream object, resulting in UR at RT.

**[Solution]**
+ The PR corrects a semantic error regarding the stream handle provided to the kernel execution configuration.
+ It resolves the type mismatch and ensures correct argument passing to the runtime across all CUDA versions (before 9.2 and starting from 9.2).
