### PR TITLE
[HIPIFY][fix][LCOMP-2369] Exclude standalone-CUB tests on CUDA >= 12.6 (fixes cstdint.h build failure)

### DIFF
--- a/tests/lit.cfg
+++ b/tests/lit.cfg
@@ -43,17 +43,24 @@ else:
     if config.cudnn_version_major >= 9:
         config.excludes.append('cudnn2miopen_before_9000.cu')
 
+# cub_0N.cu run on LLVM < 8; cub_0N_LLVM_8.cu run on LLVM >= 8.
+cub_tests_pre_llvm8 = ['cub_01.cu', 'cub_02.cu', 'cub_03.cu']
+cub_tests_llvm8 = ['cub_01_LLVM_8.cu', 'cub_02_LLVM_8.cu', 'cub_03_LLVM_8.cu']
+cub_tests = cub_tests_pre_llvm8 + cub_tests_llvm8
+
+# Single entry point so every disable-guard excludes both variants.
+def exclude_all_cub_tests():
+    config.excludes.extend(cub_tests)
+
 if not config.cuda_cub_root or config.cuda_cub_root == "OFF":
-    config.excludes.append('cub_01.cu')
-    config.excludes.append('cub_02.cu')
-    config.excludes.append('cub_03.cu')
+    exclude_all_cub_tests()
     print("WARN: CUB tests are excluded because CUDA_CUB_ROOT_DIR is not specified")
     warns = True
 else:
+    # On CUDA >= 12.6 the standalone CUB (CUDA_CUB_ROOT_DIR)
+    # pulls in <thrust/detail/cstdint.h>, removed from CCCL in 12.6. Exclude for now.
     if config.cuda_version_major == 12 and config.cuda_version_minor >= 6:
-        config.excludes.append('cub_01.cu')
-        config.excludes.append('cub_02.cu')
-        config.excludes.append('cub_03.cu')
+        exclude_all_cub_tests()
 
 if not config.cuda_tensor_root or config.cuda_tensor_root == "OFF":
     config.excludes.append('cutensor2hiptensor.cu')
@@ -95,9 +102,7 @@ if config.cuda_version_major < 9:
     config.excludes.append('benchmark_curand_kernel.cpp')
     config.excludes.append('reinterpret_cast.cu')
     config.excludes.append('half2_allocators.cu')
-    config.excludes.append('cub_01.cu')
-    config.excludes.append('cub_02.cu')
-    config.excludes.append('cub_03.cu')
+    exclude_all_cub_tests()
     config.excludes.append('runtime_functions_9000.cu')
 
 if config.cuda_version_major < 9 or (config.cuda_version_major == 9 and config.cuda_version_minor < 2):
@@ -205,13 +210,9 @@ if config.cuda_version_major < 13:
 if config.llvm_version_major < 8:
     config.excludes.append('cd_intro.cu')
     config.excludes.append('cd_intro_before_13000.cu')
-    config.excludes.append('cub_01_LLVM_8.cu')
-    config.excludes.append('cub_02_LLVM_8.cu')
-    config.excludes.append('cub_03_LLVM_8.cu')
+    config.excludes.extend(cub_tests_llvm8)
 else:
-    config.excludes.append('cub_01.cu')
-    config.excludes.append('cub_02.cu')
-    config.excludes.append('cub_03.cu')
+    config.excludes.extend(cub_tests_pre_llvm8)
 
 if config.llvm_version_major < 10:
     config.excludes.append('pp_if_else_conditionals_LLVM_10.cu')


### PR DESCRIPTION

These tests force a **standalone CUB** include path. From CCCL >= 12.6 (CUDA >= 12.6), `thrust/detail/cstdint.h` was removed, so standalone CUB include will breaks. This is a dependency-version mismatch between standalone CUB and latest CUDA versions not a clang parsing limitation. It reproduces on any CUDA >= 12.6 regardless of the LLVM/clang version.

Extend the existing CUB exclusion guard to also cover the newer `cub_*_LLVM_8.cu` variants when CUDA >= 12.6, alongside the pre-existing gates for CUDA < 9 and `CUDA_CUB_ROOT_DIR=OFF`.

Tested on **CUDA 12.8.93 / LLVM 20.1.8**:

## Follow-up (separate)
A longer-term fix is to correct include ordering (e.g. `-idirafter`) so the CCCL-bundled CUB takes precedence rather than excluding the tests. That changes header resolution globally, so it should be validated across the full CUDA x LLVM matrix and restore CUB coverage on CUDA >= 12.6 before landing. Will create a separate issue to track.