### PR TITLE
[HIPIFY][fix] Quote find output safely in bin wrapper scripts

### DIFF
--- a/bin/findcode.sh
+++ b/bin/findcode.sh
@@ -1,10 +1,16 @@
 #!/bin/bash
 
-SEARCH_DIRS=$@
+# Outputs matched CUDA/HIP source and header files, NUL-delimited.
 
-find $SEARCH_DIRS -name '*.cu' -o -name '*.CU'
-find $SEARCH_DIRS -name '*.cpp' -o -name '*.cxx' -o -name '*.c' -o -name '*.cc'
-find $SEARCH_DIRS -name '*.CPP' -o -name '*.CXX' -o -name '*.C' -o -name '*.CC'
-find $SEARCH_DIRS -name '*.cuh' -o -name '*.CUH'
-find $SEARCH_DIRS -name '*.h' -o -name '*.hpp' -o -name '*.hh' -o -name '*.inc' -o -name '*.inl' -o -name '*.hxx' -o -name '*.hdl'
-find $SEARCH_DIRS -name '*.H' -o -name '*.HPP' -o -name '*.HH' -o -name '*.INC' -o -name '*.INL' -o -name '*.HXX' -o -name '*.HDL'
+if [ "$#" -eq 0 ]; then
+  exit 0
+fi
+
+find "$@" \( \
+  -name '*.cu' -o -name '*.CU' -o \
+  -name '*.cpp' -o -name '*.cxx' -o -name '*.c' -o -name '*.cc' -o \
+  -name '*.CPP' -o -name '*.CXX' -o -name '*.C' -o -name '*.CC' -o \
+  -name '*.cuh' -o -name '*.CUH' -o \
+  -name '*.h' -o -name '*.hpp' -o -name '*.hh' -o -name '*.inc' -o -name '*.inl' -o -name '*.hxx' -o -name '*.hdl' -o \
+  -name '*.H' -o -name '*.HPP' -o -name '*.HH' -o -name '*.INC' -o -name '*.INL' -o -name '*.HXX' -o -name '*.HDL' \
+\) -print0

--- a/bin/findcode.sh
+++ b/bin/findcode.sh
@@ -2,15 +2,13 @@
 
 # Outputs matched CUDA/HIP source and header files, NUL-delimited.
 
-if [ "$#" -eq 0 ]; then
-  exit 0
+if [ "$#" -eq 0 ] || { [ "$#" -eq 1 ] && [ -z "$1" ]; }; then
+  set -- .
 fi
 
-find "$@" \( \
-  -name '*.cu' -o -name '*.CU' -o \
-  -name '*.cpp' -o -name '*.cxx' -o -name '*.c' -o -name '*.cc' -o \
-  -name '*.CPP' -o -name '*.CXX' -o -name '*.C' -o -name '*.CC' -o \
-  -name '*.cuh' -o -name '*.CUH' -o \
-  -name '*.h' -o -name '*.hpp' -o -name '*.hh' -o -name '*.inc' -o -name '*.inl' -o -name '*.hxx' -o -name '*.hdl' -o \
-  -name '*.H' -o -name '*.HPP' -o -name '*.HH' -o -name '*.INC' -o -name '*.INL' -o -name '*.HXX' -o -name '*.HDL' \
-\) -print0
+find "$@" \( -name '*.cu' -o -name '*.CU' \) -print0
+find "$@" \( -name '*.cpp' -o -name '*.cxx' -o -name '*.c' -o -name '*.cc' \) -print0
+find "$@" \( -name '*.CPP' -o -name '*.CXX' -o -name '*.C' -o -name '*.CC' \) -print0
+find "$@" \( -name '*.cuh' -o -name '*.CUH' \) -print0
+find "$@" \( -name '*.h' -o -name '*.hpp' -o -name '*.hh' -o -name '*.inc' -o -name '*.inl' -o -name '*.hxx' -o -name '*.hdl' \) -print0
+find "$@" \( -name '*.H' -o -name '*.HPP' -o -name '*.HH' -o -name '*.INC' -o -name '*.INL' -o -name '*.HXX' -o -name '*.HDL' \) -print0

