### PR TITLE
[HIPIFY][clang][fix] Remove `clang::CudaVersion::CUDA_133`

### DIFF
--- a/src/Statistics.cpp
+++ b/src/Statistics.cpp
@@ -932,7 +932,6 @@ cudaVersions Statistics::convertCudaToolkitVersion(const clang::CudaVersion &ver
     case clang::CudaVersion::CUDA_130: return CUDA_130;
     case clang::CudaVersion::CUDA_131: return CUDA_131;
     case clang::CudaVersion::CUDA_132: return CUDA_132;
-    case clang::CudaVersion::CUDA_133: return CUDA_133;
 #endif
 #endif
 #endif


### PR DESCRIPTION
+ [Reason] `CUDA_133` was removed in clang `24.0.0git`
