### PR TITLE
[HIPIFY][#2563][SPARSELt][tests][fix] Fixed `cusparselt2hipsparselt` testing

### DIFF
--- a/tests/lit.cfg
+++ b/tests/lit.cfg
@@ -125,6 +125,12 @@ if config.cuda_version_major < 10:
 if config.cuda_version_major < 10 or (config.cuda_version_major == 10 and config.cuda_version_minor < 1):
     config.excludes.append('cusparse2rocsparse_10010.cu')
 
+if config.cuda_version_major < 10 or (config.cuda_version_major == 10 and config.cuda_version_minor < 2):
+    config.excludes.append('cusparselt2hipsparselt.cu')
+
+if config.cuda_version_major < 11 and sys.platform in ['win32']:
+    config.excludes.append('cusparselt2hipsparselt.cu')
+
 if config.cuda_version_major < 10 or (config.cuda_version_major == 10 and config.cuda_version_minor < 1) or config.cuda_version_major >= 12:
     config.excludes.append('cusparse2rocsparse_10010_12000.cu')
 


### PR DESCRIPTION
+ Do not run `cusparselt2hipsparselt` for `CUDA < 10.2` on Linux and `CUDA < 11.0` on Windows
+ [Reason] `cusparselt2hipsparselt` uses `cuSPARSE` starting from the abovementioned CUDA versions