--- a/bin/findcode_custom.sh
+++ b/bin/findcode_custom.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
 
-SEARCH_DIRS=$@
+# Outputs matched .cu files (excluding .cuh), NUL-delimited.
 
-find $SEARCH_DIRS -name '*.cu' -and -not -name '*.cuh'
-find $SEARCH_DIRS -name '*.CU' -and -not -name '*.CUH'
+if [ "$#" -eq 0 ]; then
+  exit 0
+fi
+
+find "$@" \( \
+  \( -name '*.cu' -a -not -name '*.cuh' \) -o \
+  \( -name '*.CU' -a -not -name '*.CUH' \) \
+\) -print0

--- a/bin/findcode_custom.sh
+++ b/bin/findcode_custom.sh
@@ -2,11 +2,9 @@
 
 # Outputs matched .cu files (excluding .cuh), NUL-delimited.
 
-if [ "$#" -eq 0 ]; then
-  exit 0
+if [ "$#" -eq 0 ] || { [ "$#" -eq 1 ] && [ -z "$1" ]; }; then
+  set -- .
 fi
 
-find "$@" \( \
-  \( -name '*.cu' -a -not -name '*.cuh' \) -o \
-  \( -name '*.CU' -a -not -name '*.CUH' \) \
-\) -print0
+find "$@" -name '*.cu' -a -not -name '*.cuh' -print0
+find "$@" -name '*.CU' -a -not -name '*.CUH' -print0

--- a/bin/findcode_headers.sh
+++ b/bin/findcode_headers.sh
@@ -1,7 +1,13 @@
 #!/bin/bash
 
-SEARCH_DIRS=$@
+# Outputs matched header files, NUL-delimited.
 
-find $SEARCH_DIRS -name '*.cuh' -o -name '*.CUH'
-find $SEARCH_DIRS -name '*.h' -o -name '*.hpp' -o -name '*.hh' -o -name '*.inc' -o -name '*.inl' -o -name '*.hxx' -o -name '*.hdl'
-find $SEARCH_DIRS -name '*.H' -o -name '*.HPP' -o -name '*.HH' -o -name '*.INC' -o -name '*.INL' -o -name '*.HXX' -o -name '*.HDL'
+if [ "$#" -eq 0 ]; then
+  exit 0
+fi
+
+find "$@" \( \
+  -name '*.cuh' -o -name '*.CUH' -o \
+  -name '*.h' -o -name '*.hpp' -o -name '*.hh' -o -name '*.inc' -o -name '*.inl' -o -name '*.hxx' -o -name '*.hdl' -o \
+  -name '*.H' -o -name '*.HPP' -o -name '*.HH' -o -name '*.INC' -o -name '*.INL' -o -name '*.HXX' -o -name '*.HDL' \
+\) -print0

--- a/bin/findcode_headers.sh
+++ b/bin/findcode_headers.sh
@@ -2,12 +2,10 @@
 
 # Outputs matched header files, NUL-delimited.
 
-if [ "$#" -eq 0 ]; then
-  exit 0
+if [ "$#" -eq 0 ] || { [ "$#" -eq 1 ] && [ -z "$1" ]; }; then
+  set -- .
 fi
 
-find "$@" \( \
-  -name '*.cuh' -o -name '*.CUH' -o \
-  -name '*.h' -o -name '*.hpp' -o -name '*.hh' -o -name '*.inc' -o -name '*.inl' -o -name '*.hxx' -o -name '*.hdl' -o \
-  -name '*.H' -o -name '*.HPP' -o -name '*.HH' -o -name '*.INC' -o -name '*.INL' -o -name '*.HXX' -o -name '*.HDL' \
-\) -print0
+find "$@" \( -name '*.cuh' -o -name '*.CUH' \) -print0
+find "$@" \( -name '*.h' -o -name '*.hpp' -o -name '*.hh' -o -name '*.inc' -o -name '*.inl' -o -name '*.hxx' -o -name '*.hdl' \) -print0
+find "$@" \( -name '*.H' -o -name '*.HPP' -o -name '*.HH' -o -name '*.INC' -o -name '*.INL' -o -name '*.HXX' -o -name '*.HDL' \) -print0

