### PR TITLE
[HIPIFY][CUB][tests][fix] Exclude `CUB` tests for `CUDA 13`, too

### DIFF
--- a/tests/lit.cfg
+++ b/tests/lit.cfg
@@ -59,7 +59,7 @@ if not config.cuda_cub_root or config.cuda_cub_root == "OFF":
 else:
     # On CUDA >= 12.6 the standalone CUB (CUDA_CUB_ROOT_DIR)
     # pulls in <thrust/detail/cstdint.h>, removed from CCCL in 12.6. Exclude for now.
-    if config.cuda_version_major == 12 and config.cuda_version_minor >= 6:
+    if config.cuda_version_major >= 13 or (config.cuda_version_major == 12 and config.cuda_version_minor >= 6):
         exclude_all_cub_tests()
 
 if not config.cuda_tensor_root or config.cuda_tensor_root == "OFF":


### PR DESCRIPTION
+ [Reason] `<thrust/detail/cstdint.h>`, removed from `CCCL` in `CUDA 12.6`
