### PR TITLE
[HIPIFY][doc] `LLVM 22.1.6` is the latest stable supported version

### DIFF
--- a/docs/building/build-hipify-clang-linux.rst
+++ b/docs/building/build-hipify-clang-linux.rst
@@ -134,7 +134,7 @@ Linux testing
 
 On Linux, the following configurations are tested:
 
-* Ubuntu 22-24: LLVM 13.0.0 - 22.1.5, CUDA 7.0 - 12.9.1, cuDNN 8.0.5 - 9.21.1, cuTensor 1.0.1.0 - 2.6.0.0
+* Ubuntu 22-24: LLVM 13.0.0 - 22.1.6, CUDA 7.0 - 12.9.1, cuDNN 8.0.5 - 9.21.1, cuTensor 1.0.1.0 - 2.6.0.0
 * Ubuntu 20-21: LLVM 9.0.0 - 20.1.8, CUDA 7.0 - 12.8.1, cuDNN 5.1.10 - 9.21.1, cuTensor 1.0.1.0 - 2.6.0.0
 * Ubuntu 16-19: LLVM 8.0.0 - 14.0.6, CUDA 7.0 - 10.2, cuDNN 5.1.10 - 8.0.5
 * Ubuntu 14: LLVM 4.0.0 - 7.1.0, CUDA 7.0 - 9.0, cuDNN 5.0.5 - 7.6.5
@@ -164,7 +164,7 @@ Here's how to build ``hipify-clang`` with testing support on ``Ubuntu 24.04.02``
     -DLLVM_EXTERNAL_LIT=$ROOT_DIR/build/bin/llvm-lit \
     ../hipify
 
-The corresponding successful output is (assuming ROOT_DIR is ``/usr/llvm/22.1.5``):
+The corresponding successful output is (assuming ROOT_DIR is ``/usr/llvm/22.1.6``):
 
 .. code-block:: shell
 