--- a/bin/findcode_sources.sh
+++ b/bin/findcode_sources.sh
@@ -2,13 +2,11 @@
 
 # Outputs matched source files (excluding headers), NUL-delimited.
 
-if [ "$#" -eq 0 ]; then
-  exit 0
+if [ "$#" -eq 0 ] || { [ "$#" -eq 1 ] && [ -z "$1" ]; }; then
+  set -- .
 fi
 
-find "$@" \( \
-  \( -name '*.cu' -a -not -name '*.cuh' \) -o \
-  \( -name '*.CU' -a -not -name '*.CUH' \) -o \
-  -name '*.cpp' -o -name '*.cxx' -o -name '*.c' -o -name '*.cc' -o \
-  -name '*.CPP' -o -name '*.CXX' -o -name '*.C' -o -name '*.CC' \
-\) -print0
+find "$@" -name '*.cu' -a -not -name '*.cuh' -print0
+find "$@" -name '*.CU' -a -not -name '*.CUH' -print0
+find "$@" \( -name '*.cpp' -o -name '*.cxx' -o -name '*.c' -o -name '*.cc' \) -print0
+find "$@" \( -name '*.CPP' -o -name '*.CXX' -o -name '*.C' -o -name '*.CC' \) -print0

--- a/bin/findcode_sources.sh
+++ b/bin/findcode_sources.sh
@@ -1,8 +1,14 @@
 #!/bin/bash
 
-SEARCH_DIRS=$@
+# Outputs matched source files (excluding headers), NUL-delimited.
 
-find $SEARCH_DIRS -name '*.cu' -and -not -name '*.cuh'
-find $SEARCH_DIRS -name '*.CU' -and -not -name '*.CUH'
-find $SEARCH_DIRS -name '*.cpp' -o -name '*.cxx' -o -name '*.c' -o -name '*.cc'
-find $SEARCH_DIRS -name '*.CPP' -o -name '*.CXX' -o -name '*.C' -o -name '*.CC'
+if [ "$#" -eq 0 ]; then
+  exit 0
+fi
+
+find "$@" \( \
+  \( -name '*.cu' -a -not -name '*.cuh' \) -o \
+  \( -name '*.CU' -a -not -name '*.CUH' \) -o \
+  -name '*.cpp' -o -name '*.cxx' -o -name '*.c' -o -name '*.cc' -o \
+  -name '*.CPP' -o -name '*.CXX' -o -name '*.C' -o -name '*.CC' \
+\) -print0

--- a/bin/finduncodep.sh
+++ b/bin/finduncodep.sh
@@ -2,13 +2,9 @@
 
 # Outputs files that do not match known CUDA/HIP source/header extensions, NUL-delimited.
 
-SEARCH_DIR=$1
+SEARCH_DIR=${1:-.}
 
