### PR TITLE
[HIPIFY][#2563][SPARSELt][refactor][tests] `cuSPARSELt` support - Step 8 - `CUSPARSELT_VERSION`-dependent testing

### DIFF
--- a/docs/reference/tables/CUSPARSELT_API_supported_by_HIP.md
+++ b/docs/reference/tables/CUSPARSELT_API_supported_by_HIP.md
@@ -75,11 +75,11 @@
 |`cusparseLtMatmulDescriptorInit`|0.0.1| | | |`hipsparseLtMatmulDescriptorInit`|7.10.0| | | | | |
 |`cusparseLtMatmulGetWorkspace`|0.0.1| |0.3.0| |`hipsparseLtMatmulGetWorkspace`|7.10.0| | | | | |
 |`cusparseLtMatmulPlanDestroy`|0.0.1| | | |`hipsparseLtMatmulPlanDestroy`|7.10.0| | | | | |
-|`cusparseLtMatmulPlanInit`|0.0.1| | | |`hipsparseLtMatmulPlanInit`|7.10.0| | | | | |
+|`cusparseLtMatmulPlanInit`|0.0.1| |0.4.0| |`hipsparseLtMatmulPlanInit`|7.10.0| | | | | |
 |`cusparseLtMatmulSearch`|0.0.1| | | |`hipsparseLtMatmulSearch`|7.10.0| | | | | |
-|`cusparseLtSpMMACompress`|0.0.1| | | |`hipsparseLtSpMMACompress`|7.10.0| | | | | |
-|`cusparseLtSpMMACompress2`|0.1.0| | | |`hipsparseLtSpMMACompress2`|7.10.0| | | | | |
-|`cusparseLtSpMMACompressedSize`|0.0.1| | | |`hipsparseLtSpMMACompressedSize`|7.10.0| | | | | |
+|`cusparseLtSpMMACompress`|0.0.1| |0.4.0| |`hipsparseLtSpMMACompress`|7.10.0| | | | | |
+|`cusparseLtSpMMACompress2`|0.1.0| |0.4.0| |`hipsparseLtSpMMACompress2`|7.10.0| | | | | |
+|`cusparseLtSpMMACompressedSize`|0.0.1| |0.4.0| |`hipsparseLtSpMMACompressedSize`|7.10.0| | | | | |
 |`cusparseLtSpMMACompressedSize2`|0.1.0| | | |`hipsparseLtSpMMACompressedSize2`|7.10.0| | | | | |
 |`cusparseLtSpMMAPrune`|0.0.1| | | |`hipsparseLtSpMMAPrune`|7.10.0| | | | | |
 |`cusparseLtSpMMAPrune2`|0.1.0| | | |`hipsparseLtSpMMAPrune2`|7.10.0| | | | | |

--- a/src/CUDA2HIP_SPARSELT_API_functions.cpp
+++ b/src/CUDA2HIP_SPARSELT_API_functions.cpp
@@ -126,6 +126,10 @@ const std::map<llvm::StringRef, cudaAPIChangedVersions> CUDA_SPARSELT_FUNCTION_C
   std::map<llvm::StringRef, cudaAPIChangedVersions> m;
 
   m["cusparseLtMatmulGetWorkspace"]                                   = { CUSPARSELT_030 };
+  m["cusparseLtMatmulPlanInit"]                                       = { CUSPARSELT_040 };
+  m["cusparseLtSpMMACompress"]                                        = { CUSPARSELT_040 };
+  m["cusparseLtSpMMACompressedSize"]                                  = { CUSPARSELT_040 };
+  m["cusparseLtSpMMACompress2"]                                       = { CUSPARSELT_040 };
 
   return m;
 }();

--- a/tests/lit.cfg
+++ b/tests/lit.cfg
@@ -79,8 +79,15 @@ if not config.cuda_file_root or config.cuda_file_root == "OFF" or config.cuda_ve
 
 if not config.cuda_sparselt_root or config.cuda_sparselt_root == "OFF":
     config.excludes.append('cusparselt2hipsparselt.cu')
