### PR TITLE
[HIPIFY][build][cmake] Support for Python `3.15.x`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -281,7 +281,7 @@ if(HIPIFY_CLANG_TESTS OR HIPIFY_CLANG_TESTS_ONLY)
   if(${CMAKE_VERSION} VERSION_LESS "3.27.0")
     find_package(PythonInterp 3.0 REQUIRED)
   else()
-    find_package(Python 3.0...3.15 REQUIRED)
+    find_package(Python 3.0...3.16 REQUIRED)
   endif()
 
   function (require_program PROGRAM_NAME)


### PR DESCRIPTION
+ Since `Python 3.15 beta` is available, I have tested HIPIFY against it
+ HIPIFY lit testing works fine with `Python 3.15 beta`