-if [ -z "$SEARCH_DIR" ]; then
-  exit 0
-fi
-
-find "$SEARCH_DIR" \( \
+find "$SEARCH_DIR" \
   -not -name '*.cu' -a \
   -not -name '*.cpp' -a \
   -not -name '*.cxx' -a \
@@ -21,4 +17,4 @@ find "$SEARCH_DIR" \( \
   -not -name '*.inl' -a \
   -not -name '*.hxx' -a \
   -not -name '*.hdl' \
-\) -print0
+  -print0

--- a/bin/finduncodep.sh
+++ b/bin/finduncodep.sh
@@ -1,5 +1,24 @@
 #!/bin/bash
 
+# Outputs files that do not match known CUDA/HIP source/header extensions, NUL-delimited.
+
 SEARCH_DIR=$1
 
-find $SEARCH_DIR -not -name '*.cu' -and -not -name '*.cpp' -and -not -name '*.cxx' -and -not -name '*.c' -and -not -name '*.cc' -and -not -name '*.cuh' -and -not -name '*.h' -and -not -name '*.hpp' -and -not -name '*.inc' -and -not -name '*.inl' -and -not -name '*.hxx' -and -not -name '*.hdl'
+if [ -z "$SEARCH_DIR" ]; then
+  exit 0
+fi
+
+find "$SEARCH_DIR" \( \
+  -not -name '*.cu' -a \
+  -not -name '*.cpp' -a \
+  -not -name '*.cxx' -a \
+  -not -name '*.c' -a \
+  -not -name '*.cc' -a \
+  -not -name '*.cuh' -a \
+  -not -name '*.h' -a \
+  -not -name '*.hpp' -a \
+  -not -name '*.inc' -a \
+  -not -name '*.inl' -a \
+  -not -name '*.hxx' -a \
+  -not -name '*.hdl' \
+\) -print0

--- a/bin/hipconvertinplace-perl.sh
+++ b/bin/hipconvertinplace-perl.sh
@@ -32,6 +32,8 @@ shift
 fi
 shift
 
+SEARCH_DIR=${SEARCH_DIR:-.}
+
 mapfile -d '' -t files < <("$SCRIPT_DIR/$SCRIPT_NAME" "$SEARCH_DIR")
 if [ "${#files[@]}" -eq 0 ]; then
   exit 0

--- a/bin/hipconvertinplace-perl.sh
+++ b/bin/hipconvertinplace-perl.sh
@@ -27,9 +27,14 @@ SCRIPT_NAME=findcode_sources.sh
 shift
 elif [ "$2" = "-filter=custom" ]
 then
-SCRIPT_NANE=findcode_custom.sh
+SCRIPT_NAME=findcode_custom.sh
 shift
 fi
 shift
 
-$SCRIPT_DIR/hipify-perl -inplace -print-stats "$@" `$SCRIPT_DIR/$SCRIPT_NAME $SEARCH_DIR`
+mapfile -d '' -t files < <("$SCRIPT_DIR/$SCRIPT_NAME" "$SEARCH_DIR")
+if [ "${#files[@]}" -eq 0 ]; then
+  exit 0
+fi
+
+"$SCRIPT_DIR/hipify-perl" -inplace -print-stats "$@" "${files[@]}"

--- a/bin/hipconvertinplace-perl.sh
+++ b/bin/hipconvertinplace-perl.sh
@@ -13,6 +13,9 @@
 
 SCRIPT_DIR="$(dirname "$(realpath "$0")")"
 SCRIPT_NAME=findcode.sh
+if [ "$#" -eq 0 ]; then
+SEARCH_DIR=.
+else
 SEARCH_DIR=$1
 if [ "$2" = "-filter=all" ]
 then
@@ -31,8 +34,8 @@ SCRIPT_NAME=findcode_custom.sh
 shift
 fi
 shift
-
 SEARCH_DIR=${SEARCH_DIR:-.}
+fi
 
 mapfile -d '' -t files < <("$SCRIPT_DIR/$SCRIPT_NAME" "$SEARCH_DIR")
 if [ "${#files[@]}" -eq 0 ]; then

--- a/bin/hipconvertinplace.sh
+++ b/bin/hipconvertinplace.sh
@@ -8,7 +8,7 @@
 
 SCRIPT_DIR="$(dirname "$(realpath "$0")")"
 BIN_DIR="$SCRIPT_DIR/../../bin"
-SEARCH_DIR=$1
+SEARCH_DIR=${1:-.}
 shift
 
 hipify_args=()

--- a/bin/hipconvertinplace.sh
+++ b/bin/hipconvertinplace.sh
@@ -9,17 +9,24 @@
 SCRIPT_DIR="$(dirname "$(realpath "$0")")"
 BIN_DIR="$SCRIPT_DIR/../../bin"
 SEARCH_DIR=$1
+shift
 
-hipify_args=''
-while (( "$#" )); do
-  shift
-  if [ "$1" != "--" ]; then
-    hipify_args="$hipify_args $1"
+hipify_args=()
+clang_args=()
+parsing_clang=0
+for arg in "$@"; do
+  if [ "$parsing_clang" -eq 1 ]; then
+    clang_args+=("$arg")
+  elif [ "$arg" = "--" ]; then
+    parsing_clang=1
   else
-    shift
-    break
+    hipify_args+=("$arg")
   fi
 done
-clang_args="$@"
 
-$BIN_DIR/hipify-clang -inplace -print-stats $hipify_args `$SCRIPT_DIR/findcode.sh $SEARCH_DIR` -- -x cuda $clang_args
+mapfile -d '' -t files < <("$SCRIPT_DIR/findcode.sh" "$SEARCH_DIR")
+if [ "${#files[@]}" -eq 0 ]; then
+  exit 0
+fi
+
+"$BIN_DIR/hipify-clang" -inplace -print-stats "${hipify_args[@]}" "${files[@]}" -- -x cuda "${clang_args[@]}"

--- a/bin/hipconvertinplace.sh
+++ b/bin/hipconvertinplace.sh
@@ -8,8 +8,12 @@
 
 SCRIPT_DIR="$(dirname "$(realpath "$0")")"
 BIN_DIR="$SCRIPT_DIR/../../bin"
-SEARCH_DIR=${1:-.}
-shift
+if [ "$#" -gt 0 ]; then
+  SEARCH_DIR=$1
+  shift
+else
+  SEARCH_DIR=.
+fi
 
 hipify_args=()
 clang_args=()

--- a/bin/hipexamine-perl.sh
+++ b/bin/hipexamine-perl.sh
@@ -7,8 +7,12 @@
 
 
 SCRIPT_DIR="$(dirname "$(realpath "$0")")"
-SEARCH_DIR=${1:-.}
-shift
+if [ "$#" -gt 0 ]; then
+  SEARCH_DIR=$1
+  shift
+else
+  SEARCH_DIR=.
+fi
 
 mapfile -d '' -t files < <("$SCRIPT_DIR/findcode.sh" "$SEARCH_DIR")
 if [ "${#files[@]}" -eq 0 ]; then

--- a/bin/hipexamine-perl.sh
+++ b/bin/hipexamine-perl.sh
@@ -9,4 +9,10 @@
 SCRIPT_DIR="$(dirname "$(realpath "$0")")"
 SEARCH_DIR=$1
 shift
-$SCRIPT_DIR/hipify-perl -no-output -print-stats "$@" `$SCRIPT_DIR/findcode.sh $SEARCH_DIR`
+
+mapfile -d '' -t files < <("$SCRIPT_DIR/findcode.sh" "$SEARCH_DIR")
+if [ "${#files[@]}" -eq 0 ]; then
+  exit 0
+fi
+
+"$SCRIPT_DIR/hipify-perl" -no-output -print-stats "$@" "${files[@]}"

--- a/bin/hipexamine-perl.sh
+++ b/bin/hipexamine-perl.sh
@@ -7,7 +7,7 @@
 
 
 SCRIPT_DIR="$(dirname "$(realpath "$0")")"
-SEARCH_DIR=$1
+SEARCH_DIR=${1:-.}
 shift
 
 mapfile -d '' -t files < <("$SCRIPT_DIR/findcode.sh" "$SEARCH_DIR")

--- a/bin/hipexamine.sh
+++ b/bin/hipexamine.sh
@@ -6,8 +6,12 @@
 
 SCRIPT_DIR="$(dirname "$(realpath "$0")")"
 BIN_DIR="$SCRIPT_DIR/../../bin"
-SEARCH_DIR=${1:-.}
-shift
+if [ "$#" -gt 0 ]; then
+  SEARCH_DIR=$1
+  shift
+else
+  SEARCH_DIR=.
+fi
 
 hipify_args=()
 clang_args=()

--- a/bin/hipexamine.sh
+++ b/bin/hipexamine.sh
@@ -7,17 +7,24 @@
 SCRIPT_DIR="$(dirname "$(realpath "$0")")"
 BIN_DIR="$SCRIPT_DIR/../../bin"
 SEARCH_DIR=$1
+shift
 
-hipify_args=''
-while (( "$#" )); do
-  shift
-  if [ "$1" != "--" ]; then
-    hipify_args="$hipify_args $1"
+hipify_args=()
+clang_args=()
+parsing_clang=0
+for arg in "$@"; do
+  if [ "$parsing_clang" -eq 1 ]; then
+    clang_args+=("$arg")
+  elif [ "$arg" = "--" ]; then
+    parsing_clang=1
   else
-    shift
-    break
+    hipify_args+=("$arg")
   fi
 done
-clang_args="$@"
 
-$BIN_DIR/hipify-clang -examine $hipify_args `$SCRIPT_DIR/findcode.sh $SEARCH_DIR` -- -x cuda $clang_args
+mapfile -d '' -t files < <("$SCRIPT_DIR/findcode.sh" "$SEARCH_DIR")
+if [ "${#files[@]}" -eq 0 ]; then
+  exit 0
+fi
+
+"$BIN_DIR/hipify-clang" -examine "${hipify_args[@]}" "${files[@]}" -- -x cuda "${clang_args[@]}"

--- a/bin/hipexamine.sh
+++ b/bin/hipexamine.sh
@@ -6,7 +6,7 @@
 
 SCRIPT_DIR="$(dirname "$(realpath "$0")")"
 BIN_DIR="$SCRIPT_DIR/../../bin"
-SEARCH_DIR=$1
+SEARCH_DIR=${1:-.}
 shift
 
 hipify_args=()


### PR DESCRIPTION
## Motivation


The wrapper scripts pass find output through unquoted backtick substitution, which can split filenames on spaces/newlines and treat dash-prefixed names as options when calling hipify-perl / hipify-clang. T

Review follow-up restores documented legacy behavior (default to current directory, per-extension find order) while keeping the NUL-safe filename handling.

## Technical Details

Changes:
Replace `findcode*.sh $SEARCH_DIR` with find … -print0 + mapfile -d '' + "${files[@]}"
Quote "$SEARCH_DIR" and pass hipify/clang args via bash arrays
Fix SCRIPT_NANE → SCRIPT_NAME so -filter=custom uses findcode_custom.sh

Review fixes (commit 7ea40e4):
Default to current directory when no path is given (set -- . in findcode*.sh; SEARCH_DIR=${SEARCH_DIR:-.} in wrappers; ${1:-.} in finduncodep.sh)
Restore per-extension find order using separate find … -print0 calls (same grouping as original scripts)

## Test Plan

- [x] `bash -n bin/*.sh` — shell syntax
- [x] `verify-wrapper-scripts.sh` — no-arg default, empty path, extension order, security filenames
- [x] **Functional** — `hipexamine-perl.sh tests/unit_tests/samples` — hipify stats on real samples
- [x] **Filter** — `findcode_custom.sh` / `-filter=custom` — only `.cu` (not `.cuh`) selected; `SCRIPT_NAME` typo fixed
- [x] **Path with spaces** — `findcode.sh` / `hipexamine-perl.sh` on directory name containing spaces
- [ ] PR CI — HIPIFY GitHub checks (markdownlint only; wrapper scripts not in CI)

## Test Result

bash verify-wrapper-scripts.sh

=== bash -n ===
PASS
=== no-arg findcode (defaults to .) ===
PASS count=4
=== empty path (defaults to .) ===
PASS
=== extension order ===
PASS a.cu b.cpp c.cuh x.h 
=== security: spaced/newline/dash names stay single entries ===
PASS
=== finduncodep no arg ===
PASS count=3
All checks passed.



## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