+    config.excludes.append('cusparselt2hipsparselt_0100_0510.cu')
+    config.excludes.append('cusparselt2hipsparselt_after_0300.cu')
     print("WARN: cuSPARSELt tests are excluded because CUDA_SPARSELT_ROOT_DIR is not specified")
     warns = True
+else:
+    if config.cusparselt_version < 100 or config.cusparselt_version > 501:
+       config.excludes.append('cusparselt2hipsparselt_0100_0510.cu')
+    if config.cusparselt_version <= 300:
+       config.excludes.append('cusparselt2hipsparselt_after_0300.cu')
 
 if warns:
     print(delimiter)

--- a/tests/lit.site.cfg.in
+++ b/tests/lit.site.cfg.in
@@ -26,33 +26,46 @@ if sys.platform in ['win32']:
     if not config.build_type:
         config.build_type = "Debug"
 
-pattern_major = r'_MAJOR ([1-9]|1[0-9])'
+pattern_major = r'_MAJOR ([0-9]+)'
+pattern_minor = r'_MINOR ([0-9]+)'
+pattern_patch = r'_PATCH ([0-9]+)'
 
-def get_lib_major_ver(file_name):
+def get_lib_ver(file_name, pattern=pattern_major):
     if os.path.isfile(file_name):
         with open(file_name, 'r') as f:
-            match = re.search(pattern_major, f.read())
+            match = re.search(pattern, f.read())
         if match:
             s = match.group(0)[7:]
             return int(s)
     return 0
 
+def get_lib_version_sum(file_name):
+    major = get_lib_ver(file_name, pattern_major)
+    minor = get_lib_ver(file_name, pattern_minor)
+    patch = get_lib_ver(file_name, pattern_patch)
+    return major * 1000 + minor * 100 + patch
+
 def get_cudnn_major_ver():
     ver_file = config.cuda_dnn_root + '/cudnn_version.h'
-    ver = get_lib_major_ver(ver_file)
+    ver = get_lib_ver(ver_file)
     if ver == 0:
         ver_file = config.cuda_dnn_root + '/cudnn_version_v9.h'
-        ver = get_lib_major_ver(ver_file)
+        ver = get_lib_ver(ver_file)
     if ver == 0:
         ver_file = config.cuda_dnn_root + '/cudnn_version_v999.h'
-        ver = get_lib_major_ver(ver_file)
+        ver = get_lib_ver(ver_file)
     return int(ver)
 
 def get_cutensor_major_ver():
     ver_file = config.cuda_tensor_root + '/cutensor.h'
-    ver = get_lib_major_ver(ver_file)
+    ver = get_lib_ver(ver_file)
     if ver == 0:
         ver = 1
+    return ver
+
+def get_cusparselt_ver():
+    ver_file = config.cuda_sparselt_root + '/cusparselt.h'
+    ver = get_lib_version_sum(ver_file)
     return ver
 
 if config.cuda_dnn_root and config.cuda_dnn_root != "OFF":
@@ -60,6 +73,9 @@ if config.cuda_dnn_root and config.cuda_dnn_root != "OFF":
 
 if config.cuda_tensor_root and config.cuda_tensor_root != "OFF":
     config.cutensor_version_major = get_cutensor_major_ver()
+
+if config.cuda_sparselt_root and config.cuda_sparselt_root != "OFF":
+    config.cusparselt_version = get_cusparselt_ver()
 
 # Support substitution of the tools and libs dirs with user parameters. This is
 # used when we can't determine the tool dir at configuration time.

