### PR TITLE
[HIPIFY][#2584][fix] Fix failed `CUB` tests

### DIFF
--- a/tests/lit.cfg
+++ b/tests/lit.cfg
@@ -205,6 +205,13 @@ if config.cuda_version_major < 13:
 if config.llvm_version_major < 8:
     config.excludes.append('cd_intro.cu')
     config.excludes.append('cd_intro_before_13000.cu')
+    config.excludes.append('cub_01_LLVM_8.cu')
+    config.excludes.append('cub_02_LLVM_8.cu')
+    config.excludes.append('cub_03_LLVM_8.cu')
+else:
+    config.excludes.append('cub_01.cu')
+    config.excludes.append('cub_02.cu')
+    config.excludes.append('cub_03.cu')
 
 if config.llvm_version_major < 10:
     config.excludes.append('pp_if_else_conditionals_LLVM_10.cu')

--- a/tests/unit_tests/libraries/CUB/cub_01_LLVM_8.cu
+++ b/tests/unit_tests/libraries/CUB/cub_01_LLVM_8.cu
@@ -1,0 +1,61 @@
+// RUN: %run_test hipify "%s" "%t" %hipify_args 1 --hip-kernel-execution-syntax %clang_args -fgpu-rdc
+// CHECK: #include <hip/hip_runtime.h>
+#include <iostream>
+// CHECK: #include <hiprand/hiprand.h>
+#include <curand.h>
+#define THRUST_NS_QUALIFIER ::thrust
+// CHECK: #include <hipcub/hipcub.hpp>
+#include <cub/cub.cuh>
+
+#include <iostream>
+
+// TODO:
+// using namespace cub;
+
+template <typename T>
+__global__ void sort(const T* data_in, T* data_out){
+     // CHECK: typedef ::hipcub::BlockRadixSort<T, 1024, 4> BlockRadixSortT;
+     typedef ::cub::BlockRadixSort<T, 1024, 4> BlockRadixSortT;
+    __shared__ typename BlockRadixSortT::TempStorage tmp_sort;
+    double items[4];
+    int i0 = 4 * (blockIdx.x * blockDim.x + threadIdx.x);
+    for (int i = 0; i < 4; ++i){
+        items[i] = data_in[i0 + i];
+    }
+    BlockRadixSortT(tmp_sort).Sort(items);
+    for (int i = 0; i < 4; ++i){
+        data_out[i0 + i] = items[i];
+    }
+}
+
+int main(){
+    double* d_gpu = NULL;
+    double* result_gpu = NULL;
+    double* data_sorted = new double[4096];
+    // Allocate memory on the GPU
+    // CHECK: hipMalloc(&d_gpu, 4096 * sizeof(double));
+    cudaMalloc(&d_gpu, 4096 * sizeof(double));
+    // CHECK: hipMalloc(&result_gpu, 4096 * sizeof(double));
+    cudaMalloc(&result_gpu, 4096 * sizeof(double));
+    // CHECK: hiprandGenerator_t gen;
+    curandGenerator_t gen;
+    // Create generator
+    // CHECK: hiprandCreateGenerator(&gen, HIPRAND_RNG_PSEUDO_DEFAULT);
+    curandCreateGenerator(&gen, CURAND_RNG_PSEUDO_DEFAULT);
+    // Fill array with random numbers
+    // CHECK: hiprandGenerateNormalDouble(gen, d_gpu, 4096, 0.0, 1.0);
+    curandGenerateNormalDouble(gen, d_gpu, 4096, 0.0, 1.0);
+    // Destroy generator
+    // CHECK: hiprandDestroyGenerator(gen);
+    curandDestroyGenerator(gen);
+    // Sort data
+    // CHECK: hipLaunchKernelGGL(HIP_KERNEL_NAME(sort), dim3(1), dim3(1024), 0, 0, d_gpu, result_gpu);
+    sort<<<1, 1024>>>(d_gpu, result_gpu);
+    // CHECK: hipMemcpy(data_sorted, result_gpu, 4096 * sizeof(double), hipMemcpyDeviceToHost);
+    cudaMemcpy(data_sorted, result_gpu, 4096 * sizeof(double), cudaMemcpyDeviceToHost);
+    // Write the sorted data to standard out
+    for (int i = 0; i < 4096; ++i){
+        std::cout << data_sorted[i] << ", ";
+    }
+    std::cout << std::endl;
+}

--- a/tests/unit_tests/libraries/CUB/cub_02_LLVM_8.cu
+++ b/tests/unit_tests/libraries/CUB/cub_02_LLVM_8.cu
@@ -1,0 +1,70 @@
+// RUN: %run_test hipify "%s" "%t" %hipify_args 1 --hip-kernel-execution-syntax %clang_args -fgpu-rdc
+// CHECK: #include <hip/hip_runtime.h>
+#include <iostream>
+// CHECK: #include <hiprand/hiprand.h>
+#include <curand.h>
+#define THRUST_NS_QUALIFIER ::thrust
+// CHECK: #include <hipcub/hipcub.hpp>
+#include <cub/cub.cuh>
+
+#include <iostream>
+
+template <int BLOCK_WIDTH, int ITEMS_PER_THREAD,
+          // CHECK: hipcub::BlockLoadAlgorithm BLOCK_LOAD_ALGO,
+          cub::BlockLoadAlgorithm BLOCK_LOAD_ALGO,
+          // CHECK: hipcub::BlockStoreAlgorithm BLOCK_STORE_ALGO,
+          cub::BlockStoreAlgorithm BLOCK_STORE_ALGO,
+          typename T>
+__global__ void sort(const T* data_in, T* data_out){
+    // CHECK: typedef hipcub::BlockLoad<T, BLOCK_WIDTH, ITEMS_PER_THREAD, BLOCK_LOAD_ALGO> BlockLoadT;
+    typedef cub::BlockLoad<T, BLOCK_WIDTH, ITEMS_PER_THREAD, BLOCK_LOAD_ALGO> BlockLoadT;
+    // CHECK: typedef hipcub::BlockRadixSort<T, BLOCK_WIDTH, ITEMS_PER_THREAD> BlockRadixSortT;
+    typedef cub::BlockRadixSort<T, BLOCK_WIDTH, ITEMS_PER_THREAD> BlockRadixSortT;
+    // CHECK: typedef hipcub::BlockStore<T, BLOCK_WIDTH, ITEMS_PER_THREAD, BLOCK_STORE_ALGO> BlockStoreT;
+    typedef cub::BlockStore<T, BLOCK_WIDTH, ITEMS_PER_THREAD, BLOCK_STORE_ALGO> BlockStoreT;
+    __shared__ union {
+        typename BlockLoadT::TempStorage load;
+        typename BlockRadixSortT::TempStorage sort;
+        typename BlockStoreT::TempStorage store;
+    } tmp_storage;
+    T items[ITEMS_PER_THREAD];
+    BlockLoadT(tmp_storage.load).Load(data_in + blockIdx.x * BLOCK_WIDTH * ITEMS_PER_THREAD, items);
+    __syncthreads();
+    BlockRadixSortT(tmp_storage.sort).Sort(items);
+    __syncthreads();
+    BlockStoreT(tmp_storage.store).Store(data_out + blockIdx.x * BLOCK_WIDTH * ITEMS_PER_THREAD, items);
+}
+
+int main() {
+    double* d_gpu = NULL;
+    double* result_gpu = NULL;
+    double* data_sorted = new double[1000*4096];
+    // Allocate memory on the GPU
+    // CHECK: hipMalloc(&d_gpu, 1000*4096 * sizeof(double));
+    cudaMalloc(&d_gpu, 1000*4096 * sizeof(double));
+    // CHECK: hipMalloc(&result_gpu, 1000*4096 * sizeof(double));
+    cudaMalloc(&result_gpu, 1000*4096 * sizeof(double));
+    // CHECK: hiprandGenerator_t gen;
+    curandGenerator_t gen;
+    // Create generator
+    // CHECK: hiprandCreateGenerator(&gen, HIPRAND_RNG_PSEUDO_DEFAULT);
+    curandCreateGenerator(&gen, CURAND_RNG_PSEUDO_DEFAULT);
+    // Fill array with random numbers
+    // CHECK: hiprandGenerateNormalDouble(gen, d_gpu, 1000*4096, 0.0, 1.0);
+    curandGenerateNormalDouble(gen, d_gpu, 1000*4096, 0.0, 1.0);
+    // Destroy generator
+    // CHECK: hiprandDestroyGenerator(gen);
+    curandDestroyGenerator(gen);
+    // Sort data
+    // CHECK: hipLaunchKernelGGL(HIP_KERNEL_NAME(sort<512, 8, hipcub::BLOCK_LOAD_TRANSPOSE, hipcub::BLOCK_STORE_TRANSPOSE>), dim3(1000), dim3(512), 0, 0, d_gpu, result_gpu);
+    sort<512, 8, cub::BLOCK_LOAD_TRANSPOSE, cub::BLOCK_STORE_TRANSPOSE><<<1000, 512>>>(d_gpu, result_gpu);
+    // CHECK: hipLaunchKernelGGL(HIP_KERNEL_NAME(sort<256, 16, hipcub::BLOCK_LOAD_DIRECT, hipcub::BLOCK_STORE_DIRECT>), dim3(1000), dim3(256), 0, 0, d_gpu, result_gpu);
+    sort<256, 16, cub::BLOCK_LOAD_DIRECT, cub::BLOCK_STORE_DIRECT><<<1000, 256>>>(d_gpu, result_gpu);
+    // CHECK: hipMemcpy(data_sorted, result_gpu, 1000*4096*sizeof(double), hipMemcpyDeviceToHost);
+    cudaMemcpy(data_sorted, result_gpu, 1000*4096*sizeof(double), cudaMemcpyDeviceToHost);
+    // Write the sorted data to standard out
+    for (int i = 0; i < 4095; ++i) {
+        std::cout << data_sorted[i] << ", ";
+    }
+    std::cout << data_sorted[4095] << std::endl;
+}

--- a/tests/unit_tests/libraries/CUB/cub_03_LLVM_8.cu
+++ b/tests/unit_tests/libraries/CUB/cub_03_LLVM_8.cu
@@ -1,0 +1,34 @@
+// RUN: %run_test hipify "%s" "%t" %hipify_args %clang_args -fgpu-rdc
+// CHECK: #include <hip/hip_runtime.h>
+#include <iostream>
+#define THRUST_NS_QUALIFIER ::thrust
+// CHECK: #include <hipcub/hipcub.hpp>
+#include <cub/cub.cuh>
+
+// using namespace hipcub;
+using namespace cub;
+
+// Simple CUDA kernel for computing tiled partial sums
+template <int BLOCK_THREADS, int ITEMS_PER_THREAD,
+          // CHECK: hipcub::BlockLoadAlgorithm LOAD_ALGO,
+          cub::BlockLoadAlgorithm LOAD_ALGO,
+          // CHECK: hipcub::BlockScanAlgorithm SCAN_ALGO>
+          cub::BlockScanAlgorithm SCAN_ALGO>
+__global__ void ScanTilesKernel(int *d_in, int *d_out) {
+  // Specialize collective types for problem context
+  // CHECK: typedef ::hipcub::BlockLoad<int*, BLOCK_THREADS, ITEMS_PER_THREAD, LOAD_ALGO> BlockLoadT;
+  typedef ::cub::BlockLoad<int*, BLOCK_THREADS, ITEMS_PER_THREAD, LOAD_ALGO> BlockLoadT;
+  typedef BlockScan<int, BLOCK_THREADS, SCAN_ALGO> BlockScanT;
+  // Allocate on-chip temporary storage
+  __shared__ union {
+    typename BlockLoadT::TempStorage load;
+    typename BlockScanT::TempStorage reduce;
+  } temp_storage;
+  // Load data per thread
+  int thread_data[ITEMS_PER_THREAD];
+  int offset = blockIdx.x * (BLOCK_THREADS * ITEMS_PER_THREAD);
+  BlockLoadT(temp_storage.load).Load(d_in + offset, offset);
+  __syncthreads();
+  // Compute the block-wide prefix sum
+  BlockScanT(temp_storage).Sum(thread_data);
+}


### PR DESCRIPTION
**[Root Cause]**
```cpp
kernel launch from __device__ or __global__ function requires relocatable device code (i.e. requires -fgpu-rdc)
```
**[Solution]**
+ Provide two versions of `CUB` tests: with and without clang option `-fgpu-rdc`
+ [Reason] The `-fgpu-rdc` option was officially introduced in clang `8.0.0`