@@ -186,11 +186,11 @@ The corresponding successful output is (assuming ROOT_DIR is ``/usr/llvm/22.1.5`
   --    - Is part of HIP SDK    : OFF
   --    - Install clang headers : ON
   -- Found ZLIB: /usr/lib/x86_64-linux-gnu/libz.so (found version "1.3")
-  -- Found LLVM 22.1.5:
-  --    - CMake module path     : /usr/llvm/22.1.5/dist/lib/cmake/llvm
-  --    - Clang include path    : /usr/llvm/22.1.5/dist/include
-  --    - LLVM Include path     : /usr/llvm/22.1.5/dist/include
-  --    - Binary path           : /usr/llvm/22.1.5/dist/bin
+  -- Found LLVM 22.1.6:
+  --    - CMake module path     : /usr/llvm/22.1.6/dist/lib/cmake/llvm
+  --    - Clang include path    : /usr/llvm/22.1.6/dist/include
+  --    - LLVM Include path     : /usr/llvm/22.1.6/dist/include
+  --    - Binary path           : /usr/llvm/22.1.6/dist/bin
   -- Linker detection: GNU ld
   -- ---- The below configuring for hipify-clang testing only ----
   -- Found Python: /usr/bin/python3.14 (found suitable version "3.14.5", required range is "3.0...3.15") found components: Interpreter
@@ -227,7 +227,7 @@ The corresponding successful output is:
   Running HIPify regression tests
   ===============================================================
   CUDA 12.9.86 - will be used for testing
-  LLVM 22.1.5 - will be used for testing
+  LLVM 22.1.6 - will be used for testing
   x86_64 - Platform architecture
   Linux 6.5.0-15-generic - Platform OS
   64 - hipify-clang binary bitness

--- a/docs/building/build-hipify-clang-windows.rst
+++ b/docs/building/build-hipify-clang-windows.rst
@@ -258,7 +258,7 @@ Tested configurations:
     - ``2019.16.11.56, 2022.17.14.32, 2026.18.6.0``
     - ``4.3.2``
     - ``3.14.5``
-  * - ``21.1.0 - 22.1.5``
+  * - ``21.1.0 - 22.1.6``
     - ``7.0 - 12.9.1``
     - ``8.0.5  - 9.21.1``
     - ``2019.16.11.56, 2022.17.14.32, 2026.18.6.0``
@@ -296,7 +296,7 @@ Building with testing support using ``Visual Studio 18 2026`` on ``Windows 11``:
     -DLLVM_EXTERNAL_LIT=%ROOT_DIR%\build\Release\bin\llvm-lit.py \
     ..\hipify
 
-The corresponding successful output is (assuming %ROOT_DIR% is ``D:\LLVM\22.1.5``):
+The corresponding successful output is (assuming %ROOT_DIR% is ``D:\LLVM\22.1.6``):
 
 .. code-block:: shell
 
@@ -318,17 +318,17 @@ The corresponding successful output is (assuming %ROOT_DIR% is ``D:\LLVM\22.1.5`
     --    - Test hipify-clang     : ON
     --    - Is part of HIP SDK    : OFF
     --    - Install clang headers : ON
-    -- Found LLVM 22.1.5:
-    --    - CMake module path     : D:\LLVM\22.1.5\dist\lib\cmake\llvm
-    --    - Clang include path    : D:\LLVM\22.1.5\dist\include
-    --    - LLVM Include path     : D:\LLVM\22.1.5\dist\include
-    --    - Binary path           : D:\LLVM\22.1.5\dist\bin
+    -- Found LLVM 22.1.6:
+    --    - CMake module path     : D:\LLVM\22.1.6\dist\lib\cmake\llvm
+    --    - Clang include path    : D:\LLVM\22.1.6\dist\include
+    --    - LLVM Include path     : D:\LLVM\22.1.6\dist\include
+    --    - Binary path           : D:\LLVM\22.1.6\dist\bin
     -- Performing Test LLVM_LINKER_SUPPORTS_B_SYMBOLIC_FUNCTIONS
     -- Performing Test LLVM_LINKER_SUPPORTS_B_SYMBOLIC_FUNCTIONS - Failed
     -- ---- The below configuring for hipify-clang testing only ----
     -- Found Python: C:\Users\TT\AppData\Local\Programs\Python\Python314\python.exe (found suitable version "3.14.5", required range is "3.0...3.15") found components: Interpreter
     -- Found lit: C:\Users\TT\AppData\Local\Programs\Python\Python314\Scripts\lit.exe
-    -- Found FileCheck: D:\LLVM\22.1.5\dist\bin\FileCheck.exe
+    -- Found FileCheck: D:\LLVM\22.1.6\dist\bin\FileCheck.exe
     -- Initial CUDA to configure:
     --    - CUDA Toolkit path     : C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.9
     --    - CUDA Samples path     : C:\ProgramData\NVIDIA Corporation\CUDA Samples\v12.9

--- a/docs/how-to/hipify-clang.rst
+++ b/docs/how-to/hipify-clang.rst
@@ -42,7 +42,7 @@ Release Dependencies
 
 * `LLVM+Clang <http://releases.llvm.org>`_ version is determined at least partially by
   the CUDA version you are using, as shown in the table below. The recommended Clang release
-  is the latest stable release `22.1.5 <https://github.com/llvm/llvm-project/releases/tag/llvmorg-22.1.5>`_,
+  is the latest stable release `22.1.6 <https://github.com/llvm/llvm-project/releases/tag/llvmorg-22.1.6>`_,
   or at least version `4.0.0 <http://releases.llvm.org/download.html#4.0.0>`_.
 
 .. list-table::
@@ -66,7 +66,8 @@ Release Dependencies
       `22.1.2 <https://github.com/llvm/llvm-project/releases/tag/llvmorg-22.1.2>`_,
       `22.1.3 <https://github.com/llvm/llvm-project/releases/tag/llvmorg-22.1.3>`_,
       `22.1.4 <https://github.com/llvm/llvm-project/releases/tag/llvmorg-22.1.4>`_,
-      `22.1.5 <https://github.com/llvm/llvm-project/releases/tag/llvmorg-22.1.5>`_:sup:`1`
+      `22.1.5 <https://github.com/llvm/llvm-project/releases/tag/llvmorg-22.1.5>`_,
+      `22.1.6 <https://github.com/llvm/llvm-project/releases/tag/llvmorg-22.1.6>`_:sup:`1`
     - ✅
     - ✅
   * - `12.8.1 <https://developer.nvidia.com/cuda-12-8-1-download-archive>`_
@@ -266,7 +267,7 @@ Release Dependencies
 In most cases, you can get a suitable version of ``LLVM+Clang`` with your package manager. However, you can also
 `download a release archive <http://releases.llvm.org/>`_ and build or install it. In case of multiple versions of ``LLVM`` installed, set
 `CMAKE_PREFIX_PATH <https://cmake.org/cmake/help/latest/variable/CMAKE_PREFIX_PATH.html>`_ so that
-``CMake`` can find the desired version of ``LLVM``. For example, ``-DCMAKE_PREFIX_PATH=D:\LLVM\22.1.5\dist``.
+``CMake`` can find the desired version of ``LLVM``. For example, ``-DCMAKE_PREFIX_PATH=D:\LLVM\22.1.6\dist``.
 
 Usage
 =====
@@ -302,7 +303,7 @@ header files used during the hipification process:
 
 .. code:: shell
 
-  ./hipify-clang square.cu --cuda-path=/usr/local/cuda-12.9 --clang-resource-directory=/usr/llvm/22.1.5/dist/lib/clang/22
+  ./hipify-clang square.cu --cuda-path=/usr/local/cuda-12.9 --clang-resource-directory=/usr/llvm/22.1.6/dist/lib/clang/22
 
 For more information, refer to the `Clang manual for compiling CUDA <https://llvm.org/docs/CompileCudaWithLLVM.html#compiling-cuda-code>`_.
 


### PR DESCRIPTION
+ No patches are needed
+ Updated the documentation accordingly
+ Tested on `Windows 11` (latest `VS 2019`, `VS 2022`, and `VS 2026`)  and `Ubuntu 24.04.2` (`GNU C/C++ 13.3`)
