### PR TITLE
[HIPIFY][build][CMake][fix] Updating Source File Discovery (`GLOB`)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,8 +61,8 @@ if (NOT HIPIFY_CLANG_TESTS_ONLY)
   include_directories(${LLVM_INCLUDE_DIRS})
   add_definitions(${LLVM_DEFINITIONS})
 
-  file(GLOB_RECURSE HIPIFY_SOURCES src/*.cpp)
-  file(GLOB_RECURSE HIPIFY_HEADERS src/*.h)
+  file(GLOB_RECURSE HIPIFY_SOURCES CONFIGURE_DEPENDS src/*.cpp)
+  file(GLOB_RECURSE HIPIFY_HEADERS CONFIGURE_DEPENDS src/*.h)
 
   # In order to be compatible with an LLVM that uses LLVM_LINK_LLVM_DYLIB=ON,
   # hipify-clang must link core LLVM libraries via LLVM_LINK_COMPONENTS vs directly adding


### PR DESCRIPTION
+ [Reason] Adding the `CONFIGURE_DEPENDS` flag (since `CMake 3.12`) resolves a fundamental synchronization issue within the build graph when source files are added or removed from the project.
+ [Testing] `Linux` and `Windows`; `CMake` `3.16.8`, `4.4.0`.