--- a/tests/unit_tests/synthetic/libraries/cusparselt2hipsparselt.cu
+++ b/tests/unit_tests/synthetic/libraries/cusparselt2hipsparselt.cu
@@ -67,7 +67,6 @@ int main() {
   // CHECK: hipsparseLtMatmulPlan_t plan;
   cusparseLtMatmulPlan_t plan;
 
-  // cuSPARSELt data types (Added: cuSPARSELt 0.0.1)
   // CHECK: hipsparseLtSparsity_t sparsity;
   // CHECK-NEXT: hipsparseLtSparsity_t SPARSITY_50_PERCENT = HIPSPARSELT_SPARSITY_50_PERCENT;
   cusparseLtSparsity_t sparsity;
@@ -101,11 +100,6 @@ int main() {
   cusparseLtPruneAlg_t PRUNE_SPMMA_TILE = CUSPARSELT_PRUNE_SPMMA_TILE;
   cusparseLtPruneAlg_t PRUNE_SPMMA_STRIP = CUSPARSELT_PRUNE_SPMMA_STRIP;
 
-  // NOTE: CUSPARSE_COMPUTE_TF32 / CUSPARSE_COMPUTE_TF32_FAST (cuSPARSELt 0.1.0) were removed
-  // from cusparseComputeType in later cuSPARSELt (replaced by CUSPARSE_COMPUTE_32F).
-  // [ToDo]: Add the CUSPARSE_COMPUTE_32F -> HIPSPARSELT_COMPUTE_32F mapping.
-
-  // cuSPARSELt function reference (Added: cuSPARSELt 0.0.1)
   // CUDA: cusparseStatus_t cusparseLtInit(cusparseLtHandle_t* handle);
   // HIP: hipsparseStatus_t hipsparseLtInit(hipsparseLtHandle_t* handle);
   // CHECK: status = hipsparseLtInit(&handle);
@@ -146,11 +140,6 @@ int main() {
   // CHECK: status = hipsparseLtMatmulAlgGetAttribute(&handle, &algSelection, algAttribute, data, dataSize);
   status = cusparseLtMatmulAlgGetAttribute(&handle, &algSelection, algAttribute, data, dataSize);
 
-  // CUDA: cusparseStatus_t cusparseLtMatmulPlanInit(const cusparseLtHandle_t* handle, cusparseLtMatmulPlan_t* plan, const cusparseLtMatmulDescriptor_t* matmulDescr, const cusparseLtMatmulAlgSelection_t* algSelection);
-  // HIP: hipsparseStatus_t hipsparseLtMatmulPlanInit(const hipsparseLtHandle_t* handle, hipsparseLtMatmulPlan_t* plan, const hipsparseLtMatmulDescriptor_t* matmulDescr, const hipsparseLtMatmulAlgSelection_t* algSelection);
-  // CHECK: status = hipsparseLtMatmulPlanInit(&handle, &plan, &matmulDescr, &algSelection);
-  status = cusparseLtMatmulPlanInit(&handle, &plan, &matmulDescr, &algSelection);
-
   // CUDA: cusparseStatus_t cusparseLtMatmulPlanDestroy(const cusparseLtMatmulPlan_t* plan);
   // HIP: hipsparseStatus_t hipsparseLtMatmulPlanDestroy(const hipsparseLtMatmulPlan_t* plan);
   // CHECK: status = hipsparseLtMatmulPlanDestroy(&plan);
@@ -176,17 +165,7 @@ int main() {
   // CHECK: status = hipsparseLtSpMMAPruneCheck(&handle, &matmulDescr, d_in, &valid, stream);
   status = cusparseLtSpMMAPruneCheck(&handle, &matmulDescr, d_in, &valid, stream);
 
-  // CUDA: cusparseStatus_t cusparseLtSpMMACompressedSize(const cusparseLtHandle_t* handle, const cusparseLtMatmulPlan_t* plan, size_t* compressedSize, size_t* compressBufferSize);
-  // HIP: hipsparseStatus_t hipsparseLtSpMMACompressedSize(const hipsparseLtHandle_t* handle, const hipsparseLtMatmulPlan_t* plan, size_t* compressedSize, size_t* compressBufferSize);
-  // CHECK: status = hipsparseLtSpMMACompressedSize(&handle, &plan, &compressedSize, &compressBufferSize);
-  status = cusparseLtSpMMACompressedSize(&handle, &plan, &compressedSize, &compressBufferSize);
-
-  // CUDA: cusparseStatus_t cusparseLtSpMMACompress(const cusparseLtHandle_t* handle, const cusparseLtMatmulPlan_t* plan, const void* d_dense, void* d_compressed, void* d_compressBuffer, cudaStream_t stream);
-  // HIP: hipsparseStatus_t hipsparseLtSpMMACompress(const hipsparseLtHandle_t* handle, const hipsparseLtMatmulPlan_t* plan, const void* d_dense, void* d_compressed, void* d_compressBuffer, hipStream_t stream);
-  // CHECK: status = hipsparseLtSpMMACompress(&handle, &plan, d_dense, d_compressed, d_compressBuffer, stream);
-  status = cusparseLtSpMMACompress(&handle, &plan, d_dense, d_compressed, d_compressBuffer, stream);
-
-  // cuSPARSELt function reference (Added: cuSPARSELt 0.1.0)
+#if CUSPARSELT_VERSION >= 100
   // CUDA: cusparseStatus_t cusparseLtMatDescriptorDestroy(const cusparseLtMatDescriptor_t* matDescr);
   // HIP: hipsparseStatus_t hipsparseLtMatDescriptorDestroy(const hipsparseLtMatDescriptor_t* matDescr);
   // CHECK: status = hipsparseLtMatDescriptorDestroy(&matDescr);
@@ -201,16 +180,7 @@ int main() {
   // HIP: hipsparseStatus_t hipsparseLtSpMMAPruneCheck2(const hipsparseLtHandle_t* handle, const hipsparseLtMatDescriptor_t* sparseMatDescr, int isSparseA, hipsparseOperation_t op, const void* d_in, int* d_valid, hipStream_t stream);
   // CHECK: status = hipsparseLtSpMMAPruneCheck2(&handle, &matA, isSparseA, op, d_in, &valid, stream);
   status = cusparseLtSpMMAPruneCheck2(&handle, &matA, isSparseA, op, d_in, &valid, stream);
-
-  // CUDA: cusparseStatus_t cusparseLtSpMMACompressedSize2(const cusparseLtHandle_t* handle, const cusparseLtMatDescriptor_t* sparseMatDescr, size_t* compressedSize, size_t* compressBufferSize);
-  // HIP: hipsparseStatus_t hipsparseLtSpMMACompressedSize2(const hipsparseLtHandle_t* handle, const hipsparseLtMatDescriptor_t* sparseMatDescr, size_t* compressedSize, size_t* compressBufferSize);
-  // CHECK: status = hipsparseLtSpMMACompressedSize2(&handle, &matA, &compressedSize, &compressBufferSize);
-  status = cusparseLtSpMMACompressedSize2(&handle, &matA, &compressedSize, &compressBufferSize);
-
-  // CUDA: cusparseStatus_t cusparseLtSpMMACompress2(const cusparseLtHandle_t* handle, const cusparseLtMatDescriptor_t* sparseMatDescr, int isSparseA, cusparseOperation_t op, const void* d_dense, void* d_compressed, void* d_compressBuffer, cudaStream_t stream);
-  // HIP: hipsparseStatus_t hipsparseLtSpMMACompress2(const hipsparseLtHandle_t* handle, const hipsparseLtMatDescriptor_t* sparseMatDescr, int isSparseA, hipsparseOperation_t op, const void* d_dense, void* d_compressed, void* d_compressBuffer, hipStream_t stream);
-  // CHECK: status = hipsparseLtSpMMACompress2(&handle, &matA, isSparseA, op, d_dense, d_compressed, d_compressBuffer, stream);
-  status = cusparseLtSpMMACompress2(&handle, &matA, isSparseA, op, d_dense, d_compressed, d_compressBuffer, stream);
+#endif
 
 #if CUSPARSELT_VERSION >= 200
   // CHECK: hipsparseLtMatmulDescAttribute_t sparseLtMatmulDescAttribute_t;
@@ -284,5 +254,5 @@ int main() {
   status = cusparseLtMatmulGetWorkspace(&handle, &plan, &workspaceSize);
 #endif
 
-  return 0; 
+  return 0;
 }

--- a/tests/unit_tests/synthetic/libraries/cusparselt2hipsparselt_0100_0510.cu
+++ b/tests/unit_tests/synthetic/libraries/cusparselt2hipsparselt_0100_0510.cu
@@ -1,0 +1,23 @@
+// RUN: %run_test hipify "%s" "%t" %hipify_args 3 --amap --skip-excluded-preprocessor-conditional-blocks --experimental %clang_args -ferror-limit=500
+
+// CHECK: #include <hip/hip_runtime.h>
+#include <cuda_runtime.h>
+// CHECK: #include "hip/hip_complex.h"
+#include "cuComplex.h"
+#include <stdio.h>
+// CHECK: #include "hipsparseLt.h"
+#include "cusparseLt.h"
+// CHECK-NOT: #include "hipsparseLt.h"
+
+int main() {
+  printf("27.1.after_0001_before_0502 cuSPARSELt API to hipSPARSELt API synthetic test\n");
+
+#if CUSPARSELT_VERSION >= 100 && CUSPARSELT_VERSION <= 501
+  // CHECK: hipsparseLtComputetype_t SPARSE_COMPUTE_TF32 = HIPSPARSELT_COMPUTE_TF32;
+  // CHECK-NEXT: hipsparseLtComputetype_t SPARSE_COMPUTE_TF32_FAST = HIPSPARSELT_COMPUTE_TF32_FAST;
+  cusparseComputeType SPARSE_COMPUTE_TF32 = CUSPARSE_COMPUTE_TF32;
+  cusparseComputeType SPARSE_COMPUTE_TF32_FAST = CUSPARSE_COMPUTE_TF32_FAST;
+#endif
+
+  return 0;
+}

--- a/tests/unit_tests/synthetic/libraries/cusparselt2hipsparselt_after_0300.cu
+++ b/tests/unit_tests/synthetic/libraries/cusparselt2hipsparselt_after_0300.cu
@@ -1,0 +1,74 @@
+// RUN: %run_test hipify "%s" "%t" %hipify_args 3 --amap --skip-excluded-preprocessor-conditional-blocks --experimental %clang_args -ferror-limit=500
+
+// CHECK: #include <hip/hip_runtime.h>
+#include <cuda_runtime.h>
+// CHECK: #include "hip/hip_complex.h"
+#include "cuComplex.h"
+#include <stdio.h>
+// CHECK: #include "hipsparseLt.h"
+#include "cusparseLt.h"
+// CHECK-NOT: #include "hipsparseLt.h"
+
+int main() {
+  printf("27.1.after_0300 cuSPARSELt API to hipSPARSELt API synthetic test\n");
+
+  size_t compressedSize = 0;
+  size_t compressBufferSize = 0;
+  int isSparseA = 1;
+  const void *d_dense = nullptr;
+  void *d_compressed = nullptr;
+  void* d_compressBuffer = nullptr;
+
+  // CHECK: hipStream_t stream;
+  cudaStream_t stream;
+
+  // CHECK: hipsparseStatus_t status;
+  cusparseStatus_t status;
+
+  // CHECK: hipsparseLtHandle_t handle;
+  cusparseLtHandle_t handle;
+
+  // CHECK: hipsparseLtMatmulPlan_t plan;
+  cusparseLtMatmulPlan_t plan;
+
+  // CHECK: hipsparseLtMatmulDescriptor_t matmulDescr;
+  cusparseLtMatmulDescriptor_t matmulDescr;
+
+  // CHECK: hipsparseLtMatmulAlgSelection_t algSelection;
+  cusparseLtMatmulAlgSelection_t algSelection;
+
+  // CHECK: hipsparseLtMatDescriptor_t matDescr, matA, matB, matC, matD;
+  cusparseLtMatDescriptor_t matDescr, matA, matB, matC, matD;
+
+  // CHECK: hipsparseOperation_t opA, opB, op;
+  cusparseOperation_t opA, opB, op;
+
+#if CUSPARSELT_VERSION >= 400
+  // CUDA: cusparseStatus_t cusparseLtMatmulPlanInit(const cusparseLtHandle_t* handle, cusparseLtMatmulPlan_t* plan, const cusparseLtMatmulDescriptor_t* matmulDescr, const cusparseLtMatmulAlgSelection_t* algSelection);
+  // HIP: hipsparseStatus_t hipsparseLtMatmulPlanInit(const hipsparseLtHandle_t* handle, hipsparseLtMatmulPlan_t* plan, const hipsparseLtMatmulDescriptor_t* matmulDescr, const hipsparseLtMatmulAlgSelection_t* algSelection);
+  // CHECK: status = hipsparseLtMatmulPlanInit(&handle, &plan, &matmulDescr, &algSelection);
+  status = cusparseLtMatmulPlanInit(&handle, &plan, &matmulDescr, &algSelection);
+
+  // CUDA: cusparseStatus_t cusparseLtSpMMACompress(const cusparseLtHandle_t* handle, const cusparseLtMatmulPlan_t* plan, const void* d_dense, void* d_compressed, void* d_compressBuffer, cudaStream_t stream);
+  // HIP: hipsparseStatus_t hipsparseLtSpMMACompress(const hipsparseLtHandle_t* handle, const hipsparseLtMatmulPlan_t* plan, const void* d_dense, void* d_compressed, void* d_compressBuffer, hipStream_t stream);
+  // CHECK: status = hipsparseLtSpMMACompress(&handle, &plan, d_dense, d_compressed, d_compressBuffer, stream);
+  status = cusparseLtSpMMACompress(&handle, &plan, d_dense, d_compressed, d_compressBuffer, stream);
+
+  // CUDA: cusparseStatus_t cusparseLtSpMMACompressedSize(const cusparseLtHandle_t* handle, const cusparseLtMatmulPlan_t* plan, size_t* compressedSize, size_t* compressBufferSize);
+  // HIP: hipsparseStatus_t hipsparseLtSpMMACompressedSize(const hipsparseLtHandle_t* handle, const hipsparseLtMatmulPlan_t* plan, size_t* compressedSize, size_t* compressBufferSize);
+  // CHECK: status = hipsparseLtSpMMACompressedSize(&handle, &plan, &compressedSize, &compressBufferSize);
+  status = cusparseLtSpMMACompressedSize(&handle, &plan, &compressedSize, &compressBufferSize);
+
+  // CUDA: cusparseStatus_t cusparseLtSpMMACompress2(const cusparseLtHandle_t* handle, const cusparseLtMatDescriptor_t* sparseMatDescr, int isSparseA, cusparseOperation_t op, const void* d_dense, void* d_compressed, void* d_compressBuffer, cudaStream_t stream);
+  // HIP: hipsparseStatus_t hipsparseLtSpMMACompress2(const hipsparseLtHandle_t* handle, const hipsparseLtMatDescriptor_t* sparseMatDescr, int isSparseA, hipsparseOperation_t op, const void* d_dense, void* d_compressed, void* d_compressBuffer, hipStream_t stream);
+  // CHECK: status = hipsparseLtSpMMACompress2(&handle, &matA, isSparseA, op, d_dense, d_compressed, d_compressBuffer, stream);
+  status = cusparseLtSpMMACompress2(&handle, &matA, isSparseA, op, d_dense, d_compressed, d_compressBuffer, stream);
+
+  // CUDA: cusparseStatus_t cusparseLtSpMMACompressedSize2(const cusparseLtHandle_t* handle, const cusparseLtMatDescriptor_t* sparseMatDescr, size_t* compressedSize, size_t* compressBufferSize);
+  // HIP: hipsparseStatus_t hipsparseLtSpMMACompressedSize2(const hipsparseLtHandle_t* handle, const hipsparseLtMatDescriptor_t* sparseMatDescr, size_t* compressedSize, size_t* compressBufferSize);
+  // CHECK: status = hipsparseLtSpMMACompressedSize2(&handle, &matA, &compressedSize, &compressBufferSize);
+  status = cusparseLtSpMMACompressedSize2(&handle, &matA, &compressedSize, &compressBufferSize);
+#endif
+
+  return 0;
+}


### PR DESCRIPTION
+ Added a couple of `CUSPARSELT_VERSION`-dependent tests as separate files, refactored existing ones
+ Refactored `get_lib_major_ver(file_name)` into `get_lib_ver(file_name, pattern=pattern_major)` to deal with all versions
  - Affected `DNN` and `Tensor` testing
+ [Testing] `Windows` and `Linux` - All 78 CUDA versions passed
