### PR TITLE
[HIPIFY][#2563][SPARSELt][fix] Adds missing `cuSPARSELt` API name

### DIFF
--- a/src/Statistics.cpp
+++ b/src/Statistics.cpp
@@ -161,6 +161,7 @@ const char *apiNames[NUM_API_TYPES] = {
   "RTC API",
   "TENSOR API",
   "cuFile API",
+  "cuSPARSELt API"
 };
 
 const char *apiTypes[NUM_API_TYPES] = {
@@ -171,9 +172,9 @@ const char *apiTypes[NUM_API_TYPES] = {
   "API_RAND",
   "API_DNN",
   "API_FFT",
-  "API_CUB",
   "API_SPARSE",
   "API_SOLVER",
+  "API_CUB",
   "API_RTC",
   "API_TENSOR",
   "API_FILE",


### PR DESCRIPTION
## Summary

- Fixes a crash in `hipify-clang` while printing statistics for any file containing `cuSPARSELt` references. `unit_tests/synthetic/libraries/cusparselt2hipsparselt.cu` test.
- Reorders `apiTypes[]` so `API_CUB` follows `API_SPARSE/API_SOLVER` to match the enum

## Root cause
When a file with `cuSPARSELt` symbols is processed, `StatCounter::print()` calls `printStat()`, which constructs a `std::string` from `nullptr` and throws: 

```c++
# | terminate called after throwing an instance of 'std::logic_error'
# |   what():  basic_string: construction from null is not valid
# |  #0 0x000057e75c710122 llvm::sys::PrintStackTrace(llvm::raw_ostream&, int) 
# |  #1 0x000057e75c70d5e6 SignalHandler(int) Signals.cpp:0:0
# |  #2 0x0000793113a45330 (/lib/x86_64-linux-gnu/libc.so.6+0x45330)
# |  #3 0x0000793113a9eb2c __pthread_kill_implementation ./nptl/pthread_kill.c:44:76
# |  #4 0x0000793113a9eb2c __pthread_kill_internal ./nptl/pthread_kill.c:78:10
# |  #5 0x0000793113a9eb2c pthread_kill ./nptl/pthread_kill.c:89:10
# |  #6 0x0000793113a4527e raise ./signal/../sysdeps/posix/raise.c:27:6
# |  #7 0x0000793113a288ff abort ./stdlib/abort.c:81:7
# |  #8 0x0000793113ea5ff5 (/lib/x86_64-linux-gnu/libstdc++.so.6+0xa5ff5)
# |  #9 0x0000793113ebb0da (/lib/x86_64-linux-gnu/libstdc++.so.6+0xbb0da)
# | #10 0x0000793113ea5a55 std::unexpected() (/lib/x86_64-linux-gnu/libstdc++.so.6+0xa5a55)
# | #11 0x0000793113ebb391 (/lib/x86_64-linux-gnu/libstdc++.so.6+0xbb391)
# | #12 0x0000793113ea91c1 std::__throw_logic_error(char const*) (/lib/x86_64-linux-gnu/libstdc++.so.6+0xa91c1)
# | #13 0x000057e75c677e01 StatCounter::print(std::ostream*, llvm::raw_ostream*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&) 
# | #14 0x000057e75c67935d Statistics::print(std::ostream*, llvm::raw_ostream*, bool)``` 