### PR TITLE
[HIPIFY][docs] add doc for installing prebuilt packages

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -28,6 +28,10 @@ The documentation is structured as follows:
 .. grid:: 2
   :gutter: 3
 
+  .. grid-item-card:: Install
+
+    * :doc:`Install HIPIFY <./install>`
+
   .. grid-item-card:: Building
 
     * :doc:`Building hipify-clang on Linux <./building/build-hipify-clang-linux>`

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -76,6 +76,6 @@ Install a nightly build
 =======================
 
 The `TheRock <https://github.com/ROCm/TheRock>`__ build system also publishes
-nightly builds for the ROCm Core SDK and its components, including ROCm Systems
-Profiler. See `Nightly release status
+nightly builds for the ROCm Core SDK and its components, including HIPIFY
+tools. See `Nightly release status
 <https://github.com/ROCm/TheRock#nightly-release-status>`__ for details.

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -1,0 +1,81 @@
+.. meta::
+   :description: Installation instructions for HIPIFY
+   :keywords: hipify, hip, cuda, source, code, c++, cpp, rocm, translate, translator, transpile, compile, clang, cuda2hip
+
+.. _installation:
+
+**************
+Install HIPIFY
+**************
+
+Before you begin, verify that your system is supported. For more information,
+see :ref:`ROCm Core SDK components <rocm:release-components>`.
+
+For advanced workflows, source builds, or custom configurations, see
+:doc:`./building/build-hipify-clang-linux` or :doc:`./building/build-hipify-clang-windows`.
+
+.. _install-rocm:
+
+Install the ROCm Core SDK
+=========================
+
+HIPIFY is included with the ROCm Core SDK on Linux and Windows. For the most
+complete installation, we recommend that developers use the
+``amdrocm-core-sdk`` meta package.
+
+For instructions, see :doc:`Install AMD ROCm <rocm:install/rocm>`. Use the
+selector panel on that page to view instructions appropriate for your system
+environment.
+
+.. _install-base:
+
+Install the HIPIFY package on Linux
+===================================
+
+Alternatively, if you want to install HIPIFY without additional ROCm libraries
+and tools, install the ``amdrocm-hipify`` package.
+
+1. Complete the :doc:`ROCm installation prerequisites <rocm:install/rocm>` to
+   install dependencies and configure GPU access permissions.
+
+2. Install the HIPIFY package that matches your desired ROCm version.
+   Package names use the following format:
+
+   .. code-block:: shell-session
+
+      amdrocm-hipify<rocm_version>
+
+   ``<rocm_version>`` represents the ROCm Core SDK version to install. Omit
+   this suffix to install the latest available version.
+
+   For example:
+
+   .. tab-set::
+
+      .. tab-item:: Debian-based distros
+
+         .. code-block:: bash
+
+            sudo apt install amdrocm-hipify
+
+      .. tab-item:: RHEL-based distros
+
+         .. code-block:: bash
+
+            sudo dnf install amdrocm-hipify
+
+      .. tab-item:: SLES
+
+         .. code-block:: bash
+
+            sudo zypper install amdrocm-hipify
+
+.. _install-nightly:
+
+Install a nightly build
+=======================
+
+The `TheRock <https://github.com/ROCm/TheRock>`__ build system also publishes
+nightly builds for the ROCm Core SDK and its components, including ROCm Systems
+Profiler. See `Nightly release status
+<https://github.com/ROCm/TheRock#nightly-release-status>`__ for details.

--- a/docs/sphinx/_toc.yml.in
+++ b/docs/sphinx/_toc.yml.in
@@ -6,7 +6,8 @@ root: index
 subtrees:
 - caption: Install
   entries:
-  - file: Install HIPIFY
+  - file: install
+    title: Install HIPIFY
 - caption: Building
   entries:
   - file: building/build-hipify-clang-linux

--- a/docs/sphinx/_toc.yml.in
+++ b/docs/sphinx/_toc.yml.in
@@ -4,6 +4,9 @@ defaults:
   numbered: False
 root: index
 subtrees:
+- caption: Install
+  entries:
+  - file: Install HIPIFY
 - caption: Building
   entries:
   - file: building/build-hipify-clang-linux


### PR DESCRIPTION
## Motivation

Update instructions to install prebuilt packages. Generally, point to ROCm Core SDK install instructions. List a more granular package if useful to users.

Preview: https://advanced-micro-devices-demo--2550.com.readthedocs.build/projects/HIPIFY/en/2550/install.html

## Technical Details

>[!NOTE]
>Some links appear as plain text in the preview b/c the target page isn't publicly accessible yet.

Related to:
  - [x] amdsmi https://github.com/ROCm/rocm-systems/pull/6032
  - [x] hip https://github.com/ROCm/rocm-systems/pull/6037
  - [x] hipify https://github.com/ROCm/HIPIFY/pull/2550
  - [x] rccl https://github.com/ROCm/rocm-systems/pull/6040
  - [x] rdc https://github.com/ROCm/rocm-systems/pull/6041
  - [x] rocdbgapi https://github.com/ROCm/ROCdbgapi-docs/pull/113
  - [x] rocgdb https://github.com/ROCm/ROCgdb-docs/pull/141
  - [x] rocdecode https://github.com/ROCm/rocm-systems/pull/6045
  - [x] rocjpeg https://github.com/ROCm/rocm-systems/pull/6042
  - [x] rocminfo https://github.com/ROCm/rocm-systems/pull/6033
  - [x] rocprofiler-compute https://github.com/ROCm/rocm-systems/pull/6036
  - [x] rocprofiler-sdk https://github.com/ROCm/rocm-systems/pull/6034
  - [x] rocprofiler-systems https://github.com/ROCm/rocm-systems/pull/6035
  - [x] rocr-debug-agent https://github.com/ROCm/rocm-systems/pull/6038
  - [x] rocshmem https://github.com/ROCm/rocm-systems/pull/6039

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->
n / a

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
